### PR TITLE
Unrevert tmTheme sections

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.tmTheme
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.tmTheme
@@ -120,10 +120,8 @@
         </dict>
       </dict>
 
-      <!-- Temporarily removed because in VS TextMate sometimes superceeds Semantic tokens
-        and this is a common offender -->
       <!-- <a> href=["Hello"]> -->
-      <!-- <dict>
+      <dict>
         <key>scope</key>
         <string>meta.attribute, meta.attribute string.quoted</string>
         <key>settings</key>
@@ -131,7 +129,7 @@
           <key>vsclassificationtype</key>
           <string>HTML Attribute Value</string>
         </dict>
-      </dict> -->
+      </dict>
 
       <dict>
         <key>scope</key>
@@ -167,9 +165,7 @@
         </dict>
       </dict>
 
-      <!-- Temporarily removed because in VS TextMate sometimes superceeds Semantic tokens
-        and this is a common offender -->
-      <!-- <dict>
+      <dict>
         <key>scope</key>
         <string>storage.type.cs, entity.name.type.class.cs</string>
         <key>settings</key>
@@ -197,7 +193,7 @@
           <key>vsclassificationtype</key>
           <string>local name</string>
         </dict>
-      </dict> -->
+      </dict>
 
       <dict>
         <key>scope</key>


### PR DESCRIPTION
### Summary of the changes
 - Now that VS prioritizes Semantic colorization over TextMate we can add these themes back.

Fixes: https://github.com/dotnet/aspnetcore/issues/27447
