### PR TITLE
Fix ContenType lookup for docs when solution is closing.

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultLSPDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultLSPDocument.cs
@@ -48,7 +48,14 @@ namespace Microsoft.VisualStudio.LanguageServer.ContainedLanguage
         {
             get
             {
-                if (_currentSnapshot != TextBuffer.CurrentSnapshot)
+                if (TextBuffer.CurrentSnapshot.ContentType.IsOfType(InertContentType.Instance.TypeName))
+                {
+                    // TextBuffer is tearing itself down, return last known snapshot to avoid generating
+                    // a snapshot for an invalid TextBuffer
+                    return _currentSnapshot;
+                }
+
+                if (_currentSnapshot?.Snapshot != TextBuffer.CurrentSnapshot)
                 {
                     _currentSnapshot = UpdateSnapshot();
                 }

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test.Common/StringTextSnapshot.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test.Common/StringTextSnapshot.cs
@@ -14,6 +14,8 @@ namespace Microsoft.VisualStudio.Text
     public class StringTextSnapshot : ITextSnapshot2
     {
         private readonly List<ITextSnapshotLine> _lines;
+        private IContentType _contentType;
+        private ITextBuffer _textBuffer;
 
         public static readonly StringTextSnapshot Empty = new StringTextSnapshot(string.Empty);
 
@@ -65,9 +67,17 @@ namespace Microsoft.VisualStudio.Text
 
         public int Length => Content.Length;
 
-        public ITextBuffer TextBuffer { get; set; }
+        public ITextBuffer TextBuffer
+        {
+            get => _textBuffer;
+            set
+            {
+                _textBuffer = value;
+                _contentType = _textBuffer.ContentType;
+            }
+        }
 
-        public IContentType ContentType => throw new NotImplementedException();
+        public IContentType ContentType => _contentType;
 
         public int LineCount => _lines.Count;
 

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test.Common/TestInertContentType.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test.Common/TestInertContentType.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.VisualStudio.Test
+{
+    public class TestInertContentType : IContentType
+    {
+        public static readonly IContentType Instance = new TestInertContentType();
+
+        public string TypeName => "inert";
+
+        public string DisplayName => TypeName;
+
+        public IEnumerable<IContentType> BaseTypes => Enumerable.Empty<IContentType>();
+
+        public bool IsOfType(string type) => string.Equals(type, TypeName, StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
- Prior to this when a user was closing out of a solution each `TextBuffer` would be torn down and then our `LSPDocumentManager` would react by dispatching "Document Removed" requests. Turns out our document remove logic was faltering because the act of tearing down a buffer would set its content type to `inert` [invalidating all of our original ContentType filter criteria](https://github.com/dotnet/aspnetcore-tooling/blob/5c6c21e3c50916696f207cd25d9646da10762995/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/DefaultLSPDocumentManager.cs#L212-L213).
- For this fix I played around with being more strict on when we generate snapshots for documents by only updating them when virtual documents are updated but that led to many unintended consequences where our internal understanding of documents would have super stale snapshots associated with them leading to failed synchronization on feature re-invocation. In the end I landed on a simple fix where in our snapshot creation mechanism in the `DefaultLSPDocumentManager` we check to see if the underlying TextBuffer is transitioning to `inert` prior to updating a snapshot (this indicates teardown) and if so we refuse to generate new snapshots to ensure the rest of our state handlers can do the right thing.
- Updated our document & document manager tests
    - As part of this I had to expand our test infra to better handle test textbuffers and snapshots. Was fun :)

Fixes dotnet/aspnetcore#35751

/cc @ToddGrun if you see Debug Assert failures / leaks when closing/reopening solutions. This fixes it 😄 