### PR TITLE
CSharp explicit coloration

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/TagHelperSemanticRangeVisitor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/TagHelperSemanticRangeVisitor.cs
@@ -159,9 +159,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic
 
         public override void VisitCSharpExplicitExpressionBody(CSharpExplicitExpressionBodySyntax node)
         {
-            AddSemanticRange(node.OpenParen, RazorSemanticTokensLegend.CSharpPunctuation);
+            AddSemanticRange(node.OpenParen, RazorSemanticTokensLegend.RazorTransition);
             Visit(node.CSharpCode);
-            AddSemanticRange(node.CloseParen, RazorSemanticTokensLegend.CSharpPunctuation);
+            AddSemanticRange(node.CloseParen, RazorSemanticTokensLegend.RazorTransition);
         }
         #endregion C#
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/TestFiles/DefaultRazorSemanticTokenInfoServiceTest/GetSemanticTokens_CSharp_Explicit.semantic.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/TestFiles/DefaultRazorSemanticTokenInfoServiceTest/GetSemanticTokens_CSharp_Explicit.semantic.txt
@@ -2,8 +2,8 @@
 0 0 1 84 0 //razorTransition
 0 1 12 87 0 //razorDirective
 1 0 1 84 0 //razorTransition
-0 1 1 43 0 //punctuation
+0 1 1 84 0 //razorTransition
 0 1 8 8 0 //variable
 0 8 1 43 0 //punctuation
 0 1 3 8 0 //variable
-0 3 1 43 0 //punctuation
+0 3 1 84 0 //razorTransition


### PR DESCRIPTION
### Summary of the changes
 - We were marking the paren's as punctuation, but really we want them to be the same purple color as the `@`.