### PR TITLE
Format the first code block in a file to be at the start of a line

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPassBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPassBase.cs
@@ -178,13 +178,17 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
                         index = (~index) - 1;
                     }
 
-                    // This will now be set to the same value as the end of the closest source mapping.
                     if (index < 0)
                     {
-                        csharpDesiredIndentation = 0;
+                        // If we _still_ couldn't find the right indentation, then it probably means that the text is
+                        // before the first source mapping location, so we can just place it in the minimum spot (realistically
+                        // at index 0 in the razor file, but we use minCSharpIndentation because we're adjusting based on the
+                        // generated file here)
+                        csharpDesiredIndentation = minCSharpIndentation;
                     }
                     else
                     {
+                        // index will now be set to the same value as the end of the closest source mapping.
                         var absoluteIndex = sourceMappingIndentationScopes[index];
                         csharpDesiredIndentation = sourceMappingIndentations[absoluteIndex];
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
@@ -419,7 +419,7 @@ Hello World
 }
 ",
 expected: @"Hello World
-     @functions {
+@functions {
     public class Foo { }
 }
 ");
@@ -434,7 +434,7 @@ input: @"
 public class Foo{}
      }
 ",
-expected: @" @functions {
+expected: @"@functions {
     public class Foo { }
      }
 ");
@@ -731,6 +731,67 @@ expected: @"@code {
         }
     };
 }
+");
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/aspnetcore/issues/4498")]
+        public async Task IfBlock_TopLevel()
+        {
+            await RunFormattingTestAsync(
+input: @"
+        @if (true)
+{
+}
+",
+expected: @"@if (true)
+{
+}
+");
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/aspnetcore/issues/4498")]
+        public async Task IfBlock_TopLevel_WithOtherCode()
+        {
+            await RunFormattingTestAsync(
+input: @"
+@{
+    // foo
+}
+
+        @if (true)
+{
+}
+",
+expected: @"@{
+    // foo
+}
+
+@if (true)
+{
+}
+");
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/aspnetcore/issues/4498")]
+        public async Task IfBlock_Nested()
+        {
+            await RunFormattingTestAsync(
+input: @"
+<div>
+        @if (true)
+{
+}
+</div>
+",
+expected: @"
+<div>
+    @if (true)
+    {
+    }
+</div>
 ");
         }
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/aspnetcore-tooling/issues/4498

Essentially this forces the first code block in a file to be at column 0, which I think is a good change. Previously this would simply not be formatted.