### PR TITLE
Allow C# completion in middle of words.

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
@@ -139,6 +139,55 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             Assert.Equal(expectedItem.InsertText, item.InsertText);
         }
 
+        [Theory]
+        [InlineData(RazorLanguageKind.Html)]
+        [InlineData(RazorLanguageKind.CSharp)]
+        public async Task HandleRequestAsync_247Typing_InvokesLanguageServerWithExplicit(object languageKindObj) // Have to mark language kind as an object because RazorLanguageKind is internal
+        {
+            // Arrange
+            var languageKind = (RazorLanguageKind)languageKindObj;
+            var called = false;
+            var expectedItem = new CompletionItem() { Label="Sampel", InsertText = "Sample" };
+            var completionRequest = new CompletionParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Context = new VSInternalCompletionContext() { TriggerKind = CompletionTriggerKind.Invoked, InvokeKind = VSInternalCompletionInvokeKind.Typing },
+                Position = new Position(0, 1)
+            };
+
+            var documentManager = new TestDocumentManager();
+            documentManager.AddDocument(Uri, new TestLSPDocumentSnapshot(new Uri("C:/path/file.razor"), 0));
+
+            var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
+            requestInvoker
+                .Setup(r => r.ReinvokeRequestOnServerAsync<CompletionParams, SumType<CompletionItem[], CompletionList>?>(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CompletionParams>(), It.IsAny<CancellationToken>()))
+                .Callback<string, string, CompletionParams, CancellationToken>((method, clientName, completionParams, ct) =>
+                {
+                    Assert.Equal(Methods.TextDocumentCompletionName, method);
+                    var vsCompletionContext = Assert.IsType<VSInternalCompletionContext>(completionParams.Context);
+                    Assert.Equal(VSInternalCompletionInvokeKind.Explicit, vsCompletionContext.InvokeKind);
+                    called = true;
+                })
+                .Returns(Task.FromResult(new ReinvokeResponse<SumType<CompletionItem[], CompletionList>?>(_languageClient, new[] { expectedItem })));
+
+            var projectionResult = new ProjectionResult()
+            {
+                LanguageKind = languageKind
+            };
+            var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict);
+            projectionProvider.Setup(p => p.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(projectionResult));
+
+            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker.Object, documentManager, projectionProvider.Object, TextStructureNavigatorSelectorService, CompletionRequestContextCache, FormattingOptionsProvider, LoggerProvider);
+
+            // Act
+            var result = await completionHandler.HandleRequestAsync(completionRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            Assert.True(called);
+            var item = Assert.Single(((CompletionList)result.Value).Items);
+            Assert.Equal(expectedItem.InsertText, item.InsertText);
+        }
+
         [Fact]
         public async Task HandleRequestAsync_NoCompletions()
         {


### PR DESCRIPTION
- Prior to this C# completion would only ever be offered at start of word. Now we offer C# completion always to work around a racey:
When a user is doing 24/7 completion (just typing letters) HTML & C# only offer 24/7 completion at the beginning of a word. Meaning, completions will be provided at `|D` but not for `|Da` which brings us to an interesting cross-roads. Razor is currently designed with two language servers:
  1. HTML C#: Powers the HTML / C# experience
  2. Razor: Has all of the Razor understanding / powers the generated C# & HTML for a document
Because of this split, in the middle of completion requests it's possible for additional generated content (C# or HTML) to flow into the client. When additional content flows to the client we could mean to ask for completions at `|D` but in practice it'd ask C# for `|Da` (resulting in 0 completions). Therefore, to counteract this point-in-time design flaw we translate typing completion requests to explicit in order
to ensure that we still get completion results at `|Da`.
- Added tests to validate this new behavior.
- After changing C# behavior it revealed a separate unintended bug in the Razor completion engine. Basically another inherent race in how we do didChange requests. That's being addressed in future PRs (lots coming).

Part of #5017