### PR TITLE
Fix `@using` statement completion in _Imports.razor

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.VisualStudio.LanguageServer.Client;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -44,6 +45,94 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
         private Uri Uri { get; }
 
         private readonly ILanguageClient _languageClient = Mock.Of<ILanguageClient>(MockBehavior.Strict);
+
+        [Theory]
+        [WorkItem("https://github.com/dotnet/razor-tooling/issues/5606")]
+        [WorkItem("https://github.com/dotnet/aspnetcore/issues/37568")]
+        [InlineData("if")]
+        [InlineData("using")]
+        [InlineData("foreach")]
+        [InlineData("try")]
+        public void IsRazorCompilerBugWithCSharpKeywords_ReturnsTrue(string keyword)
+        {
+            // Arrange & Act
+            var result = RunTest_IsRazorCompilerBugWithCSharpKeywords($"@|{keyword}|");
+
+            //  Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/razor-tooling/issues/5606")]
+        [WorkItem("https://github.com/dotnet/aspnetcore/issues/37568")]
+        public void IsRazorCompilerBugWithCSharpKeywords_Invoked_ReturnsFalse()
+        {
+            // Arrange & Act
+            var result = RunTest_IsRazorCompilerBugWithCSharpKeywords("@|using| SomeNamespace.Foo", CompletionTriggerKind.Invoked);
+
+            //  Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/razor-tooling/issues/5606")]
+        [WorkItem("https://github.com/dotnet/aspnetcore/issues/37568")]
+        public void IsRazorCompilerBugWithCSharpKeywords_MoreThanKeyword_ReturnsFalse()
+        {
+            // Arrange & Act
+            var result = RunTest_IsRazorCompilerBugWithCSharpKeywords("@|usingMore|");
+
+            //  Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/razor-tooling/issues/5606")]
+        [WorkItem("https://github.com/dotnet/aspnetcore/issues/37568")]
+        public void IsRazorCompilerBugWithCSharpKeywords_Other_ReturnsFalse()
+        {
+            // Arrange & Act
+            var result = RunTest_IsRazorCompilerBugWithCSharpKeywords("@|unrelated|");
+
+            //  Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/razor-tooling/issues/5606")]
+        [WorkItem("https://github.com/dotnet/aspnetcore/issues/37568")]
+        public void IsRazorCompilerBugWithCSharpKeywords_NonSignificant_ReturnsFalse()
+        {
+            // Arrange & Act
+            var result = RunTest_IsRazorCompilerBugWithCSharpKeywords("@using |  |");
+
+            //  Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/razor-tooling/issues/5606")]
+        [WorkItem("https://github.com/dotnet/aspnetcore/issues/37568")]
+        public void IsRazorCompilerBugWithCSharpKeywords_Empty_ReturnsFalse()
+        {
+            // Arrange & Act
+            var result = RunTest_IsRazorCompilerBugWithCSharpKeywords("@usin||g");
+
+            //  Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/razor-tooling/issues/5606")]
+        [WorkItem("https://github.com/dotnet/aspnetcore/issues/37568")]
+        public void IsRazorCompilerBugWithCSharpKeywords_Subset_ReturnsFalse()
+        {
+            // Arrange & Act
+            var result = RunTest_IsRazorCompilerBugWithCSharpKeywords("@u|sin|g");
+
+            //  Assert
+            Assert.False(result);
+        }
 
         [Fact]
         public async Task HandleRequestAsync_DocumentNotFound_ReturnsNull()
@@ -90,6 +179,48 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
 
             // Assert
             Assert.Null(result);
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/razor-tooling/issues/5606")]
+        [WorkItem("https://github.com/dotnet/aspnetcore/issues/37568")]
+        public async Task HandleRequestAsync_ProjectionNotFound_IsCompilerBug_ReturnsPolyfills()
+        {
+            // Arrange
+            var documentManager = new TestDocumentManager();
+            var snapshot = new TestLSPDocumentSnapshot(new Uri("C:/path/file.razor"), version: 0, "@using");
+            documentManager.AddDocument(Uri, snapshot);
+            var wordExtent = GetWordExtent("@|using|");
+            var navigator = BuildNavigatorSelector(wordExtent);
+            var requestInvoker = Mock.Of<LSPRequestInvoker>(MockBehavior.Strict);
+            var projectionProvider = new Mock<LSPProjectionProvider>(MockBehavior.Strict).Object;
+            Mock.Get(projectionProvider).Setup(projectionProvider => projectionProvider.GetProjectionAsync(It.IsAny<LSPDocumentSnapshot>(), It.IsAny<Position>(), CancellationToken.None))
+                .Returns(Task.FromResult<ProjectionResult>(null));
+            var completionHandler = new CompletionHandler(JoinableTaskContext, requestInvoker, documentManager, projectionProvider, navigator, CompletionRequestContextCache, FormattingOptionsProvider, LoggerProvider);
+            var completionRequest = new CompletionParams()
+            {
+                TextDocument = new TextDocumentIdentifier() { Uri = Uri },
+                Context = new CompletionContext() { TriggerKind = CompletionTriggerKind.TriggerForIncompleteCompletions },
+                Position = new Position(0, 6)
+            };
+
+            // Act
+            var result = await completionHandler.HandleRequestAsync(completionRequest, new ClientCapabilities(), CancellationToken.None).ConfigureAwait(false);
+
+            // Assert
+            var completionList = result.Value.Second;
+            Assert.True(completionList.IsIncomplete);
+            Assert.Collection(completionList.Items,
+                item => Assert.Equal("for", item.Label),
+                item => Assert.Equal("foreach", item.Label),
+                item => Assert.Equal("while", item.Label),
+                item => Assert.Equal("switch", item.Label),
+                item => Assert.Equal("lock", item.Label),
+                item => Assert.Equal("case", item.Label),
+                item => Assert.Equal("if", item.Label),
+                item => Assert.Equal("try", item.Label),
+                item => Assert.Equal("do", item.Label),
+                item => Assert.Equal("using", item.Label));
         }
 
         [Fact]
@@ -1656,6 +1787,37 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp
             navigatorSelector.Setup(selector => selector.GetTextStructureNavigator(It.IsAny<ITextBuffer>()))
                 .Returns(navigator.Object);
             return navigatorSelector.Object;
+        }
+
+        private static bool RunTest_IsRazorCompilerBugWithCSharpKeywords(string input, CompletionTriggerKind? triggerKind = null)
+        {
+            var request = new CompletionParams()
+            {
+                Context = new CompletionContext()
+                {
+                    TriggerKind = triggerKind ?? CompletionTriggerKind.TriggerForIncompleteCompletions,
+                }
+            };
+            var wordExtent = GetWordExtent(input);
+            var result = CompletionHandler.IsRazorCompilerBugWithCSharpKeywords(request, wordExtent);
+            return result;
+        }
+
+        private static TextExtent GetWordExtent(string input)
+        {
+            var wordStart = input.IndexOf("|");
+            var wordEnd = input.LastIndexOf("|");
+            var wordLength = wordEnd - wordStart - 1;
+
+            var actualInput = input.Remove(wordEnd, count: 1);
+            actualInput = actualInput.Remove(wordStart, count: 1);
+
+            var snapshot = new StringTextSnapshot(actualInput);
+            var wordSpan = new Span(wordStart, wordLength);
+            var snapshotSpan = new SnapshotSpan(snapshot, wordSpan);
+            var isSignificant = !string.IsNullOrWhiteSpace(actualInput.Substring(wordSpan.Start, wordSpan.Length));
+            var wordExtent = new TextExtent(snapshotSpan, isSignificant);
+            return wordExtent;
         }
 
         private class TestFormattingOptionsProvider : FormattingOptionsProvider


### PR DESCRIPTION
- This is part 2/2 to fix `@using` statement completion in Razor files. Part 1 is over in the dotnet/roslyn repo: [PR](https://github.com/dotnet/roslyn/pull/57160)
- So the two components to this issue are as follows:
  1. C# was throwing whenever they'd be in the process of returning `isIncomplete: true` completion lists and filter down to 0 items. This typically happened at the `n` of `@using`. Therefore things would explode preventing us from being able to control the completion experience
  2. Found that the Razor compiler doesn't generate C# for `@using` statements. This means when we try to query what language exists at `@using|` it says "sorry nothing". My bet is that the compiler special cases C# keywords and preemptively doesn't generate C# for them. This means we bail out of our completion path entirely and return an empty completion list breaking the flow. That issue is tracked here: dotnet/razor-tooling#7494
- Razor tooling wasn't directly responsible for the second issue; however, wes till needed to come up with a low-risk fix. The fix I landed on was to special case the bug and call it out specifically in code. The special case consists of three components:
  1. Only check special cases if we failed to resolve a language. This is already a completion failure case so in the worst case we still don't provide completion
  2. Detecting if we're in an `isIncomplete: true` scenario by looking at the trigger kind and seeing if it's `TriggerForIncompleteCompletions`next we look at the word span that's currently active
  3. Detecting if the user is attempting to type a C# keyword (full match like `using` in `@using|`)
- Given this fix is going to go through QB for dev17 I added insane amounts of tests/checks to ensure things are of the highest quality / we don't degrade functionality.

### Before

![UsingFixBefore](https://i.imgur.com/bqZcWom.gif)

### After

![UsingFixAfter](https://i.imgur.com/19Gyxg5.gif)

Fixes dotnet/aspnetcore#5606

/cc @dibarbet 