### PR TITLE
Format collection and object initializers if they're empty

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
@@ -690,7 +690,7 @@ expected: @"@code {
         [WorkItem("https://github.com/dotnet/aspnetcore/issues/34320")]
         public async Task CodeBlock_ObjectCollectionArrayInitializers()
         {
-            // The C# Formatter doesn't touch these types of initializers, so nor to we. This test
+            // The C# Formatter doesn't touch these types of initializers, so nor do we. This test
             // just verifies we don't regress things and start moving code around.
             await RunFormattingTestAsync(
 input: @"
@@ -730,6 +730,45 @@ expected: @"@code {
             }
         }
     };
+}
+");
+        }
+
+        [Fact]
+        [WorkItem("https://github.com/dotnet/razor-tooling/issues/5618")]
+        public async Task CodeBlock_EmptyObjectCollectionInitializers()
+        {
+            // The C# Formatter _does_ touch these types of initializers if they're empty. Who knew ¯\_(ツ)_/¯
+            await RunFormattingTestAsync(
+input: @"
+@code {
+    public void Foo()
+    {
+        SomeMethod(new List<string>()
+            {
+                
+            });
+
+        SomeMethod(new Exception
+            {
+                
+            });
+    }
+}
+",
+expected: @"@code {
+    public void Foo()
+    {
+        SomeMethod(new List<string>()
+        {
+
+        });
+
+        SomeMethod(new Exception
+        {
+
+        });
+    }
 }
 ");
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor-tooling/issues/5618

Turns out my assumption in https://github.com/dotnet/razor-tooling/pull/4167 that the C# formatter ignores these nodes was incorrect: It doesn't if they're empty! Nice find Taylor.