### PR TITLE
Update automated dependencies.

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -29,11 +29,7 @@
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>cfabc4242644352503512f53ab660202499cf51e</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration" Version="6.0.0-rtm.21518.4">
-      <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>7785ce1aed2506859b8193a7073a8b1e394a6c29</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.Extensions.Configuration.Json" Version="6.0.0-rtm.21518.4" CoherentParentDependency="Microsoft.CodeAnalysis.Razor">
+    <Dependency Name="Microsoft.Extensions.Configuration" Version="6.0.0-rtm.21518.4" CoherentParentDependency="Microsoft.CodeAnalysis.Razor">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>7785ce1aed2506859b8193a7073a8b1e394a6c29</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -57,9 +57,8 @@
     <MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>6.0.0-rtm.21518.12</MicrosoftAspNetCoreMvcRazorExtensionsPackageVersion>
     <MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>6.0.0-rtm.21518.12</MicrosoftAspNetCoreMvcRazorExtensionsVersion1_XPackageVersion>
     <MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>6.0.0-rtm.21518.12</MicrosoftAspNetCoreMvcRazorExtensionsVersion2_XPackageVersion>
-    <MicrosoftExtensionsConfigurationPackageVersion>6.0.0-rtm.21518.4</MicrosoftExtensionsConfigurationPackageVersion>
-    <MicrosoftExtensionsConfigurationJsonPackageVersion>6.0.0-rtm.21518.4</MicrosoftExtensionsConfigurationJsonPackageVersion>
     <MicrosoftExtensionsDependencyModelPackageVersion>6.0.0-rtm.21518.4</MicrosoftExtensionsDependencyModelPackageVersion>
+    <MicrosoftExtensionsConfigurationPackageVersion>6.0.0-rtm.21518.4</MicrosoftExtensionsConfigurationPackageVersion>
     <MicrosoftExtensionsLoggingPackageVersion>6.0.0-rtm.21518.4</MicrosoftExtensionsLoggingPackageVersion>
     <MicrosoftNETCoreBrowserDebugHostTransportPackageVersion>6.0.0-rtm.21518.4</MicrosoftNETCoreBrowserDebugHostTransportPackageVersion>
     <MicrosoftNETCoreAppRefPackageVersion>6.0.0-rtm.21518.4</MicrosoftNETCoreAppRefPackageVersion>


### PR DESCRIPTION
- Saw that automation was having a hard time auto-merging and noticed some stale / incorrect dependencies. Ran a few darc commands to fix things up.
- Razor no longer depends on Configuration.Json so could remove & needed to update the Extensiosn.COnfiguration package to have a coherent parent dependency to match.