### PR TITLE
Stop crashing VS when logging errors.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDiagnosticsPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDiagnosticsPublisher.cs
@@ -252,7 +252,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer
             }
         }
 
-
         private void OnCompletingBackgroundWork()
         {
             if (NotifyBackgroundWorkCompleting != null)


### PR DESCRIPTION
Note: The changes look intimidating if you're viewing whitespace, look at changes with this to make it simpler: https://github.com/dotnet/razor-tooling/pull/5646/files?diff=unified&w=1

- Ultimately this is more of a workaround for this issue: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1405849. But let me share some insight as to how we got here. When I initially ["protected VS from crashing"](https://github.com/dotnet/razor-tooling/commit/95b33df1d60a192f1ac6e3f8417f9fa416578f6d) due to the compiler bug I added logic that would `LogError` in the case that unexpected exceptions would occur. Now the problem with my approach is that our Language Server logger can potentially explode if the language server is in the midst of shutting down. Therefore, what would happen is the compiler would unexpectedly throw, we'd then try to log an error and if we were in a shutting down state that logging of an error would then throw again resulting in VS crashing.
- Went from logging an error to an unobserved task exception. This means things will still throw; however, they'll be translated into unobserved task exceptions.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1420246