### PR TITLE
Set default for startvs.cmd

### DIFF
--- a/startvs.cmd
+++ b/startvs.cmd
@@ -16,10 +16,7 @@ SET PATH=%DOTNET_ROOT%;%PATH%
 SET sln=%~1
 
 IF "%sln%"=="" (
-    echo Error^: Expected argument ^<SLN_FILE^>
-    echo Usage^: startvs.cmd ^<SLN_FILE^>
-
-    exit /b 1
+    SET sln=%~dp0\src\Razor\Razor.sln
 )
 
 IF NOT EXIST "%DOTNET_ROOT%\dotnet.exe" (


### PR DESCRIPTION
I got annoyed with having to type out `.\startvs.cmd src\Razor\Razor.sln` when that's basically the only sln in the project. If we want to launch a different sln/proj you can still supply the path just like we used to. 