### PR TITLE
Use edge for blazorwasm config by default #33088

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/package.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/package.json
@@ -81,7 +81,7 @@
                   "browser": {
                     "type": "string",
                     "description": "The debugging browser to launch (Edge or Chrome)",
-                    "default": "chrome",
+                    "default": "edge",
                     "enum": ["chrome", "edge"]
                   },
                   "trace": {


### PR DESCRIPTION
### Summary of the changes
 - Changing default browser from chrome to edge to aid in fix #33088

Fixes: 
line 84: "chrome" > "edge"