### PR TITLE
Add explicit references for build stability

### DIFF
--- a/src/Razor/src/rzls/rzls.csproj
+++ b/src/Razor/src/rzls/rzls.csproj
@@ -38,6 +38,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsPackageVersion)" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsPackageVersion)" PrivateAssets="All" />
     <!-- We need to directly reference the O# language server here because we mark it as PrivateAssets="All" in our language server itself -->
     <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="$(OmniSharpExtensionsLanguageServerPackageVersion)" />
   </ItemGroup>


### PR DESCRIPTION
### Summary of the changes

- We're still seeing semi-random failures from logging version mismatching. This is another attempt to stem that tide.
