### PR TITLE
Integration publish data

### DIFF
--- a/eng/pipelines/test-integration-job.yml
+++ b/eng/pipelines/test-integration-job.yml
@@ -99,7 +99,7 @@ steps:
       PathtoPublish: $(Build.SourcesDirectory)\artifacts\TestResults\${{ parameters.configuration }}
       ArtifactName: '$(System.JobAttempt)-TestResults $(Build.BuildNumber)'
       publishLocation: Container
-    continueOnError: testResultsFiles
+    continueOnError: true
     condition: succeededOrFailed()
   - task: PublishBuildArtifacts@1
     displayName: Publish Logs

--- a/eng/pipelines/test-integration-job.yml
+++ b/eng/pipelines/test-integration-job.yml
@@ -93,7 +93,7 @@ steps:
       mergeTestResults: true
       testRunTitle: '$(System.JobAttempt)-Integration ${{ parameters.configuration }}'
     condition: succeededOrFailed()
-  - task: PublishBuildResults@2
+  - task: PublishBuildArtifacts@2
     displayName: Publish TestResults
     inputs:
       PathtoPublish: $(Build.SourcesDirectory)\artifacts\TestResults\${{ parameters.configuration }}

--- a/eng/pipelines/test-integration-job.yml
+++ b/eng/pipelines/test-integration-job.yml
@@ -93,7 +93,7 @@ steps:
       mergeTestResults: true
       testRunTitle: '$(System.JobAttempt)-Integration ${{ parameters.configuration }}'
     condition: succeededOrFailed()
-  - task: PublishBuildArtifacts@2
+  - task: PublishBuildArtifacts@1
     displayName: Publish TestResults
     inputs:
       PathtoPublish: $(Build.SourcesDirectory)\artifacts\TestResults\${{ parameters.configuration }}

--- a/eng/pipelines/test-integration-job.yml
+++ b/eng/pipelines/test-integration-job.yml
@@ -93,6 +93,7 @@ steps:
       mergeTestResults: true
       testRunTitle: '$(System.JobAttempt)-Integration ${{ parameters.configuration }}'
     condition: succeededOrFailed()
+
   - task: PublishBuildArtifacts@1
     displayName: Publish TestResults
     inputs:

--- a/eng/pipelines/test-integration-job.yml
+++ b/eng/pipelines/test-integration-job.yml
@@ -93,7 +93,14 @@ steps:
       mergeTestResults: true
       testRunTitle: '$(System.JobAttempt)-Integration ${{ parameters.configuration }}'
     condition: succeededOrFailed()
-
+  - task: PublishBuildResults@2
+    displayName: Publish TestResults
+    inputs:
+      PathtoPublish: $(Build.SourcesDirectory)\artifacts\TestResults\${{ parameters.configuration }}
+      ArtifactName: '$(System.JobAttempt)-TestResults $(Build.BuildNumber)'
+      publishLocation: Container
+    continueOnError: testResultsFiles
+    condition: succeededOrFailed()
   - task: PublishBuildArtifacts@1
     displayName: Publish Logs
     inputs:


### PR DESCRIPTION
### Summary of the changes

- I noticed that we weren't finding the logs that were claimed to be published in [this error case](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=6896885&view=logs&j=3e5619a1-2b1c-5cb0-1de5-24acacb5486e&t=7a357653-97cc-5c20-88c7-956a28e2bfb1&l=18). So I'm seeing if we can A) start collecting those B) can figure out what caused the failure. The failure seems intermittent, so we may need to check  this in before we're able to verify that it catches the data we want.