### PR TITLE
Update FabricBot after project changes

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -244,41 +244,6 @@
           "operator": "and",
           "operands": [
             {
-              "name": "addedToMilestone",
-              "parameters": {
-                "milestoneName": "17.5 P1"
-              }
-            }
-          ]
-        },
-        "eventType": "issue",
-        "eventNames": [
-          "issues",
-          "project_card"
-        ],
-        "actions": [
-          {
-            "name": "addToProject",
-            "parameters": {
-              "projectName": "17.5 Preview 1",
-              "columnName": "To do"
-            }
-          }
-        ],
-        "taskName": "**UPDATE EACH SPRINT**  [Issues] Add current milestone's issues to tracking project (To do)"
-      },
-      "disabled": false
-    },
-    {
-      "taskType": "trigger",
-      "capabilityId": "IssueResponder",
-      "subCapability": "IssuesOnlyResponder",
-      "version": "1.0",
-      "config": {
-        "conditions": {
-          "operator": "and",
-          "operands": [
-            {
               "name": "isAction",
               "parameters": {
                 "action": "opened"
@@ -318,40 +283,6 @@
           }
         ]
       }
-    },
-    {
-      "taskType": "trigger",
-      "capabilityId": "IssueResponder",
-      "subCapability": "IssuesOnlyResponder",
-      "version": "1.0",
-      "config": {
-        "conditions": {
-          "operator": "and",
-          "operands": [
-            {
-              "name": "removedFromMilestone",
-              "parameters": {
-                "milestoneName": "17.5 P1"
-              }
-            }
-          ]
-        },
-        "eventType": "issue",
-        "eventNames": [
-          "issues",
-          "project_card"
-        ],
-        "taskName": "**UPDATE EACH SPRINT**  [Issues] Remove non-current milestone issues from tracking project",
-        "actions": [
-          {
-            "name": "removeFromProject",
-            "parameters": {
-              "projectName": "17.5 Preview 1"
-            }
-          }
-        ]
-      },
-      "disabled": false
     },
     {
       "taskType": "trigger",


### PR DESCRIPTION
- It doesn't look like FabricBot is compatible with the new project format. Given this, I've removed the logic where adding an issue to a milestone automatically adds it to a project.
- edit: reverted this bit <s>In the process, I also renamed several of the tooling milestones to be tooling specific, e.g. `17.5 P2` -> `17.5 P2 - Tooling` so we don't have tooling issues confused with compiler issues. (Not part of this PR, but just thought I'd mention it.)</s>