### PR TITLE
Fix operator precedence and cleanup

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentGenericTypePass.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentGenericTypePass.cs
@@ -26,7 +26,7 @@ internal class ComponentGenericTypePass : ComponentIntermediateNodePassBase, IRa
     {
         get
         {
-            // Doing lazy intialization here to avoid making things really complicated when we don't
+            // Doing lazy initialization here to avoid making things really complicated when we don't
             // need to exercise this code in tests.
             if (_typeNameFeature == null)
             {
@@ -192,7 +192,6 @@ internal class ComponentGenericTypePass : ComponentIntermediateNodePassBase, IRa
             List<CascadingGenericTypeParameter>? receivesCascadingGenericTypes = null;
             foreach (var uncoveredBindingKey in bindings.Keys.ToList())
             {
-                var uncoveredBinding = bindings[uncoveredBindingKey];
                 foreach (var candidateAncestor in Ancestors.OfType<ComponentIntermediateNode>())
                 {
                     if (candidateAncestor.ProvidesCascadingGenericTypes != null
@@ -269,7 +268,7 @@ internal class ComponentGenericTypePass : ComponentIntermediateNodePassBase, IRa
             CreateTypeInferenceMethod(documentNode, node, receivesCascadingGenericTypes);
         }
 
-        private bool TryFindGenericTypeNames(BoundAttributeDescriptor boundAttribute, [NotNullWhen(true)] out IReadOnlyList<string>? typeParameters)
+        private bool TryFindGenericTypeNames(BoundAttributeDescriptor? boundAttribute, [NotNullWhen(true)] out IReadOnlyList<string>? typeParameters)
         {
             if (boundAttribute == null)
             {
@@ -358,7 +357,7 @@ internal class ComponentGenericTypePass : ComponentIntermediateNodePassBase, IRa
                     // contains "global::" which will be the case in all cases as we've computed
                     // this information from the Roslyn symbol except for when the symbol is a generic
                     // type parameter. In which case, we mark it with an additional annotation to
-                    // acount for that during code generation and avoid trying to fully qualify
+                    // account for that during code generation and avoid trying to fully qualify
                     // the type name.
                     Debug.Assert(bindings != null || hasTypeArgumentSpecified == true);
                     if (hasTypeArgumentSpecified == true)
@@ -456,8 +455,7 @@ internal class ComponentGenericTypePass : ComponentIntermediateNodePassBase, IRa
             // Now we need to insert the type inference node into the tree.
             var namespaceNode = documentNode.Children
                 .OfType<NamespaceDeclarationIntermediateNode>()
-                .Where(n => n.Annotations.Contains(new KeyValuePair<object, object>(ComponentMetadata.Component.GenericTypedKey, bool.TrueString)))
-                .FirstOrDefault();
+                .FirstOrDefault(n => n.Annotations.Contains(new KeyValuePair<object, object>(ComponentMetadata.Component.GenericTypedKey, bool.TrueString)));
             if (namespaceNode == null)
             {
                 namespaceNode = new NamespaceDeclarationIntermediateNode()
@@ -474,8 +472,7 @@ internal class ComponentGenericTypePass : ComponentIntermediateNodePassBase, IRa
 
             var classNode = namespaceNode.Children
                 .OfType<ClassDeclarationIntermediateNode>()
-                .Where(n => n.ClassName == "TypeInference")
-                .FirstOrDefault();
+                .FirstOrDefault(n => n.ClassName == "TypeInference");
             if (classNode == null)
             {
                 classNode = new ClassDeclarationIntermediateNode()

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentGenericTypePass.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentGenericTypePass.cs
@@ -347,7 +347,7 @@ internal class ComponentGenericTypePass : ComponentIntermediateNodePassBase, IRa
                     attribute.GloballyQualifiedTypeName = globallyQualifiedTypeName;
                 }
 
-                if (attribute.BoundAttribute?.IsGenericTypedProperty() ?? false && attribute.TypeName != null)
+                if (attribute.BoundAttribute?.IsGenericTypedProperty() == true && attribute.TypeName != null)
                 {
                     // If we know the type name, then replace any generic type parameter inside it with
                     // the known types.
@@ -410,7 +410,7 @@ internal class ComponentGenericTypePass : ComponentIntermediateNodePassBase, IRa
 
             foreach (var childContent in node.ChildContents)
             {
-                if (childContent.BoundAttribute?.IsGenericTypedProperty() ?? false && childContent.TypeName != null)
+                if (childContent.BoundAttribute?.IsGenericTypedProperty() == true && childContent.TypeName != null)
                 {
                     // If we know the type name, then replace any generic type parameter inside it with
                     // the known types.

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/ParserHelpers.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/ParserHelpers.cs
@@ -69,7 +69,7 @@ internal static class ParserHelpers
                value == '\f' ||
                value == '\t' ||
                value == '\u000B' || // Vertical Tab
-               char.IsSeparator(value); ;
+               char.IsSeparator(value);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptor.cs
@@ -105,7 +105,7 @@ public abstract class TagHelperDescriptor : IEquatable<TagHelperDescriptor>
     public override int GetHashCode()
     {
         // TagHelperDescriptors are immutable instances and it should be safe to cache it's hashes once.
-        return _hashCode ??= TagHelperDescriptorComparer.Default.GetHashCode(this);;
+        return _hashCode ??= TagHelperDescriptorComparer.Default.GetHashCode(this);
     }
 
     private static BoundAttributeDescriptor[] GetEditorRequiredAttributes(IReadOnlyList<BoundAttributeDescriptor> boundAttributeDescriptors)


### PR DESCRIPTION
### Summary of the changes

This fixes some issues that ReSharper complained about in the `Microsoft.AspNetCore.Razor.Language` project:

- The `&&` operator has higher precedence than `??`, so the following two lines didn't behave as intended:
  - `if (attribute.BoundAttribute?.IsGenericTypedProperty() ?? false && attribute.TypeName != null)`
  - `if (childContent.BoundAttribute?.IsGenericTypedProperty() ?? false && childContent.TypeName != null)`
- Removed two redundant `;`

I also took the opportunity to do some minor cleanup in the impacted files:

- Replaced `.Where(...).FirstOrDefault()` with `.FirstOrDefault(...)`
- Adjusted a NRT annotation
- Fixed some typos