### PR TITLE
Pass host document version through to our custom message targets

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/DelegatedCodeActionParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/DelegatedCodeActionParams.cs
@@ -7,8 +7,11 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
 
 [DataContract]
-internal class DelegatedCodeActionParams : CodeActionParams
+internal class DelegatedCodeActionParams
 {
-    [DataMember(Name = "_vs_hostDocumentVersion")]
+    [DataMember(Name = "hostDocumentVersion")]
     public int HostDocumentVersion { get; set; }
+
+    [DataMember(Name = "codeActionParams")]
+    public required CodeActionParams CodeActionParams { get; set; }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentColor/DelegatedDocumentColorParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentColor/DelegatedDocumentColorParams.cs
@@ -9,6 +9,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.DocumentColor;
 [DataContract]
 internal class DelegatedDocumentColorParams : DocumentColorParams
 {
-    [DataMember(Name = "_vs_requiredHostDocumentVersion")]
-    public int RequiredHostDocumentVersion { get; set;}
+    [DataMember(Name = "_razor_hostDocumentVersion")]
+    public int HostDocumentVersion { get; set;}
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentColor/DocumentColorEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentColor/DocumentColorEndpoint.cs
@@ -41,9 +41,15 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.DocumentColor
 
         public async Task<ColorInformation[]> HandleRequestAsync(DocumentColorParams request, RazorRequestContext requestContext, CancellationToken cancellationToken)
         {
-            var documentColors = await _languageServer.SendRequestAsync<DocumentColorParams, ColorInformation[]>(
+            var delegatedRequest = new DelegatedDocumentColorParams()
+            {
+                HostDocumentVersion = requestContext.GetRequiredDocumentContext().Version,
+                TextDocument = request.TextDocument
+            };
+
+            var documentColors = await _languageServer.SendRequestAsync<DelegatedDocumentColorParams, ColorInformation[]>(
                 RazorLanguageServerCustomMessageTargets.RazorProvideHtmlDocumentColorEndpoint,
-                request,
+                delegatedRequest,
                 cancellationToken).ConfigureAwait(false);
 
             if (documentColors is null)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -305,7 +305,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             var (synchronized, csharpDoc) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<CSharpVirtualDocumentSnapshot>(
                 codeActionParams.HostDocumentVersion,
-                codeActionParams.TextDocument.Uri,
+                codeActionParams.CodeActionParams.TextDocument.Uri,
                 cancellationToken);
 
             if (csharpDoc is null)
@@ -314,14 +314,14 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
                 return null;
             }
 
-            codeActionParams.TextDocument.Uri = csharpDoc.Uri;
+            codeActionParams.CodeActionParams.TextDocument.Uri = csharpDoc.Uri;
 
             var textBuffer = csharpDoc.Snapshot.TextBuffer;
             var requests = _requestInvoker.ReinvokeRequestOnMultipleServersAsync<CodeActionParams, IReadOnlyList<VSInternalCodeAction>>(
                 textBuffer,
                 Methods.TextDocumentCodeActionName,
                 SupportsCSharpCodeActions,
-                codeActionParams,
+                codeActionParams.CodeActionParams,
                 cancellationToken).ConfigureAwait(false);
 
             var codeActions = new List<VSInternalCodeAction>();
@@ -436,7 +436,7 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             }
 
             var (synchronized, htmlDoc) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<HtmlVirtualDocumentSnapshot>(
-                documentColorParams.RequiredHostDocumentVersion, documentColorParams.TextDocument.Uri, cancellationToken);
+                documentColorParams.HostDocumentVersion, documentColorParams.TextDocument.Uri, cancellationToken);
 
             documentColorParams.TextDocument.Uri = htmlDoc.Uri;
             var htmlTextBuffer = htmlDoc.Snapshot.TextBuffer;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
@@ -524,7 +524,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             };
 
             // Act
-            var razorCodeActionContext = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext);
+            var razorCodeActionContext = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot);
 
             // Assert
             Assert.NotNull(razorCodeActionContext);
@@ -562,7 +562,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             };
 
             // Act
-            var razorCodeActionContext = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext);
+            var razorCodeActionContext = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot);
 
             // Assert
             Assert.NotNull(razorCodeActionContext);
@@ -600,10 +600,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 Context = new VSInternalCodeActionContext()
             };
 
-            var context = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext);
+            var context = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot);
 
             // Act
-            var results = await codeActionEndpoint.GetCSharpCodeActionsFromLanguageServerAsync(context, default);
+            var results = await codeActionEndpoint.GetCSharpCodeActionsFromLanguageServerAsync(documentContext, context, default);
 
             // Assert
             Assert.Empty(results);
@@ -643,10 +643,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                 }
             };
 
-            var context = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext);
+            var context = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot);
 
             // Act
-            var results = await codeActionEndpoint.GetCSharpCodeActionsFromLanguageServerAsync(context, default);
+            var results = await codeActionEndpoint.GetCSharpCodeActionsFromLanguageServerAsync(documentContext, context, default);
 
             // Assert
             Assert.Single(results);
@@ -770,7 +770,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
                     throw new InvalidOperationException($"Unexpected method {method}");
                 }
 
-                if (@params is not CodeActionParams codeActionParams || codeActionParams.Context is not VSInternalCodeActionContext codeActionContext)
+                if (@params is not DelegatedCodeActionParams delegatedCodeActionParams ||
+                    delegatedCodeActionParams.CodeActionParams is not CodeActionParams codeActionParams ||
+                    codeActionParams.Context is not VSInternalCodeActionContext codeActionContext)
                 {
                     throw new InvalidOperationException(@params.GetType().FullName);
                 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
@@ -236,9 +236,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
             var target = new DefaultRazorLanguageServerCustomMessageTarget(documentManager.Object, documentSynchronizer);
             var request = new DelegatedCodeActionParams()
             {
-                TextDocument = new TextDocumentIdentifier()
+                HostDocumentVersion = 1,
+                CodeActionParams = new CodeActionParams()
                 {
-                    Uri = new Uri("C:/path/to/file.razor")
+                    TextDocument = new TextDocumentIdentifier()
+                    {
+                        Uri = new Uri("C:/path/to/file.razor")
+                    }
                 }
             };
 
@@ -296,9 +300,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor
 
             var request = new DelegatedCodeActionParams()
             {
-                TextDocument = new TextDocumentIdentifier()
+                HostDocumentVersion = 1,
+                CodeActionParams = new CodeActionParams()
                 {
-                    Uri = testDocUri
+                    TextDocument = new TextDocumentIdentifier()
+                    {
+                        Uri = testDocUri
+                    }
                 }
             };
 


### PR DESCRIPTION
Noticed this while working on stuff, thought I'd do it as a separate commit in the interests of speed, and possible future servicing needs.

Looks like in https://github.com/dotnet/razor/pull/7006 the delegated code actions and delegated color params types were introduced, and signatures of the custom message target were updated, but the endpoints were missed. I looked at the sync code briefly and its not really clear to me how these endpoints actually work now, because it seems like they would always be out of sync (because `HostDocumentVersion` would be `0`), but latest main of VS does seem to work 🤷‍♂️

I don't _want_ to write an analyzer to check that all custom message target calls use the right parameters.. but I kinda can't think of any easier way to validate this in future. Would love to be able to create a test for it.