### PR TITLE
[VSCode] Change `Debug.Fail` to logging to mitigate crash

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
@@ -15,13 +16,27 @@ using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Razor;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Elfie.Diagnostics;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
 {
     internal class ExtractToCodeBehindCodeActionProvider : RazorCodeActionProvider
     {
         private static readonly Task<IReadOnlyList<RazorVSInternalCodeAction>?> s_emptyResult = Task.FromResult<IReadOnlyList<RazorVSInternalCodeAction>?>(null);
+        private readonly ILogger<ExtractToCodeBehindCodeActionProvider> _logger;
+
+        public ExtractToCodeBehindCodeActionProvider(ILoggerFactory loggerFactory)
+        {
+            if (loggerFactory is null)
+            {
+                throw new ArgumentNullException(nameof(loggerFactory));
+            }
+
+            _logger = loggerFactory.CreateLogger<ExtractToCodeBehindCodeActionProvider>();
+        }
 
         public override Task<IReadOnlyList<RazorVSInternalCodeAction>?> ProvideAsync(RazorCodeActionContext context, CancellationToken cancellationToken)
         {
@@ -50,7 +65,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var owner = syntaxTree.Root.LocateOwner(change);
             if (owner is null)
             {
-                Debug.Assert("Owner should never be null.");
+                _logger.LogWarning("Owner should never be null.");
                 return s_emptyResult;
             }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionProvider.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
@@ -16,9 +15,7 @@ using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Razor;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
-using Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Elfie.Diagnostics;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionProvider.cs
@@ -50,7 +50,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var owner = syntaxTree.Root.LocateOwner(change);
             if (owner is null)
             {
-                Debug.Fail("Owner should never be null.");
+                Debug.Assert("Owner should never be null.");
                 return s_emptyResult;
             }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionProviderTest.cs
@@ -44,7 +44,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var context = CreateRazorCodeActionContext(request, location, documentPath, contents);
             context.CodeDocument.SetFileKind(FileKinds.Legacy);
 
-            var provider = new ExtractToCodeBehindCodeActionProvider();
+            var provider = new ExtractToCodeBehindCodeActionProvider(LoggerFactory);
 
             // Act
             var commandOrCodeActionContainer = await provider.ProvideAsync(context, default);
@@ -68,7 +68,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var location = new SourceLocation(contents.IndexOf("test", StringComparison.Ordinal), -1, -1);
             var context = CreateRazorCodeActionContext(request, location, documentPath, contents);
 
-            var provider = new ExtractToCodeBehindCodeActionProvider();
+            var provider = new ExtractToCodeBehindCodeActionProvider(LoggerFactory);
 
             // Act
             var commandOrCodeActionContainer = await provider.ProvideAsync(context, default);
@@ -92,7 +92,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var location = new SourceLocation(contents.IndexOf("code", StringComparison.Ordinal) + 6, -1, -1);
             var context = CreateRazorCodeActionContext(request, location, documentPath, contents);
 
-            var provider = new ExtractToCodeBehindCodeActionProvider();
+            var provider = new ExtractToCodeBehindCodeActionProvider(LoggerFactory);
 
             // Act
             var commandOrCodeActionContainer = await provider.ProvideAsync(context, default);
@@ -116,7 +116,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var location = new SourceLocation(contents.IndexOf("code", StringComparison.Ordinal), -1, -1);
             var context = CreateRazorCodeActionContext(request, location, documentPath, contents);
 
-            var provider = new ExtractToCodeBehindCodeActionProvider();
+            var provider = new ExtractToCodeBehindCodeActionProvider(LoggerFactory);
 
             // Act
             var commandOrCodeActionContainer = await provider.ProvideAsync(context, default);
@@ -140,7 +140,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var location = new SourceLocation(contents.IndexOf("code", StringComparison.Ordinal), -1, -1);
             var context = CreateRazorCodeActionContext(request, location, documentPath, contents);
 
-            var provider = new ExtractToCodeBehindCodeActionProvider();
+            var provider = new ExtractToCodeBehindCodeActionProvider(LoggerFactory);
 
             // Act
             var commandOrCodeActionContainer = await provider.ProvideAsync(context, default);
@@ -164,7 +164,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var location = new SourceLocation(contents.IndexOf("code", StringComparison.Ordinal), -1, -1);
             var context = CreateRazorCodeActionContext(request, location, documentPath, contents, supportsFileCreation: true);
 
-            var provider = new ExtractToCodeBehindCodeActionProvider();
+            var provider = new ExtractToCodeBehindCodeActionProvider(LoggerFactory);
 
             // Act
             var commandOrCodeActionContainer = await provider.ProvideAsync(context, default);
@@ -194,7 +194,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var location = new SourceLocation(contents.IndexOf("code", StringComparison.Ordinal), -1, -1);
             var context = CreateRazorCodeActionContext(request, location, documentPath, contents, supportsFileCreation: false);
 
-            var provider = new ExtractToCodeBehindCodeActionProvider();
+            var provider = new ExtractToCodeBehindCodeActionProvider(LoggerFactory);
 
             // Act
             var commandOrCodeActionContainer = await provider.ProvideAsync(context, default);
@@ -218,7 +218,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var location = new SourceLocation(contents.IndexOf("functions", StringComparison.Ordinal), -1, -1);
             var context = CreateRazorCodeActionContext(request, location, documentPath, contents);
 
-            var provider = new ExtractToCodeBehindCodeActionProvider();
+            var provider = new ExtractToCodeBehindCodeActionProvider(LoggerFactory);
 
             // Act
             var commandOrCodeActionContainer = await provider.ProvideAsync(context, default);
@@ -248,7 +248,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions
             var location = new SourceLocation(contents.IndexOf("code", StringComparison.Ordinal), -1, -1);
             var context = CreateRazorCodeActionContext(request, location, documentPath, contents, relativePath: null);
 
-            var provider = new ExtractToCodeBehindCodeActionProvider();
+            var provider = new ExtractToCodeBehindCodeActionProvider(LoggerFactory);
 
             // Act
             var commandOrCodeActionContainer = await provider.ProvideAsync(context, default);


### PR DESCRIPTION
### Summary of the changes
- While debugging, I ran into https://github.com/dotnet/razor/issues/7901
- This changes `Debug.Fail` to logging so the language server doesn't crash:
![image](https://user-images.githubusercontent.com/16968319/200981258-295a49cf-8f19-41e7-a0a5-9f5d3eeda9b9.png)
