### PR TITLE
Re-enable test Handle_SingleServer_CSharpBraceMatching

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/OnAutoInsertEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/OnAutoInsertEndpointTest.cs
@@ -354,7 +354,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting
             await VerifyCSharpOnAutoInsertAsync(input, expected, character);
         }
 
-        [Fact(Skip = "Roslyn only responds to the Razor server kind for this request, but uses the C# server kind in tests")]
+        [Fact]
         public async Task Handle_SingleServer_CSharpBraceMatching()
         {
             // Arrange


### PR DESCRIPTION
Fixes: #6795 by un-skipping test now that the version of Roslyn that Razor uses has been updated by #7012
