### PR TITLE
[release/3.1] Use simpler Docker tags

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -309,7 +309,7 @@ stages:
 
       - job: Linux
         container:
-          image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-14.04-cross-0cd4667-20170319080304
+          image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-18.04-cross
           options: --init # This ensures all the stray defunct processes are reaped.
         pool:
           vmImage: ubuntu-20.04


### PR DESCRIPTION
- similar to #6907 but stick w/ `ubuntu-18.04-cross` (versus `centos-7` in main)
  - was `ubuntu-14.05-cross-blah` but that's _really_ old and doesn't have a simpler tag