### PR TITLE
Remove unused assemblies

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -80,7 +80,6 @@
       <package pattern="humanizer.core" />
       <package pattern="iced" />
       <package pattern="icsharpcode.decompiler" />
-      <package pattern="mediatr" />
       <package pattern="messagepack" />
       <package pattern="messagepack.annotations" />
       <package pattern="messagepackanalyzer" />
@@ -104,12 +103,12 @@
       <package pattern="omnisharp.abstractions" />
       <!-- The following are all needed because of a single reference to DocumentUri in
       FormattingLanguageServerClient for testing. We should remove them -->
-      <package pattern="omnisharp.abstractions" />
+      <package pattern="mediatr" />
       <package pattern="omnisharp.extensions.jsonrpc" />
       <package pattern="omnisharp.extensions.jsonrpc.generators" />
       <package pattern="omnisharp.extensions.languageprotocol" />
-      <package pattern="omnisharp.extensions.languageserver" />
-      <package pattern="omnisharp.extensions.languageserver.shared" />
+      <!-- -->
+      <package pattern="omnisharp.abstractions" />
       <package pattern="omnisharp.msbuild" />
       <package pattern="omnisharp.roslyn" />
       <package pattern="omnisharp.roslyn.csharp" />

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -14,11 +14,6 @@
   -->
   <ItemGroup>
     <FileSignInfo Include="Newtonsoft.Json.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="MediatR.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="OmniSharp.Extensions.JsonRpc.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="OmniSharp.Extensions.LanguageProtocol.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="OmniSharp.Extensions.LanguageServer.dll" CertificateName="3PartySHA2" />
-    <FileSignInfo Include="OmniSharp.Extensions.LanguageServer.Shared.dll" CertificateName="3PartySHA2" />
     <FileSignInfo Include="Nerdbank.Streams.dll" CertificateName="3PartySHA2" />
   </ItemGroup>
 

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/AssemblyCodeBases.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/AssemblyCodeBases.cs
@@ -3,11 +3,6 @@
 
 using Microsoft.VisualStudio.Shell;
 
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\MediatR.dll")]
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\OmniSharp.Extensions.JsonRpc.dll")]
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\OmniSharp.Extensions.LanguageProtocol.dll")]
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\OmniSharp.Extensions.LanguageServer.dll")]
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\OmniSharp.Extensions.LanguageServer.Shared.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.CommonLanguageServerProtocol.Framework.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Extensions.Options.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Extensions.Primitives.dll")]
@@ -18,5 +13,3 @@ using Microsoft.VisualStudio.Shell;
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Extensions.Logging.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Extensions.Logging.Abstractions.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.IO.Pipelines.dll")]
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Reactive.dll")]
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\System.Threading.Channels.dll")]

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
@@ -138,25 +138,15 @@
       NOTE: Adding OSS components to this list must be reviewed against our component governance standards. For now this is a curated list. You can read more about the CG process at https://aka.ms/component-governance
     ***************************************************************************************************************************************
     -->
-    <RazorNgendVSIXSourceItem Include="$(OutputPath)MediatR.dll" />
-    <RazorNgendVSIXSourceItem Include="$(OutputPath)OmniSharp.Extensions.JsonRpc.dll" />
-    <RazorNgendVSIXSourceItem Include="$(OutputPath)OmniSharp.Extensions.LanguageProtocol.dll" />
-    <RazorNgendVSIXSourceItem Include="$(OutputPath)OmniSharp.Extensions.LanguageServer.dll" />
-    <RazorNgendVSIXSourceItem Include="$(OutputPath)OmniSharp.Extensions.LanguageServer.Shared.dll" />
     <RazorNgendVSIXSourceItem Include="$(OutputPath)Microsoft.Extensions.Options.dll" />
-    <RazorNgendVSIXSourceItem Include="$(OutputPath)Microsoft.Extensions.Options.ConfigurationExtensions.dll" />
     <RazorNgendVSIXSourceItem Include="$(OutputPath)Microsoft.Extensions.Primitives.dll" />
     <RazorNgendVSIXSourceItem Include="$(OutputPath)Microsoft.Extensions.DependencyInjection.dll" />
     <RazorNgendVSIXSourceItem Include="$(OutputPath)Microsoft.Extensions.DependencyInjection.Abstractions.dll" />
     <RazorNgendVSIXSourceItem Include="$(OutputPath)Microsoft.Extensions.Configuration.dll" />
     <RazorNgendVSIXSourceItem Include="$(OutputPath)Microsoft.Extensions.Configuration.Abstractions.dll" />
-    <RazorNgendVSIXSourceItem Include="$(OutputPath)Microsoft.Extensions.Configuration.Binder.dll" />
     <RazorNgendVSIXSourceItem Include="$(OutputPath)Microsoft.Extensions.Logging.dll" />
     <RazorNgendVSIXSourceItem Include="$(OutputPath)Microsoft.Extensions.Logging.Abstractions.dll" />
     <RazorNgendVSIXSourceItem Include="$(OutputPath)System.IO.Pipelines.dll" />
-    <RazorNgendVSIXSourceItem Include="$(OutputPath)System.Reactive.dll" />
-    <RazorNgendVSIXSourceItem Include="$(OutputPath)System.Runtime.CompilerServices.Unsafe.dll" />
-    <RazorNgendVSIXSourceItem Include="$(OutputPath)System.Threading.Channels.dll" />
 
     <VSIXSourceItem Include="$(OutputPath)Microsoft.VisualStudio.LanguageServer.Protocol.dll" />
     <VSIXSourceItem Include="$(OutputPath)Microsoft.VisualStudio.LanguageServer.Protocol.Extensions.dll" />
@@ -232,10 +222,6 @@
     <PackageReference Include="Microsoft.NET.Sdk.Razor" Version="$(MicrosoftNETSdkRazorPackageVersion)" IncludeAssets="None" PrivateAssets="All" GeneratePathProperty="true" />
     <PackageReference Include="System.Resources.Extensions" Version="$(SystemResourcesExtensionsPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150PackageVersion)" />
-
-    <!-- We need to directly reference the O# language server here because we mark it as PrivateAssets="All" in our language server itself
-    We don't actual use it, but for now WebTools depends on it. -->
-    <PackageReference Include="OmniSharp.Extensions.LanguageServer" Version="$(OmniSharpExtensionsLanguageServerPackageVersion)" />
 
     <!--
       Pinning packages to avoid misaligned reference CI failures.

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/source.extension.vsixmanifest
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/source.extension.vsixmanifest
@@ -35,15 +35,8 @@
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.AspNetCore.Razor.Language.dll" />
-    <Asset Type="Microsoft.VisualStudio.Assembly" Path="MediatR.dll" />
-    <Asset Type="Microsoft.VisualStudio.Assembly" Path="OmniSharp.Extensions.JsonRpc.dll" />
-    <Asset Type="Microsoft.VisualStudio.Assembly" Path="OmniSharp.Extensions.LanguageProtocol.dll" />
-    <Asset Type="Microsoft.VisualStudio.Assembly" Path="OmniSharp.Extensions.LanguageServer.dll" />
-    <Asset Type="Microsoft.VisualStudio.Assembly" Path="OmniSharp.Extensions.LanguageServer.Shared.dll" />
-    <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.Configuration.Binder.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.CommonLanguageServerProtocol.Framework.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.Options.dll" />
-    <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.Options.ConfigurationExtensions.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.Primitives.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.DependencyInjection.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.DependencyInjection.Abstractions.dll" />
@@ -52,9 +45,6 @@
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.Logging.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.Logging.Abstractions.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="System.IO.Pipelines.dll" />
-    <Asset Type="Microsoft.VisualStudio.Assembly" Path="System.Reactive.dll" />
-    <Asset Type="Microsoft.VisualStudio.Assembly" Path="System.Runtime.CompilerServices.Unsafe.dll" />
-    <Asset Type="Microsoft.VisualStudio.Assembly" Path="System.Threading.Channels.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.AspNetCore.Razor.LanguageServer.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.AspNetCore.Razor.LanguageSupport.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.AspNetCore.Razor.LanguageServer.Protocol.dll" />


### PR DESCRIPTION
### Summary of the changes

- We're currently including these assemblies just because WebTools have a dependency on them, but WebTools is getting ready to take that on themselves, so I prepared this PR to remove them from our vsix.
- We MUST insert this in coordination with WebTools, probably as part of a joint VS insertion PR.

Fixes: https://github.com/dotnet/razor/issues/6903

CC @jimmylewis 