### PR TITLE
Remove pre-release version iteration

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -19,7 +19,6 @@
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>5</PreReleaseVersionIteration>
     <!--
         When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages
     -->


### PR DESCRIPTION
The packages are only for transport and the "5" can be confusing when looking at the SDK input version numbers.
