### PR TITLE
Clean up code actions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -45,6 +45,9 @@ dotnet_diagnostic.IDE0005.severity = suggestion
 # IDE0046: If expression can be simplified
 dotnet_style_prefer_conditional_expression_over_return = false:silent
 
+# IDE0060 - Remove unused parameter
+dotnet_diagnostic.IDE0060.severity = warning
+
 # Don't use this. qualifier
 dotnet_style_qualification_for_field = false:suggestion
 dotnet_style_qualification_for_property = false:suggestion

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/BaseDelegatedCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/BaseDelegatedCodeActionResolver.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -23,6 +24,8 @@ internal abstract class BaseDelegatedCodeActionResolver : BaseCodeActionResolver
 
         LanguageServer = languageServer;
     }
+
+    public abstract Task<CodeAction> ResolveAsync(CodeActionResolveParams resolveParams, CodeAction codeAction, CancellationToken cancellationToken);
 
     protected async Task<CodeAction?> ResolveCodeActionWithServerAsync(Uri razorFileUri, int hostDocumentVersion, RazorLanguageKind languageKind, CodeAction codeAction, CancellationToken cancellationToken)
     {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/CSharpCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/CSharpCodeActionResolver.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
-using Microsoft.VisualStudio.LanguageServer.Protocol;
-
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
 
 internal abstract class CSharpCodeActionResolver : BaseDelegatedCodeActionResolver
@@ -14,9 +9,4 @@ internal abstract class CSharpCodeActionResolver : BaseDelegatedCodeActionResolv
         : base(languageServer)
     {
     }
-
-    public abstract Task<CodeAction> ResolveAsync(
-        CodeActionResolveParams csharpParams,
-        CodeAction codeAction,
-        CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Html/HtmlCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Html/HtmlCodeActionResolver.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
-using Microsoft.VisualStudio.LanguageServer.Protocol;
-
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
 
 internal abstract class HtmlCodeActionResolver : BaseDelegatedCodeActionResolver
@@ -14,9 +9,4 @@ internal abstract class HtmlCodeActionResolver : BaseDelegatedCodeActionResolver
         : base(languageServer)
     {
     }
-
-    public abstract Task<CodeAction> ResolveAsync(
-        CodeActionResolveParams csharpParams,
-        CodeAction codeAction,
-        CancellationToken cancellationToken);
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/LanguageServerTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/LanguageServerTestBase.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -91,9 +90,9 @@ public abstract class LanguageServerTestBase : TestBase
         return CreateDocumentContextFactory(documentPath, codeDocument);
     }
 
-    internal static DocumentContext? CreateDocumentContext(Uri documentPath, RazorCodeDocument codeDocument, [NotNullWhen(true)] bool documentFound = true)
+    internal static DocumentContext CreateDocumentContext(Uri documentPath, RazorCodeDocument codeDocument)
     {
-        return documentFound ? TestDocumentContext.From(documentPath.GetAbsoluteOrUNCPath(), codeDocument, hostDocumentVersion: 1337) : null;
+        return TestDocumentContext.From(documentPath.GetAbsoluteOrUNCPath(), codeDocument, hostDocumentVersion: 1337);
     }
 
     internal static string GetString(SourceText sourceText)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/AddUsingsCodeActionProviderFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/AddUsingsCodeActionProviderFactoryTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Xunit;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/AddUsingsCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/AddUsingsCodeActionResolverTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using System.Threading;
@@ -30,7 +28,7 @@ public class AddUsingsCodeActionResolverTest : LanguageServerTestBase
         _emptyDocumentContextFactory = Mock.Of<DocumentContextFactory>(
             r => r.TryCreateAsync(
                 It.IsAny<Uri>(),
-                It.IsAny<CancellationToken>()) == Task.FromResult<DocumentContext>(null),
+                It.IsAny<CancellationToken>()) == Task.FromResult<DocumentContext?>(null),
             MockBehavior.Strict);
     }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/AddUsingsCSharpCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/AddUsingsCSharpCodeActionResolverTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,29 +18,29 @@ using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
 
-    public class AddUsingsCSharpCodeActionResolverTest : LanguageServerTestBase
+public class AddUsingsCSharpCodeActionResolverTest : LanguageServerTestBase
+{
+    private static readonly CodeAction s_defaultUnresolvedCodeAction = new()
     {
-        private static readonly CodeAction s_defaultUnresolvedCodeAction = new()
-        {
-            Title = "@using System.Net"
-        };
+        Title = "@using System.Net"
+    };
 
-        public AddUsingsCSharpCodeActionResolverTest(ITestOutputHelper testOutput)
-            : base(testOutput)
-        {
-        }
+    public AddUsingsCSharpCodeActionResolverTest(ITestOutputHelper testOutput)
+        : base(testOutput)
+    {
+    }
 
-        [Fact]
-        public async Task ResolveAsync_ReturnsResolvedCodeAction()
+    [Fact]
+    public async Task ResolveAsync_ReturnsResolvedCodeAction()
+    {
+        // Arrange
+        var resolvedCodeAction = new CodeAction()
         {
-            // Arrange
-            var resolvedCodeAction = new CodeAction()
+            Title = "@using System.Net",
+            Data = null,
+            Edit = new WorkspaceEdit()
             {
-                Title = "@using System.Net",
-                Data = null,
-                Edit = new WorkspaceEdit()
-                {
-                    DocumentChanges = new TextDocumentEdit[] {
+                DocumentChanges = new TextDocumentEdit[] {
                         new TextDocumentEdit()
                         {
                             Edits = new TextEdit[] {
@@ -58,35 +56,36 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
                             }
                         }
                     }
-                }
-            };
-            CreateCodeActionResolver(out var codeActionParams, out var csharpCodeActionResolver, resolvedCodeAction);
+            }
+        };
+        CreateCodeActionResolver(out var codeActionParams, out var csharpCodeActionResolver, resolvedCodeAction);
 
-            // Act
-            var returnedCodeAction = await csharpCodeActionResolver.ResolveAsync(codeActionParams, s_defaultUnresolvedCodeAction, default);
+        // Act
+        var returnedCodeAction = await csharpCodeActionResolver.ResolveAsync(codeActionParams, s_defaultUnresolvedCodeAction, default);
 
-            // Assert
-            Assert.Equal(resolvedCodeAction.Title, returnedCodeAction.Title);
-            Assert.Equal(resolvedCodeAction.Data, returnedCodeAction.Data);
+        // Assert
+        Assert.Equal(resolvedCodeAction.Title, returnedCodeAction.Title);
+        Assert.Equal(resolvedCodeAction.Data, returnedCodeAction.Data);
 
-            Assert.Equal(1, returnedCodeAction.Edit.DocumentChanges.Value.Count());
-            var returnedEdits = returnedCodeAction.Edit.DocumentChanges.Value.First();
-            Assert.True(returnedEdits.TryGetFirst(out var textDocumentEdit));
-            var returnedTextDocumentEdit = Assert.Single(textDocumentEdit.Edits);
-            Assert.Equal($"@using System.Net;{Environment.NewLine}", returnedTextDocumentEdit.NewText);
-        }
+        Assert.NotNull(returnedCodeAction.Edit?.DocumentChanges);
+        Assert.Equal(1, returnedCodeAction.Edit.DocumentChanges.Value.Count());
+        var returnedEdits = returnedCodeAction.Edit.DocumentChanges.Value.First();
+        Assert.True(returnedEdits.TryGetFirst(out var textDocumentEdit));
+        var returnedTextDocumentEdit = Assert.Single(textDocumentEdit.Edits);
+        Assert.Equal($"@using System.Net;{Environment.NewLine}", returnedTextDocumentEdit.NewText);
+    }
 
-        [Fact]
-        public async Task ResolveAsync_FragmentedEdit_ReturnsResolvedCodeAction()
+    [Fact]
+    public async Task ResolveAsync_FragmentedEdit_ReturnsResolvedCodeAction()
+    {
+        // Arrange
+        var resolvedCodeAction = new CodeAction()
         {
-            // Arrange
-            var resolvedCodeAction = new CodeAction()
+            Title = "@using System.Net",
+            Data = null,
+            Edit = new WorkspaceEdit()
             {
-                Title = "@using System.Net",
-                Data = null,
-                Edit = new WorkspaceEdit()
-                {
-                    DocumentChanges = new TextDocumentEdit[] {
+                DocumentChanges = new TextDocumentEdit[] {
                         new TextDocumentEdit()
                         {
                             Edits = new TextEdit[] {
@@ -103,35 +102,36 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
                             }
                         }
                     }
-                }
-            };
-            CreateCodeActionResolver(out var codeActionParams, out var csharpCodeActionResolver, resolvedCodeAction);
+            }
+        };
+        CreateCodeActionResolver(out var codeActionParams, out var csharpCodeActionResolver, resolvedCodeAction);
 
-            // Act
-            var returnedCodeAction = await csharpCodeActionResolver.ResolveAsync(codeActionParams, s_defaultUnresolvedCodeAction, default);
+        // Act
+        var returnedCodeAction = await csharpCodeActionResolver.ResolveAsync(codeActionParams, s_defaultUnresolvedCodeAction, default);
 
-            // Assert
-            Assert.Equal(resolvedCodeAction.Title, returnedCodeAction.Title);
-            Assert.Equal(resolvedCodeAction.Data, returnedCodeAction.Data);
+        // Assert
+        Assert.Equal(resolvedCodeAction.Title, returnedCodeAction.Title);
+        Assert.Equal(resolvedCodeAction.Data, returnedCodeAction.Data);
 
-            Assert.Equal(1, returnedCodeAction.Edit.DocumentChanges.Value.Count());
-            var returnedEdits = returnedCodeAction.Edit.DocumentChanges.Value.First();
-            Assert.True(returnedEdits.TryGetFirst(out var textDocumentEdit));
-            var returnedTextDocumentEdit = Assert.Single(textDocumentEdit.Edits);
-            Assert.Equal($"@using System.Net;{Environment.NewLine}", returnedTextDocumentEdit.NewText);
-        }
+        Assert.NotNull(returnedCodeAction.Edit?.DocumentChanges);
+        Assert.Equal(1, returnedCodeAction.Edit.DocumentChanges.Value.Count());
+        var returnedEdits = returnedCodeAction.Edit.DocumentChanges.Value.First();
+        Assert.True(returnedEdits.TryGetFirst(out var textDocumentEdit));
+        var returnedTextDocumentEdit = Assert.Single(textDocumentEdit.Edits);
+        Assert.Equal($"@using System.Net;{Environment.NewLine}", returnedTextDocumentEdit.NewText);
+    }
 
-        [Fact]
-        public async Task ResolveAsync_GlobalUsing_ReturnsResolvedCodeAction()
+    [Fact]
+    public async Task ResolveAsync_GlobalUsing_ReturnsResolvedCodeAction()
+    {
+        // Arrange
+        var resolvedCodeAction = new CodeAction()
         {
-            // Arrange
-            var resolvedCodeAction = new CodeAction()
+            Title = "@using System.Net",
+            Data = null,
+            Edit = new WorkspaceEdit()
             {
-                Title = "@using System.Net",
-                Data = null,
-                Edit = new WorkspaceEdit()
-                {
-                    DocumentChanges = new TextDocumentEdit[] {
+                DocumentChanges = new TextDocumentEdit[] {
                         new TextDocumentEdit()
                         {
                             Edits = new TextEdit[] {
@@ -147,62 +147,63 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
                             }
                         }
                     }
-                }
-            };
-            CreateCodeActionResolver(out var codeActionParams, out var csharpCodeActionResolver, resolvedCodeAction);
+            }
+        };
+        CreateCodeActionResolver(out var codeActionParams, out var csharpCodeActionResolver, resolvedCodeAction);
 
-            // Act
-            var returnedCodeAction = await csharpCodeActionResolver.ResolveAsync(codeActionParams, s_defaultUnresolvedCodeAction, default);
+        // Act
+        var returnedCodeAction = await csharpCodeActionResolver.ResolveAsync(codeActionParams, s_defaultUnresolvedCodeAction, default);
 
-            // Assert
-            Assert.Equal(resolvedCodeAction.Title, returnedCodeAction.Title);
-            Assert.Equal(resolvedCodeAction.Data, returnedCodeAction.Data);
+        // Assert
+        Assert.Equal(resolvedCodeAction.Title, returnedCodeAction.Title);
+        Assert.Equal(resolvedCodeAction.Data, returnedCodeAction.Data);
 
-            Assert.Equal(1, returnedCodeAction.Edit.DocumentChanges.Value.Count());
-            var returnedEdits = returnedCodeAction.Edit.DocumentChanges.Value.First();
-            Assert.True(returnedEdits.TryGetFirst(out var textDocumentEdit));
-            var returnedTextDocumentEdit = Assert.Single(textDocumentEdit.Edits);
-            Assert.Equal($"@using global::System.Net;{Environment.NewLine}", returnedTextDocumentEdit.NewText);
-        }
-
-        private void CreateCodeActionResolver(
-            out CodeActionResolveParams codeActionParams,
-            out AddUsingsCSharpCodeActionResolver addUsingResolver,
-            CodeAction resolvedCodeAction)
-        {
-            var documentUri = new Uri("c:/Test.razor");
-            var contents = string.Empty;
-            var codeDocument = CreateCodeDocument(contents, documentUri.AbsolutePath);
-
-            codeActionParams = new CodeActionResolveParams()
-            {
-                Data = new JObject(),
-                RazorFileUri = documentUri
-            };
-
-            var languageServer = CreateLanguageServer(resolvedCodeAction);
-
-            addUsingResolver = new AddUsingsCSharpCodeActionResolver(
-                CreateDocumentContextFactory(documentUri, codeDocument),
-                languageServer);
-        }
-
-        private static ClientNotifierServiceBase CreateLanguageServer(CodeAction resolvedCodeAction)
-        {
-            var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
-            languageServer
-                .Setup(l => l.SendRequestAsync<RazorResolveCodeActionParams, CodeAction>(RazorLanguageServerCustomMessageTargets.RazorResolveCodeActionsEndpoint, It.IsAny<RazorResolveCodeActionParams>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(resolvedCodeAction);
-
-            return languageServer.Object;
-        }
-
-        private static RazorCodeDocument CreateCodeDocument(string text, string documentPath)
-        {
-            var projectItem = new TestRazorProjectItem(documentPath) { Content = text };
-            var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty, (builder) => PageDirective.Register(builder));
-            var codeDocument = projectEngine.Process(projectItem);
-            codeDocument.SetFileKind(FileKinds.Component);
-            return codeDocument;
-        }
+        Assert.NotNull(returnedCodeAction.Edit?.DocumentChanges);
+        Assert.Equal(1, returnedCodeAction.Edit.DocumentChanges.Value.Count());
+        var returnedEdits = returnedCodeAction.Edit.DocumentChanges.Value.First();
+        Assert.True(returnedEdits.TryGetFirst(out var textDocumentEdit));
+        var returnedTextDocumentEdit = Assert.Single(textDocumentEdit.Edits);
+        Assert.Equal($"@using global::System.Net;{Environment.NewLine}", returnedTextDocumentEdit.NewText);
     }
+
+    private static void CreateCodeActionResolver(
+        out CodeActionResolveParams codeActionParams,
+        out AddUsingsCSharpCodeActionResolver addUsingResolver,
+        CodeAction resolvedCodeAction)
+    {
+        var documentUri = new Uri("c:/Test.razor");
+        var contents = string.Empty;
+        var codeDocument = CreateCodeDocument(contents, documentUri.AbsolutePath);
+
+        codeActionParams = new CodeActionResolveParams()
+        {
+            Data = new JObject(),
+            RazorFileUri = documentUri
+        };
+
+        var languageServer = CreateLanguageServer(resolvedCodeAction);
+
+        addUsingResolver = new AddUsingsCSharpCodeActionResolver(
+            CreateDocumentContextFactory(documentUri, codeDocument),
+            languageServer);
+    }
+
+    private static ClientNotifierServiceBase CreateLanguageServer(CodeAction resolvedCodeAction)
+    {
+        var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
+        languageServer
+            .Setup(l => l.SendRequestAsync<RazorResolveCodeActionParams, CodeAction>(RazorLanguageServerCustomMessageTargets.RazorResolveCodeActionsEndpoint, It.IsAny<RazorResolveCodeActionParams>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(resolvedCodeAction);
+
+        return languageServer.Object;
+    }
+
+    private static RazorCodeDocument CreateCodeDocument(string text, string documentPath)
+    {
+        var projectItem = new TestRazorProjectItem(documentPath) { Content = text };
+        var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty, (builder) => PageDirective.Register(builder));
+        var codeDocument = projectEngine.Process(projectItem);
+        codeDocument.SetFileKind(FileKinds.Component);
+        return codeDocument;
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/DefaultCSharpCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/DefaultCSharpCodeActionProviderTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -65,6 +63,7 @@ public class DefaultCSharpCodeActionProviderTest : LanguageServerTestBase
         var providedCodeActions = await provider.ProvideAsync(context, _supportedCodeActions, default);
 
         // Assert
+        Assert.NotNull(providedCodeActions);
         Assert.Equal(_supportedCodeActions.Length, providedCodeActions.Count);
         var providedNames = providedCodeActions.Select(action => action.Name);
         var expectedNames = _supportedCodeActions.Select(action => action.Name);
@@ -96,6 +95,7 @@ public class DefaultCSharpCodeActionProviderTest : LanguageServerTestBase
         var providedCodeActions = await provider.ProvideAsync(context, _supportedCodeActions, default);
 
         // Assert
+        Assert.NotNull(providedCodeActions);
         Assert.Empty(providedCodeActions);
     }
 
@@ -124,6 +124,7 @@ public class DefaultCSharpCodeActionProviderTest : LanguageServerTestBase
         var providedCodeActions = await provider.ProvideAsync(context, _supportedCodeActions, default);
 
         // Assert
+        Assert.NotNull(providedCodeActions);
         Assert.Equal(_supportedCodeActions.Length, providedCodeActions.Count);
         var providedNames = providedCodeActions.Select(action => action.Name);
         var expectedNames = _supportedCodeActions.Select(action => action.Name);
@@ -157,6 +158,7 @@ $$Path;
         var providedCodeActions = await provider.ProvideAsync(context, _supportedCodeActions, default);
 
         // Assert
+        Assert.NotNull(providedCodeActions);
         Assert.Equal(_supportedCodeActions.Length, providedCodeActions.Count);
         var providedNames = providedCodeActions.Select(action => action.Name);
         var expectedNames = _supportedCodeActions.Select(action => action.Name);
@@ -191,6 +193,7 @@ $$Path;
         var providedCodeActions = await provider.ProvideAsync(context, _supportedCodeActions, default);
 
         // Assert
+        Assert.NotNull(providedCodeActions);
         Assert.Equal(_supportedCodeActions.Length, providedCodeActions.Count);
         var providedNames = providedCodeActions.Select(action => action.Name);
         var expectedNames = _supportedCodeActions.Select(action => action.Name);
@@ -231,6 +234,7 @@ $$Path;
         var providedCodeActions = await provider.ProvideAsync(context, codeActions, default);
 
         // Assert
+        Assert.NotNull(providedCodeActions);
         Assert.Empty(providedCodeActions);
     }
 
@@ -267,6 +271,7 @@ $$Path;
         var providedCodeActions = await provider.ProvideAsync(context, _supportedCodeActions, default);
 
         // Assert
+        Assert.NotNull(providedCodeActions);
         Assert.Equal(_supportedImplicitExpressionCodeActions.Length, providedCodeActions.Count);
         var providedNames = providedCodeActions.Select(action => action.Name);
         var expectedNames = _supportedImplicitExpressionCodeActions.Select(action => action.Name);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/DefaultCSharpCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/DefaultCSharpCodeActionResolverTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using System.Threading;
@@ -15,7 +13,6 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.AspNetCore.Razor.Test.Common;
-using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Moq;
 using Newtonsoft.Json.Linq;
@@ -24,101 +21,102 @@ using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
 
-    public class DefaultCSharpCodeActionResolverTest : LanguageServerTestBase
+public class DefaultCSharpCodeActionResolverTest : LanguageServerTestBase
+{
+    private static readonly CodeAction s_defaultResolvedCodeAction = new()
     {
-        private static readonly CodeAction s_defaultResolvedCodeAction = new()
+        Title = "ResolvedCodeAction",
+        Data = JToken.FromObject(new object()),
+        Edit = new WorkspaceEdit()
+        {
+            DocumentChanges = new TextDocumentEdit[] {
+                new TextDocumentEdit()
+                {
+                    Edits = new TextEdit[]{
+                        new TextEdit()
+                        {
+                            NewText = "Generated C# Based Edit"
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+    private static readonly TextEdit[] s_defaultFormattedEdits = new TextEdit[]
+    {
+        new TextEdit()
+        {
+            NewText = "Remapped & Formatted Edit"
+        }
+    };
+
+    private static readonly CodeAction s_defaultUnresolvedCodeAction = new CodeAction()
+    {
+        Title = "Unresolved Code Action"
+    };
+
+    public DefaultCSharpCodeActionResolverTest(ITestOutputHelper testOutput)
+        : base(testOutput)
+    {
+    }
+
+    [Fact]
+    public async Task ResolveAsync_ReturnsResolvedCodeAction()
+    {
+        // Arrange
+        CreateCodeActionResolver(out var codeActionParams, out var csharpCodeActionResolver);
+
+        // Act
+        var returnedCodeAction = await csharpCodeActionResolver.ResolveAsync(codeActionParams, s_defaultUnresolvedCodeAction, default);
+
+        // Assert
+        Assert.Equal(s_defaultResolvedCodeAction.Title, returnedCodeAction.Title);
+        Assert.Equal(s_defaultResolvedCodeAction.Data, returnedCodeAction.Data);
+        Assert.NotNull(returnedCodeAction.Edit?.DocumentChanges);
+        Assert.Equal(1, returnedCodeAction.Edit.DocumentChanges.Value.Count());
+        var returnedEdits = returnedCodeAction.Edit.DocumentChanges.Value;
+        Assert.True(returnedEdits.TryGetFirst(out var textDocumentEdits));
+        var returnedTextDocumentEdit = Assert.Single(textDocumentEdits[0].Edits);
+        Assert.Equal(s_defaultFormattedEdits.First(), returnedTextDocumentEdit);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_NoDocumentChanges_ReturnsOriginalCodeAction()
+    {
+        // Arrange
+        var resolvedCodeAction = new CodeAction()
+        {
+            Title = "ResolvedCodeAction",
+            Data = JToken.FromObject(new object()),
+            Edit = new WorkspaceEdit()
+            {
+                DocumentChanges = null
+            }
+        };
+
+        var languageServer = CreateLanguageServer(resolvedCodeAction);
+
+        CreateCodeActionResolver(out var codeActionParams, out var csharpCodeActionResolver, languageServer: languageServer);
+
+        // Act
+        var returnedCodeAction = await csharpCodeActionResolver.ResolveAsync(codeActionParams, s_defaultUnresolvedCodeAction, default);
+
+        // Assert
+        Assert.Equal(s_defaultUnresolvedCodeAction.Title, returnedCodeAction.Title);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_MultipleDocumentChanges_ReturnsOriginalCodeAction()
+    {
+        // Arrange
+        var resolvedCodeAction = new CodeAction()
         {
             Title = "ResolvedCodeAction",
             Data = JToken.FromObject(new object()),
             Edit = new WorkspaceEdit()
             {
                 DocumentChanges = new TextDocumentEdit[] {
-                    new TextDocumentEdit()
-                    {
-                        Edits = new TextEdit[]{
-                            new TextEdit()
-                            {
-                                NewText = "Generated C# Based Edit"
-                            }
-                        }
-                    }
-                }
-            }
-        };
-
-        private static readonly TextEdit[] s_defaultFormattedEdits = new TextEdit[]
-        {
-            new TextEdit()
-            {
-                NewText = "Remapped & Formatted Edit"
-            }
-        };
-
-        private static readonly CodeAction s_defaultUnresolvedCodeAction = new CodeAction()
-        {
-            Title = "Unresolved Code Action"
-        };
-
-        public DefaultCSharpCodeActionResolverTest(ITestOutputHelper testOutput)
-            : base(testOutput)
-        {
-        }
-
-        [Fact]
-        public async Task ResolveAsync_ReturnsResolvedCodeAction()
-        {
-            // Arrange
-            CreateCodeActionResolver(out var codeActionParams, out var csharpCodeActionResolver);
-
-            // Act
-            var returnedCodeAction = await csharpCodeActionResolver.ResolveAsync(codeActionParams, s_defaultUnresolvedCodeAction, default);
-
-            // Assert
-            Assert.Equal(s_defaultResolvedCodeAction.Title, returnedCodeAction.Title);
-            Assert.Equal(s_defaultResolvedCodeAction.Data, returnedCodeAction.Data);
-            Assert.Equal(1, returnedCodeAction.Edit.DocumentChanges.Value.Count());
-            var returnedEdits = returnedCodeAction.Edit.DocumentChanges.Value;
-            Assert.True(returnedEdits.TryGetFirst(out var textDocumentEdits));
-            var returnedTextDocumentEdit = Assert.Single(textDocumentEdits[0].Edits);
-            Assert.Equal(s_defaultFormattedEdits.First(), returnedTextDocumentEdit);
-        }
-
-        [Fact]
-        public async Task ResolveAsync_NoDocumentChanges_ReturnsOriginalCodeAction()
-        {
-            // Arrange
-            var resolvedCodeAction = new CodeAction()
-            {
-                Title = "ResolvedCodeAction",
-                Data = JToken.FromObject(new object()),
-                Edit = new WorkspaceEdit()
-                {
-                    DocumentChanges = null
-                }
-            };
-
-            var languageServer = CreateLanguageServer(resolvedCodeAction);
-
-            CreateCodeActionResolver(out var codeActionParams, out var csharpCodeActionResolver, languageServer: languageServer);
-
-            // Act
-            var returnedCodeAction = await csharpCodeActionResolver.ResolveAsync(codeActionParams, s_defaultUnresolvedCodeAction, default);
-
-            // Assert
-            Assert.Equal(s_defaultUnresolvedCodeAction.Title, returnedCodeAction.Title);
-        }
-
-        [Fact]
-        public async Task ResolveAsync_MultipleDocumentChanges_ReturnsOriginalCodeAction()
-        {
-            // Arrange
-            var resolvedCodeAction = new CodeAction()
-            {
-                Title = "ResolvedCodeAction",
-                Data = JToken.FromObject(new object()),
-                Edit = new WorkspaceEdit()
-                {
-                    DocumentChanges = new TextDocumentEdit[] {
                         new TextDocumentEdit()
                         {
                             Edits = new TextEdit[] {
@@ -138,106 +136,106 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
                             }
                         }
                     }
-                }
-            };
+            }
+        };
 
-            var languageServer = CreateLanguageServer(resolvedCodeAction);
+        var languageServer = CreateLanguageServer(resolvedCodeAction);
 
-            CreateCodeActionResolver(out var codeActionParams, out var csharpCodeActionResolver, languageServer: languageServer);
+        CreateCodeActionResolver(out var codeActionParams, out var csharpCodeActionResolver, languageServer: languageServer);
 
-            // Act
-            var returnedCodeAction = await csharpCodeActionResolver.ResolveAsync(codeActionParams, s_defaultUnresolvedCodeAction, default);
+        // Act
+        var returnedCodeAction = await csharpCodeActionResolver.ResolveAsync(codeActionParams, s_defaultUnresolvedCodeAction, default);
 
-            // Assert
-            Assert.Equal(s_defaultUnresolvedCodeAction.Title, returnedCodeAction.Title);
-        }
+        // Assert
+        Assert.Equal(s_defaultUnresolvedCodeAction.Title, returnedCodeAction.Title);
+    }
 
-        [Fact]
-        public async Task ResolveAsync_NonTextDocumentEdit_ReturnsOriginalCodeAction()
+    [Fact]
+    public async Task ResolveAsync_NonTextDocumentEdit_ReturnsOriginalCodeAction()
+    {
+        // Arrange
+        var resolvedCodeAction = new CodeAction()
         {
-            // Arrange
-            var resolvedCodeAction = new CodeAction()
+            Title = "ResolvedCodeAction",
+            Data = JToken.FromObject(new object()),
+            Edit = new WorkspaceEdit()
             {
-                Title = "ResolvedCodeAction",
-                Data = JToken.FromObject(new object()),
-                Edit = new WorkspaceEdit()
-                {
-                    DocumentChanges = new SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>[] {
+                DocumentChanges = new SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>[] {
                         new CreateFile()
                         {
                             Uri = new Uri("c:/some/uri.razor")
                         }
                     }
-                }
-            };
+            }
+        };
 
-            var languageServer = CreateLanguageServer(resolvedCodeAction);
+        var languageServer = CreateLanguageServer(resolvedCodeAction);
 
-            CreateCodeActionResolver(out var codeActionParams, out var csharpCodeActionResolver, languageServer: languageServer);
+        CreateCodeActionResolver(out var codeActionParams, out var csharpCodeActionResolver, languageServer: languageServer);
 
-            // Act
-            var returnedCodeAction = await csharpCodeActionResolver.ResolveAsync(codeActionParams, s_defaultUnresolvedCodeAction, default);
+        // Act
+        var returnedCodeAction = await csharpCodeActionResolver.ResolveAsync(codeActionParams, s_defaultUnresolvedCodeAction, default);
 
-            // Assert
-            Assert.Equal(s_defaultUnresolvedCodeAction.Title, returnedCodeAction.Title);
-        }
-
-        private void CreateCodeActionResolver(
-            out CodeActionResolveParams codeActionParams,
-            out DefaultCSharpCodeActionResolver csharpCodeActionResolver,
-            ClientNotifierServiceBase languageServer = null,
-            RazorFormattingService razorFormattingService = null)
-        {
-            var documentPath = "c:/Test.razor";
-            var documentUri = new Uri(documentPath);
-            var contents = string.Empty;
-            var codeDocument = CreateCodeDocument(contents, documentPath);
-
-            codeActionParams = new CodeActionResolveParams()
-            {
-                Data = new JObject(),
-                RazorFileUri = documentUri
-            };
-
-            languageServer ??= CreateLanguageServer();
-            razorFormattingService ??= CreateRazorFormattingService(documentUri);
-
-            csharpCodeActionResolver = new DefaultCSharpCodeActionResolver(
-                CreateDocumentContextFactory(documentUri, codeDocument),
-                languageServer,
-                razorFormattingService);
-        }
-
-        private static RazorFormattingService CreateRazorFormattingService(Uri documentUri)
-        {
-            var razorFormattingService = Mock.Of<RazorFormattingService>(
-                            rfs => rfs.FormatCodeActionAsync(
-                                It.Is<DocumentContext>(c => c.Uri == documentUri),
-                                RazorLanguageKind.CSharp,
-                                It.IsAny<TextEdit[]>(),
-                                It.IsAny<FormattingOptions>(),
-                                It.IsAny<CancellationToken>()) == Task.FromResult(s_defaultFormattedEdits), MockBehavior.Strict);
-            return razorFormattingService;
-        }
-
-        private static ClientNotifierServiceBase CreateLanguageServer(CodeAction resolvedCodeAction = null)
-        {
-            var response = resolvedCodeAction ?? s_defaultResolvedCodeAction;
-
-            var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
-            languageServer
-                .Setup(l => l.SendRequestAsync<RazorResolveCodeActionParams, CodeAction>(RazorLanguageServerCustomMessageTargets.RazorResolveCodeActionsEndpoint, It.IsAny<RazorResolveCodeActionParams>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(response);
-
-            return languageServer.Object;
-        }
-
-        private static RazorCodeDocument CreateCodeDocument(string text, string documentPath)
-        {
-            var projectItem = new TestRazorProjectItem(documentPath) { Content = text };
-            var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty, (builder) => PageDirective.Register(builder));
-            var codeDocument = projectEngine.Process(projectItem);
-            codeDocument.SetFileKind(FileKinds.Component);
-            return codeDocument;
-        }
+        // Assert
+        Assert.Equal(s_defaultUnresolvedCodeAction.Title, returnedCodeAction.Title);
     }
+
+    private static void CreateCodeActionResolver(
+        out CodeActionResolveParams codeActionParams,
+        out DefaultCSharpCodeActionResolver csharpCodeActionResolver,
+        ClientNotifierServiceBase? languageServer = null,
+        RazorFormattingService? razorFormattingService = null)
+    {
+        var documentPath = "c:/Test.razor";
+        var documentUri = new Uri(documentPath);
+        var contents = string.Empty;
+        var codeDocument = CreateCodeDocument(contents, documentPath);
+
+        codeActionParams = new CodeActionResolveParams()
+        {
+            Data = new JObject(),
+            RazorFileUri = documentUri
+        };
+
+        languageServer ??= CreateLanguageServer();
+        razorFormattingService ??= CreateRazorFormattingService(documentUri);
+
+        csharpCodeActionResolver = new DefaultCSharpCodeActionResolver(
+            CreateDocumentContextFactory(documentUri, codeDocument),
+            languageServer,
+            razorFormattingService);
+    }
+
+    private static RazorFormattingService CreateRazorFormattingService(Uri documentUri)
+    {
+        var razorFormattingService = Mock.Of<RazorFormattingService>(
+                        rfs => rfs.FormatCodeActionAsync(
+                            It.Is<DocumentContext>(c => c.Uri == documentUri),
+                            RazorLanguageKind.CSharp,
+                            It.IsAny<TextEdit[]>(),
+                            It.IsAny<FormattingOptions>(),
+                            It.IsAny<CancellationToken>()) == Task.FromResult(s_defaultFormattedEdits), MockBehavior.Strict);
+        return razorFormattingService;
+    }
+
+    private static ClientNotifierServiceBase CreateLanguageServer(CodeAction? resolvedCodeAction = null)
+    {
+        var response = resolvedCodeAction ?? s_defaultResolvedCodeAction;
+
+        var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
+        languageServer
+            .Setup(l => l.SendRequestAsync<RazorResolveCodeActionParams, CodeAction>(RazorLanguageServerCustomMessageTargets.RazorResolveCodeActionsEndpoint, It.IsAny<RazorResolveCodeActionParams>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        return languageServer.Object;
+    }
+
+    private static RazorCodeDocument CreateCodeDocument(string text, string documentPath)
+    {
+        var projectItem = new TestRazorProjectItem(documentPath) { Content = text };
+        var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty, (builder) => PageDirective.Register(builder));
+        var codeDocument = projectEngine.Process(projectItem);
+        codeDocument.SetFileKind(FileKinds.Component);
+        return codeDocument;
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/TypeAccessibilityCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/TypeAccessibilityCodeActionProviderTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Razor.Extensions;
@@ -41,7 +39,8 @@ public class TypeAccessibilityCodeActionProviderTest : LanguageServerTestBase
             Range = new Range(),
             Context = new CodeActionContext()
             {
-                Diagnostics = null
+                // Even though the DTO declares this as non-null, we want to make sure we behave
+                Diagnostics = null!
             },
         };
 
@@ -61,6 +60,7 @@ public class TypeAccessibilityCodeActionProviderTest : LanguageServerTestBase
         var results = await provider.ProvideAsync(context, csharpCodeActions, default);
 
         // Assert
+        Assert.NotNull(results);
         Assert.Empty(results);
     }
 
@@ -115,7 +115,9 @@ public class TypeAccessibilityCodeActionProviderTest : LanguageServerTestBase
         var results = await provider.ProvideAsync(context, csharpCodeActions, default);
 
         // Assert
+        Assert.NotNull(results);
         Assert.Empty(results);
+
     }
 
     [Fact]
@@ -126,7 +128,7 @@ public class TypeAccessibilityCodeActionProviderTest : LanguageServerTestBase
         var contents = "";
         var request = new CodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier{ Uri = new Uri(documentPath) },
+            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
             Context = new CodeActionContext()
             {
@@ -151,7 +153,9 @@ public class TypeAccessibilityCodeActionProviderTest : LanguageServerTestBase
         var results = await provider.ProvideAsync(context, csharpCodeActions, default);
 
         // Assert
+        Assert.NotNull(results);
         Assert.Empty(results);
+
     }
 
     [Theory]
@@ -165,7 +169,7 @@ public class TypeAccessibilityCodeActionProviderTest : LanguageServerTestBase
         var contents = "@code { Path; }";
         var request = new CodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier{ Uri = new Uri(documentPath) },
+            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
             Context = new CodeActionContext()
             {
@@ -215,13 +219,15 @@ public class TypeAccessibilityCodeActionProviderTest : LanguageServerTestBase
         var results = await provider.ProvideAsync(context, csharpCodeActions, default);
 
         // Assert
+        Assert.NotNull(results);
         Assert.Collection(results,
             r =>
             {
                 Assert.Equal("@using System.IO", r.Title);
                 Assert.Null(r.Edit);
                 Assert.NotNull(r.Data);
-                var resolutionParams = (r.Data as JObject).ToObject<RazorCodeActionResolutionParams>();
+                var resolutionParams = ((JObject)r.Data).ToObject<RazorCodeActionResolutionParams>();
+                Assert.NotNull(resolutionParams);
                 Assert.Equal(LanguageServerConstants.CodeActions.AddUsing, resolutionParams.Action);
             },
             r =>
@@ -242,7 +248,7 @@ public class TypeAccessibilityCodeActionProviderTest : LanguageServerTestBase
         var contents = "@inject Path";
         var request = new CodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier{ Uri = new Uri(documentPath) },
+            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
             Context = new CodeActionContext()
             {
@@ -272,13 +278,15 @@ public class TypeAccessibilityCodeActionProviderTest : LanguageServerTestBase
         var results = await provider.ProvideAsync(context, csharpCodeActions, default);
 
         // Assert
+        Assert.NotNull(results);
         Assert.Collection(results,
             r =>
             {
                 Assert.Equal("@using System.IO", r.Title);
                 Assert.Null(r.Edit);
                 Assert.NotNull(r.Data);
-                var resolutionParams = (r.Data as JObject).ToObject<RazorCodeActionResolutionParams>();
+                var resolutionParams = ((JObject)r.Data).ToObject<RazorCodeActionResolutionParams>();
+                Assert.NotNull(resolutionParams);
                 Assert.Equal(LanguageServerConstants.CodeActions.AddUsing, resolutionParams.Action);
             }
         );
@@ -292,7 +300,7 @@ public class TypeAccessibilityCodeActionProviderTest : LanguageServerTestBase
         var contents = "@code { Path; }";
         var request = new CodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier{ Uri = new Uri(documentPath) },
+            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
             Context = new CodeActionContext()
             {
@@ -322,13 +330,15 @@ public class TypeAccessibilityCodeActionProviderTest : LanguageServerTestBase
         var results = await provider.ProvideAsync(context, csharpCodeActions, default);
 
         // Assert
+        Assert.NotNull(results);
         Assert.Collection(results,
             r =>
             {
                 Assert.Equal("@using System.IO", r.Title);
                 Assert.Null(r.Edit);
                 Assert.NotNull(r.Data);
-                var resolutionParams = (r.Data as JObject).ToObject<RazorCodeActionResolutionParams>();
+                var resolutionParams = ((JObject)r.Data).ToObject<RazorCodeActionResolutionParams>();
+                Assert.NotNull(resolutionParams);
                 Assert.Equal(LanguageServerConstants.CodeActions.AddUsing, resolutionParams.Action);
             },
             r =>
@@ -348,7 +358,7 @@ public class TypeAccessibilityCodeActionProviderTest : LanguageServerTestBase
         var contents = "@code { Path; }";
         var request = new CodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier{ Uri = new Uri(documentPath) },
+            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
             Context = new CodeActionContext()
             {
@@ -398,13 +408,15 @@ public class TypeAccessibilityCodeActionProviderTest : LanguageServerTestBase
         var results = await provider.ProvideAsync(context, csharpCodeActions, default);
 
         // Assert
+        Assert.NotNull(results);
         Assert.Collection(results,
             r =>
             {
                 Assert.Equal("@using SuperSpecialNamespace", r.Title);
                 Assert.Null(r.Edit);
                 Assert.NotNull(r.Data);
-                var resolutionParams = (r.Data as JObject).ToObject<RazorCodeActionResolutionParams>();
+                var resolutionParams = ((JObject)r.Data).ToObject<RazorCodeActionResolutionParams>();
+                Assert.NotNull(resolutionParams);
                 Assert.Equal(LanguageServerConstants.CodeActions.AddUsing, resolutionParams.Action);
             },
             r =>
@@ -412,7 +424,8 @@ public class TypeAccessibilityCodeActionProviderTest : LanguageServerTestBase
                 Assert.Equal("@using System.IO", r.Title);
                 Assert.Null(r.Edit);
                 Assert.NotNull(r.Data);
-                var resolutionParams = (r.Data as JObject).ToObject<RazorCodeActionResolutionParams>();
+                var resolutionParams = ((JObject)r.Data).ToObject<RazorCodeActionResolutionParams>();
+                Assert.NotNull(resolutionParams);
                 Assert.Equal(LanguageServerConstants.CodeActions.AddUsing, resolutionParams.Action);
             },
             r =>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -24,726 +22,737 @@ using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
 
-    public class CodeActionEndpointTest : LanguageServerTestBase
+public class CodeActionEndpointTest : LanguageServerTestBase
+{
+    private readonly RazorDocumentMappingService _documentMappingService;
+    private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
+    private readonly ClientNotifierServiceBase _languageServer;
+
+    public CodeActionEndpointTest(ITestOutputHelper testOutput)
+        : base(testOutput)
     {
-        private readonly RazorDocumentMappingService _documentMappingService;
-        private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
-        private readonly ClientNotifierServiceBase _languageServer;
+        _documentMappingService = Mock.Of<RazorDocumentMappingService>(
+            s => s.TryMapToProjectedDocumentRange(
+                It.IsAny<RazorCodeDocument>(),
+                It.IsAny<Range>(),
+                out It.Ref<Range?>.IsAny) == false &&
 
-        public CodeActionEndpointTest(ITestOutputHelper testOutput)
-            : base(testOutput)
+                s.GetLanguageKind(It.IsAny<RazorCodeDocument>(), It.IsAny<int>(), It.IsAny<bool>()) == RazorLanguageKind.CSharp,
+
+            MockBehavior.Strict);
+
+        _languageServerFeatureOptions = Mock.Of<LanguageServerFeatureOptions>(
+            l => l.SupportsFileManipulation == true,
+            MockBehavior.Strict);
+
+        _languageServer = Mock.Of<ClientNotifierServiceBase>(MockBehavior.Strict);
+    }
+
+    [Fact]
+    public async Task Handle_NoDocument()
+    {
+        // Arrange
+        var documentPath = new Uri("C:/path/to/Page.razor");
+        var codeActionEndpoint = new CodeActionEndpoint(
+            _documentMappingService,
+            Array.Empty<RazorCodeActionProvider>(),
+            Array.Empty<CSharpCodeActionProvider>(),
+            Array.Empty<HtmlCodeActionProvider>(),
+            _languageServer,
+            _languageServerFeatureOptions)
         {
-            _documentMappingService = Mock.Of<RazorDocumentMappingService>(
-                s => s.TryMapToProjectedDocumentRange(
-                    It.IsAny<RazorCodeDocument>(),
-                    It.IsAny<Range>(),
-                    out It.Ref<Range>.IsAny) == false &&
-
-                    s.GetLanguageKind(It.IsAny<RazorCodeDocument>(), It.IsAny<int>(), It.IsAny<bool>()) == RazorLanguageKind.CSharp,
-
-                MockBehavior.Strict);
-
-            _languageServerFeatureOptions = Mock.Of<LanguageServerFeatureOptions>(
-                l => l.SupportsFileManipulation == true,
-                MockBehavior.Strict);
-
-            _languageServer = Mock.Of<ClientNotifierServiceBase>(MockBehavior.Strict);
-        }
-
-        [Fact]
-        public async Task Handle_NoDocument()
+            _supportsCodeActionResolve = false
+        };
+        var request = new CodeActionParams()
         {
-            // Arrange
-            var documentPath = new Uri("C:/path/to/Page.razor");
-            var codeActionEndpoint = new CodeActionEndpoint(
-                _documentMappingService,
-                Array.Empty<RazorCodeActionProvider>(),
-                Array.Empty<CSharpCodeActionProvider>(),
-                Array.Empty<HtmlCodeActionProvider>(),
-                _languageServer,
-                _languageServerFeatureOptions)
-            {
-                _supportsCodeActionResolve = false
-            };
-            var request = new CodeActionParams()
-            {
-                TextDocument = new TextDocumentIdentifier { Uri = documentPath },
-                Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
-                Context = new CodeActionContext()
-            };
+            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
+            Context = new CodeActionContext()
+        };
 
-            var requestContext = CreateRazorRequestContext(documentContext: null);
+        var requestContext = CreateRazorRequestContext(documentContext: null);
 
-            // Act
-            var commandOrCodeActionContainer = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
+        // Act
+        var commandOrCodeActionContainer = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
 
-            // Assert
-            Assert.Null(commandOrCodeActionContainer);
-        }
+        // Assert
+        Assert.Null(commandOrCodeActionContainer);
+    }
 
-        [Fact]
-        public async Task Handle_UnsupportedDocument()
+    [Fact]
+    public async Task Handle_UnsupportedDocument()
+    {
+        // Arrange
+        var documentPath = new Uri("C:/path/to/Page.razor");
+        var codeDocument = CreateCodeDocument("@code {}");
+        var documentContext = CreateDocumentContext(documentPath, codeDocument);
+        codeDocument.SetUnsupported();
+        var codeActionEndpoint = new CodeActionEndpoint(
+            _documentMappingService,
+            Array.Empty<RazorCodeActionProvider>(),
+            Array.Empty<CSharpCodeActionProvider>(),
+            Array.Empty<HtmlCodeActionProvider>(),
+            _languageServer,
+            _languageServerFeatureOptions)
         {
-            // Arrange
-            var documentPath = new Uri("C:/path/to/Page.razor");
-            var codeDocument = CreateCodeDocument("@code {}");
-            var documentContext = CreateDocumentContext(documentPath, codeDocument);
-            codeDocument.SetUnsupported();
-            var codeActionEndpoint = new CodeActionEndpoint(
-                _documentMappingService,
-                Array.Empty<RazorCodeActionProvider>(),
-                Array.Empty<CSharpCodeActionProvider>(),
-                Array.Empty<HtmlCodeActionProvider>(),
-                _languageServer,
-                _languageServerFeatureOptions)
-            {
-                _supportsCodeActionResolve = false
-            };
-            var request = new CodeActionParams()
-            {
-                TextDocument = new TextDocumentIdentifier { Uri = documentPath },
-                Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
-                Context = new VSInternalCodeActionContext()
-            };
-            var requestContext = CreateRazorRequestContext(documentContext);
-
-            // Act
-            var commandOrCodeActionContainer = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
-
-            // Assert
-            Assert.Null(commandOrCodeActionContainer);
-        }
-
-        [Fact]
-        public async Task Handle_NoProviders()
+            _supportsCodeActionResolve = false
+        };
+        var request = new CodeActionParams()
         {
-            // Arrange
-            var documentPath = new Uri("C:/path/to/Page.razor");
-            var codeDocument = CreateCodeDocument("@code {}");
-            var documentContext = CreateDocumentContext(documentPath, codeDocument);
-            var codeActionEndpoint = new CodeActionEndpoint(
-                _documentMappingService,
-                Array.Empty<RazorCodeActionProvider>(),
-                Array.Empty<CSharpCodeActionProvider>(),
-                Array.Empty<HtmlCodeActionProvider>(),
-                _languageServer,
-                _languageServerFeatureOptions)
-            {
-                _supportsCodeActionResolve = false
-            };
-            var request = new CodeActionParams()
-            {
-                TextDocument = new TextDocumentIdentifier { Uri = documentPath },
-                Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
-                Context = new VSInternalCodeActionContext()
-            };
-            var requestContext = CreateRazorRequestContext(documentContext);
+            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
+            Context = new VSInternalCodeActionContext()
+        };
+        var requestContext = CreateRazorRequestContext(documentContext);
 
-            // Act
-            var commandOrCodeActionContainer = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
+        // Act
+        var commandOrCodeActionContainer = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
 
-            // Assert
-            Assert.Null(commandOrCodeActionContainer);
-        }
+        // Assert
+        Assert.Null(commandOrCodeActionContainer);
+    }
 
-        [Fact]
-        public async Task Handle_OneRazorCodeActionProvider()
+    [Fact]
+    public async Task Handle_NoProviders()
+    {
+        // Arrange
+        var documentPath = new Uri("C:/path/to/Page.razor");
+        var codeDocument = CreateCodeDocument("@code {}");
+        var documentContext = CreateDocumentContext(documentPath, codeDocument);
+        var codeActionEndpoint = new CodeActionEndpoint(
+            _documentMappingService,
+            Array.Empty<RazorCodeActionProvider>(),
+            Array.Empty<CSharpCodeActionProvider>(),
+            Array.Empty<HtmlCodeActionProvider>(),
+            _languageServer,
+            _languageServerFeatureOptions)
         {
-            // Arrange
-            var documentPath = new Uri("C:/path/to/Page.razor");
-            var codeDocument = CreateCodeDocument("@code {}");
-            var documentContext = CreateDocumentContext(documentPath, codeDocument);
-            var codeActionEndpoint = new CodeActionEndpoint(
-                _documentMappingService,
-                new RazorCodeActionProvider[] {
+            _supportsCodeActionResolve = false
+        };
+        var request = new CodeActionParams()
+        {
+            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
+            Context = new VSInternalCodeActionContext()
+        };
+        var requestContext = CreateRazorRequestContext(documentContext);
+
+        // Act
+        var commandOrCodeActionContainer = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
+
+        // Assert
+        Assert.Null(commandOrCodeActionContainer);
+    }
+
+    [Fact]
+    public async Task Handle_OneRazorCodeActionProvider()
+    {
+        // Arrange
+        var documentPath = new Uri("C:/path/to/Page.razor");
+        var codeDocument = CreateCodeDocument("@code {}");
+        var documentContext = CreateDocumentContext(documentPath, codeDocument);
+        var codeActionEndpoint = new CodeActionEndpoint(
+            _documentMappingService,
+            new RazorCodeActionProvider[] {
                     new MockRazorCodeActionProvider()
-                },
-                Array.Empty<CSharpCodeActionProvider>(),
-                Array.Empty<HtmlCodeActionProvider>(),
-                _languageServer,
-                _languageServerFeatureOptions)
-            {
-                _supportsCodeActionResolve = false
-            };
-
-            var request = new CodeActionParams()
-            {
-                TextDocument = new TextDocumentIdentifier { Uri = documentPath },
-                Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
-                Context = new VSInternalCodeActionContext()
-            };
-            var requestContext = CreateRazorRequestContext(documentContext);
-
-            // Act
-            var commandOrCodeActionContainer = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
-
-            // Assert
-            Assert.Single(commandOrCodeActionContainer);
-        }
-
-        [Fact]
-        public async Task Handle_OneCSharpCodeActionProvider()
+            },
+            Array.Empty<CSharpCodeActionProvider>(),
+            Array.Empty<HtmlCodeActionProvider>(),
+            _languageServer,
+            _languageServerFeatureOptions)
         {
-            // Arrange
-            var documentPath = new Uri("C:/path/to/Page.razor");
-            var codeDocument = CreateCodeDocument("@code {}");
-            var documentContext = CreateDocumentContext(documentPath, codeDocument);
-            var documentMappingService = CreateDocumentMappingService();
-            var languageServer = CreateLanguageServer();
-            var codeActionEndpoint = new CodeActionEndpoint(
-                documentMappingService,
-                Array.Empty<RazorCodeActionProvider>(),
-                new CSharpCodeActionProvider[] {
+            _supportsCodeActionResolve = false
+        };
+
+        var request = new CodeActionParams()
+        {
+            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
+            Context = new VSInternalCodeActionContext()
+        };
+        var requestContext = CreateRazorRequestContext(documentContext);
+
+        // Act
+        var commandOrCodeActionContainer = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
+
+        // Assert
+        Assert.NotNull(commandOrCodeActionContainer);
+        Assert.Single(commandOrCodeActionContainer);
+    }
+
+    [Fact]
+    public async Task Handle_OneCSharpCodeActionProvider()
+    {
+        // Arrange
+        var documentPath = new Uri("C:/path/to/Page.razor");
+        var codeDocument = CreateCodeDocument("@code {}");
+        var documentContext = CreateDocumentContext(documentPath, codeDocument);
+        var documentMappingService = CreateDocumentMappingService();
+        var languageServer = CreateLanguageServer();
+        var codeActionEndpoint = new CodeActionEndpoint(
+            documentMappingService,
+            Array.Empty<RazorCodeActionProvider>(),
+            new CSharpCodeActionProvider[] {
                     new MockCSharpCodeActionProvider()
-                },
-                Array.Empty<HtmlCodeActionProvider>(),
-                languageServer,
-                _languageServerFeatureOptions)
-            {
-                _supportsCodeActionResolve = false
-            };
-
-            var request = new CodeActionParams()
-            {
-                TextDocument = new TextDocumentIdentifier { Uri = documentPath },
-                Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
-                Context = new VSInternalCodeActionContext()
-            };
-            var requestContext = CreateRazorRequestContext(documentContext);
-
-            // Act
-            var commandOrCodeActionContainer = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
-
-            // Assert
-            Assert.Single(commandOrCodeActionContainer);
-        }
-
-        [Fact]
-        public async Task Handle_OneCodeActionProviderWithMultipleCodeActions()
+            },
+            Array.Empty<HtmlCodeActionProvider>(),
+            languageServer,
+            _languageServerFeatureOptions)
         {
-            // Arrange
-            var documentPath = new Uri("C:/path/to/Page.razor");
-            var codeDocument = CreateCodeDocument("@code {}");
-            var documentContext = CreateDocumentContext(documentPath, codeDocument);
-            var codeActionEndpoint = new CodeActionEndpoint(
-                _documentMappingService,
-                new RazorCodeActionProvider[] {
+            _supportsCodeActionResolve = false
+        };
+
+        var request = new CodeActionParams()
+        {
+            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
+            Context = new VSInternalCodeActionContext()
+        };
+        var requestContext = CreateRazorRequestContext(documentContext);
+
+        // Act
+        var commandOrCodeActionContainer = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
+
+        // Assert
+        Assert.NotNull(commandOrCodeActionContainer);
+        Assert.Single(commandOrCodeActionContainer);
+    }
+
+    [Fact]
+    public async Task Handle_OneCodeActionProviderWithMultipleCodeActions()
+    {
+        // Arrange
+        var documentPath = new Uri("C:/path/to/Page.razor");
+        var codeDocument = CreateCodeDocument("@code {}");
+        var documentContext = CreateDocumentContext(documentPath, codeDocument);
+        var codeActionEndpoint = new CodeActionEndpoint(
+            _documentMappingService,
+            new RazorCodeActionProvider[] {
                     new MockMultipleRazorCodeActionProvider(),
-                },
-                Array.Empty<CSharpCodeActionProvider>(),
-                Array.Empty<HtmlCodeActionProvider>(),
-                _languageServer,
-                _languageServerFeatureOptions)
-            {
-                _supportsCodeActionResolve = false
-            };
-
-            var request = new CodeActionParams()
-            {
-                TextDocument = new TextDocumentIdentifier { Uri = documentPath },
-                Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
-                Context = new VSInternalCodeActionContext()
-            };
-            var requestContext = CreateRazorRequestContext(documentContext);
-
-            // Act
-            var commandOrCodeActionContainer = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
-
-            // Assert
-            Assert.Equal(2, commandOrCodeActionContainer.Count());
-        }
-
-        [Fact]
-        public async Task Handle_MultipleCodeActionProvidersWithMultipleCodeActions()
+            },
+            Array.Empty<CSharpCodeActionProvider>(),
+            Array.Empty<HtmlCodeActionProvider>(),
+            _languageServer,
+            _languageServerFeatureOptions)
         {
-            // Arrange
-            var documentPath = new Uri("C:/path/to/Page.razor");
-            var codeDocument = CreateCodeDocument("@code {}");
-            var documentContext = CreateDocumentContext(documentPath, codeDocument);
-            var documentMappingService = CreateDocumentMappingService();
-            var languageServer = CreateLanguageServer();
-            var codeActionEndpoint = new CodeActionEndpoint(
-                documentMappingService,
-                new RazorCodeActionProvider[] {
+            _supportsCodeActionResolve = false
+        };
+
+        var request = new CodeActionParams()
+        {
+            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
+            Context = new VSInternalCodeActionContext()
+        };
+        var requestContext = CreateRazorRequestContext(documentContext);
+
+        // Act
+        var commandOrCodeActionContainer = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
+
+        // Assert
+        Assert.NotNull(commandOrCodeActionContainer);
+        Assert.Equal(2, commandOrCodeActionContainer.Length);
+    }
+
+    [Fact]
+    public async Task Handle_MultipleCodeActionProvidersWithMultipleCodeActions()
+    {
+        // Arrange
+        var documentPath = new Uri("C:/path/to/Page.razor");
+        var codeDocument = CreateCodeDocument("@code {}");
+        var documentContext = CreateDocumentContext(documentPath, codeDocument);
+        var documentMappingService = CreateDocumentMappingService();
+        var languageServer = CreateLanguageServer();
+        var codeActionEndpoint = new CodeActionEndpoint(
+            documentMappingService,
+            new RazorCodeActionProvider[] {
                     new MockMultipleRazorCodeActionProvider(),
                     new MockMultipleRazorCodeActionProvider(),
                     new MockRazorCodeActionProvider(),
-                },
-                new CSharpCodeActionProvider[] {
+            },
+            new CSharpCodeActionProvider[] {
                     new MockCSharpCodeActionProvider(),
                     new MockCSharpCodeActionProvider()
-                },
-                Array.Empty<HtmlCodeActionProvider>(),
-                languageServer,
-                _languageServerFeatureOptions)
-            {
-                _supportsCodeActionResolve = false
-            };
-
-            var request = new CodeActionParams()
-            {
-                TextDocument = new TextDocumentIdentifier { Uri = documentPath },
-                Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
-                Context = new VSInternalCodeActionContext()
-            };
-            var requestContext = CreateRazorRequestContext(documentContext);
-
-            // Act
-            var commandOrCodeActionContainer = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
-
-            // Assert
-            Assert.Equal(7, commandOrCodeActionContainer.Count());
-        }
-
-        [Fact]
-        public async Task Handle_MultipleProviders()
+            },
+            Array.Empty<HtmlCodeActionProvider>(),
+            languageServer,
+            _languageServerFeatureOptions)
         {
-            // Arrange
-            var documentPath = new Uri("C:/path/to/Page.razor");
-            var codeDocument = CreateCodeDocument("@code {}");
-            var documentContext = CreateDocumentContext(documentPath, codeDocument);
-            var documentMappingService = CreateDocumentMappingService();
-            var languageServer = CreateLanguageServer();
-            var codeActionEndpoint = new CodeActionEndpoint(
-                documentMappingService,
-                new RazorCodeActionProvider[] {
+            _supportsCodeActionResolve = false
+        };
+
+        var request = new CodeActionParams()
+        {
+            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
+            Context = new VSInternalCodeActionContext()
+        };
+        var requestContext = CreateRazorRequestContext(documentContext);
+
+        // Act
+        var commandOrCodeActionContainer = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
+
+        // Assert
+        Assert.NotNull(commandOrCodeActionContainer);
+        Assert.Equal(7, commandOrCodeActionContainer.Length);
+    }
+
+    [Fact]
+    public async Task Handle_MultipleProviders()
+    {
+        // Arrange
+        var documentPath = new Uri("C:/path/to/Page.razor");
+        var codeDocument = CreateCodeDocument("@code {}");
+        var documentContext = CreateDocumentContext(documentPath, codeDocument);
+        var documentMappingService = CreateDocumentMappingService();
+        var languageServer = CreateLanguageServer();
+        var codeActionEndpoint = new CodeActionEndpoint(
+            documentMappingService,
+            new RazorCodeActionProvider[] {
                     new MockRazorCodeActionProvider(),
                     new MockRazorCodeActionProvider(),
                     new MockRazorCodeActionProvider(),
-                },
-                new CSharpCodeActionProvider[] {
+            },
+            new CSharpCodeActionProvider[] {
                     new MockCSharpCodeActionProvider(),
                     new MockCSharpCodeActionProvider()
-                },
-                Array.Empty<HtmlCodeActionProvider>(),
-                languageServer,
-                _languageServerFeatureOptions)
-            {
-                _supportsCodeActionResolve = false
-            };
-
-            var request = new CodeActionParams()
-            {
-                TextDocument = new TextDocumentIdentifier { Uri = documentPath },
-                Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
-                Context = new VSInternalCodeActionContext()
-            };
-            var requestContext = CreateRazorRequestContext(documentContext);
-
-            // Act
-            var commandOrCodeActionContainer = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
-
-            // Assert
-            Assert.Equal(5, commandOrCodeActionContainer.Count());
-        }
-
-        [Fact]
-        public async Task Handle_OneNullReturningProvider()
+            },
+            Array.Empty<HtmlCodeActionProvider>(),
+            languageServer,
+            _languageServerFeatureOptions)
         {
-            // Arrange
-            var documentPath = new Uri("C:/path/to/Page.razor");
-            var codeDocument = CreateCodeDocument("@code {}");
-            var documentContext = CreateDocumentContext(documentPath, codeDocument);
-            var codeActionEndpoint = new CodeActionEndpoint(
-                _documentMappingService,
-                new RazorCodeActionProvider[] {
+            _supportsCodeActionResolve = false
+        };
+
+        var request = new CodeActionParams()
+        {
+            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
+            Context = new VSInternalCodeActionContext()
+        };
+        var requestContext = CreateRazorRequestContext(documentContext);
+
+        // Act
+        var commandOrCodeActionContainer = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
+
+        // Assert
+        Assert.NotNull(commandOrCodeActionContainer);
+        Assert.Equal(5, commandOrCodeActionContainer.Length);
+    }
+
+    [Fact]
+    public async Task Handle_OneNullReturningProvider()
+    {
+        // Arrange
+        var documentPath = new Uri("C:/path/to/Page.razor");
+        var codeDocument = CreateCodeDocument("@code {}");
+        var documentContext = CreateDocumentContext(documentPath, codeDocument);
+        var codeActionEndpoint = new CodeActionEndpoint(
+            _documentMappingService,
+            new RazorCodeActionProvider[] {
                     new MockNullRazorCodeActionProvider()
-                },
-                Array.Empty<CSharpCodeActionProvider>(),
-                Array.Empty<HtmlCodeActionProvider>(),
-                _languageServer,
-                _languageServerFeatureOptions)
-            {
-                _supportsCodeActionResolve = false
-            };
-
-            var request = new CodeActionParams()
-            {
-                TextDocument = new TextDocumentIdentifier { Uri = documentPath },
-                Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
-                Context = new VSInternalCodeActionContext()
-            };
-            var requestContext = CreateRazorRequestContext(documentContext);
-
-            // Act
-            var commandOrCodeActionContainer = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
-
-            // Assert
-            Assert.Null(commandOrCodeActionContainer);
-        }
-
-        [Fact]
-        public async Task Handle_MultipleMixedProvider()
+            },
+            Array.Empty<CSharpCodeActionProvider>(),
+            Array.Empty<HtmlCodeActionProvider>(),
+            _languageServer,
+            _languageServerFeatureOptions)
         {
-            // Arrange
-            var documentPath = new Uri("C:/path/to/Page.razor");
-            var codeDocument = CreateCodeDocument("@code {}");
-            var documentContext = CreateDocumentContext(documentPath, codeDocument);
-            var documentMappingService = CreateDocumentMappingService();
-            var languageServer = CreateLanguageServer();
-            var codeActionEndpoint = new CodeActionEndpoint(
-                documentMappingService,
-                new RazorCodeActionProvider[] {
+            _supportsCodeActionResolve = false
+        };
+
+        var request = new CodeActionParams()
+        {
+            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
+            Context = new VSInternalCodeActionContext()
+        };
+        var requestContext = CreateRazorRequestContext(documentContext);
+
+        // Act
+        var commandOrCodeActionContainer = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
+
+        // Assert
+        Assert.Null(commandOrCodeActionContainer);
+    }
+
+    [Fact]
+    public async Task Handle_MultipleMixedProvider()
+    {
+        // Arrange
+        var documentPath = new Uri("C:/path/to/Page.razor");
+        var codeDocument = CreateCodeDocument("@code {}");
+        var documentContext = CreateDocumentContext(documentPath, codeDocument);
+        var documentMappingService = CreateDocumentMappingService();
+        var languageServer = CreateLanguageServer();
+        var codeActionEndpoint = new CodeActionEndpoint(
+            documentMappingService,
+            new RazorCodeActionProvider[] {
                     new MockRazorCodeActionProvider(),
                     new MockNullRazorCodeActionProvider(),
                     new MockRazorCodeActionProvider(),
                     new MockNullRazorCodeActionProvider(),
-                },
-                new CSharpCodeActionProvider[] {
+            },
+            new CSharpCodeActionProvider[] {
                     new MockCSharpCodeActionProvider(),
                     new MockCSharpCodeActionProvider()
-                },
-                Array.Empty<HtmlCodeActionProvider>(),
-                languageServer,
-                _languageServerFeatureOptions)
-            {
-                _supportsCodeActionResolve = false
-            };
-
-            var request = new CodeActionParams()
-            {
-                TextDocument = new TextDocumentIdentifier { Uri = documentPath },
-                Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
-                Context = new VSInternalCodeActionContext()
-            };
-            var requestContext = CreateRazorRequestContext(documentContext);
-
-            // Act
-            var commandOrCodeActionContainer = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
-
-            // Assert
-            Assert.Equal(4, commandOrCodeActionContainer.Count());
-        }
-
-        [Fact]
-        public async Task Handle_MultipleMixedProvider_SupportsCodeActionResolveTrue()
+            },
+            Array.Empty<HtmlCodeActionProvider>(),
+            languageServer,
+            _languageServerFeatureOptions)
         {
-            // Arrange
-            var documentPath = new Uri("C:/path/to/Page.razor");
-            var codeDocument = CreateCodeDocument("@code {}");
-            var documentContext = CreateDocumentContext(documentPath, codeDocument);
-            var codeActionEndpoint = new CodeActionEndpoint(
-                _documentMappingService,
-                new RazorCodeActionProvider[] {
+            _supportsCodeActionResolve = false
+        };
+
+        var request = new CodeActionParams()
+        {
+            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
+            Context = new VSInternalCodeActionContext()
+        };
+        var requestContext = CreateRazorRequestContext(documentContext);
+
+        // Act
+        var commandOrCodeActionContainer = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
+
+        // Assert
+        Assert.NotNull(commandOrCodeActionContainer);
+        Assert.Equal(4, commandOrCodeActionContainer.Length);
+    }
+
+    [Fact]
+    public async Task Handle_MultipleMixedProvider_SupportsCodeActionResolveTrue()
+    {
+        // Arrange
+        var documentPath = new Uri("C:/path/to/Page.razor");
+        var codeDocument = CreateCodeDocument("@code {}");
+        var documentContext = CreateDocumentContext(documentPath, codeDocument);
+        var codeActionEndpoint = new CodeActionEndpoint(
+            _documentMappingService,
+            new RazorCodeActionProvider[] {
                     new MockRazorCodeActionProvider(),
                     new MockRazorCommandProvider(),
                     new MockNullRazorCodeActionProvider()
-                },
-                Array.Empty<CSharpCodeActionProvider>(),
-                Array.Empty<HtmlCodeActionProvider>(),
-                _languageServer,
-                _languageServerFeatureOptions)
-            {
-                _supportsCodeActionResolve = true
-            };
-
-            var request = new CodeActionParams()
-            {
-                TextDocument = new TextDocumentIdentifier { Uri = documentPath },
-                Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
-                Context = new VSInternalCodeActionContext()
-            };
-            var requestContext = CreateRazorRequestContext(documentContext);
-
-            // Act
-            var commandOrCodeActionContainer = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
-
-            // Assert
-            Assert.Collection(commandOrCodeActionContainer,
-                c =>
-                {
-                    Assert.True(c.TryGetSecond(out var codeAction));
-                    Assert.True(codeAction is VSInternalCodeAction);
-                },
-                c =>
-                {
-                    Assert.True(c.TryGetSecond(out var codeAction));
-                    Assert.True(codeAction is VSInternalCodeAction);
-                });
-        }
-
-        [Fact]
-        public async Task Handle_MultipleMixedProvider_SupportsCodeActionResolveFalse()
+            },
+            Array.Empty<CSharpCodeActionProvider>(),
+            Array.Empty<HtmlCodeActionProvider>(),
+            _languageServer,
+            _languageServerFeatureOptions)
         {
-            // Arrange
-            var documentPath = new Uri("C:/path/to/Page.razor");
-            var codeDocument = CreateCodeDocument("@code {}");
-            var documentContext = CreateDocumentContext(documentPath, codeDocument);
-            var codeActionEndpoint = new CodeActionEndpoint(
-                _documentMappingService,
-                new RazorCodeActionProvider[] {
+            _supportsCodeActionResolve = true
+        };
+
+        var request = new CodeActionParams()
+        {
+            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
+            Context = new VSInternalCodeActionContext()
+        };
+        var requestContext = CreateRazorRequestContext(documentContext);
+
+        // Act
+        var commandOrCodeActionContainer = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
+
+        // Assert
+        Assert.NotNull(commandOrCodeActionContainer);
+        Assert.Collection(commandOrCodeActionContainer,
+            c =>
+            {
+                Assert.True(c.TryGetSecond(out var codeAction));
+                Assert.True(codeAction is VSInternalCodeAction);
+            },
+            c =>
+            {
+                Assert.True(c.TryGetSecond(out var codeAction));
+                Assert.True(codeAction is VSInternalCodeAction);
+            });
+    }
+
+    [Fact]
+    public async Task Handle_MultipleMixedProvider_SupportsCodeActionResolveFalse()
+    {
+        // Arrange
+        var documentPath = new Uri("C:/path/to/Page.razor");
+        var codeDocument = CreateCodeDocument("@code {}");
+        var documentContext = CreateDocumentContext(documentPath, codeDocument);
+        var codeActionEndpoint = new CodeActionEndpoint(
+            _documentMappingService,
+            new RazorCodeActionProvider[] {
                     new MockRazorCodeActionProvider(),
                     new MockRazorCommandProvider(),
                     new MockNullRazorCodeActionProvider()
-                },
-                Array.Empty<CSharpCodeActionProvider>(),
-                Array.Empty<HtmlCodeActionProvider>(),
-                _languageServer,
-                _languageServerFeatureOptions)
-            {
-                _supportsCodeActionResolve = false
-            };
-
-            var request = new CodeActionParams()
-            {
-                TextDocument = new TextDocumentIdentifier { Uri = documentPath },
-                Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
-                Context = new VSInternalCodeActionContext()
-            };
-            var requestContext = CreateRazorRequestContext(documentContext);
-
-            // Act
-            var commandOrCodeActionContainer = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
-
-            // Assert
-            Assert.Collection(commandOrCodeActionContainer,
-                c =>
-                {
-                    Assert.True(c.TryGetFirst(out var command1));
-                    var command = Assert.IsType<Command>(command1);
-                    var codeActionParamsToken = (JToken)command.Arguments.First();
-                    var codeActionParams = codeActionParamsToken.ToObject<RazorCodeActionResolutionParams>();
-                    Assert.Equal(LanguageServerConstants.CodeActions.EditBasedCodeActionCommand, codeActionParams.Action);
-                },
-                c => Assert.True(c.TryGetFirst(out var _)));
-        }
-
-        [Fact]
-        public async Task GenerateRazorCodeActionContextAsync_WithSelectionRange()
+            },
+            Array.Empty<CSharpCodeActionProvider>(),
+            Array.Empty<HtmlCodeActionProvider>(),
+            _languageServer,
+            _languageServerFeatureOptions)
         {
-            // Arrange
-            var documentPath = new Uri("C:/path/to/Page.razor");
-            var codeDocument = CreateCodeDocument("@code {}");
-            var documentContext = CreateDocumentContext(documentPath, codeDocument);
-            var codeActionEndpoint = new CodeActionEndpoint(
-                _documentMappingService,
-                new RazorCodeActionProvider[] {
+            _supportsCodeActionResolve = false
+        };
+
+        var request = new CodeActionParams()
+        {
+            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
+            Context = new VSInternalCodeActionContext()
+        };
+        var requestContext = CreateRazorRequestContext(documentContext);
+
+        // Act
+        var commandOrCodeActionContainer = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
+
+        // Assert
+        Assert.NotNull(commandOrCodeActionContainer);
+        Assert.Collection(commandOrCodeActionContainer,
+            c =>
+            {
+                Assert.True(c.TryGetFirst(out var command1));
+                var command = Assert.IsType<Command>(command1);
+                var codeActionParamsToken = (JToken)command.Arguments!.First();
+                var codeActionParams = codeActionParamsToken.ToObject<RazorCodeActionResolutionParams>();
+                Assert.NotNull(codeActionParams);
+                Assert.Equal(LanguageServerConstants.CodeActions.EditBasedCodeActionCommand, codeActionParams.Action);
+            },
+            c => Assert.True(c.TryGetFirst(out var _)));
+    }
+
+    [Fact]
+    public async Task GenerateRazorCodeActionContextAsync_WithSelectionRange()
+    {
+        // Arrange
+        var documentPath = new Uri("C:/path/to/Page.razor");
+        var codeDocument = CreateCodeDocument("@code {}");
+        var documentContext = CreateDocumentContext(documentPath, codeDocument);
+        var codeActionEndpoint = new CodeActionEndpoint(
+            _documentMappingService,
+            new RazorCodeActionProvider[] {
                     new MockRazorCodeActionProvider()
-                },
-                Array.Empty<CSharpCodeActionProvider>(),
-                Array.Empty<HtmlCodeActionProvider>(),
-                _languageServer,
-                _languageServerFeatureOptions)
-            {
-                _supportsCodeActionResolve = false
-            };
-
-            var initialRange = new Range { Start = new Position(0, 1), End = new Position(0, 1) };
-            var selectionRange = new Range { Start = new Position(0, 5), End = new Position(0, 5) };
-            var request = new CodeActionParams()
-            {
-                TextDocument = new TextDocumentIdentifier { Uri = documentPath },
-                Range = initialRange,
-                Context = new VSInternalCodeActionContext()
-                {
-                    SelectionRange = selectionRange,
-                }
-            };
-
-            // Act
-            var razorCodeActionContext = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot);
-
-            // Assert
-            Assert.NotNull(razorCodeActionContext);
-            Assert.Equal(selectionRange, razorCodeActionContext.Request.Range);
-        }
-
-        [Fact]
-        public async Task GenerateRazorCodeActionContextAsync_WithoutSelectionRange()
+            },
+            Array.Empty<CSharpCodeActionProvider>(),
+            Array.Empty<HtmlCodeActionProvider>(),
+            _languageServer,
+            _languageServerFeatureOptions)
         {
-            // Arrange
-            var documentPath = new Uri("C:/path/to/Page.razor");
-            var codeDocument = CreateCodeDocument("@code {}");
-            var documentContext = CreateDocumentContext(documentPath, codeDocument);
-            var codeActionEndpoint = new CodeActionEndpoint(
-                _documentMappingService,
-                new RazorCodeActionProvider[] {
-                    new MockRazorCodeActionProvider()
-                },
-                Array.Empty<CSharpCodeActionProvider>(),
-                Array.Empty<HtmlCodeActionProvider>(),
-                _languageServer,
-                _languageServerFeatureOptions)
-            {
-                _supportsCodeActionResolve = false
-            };
+            _supportsCodeActionResolve = false
+        };
 
-            var initialRange = new Range { Start = new Position(0, 1), End = new Position(0, 1) };
-            var request = new CodeActionParams()
-            {
-                TextDocument = new TextDocumentIdentifier { Uri = documentPath },
-                Range = initialRange,
-                Context = new VSInternalCodeActionContext()
-                {
-                    SelectionRange = null
-                }
-            };
-
-            // Act
-            var razorCodeActionContext = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot);
-
-            // Assert
-            Assert.NotNull(razorCodeActionContext);
-            Assert.Equal(initialRange, razorCodeActionContext.Request.Range);
-        }
-
-        [Fact]
-        public async Task GetCSharpCodeActionsFromLanguageServerAsync_InvalidRangeMapping()
+        var initialRange = new Range { Start = new Position(0, 1), End = new Position(0, 1) };
+        var selectionRange = new Range { Start = new Position(0, 5), End = new Position(0, 5) };
+        var request = new CodeActionParams()
         {
-            // Arrange
-            var documentPath = new Uri("C:/path/to/Page.razor");
-            var codeDocument = CreateCodeDocument("@code {}");
-            var documentContext = CreateDocumentContext(documentPath, codeDocument);
-            Range projectedRange = null;
-            var documentMappingService = Mock.Of<DefaultRazorDocumentMappingService>(
-                d => d.TryMapToProjectedDocumentRange(It.IsAny<RazorCodeDocument>(), It.IsAny<Range>(), out projectedRange) == false
-            , MockBehavior.Strict);
-            var codeActionEndpoint = new CodeActionEndpoint(
-                documentMappingService,
-                Array.Empty<RazorCodeActionProvider>(),
-                new CSharpCodeActionProvider[] {
-                    new MockCSharpCodeActionProvider()
-                },
-                Array.Empty<HtmlCodeActionProvider>(),
-                _languageServer,
-                _languageServerFeatureOptions)
+            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            Range = initialRange,
+            Context = new VSInternalCodeActionContext()
             {
-                _supportsCodeActionResolve = false
-            };
-
-            var initialRange = new Range { Start = new Position(0, 1), End = new Position(0, 1) };
-            var request = new CodeActionParams()
-            {
-                TextDocument = new TextDocumentIdentifier { Uri = documentPath },
-                Range = initialRange,
-                Context = new VSInternalCodeActionContext()
-            };
-
-            var context = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot);
-
-            // Act
-            var results = await codeActionEndpoint.GetCodeActionsFromLanguageServerAsync(RazorLanguageKind.CSharp, documentContext, context, default);
-
-            // Assert
-            Assert.Empty(results);
-            Assert.Equal(initialRange, context.Request.Range);
-        }
-
-        [Fact]
-        public async Task GetCSharpCodeActionsFromLanguageServerAsync_ReturnsCodeActions()
-        {
-            // Arrange
-            var documentPath = new Uri("C:/path/to/Page.razor");
-            var codeDocument = CreateCodeDocument("@code {}");
-            var documentContext = CreateDocumentContext(documentPath, codeDocument);
-            var projectedRange = new Range { Start = new Position(15, 2), End = new Position(15, 2) };
-            var documentMappingService = CreateDocumentMappingService(projectedRange);
-            var languageServer = CreateLanguageServer();
-            var codeActionEndpoint = new CodeActionEndpoint(
-                documentMappingService,
-                Array.Empty<RazorCodeActionProvider>(),
-                new CSharpCodeActionProvider[] {
-                    new MockCSharpCodeActionProvider()
-                },
-                Array.Empty<HtmlCodeActionProvider>(),
-                languageServer,
-                _languageServerFeatureOptions)
-            {
-                _supportsCodeActionResolve = false
-            };
-
-            var initialRange = new Range { Start = new Position(0, 1), End = new Position(0, 1) };
-            var request = new CodeActionParams()
-            {
-                TextDocument = new TextDocumentIdentifier { Uri = documentPath },
-                Range = initialRange,
-                Context = new VSInternalCodeActionContext()
-                {
-                    SelectionRange = initialRange
-                }
-            };
-
-            var context = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot);
-
-            // Act
-            var results = await codeActionEndpoint.GetCodeActionsFromLanguageServerAsync(RazorLanguageKind.CSharp, documentContext, context, default);
-
-            // Assert
-            Assert.Single(results);
-            var diagnostics = results.Single().Diagnostics.ToArray();
-            Assert.Equal(2, diagnostics.Length);
-
-            // Diagnostic ranges contain the projected range for
-            // 1. Range
-            // 2. SelectionRange
-            //
-            // This helps verify that the CodeActionEndpoint is mapping the
-            // ranges correctly using the mapping service
-            Assert.Equal(projectedRange, diagnostics[0].Range);
-            Assert.Equal(projectedRange, diagnostics[1].Range);
-        }
-
-        private static DefaultRazorDocumentMappingService CreateDocumentMappingService(Range projectedRange = null)
-        {
-            projectedRange ??= new Range { Start = new Position(5, 2), End = new Position(5, 2) };
-            var documentMappingService = Mock.Of<DefaultRazorDocumentMappingService>(
-                d => d.TryMapToProjectedDocumentRange(It.IsAny<RazorCodeDocument>(), It.IsAny<Range>(), out projectedRange) == true &&
-                     d.GetLanguageKind(It.IsAny<RazorCodeDocument>(), It.IsAny<int>(), It.IsAny<bool>()) == RazorLanguageKind.CSharp
-            , MockBehavior.Strict);
-            return documentMappingService;
-        }
-
-        private static ClientNotifierServiceBase CreateLanguageServer()
-        {
-            return new TestLanguageServer();
-        }
-
-        private static RazorCodeDocument CreateCodeDocument(string text)
-        {
-            var codeDocument = TestRazorCodeDocument.CreateEmpty();
-            var sourceDocument = TestRazorSourceDocument.Create(text);
-            var syntaxTree = RazorSyntaxTree.Parse(sourceDocument);
-            codeDocument.SetSyntaxTree(syntaxTree);
-            return codeDocument;
-        }
-
-        private class MockRazorCodeActionProvider : RazorCodeActionProvider
-        {
-            public override Task<IReadOnlyList<RazorVSInternalCodeAction>> ProvideAsync(RazorCodeActionContext context, CancellationToken cancellationToken)
-            {
-                return Task.FromResult(new List<RazorVSInternalCodeAction>() { new RazorVSInternalCodeAction() } as IReadOnlyList<RazorVSInternalCodeAction>);
+                SelectionRange = selectionRange,
             }
-        }
+        };
 
-        private class MockMultipleRazorCodeActionProvider : RazorCodeActionProvider
+        // Act
+        var razorCodeActionContext = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot);
+
+        // Assert
+        Assert.NotNull(razorCodeActionContext);
+        Assert.Equal(selectionRange, razorCodeActionContext.Request.Range);
+    }
+
+    [Fact]
+    public async Task GenerateRazorCodeActionContextAsync_WithoutSelectionRange()
+    {
+        // Arrange
+        var documentPath = new Uri("C:/path/to/Page.razor");
+        var codeDocument = CreateCodeDocument("@code {}");
+        var documentContext = CreateDocumentContext(documentPath, codeDocument);
+        var codeActionEndpoint = new CodeActionEndpoint(
+            _documentMappingService,
+            new RazorCodeActionProvider[] {
+                    new MockRazorCodeActionProvider()
+            },
+            Array.Empty<CSharpCodeActionProvider>(),
+            Array.Empty<HtmlCodeActionProvider>(),
+            _languageServer,
+            _languageServerFeatureOptions)
         {
-            public override Task<IReadOnlyList<RazorVSInternalCodeAction>> ProvideAsync(RazorCodeActionContext context, CancellationToken cancellationToken)
+            _supportsCodeActionResolve = false
+        };
+
+        var initialRange = new Range { Start = new Position(0, 1), End = new Position(0, 1) };
+        var request = new CodeActionParams()
+        {
+            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            Range = initialRange,
+            Context = new VSInternalCodeActionContext()
             {
-                return Task.FromResult(new List<RazorVSInternalCodeAction>()
+                SelectionRange = null
+            }
+        };
+
+        // Act
+        var razorCodeActionContext = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot);
+
+        // Assert
+        Assert.NotNull(razorCodeActionContext);
+        Assert.Equal(initialRange, razorCodeActionContext.Request.Range);
+    }
+
+    [Fact]
+    public async Task GetCSharpCodeActionsFromLanguageServerAsync_InvalidRangeMapping()
+    {
+        // Arrange
+        var documentPath = new Uri("C:/path/to/Page.razor");
+        var codeDocument = CreateCodeDocument("@code {}");
+        var documentContext = CreateDocumentContext(documentPath, codeDocument);
+        Range? projectedRange = null;
+        var documentMappingService = Mock.Of<DefaultRazorDocumentMappingService>(
+            d => d.TryMapToProjectedDocumentRange(It.IsAny<RazorCodeDocument>(), It.IsAny<Range>(), out projectedRange) == false
+        , MockBehavior.Strict);
+        var codeActionEndpoint = new CodeActionEndpoint(
+            documentMappingService,
+            Array.Empty<RazorCodeActionProvider>(),
+            new CSharpCodeActionProvider[] {
+                    new MockCSharpCodeActionProvider()
+            },
+            Array.Empty<HtmlCodeActionProvider>(),
+            _languageServer,
+            _languageServerFeatureOptions)
+        {
+            _supportsCodeActionResolve = false
+        };
+
+        var initialRange = new Range { Start = new Position(0, 1), End = new Position(0, 1) };
+        var request = new CodeActionParams()
+        {
+            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            Range = initialRange,
+            Context = new VSInternalCodeActionContext()
+        };
+
+        var context = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot);
+        Assert.NotNull(context);
+
+        // Act
+        var results = await codeActionEndpoint.GetCodeActionsFromLanguageServerAsync(RazorLanguageKind.CSharp, documentContext, context, default);
+
+        // Assert
+        Assert.Empty(results);
+        Assert.Equal(initialRange, context.Request.Range);
+    }
+
+    [Fact]
+    public async Task GetCSharpCodeActionsFromLanguageServerAsync_ReturnsCodeActions()
+    {
+        // Arrange
+        var documentPath = new Uri("C:/path/to/Page.razor");
+        var codeDocument = CreateCodeDocument("@code {}");
+        var documentContext = CreateDocumentContext(documentPath, codeDocument);
+        var projectedRange = new Range { Start = new Position(15, 2), End = new Position(15, 2) };
+        var documentMappingService = CreateDocumentMappingService(projectedRange);
+        var languageServer = CreateLanguageServer();
+        var codeActionEndpoint = new CodeActionEndpoint(
+            documentMappingService,
+            Array.Empty<RazorCodeActionProvider>(),
+            new CSharpCodeActionProvider[] {
+                    new MockCSharpCodeActionProvider()
+            },
+            Array.Empty<HtmlCodeActionProvider>(),
+            languageServer,
+            _languageServerFeatureOptions)
+        {
+            _supportsCodeActionResolve = false
+        };
+
+        var initialRange = new Range { Start = new Position(0, 1), End = new Position(0, 1) };
+        var request = new CodeActionParams()
+        {
+            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            Range = initialRange,
+            Context = new VSInternalCodeActionContext()
+            {
+                SelectionRange = initialRange
+            }
+        };
+
+        var context = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot);
+        Assert.NotNull(context);
+
+        // Act
+        var results = await codeActionEndpoint.GetCodeActionsFromLanguageServerAsync(RazorLanguageKind.CSharp, documentContext, context, default);
+
+        // Assert
+        var result = Assert.Single(results);
+        var diagnostics = result.Diagnostics!.ToArray();
+        Assert.Equal(2, diagnostics.Length);
+
+        // Diagnostic ranges contain the projected range for
+        // 1. Range
+        // 2. SelectionRange
+        //
+        // This helps verify that the CodeActionEndpoint is mapping the
+        // ranges correctly using the mapping service
+        Assert.Equal(projectedRange, diagnostics[0].Range);
+        Assert.Equal(projectedRange, diagnostics[1].Range);
+    }
+
+    private static DefaultRazorDocumentMappingService CreateDocumentMappingService(Range? projectedRange = null)
+    {
+        projectedRange ??= new Range { Start = new Position(5, 2), End = new Position(5, 2) };
+        var documentMappingService = Mock.Of<DefaultRazorDocumentMappingService>(
+            d => d.TryMapToProjectedDocumentRange(It.IsAny<RazorCodeDocument>(), It.IsAny<Range>(), out projectedRange) == true &&
+                 d.GetLanguageKind(It.IsAny<RazorCodeDocument>(), It.IsAny<int>(), It.IsAny<bool>()) == RazorLanguageKind.CSharp
+        , MockBehavior.Strict);
+        return documentMappingService;
+    }
+
+    private static ClientNotifierServiceBase CreateLanguageServer()
+    {
+        return new TestLanguageServer();
+    }
+
+    private static RazorCodeDocument CreateCodeDocument(string text)
+    {
+        var codeDocument = TestRazorCodeDocument.CreateEmpty();
+        var sourceDocument = TestRazorSourceDocument.Create(text);
+        var syntaxTree = RazorSyntaxTree.Parse(sourceDocument);
+        codeDocument.SetSyntaxTree(syntaxTree);
+        return codeDocument;
+    }
+
+    private class MockRazorCodeActionProvider : RazorCodeActionProvider
+    {
+        public override Task<IReadOnlyList<RazorVSInternalCodeAction>?> ProvideAsync(RazorCodeActionContext context, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<IReadOnlyList<RazorVSInternalCodeAction>?>(new List<RazorVSInternalCodeAction>() { new RazorVSInternalCodeAction() });
+        }
+    }
+
+    private class MockMultipleRazorCodeActionProvider : RazorCodeActionProvider
+    {
+        public override Task<IReadOnlyList<RazorVSInternalCodeAction>?> ProvideAsync(RazorCodeActionContext context, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<IReadOnlyList<RazorVSInternalCodeAction>?>(new List<RazorVSInternalCodeAction>()
                 {
                     new RazorVSInternalCodeAction(),
                     new RazorVSInternalCodeAction()
-                } as IReadOnlyList<RazorVSInternalCodeAction>);
-            }
+                });
         }
+    }
 
-        private class MockCSharpCodeActionProvider : CSharpCodeActionProvider
+    private class MockCSharpCodeActionProvider : CSharpCodeActionProvider
+    {
+        public override Task<IReadOnlyList<RazorVSInternalCodeAction>?> ProvideAsync(RazorCodeActionContext context, IEnumerable<RazorVSInternalCodeAction> codeActions, CancellationToken cancellationToken)
         {
-            public override Task<IReadOnlyList<RazorVSInternalCodeAction>> ProvideAsync(RazorCodeActionContext context, IEnumerable<RazorVSInternalCodeAction> codeActions, CancellationToken cancellationToken)
-            {
-                return Task.FromResult(new List<RazorVSInternalCodeAction>()
+            return Task.FromResult<IReadOnlyList<RazorVSInternalCodeAction>?>(new List<RazorVSInternalCodeAction>()
                 {
                     new RazorVSInternalCodeAction()
-                } as IReadOnlyList<RazorVSInternalCodeAction>);
-            }
+                });
         }
+    }
 
-        private class MockRazorCommandProvider : RazorCodeActionProvider
+    private class MockRazorCommandProvider : RazorCodeActionProvider
+    {
+        public override Task<IReadOnlyList<RazorVSInternalCodeAction>?> ProvideAsync(RazorCodeActionContext context, CancellationToken cancellationToken)
         {
-            public override Task<IReadOnlyList<RazorVSInternalCodeAction>> ProvideAsync(RazorCodeActionContext context, CancellationToken cancellationToken)
-            {
-                // O# Code Actions don't have `Data`, but `Commands` do
-                return Task.FromResult(new List<RazorVSInternalCodeAction>() {
+            // O# Code Actions don't have `Data`, but `Commands` do
+            return Task.FromResult<IReadOnlyList<RazorVSInternalCodeAction>?>(new List<RazorVSInternalCodeAction>() {
                     new RazorVSInternalCodeAction() {
                         Title = "SomeTitle",
                         Data = JToken.FromObject(new AddUsingsCodeActionParams()
@@ -752,78 +761,83 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
                             Uri = new Uri("C:/path/to/Page.razor")
                         })
                     }
-                } as IReadOnlyList<RazorVSInternalCodeAction>);
+                });
+        }
+    }
+
+    private class MockNullRazorCodeActionProvider : RazorCodeActionProvider
+    {
+        public override Task<IReadOnlyList<RazorVSInternalCodeAction>?> ProvideAsync(RazorCodeActionContext context, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<IReadOnlyList<RazorVSInternalCodeAction>?>(null);
+        }
+    }
+
+    private class TestLanguageServer : ClientNotifierServiceBase
+    {
+        public override Task OnInitializedAsync(VSInternalClientCapabilities clientCapabilities, CancellationToken cancellationToken)
+            => Task.CompletedTask;
+
+        public override Task SendNotificationAsync<TParams>(string method, TParams @params, CancellationToken cancellationToken)
+        {
+            if (method != RazorLanguageServerCustomMessageTargets.RazorProvideCodeActionsEndpoint)
+            {
+                throw new InvalidOperationException($"Unexpected method {method}");
             }
+
+            return Task.CompletedTask;
         }
 
-        private class MockNullRazorCodeActionProvider : RazorCodeActionProvider
+        public override Task SendNotificationAsync(string method, CancellationToken cancellationToken)
         {
-            public override Task<IReadOnlyList<RazorVSInternalCodeAction>> ProvideAsync(RazorCodeActionContext context, CancellationToken cancellationToken)
-            {
-                return Task.FromResult<IReadOnlyList<RazorVSInternalCodeAction>>(null);
-            }
+            throw new NotImplementedException();
         }
 
-        private class TestLanguageServer : ClientNotifierServiceBase
+        public override Task<TResponse> SendRequestAsync<TParams, TResponse>(string method, TParams @params, CancellationToken cancellationToken)
         {
-            public override Task OnInitializedAsync(VSInternalClientCapabilities clientCapabilities, CancellationToken cancellationToken)
-                => Task.CompletedTask;
-
-            public override Task SendNotificationAsync<TParams>(string method, TParams @params, CancellationToken cancellationToken)
+            if (method != RazorLanguageServerCustomMessageTargets.RazorProvideCodeActionsEndpoint)
             {
-                if (method != RazorLanguageServerCustomMessageTargets.RazorProvideCodeActionsEndpoint)
-                {
-                    throw new InvalidOperationException($"Unexpected method {method}");
-                }
-
-                return Task.CompletedTask;
+                throw new InvalidOperationException($"Unexpected method {method}");
             }
 
-            public override Task SendNotificationAsync(string method, CancellationToken cancellationToken)
+            if (@params is not DelegatedCodeActionParams delegatedCodeActionParams ||
+                delegatedCodeActionParams.CodeActionParams is not CodeActionParams codeActionParams ||
+                codeActionParams.Context is not VSInternalCodeActionContext codeActionContext)
             {
-                throw new NotImplementedException();
+                throw new InvalidOperationException(@params!.GetType().FullName);
             }
 
-            public override Task<TResponse> SendRequestAsync<TParams, TResponse>(string method, TParams @params, CancellationToken cancellationToken)
+            var diagnostics = new List<Diagnostic>
             {
-                if (method != RazorLanguageServerCustomMessageTargets.RazorProvideCodeActionsEndpoint)
+                new Diagnostic()
                 {
-                    throw new InvalidOperationException($"Unexpected method {method}");
+                    Range = codeActionParams.Range,
+                    Message = "Range"
                 }
-
-                if (@params is not DelegatedCodeActionParams delegatedCodeActionParams ||
-                    delegatedCodeActionParams.CodeActionParams is not CodeActionParams codeActionParams ||
-                    codeActionParams.Context is not VSInternalCodeActionContext codeActionContext)
+            };
+            if (codeActionContext.SelectionRange is not null)
+            {
+                diagnostics.Add(new Diagnostic()
                 {
-                    throw new InvalidOperationException(@params.GetType().FullName);
-                }
+                    Range = codeActionContext.SelectionRange,
+                    Message = "Selection Range"
+                });
+            }
 
-                // Create a code action specifically with diagnostics that
-                // contain the contextual information for it's creation. This is
-                // a hacky way to verify that data transmitted to the language server
-                // is correct rather than providing specific test hooks in the CodeActionEndpoint
-                var result = new[]
-                {
+            // Create a code action specifically with diagnostics that
+            // contain the contextual information for it's creation. This is
+            // a hacky way to verify that data transmitted to the language server
+            // is correct rather than providing specific test hooks in the CodeActionEndpoint
+            var result = new[]
+            {
                     new RazorVSInternalCodeAction()
                     {
                         Data = JToken.FromObject(new { CustomTags = new object[] { "CodeActionName" } }),
-                        Diagnostics = new[]
-                        {
-                            new Diagnostic()
-                            {
-                                Range = codeActionParams.Range,
-                                Message = "Range"
-                            },
-                            new Diagnostic()
-                            {
-                                Range = codeActionContext.SelectionRange,
-                                Message = "Selection Range"
-                            }
-                        }
+                        Diagnostics = diagnostics.ToArray()
                     }
                 };
 
-                return Task.FromResult((TResponse)(object)result);
-            }
+            return Task.FromResult((TResponse)(object)result);
         }
     }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionResolutionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionResolutionEndpointTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,519 +15,521 @@ using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
 
-    public class CodeActionResolutionEndpointTest : LanguageServerTestBase
+public class CodeActionResolutionEndpointTest : LanguageServerTestBase
+{
+    public CodeActionResolutionEndpointTest(ITestOutputHelper testOutput)
+        : base(testOutput)
     {
-        public CodeActionResolutionEndpointTest(ITestOutputHelper testOutput)
-            : base(testOutput)
-        {
-        }
+    }
 
-        [Fact]
-        public async Task Handle_Valid_RazorCodeAction_WithResolver()
+    [Fact]
+    public async Task Handle_Valid_RazorCodeAction_WithResolver()
+    {
+        // Arrange
+        var codeActionEndpoint = new CodeActionResolutionEndpoint(
+            new RazorCodeActionResolver[] {
+                new MockRazorCodeActionResolver("Test"),
+            },
+            Array.Empty<CSharpCodeActionResolver>(),
+            Array.Empty<HtmlCodeActionResolver>(),
+            LoggerFactory);
+        var requestParams = new RazorCodeActionResolutionParams()
         {
-            // Arrange
-            var codeActionEndpoint = new CodeActionResolutionEndpoint(
+            Action = "Test",
+            Language = LanguageServerConstants.CodeActions.Languages.Razor,
+            Data = new AddUsingsCodeActionParams()
+            {
+                Namespace = "Test",
+                Uri = new Uri("C:/path/to/Page.razor")
+            }
+        };
+        var request = new CodeAction()
+        {
+            Title = "Valid request",
+            Data = JToken.FromObject(requestParams)
+        };
+        var requestContext = CreateRazorRequestContext(documentContext: null);
+
+        // Act
+        var razorCodeAction = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
+
+        // Assert
+        Assert.NotNull(razorCodeAction.Edit);
+    }
+
+    [Fact]
+    public async Task Handle_Valid_CSharpCodeAction_WithResolver()
+    {
+        // Arrange
+        var codeActionEndpoint = new CodeActionResolutionEndpoint(
+            Array.Empty<RazorCodeActionResolver>(),
+            new CSharpCodeActionResolver[] {
+                new MockCSharpCodeActionResolver("Test"),
+            },
+            Array.Empty<HtmlCodeActionResolver>(),
+            LoggerFactory);
+        var requestParams = new RazorCodeActionResolutionParams()
+        {
+            Action = "Test",
+            Language = LanguageServerConstants.CodeActions.Languages.CSharp,
+            Data = JObject.FromObject(new CodeActionResolveParams()
+            {
+                RazorFileUri = new Uri("C:/path/to/Page.razor"),
+            })
+        };
+        var request = new CodeAction()
+        {
+            Title = "Valid request",
+            Data = JToken.FromObject(requestParams)
+        };
+        var requestContext = CreateRazorRequestContext(documentContext: null);
+
+        // Act
+        var razorCodeAction = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
+
+        // Assert
+        Assert.NotNull(razorCodeAction.Edit);
+    }
+
+    [Fact]
+    public async Task Handle_Valid_CSharpCodeAction_WithMultipleLanguageResolvers()
+    {
+        // Arrange
+        var codeActionEndpoint = new CodeActionResolutionEndpoint(
+            new RazorCodeActionResolver[] {
+                new MockRazorCodeActionResolver("TestRazor"),
+            },
+            new CSharpCodeActionResolver[] {
+                new MockCSharpCodeActionResolver("TestCSharp"),
+            },
+            Array.Empty<HtmlCodeActionResolver>(),
+            LoggerFactory);
+        var requestParams = new RazorCodeActionResolutionParams()
+        {
+            Action = "TestCSharp",
+            Language = LanguageServerConstants.CodeActions.Languages.CSharp,
+            Data = JObject.FromObject(new CodeActionResolveParams()
+            {
+                RazorFileUri = new Uri("C:/path/to/Page.razor"),
+            })
+        };
+        var request = new CodeAction()
+        {
+            Title = "Valid request",
+            Data = JToken.FromObject(requestParams)
+        };
+        var requestContext = CreateRazorRequestContext(documentContext: null);
+
+        // Act
+        var razorCodeAction = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
+
+        // Assert
+        Assert.NotNull(razorCodeAction.Edit);
+    }
+
+    [Fact(Skip = "Debug.Fail fails in CI")]
+    public async Task Handle_Valid_RazorCodeAction_WithoutResolver()
+    {
+        // Arrange
+        var codeActionEndpoint = new CodeActionResolutionEndpoint(
+            Array.Empty<RazorCodeActionResolver>(),
+            Array.Empty<CSharpCodeActionResolver>(),
+            Array.Empty<HtmlCodeActionResolver>(),
+            LoggerFactory);
+        var requestParams = new RazorCodeActionResolutionParams()
+        {
+            Action = "Test",
+            Language = LanguageServerConstants.CodeActions.Languages.Razor,
+            Data = new AddUsingsCodeActionParams()
+            {
+                Namespace = "Test",
+                Uri = new Uri("C:/path/to/Page.razor")
+            }
+        };
+        var request = new CodeAction()
+        {
+            Title = "Valid request",
+            Data = JToken.FromObject(requestParams)
+        };
+        var requestContext = CreateRazorRequestContext(documentContext: null);
+
+#if DEBUG
+        // Act & Assert (Throws due to debug assert on no Razor.Test resolver)
+        await Assert.ThrowsAnyAsync<Exception>(async () => await codeActionEndpoint.HandleRequestAsync(request, requestContext, default));
+#else
+        // Act
+        var resolvedCodeAction = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
+
+        // Assert
+        Assert.Null(resolvedCodeAction.Edit);
+#endif
+    }
+
+    [Fact(Skip = "Debug.Fail fails in CI")]
+    public async Task Handle_Valid_CSharpCodeAction_WithoutResolver()
+    {
+        // Arrange
+        var codeActionEndpoint = new CodeActionResolutionEndpoint(
+            Array.Empty<RazorCodeActionResolver>(),
+            Array.Empty<CSharpCodeActionResolver>(),
+            Array.Empty<HtmlCodeActionResolver>(),
+            LoggerFactory);
+        var requestParams = new RazorCodeActionResolutionParams()
+        {
+            Action = "Test",
+            Language = LanguageServerConstants.CodeActions.Languages.CSharp,
+            Data = JObject.FromObject(new CodeActionResolveParams()
+            {
+                RazorFileUri = new Uri("C:/path/to/Page.razor"),
+            })
+        };
+        var request = new CodeAction()
+        {
+            Title = "Valid request",
+            Data = JToken.FromObject(requestParams)
+        };
+        var requestContext = CreateRazorRequestContext(documentContext: null);
+
+#if DEBUG
+        // Act & Assert (Throws due to debug assert on no resolver registered for CSharp.Test)
+        await Assert.ThrowsAnyAsync<Exception>(async () => await codeActionEndpoint.HandleRequestAsync(request, requestContext, default));
+#else
+        // Act
+        var resolvedCodeAction = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
+
+        // Assert
+        Assert.Null(resolvedCodeAction.Edit);
+#endif
+    }
+
+    [Fact(Skip = "Debug.Fail fails in CI")]
+    public async Task Handle_Valid_RazorCodeAction_WithCSharpResolver_ResolvesNull()
+    {
+        // Arrange
+        var codeActionEndpoint = new CodeActionResolutionEndpoint(
+            Array.Empty<RazorCodeActionResolver>(),
+            new CSharpCodeActionResolver[] {
+                new MockCSharpCodeActionResolver("Test"),
+            },
+            Array.Empty<HtmlCodeActionResolver>(),
+            LoggerFactory);
+        var requestParams = new RazorCodeActionResolutionParams()
+        {
+            Action = "Test",
+            Language = LanguageServerConstants.CodeActions.Languages.Razor,
+            Data = new AddUsingsCodeActionParams()
+            {
+                Namespace = "Test",
+                Uri = new Uri("C:/path/to/Page.razor")
+            }
+        };
+        var request = new CodeAction()
+        {
+            Title = "Valid request",
+            Data = JToken.FromObject(requestParams)
+        };
+        var requestContext = CreateRazorRequestContext(documentContext: null);
+
+#if DEBUG
+        // Act & Assert (Throws due to debug assert on no resolver registered for Razor.Test)
+        await Assert.ThrowsAnyAsync<Exception>(async () => await codeActionEndpoint.HandleRequestAsync(request, requestContext, default));
+#else
+        // Act
+        var resolvedCodeAction = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
+
+        // Assert
+        Assert.Null(resolvedCodeAction.Edit);
+#endif
+    }
+
+    [Fact(Skip = "Debug.Fail fails in CI")]
+    public async Task Handle_Valid_CSharpCodeAction_WithRazorResolver_ResolvesNull()
+    {
+        // Arrange
+        var codeActionEndpoint = new CodeActionResolutionEndpoint(
+            new RazorCodeActionResolver[] {
+                new MockRazorCodeActionResolver("Test"),
+            },
+            Array.Empty<CSharpCodeActionResolver>(),
+            Array.Empty<HtmlCodeActionResolver>(),
+            LoggerFactory);
+        var requestParams = new RazorCodeActionResolutionParams()
+        {
+            Action = "Test",
+            Language = LanguageServerConstants.CodeActions.Languages.CSharp,
+            Data = JObject.FromObject(new CodeActionResolveParams()
+            {
+                RazorFileUri = new Uri("C:/path/to/Page.razor"),
+            })
+        };
+        var request = new CodeAction()
+        {
+            Title = "Valid request",
+            Data = JToken.FromObject(requestParams)
+        };
+        var requestContext = CreateRazorRequestContext(documentContext: null);
+
+#if DEBUG
+        // Act & Assert (Throws due to debug asserts)
+        await Assert.ThrowsAnyAsync<Exception>(async () => await codeActionEndpoint.HandleRequestAsync(request, requestContext, default));
+#else
+        // Act
+        var resolvedCodeAction = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
+
+        // Assert
+        Assert.Null(resolvedCodeAction.Edit);
+#endif
+    }
+
+    [Fact]
+    public async Task ResolveRazorCodeAction_ResolveMultipleRazorProviders_FirstMatches()
+    {
+        // Arrange
+        var codeActionEndpoint = new CodeActionResolutionEndpoint(
                 new RazorCodeActionResolver[] {
-                    new MockRazorCodeActionResolver("Test"),
-                },
-                Array.Empty<CSharpCodeActionResolver>(),
-                Array.Empty<HtmlCodeActionResolver>(),
-                LoggerFactory);
-            var requestParams = new RazorCodeActionResolutionParams()
-            {
-                Action = "Test",
-                Language = LanguageServerConstants.CodeActions.Languages.Razor,
-                Data = new AddUsingsCodeActionParams()
-                {
-                    Namespace = "Test",
-                    Uri = new Uri("C:/path/to/Page.razor")
-                }
-            };
-            var request = new CodeAction()
-            {
-                Title = "Valid request",
-                Data = JToken.FromObject(requestParams)
-            };
-            var requestContext = CreateRazorRequestContext(documentContext: null);
-
-            // Act
-            var razorCodeAction = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
-
-            // Assert
-            Assert.NotNull(razorCodeAction.Edit);
-        }
-
-        [Fact]
-        public async Task Handle_Valid_CSharpCodeAction_WithResolver()
-        {
-            // Arrange
-            var codeActionEndpoint = new CodeActionResolutionEndpoint(
-                Array.Empty<RazorCodeActionResolver>(),
-                new CSharpCodeActionResolver[] {
-                    new MockCSharpCodeActionResolver("Test"),
-                },
-                Array.Empty<HtmlCodeActionResolver>(),
-                LoggerFactory);
-            var requestParams = new RazorCodeActionResolutionParams()
-            {
-                Action = "Test",
-                Language = LanguageServerConstants.CodeActions.Languages.CSharp,
-                Data = JObject.FromObject(new CodeActionResolveParams()
-                {
-                    RazorFileUri = new Uri("C:/path/to/Page.razor"),
-                })
-            };
-            var request = new CodeAction()
-            {
-                Title = "Valid request",
-                Data = JToken.FromObject(requestParams)
-            };
-            var requestContext = CreateRazorRequestContext(documentContext: null);
-
-            // Act
-            var razorCodeAction = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
-
-            // Assert
-            Assert.NotNull(razorCodeAction.Edit);
-        }
-
-        [Fact]
-        public async Task Handle_Valid_CSharpCodeAction_WithMultipleLanguageResolvers()
-        {
-            // Arrange
-            var codeActionEndpoint = new CodeActionResolutionEndpoint(
-                new RazorCodeActionResolver[] {
-                    new MockRazorCodeActionResolver("TestRazor"),
-                },
-                new CSharpCodeActionResolver[] {
-                    new MockCSharpCodeActionResolver("TestCSharp"),
-                },
-                Array.Empty<HtmlCodeActionResolver>(),
-                LoggerFactory);
-            var requestParams = new RazorCodeActionResolutionParams()
-            {
-                Action = "TestCSharp",
-                Language = LanguageServerConstants.CodeActions.Languages.CSharp,
-                Data = JObject.FromObject(new CodeActionResolveParams()
-                {
-                    RazorFileUri = new Uri("C:/path/to/Page.razor"),
-                })
-            };
-            var request = new CodeAction()
-            {
-                Title = "Valid request",
-                Data = JToken.FromObject(requestParams)
-            };
-            var requestContext = CreateRazorRequestContext(documentContext: null);
-
-            // Act
-            var razorCodeAction = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
-
-            // Assert
-            Assert.NotNull(razorCodeAction.Edit);
-        }
-
-        [Fact(Skip = "Debug.Fail fails in CI")]
-        public async Task Handle_Valid_RazorCodeAction_WithoutResolver()
-        {
-            // Arrange
-            var codeActionEndpoint = new CodeActionResolutionEndpoint(
-                Array.Empty<RazorCodeActionResolver>(),
-                Array.Empty<CSharpCodeActionResolver>(),
-                Array.Empty<HtmlCodeActionResolver>(),
-                LoggerFactory);
-            var requestParams = new RazorCodeActionResolutionParams()
-            {
-                Action = "Test",
-                Language = LanguageServerConstants.CodeActions.Languages.Razor,
-                Data = new AddUsingsCodeActionParams()
-                {
-                    Namespace = "Test",
-                    Uri = new Uri("C:/path/to/Page.razor")
-                }
-            };
-            var request = new CodeAction()
-            {
-                Title = "Valid request",
-                Data = JToken.FromObject(requestParams)
-            };
-            var requestContext = CreateRazorRequestContext(documentContext: null);
-
-#if DEBUG
-            // Act & Assert (Throws due to debug assert on no Razor.Test resolver)
-            await Assert.ThrowsAnyAsync<Exception>(async () => await codeActionEndpoint.HandleRequestAsync(request, requestContext, default));
-#else
-            // Act
-            var resolvedCodeAction = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
-
-            // Assert
-            Assert.Null(resolvedCodeAction.Edit);
-#endif
-        }
-
-        [Fact(Skip = "Debug.Fail fails in CI")]
-        public async Task Handle_Valid_CSharpCodeAction_WithoutResolver()
-        {
-            // Arrange
-            var codeActionEndpoint = new CodeActionResolutionEndpoint(
-                Array.Empty<RazorCodeActionResolver>(),
-                Array.Empty<CSharpCodeActionResolver>(),
-                Array.Empty<HtmlCodeActionResolver>(),
-                LoggerFactory);
-            var requestParams = new RazorCodeActionResolutionParams()
-            {
-                Action = "Test",
-                Language = LanguageServerConstants.CodeActions.Languages.CSharp,
-                Data = JObject.FromObject(new CodeActionResolveParams()
-                {
-                    RazorFileUri = new Uri("C:/path/to/Page.razor"),
-                })
-            };
-            var request = new CodeAction()
-            {
-                Title = "Valid request",
-                Data = JToken.FromObject(requestParams)
-            };
-            var requestContext = CreateRazorRequestContext(documentContext: null);
-
-#if DEBUG
-            // Act & Assert (Throws due to debug assert on no resolver registered for CSharp.Test)
-            await Assert.ThrowsAnyAsync<Exception>(async () => await codeActionEndpoint.HandleRequestAsync(request, requestContext, default));
-#else
-            // Act
-            var resolvedCodeAction = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
-
-            // Assert
-            Assert.Null(resolvedCodeAction.Edit);
-#endif
-        }
-
-        [Fact(Skip = "Debug.Fail fails in CI")]
-        public async Task Handle_Valid_RazorCodeAction_WithCSharpResolver_ResolvesNull()
-        {
-            // Arrange
-            var codeActionEndpoint = new CodeActionResolutionEndpoint(
-                Array.Empty<RazorCodeActionResolver>(),
-                new CSharpCodeActionResolver[] {
-                    new MockCSharpCodeActionResolver("Test"),
-                },
-                Array.Empty<HtmlCodeActionResolver>(),
-                LoggerFactory);
-            var requestParams = new RazorCodeActionResolutionParams()
-            {
-                Action = "Test",
-                Language = LanguageServerConstants.CodeActions.Languages.Razor,
-                Data = new AddUsingsCodeActionParams()
-                {
-                    Namespace = "Test",
-                    Uri = new Uri("C:/path/to/Page.razor")
-                }
-            };
-            var request = new CodeAction()
-            {
-                Title = "Valid request",
-                Data = JToken.FromObject(requestParams)
-            };
-            var requestContext = CreateRazorRequestContext(documentContext: null);
-
-#if DEBUG
-            // Act & Assert (Throws due to debug assert on no resolver registered for Razor.Test)
-            await Assert.ThrowsAnyAsync<Exception>(async () => await codeActionEndpoint.HandleRequestAsync(request, requestContext, default));
-#else
-            // Act
-            var resolvedCodeAction = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
-
-            // Assert
-            Assert.Null(resolvedCodeAction.Edit);
-#endif
-        }
-
-        [Fact(Skip = "Debug.Fail fails in CI")]
-        public async Task Handle_Valid_CSharpCodeAction_WithRazorResolver_ResolvesNull()
-        {
-            // Arrange
-            var codeActionEndpoint = new CodeActionResolutionEndpoint(
-                new RazorCodeActionResolver[] {
-                    new MockRazorCodeActionResolver("Test"),
-                },
-                Array.Empty<CSharpCodeActionResolver>(),
-                Array.Empty<HtmlCodeActionResolver>(),
-                LoggerFactory);
-            var requestParams = new RazorCodeActionResolutionParams()
-            {
-                Action = "Test",
-                Language = LanguageServerConstants.CodeActions.Languages.CSharp,
-                Data = JObject.FromObject(new CodeActionResolveParams()
-                {
-                    RazorFileUri = new Uri("C:/path/to/Page.razor"),
-                })
-            };
-            var request = new CodeAction()
-            {
-                Title = "Valid request",
-                Data = JToken.FromObject(requestParams)
-            };
-            var requestContext = CreateRazorRequestContext(documentContext: null);
-
-#if DEBUG
-            // Act & Assert (Throws due to debug asserts)
-            await Assert.ThrowsAnyAsync<Exception>(async () => await codeActionEndpoint.HandleRequestAsync(request, requestContext, default));
-#else
-            // Act
-            var resolvedCodeAction = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
-
-            // Assert
-            Assert.Null(resolvedCodeAction.Edit);
-#endif
-        }
-
-        [Fact]
-        public async Task ResolveRazorCodeAction_ResolveMultipleRazorProviders_FirstMatches()
-        {
-            // Arrange
-            var codeActionEndpoint = new CodeActionResolutionEndpoint(
-                    new RazorCodeActionResolver[] {
                     new MockRazorCodeActionResolver("A"),
                     new MockRazorNullCodeActionResolver("B"),
-                },
-                Array.Empty<CSharpCodeActionResolver>(),
-                Array.Empty<HtmlCodeActionResolver>(),
-                LoggerFactory);
-            var codeAction = new CodeAction();
-            var request = new RazorCodeActionResolutionParams()
+            },
+            Array.Empty<CSharpCodeActionResolver>(),
+            Array.Empty<HtmlCodeActionResolver>(),
+            LoggerFactory);
+        var codeAction = new CodeAction();
+        var request = new RazorCodeActionResolutionParams()
+        {
+            Action = "A",
+            Language = LanguageServerConstants.CodeActions.Languages.Razor,
+            Data = JToken.FromObject(new AddUsingsCodeActionParams()
             {
-                Action = "A",
-                Language = LanguageServerConstants.CodeActions.Languages.Razor,
-                Data = JToken.FromObject(new AddUsingsCodeActionParams()
-                {
-                    Namespace = "Test",
-                    Uri = new Uri("C:/path/to/Page.razor")
-                }),
-            };
+                Namespace = "Test",
+                Uri = new Uri("C:/path/to/Page.razor")
+            }),
+        };
 
-            // Act
-            var resolvedCodeAction = await codeActionEndpoint.ResolveRazorCodeActionAsync(codeAction, request, default);
+        // Act
+        var resolvedCodeAction = await codeActionEndpoint.ResolveRazorCodeActionAsync(codeAction, request, default);
 
-            // Assert
-            Assert.NotNull(resolvedCodeAction.Edit);
+        // Assert
+        Assert.NotNull(resolvedCodeAction.Edit);
+    }
+
+    [Fact]
+    public async Task ResolveRazorCodeAction_ResolveMultipleRazorProviders_SecondMatches()
+    {
+        // Arrange
+        var codeActionEndpoint = new CodeActionResolutionEndpoint(
+            new RazorCodeActionResolver[] {
+                new MockRazorNullCodeActionResolver("A"),
+                new MockRazorCodeActionResolver("B"),
+            },
+            Array.Empty<CSharpCodeActionResolver>(),
+            Array.Empty<HtmlCodeActionResolver>(),
+            LoggerFactory);
+        var codeAction = new CodeAction();
+        var request = new RazorCodeActionResolutionParams()
+        {
+            Action = "B",
+            Language = LanguageServerConstants.CodeActions.Languages.Razor,
+            Data = JToken.FromObject(new AddUsingsCodeActionParams()
+            {
+                Namespace = "Test",
+                Uri = new Uri("C:/path/to/Page.razor")
+            })
+        };
+
+        // Act
+        var resolvedCodeAction = await codeActionEndpoint.ResolveRazorCodeActionAsync(codeAction, request, default);
+
+        // Assert
+        Assert.NotNull(resolvedCodeAction.Edit);
+    }
+
+    [Fact]
+    public async Task ResolveCSharpCodeAction_ResolveMultipleCSharpProviders_FirstMatches()
+    {
+        // Arrange
+        var codeActionEndpoint = new CodeActionResolutionEndpoint(
+            Array.Empty<RazorCodeActionResolver>(),
+            new CSharpCodeActionResolver[] {
+                new MockCSharpCodeActionResolver("A"),
+                new MockCSharpNullCodeActionResolver("B"),
+            },
+            Array.Empty<HtmlCodeActionResolver>(),
+            LoggerFactory);
+        var codeAction = new CodeAction();
+        var request = new RazorCodeActionResolutionParams()
+        {
+            Action = "A",
+            Language = LanguageServerConstants.CodeActions.Languages.CSharp,
+            Data = JObject.FromObject(new CodeActionResolveParams()
+            {
+                RazorFileUri = new Uri("C:/path/to/Page.razor"),
+            })
+        };
+
+        // Act
+        var resolvedCodeAction = await codeActionEndpoint.ResolveCSharpCodeActionAsync(codeAction, request, default);
+
+        // Assert
+        Assert.NotNull(resolvedCodeAction.Edit);
+    }
+
+    [Fact]
+    public async Task ResolveCSharpCodeAction_ResolveMultipleCSharpProviders_SecondMatches()
+    {
+        // Arrange
+        var codeActionEndpoint = new CodeActionResolutionEndpoint(
+            Array.Empty<RazorCodeActionResolver>(),
+            new CSharpCodeActionResolver[] {
+                new MockCSharpNullCodeActionResolver("A"),
+                new MockCSharpCodeActionResolver("B"),
+            },
+            Array.Empty<HtmlCodeActionResolver>(),
+            LoggerFactory);
+        var codeAction = new CodeAction();
+        var request = new RazorCodeActionResolutionParams()
+        {
+            Action = "B",
+            Language = LanguageServerConstants.CodeActions.Languages.Razor,
+            Data = JObject.FromObject(new CodeActionResolveParams()
+            {
+                RazorFileUri = new Uri("C:/path/to/Page.razor"),
+            })
+        };
+
+        // Act
+        var resolvedCodeAction = await codeActionEndpoint.ResolveCSharpCodeActionAsync(codeAction, request, default);
+
+        // Assert
+        Assert.NotNull(resolvedCodeAction.Edit);
+    }
+
+    [Fact]
+    public async Task ResolveCSharpCodeAction_ResolveMultipleLanguageProviders()
+    {
+        // Arrange
+        var codeActionEndpoint = new CodeActionResolutionEndpoint(
+            new RazorCodeActionResolver[] {
+                new MockRazorNullCodeActionResolver("A"),
+                new MockRazorCodeActionResolver("B"),
+            },
+            new CSharpCodeActionResolver[] {
+                new MockCSharpNullCodeActionResolver("C"),
+                new MockCSharpCodeActionResolver("D"),
+            },
+            Array.Empty<HtmlCodeActionResolver>(),
+            LoggerFactory);
+        var codeAction = new CodeAction();
+        var request = new RazorCodeActionResolutionParams()
+        {
+            Action = "D",
+            Language = LanguageServerConstants.CodeActions.Languages.CSharp,
+            Data = JObject.FromObject(new CodeActionResolveParams()
+            {
+                RazorFileUri = new Uri("C:/path/to/Page.razor"),
+            })
+        };
+
+        // Act
+        var resolvedCodeAction = await codeActionEndpoint.ResolveCSharpCodeActionAsync(codeAction, request, default);
+
+        // Assert
+        Assert.NotNull(resolvedCodeAction.Edit);
+    }
+
+    [Fact]
+    public async Task Handle_ResolveEditBasedCodeActionCommand()
+    {
+        // Arrange
+        var codeActionEndpoint = new CodeActionResolutionEndpoint(
+            Array.Empty<RazorCodeActionResolver>(),
+            new CSharpCodeActionResolver[] {
+                new MockCSharpCodeActionResolver("Test"),
+            },
+            Array.Empty<HtmlCodeActionResolver>(),
+            LoggerFactory);
+        var requestParams = new RazorCodeActionResolutionParams()
+        {
+            Action = LanguageServerConstants.CodeActions.EditBasedCodeActionCommand,
+            Language = LanguageServerConstants.CodeActions.Languages.Razor,
+            Data = JToken.FromObject(new WorkspaceEdit())
+        };
+
+        var request = new CodeAction()
+        {
+            Title = "Valid request",
+            Data = JToken.FromObject(requestParams)
+        };
+        var requestContext = CreateRazorRequestContext(documentContext: null);
+
+        // Act
+        var razorCodeAction = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
+
+        // Assert
+        Assert.NotNull(razorCodeAction.Edit);
+    }
+
+    private class MockRazorCodeActionResolver : RazorCodeActionResolver
+    {
+        public override string Action { get; }
+
+        internal MockRazorCodeActionResolver(string action)
+        {
+            Action = action;
         }
 
-        [Fact]
-        public async Task ResolveRazorCodeAction_ResolveMultipleRazorProviders_SecondMatches()
+        public override Task<WorkspaceEdit?> ResolveAsync(JObject data, CancellationToken cancellationToken)
         {
-            // Arrange
-            var codeActionEndpoint = new CodeActionResolutionEndpoint(
-                new RazorCodeActionResolver[] {
-                    new MockRazorNullCodeActionResolver("A"),
-                    new MockRazorCodeActionResolver("B"),
-                },
-                Array.Empty<CSharpCodeActionResolver>(),
-                Array.Empty<HtmlCodeActionResolver>(),
-                LoggerFactory);
-            var codeAction = new CodeAction();
-            var request = new RazorCodeActionResolutionParams()
-            {
-                Action = "B",
-                Language = LanguageServerConstants.CodeActions.Languages.Razor,
-                Data = JToken.FromObject(new AddUsingsCodeActionParams()
-                {
-                    Namespace = "Test",
-                    Uri = new Uri("C:/path/to/Page.razor")
-                })
-            };
-
-            // Act
-            var resolvedCodeAction = await codeActionEndpoint.ResolveRazorCodeActionAsync(codeAction, request, default);
-
-            // Assert
-            Assert.NotNull(resolvedCodeAction.Edit);
-        }
-
-        [Fact]
-        public async Task ResolveCSharpCodeAction_ResolveMultipleCSharpProviders_FirstMatches()
-        {
-            // Arrange
-            var codeActionEndpoint = new CodeActionResolutionEndpoint(
-                Array.Empty<RazorCodeActionResolver>(),
-                new CSharpCodeActionResolver[] {
-                    new MockCSharpCodeActionResolver("A"),
-                    new MockCSharpNullCodeActionResolver("B"),
-                },
-                Array.Empty<HtmlCodeActionResolver>(),
-                LoggerFactory);
-            var codeAction = new CodeAction();
-            var request = new RazorCodeActionResolutionParams()
-            {
-                Action = "A",
-                Language = LanguageServerConstants.CodeActions.Languages.CSharp,
-                Data = JObject.FromObject(new CodeActionResolveParams()
-                {
-                    RazorFileUri = new Uri("C:/path/to/Page.razor"),
-                })
-            };
-
-            // Act
-            var resolvedCodeAction = await codeActionEndpoint.ResolveCSharpCodeActionAsync(codeAction, request, default);
-
-            // Assert
-            Assert.NotNull(resolvedCodeAction.Edit);
-        }
-
-        [Fact]
-        public async Task ResolveCSharpCodeAction_ResolveMultipleCSharpProviders_SecondMatches()
-        {
-            // Arrange
-            var codeActionEndpoint = new CodeActionResolutionEndpoint(
-                Array.Empty<RazorCodeActionResolver>(),
-                new CSharpCodeActionResolver[] {
-                    new MockCSharpNullCodeActionResolver("A"),
-                    new MockCSharpCodeActionResolver("B"),
-                },
-                Array.Empty<HtmlCodeActionResolver>(),
-                LoggerFactory);
-            var codeAction = new CodeAction();
-            var request = new RazorCodeActionResolutionParams()
-            {
-                Action = "B",
-                Language = LanguageServerConstants.CodeActions.Languages.Razor,
-                Data = JObject.FromObject(new CodeActionResolveParams()
-                {
-                    RazorFileUri = new Uri("C:/path/to/Page.razor"),
-                })
-            };
-
-            // Act
-            var resolvedCodeAction = await codeActionEndpoint.ResolveCSharpCodeActionAsync(codeAction, request, default);
-
-            // Assert
-            Assert.NotNull(resolvedCodeAction.Edit);
-        }
-
-        [Fact]
-        public async Task ResolveCSharpCodeAction_ResolveMultipleLanguageProviders()
-        {
-            // Arrange
-            var codeActionEndpoint = new CodeActionResolutionEndpoint(
-                new RazorCodeActionResolver[] {
-                    new MockRazorNullCodeActionResolver("A"),
-                    new MockRazorCodeActionResolver("B"),
-                },
-                new CSharpCodeActionResolver[] {
-                    new MockCSharpNullCodeActionResolver("C"),
-                    new MockCSharpCodeActionResolver("D"),
-                },
-                Array.Empty<HtmlCodeActionResolver>(),
-                LoggerFactory);
-            var codeAction = new CodeAction();
-            var request = new RazorCodeActionResolutionParams()
-            {
-                Action = "D",
-                Language = LanguageServerConstants.CodeActions.Languages.CSharp,
-                Data = JObject.FromObject(new CodeActionResolveParams()
-                {
-                    RazorFileUri = new Uri("C:/path/to/Page.razor"),
-                })
-            };
-
-            // Act
-            var resolvedCodeAction = await codeActionEndpoint.ResolveCSharpCodeActionAsync(codeAction, request, default);
-
-            // Assert
-            Assert.NotNull(resolvedCodeAction.Edit);
-        }
-
-        [Fact]
-        public async Task Handle_ResolveEditBasedCodeActionCommand()
-        {
-            // Arrange
-            var codeActionEndpoint = new CodeActionResolutionEndpoint(
-                Array.Empty<RazorCodeActionResolver>(),
-                new CSharpCodeActionResolver[] {
-                    new MockCSharpCodeActionResolver("Test"),
-                },
-                Array.Empty<HtmlCodeActionResolver>(),
-                LoggerFactory);
-            var requestParams = new RazorCodeActionResolutionParams()
-            {
-                Action = LanguageServerConstants.CodeActions.EditBasedCodeActionCommand,
-                Language = LanguageServerConstants.CodeActions.Languages.Razor,
-                Data = JToken.FromObject(new WorkspaceEdit())
-            };
-
-            var request = new CodeAction()
-            {
-                Title = "Valid request",
-                Data = JToken.FromObject(requestParams)
-            };
-            var requestContext = CreateRazorRequestContext(documentContext: null);
-
-            // Act
-            var razorCodeAction = await codeActionEndpoint.HandleRequestAsync(request, requestContext, default);
-
-            // Assert
-            Assert.NotNull(razorCodeAction.Edit);
-        }
-
-        private class MockRazorCodeActionResolver : RazorCodeActionResolver
-        {
-            public override string Action { get; }
-
-            internal MockRazorCodeActionResolver(string action)
-            {
-                Action = action;
-            }
-
-            public override Task<WorkspaceEdit> ResolveAsync(JObject data, CancellationToken cancellationToken)
-            {
-                return Task.FromResult(new WorkspaceEdit());
-            }
-        }
-
-        private class MockRazorNullCodeActionResolver : RazorCodeActionResolver
-        {
-            public override string Action { get; }
-
-            internal MockRazorNullCodeActionResolver(string action)
-            {
-                Action = action;
-            }
-
-            public override Task<WorkspaceEdit> ResolveAsync(JObject data, CancellationToken cancellationToken)
-            {
-                return Task.FromResult<WorkspaceEdit>(null);
-            }
-        }
-
-        private class MockCSharpCodeActionResolver : CSharpCodeActionResolver
-        {
-            public override string Action { get; }
-
-            internal MockCSharpCodeActionResolver(string action)
-                : base(Mock.Of<ClientNotifierServiceBase>(MockBehavior.Strict))
-            {
-                Action = action;
-            }
-
-            public override Task<CodeAction> ResolveAsync(CodeActionResolveParams csharpParams, CodeAction codeAction, CancellationToken cancellationToken)
-            {
-                codeAction.Edit = new WorkspaceEdit();
-                return Task.FromResult(codeAction);
-            }
-        }
-
-        private class MockCSharpNullCodeActionResolver : CSharpCodeActionResolver
-        {
-            public override string Action { get; }
-
-            internal MockCSharpNullCodeActionResolver(string action)
-                : base(Mock.Of<ClientNotifierServiceBase>(MockBehavior.Strict))
-            {
-                Action = action;
-            }
-
-            public override Task<CodeAction> ResolveAsync(CodeActionResolveParams csharpParams, CodeAction codeAction, CancellationToken cancellationToken)
-            {
-                return Task.FromResult<CodeAction>(null);
-            }
+            return Task.FromResult<WorkspaceEdit?>(new WorkspaceEdit());
         }
     }
+
+    private class MockRazorNullCodeActionResolver : RazorCodeActionResolver
+    {
+        public override string Action { get; }
+
+        internal MockRazorNullCodeActionResolver(string action)
+        {
+            Action = action;
+        }
+
+        public override Task<WorkspaceEdit?> ResolveAsync(JObject data, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<WorkspaceEdit?>(null);
+        }
+    }
+
+    private class MockCSharpCodeActionResolver : CSharpCodeActionResolver
+    {
+        public override string Action { get; }
+
+        internal MockCSharpCodeActionResolver(string action)
+            : base(Mock.Of<ClientNotifierServiceBase>(MockBehavior.Strict))
+        {
+            Action = action;
+        }
+
+        public override Task<CodeAction> ResolveAsync(CodeActionResolveParams csharpParams, CodeAction codeAction, CancellationToken cancellationToken)
+        {
+            codeAction.Edit = new WorkspaceEdit();
+            return Task.FromResult(codeAction);
+        }
+    }
+
+    private class MockCSharpNullCodeActionResolver : CSharpCodeActionResolver
+    {
+        public override string Action { get; }
+
+        internal MockCSharpNullCodeActionResolver(string action)
+            : base(Mock.Of<ClientNotifierServiceBase>(MockBehavior.Strict))
+        {
+            Action = action;
+        }
+
+        public override Task<CodeAction> ResolveAsync(CodeActionResolveParams csharpParams, CodeAction codeAction, CancellationToken cancellationToken)
+        {
+            // This is deliberately returning null when it's not supposed to, so that if this code action
+            // is ever returned by a method, the test will fail
+            return Task.FromResult<CodeAction>(null!);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ComponentAccessibilityCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ComponentAccessibilityCodeActionProviderTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
@@ -120,6 +118,7 @@ public class ComponentAccessibilityCodeActionProviderTest : LanguageServerTestBa
         var commandOrCodeActionContainer = await provider.ProvideAsync(context, default);
 
         // Assert
+        Assert.NotNull(commandOrCodeActionContainer);
         Assert.Collection(commandOrCodeActionContainer,
             e =>
             {
@@ -163,6 +162,7 @@ public class ComponentAccessibilityCodeActionProviderTest : LanguageServerTestBa
         var commandOrCodeActionContainer = await provider.ProvideAsync(context, default);
 
         // Assert
+        Assert.NotNull(commandOrCodeActionContainer);
         var command = Assert.Single(commandOrCodeActionContainer);
         Assert.Equal(RazorLS.Resources.Create_Component_FromTag_Title, command.Title);
         Assert.NotNull(command.Data);
@@ -189,6 +189,7 @@ public class ComponentAccessibilityCodeActionProviderTest : LanguageServerTestBa
         var commandOrCodeActionContainer = await provider.ProvideAsync(context, default);
 
         // Assert
+        Assert.NotNull(commandOrCodeActionContainer);
         Assert.Empty(commandOrCodeActionContainer);
     }
 
@@ -213,6 +214,7 @@ public class ComponentAccessibilityCodeActionProviderTest : LanguageServerTestBa
         var commandOrCodeActionContainer = await provider.ProvideAsync(context, default);
 
         // Assert
+        Assert.NotNull(commandOrCodeActionContainer);
         Assert.Collection(commandOrCodeActionContainer,
             e =>
             {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/CreateComponentCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/CreateComponentCodeActionResolverTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Linq;
 using System.Threading;
@@ -30,7 +28,7 @@ public class CreateComponentCodeActionResolverTest : LanguageServerTestBase
         _emptyDocumentContextFactory = Mock.Of<DocumentContextFactory>(
             r => r.TryCreateAsync(
                 It.IsAny<Uri>(),
-                It.IsAny<CancellationToken>()) == Task.FromResult<DocumentContext>(null),
+                It.IsAny<CancellationToken>()) == Task.FromResult<DocumentContext?>(null),
             MockBehavior.Strict);
     }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionProviderTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
@@ -170,9 +168,12 @@ public class ExtractToCodeBehindCodeActionProviderTest : LanguageServerTestBase
         var commandOrCodeActionContainer = await provider.ProvideAsync(context, default);
 
         // Assert
+        Assert.NotNull(commandOrCodeActionContainer);
         var codeAction = Assert.Single(commandOrCodeActionContainer);
-        var razorCodeActionResolutionParams = ((JObject)codeAction.Data).ToObject<RazorCodeActionResolutionParams>();
-        var actionParams = (razorCodeActionResolutionParams.Data as JObject).ToObject<ExtractToCodeBehindCodeActionParams>();
+        var razorCodeActionResolutionParams = ((JObject)codeAction.Data!).ToObject<RazorCodeActionResolutionParams>();
+        Assert.NotNull(razorCodeActionResolutionParams);
+        var actionParams = ((JObject)razorCodeActionResolutionParams.Data).ToObject<ExtractToCodeBehindCodeActionParams>();
+        Assert.NotNull(actionParams);
         Assert.Equal(14, actionParams.RemoveStart);
         Assert.Equal(19, actionParams.ExtractStart);
         Assert.Equal(42, actionParams.ExtractEnd);
@@ -224,9 +225,12 @@ public class ExtractToCodeBehindCodeActionProviderTest : LanguageServerTestBase
         var commandOrCodeActionContainer = await provider.ProvideAsync(context, default);
 
         // Assert
+        Assert.NotNull(commandOrCodeActionContainer);
         var codeAction = Assert.Single(commandOrCodeActionContainer);
-        var razorCodeActionResolutionParams = ((JObject)codeAction.Data).ToObject<RazorCodeActionResolutionParams>();
-        var actionParams = (razorCodeActionResolutionParams.Data as JObject).ToObject<ExtractToCodeBehindCodeActionParams>();
+        var razorCodeActionResolutionParams = ((JObject)codeAction.Data!).ToObject<RazorCodeActionResolutionParams>();
+        Assert.NotNull(razorCodeActionResolutionParams);
+        var actionParams = ((JObject)razorCodeActionResolutionParams.Data).ToObject<ExtractToCodeBehindCodeActionParams>();
+        Assert.NotNull(actionParams);
         Assert.Equal(14, actionParams.RemoveStart);
         Assert.Equal(24, actionParams.ExtractStart);
         Assert.Equal(47, actionParams.ExtractEnd);
@@ -260,7 +264,7 @@ public class ExtractToCodeBehindCodeActionProviderTest : LanguageServerTestBase
     private static RazorCodeActionContext CreateRazorCodeActionContext(CodeActionParams request, SourceLocation location, string filePath, string text, bool supportsFileCreation = true)
         => CreateRazorCodeActionContext(request, location, filePath, text, relativePath: filePath, supportsFileCreation: supportsFileCreation);
 
-    private static RazorCodeActionContext CreateRazorCodeActionContext(CodeActionParams request, SourceLocation location, string filePath, string text, string relativePath, bool supportsFileCreation = true)
+    private static RazorCodeActionContext CreateRazorCodeActionContext(CodeActionParams request, SourceLocation location, string filePath, string text, string? relativePath, bool supportsFileCreation = true)
     {
         var sourceDocument = RazorSourceDocument.Create(text, new RazorSourceDocumentProperties(filePath, relativePath));
         var options = RazorParserOptions.Create(o =>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorTranslateDiagnosticsEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorTranslateDiagnosticsEndpointTest.cs
@@ -63,7 +63,7 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(4, 12),
                     new SourceSpan(10, 12))
             });
-        var documentContext = CreateDocumentContext(documentPath, codeDocument, documentFound: false);
+        var documentContext = (DocumentContext?)null;
 
         var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
         var request = new RazorDiagnosticsParams()

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentPresentation/TextDocumentUriPresentationEndpointTests.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentPresentation/TextDocumentUriPresentationEndpointTests.cs
@@ -11,7 +11,6 @@ using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Moq;
 using Xunit;
@@ -608,26 +607,5 @@ public class TextDocumentUriPresentationEndpointTests : LanguageServerTestBase
 
         // Assert
         Assert.Null(result);
-    }
-
-    private static DocumentContext CreateDocumentContext(Uri documentPath, RazorCodeDocument codeDocument)
-    {
-        var documentContext = SetupDocumentContextFactory(documentPath, codeDocument);
-
-        return documentContext;
-
-        static DocumentContext SetupDocumentContextFactory(Uri documentPath, RazorCodeDocument codeDocument)
-        {
-            var sourceTextChars = new char[codeDocument.Source.Length];
-            codeDocument.Source.CopyTo(0, sourceTextChars, 0, codeDocument.Source.Length);
-            var sourceText = SourceText.From(new string(sourceTextChars));
-            var snapshot = Mock.Of<DocumentSnapshot>(document =>
-                document.GetGeneratedOutputAsync() == Task.FromResult(codeDocument) &&
-                document.GetTextAsync() == Task.FromResult(sourceText), MockBehavior.Strict);
-            var version = 1337;
-            var documentContext = new DocumentContext(documentPath, snapshot, version);
-
-            return documentContext;
-        }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/CSharpCodeActionsTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/CSharpCodeActionsTests.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.VisualStudio.Razor.IntegrationTests;
+
+public class CSharpCodeActionsTests : AbstractRazorEditorTest
+{
+    [IdeFact]
+    public async Task CSharpCodeActionsTests_MakeExpressionBodiedMethod()
+    {
+        // Open the file
+        await TestServices.SolutionExplorer.OpenFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.CounterRazorFile, ControlledHangMitigatingCancellationToken);
+
+        await TestServices.Editor.PlaceCaretAsync("IncrementCount", charsOffset: 2, occurrence: 2, extendSelection: false, selectBlock: false, ControlledHangMitigatingCancellationToken);
+
+        // Act
+        var codeActions = await TestServices.Editor.InvokeCodeActionListAsync(ControlledHangMitigatingCancellationToken);
+
+        // Assert
+        var codeActionSet = Assert.Single(codeActions);
+        var codeAction = Assert.Single(codeActionSet.Actions, a => a.DisplayText.Equals("Use expression body for method"));
+
+        await TestServices.Editor.InvokeCodeActionAsync(codeAction, ControlledHangMitigatingCancellationToken);
+
+        await TestServices.Editor.WaitForCurrentLineTextAsync("private void IncrementCount() => currentCount++;", ControlledHangMitigatingCancellationToken);
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/EditorInProcess_Text.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/EditorInProcess_Text.cs
@@ -11,115 +11,127 @@ using Xunit;
 
 namespace Microsoft.VisualStudio.Extensibility.Testing;
 
-    internal partial class EditorInProcess
+internal partial class EditorInProcess
+{
+    public async Task UndoTextAsync(CancellationToken cancellationToken)
     {
-        public async Task UndoTextAsync(CancellationToken cancellationToken)
+        await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+        var dte = await GetRequiredGlobalServiceAsync<SDTE, EnvDTE.DTE>(cancellationToken);
+        dte.ActiveDocument.Undo();
+    }
+
+    public async Task SetTextAsync(string text, CancellationToken cancellationToken)
+    {
+        await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+        var view = await GetActiveTextViewAsync(cancellationToken);
+        var textSnapshot = view.TextSnapshot;
+        var replacementSpan = new SnapshotSpan(textSnapshot, 0, textSnapshot.Length);
+        _ = view.TextBuffer.Replace(replacementSpan, text);
+    }
+
+    public async Task WaitForTextChangeAsync(Action action, CancellationToken cancellationToken)
+    {
+        using var semaphore = new SemaphoreSlim(1);
+        await semaphore.WaitAsync(cancellationToken);
+
+        var view = await GetActiveTextViewAsync(cancellationToken);
+        view.TextBuffer.PostChanged += TextBuffer_PostChanged;
+
+        action.Invoke();
+
+        try
         {
-            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
-            var dte = await GetRequiredGlobalServiceAsync<SDTE, EnvDTE.DTE>(cancellationToken);
-            dte.ActiveDocument.Undo();
-        }
-
-        public async Task SetTextAsync(string text, CancellationToken cancellationToken)
-        {
-            await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
-            var view = await GetActiveTextViewAsync(cancellationToken);
-            var textSnapshot = view.TextSnapshot;
-            var replacementSpan = new SnapshotSpan(textSnapshot, 0, textSnapshot.Length);
-            _ = view.TextBuffer.Replace(replacementSpan, text);
-        }
-
-        public async Task WaitForTextChangeAsync(Action action, CancellationToken cancellationToken)
-        {
-            using var semaphore = new SemaphoreSlim(1);
             await semaphore.WaitAsync(cancellationToken);
-
-            var view = await GetActiveTextViewAsync(cancellationToken);
-            view.TextBuffer.PostChanged += TextBuffer_PostChanged;
-
-            action.Invoke();
-
-            try
-            {
-                await semaphore.WaitAsync(cancellationToken);
-            }
-            finally
-            {
-                view.TextBuffer.PostChanged -= TextBuffer_PostChanged;
-            }
-
-            void TextBuffer_PostChanged(object sender, EventArgs e)
-            {
-                semaphore.Release();
-                view.TextBuffer.PostChanged -= TextBuffer_PostChanged;
-            }
+        }
+        finally
+        {
+            view.TextBuffer.PostChanged -= TextBuffer_PostChanged;
         }
 
-        public async Task<string> WaitForTextChangeAsync(string text, CancellationToken cancellationToken)
+        void TextBuffer_PostChanged(object sender, EventArgs e)
         {
-            var result = await Helper.RetryAsync(async ct =>
-                {
-                    var view = await GetActiveTextViewAsync(cancellationToken);
-                    var content = view.TextBuffer.CurrentSnapshot.GetText();
-
-                    if (text != content)
-                    {
-                        return content;
-                    }
-
-                    return null;
-                },
-                TimeSpan.FromMilliseconds(50),
-                cancellationToken).ConfigureAwait(false);
-
-            return result!;
-        }
-
-        public async Task VerifyTextContainsAsync(string text, CancellationToken cancellationToken)
-        {
-            var view = await GetActiveTextViewAsync(cancellationToken);
-            var content = view.TextBuffer.CurrentSnapshot.GetText();
-            Assert.Contains(text, content);
-        }
-
-        public async Task VerifyTextDoesntContainAsync(string text, CancellationToken cancellationToken)
-        {
-            var view = await GetActiveTextViewAsync(cancellationToken);
-            var content = view.TextBuffer.CurrentSnapshot.GetText();
-            Assert.DoesNotContain(text, content);
-        }
-
-        public async Task WaitForCurrentLineTextAsync(string text, CancellationToken cancellationToken)
-        {
-            await Helper.RetryAsync(async ct =>
-                {
-                    var view = await GetActiveTextViewAsync(cancellationToken);
-                    var caret = view.Caret.Position.BufferPosition;
-                    var line = view.TextBuffer.CurrentSnapshot.GetLineFromPosition(caret).GetText();
-
-                    return line.Trim() == text.Trim();
-                },
-                TimeSpan.FromMilliseconds(50),
-                cancellationToken);
-        }
-
-        public async Task WaitForActiveWindowAsync(string windowTitle, CancellationToken cancellationToken)
-        {
-            await Helper.RetryAsync(async ct =>
-                {
-                    var activeWindowCaption = await TestServices.Shell.GetActiveWindowCaptionAsync(cancellationToken);
-
-                    return activeWindowCaption == windowTitle;
-                },
-                TimeSpan.FromMilliseconds(50),
-                cancellationToken);
-        }
-
-        public async Task WaitForProjectReadyAsync(CancellationToken cancellationToken)
-        {
-            await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.LanguageServer, cancellationToken);
-            await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.Workspace, cancellationToken);
+            semaphore.Release();
+            view.TextBuffer.PostChanged -= TextBuffer_PostChanged;
         }
     }
+
+    public async Task<string> WaitForTextChangeAsync(string text, CancellationToken cancellationToken)
+    {
+        var result = await Helper.RetryAsync(async ct =>
+            {
+                var view = await GetActiveTextViewAsync(cancellationToken);
+                var content = view.TextBuffer.CurrentSnapshot.GetText();
+
+                if (text != content)
+                {
+                    return content;
+                }
+
+                return null;
+            },
+            TimeSpan.FromMilliseconds(50),
+            cancellationToken).ConfigureAwait(false);
+
+        return result!;
+    }
+
+    public async Task VerifyTextContainsAsync(string text, CancellationToken cancellationToken)
+    {
+        var view = await GetActiveTextViewAsync(cancellationToken);
+        var content = view.TextBuffer.CurrentSnapshot.GetText();
+        Assert.Contains(text, content);
+    }
+
+    public async Task VerifyTextDoesntContainAsync(string text, CancellationToken cancellationToken)
+    {
+        var view = await GetActiveTextViewAsync(cancellationToken);
+        var content = view.TextBuffer.CurrentSnapshot.GetText();
+        Assert.DoesNotContain(text, content);
+    }
+
+    public async Task WaitForCurrentLineTextAsync(string text, CancellationToken cancellationToken)
+    {
+        await Helper.RetryAsync(async ct =>
+            {
+                var view = await GetActiveTextViewAsync(cancellationToken);
+                var caret = view.Caret.Position.BufferPosition;
+                var line = view.TextBuffer.CurrentSnapshot.GetLineFromPosition(caret).GetText();
+
+                return line.Trim() == text.Trim();
+            },
+            TimeSpan.FromMilliseconds(50),
+            cancellationToken);
+    }
+
+    public async Task WaitForActiveWindowAsync(string windowTitle, CancellationToken cancellationToken)
+    {
+        await Helper.RetryAsync(async ct =>
+            {
+                var activeWindowCaption = await TestServices.Shell.GetActiveWindowCaptionAsync(cancellationToken);
+
+                return activeWindowCaption == windowTitle;
+            },
+            TimeSpan.FromMilliseconds(50),
+            cancellationToken);
+    }
+
+    public async Task WaitForActiveWindowByFileAsync(string fileName, CancellationToken cancellationToken)
+    {
+        await Helper.RetryAsync(async ct =>
+            {
+                var activeWindowCaption = await TestServices.Shell.GetActiveDocumentFileNameAsync(cancellationToken);
+
+                return activeWindowCaption == fileName;
+            },
+            TimeSpan.FromMilliseconds(50),
+            cancellationToken);
+    }
+
+    public async Task WaitForProjectReadyAsync(CancellationToken cancellationToken)
+    {
+        await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.LanguageServer, cancellationToken);
+        await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.Workspace, cancellationToken);
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/ShellInProcess.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/ShellInProcess.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.VisualStudio.Extensibility.Testing;
+
+internal partial class ShellInProcess
+{
+    public async Task<string> GetActiveDocumentFileNameAsync(CancellationToken cancellationToken)
+    {
+        await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+        var monitorSelection = await GetRequiredGlobalServiceAsync<SVsShellMonitorSelection, IVsMonitorSelection>(cancellationToken);
+        ErrorHandler.ThrowOnFailure(monitorSelection.GetCurrentElementValue((uint)VSConstants.VSSELELEMID.SEID_WindowFrame, out var windowFrameObj));
+        var windowFrame = (IVsWindowFrame)windowFrameObj;
+
+        ErrorHandler.ThrowOnFailure(windowFrame.GetProperty((int)__VSFPROPID.VSFPROPID_pszMkDocument, out var documentPathObj));
+        var documentPath = (string)documentPathObj;
+        return Path.GetFileName(documentPath);
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/RazorCodeActionsTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/RazorCodeActionsTests.cs
@@ -51,6 +51,6 @@ public class RazorCodeActionsTests : AbstractRazorEditorTest
 
         await TestServices.Editor.InvokeCodeActionAsync(codeAction, ControlledHangMitigatingCancellationToken);
 
-        Assert.Equal("Counter.razor.cs", await TestServices.Shell.GetActiveDocumentFileNameAsync(ControlledHangMitigatingCancellationToken));
+        await TestServices.Editor.WaitForActiveWindowByFileAsync("Counter.razor.cs", ControlledHangMitigatingCancellationToken);
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/RazorCodeActionsTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/RazorCodeActionsTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests;
 public class RazorCodeActionsTests : AbstractRazorEditorTest
 {
     [IdeFact]
-    public async Task RazorCodeActions_Show()
+    public async Task RazorCodeActions_AddUsing()
     {
         // Create Warnings by removing usings
         await TestServices.SolutionExplorer.OpenFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.ImportsRazorFile, ControlledHangMitigatingCancellationToken);
@@ -32,5 +32,25 @@ public class RazorCodeActionsTests : AbstractRazorEditorTest
         await TestServices.Editor.InvokeCodeActionAsync(codeAction, ControlledHangMitigatingCancellationToken);
 
         await TestServices.Editor.VerifyTextContainsAsync(usingString, ControlledHangMitigatingCancellationToken);
+    }
+
+    [IdeFact]
+    public async Task RazorCodeActions_ExtractToCodeBehind()
+    {
+        // Open the file
+        await TestServices.SolutionExplorer.OpenFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.CounterRazorFile, ControlledHangMitigatingCancellationToken);
+
+        await TestServices.Editor.PlaceCaretAsync("@code", 1, ControlledHangMitigatingCancellationToken);
+
+        // Act
+        var codeActions = await TestServices.Editor.InvokeCodeActionListAsync(ControlledHangMitigatingCancellationToken);
+
+        // Assert
+        var codeActionSet = Assert.Single(codeActions);
+        var codeAction = Assert.Single(codeActionSet.Actions, a => a.DisplayText.Equals("Extract block to code behind"));
+
+        await TestServices.Editor.InvokeCodeActionAsync(codeAction, ControlledHangMitigatingCancellationToken);
+
+        Assert.Equal("Counter.razor.cs", await TestServices.Shell.GetActiveDocumentFileNameAsync(ControlledHangMitigatingCancellationToken));
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/7926

Well not really, because one of the suggestions turned out to not be possible, but I null annotated all of the code actions tests, and added new integration tests, to make up for it :)