### PR TITLE
Change Razor component route syntax to use option

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Extensions/DesignTimeDirectiveTargetExtension.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Extensions/DesignTimeDirectiveTargetExtension.cs
@@ -158,7 +158,7 @@ internal class DesignTimeDirectiveTargetExtension : IDesignTimeDirectiveTargetEx
                     var stringSyntax = context.DocumentKind switch
                     {
                         "mvc.1.0.razor-page" => "Route",
-                        "component.1.0" => "ComponentRoute",
+                        "component.1.0" => "Route,Component",
                         _ => null
                     };
                     if (stringSyntax is not null)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithPageDirective/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithPageDirective/TestComponent.codegen.cs
@@ -15,7 +15,7 @@ namespace Test
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-// language=ComponentRoute
+// language=Route,Component
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
 global::System.Object __typeHelper = "/MyPage";
@@ -26,7 +26,7 @@ global::System.Object __typeHelper = "/MyPage";
         }
         ))();
         ((System.Action)(() => {
-// language=ComponentRoute
+// language=Route,Component
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
 global::System.Object __typeHelper = "/AnotherRoute/{id}";

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithPageDirective/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/ChildComponent_WithPageDirective/TestComponent.mappings.txt
@@ -1,10 +1,10 @@
 Source Location: (6:0,6 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |"/MyPage"|
-Generated Location: (773:20,37 [9] )
+Generated Location: (774:20,37 [9] )
 |"/MyPage"|
 
 Source Location: (23:1,6 [20] x:\dir\subdir\Test\TestComponent.cshtml)
 |"/AnotherRoute/{id}"|
-Generated Location: (1030:31,37 [20] )
+Generated Location: (1032:31,37 [20] )
 |"/AnotherRoute/{id}"|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithUsingDirectives/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithUsingDirectives/TestComponent.codegen.cs
@@ -22,7 +22,7 @@ using Test2;
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-// language=ComponentRoute
+// language=Route,Component
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
 global::System.Object __typeHelper = "/MyPage";
@@ -33,7 +33,7 @@ global::System.Object __typeHelper = "/MyPage";
         }
         ))();
         ((System.Action)(() => {
-// language=ComponentRoute
+// language=Route,Component
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
 global::System.Object __typeHelper = "/AnotherRoute/{id}";

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithUsingDirectives/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithUsingDirectives/TestComponent.mappings.txt
@@ -5,11 +5,11 @@ Generated Location: (320:12,0 [11] )
 
 Source Location: (6:0,6 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |"/MyPage"|
-Generated Location: (907:27,37 [9] )
+Generated Location: (908:27,37 [9] )
 |"/MyPage"|
 
 Source Location: (23:1,6 [20] x:\dir\subdir\Test\TestComponent.cshtml)
 |"/AnotherRoute/{id}"|
-Generated Location: (1164:38,37 [20] )
+Generated Location: (1166:38,37 [20] )
 |"/AnotherRoute/{id}"|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Legacy_3_1_TrailingWhiteSpace_WithDirective/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Legacy_3_1_TrailingWhiteSpace_WithDirective/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-// language=ComponentRoute
+// language=Route,Component
 #nullable restore
 #line 3 "x:\dir\subdir\Test\TestComponent.cshtml"
 global::System.Object __typeHelper = "/my/url";

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Legacy_3_1_TrailingWhiteSpace_WithDirective/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Legacy_3_1_TrailingWhiteSpace_WithDirective/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (24:2,6 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |"/my/url"|
-Generated Location: (689:19,37 [9] )
+Generated Location: (690:19,37 [9] )
 |"/my/url"|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_772/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_772/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-// language=ComponentRoute
+// language=Route,Component
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
 global::System.Object __typeHelper = "/";

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_772/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_772/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (6:0,6 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |"/"|
-Generated Location: (683:19,37 [3] )
+Generated Location: (684:19,37 [3] )
 |"/"|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_773/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_773/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-// language=ComponentRoute
+// language=Route,Component
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
 global::System.Object __typeHelper = "/";

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_773/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Regression_773/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (6:0,6 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |"/"|
-Generated Location: (683:19,37 [3] )
+Generated Location: (684:19,37 [3] )
 |"/"|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/TrailingWhiteSpace_WithDirective/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/TrailingWhiteSpace_WithDirective/TestComponent.codegen.cs
@@ -14,7 +14,7 @@ namespace Test
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((System.Action)(() => {
-// language=ComponentRoute
+// language=Route,Component
 #nullable restore
 #line 3 "x:\dir\subdir\Test\TestComponent.cshtml"
 global::System.Object __typeHelper = "/my/url";

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/TrailingWhiteSpace_WithDirective/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/TrailingWhiteSpace_WithDirective/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 Source Location: (24:2,6 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |"/my/url"|
-Generated Location: (689:19,37 [9] )
+Generated Location: (690:19,37 [9] )
 |"/my/url"|
 

--- a/src/Compiler/test/Microsoft.AspNetCore.Razor.Test.Common/Microsoft.AspNetCore.Razor.Test.Common.Compiler.csproj
+++ b/src/Compiler/test/Microsoft.AspNetCore.Razor.Test.Common/Microsoft.AspNetCore.Razor.Test.Common.Compiler.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <!-- To generate baselines, run tests with /p:GenerateBaselines=true -->

--- a/src/Compiler/test/Microsoft.AspNetCore.Razor.Test.Common/Microsoft.AspNetCore.Razor.Test.Common.Compiler.csproj
+++ b/src/Compiler/test/Microsoft.AspNetCore.Razor.Test.Common/Microsoft.AspNetCore.Razor.Test.Common.Compiler.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <!-- To generate baselines, run tests with /p:GenerateBaselines=true -->


### PR DESCRIPTION
https://github.com/dotnet/razor/pull/6997 added string syntaxes to Razor pages and component page routes. This PR changes the string syntax for components to `Route,Component` so the same integration can be used for both.