### PR TITLE
Remove duplicate "razor." on property name

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperResolver.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperResolver.cs
@@ -64,7 +64,7 @@ internal abstract class TagHelperResolver : IWorkspaceService
             provider.Execute(context);
 
             stopWatch.Stop();
-            var propertyName = $"razor.{provider.Name}.elapsedtimems";
+            var propertyName = $"{provider.Name}.elapsedtimems";
             Debug.Assert(!timingDictionary.ContainsKey(propertyName));
             timingDictionary[propertyName] = stopWatch.ElapsedMilliseconds;
         }


### PR DESCRIPTION
@AllenD-MSFT noticed a property name coming through telemetry of `razor.razor.bindtaghelperdescriptorprovider.elapsedtime`. Turns out we prefixed the property name when creating the data, and then [prefixed it again](https://github.com/dotnet/razor/blob/main/src/Razor/src/Microsoft.AspNetCore.Razor.Common/Telemetry/TelemetryReporter.cs#L50) when reporting.