### PR TITLE
Exclude non-shipping files from vsix

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor.CoreComponents/Microsoft.CodeAnalysis.Remote.Razor.CoreComponents.csproj
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor.CoreComponents/Microsoft.CodeAnalysis.Remote.Razor.CoreComponents.csproj
@@ -22,8 +22,11 @@
         Also only include dependencies exclusive to Razor. For any common dependencies between Roslyn and Razor, we want to share the ones
         loaded in Roslyn's ALC at runtime.
       -->
+
+      <_ExcludedFiles Include="$(PublishDir)**\Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.*" />
+
       <_PublishedFiles Include="$(PublishDir)**\Microsoft.CodeAnalysis.Razor.*" />
-      <_PublishedFiles Include="$(PublishDir)**\Microsoft.CodeAnalysis.Remote.Razor.*" />
+      <_PublishedFiles Include="$(PublishDir)**\Microsoft.CodeAnalysis.Remote.Razor.*" Exclude="@(_ExcludedFiles)"/>
       <_PublishedFiles Include="$(PublishDir)**\Microsoft.AspNetCore.*" />
       <_PublishedFiles Include="$(PublishDir)**\Microsoft.Extensions.Logging.Abstractions.dll" />
 


### PR DESCRIPTION
Following files should not be included in `ServiceHubCore` inthe razor vsix

![image](https://user-images.githubusercontent.com/788783/203147073-1624d3af-2b30-4119-9b14-a9bf78acdeee.png)