### PR TITLE
Remove Name from interface, use runtime type instead

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/src/ViewComponentTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/src/ViewComponentTagHelperDescriptorProvider.cs
@@ -13,8 +13,6 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X;
 
 public sealed class ViewComponentTagHelperDescriptorProvider : RazorEngineFeatureBase, ITagHelperDescriptorProvider
 {
-    public string Name => nameof(ViewComponentTagHelperDescriptorProvider);
-
     public int Order { get; set; }
 
     public void Execute(TagHelperDescriptorProviderContext context)

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/src/ViewComponentTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/src/ViewComponentTagHelperDescriptorProvider.cs
@@ -13,7 +13,6 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X;
 
 public sealed class ViewComponentTagHelperDescriptorProvider : RazorEngineFeatureBase, ITagHelperDescriptorProvider
 {
-    public string Name => nameof(ViewComponentTagHelperDescriptorProvider);
     public int Order { get; set; }
 
     public void Execute(TagHelperDescriptorProviderContext context)

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/src/ViewComponentTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/src/ViewComponentTagHelperDescriptorProvider.cs
@@ -13,7 +13,6 @@ namespace Microsoft.AspNetCore.Mvc.Razor.Extensions;
 
 public sealed class ViewComponentTagHelperDescriptorProvider : RazorEngineFeatureBase, ITagHelperDescriptorProvider
 {
-    public string Name => nameof(ViewComponentTagHelperDescriptorProvider);
     public int Order { get; set; }
 
     public void Execute(TagHelperDescriptorProviderContext context)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/ITagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/ITagHelperDescriptorProvider.cs
@@ -7,7 +7,6 @@ namespace Microsoft.AspNetCore.Razor.Language;
 
 public interface ITagHelperDescriptorProvider : IRazorEngineFeature
 {
-    string Name { get; }
     int Order { get; }
 
     void Execute(TagHelperDescriptorProviderContext context);

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/BindTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/BindTagHelperDescriptorProvider.cs
@@ -15,8 +15,6 @@ namespace Microsoft.CodeAnalysis.Razor;
 
 internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
 {
-    public string Name => nameof(BindTagHelperDescriptorProvider);
-
     // Run after the component tag helper provider, because we need to see the results.
     public int Order { get; set; } = 1000;
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentTagHelperDescriptorProvider.cs
@@ -26,7 +26,6 @@ internal class ComponentTagHelperDescriptorProvider : RazorEngineFeatureBase, IT
             .WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Included)
             .WithMiscellaneousOptions(SymbolDisplayFormat.FullyQualifiedFormat.MiscellaneousOptions & (~SymbolDisplayMiscellaneousOptions.UseSpecialTypes));
 
-    public string Name => nameof(ComponentTagHelperDescriptorProvider);
     public bool IncludeDocumentation { get; set; }
 
     public int Order { get; set; }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/DefaultTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/DefaultTagHelperDescriptorProvider.cs
@@ -11,7 +11,6 @@ namespace Microsoft.CodeAnalysis.Razor;
 
 public sealed class DefaultTagHelperDescriptorProvider : RazorEngineFeatureBase, ITagHelperDescriptorProvider
 {
-    public string Name => nameof(DefaultTagHelperDescriptorProvider);
     public int Order { get; set; }
 
     public void Execute(TagHelperDescriptorProviderContext context)

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/EventHandlerTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/EventHandlerTagHelperDescriptorProvider.cs
@@ -13,7 +13,6 @@ namespace Microsoft.CodeAnalysis.Razor;
 
 internal class EventHandlerTagHelperDescriptorProvider : ITagHelperDescriptorProvider
 {
-    public string Name => nameof(EventHandlerTagHelperDescriptorProvider);
     public int Order { get; set; }
 
     public RazorEngine Engine { get; set; }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/KeyTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/KeyTagHelperDescriptorProvider.cs
@@ -11,7 +11,6 @@ namespace Microsoft.CodeAnalysis.Razor;
 
 internal class KeyTagHelperDescriptorProvider : ITagHelperDescriptorProvider
 {
-    public string Name => nameof(KeyTagHelperDescriptorProvider);
     // Run after the component tag helper provider
     public int Order { get; set; } = 1000;
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/RefTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/RefTagHelperDescriptorProvider.cs
@@ -11,8 +11,6 @@ namespace Microsoft.CodeAnalysis.Razor;
 
 internal class RefTagHelperDescriptorProvider : ITagHelperDescriptorProvider
 {
-    public string Name => nameof(RefTagHelperDescriptorProvider);
-
     // Run after the component tag helper provider, because later we may want component-type-specific variants of this
     public int Order { get; set; } = 1000;
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/SplatTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/SplatTagHelperDescriptorProvider.cs
@@ -11,8 +11,6 @@ namespace Microsoft.CodeAnalysis.Razor;
 
 internal class SplatTagHelperDescriptorProvider : ITagHelperDescriptorProvider
 {
-    public string Name => nameof(SplatTagHelperDescriptorProvider);
-
     // Order doesn't matter
     public int Order { get; set; }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperResolver.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperResolver.cs
@@ -64,7 +64,7 @@ internal abstract class TagHelperResolver : IWorkspaceService
             provider.Execute(context);
 
             stopWatch.Stop();
-            var propertyName = $"{provider.Name}.elapsedtimems";
+            var propertyName = $"{provider.GetType().Name}.elapsedtimems";
             Debug.Assert(!timingDictionary.ContainsKey(propertyName));
             timingDictionary[propertyName] = stopWatch.ElapsedMilliseconds;
         }


### PR DESCRIPTION
PR https://github.com/dotnet/razor/pull/7001 added a `Name` property to `ITagHelperDescriptorProvider`.

Unfortunately, for some legacy razor projects (MVC Extensions 2.x and 1.x) the assembly versions from NuGet are hard coded, meaning changes need to be backwards compatible. With this change, the razor tool in the SDK starts throwing `MethodNotFoundException` for the legacy projects because the hard coded nuget versions don't implement the new `Name` property. 

We can think through how we want to handle this in the future, and I think there is scope to make changes, but for now we're blocked inserting into the SDK by this.  As a temporary remediation, I've removed the `Name` property, and am just using the runtime type instead.

