### PR TITLE
Fix classification of C#-looking text in Html tags

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json
@@ -39,6 +39,31 @@
         }
       ]
     },
+    "optionally-transitioned-razor-control-structures": {
+      "patterns": [
+        {
+          "include": "#razor-comment"
+        },
+        {
+          "include": "#razor-codeblock"
+        },
+        {
+          "include": "#explicit-razor-expression"
+        },
+        {
+          "include": "#escaped-transition"
+        },
+        {
+          "include": "#directives"
+        },
+        {
+          "include": "#optionally-transitioned-csharp-control-structures"
+        },
+        {
+          "include": "#implicit-expression"
+        }
+      ]
+    },
     "escaped-transition": {
       "name": "constant.character.escape.razor.transition",
       "match": "@@"
@@ -87,7 +112,7 @@
           "include": "#razor-single-line-markup"
         },
         {
-          "include": "#razor-control-structures"
+          "include": "#optionally-transitioned-razor-control-structures"
         },
         {
           "include": "source.cs"
@@ -964,6 +989,40 @@
         }
       }
     },
+    "optionally-transitioned-csharp-control-structures": {
+      "patterns": [
+        {
+          "include": "#using-statement-with-optional-transition"
+        },
+        {
+          "include": "#if-statement-with-optional-transition"
+        },
+        {
+          "include": "#else-part"
+        },
+        {
+          "include": "#foreach-statement-with-optional-transition"
+        },
+        {
+          "include": "#for-statement-with-optional-transition"
+        },
+        {
+          "include": "#while-statement"
+        },
+        {
+          "include": "#switch-statement-with-optional-transition"
+        },
+        {
+          "include": "#lock-statement-with-optional-transition"
+        },
+        {
+          "include": "#do-statement-with-optional-transition"
+        },
+        {
+          "include": "#try-statement-with-optional-transition"
+        }
+      ]
+    },
     "transitioned-csharp-control-structures": {
       "patterns": [
         {
@@ -1000,6 +1059,34 @@
     },
     "using-statement": {
       "name": "meta.statement.using.razor",
+      "begin": "(?:(@))(using)\\b\\s*(?=\\()",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.other.using.cs"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#csharp-condition"
+        },
+        {
+          "include": "#csharp-code-block"
+        },
+        {
+          "include": "#razor-codeblock-body"
+        }
+      ],
+      "end": "(?<=})"
+    },
+    "using-statement-with-optional-transition": {
+      "name": "meta.statement.using.razor",
       "begin": "(?:^\\s*|(@))(using)\\b\\s*(?=\\()",
       "beginCaptures": {
         "1": {
@@ -1027,6 +1114,34 @@
       "end": "(?<=})"
     },
     "if-statement": {
+      "name": "meta.statement.if.razor",
+      "begin": "(?:(@))(if)\\b\\s*(?=\\()",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.control.conditional.if.cs"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#csharp-condition"
+        },
+        {
+          "include": "#csharp-code-block"
+        },
+        {
+          "include": "#razor-codeblock-body"
+        }
+      ],
+      "end": "(?<=})"
+    },
+    "if-statement-with-optional-transition": {
       "name": "meta.statement.if.razor",
       "begin": "(?:^\\s*|(@))(if)\\b\\s*(?=\\()",
       "beginCaptures": {
@@ -1080,6 +1195,34 @@
     },
     "for-statement": {
       "name": "meta.statement.for.razor",
+      "begin": "(?:(@))(for)\\b\\s*(?=\\()",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.control.loop.for.cs"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#csharp-condition"
+        },
+        {
+          "include": "#csharp-code-block"
+        },
+        {
+          "include": "#razor-codeblock-body"
+        }
+      ],
+      "end": "(?<=})"
+    },
+    "for-statement-with-optional-transition": {
+      "name": "meta.statement.for.razor",
       "begin": "(?:^\\s*|(@))(for)\\b\\s*(?=\\()",
       "beginCaptures": {
         "1": {
@@ -1107,6 +1250,41 @@
       "end": "(?<=})"
     },
     "foreach-statement": {
+      "name": "meta.statement.foreach.razor",
+      "begin": "(?:(@)(await\\s+)?)(foreach)\\b\\s*(?=\\()",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#await-prefix"
+            }
+          ]
+        },
+        "3": {
+          "name": "keyword.control.loop.foreach.cs"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#foreach-condition"
+        },
+        {
+          "include": "#csharp-code-block"
+        },
+        {
+          "include": "#razor-codeblock-body"
+        }
+      ],
+      "end": "(?<=})"
+    },
+    "foreach-statement-with-optional-transition": {
       "name": "meta.statement.foreach.razor",
       "begin": "(?:^\\s*|(@)(await\\s+)?)(foreach)\\b\\s*(?=\\()",
       "beginCaptures": {
@@ -1201,7 +1379,35 @@
     },
     "do-statement": {
       "name": "meta.statement.do.razor",
-      "begin": "(?:^\\s*|(@))(do)\\b\\s*",
+      "begin": "(?:(@))(do)\\b\\s",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.control.loop.do.cs"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#csharp-condition"
+        },
+        {
+          "include": "#csharp-code-block"
+        },
+        {
+          "include": "#razor-codeblock-body"
+        }
+      ],
+      "end": "(?<=})"
+    },
+    "do-statement-with-optional-transition": {
+      "name": "meta.statement.do.razor",
+      "begin": "(?:^\\s*|(@))(do)\\b\\s",
       "beginCaptures": {
         "1": {
           "patterns": [
@@ -1262,6 +1468,34 @@
     },
     "switch-statement": {
       "name": "meta.statement.switch.razor",
+      "begin": "(?:(@))(switch)\\b\\s*(?=\\()",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.control.switch.cs"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#csharp-condition"
+        },
+        {
+          "include": "#switch-code-block"
+        },
+        {
+          "include": "#razor-codeblock-body"
+        }
+      ],
+      "end": "(?<=})"
+    },
+    "switch-statement-with-optional-transition": {
+      "name": "meta.statement.switch.razor",
       "begin": "(?:^\\s*|(@))(switch)\\b\\s*(?=\\()",
       "beginCaptures": {
         "1": {
@@ -1313,6 +1547,34 @@
     },
     "lock-statement": {
       "name": "meta.statement.lock.razor",
+      "begin": "(?:(@))(lock)\\b\\s*(?=\\()",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.other.lock.cs"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#csharp-condition"
+        },
+        {
+          "include": "#csharp-code-block"
+        },
+        {
+          "include": "#razor-codeblock-body"
+        }
+      ],
+      "end": "(?<=})"
+    },
+    "lock-statement-with-optional-transition": {
+      "name": "meta.statement.lock.razor",
       "begin": "(?:^\\s*|(@))(lock)\\b\\s*(?=\\()",
       "beginCaptures": {
         "1": {
@@ -1352,7 +1614,48 @@
         }
       ]
     },
+    "try-statement-with-optional-transition": {
+      "patterns": [
+        {
+          "include": "#try-block-with-optional-transition"
+        },
+        {
+          "include": "#catch-clause"
+        },
+        {
+          "include": "#finally-clause"
+        }
+      ]
+    },
     "try-block": {
+      "name": "meta.statement.try.razor",
+      "begin": "(?:(@))(try)\\b\\s*",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.control.try.cs"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#csharp-condition"
+        },
+        {
+          "include": "#csharp-code-block"
+        },
+        {
+          "include": "#razor-codeblock-body"
+        }
+      ],
+      "end": "(?<=})"
+    },
+    "try-block-with-optional-transition": {
       "name": "meta.statement.try.razor",
       "begin": "(?:^\\s*|(@))(try)\\b\\s*",
       "beginCaptures": {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -8,6 +8,8 @@ patterns:
   - include: 'text.html.basic'
 
 repository:
+
+ # Razor control structures, including C# control structures that require an '@'
   razor-control-structures:
     patterns:
       - include: '#razor-comment'
@@ -16,6 +18,17 @@ repository:
       - include: '#escaped-transition'
       - include: '#directives'
       - include: '#transitioned-csharp-control-structures'
+      - include: '#implicit-expression'
+
+# Razor control structures, including C# control structures that don't require an '@' (ie, are nested in a C# context)
+  optionally-transitioned-razor-control-structures:
+    patterns:
+      - include: '#razor-comment'
+      - include: '#razor-codeblock'
+      - include: '#explicit-razor-expression'
+      - include: '#escaped-transition'
+      - include: '#directives'
+      - include: '#optionally-transitioned-csharp-control-structures'
       - include: '#implicit-expression'
 
   escaped-transition:
@@ -46,7 +59,7 @@ repository:
       - include: '#text-tag'
       - include: '#wellformed-html'
       - include: '#razor-single-line-markup'
-      - include: '#razor-control-structures'
+      - include: '#optionally-transitioned-razor-control-structures'
       - include: 'source.cs'
 
   razor-single-line-markup:
@@ -477,6 +490,19 @@ repository:
       1: { name: 'entity.name.type.namespace.cs' }
 
   # ----------  Razor C# Control Structures ------------
+
+  optionally-transitioned-csharp-control-structures:
+    patterns:
+      - include: '#using-statement'
+      - include: '#if-statement'
+      - include: '#else-part'
+      - include: '#foreach-statement'
+      - include: '#for-statement'
+      - include: '#while-statement'
+      - include: '#switch-statement'
+      - include: '#lock-statement'
+      - include: '#do-statement'
+      - include: '#try-statement'
 
   transitioned-csharp-control-structures:
     patterns:

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -501,7 +501,7 @@ repository:
       - include: '#while-statement'
       - include: '#switch-statement'
       - include: '#lock-statement'
-      - include: '#do-statement'
+      - include: '#do-statement-with-optional-transition'
       - include: '#try-statement'
 
   transitioned-csharp-control-structures:
@@ -647,7 +647,19 @@ repository:
 
   do-statement:
     name: 'meta.statement.do.razor'
-    begin: '(?:^\s*|(@))(do)\b\s*'
+    begin: '(?:(@))(do)\b\s'
+    beginCaptures:
+      1: { patterns: [ include: '#transition' ] }
+      2: { name: 'keyword.control.loop.do.cs' }
+    patterns:
+      - include: '#csharp-condition'
+      - include: '#csharp-code-block'
+      - include: '#razor-codeblock-body'
+    end: '(?<=})'
+
+  do-statement-with-optional-transition:
+    name: 'meta.statement.do.razor'
+    begin: '(?:^\s*|(@))(do)\b\s'
     beginCaptures:
       1: { patterns: [ include: '#transition' ] }
       2: { name: 'keyword.control.loop.do.cs' }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -504,7 +504,7 @@ repository:
       - include: '#switch-statement-with-optional-transition'
       - include: '#lock-statement-with-optional-transition'
       - include: '#do-statement-with-optional-transition'
-      - include: '#try-statement'
+      - include: '#try-statement-with-optional-transition'
 
   transitioned-csharp-control-structures:
     patterns:
@@ -808,7 +808,25 @@ repository:
       - include: '#catch-clause'
       - include: '#finally-clause'
 
+  try-statement-with-optional-transition:
+    patterns:
+      - include: '#try-block-with-optional-transition'
+      - include: '#catch-clause'
+      - include: '#finally-clause'
+
   try-block:
+    name: 'meta.statement.try.razor'
+    begin: '(?:(@))(try)\b\s*'
+    beginCaptures:
+      1: { patterns: [ include: '#transition' ] }
+      2: { name: 'keyword.control.try.cs' }
+    patterns:
+      - include: '#csharp-condition'
+      - include: '#csharp-code-block'
+      - include: '#razor-codeblock-body'
+    end: '(?<=})'
+
+  try-block-with-optional-transition:
     name: 'meta.statement.try.razor'
     begin: '(?:^\s*|(@))(try)\b\s*'
     beginCaptures:

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -496,7 +496,7 @@ repository:
       - include: '#using-statement-with-optional-transition'
       - include: '#if-statement-with-optional-transition'
       - include: '#else-part'
-      - include: '#foreach-statement'
+      - include: '#foreach-statement-with-optional-transition'
       - include: '#for-statement'
       - include: '#while-statement'
       - include: '#switch-statement'
@@ -600,6 +600,19 @@ repository:
   #>>>>> @foreach (...) { ... } <<<<<
 
   foreach-statement:
+    name: 'meta.statement.foreach.razor'
+    begin: '(?:(@)(await\s+)?)(foreach)\b\s*(?=\()'
+    beginCaptures:
+      1: { patterns: [ include: '#transition' ] }
+      2: { patterns: [ include: '#await-prefix' ] }
+      3: { name: 'keyword.control.loop.foreach.cs' }
+    patterns:
+      - include: '#foreach-condition'
+      - include: '#csharp-code-block'
+      - include: '#razor-codeblock-body'
+    end: '(?<=})'
+
+  foreach-statement-with-optional-transition:
     name: 'meta.statement.foreach.razor'
     begin: '(?:^\s*|(@)(await\s+)?)(foreach)\b\s*(?=\()'
     beginCaptures:

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -501,7 +501,7 @@ repository:
   # while is incompatible with optional transitions because @do { } \n while { } is valid everywhere, and textmate only matches
   # one line at a time
       - include: '#while-statement'
-      - include: '#switch-statement'
+      - include: '#switch-statement-with-optional-transition'
       - include: '#lock-statement'
       - include: '#do-statement-with-optional-transition'
       - include: '#try-statement'
@@ -739,6 +739,18 @@ repository:
   #>>>>> @switch (...) { ... } <<<<<
 
   switch-statement:
+    name: 'meta.statement.switch.razor'
+    begin: '(?:(@))(switch)\b\s*(?=\()'
+    beginCaptures:
+      1: { patterns: [ include: '#transition' ] }
+      2: { name: 'keyword.control.switch.cs' }
+    patterns:
+      - include: '#csharp-condition'
+      - include: '#switch-code-block'
+      - include: '#razor-codeblock-body'
+    end: '(?<=})'
+
+  switch-statement-with-optional-transition:
     name: 'meta.statement.switch.razor'
     begin: '(?:^\s*|(@))(switch)\b\s*(?=\()'
     beginCaptures:

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -494,7 +494,7 @@ repository:
   optionally-transitioned-csharp-control-structures:
     patterns:
       - include: '#using-statement-with-optional-transition'
-      - include: '#if-statement'
+      - include: '#if-statement-with-optional-transition'
       - include: '#else-part'
       - include: '#foreach-statement'
       - include: '#for-statement'
@@ -546,6 +546,18 @@ repository:
   #>>>>> @if (...) { ... } <<<<<
 
   if-statement:
+    name: 'meta.statement.if.razor'
+    begin: '(?:(@))(if)\b\s*(?=\()'
+    beginCaptures:
+      1: { patterns: [ include: '#transition' ] }
+      2: { name: 'keyword.control.conditional.if.cs' }
+    patterns:
+      - include: '#csharp-condition'
+      - include: '#csharp-code-block'
+      - include: '#razor-codeblock-body'
+    end: '(?<=})'
+
+  if-statement-with-optional-transition:
     name: 'meta.statement.if.razor'
     begin: '(?:^\s*|(@))(if)\b\s*(?=\()'
     beginCaptures:

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -493,7 +493,7 @@ repository:
 
   optionally-transitioned-csharp-control-structures:
     patterns:
-      - include: '#using-statement'
+      - include: '#using-statement-with-optional-transition'
       - include: '#if-statement'
       - include: '#else-part'
       - include: '#foreach-statement'
@@ -520,6 +520,18 @@ repository:
   #>>>>> @using (...) { ... } <<<<<
 
   using-statement:
+    name: 'meta.statement.using.razor'
+    begin: '(?:(@))(using)\b\s*(?=\()'
+    beginCaptures:
+      1: { patterns: [ include: '#transition' ] }
+      2: { name: 'keyword.other.using.cs' }
+    patterns:
+      - include: '#csharp-condition'
+      - include: '#csharp-code-block'
+      - include: '#razor-codeblock-body'
+    end: '(?<=})'
+
+  using-statement-with-optional-transition:
     name: 'meta.statement.using.razor'
     begin: '(?:^\s*|(@))(using)\b\s*(?=\()'
     beginCaptures:

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -498,6 +498,8 @@ repository:
       - include: '#else-part'
       - include: '#foreach-statement-with-optional-transition'
       - include: '#for-statement-with-optional-transition'
+  # while is incompatible with optional transitions because @do { } \n while { } is valid everywhere, and textmate only matches
+  # one line at a time
       - include: '#while-statement'
       - include: '#switch-statement'
       - include: '#lock-statement'

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -502,7 +502,7 @@ repository:
   # one line at a time
       - include: '#while-statement'
       - include: '#switch-statement-with-optional-transition'
-      - include: '#lock-statement'
+      - include: '#lock-statement-with-optional-transition'
       - include: '#do-statement-with-optional-transition'
       - include: '#try-statement'
 
@@ -777,6 +777,18 @@ repository:
   #>>>>> @lock (...) { ... } <<<<<
 
   lock-statement:
+    name: 'meta.statement.lock.razor'
+    begin: '(?:(@))(lock)\b\s*(?=\()'
+    beginCaptures:
+      1: { patterns: [ include: '#transition' ] }
+      2: { name: 'keyword.other.lock.cs' }
+    patterns:
+      - include: '#csharp-condition'
+      - include: '#csharp-code-block'
+      - include: '#razor-codeblock-body'
+    end: '(?<=})'
+
+  lock-statement-with-optional-transition:
     name: 'meta.statement.lock.razor'
     begin: '(?:^\s*|(@))(lock)\b\s*(?=\()'
     beginCaptures:

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.yml
@@ -497,7 +497,7 @@ repository:
       - include: '#if-statement-with-optional-transition'
       - include: '#else-part'
       - include: '#foreach-statement-with-optional-transition'
-      - include: '#for-statement'
+      - include: '#for-statement-with-optional-transition'
       - include: '#while-statement'
       - include: '#switch-statement'
       - include: '#lock-statement'
@@ -586,6 +586,18 @@ repository:
   #>>>>> @for (...) { ... } <<<<<
 
   for-statement:
+    name: 'meta.statement.for.razor'
+    begin: '(?:(@))(for)\b\s*(?=\()'
+    beginCaptures:
+      1: { patterns: [ include: '#transition' ] }
+      2: { name: 'keyword.control.loop.for.cs' }
+    patterns:
+      - include: '#csharp-condition'
+      - include: '#csharp-code-block'
+      - include: '#razor-codeblock-body'
+    end: '(?<=})'
+
+  for-statement-with-optional-transition:
     name: 'meta.statement.for.razor'
     begin: '(?:^\s*|(@))(for)\b\s*(?=\()'
     beginCaptures:

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/DoStatement.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/DoStatement.ts
@@ -52,5 +52,22 @@ while (
     </div>
 }while(true);`);
         });
+
+        it('Nested inside if', async () => {
+            await assertMatchesSnapshot(
+`@if (true)
+{
+    do {
+        <p></p>
+    } while(GetAnotherValue());
+}`);
+        });
+
+        it('Not in HTML', async () => {
+            await assertMatchesSnapshot(
+`<div>
+    do not classify this
+</div>`);
+        });
     });
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/ForStatement.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/ForStatement.ts
@@ -47,5 +47,22 @@ export function RunForStatementSuite() {
     </div>
 }`);
         });
+
+        it('Nested inside if', async () => {
+            await assertMatchesSnapshot(
+`@if (true)
+{
+    for (var i = 0; i < 10; i++) {
+        <p></p>
+    }
+}`);
+        });
+
+        it('Not in HTML', async () => {
+            await assertMatchesSnapshot(
+`<div>
+    for (this) is the best classification
+</div>`);
+        });
     });
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/ForeachStatement.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/ForeachStatement.ts
@@ -57,5 +57,22 @@ export function RunForeachStatementSuite() {
     </div>
 }`);
         });
+
+        it('Nested inside if', async () => {
+            await assertMatchesSnapshot(
+`@if (true)
+{
+    foreach (var i in numbers) {
+        <p></p>
+    }
+}`);
+        });
+
+        it('Not in HTML', async () => {
+            await assertMatchesSnapshot(
+`<div>
+    foreach (is not) an English word
+</div>`);
+        });
     });
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/IfStatement.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/IfStatement.ts
@@ -45,5 +45,22 @@ export function RunIfStatementSuite() {
     </div>
 }else if (true){}`);
         });
+
+        it('Nested inside if', async () => {
+            await assertMatchesSnapshot(
+`@if (true)
+{
+    if (true) {
+        <p></p>
+    }
+}`);
+        });
+
+        it('Not in HTML', async () => {
+            await assertMatchesSnapshot(
+`<div>
+    if (this is classified) we have a problem
+</div>`);
+        });
     });
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/LockStatement.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/LockStatement.ts
@@ -45,5 +45,22 @@ export function RunLockStatementSuite() {
     </div>
 }`);
         });
+
+        it('Nested inside if', async () => {
+            await assertMatchesSnapshot(
+`@if (true)
+{
+    lock (SomeObject) {
+        <p></p>
+    }
+}`);
+        });
+
+        it('Not in HTML', async () => {
+            await assertMatchesSnapshot(
+`<div>
+    lock (the taskbar)
+</div>`);
+        });
     });
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/SwitchStatement.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/SwitchStatement.ts
@@ -53,5 +53,24 @@ export function RunSwitchStatementSuite() {
         break;
 }`);
         });
+
+        it('Nested inside if', async () => {
+            await assertMatchesSnapshot(
+`@if (true)
+{
+    switch (SomeProp) {
+        case 123:
+            <p></p>
+            break;
+    }
+}`);
+        });
+
+        it('Not in HTML', async () => {
+            await assertMatchesSnapshot(
+`<div>
+    switch (over to better classifications)
+</div>`);
+        });
     });
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/TryStatement.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/TryStatement.ts
@@ -50,5 +50,23 @@ catch (
     </div>
 }finally{}`);
         });
+
+        it('Nested inside if', async () => {
+            await assertMatchesSnapshot(
+`@if (true)
+{
+    try {
+        <p></p>
+    } catch(Exception ex) {
+    }
+}`);
+        });
+
+        it('Not in HTML', async () => {
+            await assertMatchesSnapshot(
+`<div>
+    try not to classify this
+</div>`);
+        });
     });
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/UsingStatement.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/UsingStatement.ts
@@ -45,5 +45,22 @@ export function RunUsingStatementSuite() {
     </div>
 }`);
         });
+
+        it('Nested inside if', async () => {
+            await assertMatchesSnapshot(
+`@if (true)
+{
+    using (SomeDisposable) {
+        <p></p>
+    }
+}`);
+        });
+
+        it('Not in HTML', async () => {
+            await assertMatchesSnapshot(
+`<div>
+    using (the best potatoes)
+</div>`);
+        });
     });
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/WhileStatement.ts
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/WhileStatement.ts
@@ -45,5 +45,15 @@ export function RunWhileStatementSuite() {
     </div>
 }`);
         });
+
+        it('Nested inside if', async () => {
+            await assertMatchesSnapshot(
+`@if (true)
+{
+    while (SomeProperty {
+        <p></p>
+    }
+}`);
+        });
     });
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -3768,22 +3768,12 @@ exports[`Grammar tests @using ( ... ) { ... } Not in HTML 1`] = `
  - token from 4 to 5 (>) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, punctuation.definition.tag.end.html
 
 Line:     using (the best potatoes)
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.using.razor
- - token from 4 to 9 (using) with scopes text.aspnetcorerazor, meta.statement.using.razor, keyword.other.using.cs
- - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor
- - token from 10 to 11 (() with scopes text.aspnetcorerazor, meta.statement.using.razor, punctuation.parenthesis.open.cs
- - token from 11 to 14 (the) with scopes text.aspnetcorerazor, meta.statement.using.razor, variable.other.readwrite.cs
- - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor
- - token from 15 to 19 (best) with scopes text.aspnetcorerazor, meta.statement.using.razor, entity.name.type.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor
- - token from 20 to 28 (potatoes) with scopes text.aspnetcorerazor, meta.statement.using.razor, entity.name.variable.local.cs
- - token from 28 to 29 ()) with scopes text.aspnetcorerazor, meta.statement.using.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 30 (    using (the best potatoes)) with scopes text.aspnetcorerazor
 
 Line: </div>
- - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.statement.using.razor, keyword.operator.relational.cs
- - token from 1 to 2 (/) with scopes text.aspnetcorerazor, meta.statement.using.razor, keyword.operator.arithmetic.cs
- - token from 2 to 5 (div) with scopes text.aspnetcorerazor, meta.statement.using.razor, variable.other.readwrite.cs
- - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.statement.using.razor, keyword.operator.relational.cs
+ - token from 0 to 2 (</) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, punctuation.definition.tag.begin.html
+ - token from 2 to 5 (div) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, entity.name.tag.html
+ - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, punctuation.definition.tag.end.html
 "
 `;
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -2041,30 +2041,12 @@ exports[`Grammar tests @if ( ... ) { ... } Not in HTML 1`] = `
  - token from 4 to 5 (>) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, punctuation.definition.tag.end.html
 
 Line:     if (this is classified) we have a problem
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor
- - token from 4 to 6 (if) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.control.conditional.if.cs
- - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
- - token from 7 to 8 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.open.cs
- - token from 8 to 12 (this) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.other.this.cs
- - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
- - token from 13 to 15 (is) with scopes text.aspnetcorerazor, meta.statement.if.razor, entity.name.type.cs
- - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
- - token from 16 to 26 (classified) with scopes text.aspnetcorerazor, meta.statement.if.razor, entity.name.variable.local.cs
- - token from 26 to 27 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.close.cs
- - token from 27 to 28 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
- - token from 28 to 30 (we) with scopes text.aspnetcorerazor, meta.statement.if.razor, variable.other.readwrite.cs
- - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
- - token from 31 to 35 (have) with scopes text.aspnetcorerazor, meta.statement.if.razor, variable.other.readwrite.cs
- - token from 35 to 36 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
- - token from 36 to 37 (a) with scopes text.aspnetcorerazor, meta.statement.if.razor, variable.other.readwrite.cs
- - token from 37 to 38 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
- - token from 38 to 45 (problem) with scopes text.aspnetcorerazor, meta.statement.if.razor, variable.other.readwrite.cs
+ - token from 0 to 46 (    if (this is classified) we have a problem) with scopes text.aspnetcorerazor
 
 Line: </div>
- - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.operator.relational.cs
- - token from 1 to 2 (/) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.operator.arithmetic.cs
- - token from 2 to 5 (div) with scopes text.aspnetcorerazor, meta.statement.if.razor, variable.other.readwrite.cs
- - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.operator.relational.cs
+ - token from 0 to 2 (</) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, punctuation.definition.tag.begin.html
+ - token from 2 to 5 (div) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, entity.name.tag.html
+ - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, punctuation.definition.tag.end.html
 "
 `;
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -2454,20 +2454,12 @@ exports[`Grammar tests @lock ( ... ) { ... } Not in HTML 1`] = `
  - token from 4 to 5 (>) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, punctuation.definition.tag.end.html
 
 Line:     lock (the taskbar)
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.lock.razor
- - token from 4 to 8 (lock) with scopes text.aspnetcorerazor, meta.statement.lock.razor, keyword.other.lock.cs
- - token from 8 to 9 ( ) with scopes text.aspnetcorerazor, meta.statement.lock.razor
- - token from 9 to 10 (() with scopes text.aspnetcorerazor, meta.statement.lock.razor, punctuation.parenthesis.open.cs
- - token from 10 to 13 (the) with scopes text.aspnetcorerazor, meta.statement.lock.razor, entity.name.type.cs
- - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.statement.lock.razor
- - token from 14 to 21 (taskbar) with scopes text.aspnetcorerazor, meta.statement.lock.razor, entity.name.variable.local.cs
- - token from 21 to 22 ()) with scopes text.aspnetcorerazor, meta.statement.lock.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 23 (    lock (the taskbar)) with scopes text.aspnetcorerazor
 
 Line: </div>
- - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.statement.lock.razor, keyword.operator.relational.cs
- - token from 1 to 2 (/) with scopes text.aspnetcorerazor, meta.statement.lock.razor, keyword.operator.arithmetic.cs
- - token from 2 to 5 (div) with scopes text.aspnetcorerazor, meta.statement.lock.razor, variable.other.readwrite.cs
- - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.statement.lock.razor, keyword.operator.relational.cs
+ - token from 0 to 2 (</) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, punctuation.definition.tag.begin.html
+ - token from 2 to 5 (div) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, entity.name.tag.html
+ - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, punctuation.definition.tag.end.html
 "
 `;
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -1498,26 +1498,12 @@ exports[`Grammar tests @foreach ( ... ) { ... } Not in HTML 1`] = `
  - token from 4 to 5 (>) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, punctuation.definition.tag.end.html
 
 Line:     foreach (is not) an English word
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
- - token from 4 to 11 (foreach) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, keyword.control.loop.foreach.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
- - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.statement.foreach.razor, punctuation.parenthesis.open.cs
- - token from 13 to 15 (is) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, keyword.other.is.cs
- - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
- - token from 16 to 19 (not) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, entity.name.type.cs
- - token from 19 to 20 ()) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, punctuation.parenthesis.close.cs
- - token from 20 to 21 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
- - token from 21 to 23 (an) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, variable.other.readwrite.cs
- - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
- - token from 24 to 31 (English) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, variable.other.readwrite.cs
- - token from 31 to 32 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
- - token from 32 to 36 (word) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, variable.other.readwrite.cs
+ - token from 0 to 37 (    foreach (is not) an English word) with scopes text.aspnetcorerazor
 
 Line: </div>
- - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, keyword.operator.relational.cs
- - token from 1 to 2 (/) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, keyword.operator.arithmetic.cs
- - token from 2 to 5 (div) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, variable.other.readwrite.cs
- - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, keyword.operator.relational.cs
+ - token from 0 to 2 (</) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, punctuation.definition.tag.begin.html
+ - token from 2 to 5 (div) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, entity.name.tag.html
+ - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, punctuation.definition.tag.end.html
 "
 `;
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -782,6 +782,74 @@ Line: ));
 "
 `;
 
+exports[`Grammar tests @do { ... } while ( ... ); Nested inside if 1`] = `
+"Line: @if (true)
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.control.cshtml.transition
+ - token from 1 to 3 (if) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.control.conditional.if.cs
+ - token from 3 to 4 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
+ - token from 4 to 5 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.open.cs
+ - token from 5 to 9 (true) with scopes text.aspnetcorerazor, meta.statement.if.razor, constant.language.boolean.true.cs
+ - token from 9 to 10 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.close.cs
+
+Line: {
+ - token from 0 to 1 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:     do {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.do.razor
+ - token from 4 to 6 (do) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.do.razor, keyword.control.loop.do.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.do.razor
+ - token from 7 to 8 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:         <p></p>
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 13 (</) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 13 to 14 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line:     } while(GetAnotherValue());
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.do.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 6 to 11 (while) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.control.loop.while.cs
+ - token from 11 to 12 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.parenthesis.open.cs
+ - token from 12 to 27 (GetAnotherValue) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, entity.name.function.cs
+ - token from 27 to 28 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.parenthesis.open.cs
+ - token from 28 to 29 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.parenthesis.close.cs
+ - token from 29 to 30 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.parenthesis.close.cs
+ - token from 30 to 31 (;) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.terminator.statement.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+"
+`;
+
+exports[`Grammar tests @do { ... } while ( ... ); Not in HTML 1`] = `
+"Line: <div>
+ - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, punctuation.definition.tag.begin.html
+ - token from 1 to 4 (div) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, entity.name.tag.html
+ - token from 4 to 5 (>) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, punctuation.definition.tag.end.html
+
+Line:     do not classify this
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.do.razor
+ - token from 4 to 6 (do) with scopes text.aspnetcorerazor, meta.statement.do.razor, keyword.control.loop.do.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.statement.do.razor
+ - token from 7 to 10 (not) with scopes text.aspnetcorerazor, meta.statement.do.razor, variable.other.readwrite.cs
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.statement.do.razor
+ - token from 11 to 19 (classify) with scopes text.aspnetcorerazor, meta.statement.do.razor, variable.other.readwrite.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.do.razor
+ - token from 20 to 24 (this) with scopes text.aspnetcorerazor, meta.statement.do.razor, keyword.other.this.cs
+
+Line: </div>
+ - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.statement.do.razor, keyword.operator.relational.cs
+ - token from 1 to 2 (/) with scopes text.aspnetcorerazor, meta.statement.do.razor, keyword.operator.arithmetic.cs
+ - token from 2 to 5 (div) with scopes text.aspnetcorerazor, meta.statement.do.razor, variable.other.readwrite.cs
+ - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.statement.do.razor, keyword.operator.relational.cs
+"
+`;
+
 exports[`Grammar tests @do { ... } while ( ... ); Single line 1`] = `
 "Line: @do { var x = 123;<p>Hello World</p> }while (   true  );
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.statement.do.razor, keyword.control.cshtml.transition
@@ -1021,6 +1089,93 @@ Line: ){}
  - token from 0 to 1 ()) with scopes text.aspnetcorerazor, meta.statement.for.razor, punctuation.parenthesis.close.cs
  - token from 1 to 2 ({) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
  - token from 2 to 3 (}) with scopes text.aspnetcorerazor, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+"
+`;
+
+exports[`Grammar tests @for ( ... ) { ... } Nested inside if 1`] = `
+"Line: @if (true)
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.control.cshtml.transition
+ - token from 1 to 3 (if) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.control.conditional.if.cs
+ - token from 3 to 4 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
+ - token from 4 to 5 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.open.cs
+ - token from 5 to 9 (true) with scopes text.aspnetcorerazor, meta.statement.if.razor, constant.language.boolean.true.cs
+ - token from 9 to 10 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.close.cs
+
+Line: {
+ - token from 0 to 1 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:     for (var i = 0; i < 10; i++) {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor
+ - token from 4 to 7 (for) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, keyword.control.loop.for.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor
+ - token from 8 to 9 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, punctuation.parenthesis.open.cs
+ - token from 9 to 12 (var) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, keyword.other.var.cs
+ - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor
+ - token from 13 to 14 (i) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, entity.name.variable.local.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor
+ - token from 15 to 16 (=) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, keyword.operator.assignment.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor
+ - token from 17 to 18 (0) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, constant.numeric.decimal.cs
+ - token from 18 to 19 (;) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, punctuation.terminator.statement.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor
+ - token from 20 to 21 (i) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, variable.other.readwrite.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor
+ - token from 22 to 23 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, keyword.operator.relational.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor
+ - token from 24 to 26 (10) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, constant.numeric.decimal.cs
+ - token from 26 to 27 (;) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, punctuation.terminator.statement.cs
+ - token from 27 to 28 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor
+ - token from 28 to 29 (i) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, variable.other.readwrite.cs
+ - token from 29 to 31 (++) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, keyword.operator.increment.cs
+ - token from 31 to 32 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, punctuation.parenthesis.close.cs
+ - token from 32 to 33 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor
+ - token from 33 to 34 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:         <p></p>
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 13 (</) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 13 to 14 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.for.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+"
+`;
+
+exports[`Grammar tests @for ( ... ) { ... } Not in HTML 1`] = `
+"Line: <div>
+ - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, punctuation.definition.tag.begin.html
+ - token from 1 to 4 (div) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, entity.name.tag.html
+ - token from 4 to 5 (>) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, punctuation.definition.tag.end.html
+
+Line:     for (this) is the best classification
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.for.razor
+ - token from 4 to 7 (for) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.control.loop.for.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
+ - token from 8 to 9 (() with scopes text.aspnetcorerazor, meta.statement.for.razor, punctuation.parenthesis.open.cs
+ - token from 9 to 13 (this) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.other.this.cs
+ - token from 13 to 14 ()) with scopes text.aspnetcorerazor, meta.statement.for.razor, punctuation.parenthesis.close.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
+ - token from 15 to 17 (is) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.other.is.cs
+ - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
+ - token from 18 to 21 (the) with scopes text.aspnetcorerazor, meta.statement.for.razor, entity.name.type.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
+ - token from 22 to 26 (best) with scopes text.aspnetcorerazor, meta.statement.for.razor, variable.other.readwrite.cs
+ - token from 26 to 27 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
+ - token from 27 to 41 (classification) with scopes text.aspnetcorerazor, meta.statement.for.razor, variable.other.readwrite.cs
+
+Line: </div>
+ - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.operator.relational.cs
+ - token from 1 to 2 (/) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.operator.arithmetic.cs
+ - token from 2 to 5 (div) with scopes text.aspnetcorerazor, meta.statement.for.razor, variable.other.readwrite.cs
+ - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.operator.relational.cs
 "
 `;
 
@@ -1295,6 +1450,82 @@ Line: ){@value}
  - token from 2 to 3 (@) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, keyword.control.cshtml.transition
  - token from 3 to 8 (value) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, meta.expression.implicit.cshtml, source.cs, variable.other.object.cs
  - token from 8 to 9 (}) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+"
+`;
+
+exports[`Grammar tests @foreach ( ... ) { ... } Nested inside if 1`] = `
+"Line: @if (true)
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.control.cshtml.transition
+ - token from 1 to 3 (if) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.control.conditional.if.cs
+ - token from 3 to 4 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
+ - token from 4 to 5 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.open.cs
+ - token from 5 to 9 (true) with scopes text.aspnetcorerazor, meta.statement.if.razor, constant.language.boolean.true.cs
+ - token from 9 to 10 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.close.cs
+
+Line: {
+ - token from 0 to 1 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:     foreach (var i in numbers) {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor
+ - token from 4 to 11 (foreach) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor, keyword.control.loop.foreach.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor
+ - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor, punctuation.parenthesis.open.cs
+ - token from 13 to 16 (var) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor, keyword.other.var.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor
+ - token from 17 to 18 (i) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor, entity.name.variable.local.cs
+ - token from 18 to 19 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor
+ - token from 19 to 21 (in) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor, keyword.control.loop.in.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor
+ - token from 22 to 29 (numbers) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor, variable.other.readwrite.cs
+ - token from 29 to 30 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor, punctuation.parenthesis.close.cs
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor
+ - token from 31 to 32 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:         <p></p>
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 13 (</) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 13 to 14 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.foreach.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+"
+`;
+
+exports[`Grammar tests @foreach ( ... ) { ... } Not in HTML 1`] = `
+"Line: <div>
+ - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, punctuation.definition.tag.begin.html
+ - token from 1 to 4 (div) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, entity.name.tag.html
+ - token from 4 to 5 (>) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, punctuation.definition.tag.end.html
+
+Line:     foreach (is not) an English word
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
+ - token from 4 to 11 (foreach) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, keyword.control.loop.foreach.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
+ - token from 12 to 13 (() with scopes text.aspnetcorerazor, meta.statement.foreach.razor, punctuation.parenthesis.open.cs
+ - token from 13 to 15 (is) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, keyword.other.is.cs
+ - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
+ - token from 16 to 19 (not) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, entity.name.type.cs
+ - token from 19 to 20 ()) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, punctuation.parenthesis.close.cs
+ - token from 20 to 21 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
+ - token from 21 to 23 (an) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, variable.other.readwrite.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
+ - token from 24 to 31 (English) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, variable.other.readwrite.cs
+ - token from 31 to 32 ( ) with scopes text.aspnetcorerazor, meta.statement.foreach.razor
+ - token from 32 to 36 (word) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, variable.other.readwrite.cs
+
+Line: </div>
+ - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, keyword.operator.relational.cs
+ - token from 1 to 2 (/) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, keyword.operator.arithmetic.cs
+ - token from 2 to 5 (div) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, variable.other.readwrite.cs
+ - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.statement.foreach.razor, keyword.operator.relational.cs
 "
 `;
 
@@ -1771,6 +2002,80 @@ Line: )){}
 "
 `;
 
+exports[`Grammar tests @if ( ... ) { ... } Nested inside if 1`] = `
+"Line: @if (true)
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.control.cshtml.transition
+ - token from 1 to 3 (if) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.control.conditional.if.cs
+ - token from 3 to 4 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
+ - token from 4 to 5 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.open.cs
+ - token from 5 to 9 (true) with scopes text.aspnetcorerazor, meta.statement.if.razor, constant.language.boolean.true.cs
+ - token from 9 to 10 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.close.cs
+
+Line: {
+ - token from 0 to 1 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:     if (true) {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.if.razor
+ - token from 4 to 6 (if) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.if.razor, keyword.control.conditional.if.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.if.razor
+ - token from 7 to 8 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.if.razor, punctuation.parenthesis.open.cs
+ - token from 8 to 12 (true) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.if.razor, constant.language.boolean.true.cs
+ - token from 12 to 13 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.if.razor, punctuation.parenthesis.close.cs
+ - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.if.razor
+ - token from 14 to 15 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:         <p></p>
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 13 (</) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 13 to 14 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+"
+`;
+
+exports[`Grammar tests @if ( ... ) { ... } Not in HTML 1`] = `
+"Line: <div>
+ - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, punctuation.definition.tag.begin.html
+ - token from 1 to 4 (div) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, entity.name.tag.html
+ - token from 4 to 5 (>) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, punctuation.definition.tag.end.html
+
+Line:     if (this is classified) we have a problem
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor
+ - token from 4 to 6 (if) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.control.conditional.if.cs
+ - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
+ - token from 7 to 8 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.open.cs
+ - token from 8 to 12 (this) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.other.this.cs
+ - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
+ - token from 13 to 15 (is) with scopes text.aspnetcorerazor, meta.statement.if.razor, entity.name.type.cs
+ - token from 15 to 16 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
+ - token from 16 to 26 (classified) with scopes text.aspnetcorerazor, meta.statement.if.razor, entity.name.variable.local.cs
+ - token from 26 to 27 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.close.cs
+ - token from 27 to 28 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
+ - token from 28 to 30 (we) with scopes text.aspnetcorerazor, meta.statement.if.razor, variable.other.readwrite.cs
+ - token from 30 to 31 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
+ - token from 31 to 35 (have) with scopes text.aspnetcorerazor, meta.statement.if.razor, variable.other.readwrite.cs
+ - token from 35 to 36 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
+ - token from 36 to 37 (a) with scopes text.aspnetcorerazor, meta.statement.if.razor, variable.other.readwrite.cs
+ - token from 37 to 38 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
+ - token from 38 to 45 (problem) with scopes text.aspnetcorerazor, meta.statement.if.razor, variable.other.readwrite.cs
+
+Line: </div>
+ - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.operator.relational.cs
+ - token from 1 to 2 (/) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.operator.arithmetic.cs
+ - token from 2 to 5 (div) with scopes text.aspnetcorerazor, meta.statement.if.razor, variable.other.readwrite.cs
+ - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.operator.relational.cs
+"
+`;
+
 exports[`Grammar tests @if ( ... ) { ... } Single line 1`] = `
 "Line: @if (true) { var x = 123;<p>Hello World</p> }
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.control.cshtml.transition
@@ -2153,6 +2458,70 @@ Line: )){}
  - token from 1 to 2 ()) with scopes text.aspnetcorerazor, meta.statement.lock.razor, punctuation.parenthesis.close.cs
  - token from 2 to 3 ({) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
  - token from 3 to 4 (}) with scopes text.aspnetcorerazor, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+"
+`;
+
+exports[`Grammar tests @lock ( ... ) { ... } Nested inside if 1`] = `
+"Line: @if (true)
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.control.cshtml.transition
+ - token from 1 to 3 (if) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.control.conditional.if.cs
+ - token from 3 to 4 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
+ - token from 4 to 5 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.open.cs
+ - token from 5 to 9 (true) with scopes text.aspnetcorerazor, meta.statement.if.razor, constant.language.boolean.true.cs
+ - token from 9 to 10 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.close.cs
+
+Line: {
+ - token from 0 to 1 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:     lock (SomeObject) {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.lock.razor
+ - token from 4 to 8 (lock) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.lock.razor, keyword.other.lock.cs
+ - token from 8 to 9 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.lock.razor
+ - token from 9 to 10 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.lock.razor, punctuation.parenthesis.open.cs
+ - token from 10 to 20 (SomeObject) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.lock.razor, variable.other.readwrite.cs
+ - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.lock.razor, punctuation.parenthesis.close.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.lock.razor
+ - token from 22 to 23 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:         <p></p>
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 13 (</) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 13 to 14 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.lock.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+"
+`;
+
+exports[`Grammar tests @lock ( ... ) { ... } Not in HTML 1`] = `
+"Line: <div>
+ - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, punctuation.definition.tag.begin.html
+ - token from 1 to 4 (div) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, entity.name.tag.html
+ - token from 4 to 5 (>) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, punctuation.definition.tag.end.html
+
+Line:     lock (the taskbar)
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.lock.razor
+ - token from 4 to 8 (lock) with scopes text.aspnetcorerazor, meta.statement.lock.razor, keyword.other.lock.cs
+ - token from 8 to 9 ( ) with scopes text.aspnetcorerazor, meta.statement.lock.razor
+ - token from 9 to 10 (() with scopes text.aspnetcorerazor, meta.statement.lock.razor, punctuation.parenthesis.open.cs
+ - token from 10 to 13 (the) with scopes text.aspnetcorerazor, meta.statement.lock.razor, entity.name.type.cs
+ - token from 13 to 14 ( ) with scopes text.aspnetcorerazor, meta.statement.lock.razor
+ - token from 14 to 21 (taskbar) with scopes text.aspnetcorerazor, meta.statement.lock.razor, entity.name.variable.local.cs
+ - token from 21 to 22 ()) with scopes text.aspnetcorerazor, meta.statement.lock.razor, punctuation.parenthesis.close.cs
+
+Line: </div>
+ - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.statement.lock.razor, keyword.operator.relational.cs
+ - token from 1 to 2 (/) with scopes text.aspnetcorerazor, meta.statement.lock.razor, keyword.operator.arithmetic.cs
+ - token from 2 to 5 (div) with scopes text.aspnetcorerazor, meta.statement.lock.razor, variable.other.readwrite.cs
+ - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.statement.lock.razor, keyword.operator.relational.cs
 "
 `;
 
@@ -2716,6 +3085,86 @@ Line: )){}
 "
 `;
 
+exports[`Grammar tests @switch ( ... ) { ... } Nested inside if 1`] = `
+"Line: @if (true)
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.control.cshtml.transition
+ - token from 1 to 3 (if) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.control.conditional.if.cs
+ - token from 3 to 4 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
+ - token from 4 to 5 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.open.cs
+ - token from 5 to 9 (true) with scopes text.aspnetcorerazor, meta.statement.if.razor, constant.language.boolean.true.cs
+ - token from 9 to 10 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.close.cs
+
+Line: {
+ - token from 0 to 1 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:     switch (SomeProp) {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.switch.razor
+ - token from 4 to 10 (switch) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.switch.razor, keyword.control.switch.cs
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.switch.razor
+ - token from 11 to 12 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.switch.razor, punctuation.parenthesis.open.cs
+ - token from 12 to 20 (SomeProp) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.switch.razor, variable.other.readwrite.cs
+ - token from 20 to 21 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.switch.razor, punctuation.parenthesis.close.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.switch.razor
+ - token from 22 to 23 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.curlybrace.open.cs
+
+Line:         case 123:
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 8 to 12 (case) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.control.case.cs
+ - token from 12 to 13 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 13 to 16 (123) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, constant.numeric.decimal.cs
+ - token from 16 to 17 (:) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.separator.colon.cs
+
+Line:             <p></p>
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 12 to 13 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.tag.begin.html
+ - token from 13 to 14 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, entity.name.tag.html
+ - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.tag.end.html
+ - token from 15 to 17 (</) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.tag.begin.html
+ - token from 17 to 18 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, entity.name.tag.html
+ - token from 18 to 19 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.definition.tag.end.html
+
+Line:             break;
+ - token from 0 to 12 (            ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 12 to 17 (break) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, keyword.control.flow.break.cs
+ - token from 17 to 18 (;) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.terminator.statement.cs
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.switch.razor, meta.structure.razor.csharp.codeblock.switch, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+"
+`;
+
+exports[`Grammar tests @switch ( ... ) { ... } Not in HTML 1`] = `
+"Line: <div>
+ - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, punctuation.definition.tag.begin.html
+ - token from 1 to 4 (div) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, entity.name.tag.html
+ - token from 4 to 5 (>) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, punctuation.definition.tag.end.html
+
+Line:     switch (over to better classifications)
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.switch.razor
+ - token from 4 to 10 (switch) with scopes text.aspnetcorerazor, meta.statement.switch.razor, keyword.control.switch.cs
+ - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.statement.switch.razor
+ - token from 11 to 12 (() with scopes text.aspnetcorerazor, meta.statement.switch.razor, punctuation.parenthesis.open.cs
+ - token from 12 to 16 (over) with scopes text.aspnetcorerazor, meta.statement.switch.razor, variable.other.readwrite.cs
+ - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.statement.switch.razor
+ - token from 17 to 19 (to) with scopes text.aspnetcorerazor, meta.statement.switch.razor, variable.other.readwrite.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.switch.razor
+ - token from 20 to 26 (better) with scopes text.aspnetcorerazor, meta.statement.switch.razor, entity.name.type.cs
+ - token from 26 to 27 ( ) with scopes text.aspnetcorerazor, meta.statement.switch.razor
+ - token from 27 to 42 (classifications) with scopes text.aspnetcorerazor, meta.statement.switch.razor, entity.name.variable.local.cs
+ - token from 42 to 43 ()) with scopes text.aspnetcorerazor, meta.statement.switch.razor, punctuation.parenthesis.close.cs
+
+Line: </div>
+ - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.statement.switch.razor, keyword.operator.relational.cs
+ - token from 1 to 2 (/) with scopes text.aspnetcorerazor, meta.statement.switch.razor, keyword.operator.arithmetic.cs
+ - token from 2 to 5 (div) with scopes text.aspnetcorerazor, meta.statement.switch.razor, variable.other.readwrite.cs
+ - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.statement.switch.razor, keyword.operator.relational.cs
+"
+`;
+
 exports[`Grammar tests @switch ( ... ) { ... } Single line 1`] = `
 "Line: @switch (   value  ) { case 123: var x = 123;<p>Hello World</p>break; }
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.statement.switch.razor, keyword.control.cshtml.transition
@@ -3003,6 +3452,81 @@ Line: }finally{}
 "
 `;
 
+exports[`Grammar tests @try { ... } catch/finally { ... } Nested inside if 1`] = `
+"Line: @if (true)
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.control.cshtml.transition
+ - token from 1 to 3 (if) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.control.conditional.if.cs
+ - token from 3 to 4 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
+ - token from 4 to 5 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.open.cs
+ - token from 5 to 9 (true) with scopes text.aspnetcorerazor, meta.statement.if.razor, constant.language.boolean.true.cs
+ - token from 9 to 10 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.close.cs
+
+Line: {
+ - token from 0 to 1 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:     try {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.try.razor
+ - token from 4 to 7 (try) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.try.razor, keyword.control.try.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.try.razor
+ - token from 8 to 9 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:         <p></p>
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 13 (</) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 13 to 14 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line:     } catch(Exception ex) {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.try.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+ - token from 5 to 6 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.catch.razor
+ - token from 6 to 11 (catch) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.catch.razor, keyword.control.try.catch.cs
+ - token from 11 to 12 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.catch.razor, punctuation.parenthesis.open.cs
+ - token from 12 to 21 (Exception) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.catch.razor, entity.name.type.cs
+ - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.catch.razor
+ - token from 22 to 24 (ex) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.catch.razor, entity.name.variable.local.cs
+ - token from 24 to 25 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.catch.razor, punctuation.parenthesis.close.cs
+ - token from 25 to 26 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.catch.razor
+ - token from 26 to 27 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.catch.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+"
+`;
+
+exports[`Grammar tests @try { ... } catch/finally { ... } Not in HTML 1`] = `
+"Line: <div>
+ - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, punctuation.definition.tag.begin.html
+ - token from 1 to 4 (div) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, entity.name.tag.html
+ - token from 4 to 5 (>) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, punctuation.definition.tag.end.html
+
+Line:     try not to classify this
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.try.razor
+ - token from 4 to 7 (try) with scopes text.aspnetcorerazor, meta.statement.try.razor, keyword.control.try.cs
+ - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.statement.try.razor
+ - token from 8 to 11 (not) with scopes text.aspnetcorerazor, meta.statement.try.razor, variable.other.readwrite.cs
+ - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.statement.try.razor
+ - token from 12 to 14 (to) with scopes text.aspnetcorerazor, meta.statement.try.razor, variable.other.readwrite.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.statement.try.razor
+ - token from 15 to 23 (classify) with scopes text.aspnetcorerazor, meta.statement.try.razor, variable.other.readwrite.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.statement.try.razor
+ - token from 24 to 28 (this) with scopes text.aspnetcorerazor, meta.statement.try.razor, keyword.other.this.cs
+
+Line: </div>
+ - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.statement.try.razor, keyword.operator.relational.cs
+ - token from 1 to 2 (/) with scopes text.aspnetcorerazor, meta.statement.try.razor, keyword.operator.arithmetic.cs
+ - token from 2 to 5 (div) with scopes text.aspnetcorerazor, meta.statement.try.razor, variable.other.readwrite.cs
+ - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.statement.try.razor, keyword.operator.relational.cs
+"
+`;
+
 exports[`Grammar tests @try { ... } catch/finally { ... } Single line 1`] = `
 "Line: @try { var x = 123;<p>Hello World</p> } catch (Exception ex) {@DateTime.Now}finally{<section></section>var y = 456;}
  - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.statement.try.razor, keyword.control.cshtml.transition
@@ -3202,6 +3726,72 @@ Line: )){}
  - token from 1 to 2 ()) with scopes text.aspnetcorerazor, meta.statement.using.razor, punctuation.parenthesis.close.cs
  - token from 2 to 3 ({) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
  - token from 3 to 4 (}) with scopes text.aspnetcorerazor, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+"
+`;
+
+exports[`Grammar tests @using ( ... ) { ... } Nested inside if 1`] = `
+"Line: @if (true)
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.control.cshtml.transition
+ - token from 1 to 3 (if) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.control.conditional.if.cs
+ - token from 3 to 4 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
+ - token from 4 to 5 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.open.cs
+ - token from 5 to 9 (true) with scopes text.aspnetcorerazor, meta.statement.if.razor, constant.language.boolean.true.cs
+ - token from 9 to 10 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.close.cs
+
+Line: {
+ - token from 0 to 1 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:     using (SomeDisposable) {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor
+ - token from 4 to 9 (using) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, keyword.other.using.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor
+ - token from 10 to 11 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, punctuation.parenthesis.open.cs
+ - token from 11 to 25 (SomeDisposable) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, variable.other.readwrite.cs
+ - token from 25 to 26 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, punctuation.parenthesis.close.cs
+ - token from 26 to 27 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor
+ - token from 27 to 28 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:         <p></p>
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+ - token from 11 to 13 (</) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.begin.html
+ - token from 13 to 14 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, entity.name.tag.html
+ - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.definition.tag.end.html
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.using.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 1 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+"
+`;
+
+exports[`Grammar tests @using ( ... ) { ... } Not in HTML 1`] = `
+"Line: <div>
+ - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, punctuation.definition.tag.begin.html
+ - token from 1 to 4 (div) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, entity.name.tag.html
+ - token from 4 to 5 (>) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, punctuation.definition.tag.end.html
+
+Line:     using (the best potatoes)
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.using.razor
+ - token from 4 to 9 (using) with scopes text.aspnetcorerazor, meta.statement.using.razor, keyword.other.using.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor
+ - token from 10 to 11 (() with scopes text.aspnetcorerazor, meta.statement.using.razor, punctuation.parenthesis.open.cs
+ - token from 11 to 14 (the) with scopes text.aspnetcorerazor, meta.statement.using.razor, variable.other.readwrite.cs
+ - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor
+ - token from 15 to 19 (best) with scopes text.aspnetcorerazor, meta.statement.using.razor, entity.name.type.cs
+ - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.using.razor
+ - token from 20 to 28 (potatoes) with scopes text.aspnetcorerazor, meta.statement.using.razor, entity.name.variable.local.cs
+ - token from 28 to 29 ()) with scopes text.aspnetcorerazor, meta.statement.using.razor, punctuation.parenthesis.close.cs
+
+Line: </div>
+ - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.statement.using.razor, keyword.operator.relational.cs
+ - token from 1 to 2 (/) with scopes text.aspnetcorerazor, meta.statement.using.razor, keyword.operator.arithmetic.cs
+ - token from 2 to 5 (div) with scopes text.aspnetcorerazor, meta.statement.using.razor, variable.other.readwrite.cs
+ - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.statement.using.razor, keyword.operator.relational.cs
 "
 `;
 
@@ -3589,6 +4179,46 @@ Line: )){}
  - token from 1 to 2 ()) with scopes text.aspnetcorerazor, meta.statement.while.razor, punctuation.parenthesis.close.cs
  - token from 2 to 3 ({) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
  - token from 3 to 4 (}) with scopes text.aspnetcorerazor, meta.statement.while.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.close.cs
+"
+`;
+
+exports[`Grammar tests @while ( ... ) { ... } Nested inside if 1`] = `
+"Line: @if (true)
+ - token from 0 to 1 (@) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.control.cshtml.transition
+ - token from 1 to 3 (if) with scopes text.aspnetcorerazor, meta.statement.if.razor, keyword.control.conditional.if.cs
+ - token from 3 to 4 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor
+ - token from 4 to 5 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.open.cs
+ - token from 5 to 9 (true) with scopes text.aspnetcorerazor, meta.statement.if.razor, constant.language.boolean.true.cs
+ - token from 9 to 10 ()) with scopes text.aspnetcorerazor, meta.statement.if.razor, punctuation.parenthesis.close.cs
+
+Line: {
+ - token from 0 to 1 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, punctuation.curlybrace.open.cs
+
+Line:     while (SomeProperty {
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 4 to 9 (while) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.control.loop.while.cs
+ - token from 9 to 10 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 10 to 11 (() with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.parenthesis.open.cs
+ - token from 11 to 23 (SomeProperty) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, variable.other.readwrite.cs
+ - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 24 to 25 ({) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.curlybrace.open.cs
+
+Line:         <p></p>
+ - token from 0 to 8 (        ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 8 to 9 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.relational.cs
+ - token from 9 to 10 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, variable.other.readwrite.cs
+ - token from 10 to 11 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.relational.cs
+ - token from 11 to 12 (<) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.relational.cs
+ - token from 12 to 13 (/) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.arithmetic.cs
+ - token from 13 to 14 (p) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, variable.other.readwrite.cs
+ - token from 14 to 15 (>) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, keyword.operator.relational.cs
+
+Line:     }
+ - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
+ - token from 4 to 5 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor, punctuation.curlybrace.close.cs
+
+Line: }
+ - token from 0 to 2 (}) with scopes text.aspnetcorerazor, meta.statement.if.razor, meta.structure.razor.csharp.codeblock, meta.statement.while.razor
 "
 `;
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -3434,22 +3434,12 @@ exports[`Grammar tests @try { ... } catch/finally { ... } Not in HTML 1`] = `
  - token from 4 to 5 (>) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, punctuation.definition.tag.end.html
 
 Line:     try not to classify this
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.try.razor
- - token from 4 to 7 (try) with scopes text.aspnetcorerazor, meta.statement.try.razor, keyword.control.try.cs
- - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.statement.try.razor
- - token from 8 to 11 (not) with scopes text.aspnetcorerazor, meta.statement.try.razor, variable.other.readwrite.cs
- - token from 11 to 12 ( ) with scopes text.aspnetcorerazor, meta.statement.try.razor
- - token from 12 to 14 (to) with scopes text.aspnetcorerazor, meta.statement.try.razor, variable.other.readwrite.cs
- - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.statement.try.razor
- - token from 15 to 23 (classify) with scopes text.aspnetcorerazor, meta.statement.try.razor, variable.other.readwrite.cs
- - token from 23 to 24 ( ) with scopes text.aspnetcorerazor, meta.statement.try.razor
- - token from 24 to 28 (this) with scopes text.aspnetcorerazor, meta.statement.try.razor, keyword.other.this.cs
+ - token from 0 to 29 (    try not to classify this) with scopes text.aspnetcorerazor
 
 Line: </div>
- - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.statement.try.razor, keyword.operator.relational.cs
- - token from 1 to 2 (/) with scopes text.aspnetcorerazor, meta.statement.try.razor, keyword.operator.arithmetic.cs
- - token from 2 to 5 (div) with scopes text.aspnetcorerazor, meta.statement.try.razor, variable.other.readwrite.cs
- - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.statement.try.razor, keyword.operator.relational.cs
+ - token from 0 to 2 (</) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, punctuation.definition.tag.begin.html
+ - token from 2 to 5 (div) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, entity.name.tag.html
+ - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, punctuation.definition.tag.end.html
 "
 `;
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -833,20 +833,12 @@ exports[`Grammar tests @do { ... } while ( ... ); Not in HTML 1`] = `
  - token from 4 to 5 (>) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, punctuation.definition.tag.end.html
 
 Line:     do not classify this
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.do.razor
- - token from 4 to 6 (do) with scopes text.aspnetcorerazor, meta.statement.do.razor, keyword.control.loop.do.cs
- - token from 6 to 7 ( ) with scopes text.aspnetcorerazor, meta.statement.do.razor
- - token from 7 to 10 (not) with scopes text.aspnetcorerazor, meta.statement.do.razor, variable.other.readwrite.cs
- - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.statement.do.razor
- - token from 11 to 19 (classify) with scopes text.aspnetcorerazor, meta.statement.do.razor, variable.other.readwrite.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.do.razor
- - token from 20 to 24 (this) with scopes text.aspnetcorerazor, meta.statement.do.razor, keyword.other.this.cs
+ - token from 0 to 25 (    do not classify this) with scopes text.aspnetcorerazor
 
 Line: </div>
- - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.statement.do.razor, keyword.operator.relational.cs
- - token from 1 to 2 (/) with scopes text.aspnetcorerazor, meta.statement.do.razor, keyword.operator.arithmetic.cs
- - token from 2 to 5 (div) with scopes text.aspnetcorerazor, meta.statement.do.razor, variable.other.readwrite.cs
- - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.statement.do.razor, keyword.operator.relational.cs
+ - token from 0 to 2 (</) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, punctuation.definition.tag.begin.html
+ - token from 2 to 5 (div) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, entity.name.tag.html
+ - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, punctuation.definition.tag.end.html
 "
 `;
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -3090,24 +3090,12 @@ exports[`Grammar tests @switch ( ... ) { ... } Not in HTML 1`] = `
  - token from 4 to 5 (>) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, punctuation.definition.tag.end.html
 
 Line:     switch (over to better classifications)
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.switch.razor
- - token from 4 to 10 (switch) with scopes text.aspnetcorerazor, meta.statement.switch.razor, keyword.control.switch.cs
- - token from 10 to 11 ( ) with scopes text.aspnetcorerazor, meta.statement.switch.razor
- - token from 11 to 12 (() with scopes text.aspnetcorerazor, meta.statement.switch.razor, punctuation.parenthesis.open.cs
- - token from 12 to 16 (over) with scopes text.aspnetcorerazor, meta.statement.switch.razor, variable.other.readwrite.cs
- - token from 16 to 17 ( ) with scopes text.aspnetcorerazor, meta.statement.switch.razor
- - token from 17 to 19 (to) with scopes text.aspnetcorerazor, meta.statement.switch.razor, variable.other.readwrite.cs
- - token from 19 to 20 ( ) with scopes text.aspnetcorerazor, meta.statement.switch.razor
- - token from 20 to 26 (better) with scopes text.aspnetcorerazor, meta.statement.switch.razor, entity.name.type.cs
- - token from 26 to 27 ( ) with scopes text.aspnetcorerazor, meta.statement.switch.razor
- - token from 27 to 42 (classifications) with scopes text.aspnetcorerazor, meta.statement.switch.razor, entity.name.variable.local.cs
- - token from 42 to 43 ()) with scopes text.aspnetcorerazor, meta.statement.switch.razor, punctuation.parenthesis.close.cs
+ - token from 0 to 44 (    switch (over to better classifications)) with scopes text.aspnetcorerazor
 
 Line: </div>
- - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.statement.switch.razor, keyword.operator.relational.cs
- - token from 1 to 2 (/) with scopes text.aspnetcorerazor, meta.statement.switch.razor, keyword.operator.arithmetic.cs
- - token from 2 to 5 (div) with scopes text.aspnetcorerazor, meta.statement.switch.razor, variable.other.readwrite.cs
- - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.statement.switch.razor, keyword.operator.relational.cs
+ - token from 0 to 2 (</) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, punctuation.definition.tag.begin.html
+ - token from 2 to 5 (div) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, entity.name.tag.html
+ - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, punctuation.definition.tag.end.html
 "
 `;
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/tests/__snapshots__/GrammarTests.test.ts.snap
@@ -1148,26 +1148,12 @@ exports[`Grammar tests @for ( ... ) { ... } Not in HTML 1`] = `
  - token from 4 to 5 (>) with scopes text.aspnetcorerazor, meta.tag.structure.div.start.html, punctuation.definition.tag.end.html
 
 Line:     for (this) is the best classification
- - token from 0 to 4 (    ) with scopes text.aspnetcorerazor, meta.statement.for.razor
- - token from 4 to 7 (for) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.control.loop.for.cs
- - token from 7 to 8 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
- - token from 8 to 9 (() with scopes text.aspnetcorerazor, meta.statement.for.razor, punctuation.parenthesis.open.cs
- - token from 9 to 13 (this) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.other.this.cs
- - token from 13 to 14 ()) with scopes text.aspnetcorerazor, meta.statement.for.razor, punctuation.parenthesis.close.cs
- - token from 14 to 15 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
- - token from 15 to 17 (is) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.other.is.cs
- - token from 17 to 18 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
- - token from 18 to 21 (the) with scopes text.aspnetcorerazor, meta.statement.for.razor, entity.name.type.cs
- - token from 21 to 22 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
- - token from 22 to 26 (best) with scopes text.aspnetcorerazor, meta.statement.for.razor, variable.other.readwrite.cs
- - token from 26 to 27 ( ) with scopes text.aspnetcorerazor, meta.statement.for.razor
- - token from 27 to 41 (classification) with scopes text.aspnetcorerazor, meta.statement.for.razor, variable.other.readwrite.cs
+ - token from 0 to 42 (    for (this) is the best classification) with scopes text.aspnetcorerazor
 
 Line: </div>
- - token from 0 to 1 (<) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.operator.relational.cs
- - token from 1 to 2 (/) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.operator.arithmetic.cs
- - token from 2 to 5 (div) with scopes text.aspnetcorerazor, meta.statement.for.razor, variable.other.readwrite.cs
- - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.statement.for.razor, keyword.operator.relational.cs
+ - token from 0 to 2 (</) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, punctuation.definition.tag.begin.html
+ - token from 2 to 5 (div) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, entity.name.tag.html
+ - token from 5 to 6 (>) with scopes text.aspnetcorerazor, meta.tag.structure.div.end.html, punctuation.definition.tag.end.html
 "
 `;
 


### PR DESCRIPTION
Fixes #4581

I've done this as lots of commits to hopefully make things easier to review, since all test results are in the one single snapshot results file.

First commit adds more tests and updates the snapshot to illustrate the bad thing.
Second commit sets up the textmate system I'm going to use, which sadly involves duplicating a bunch of rules.
Subsequent commits then fix one type of statement at a time, including the test snapshot results change, so you can see that things are actually fixed.
Final commit is compiling the json file from the yaml, and can be ignored.