### PR TITLE
Try doing one build instead of two

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -197,20 +197,20 @@ stages:
             env:
               Token: $(dn-bot-dnceng-artifact-feeds-rw)
 
-        - script: eng\CIBuild.cmd
+        - script: eng\cibuild.cmd
+            -configuration $(_BuildConfig)
+            -msbuildEngine vs
+            -prepareMachine
             -restore
             -build
-            -sign
             -pack
             -publish
-            -configuration $(_BuildConfig)
-            -msbuildEngine dotnet
-            -prepareMachine
+            -sign
             $(_BuildArgs)
             $(_PublishArgs)
             $(_InternalRuntimeDownloadArgs)
           name: Build
-          displayName: Build
+          displayName: Build and Deploy
           condition: succeeded()
 
         - task: PublishBuildArtifacts@1
@@ -220,33 +220,6 @@ stages:
           inputs:
               pathtoPublish: artifacts/log/$(_BuildConfig)/Build.binlog
               artifactName: $(Agent.Os)_$(Agent.JobName) BuildBinLog
-              artifactType: Container
-              parallel: true
-
-        - script: eng\cibuild.cmd
-            -configuration $(_BuildConfig)
-            -msbuildEngine vs
-            -prepareMachine
-            -restore
-            -build
-            -pack
-            -sign
-            /p:BuildVsix=true
-            /p:BuildProjectReferences=false
-            $(_BuildArgs)
-            $(_PublishArgs)
-            $(_InternalRuntimeDownloadArgs)
-          name: Build_Vsix
-          displayName: Build and Deploy Vsix
-          condition: succeeded()
-
-        - task: PublishBuildArtifacts@1
-          displayName: Upload Build VSIX BinLog
-          condition: always()
-          continueOnError: true
-          inputs:
-              pathtoPublish: artifacts/log/$(_BuildConfig)/Build.binlog
-              artifactName: $(Agent.Os)_$(Agent.JobName) BuildVSIXBinLog
               artifactType: Container
               parallel: true
 
@@ -306,7 +279,7 @@ stages:
         #     searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
         #   continueOnError: true
         #   condition: always()
-        
+
         # Publish an artifact that the RoslynInsertionTool is able to find by its name.
         - task: PublishBuildArtifacts@1
           displayName: Publish Artifact VSSetup
@@ -339,10 +312,10 @@ stages:
             ArtifactName: BlazorWasmDebuggingExtension
           continueOnError: true
           condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
-          
+
         - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)"
           displayName: Setting VisualStudio.DropName variable
-          
+
         # Publishes setup VSIXes to a drop.
         # Note: The insertion tool looks for the display name of this task in the logs.
         - ${{ if ne(variables['System.TeamProject'], 'public') }}:

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -6,9 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectToBuild Condition="'$(OS)'=='WINDOWS_NT' and '$(SdkTaskProjects)'=='' And '$(BuildVsix)' != 'true'" Include="$(MSBuildThisFileDirectory)..\Razor.sln" />
-    <ProjectToBuild Condition="'$(OS)'=='WINDOWS_NT' and '$(SdkTaskProjects)'=='' And '$(BuildVsix)' == 'true'" Include="$(MSBuildThisFileDirectory)..\src\Razor\src\Microsoft.VisualStudio.RazorExtension\Microsoft.VisualStudio.RazorExtension.csproj" />
-    <ProjectToBuild Condition="'$(OS)'=='WINDOWS_NT' and '$(SdkTaskProjects)'=='' And '$(BuildVsix)' == 'true' AND '$(BuildDependencyVsix)' != 'false'" Include="$(MSBuildThisFileDirectory)..\src\Razor\src\Microsoft.VisualStudio.RazorExtension.Dependencies\Microsoft.VisualStudio.RazorExtension.Dependencies.csproj" />
+    <ProjectToBuild Condition="'$(OS)'=='WINDOWS_NT' and '$(SdkTaskProjects)'==''" Include="$(MSBuildThisFileDirectory)..\Razor.sln" />
 
     <!-- Exclude VSIX projects on non-Windows -->
     <ProjectToBuild Condition="'$(OS)'!='WINDOWS_NT' and '$(SdkTaskProjects)'==''" Include="$(MSBuildThisFileDirectory)..\Razor.Slim.slnf" />

--- a/eng/pipelines/test-integration-job.yml
+++ b/eng/pipelines/test-integration-job.yml
@@ -51,7 +51,6 @@ steps:
       -configuration ${{ parameters.configuration }}
       -msbuildEngine vs
       -prepareMachine
-      /p:BuildVsix=true
       /p:BuildDependencyVsix=false
       /p:BuildProjectReferences=false
     name: BuildVSIX

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/README.md
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/README.md
@@ -2,4 +2,4 @@
 
 ## Running
 
-If you run the integration tests from the command line using something like "dotnet test" they may fail because the Extension was now deployed. To ensure the extension was deployed you can either launch tests through Visual Studio or first run a command like `eng\cibuild.cmd -configuration Debug -msbuildEngine vs -prepareMachine /p:BuildVsix=true`
+If you run the integration tests from the command line using something like "dotnet test" they may fail because the Extension was now deployed. To ensure the extension was deployed you can either launch tests through Visual Studio or first run a command like `eng\cibuild.cmd -configuration Debug -msbuildEngine vs -prepareMachine`

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/README.md
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/README.md
@@ -2,4 +2,4 @@
 
 ## Running
 
-If you run the integration tests from the command line using something like "dotnet test" they may fail because the Extension was now deployed. To ensure the extension was deployed you can either launch tests through Visual Studio or first run a command like `eng\cibuild.cmd -configuration Debug -msbuildEngine vs -prepareMachine`
+If you run the integration tests from the command line using something like "dotnet test" they may fail because the Extension was not deployed. To ensure the extension was deployed you can either launch tests through Visual Studio or first run a command like `eng\cibuild.cmd -configuration Debug -msbuildEngine vs -prepareMachine`


### PR DESCRIPTION
This is _somewhat_ a guess, but I think this might solve the symbol issue, plus it just makes sense.

Currently we build all of Razor.sln, then the RazorExtension.csproj even though its part of the solution. This change means we just build the solution, and call it a day.

Will do a validation build once the RPS issue has been fixed, so I can be sure it will work, but looking at build artifacts, the VSIX contents are identical.