### PR TITLE
Update compiler toolset version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -80,7 +80,7 @@
     <MicrosoftVisualStudioPackagesVersion>17.5.42-preview</MicrosoftVisualStudioPackagesVersion>
     <RoslynPackageVersion>4.5.0-2.22527.10</RoslynPackageVersion>
     <VisualStudioLanguageServerProtocolVersion>17.4.1008-preview</VisualStudioLanguageServerProtocolVersion>
-    <MicrosoftNetCompilersToolsetVersion>4.4.0-4.final</MicrosoftNetCompilersToolsetVersion>
+    <MicrosoftNetCompilersToolsetVersion>4.4.0</MicrosoftNetCompilersToolsetVersion>
     <MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>$(RoslynPackageVersion)</MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="Manual">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -80,7 +80,7 @@
     <MicrosoftVisualStudioPackagesVersion>17.5.42-preview</MicrosoftVisualStudioPackagesVersion>
     <RoslynPackageVersion>4.5.0-2.22527.10</RoslynPackageVersion>
     <VisualStudioLanguageServerProtocolVersion>17.4.1008-preview</VisualStudioLanguageServerProtocolVersion>
-    <MicrosoftNetCompilersToolsetVersion>4.4.0-1.final</MicrosoftNetCompilersToolsetVersion>
+    <MicrosoftNetCompilersToolsetVersion>4.4.0-4.final</MicrosoftNetCompilersToolsetVersion>
     <MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>$(RoslynPackageVersion)</MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>
   </PropertyGroup>
   <PropertyGroup Label="Manual">


### PR DESCRIPTION
### Summary of the changes

- Was seeing errors similar to https://github.com/dotnet/roslyn/issues/63318 when building within VS. Upgrading the compiler toolset version seemed to have fixed it.