### PR TITLE
Exclude Razor.CoreComponents.* files from VSIX

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor.CoreComponents/Microsoft.CodeAnalysis.Remote.Razor.CoreComponents.csproj
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor.CoreComponents/Microsoft.CodeAnalysis.Remote.Razor.CoreComponents.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
 
-    <!-- The purpose of this project is to include all dependecies of Microsoft.CodeAnalysis.Remote.Razor targeting .Net Core -->
+    <!-- The purpose of this project is to include all dependencies of Microsoft.CodeAnalysis.Remote.Razor targeting .Net Core -->
     <IsShipping>false</IsShipping>
   </PropertyGroup>
 
@@ -18,12 +18,12 @@
       <!-- Need to include and then update items (https://github.com/microsoft/msbuild/issues/1053) -->
 
       <!--
-        We're only targeting netcoreapp3.1 to ensure the SDK consumes all transitive dependencies, we don't actually need an executable.
+        We're only targeting net6.0 to ensure the SDK consumes all transitive dependencies, we don't actually need an executable.
         Also only include dependencies exclusive to Razor. For any common dependencies between Roslyn and Razor, we want to share the ones
         loaded in Roslyn's ALC at runtime.
       -->
 
-      <_ExcludedFiles Include="$(PublishDir)**\Microsoft.CodeAnalysis.Remote.ServiceHub.CoreComponents.*" />
+      <_ExcludedFiles Include="$(PublishDir)**\Microsoft.CodeAnalysis.Remote.Razor.CoreComponents.*" />
 
       <_PublishedFiles Include="$(PublishDir)**\Microsoft.CodeAnalysis.Razor.*" />
       <_PublishedFiles Include="$(PublishDir)**\Microsoft.CodeAnalysis.Remote.Razor.*" Exclude="@(_ExcludedFiles)"/>


### PR DESCRIPTION
This fixes a typo in `Microsoft.CodeAnalysis.Remote.Razor.CoreComponents.csproj` that caused the `.dll`, `.exe`, `.deps.json`, and `.runtimeConfig.json` to be included in the Razor VSIX's `ServiceHubCore` folder. In addition, I've updated this project to target `net6.0`. There's no reason it needs to target `netcoreapp3.1`. The only reason this project exists is to define an output group target that our VSIX's build can access to pull in the assets needed for the `ServiceHubCore` folder. 

**Before:**

![image](https://user-images.githubusercontent.com/116161/205116133-8b5b34b0-6734-4631-bcf9-d67142d65b83.png)

**After:**

![image](https://user-images.githubusercontent.com/116161/205116266-52222455-b54c-448d-ab6c-3b7a312341f1.png)
