### PR TITLE
Update dependency versions

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -75,10 +75,10 @@
     <Tooling_HtmlEditorPackageVersion>17.5.101-preview-0002</Tooling_HtmlEditorPackageVersion>
     <!-- Several packages share the MS.CA.Testing version -->
     <Tooling_MicrosoftCodeAnalysisTestingVersion>1.1.2-beta1.22512.1</Tooling_MicrosoftCodeAnalysisTestingVersion>
-    <MicrosoftVisualStudioShellPackagesVersion>17.4.0-preview-2-32826-307</MicrosoftVisualStudioShellPackagesVersion>
-    <MicrosoftVisualStudioPackagesVersion>17.5.42-preview</MicrosoftVisualStudioPackagesVersion>
-    <RoslynPackageVersion>4.5.0-2.22527.10</RoslynPackageVersion>
-    <VisualStudioLanguageServerProtocolVersion>17.4.1008-preview</VisualStudioLanguageServerProtocolVersion>
+    <MicrosoftVisualStudioShellPackagesVersion>17.5.0-preview-2-33130-046</MicrosoftVisualStudioShellPackagesVersion>
+    <MicrosoftVisualStudioPackagesVersion>17.5.195-preview</MicrosoftVisualStudioPackagesVersion>
+    <RoslynPackageVersion>4.5.0-3.22580.15</RoslynPackageVersion>
+    <VisualStudioLanguageServerProtocolVersion>17.5.20-preview</VisualStudioLanguageServerProtocolVersion>
     <MicrosoftNetCompilersToolsetVersion>4.4.0</MicrosoftNetCompilersToolsetVersion>
     <MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>$(RoslynPackageVersion)</MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>
   </PropertyGroup>
@@ -113,14 +113,14 @@
     <MicrosoftVisualStudioShell150PackageVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioShell150PackageVersion>
     <MicrosoftVisualStudioInteropPackageVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioInteropPackageVersion>
     <MicrosoftInternalVisualStudioInteropPackageVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftInternalVisualStudioInteropPackageVersion>
-    <MicrosoftVisualStudioRpcContractsPackageVersion>17.4.5-alpha</MicrosoftVisualStudioRpcContractsPackageVersion>
-    <MicrosoftVisualStudioTelemetryVersion>16.5.2</MicrosoftVisualStudioTelemetryVersion>
+    <MicrosoftVisualStudioRpcContractsPackageVersion>17.5.18-alpha</MicrosoftVisualStudioRpcContractsPackageVersion>
+    <MicrosoftVisualStudioTelemetryVersion>16.6.9</MicrosoftVisualStudioTelemetryVersion>
     <MicrosoftVisualStudioTextDataPackageVersion>$(MicrosoftVisualStudioPackagesVersion)</MicrosoftVisualStudioTextDataPackageVersion>
     <MicrosoftVisualStudioTextImplementationPackageVersion>$(MicrosoftVisualStudioPackagesVersion)</MicrosoftVisualStudioTextImplementationPackageVersion>
     <MicrosoftVisualStudioTextLogicPackageVersion>$(MicrosoftVisualStudioPackagesVersion)</MicrosoftVisualStudioTextLogicPackageVersion>
-    <MicrosoftVisualStudioThreadingPackageVersion>17.4.27</MicrosoftVisualStudioThreadingPackageVersion>
+    <MicrosoftVisualStudioThreadingPackageVersion>17.5.10-alpha</MicrosoftVisualStudioThreadingPackageVersion>
     <MicrosoftVisualStudioWebPackageVersion>16.10.0-preview-1-31008-014</MicrosoftVisualStudioWebPackageVersion>
-    <MicrosoftVisualStudioValidationPackageVersion>17.0.64</MicrosoftVisualStudioValidationPackageVersion>
+    <MicrosoftVisualStudioValidationPackageVersion>17.0.71</MicrosoftVisualStudioValidationPackageVersion>
     <MicrosoftWebToolsLanguagesHtmlPackageVersion>$(Tooling_HtmlEditorPackageVersion)</MicrosoftWebToolsLanguagesHtmlPackageVersion>
     <MicrosoftWebToolsLanguagesLanguageServerServerPackageVersion>$(Tooling_HtmlEditorPackageVersion)</MicrosoftWebToolsLanguagesLanguageServerServerPackageVersion>
     <MicrosoftWebToolsLanguagesSharedPackageVersion>$(Tooling_HtmlEditorPackageVersion)</MicrosoftWebToolsLanguagesSharedPackageVersion>
@@ -130,12 +130,12 @@
     <MonoDevelopSdkPackageVersion>1.0.15</MonoDevelopSdkPackageVersion>
     <MoqPackageVersion>4.16.0</MoqPackageVersion>
     <NewtonsoftJsonPackageVersion>13.0.1</NewtonsoftJsonPackageVersion>
-    <NerdbankStreamsPackageVersion>2.9.87-alpha</NerdbankStreamsPackageVersion>
+    <NerdbankStreamsPackageVersion>2.9.112</NerdbankStreamsPackageVersion>
     <NuGetSolutionRestoreManagerInteropVersion>4.8.0</NuGetSolutionRestoreManagerInteropVersion>
     <OmniSharpExtensionsLanguageServerPackageVersion>0.19.5</OmniSharpExtensionsLanguageServerPackageVersion>
     <OmniSharpExtensionsLanguageProtocolPackageVersion>$(OmniSharpExtensionsLanguageServerPackageVersion)</OmniSharpExtensionsLanguageProtocolPackageVersion>
     <OmniSharpMSBuildPackageVersion>1.39.1</OmniSharpMSBuildPackageVersion>
-    <StreamJsonRpcPackageVersion>2.13.21-alpha</StreamJsonRpcPackageVersion>
+    <StreamJsonRpcPackageVersion>2.14.17-alpha</StreamJsonRpcPackageVersion>
     <SystemRuntimeInteropServicesRuntimePackageVersion>4.3.0</SystemRuntimeInteropServicesRuntimePackageVersion>
     <Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion>3.3.3</Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion>
     <Tooling_MicrosoftCodeAnalysisNetAnalyzersPackageVersion>7.0.0-preview1.22116.1</Tooling_MicrosoftCodeAnalysisNetAnalyzersPackageVersion>
@@ -160,7 +160,7 @@
     <XunitExtensibilityExecutionPackageVersion>$(XunitVersion)</XunitExtensibilityExecutionPackageVersion>
     <!-- Temporary hack to workaround package restrictions for dev17 -->
     <MicrosoftInternalVisualStudioShellFrameworkPackageVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftInternalVisualStudioShellFrameworkPackageVersion>
-    <MicrosoftIORedistPackageVersion>4.7.1</MicrosoftIORedistPackageVersion>
+    <MicrosoftIORedistPackageVersion>6.0.0</MicrosoftIORedistPackageVersion>
     <!-- Compiler Deps -->
     <BenchmarkDotNetVersion>0.13.0.1555</BenchmarkDotNetVersion>
     <DiffPlexVersion>1.5.0</DiffPlexVersion>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultRemoteTextLoaderFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultRemoteTextLoaderFactory.cs
@@ -37,7 +37,7 @@ public class DefaultRemoteTextLoaderFactory : RemoteTextLoaderFactory
             _filePath = filePath;
         }
 
-        public override Task<TextAndVersion> LoadTextAndVersionAsync(Workspace? workspace, DocumentId? documentId, CancellationToken cancellationToken)
+        public override Task<TextAndVersion> LoadTextAndVersionAsync(LoadTextOptions options, CancellationToken cancellationToken)
         {
 
             TextAndVersion textAndVersion;
@@ -69,6 +69,13 @@ public class DefaultRemoteTextLoaderFactory : RemoteTextLoaderFactory
             }
 
             return Task.FromResult(textAndVersion);
+        }
+
+        [Obsolete]
+        public override Task<TextAndVersion> LoadTextAndVersionAsync(Workspace? workspace, DocumentId? documentId, CancellationToken cancellationToken)
+        {
+            var options = new LoadTextOptions();
+            return LoadTextAndVersionAsync(options, cancellationToken);
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AbstractRazorDelegatingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AbstractRazorDelegatingEndpoint.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using ITextDocumentPositionParams = Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts.ITextDocumentPositionParams;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentSnapshotTextLoader.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentSnapshotTextLoader.cs
@@ -23,11 +23,18 @@ internal class DocumentSnapshotTextLoader : TextLoader
         _documentSnapshot = documentSnapshot;
     }
 
-    public override async Task<TextAndVersion> LoadTextAndVersionAsync(Workspace? workspace, DocumentId? documentId, CancellationToken cancellationToken)
+    public override async Task<TextAndVersion> LoadTextAndVersionAsync(LoadTextOptions options, CancellationToken cancellationToken)
     {
         var sourceText = await _documentSnapshot.GetTextAsync();
         var textAndVersion = TextAndVersion.Create(sourceText, VersionStamp.Default);
 
         return textAndVersion;
+    }
+
+    [Obsolete]
+    public override Task<TextAndVersion> LoadTextAndVersionAsync(Workspace? workspace, DocumentId? documentId, CancellationToken cancellationToken)
+    {
+        var options = new LoadTextOptions();
+        return LoadTextAndVersionAsync(options, cancellationToken);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/SignatureHelpParamsBridge.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/SignatureHelpParamsBridge.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using ITextDocumentPositionParams = Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts.ITextDocumentPositionParams;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.SignatureHelp;
 
-internal class SignatureHelpParamsBridge : SignatureHelpParams, ITextDocumentPositionParams
+internal class SignatureHelpParamsBridge : SignatureHelpParams, ITextDocumentPositionParams //
 {
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
@@ -488,15 +488,25 @@ internal class DefaultRazorProjectService : RazorProjectService
         {
             _fromDocument = fromDocument ?? throw new ArgumentNullException(nameof(fromDocument));
         }
+
         public override async Task<TextAndVersion> LoadTextAndVersionAsync(
-           Workspace? workspace,
-           DocumentId? documentId,
-           CancellationToken cancellationToken)
-        {
+            LoadTextOptions options,
+            CancellationToken cancellationToken)
+        { 
             var sourceText = await _fromDocument.GetTextAsync();
             var version = await _fromDocument.GetTextVersionAsync();
             var textAndVersion = TextAndVersion.Create(sourceText, version.GetNewerVersion());
             return textAndVersion;
+        }
+
+        [Obsolete]
+        public override Task<TextAndVersion> LoadTextAndVersionAsync(
+            Workspace? workspace,
+            DocumentId? documentId,
+            CancellationToken cancellationToken)
+        {
+            var options = new LoadTextOptions();
+            return LoadTextAndVersionAsync(options, cancellationToken);
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/BackgroundDocumentProcessedPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/BackgroundDocumentProcessedPublisher.cs
@@ -286,12 +286,19 @@ internal class BackgroundDocumentProcessedPublisher : OmniSharpDocumentProcessed
             _document = document;
         }
 
-        public async override Task<TextAndVersion> LoadTextAndVersionAsync(Workspace workspace, DocumentId documentId, CancellationToken cancellationToken)
+        public async override Task<TextAndVersion> LoadTextAndVersionAsync(LoadTextOptions options, CancellationToken cancellationToken)
         {
             var sourceText = await _document.GetTextAsync(cancellationToken);
             var textVersion = await _document.GetTextVersionAsync(cancellationToken);
             var textAndVersion = TextAndVersion.Create(sourceText, textVersion);
             return textAndVersion;
+        }
+
+        [Obsolete]
+        public override Task<TextAndVersion> LoadTextAndVersionAsync(Workspace workspace, DocumentId documentId, CancellationToken cancellationToken)
+        {
+            var options = new LoadTextOptions();
+            return LoadTextAndVersionAsync(options, cancellationToken);
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/EmptyTextLoader.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.OmniSharpPlugin/EmptyTextLoader.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
+using System;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,10 +21,17 @@ internal class EmptyTextLoader : TextLoader
         _version = VersionStamp.Create(); // Version will never change so this can be reused.
     }
 
-    public override Task<TextAndVersion> LoadTextAndVersionAsync(Workspace workspace, DocumentId documentId, CancellationToken cancellationToken)
+    public override Task<TextAndVersion> LoadTextAndVersionAsync(LoadTextOptions options, CancellationToken cancellationToken)
     {
         // Providing an encoding here is important for debuggability. Without this edit-and-continue
         // won't work for projects with Razor files.
         return Task.FromResult(TextAndVersion.Create(SourceText.From(string.Empty, Encoding.UTF8), _version, _filePath));
+    }
+
+    [Obsolete]
+    public override Task<TextAndVersion> LoadTextAndVersionAsync(Workspace? workspace, DocumentId? documentId, CancellationToken cancellationToken)
+    {
+        var options = new LoadTextOptions();
+        return LoadTextAndVersionAsync(options, cancellationToken);
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultRazorDynamicFileInfoProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultRazorDynamicFileInfoProvider.cs
@@ -418,11 +418,18 @@ internal class DefaultRazorDynamicFileInfoProvider : RazorDynamicFileInfoProvide
             _version = VersionStamp.Default; // Version will never change so this can be reused.
         }
 
-        public override Task<TextAndVersion> LoadTextAndVersionAsync(Workspace workspace, DocumentId documentId, CancellationToken cancellationToken)
+        public override Task<TextAndVersion> LoadTextAndVersionAsync(LoadTextOptions options, CancellationToken cancellationToken)
         {
             // Providing an encoding here is important for debuggability. Without this edit-and-continue
             // won't work for projects with Razor files.
             return Task.FromResult(TextAndVersion.Create(SourceText.From("", Encoding.UTF8), _version, _filePath));
+        }
+
+        [Obsolete]
+        public override Task<TextAndVersion> LoadTextAndVersionAsync(Workspace workspace, DocumentId documentId, CancellationToken cancellationToken)
+        {
+            var options = new LoadTextOptions();
+            return LoadTextAndVersionAsync(options, cancellationToken);
         }
     }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultProjectSnapshotManager.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultProjectSnapshotManager.cs
@@ -191,9 +191,10 @@ internal class DefaultProjectSnapshotManager : ProjectSnapshotManagerBase
             }
             else
             {
+                var options = new LoadTextOptions();
                 var loader = textLoader is null
                     ? DocumentState.EmptyLoader
-                    : (() => textLoader.LoadTextAndVersionAsync(Workspace, documentId: null, CancellationToken.None));
+                    : (() => textLoader.LoadTextAndVersionAsync(options, CancellationToken.None));
                 var state = entry.State.WithAddedHostDocument(document, loader);
 
                 // Document updates can no-op.
@@ -341,9 +342,10 @@ internal class DefaultProjectSnapshotManager : ProjectSnapshotManagerBase
             }
             else
             {
+                var options = new LoadTextOptions();
                 var state = entry.State.WithChangedHostDocument(
                     older.HostDocument,
-                    async () => await textLoader.LoadTextAndVersionAsync(Workspace, documentId: null, cancellationToken: default));
+                    async () => await textLoader.LoadTextAndVersionAsync(options, cancellationToken: default));
 
                 _openDocuments.Remove(documentFilePath);
 
@@ -453,9 +455,10 @@ internal class DefaultProjectSnapshotManager : ProjectSnapshotManagerBase
             }
             else
             {
+                var options = new LoadTextOptions();
                 var state = entry.State.WithChangedHostDocument(
                     older.HostDocument,
-                    async () => await textLoader.LoadTextAndVersionAsync(Workspace, documentId: default, cancellationToken: default));
+                    async () => await textLoader.LoadTextAndVersionAsync(options, cancellationToken: default));
 
                 // Document updates can no-op.
                 if (!ReferenceEquals(state, entry.State))

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/EmptyTextLoader.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/EmptyTextLoader.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
+using System;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -21,10 +20,17 @@ internal class EmptyTextLoader : TextLoader
         _version = VersionStamp.Create(); // Version will never change so this can be reused.
     }
 
-    public override Task<TextAndVersion> LoadTextAndVersionAsync(Workspace workspace, DocumentId documentId, CancellationToken cancellationToken)
+    public override Task<TextAndVersion> LoadTextAndVersionAsync(LoadTextOptions options, CancellationToken cancellationToken)
     {
         // Providing an encoding here is important for debuggability. Without this edit-and-continue
         // won't work for projects with Razor files.
         return Task.FromResult(TextAndVersion.Create(SourceText.From("", Encoding.UTF8), _version, _filePath));
+    }
+
+    [Obsolete]
+    public override Task<TextAndVersion> LoadTextAndVersionAsync(Workspace? workspace, DocumentId? documentId, CancellationToken cancellationToken)
+    {
+        var lto = new LoadTextOptions();
+        return LoadTextAndVersionAsync(lto, cancellationToken);
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/GeneratedDocumentTextLoader.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/GeneratedDocumentTextLoader.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Text;
 using System.Threading;
@@ -30,12 +28,19 @@ internal class GeneratedDocumentTextLoader : TextLoader
         _version = VersionStamp.Create();
     }
 
-    public override async Task<TextAndVersion> LoadTextAndVersionAsync(Workspace workspace, DocumentId documentId, CancellationToken cancellationToken)
+    public override async Task<TextAndVersion> LoadTextAndVersionAsync(LoadTextOptions options, CancellationToken cancellationToken)
     {
         var output = await _document.GetGeneratedOutputAsync().ConfigureAwait(false);
 
         // Providing an encoding here is important for debuggability. Without this edit-and-continue
         // won't work for projects with Razor files.
         return TextAndVersion.Create(SourceText.From(output.GetCSharpDocument().GeneratedCode, Encoding.UTF8), _version, _filePath);
+    }
+
+    [Obsolete]
+    public override Task<TextAndVersion> LoadTextAndVersionAsync(Workspace? workspace, DocumentId? documentId, CancellationToken cancellationToken)
+    {
+        var options = new LoadTextOptions();
+        return LoadTextAndVersionAsync(options, cancellationToken);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocumentPublisher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocumentPublisher.cs
@@ -158,9 +158,16 @@ internal class CSharpVirtualDocumentPublisher : LSPDocumentChangeListener
                 _filePath = filePath;
             }
 
-            public override Task<TextAndVersion> LoadTextAndVersionAsync(CodeAnalysisWorkspace? workspace, DocumentId? documentId, CancellationToken cancellationToken)
+            public override Task<TextAndVersion> LoadTextAndVersionAsync(LoadTextOptions options, CancellationToken cancellationToken)
             {
                 return Task.FromResult(TextAndVersion.Create(_sourceText, VersionStamp.Default, _filePath));
+            }
+
+            [Obsolete]
+            public override Task<TextAndVersion> LoadTextAndVersionAsync(CodeAnalysisWorkspace? workspace, DocumentId? documentId, CancellationToken cancellationToken)
+            {
+                var options = new LoadTextOptions();
+                return LoadTextAndVersionAsync(options, cancellationToken);
             }
         }
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/CSharpTestLspServer.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/CSharpTestLspServer.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.Host;
 using Microsoft.VisualStudio.Composition;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Nerdbank.Streams;
@@ -79,7 +80,10 @@ public sealed class CSharpTestLspServer : IAsyncDisposable
             registrationService.Register(workspace);
 
             var languageServerFactory = exportProvider.GetExportedValue<IRazorLanguageServerFactoryWrapper>();
-            var languageServer = languageServerFactory.CreateLanguageServer(serverRpc, capabilitiesProvider);
+
+            var hostServices = TestServices.Create(Array.Empty<IWorkspaceService>(), Array.Empty<ILanguageService>());
+
+            var languageServer = languageServerFactory.CreateLanguageServer(serverRpc, capabilitiesProvider, hostServices);
 
             serverRpc.StartListening();
             return languageServer;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeDocumentReferenceHolderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeDocumentReferenceHolderTest.cs
@@ -193,9 +193,17 @@ public class CodeDocumentReferenceHolderTest : LanguageServerTestBase
         }
 
         public override Task<TextAndVersion> LoadTextAndVersionAsync(
-            Workspace? workspace, DocumentId? documentId, CancellationToken cancellationToken)
+             LoadTextOptions options, CancellationToken cancellationToken)
         {
             return Task.FromResult(TextAndVersion.Create(_sourceText, VersionStamp.Default, _filePath));
+        }
+
+        [Obsolete]
+        public override Task<TextAndVersion> LoadTextAndVersionAsync(
+            Workspace? workspace, DocumentId? documentId, CancellationToken cancellationToken)
+        {
+            var options = new LoadTextOptions();
+            return LoadTextAndVersionAsync(options, cancellationToken);
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentSnapshotTextLoaderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentSnapshotTextLoaderTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -30,7 +28,7 @@ public class DocumentSnapshotTextLoaderTest : TestBase
         var textLoader = new DocumentSnapshotTextLoader(snapshot);
 
         // Act
-        var actual = await textLoader.LoadTextAndVersionAsync(default, default, default);
+        var actual = await textLoader.LoadTextAndVersionAsync(default, default);
 
         // Assert
         Assert.Same(expectedSourceText, actual.Text);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/EmptyTextLoaderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/EmptyTextLoaderTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Test.Common;
@@ -26,7 +24,7 @@ public class EmptyTextLoaderTest : TestBase
         var loader = new EmptyTextLoader("file.cshtml");
 
         // Act
-        var textAndVersion = await loader.LoadTextAndVersionAsync(default, default, default);
+        var textAndVersion = await loader.LoadTextAndVersionAsync(default, default);
 
         // Assert
         Assert.True(textAndVersion.Text.CanBeEmbedded);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/GeneratedDocumentTextLoaderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/GeneratedDocumentTextLoaderTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Text;
@@ -37,7 +35,7 @@ public class GeneratedDocumentTextLoaderTest : WorkspaceTestBase
         var loader = new GeneratedDocumentTextLoader(document, "file.cshtml");
 
         // Act
-        var textAndVersion = await loader.LoadTextAndVersionAsync(default, default, default);
+        var textAndVersion = await loader.LoadTextAndVersionAsync(default, default);
 
         // Assert
         Assert.True(textAndVersion.Text.CanBeEmbedded);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DocumentGenerator/BackgroundDocumentGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DocumentGenerator/BackgroundDocumentGeneratorTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -56,7 +54,7 @@ public class BackgroundDocumentGeneratorTest : ProjectSnapshotManagerDispatcherW
         // We utilize a task completion source here so we can "fake" a document parse taking a significant amount of time
         var tcs = new TaskCompletionSource<TextAndVersion>();
         var textLoader = new Mock<TextLoader>(MockBehavior.Strict);
-        textLoader.Setup(loader => loader.LoadTextAndVersionAsync(It.IsAny<Workspace>(), It.IsAny<DocumentId>(), It.IsAny<CancellationToken>()))
+        textLoader.Setup(loader => loader.LoadTextAndVersionAsync(It.IsAny<LoadTextOptions>(), It.IsAny<CancellationToken>()))
             .Returns(tcs.Task);
         var hostDocument = _documents[0];
 
@@ -100,7 +98,7 @@ public class BackgroundDocumentGeneratorTest : ProjectSnapshotManagerDispatcherW
         projectManager.ProjectAdded(_hostProject1);
 
         var textLoader = new Mock<TextLoader>(MockBehavior.Strict);
-        textLoader.Setup(loader => loader.LoadTextAndVersionAsync(It.IsAny<Workspace>(), It.IsAny<DocumentId>(), It.IsAny<CancellationToken>()))
+        textLoader.Setup(loader => loader.LoadTextAndVersionAsync(It.IsAny<LoadTextOptions>(), It.IsAny<CancellationToken>()))
             .Throws<FileNotFoundException>();
         projectManager.DocumentAdded(_hostProject1, _documents[0], textLoader.Object);
 
@@ -131,7 +129,7 @@ public class BackgroundDocumentGeneratorTest : ProjectSnapshotManagerDispatcherW
         projectManager.ProjectAdded(_hostProject1);
 
         var textLoader = new Mock<TextLoader>(MockBehavior.Strict);
-        textLoader.Setup(loader => loader.LoadTextAndVersionAsync(It.IsAny<Workspace>(), It.IsAny<DocumentId>(), It.IsAny<CancellationToken>()))
+        textLoader.Setup(loader => loader.LoadTextAndVersionAsync(It.IsAny<LoadTextOptions>(), It.IsAny<CancellationToken>()))
             .Throws<UnauthorizedAccessException>();
         projectManager.DocumentAdded(_hostProject1, _documents[0], textLoader.Object);
 
@@ -374,14 +372,14 @@ public class BackgroundDocumentGeneratorTest : ProjectSnapshotManagerDispatcherW
 
     private class TestDynamicFileInfoProvider : RazorDynamicFileInfoProvider
     {
-        private readonly Dictionary<string, DynamicDocumentContainer> _dynamicDocuments;
+        private readonly Dictionary<string, DynamicDocumentContainer?> _dynamicDocuments;
 
         public TestDynamicFileInfoProvider()
         {
-            _dynamicDocuments = new Dictionary<string, DynamicDocumentContainer>();
+            _dynamicDocuments = new Dictionary<string, DynamicDocumentContainer?>();
         }
 
-        public IReadOnlyDictionary<string, DynamicDocumentContainer> DynamicDocuments => _dynamicDocuments;
+        public IReadOnlyDictionary<string, DynamicDocumentContainer?> DynamicDocuments => _dynamicDocuments;
 
         public override void Initialize(ProjectSnapshotManagerBase projectManager)
         {

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Microsoft.VisualStudio.LanguageServices.Razor.Test.csproj
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Microsoft.VisualStudio.LanguageServices.Razor.Test.csproj
@@ -39,6 +39,6 @@
 
   <ItemGroup>
     <!-- Package changes to enable dev17 builds that have incoherent versions -->
-    <PackageReference Include="Microsoft.IO.Redist" Version="4.7.1" />
+    <PackageReference Include="Microsoft.IO.Redist" Version="$(MicrosoftIORedistPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultProjectSnapshotManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultProjectSnapshotManagerTest.cs
@@ -646,7 +646,7 @@ public class DefaultProjectSnapshotManagerTest : ProjectSnapshotManagerDispatche
 
         // Assert
         Assert.Equal(ProjectChangeKind.DocumentAdded, _projectManager.ListenersNotifiedOf);
-        textLoader.Verify(d => d.LoadTextAndVersionAsync(It.IsAny<Workspace>(), It.IsAny<DocumentId>(), It.IsAny<CancellationToken>()), Times.Never());
+        textLoader.Verify(d => d.LoadTextAndVersionAsync(It.IsAny<LoadTextOptions>(), It.IsAny<CancellationToken>()), Times.Never());
     }
 
     private class TestProjectSnapshotManager : DefaultProjectSnapshotManager


### PR DESCRIPTION
Update dependency versions

Fixes:
Updates a number of packages to more modern versions, including (and most interestingly) taking the now obsolete LoadTextAndVersionAsync virtual method and providing implementations of the updated method signature and updating all callers to use the new method signature.