### PR TITLE
[Infra] Update PublishData.json for 17.5 P3

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -8,7 +8,17 @@
       "vsBranch": "main",
       "vsMajorVersion": 17,
       "insertionCreateDraftPR": false,
+      "insertionTitlePrefix": "[17.5p3]"
+    },
+    "release/dev17.5": {
+      "nugetKind": [
+        "Shipping",
+        "NonShipping"
+      ],
+      "vsBranch": "rel/d17.5",
+      "vsMajorVersion": 17,
+      "insertionCreateDraftPR": false,
       "insertionTitlePrefix": "[17.5p2]"
-    }
+    },
   }
 }

--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -19,6 +19,6 @@
       "vsMajorVersion": 17,
       "insertionCreateDraftPR": false,
       "insertionTitlePrefix": "[17.5p2]"
-    },
+    }
   }
 }


### PR DESCRIPTION
### Summary of the changes
- Separate from this PR, I created a `release/dev17.5` branch to match Roslyn's branching strategy. This will make it easier in the future if we need to take a fix for servicing or QB approval.
- This PR updates our GitHub -> VS branch mapping targets after the 17.5 P2 snap.
