### PR TITLE
Have a separate feature flag for single server diagnostics, that defaults to off

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultLanguageServerFeatureOptions.cs
@@ -19,4 +19,6 @@ internal class DefaultLanguageServerFeatureOptions : LanguageServerFeatureOption
     public override bool SingleServerCompletionSupport => false;
 
     public override bool SingleServerSupport => false;
+
+    public override bool SingleServerDiagnosticsSupport => false;
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorPullDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorPullDiagnosticsEndpoint.cs
@@ -49,12 +49,12 @@ internal class RazorPullDiagnosticsEndpoint
 
     public async Task<IEnumerable<VSInternalDiagnosticReport>?> HandleRequestAsync(VSInternalDocumentDiagnosticsParams request, RazorRequestContext context, CancellationToken cancellationToken)
     {
-        var documentContext = context.GetRequiredDocumentContext();
-
-        if (!_languageServerFeatureOptions.SingleServerSupport)
+        if (!_languageServerFeatureOptions.SingleServerDiagnosticsSupport)
         {
             return default;
         }
+
+        var documentContext = context.GetRequiredDocumentContext();
 
         var delegatedParams = new DelegatedDiagnosticParams(documentContext.Identifier);
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
@@ -19,6 +19,8 @@ internal abstract class LanguageServerFeatureOptions
 
     public abstract bool SingleServerSupport { get; }
 
+    public abstract bool SingleServerDiagnosticsSupport { get; }
+
     public string GetRazorCSharpFilePath(string razorFilePath) => razorFilePath + CSharpVirtualDocumentSuffix;
 
     public string GetRazorHtmlFilePath(string razorFilePath) => razorFilePath + HtmlVirtualDocumentSuffix;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
@@ -115,6 +115,10 @@ internal class InitializeHandler : IRequestHandler<InitializeParams, InitializeR
             _initializeResult.Capabilities.ImplementationProvider = false;
 
             ((VSInternalServerCapabilities)_initializeResult.Capabilities).OnAutoInsertProvider = null;
+        }
+
+        if (_languageServerFeatureOptions.SingleServerDiagnosticsSupport)
+        {
             ((VSInternalServerCapabilities)_initializeResult.Capabilities).SupportsDiagnosticRequests = false;
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
@@ -14,10 +14,12 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
 {
     private const string SingleServerCompletionFeatureFlag = "Razor.LSP.SingleServerCompletion";
     private const string SingleServerFeatureFlag = "Razor.LSP.SingleServer";
+    private const string SingleServerDiagnosticsFeatureFlag = "Razor.LSP.SingleServerDiagnostics";
 
     private readonly LSPEditorFeatureDetector _lspEditorFeatureDetector;
     private readonly Lazy<bool> _singleServerCompletionSupport;
     private readonly Lazy<bool> _singleServerSupport;
+    private readonly Lazy<bool> _singleServerDiagnosticsSupport;
 
     [ImportingConstructor]
     public VisualStudioWindowsLanguageServerFeatureOptions(LSPEditorFeatureDetector lspEditorFeatureDetector)
@@ -42,6 +44,13 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
             var singleServerEnabled = featureFlags.IsFeatureEnabled(SingleServerFeatureFlag, defaultValue: false);
             return singleServerEnabled;
         });
+
+        _singleServerDiagnosticsSupport = new Lazy<bool>(() =>
+        {
+            var featureFlags = (IVsFeatureFlags)AsyncPackage.GetGlobalService(typeof(SVsFeatureFlags));
+            var singleServerDiagnosticsEnabled = featureFlags.IsFeatureEnabled(SingleServerDiagnosticsFeatureFlag, defaultValue: false);
+            return singleServerDiagnosticsEnabled;
+        });
     }
 
     // We don't currently support file creation operations on VS Codespaces or VS Liveshare
@@ -57,6 +66,8 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
     public override bool SingleServerCompletionSupport => _singleServerCompletionSupport.Value;
 
     public override bool SingleServerSupport => _singleServerSupport.Value;
+
+    public override bool SingleServerDiagnosticsSupport => _singleServerDiagnosticsSupport.Value;
 
     private bool IsCodespacesOrLiveshare => _lspEditorFeatureDetector.IsRemoteClient() || _lspEditorFeatureDetector.IsLiveShareHost();
 }

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacLanguageServerFeatureOptions.cs
@@ -37,6 +37,8 @@ internal class VisualStudioMacLanguageServerFeatureOptions : LanguageServerFeatu
 
     public override bool SingleServerSupport => false;
 
+    public override bool SingleServerDiagnosticsSupport => false;
+
     private bool IsCodespacesOrLiveshare => _lspEditorFeatureDetector.IsRemoteClient() || _lspEditorFeatureDetector.IsLiveShareHost();
 
 }

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
@@ -54,3 +54,9 @@
 "Value"=dword:00000001
 "Title"="Enable enhanced Razor LSP server (requires restart)"
 "PreviewPaneChannels"="IntPreview,int.main"
+
+[$RootKey$\FeatureFlags\Razor\LSP\SingleServerDiagnostics]
+"Description"="Enable single server diagnostics support when editing Razor (ASP.NET Core)."
+"Value"=dword:00000000
+"Title"="Enable enhanced Razor LSP diagnostics (requires restart)"
+"PreviewPaneChannels"="IntPreview,int.main"

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common/TestLanguageServerFeatureOptions.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common/TestLanguageServerFeatureOptions.cs
@@ -24,4 +24,6 @@ internal class TestLanguageServerFeatureOptions : LanguageServerFeatureOptions
     public override bool SingleServerCompletionSupport => false;
 
     public override bool SingleServerSupport => false;
+
+    public override bool SingleServerDiagnosticsSupport => false;
 }


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1690006

I could have just reverted the PR, but I like having the code still there for easier fixing later.

It looks like the single server code never calls the diagnostic translator code, which is needed for corrent remapping of diagnotsics (since they don't strictly map) and for some filtering (eg, for edit and continue). Adding in the call seemed like it shouldn't be too hard, but the `RazorDiagnosticsEndpoint` is hardcoded to only call Roslyn for C# diagnostics, which means even adding that call would mean nothing is filtering or dealing with Html diagnostics, and it wasn't clear to me hiow to fix that, so in the interests of time, I've just turned them off.

FYI @ryanbrandenburg 

@allisonchou since I'm away, can you look after getting this in? Its one commit, so if it needs to go in a different branch, it should be easily cherry-pickable

Also FYI @phil-allen-msft for M2/QB/whatevs