### PR TITLE
Handle project files in root directory

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorProjectFileSystem.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorProjectFileSystem.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorProjectFileSystem.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorProjectFileSystem.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -90,7 +90,15 @@ internal class DefaultRazorProjectFileSystem : RazorProjectFileSystem
                 path = path.Substring(1);
             }
 
-            absolutePath = Path.Combine(Root, path);
+            // Instead of `C:filename.ext`, we want `C:/filename.ext`.
+            if (Root.EndsWith(":", StringComparison.Ordinal) && !string.IsNullOrEmpty(path))
+            {
+                absolutePath = Root + "/" + path;
+            }
+            else
+            {
+                absolutePath = Path.Combine(Root, path);
+            }
         }
 
         absolutePath = absolutePath.Replace('\\', '/');

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorProject.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorProject.cs
@@ -99,8 +99,7 @@ public abstract class RazorProject
         var fileNameIndex = path.LastIndexOf('/');
         var length = path.Length;
 
-        // https://github.com/dotnet/razor-tooling/issues/6965
-        // Debug.Assert(fileNameIndex != -1);
+        Debug.Assert(fileNameIndex != -1);
 
         if (string.Compare(path, fileNameIndex + 1, fileName, 0, fileName.Length, StringComparison.Ordinal) == 0)
         {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorProject.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorProject.cs
@@ -97,12 +97,19 @@ public abstract class RazorProject
 
         StringBuilder builder;
         var fileNameIndex = path.LastIndexOf('/');
-        var length = path.Length;
+
+        // Handle paths like `C:file.ext`.
+        if (fileNameIndex == -1)
+        {
+            fileNameIndex = path.LastIndexOf(':');
+        }
 
         if (fileNameIndex == -1)
         {
-            throw new InvalidOperationException($"Cannot find '/' in path '{path}'");
+            throw new InvalidOperationException($"Cannot find file name in path '{path}'");
         }
+
+        var length = path.Length;
 
         if (string.Compare(path, fileNameIndex + 1, fileName, 0, fileName.Length, StringComparison.Ordinal) == 0)
         {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorProject.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorProject.cs
@@ -97,19 +97,12 @@ public abstract class RazorProject
 
         StringBuilder builder;
         var fileNameIndex = path.LastIndexOf('/');
-
-        // Handle paths like `C:file.ext`.
-        if (fileNameIndex == -1)
-        {
-            fileNameIndex = path.LastIndexOf(':');
-        }
+        var length = path.Length;
 
         if (fileNameIndex == -1)
         {
             throw new InvalidOperationException($"Cannot find file name in path '{path}'");
         }
-
-        var length = path.Length;
 
         if (string.Compare(path, fileNameIndex + 1, fileName, 0, fileName.Length, StringComparison.Ordinal) == 0)
         {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorProject.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorProject.cs
@@ -99,7 +99,10 @@ public abstract class RazorProject
         var fileNameIndex = path.LastIndexOf('/');
         var length = path.Length;
 
-        Debug.Assert(fileNameIndex != -1);
+        if (fileNameIndex == -1)
+        {
+            throw new InvalidOperationException($"Cannot find '/' in path '{path}'");
+        }
 
         if (string.Compare(path, fileNameIndex + 1, fileName, 0, fileName.Length, StringComparison.Ordinal) == 0)
         {


### PR DESCRIPTION
Fixes #6965.

In the CI, the path happens to be `C:document1.razor`, so it doesn't contain `/`, failing the original assert. This PR handles that case.

`Debug.Assert` hangs the CI build (seems .NET Framework [shows modal dialog](https://github.com/xunit/xunit/issues/382) instead of failing), so I replaced this one with exception. It would be better to configure this globally like [in Roslyn](https://github.com/dotnet/roslyn/blob/55259597ad41ac41e0d1888fa52a92e73318b57e/eng/config/test/Desktop/app.config#L9), I guess.