### PR TITLE
Fix hover when it should separate multiple summaries

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultVSLSPTagHelperTooltipFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultVSLSPTagHelperTooltipFactory.cs
@@ -428,7 +428,7 @@ internal class DefaultVSLSPTagHelperTooltipFactory : VSLSPTagHelperTooltipFactor
             }
             else
             {
-                classifiedElementContainer.Add(new ContainerElement(ContainerElementStyle.Wrapped, new ClassifiedTextElement(s_newLine)));
+                classifiedElementContainer.Add(new ContainerElement(ContainerElementStyle.Wrapped, new ClassifiedTextElement()));
             }
 
             classifiedElementContainer.Add(new ContainerElement(ContainerElementStyle.Wrapped, glyph, new ClassifiedTextElement(classification.Type)));

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultVSLSPTagHelperTooltipFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultVSLSPTagHelperTooltipFactory.cs
@@ -422,6 +422,7 @@ internal class DefaultVSLSPTagHelperTooltipFactory : VSLSPTagHelperTooltipFactor
         var classifiedElementContainer = new List<ContainerElement>();
         foreach (var classification in descriptionClassifications)
         {
+            // Adds blank lines between multiple classified elements
             if (isFirstElement)
             {
                 isFirstElement = false;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultVSLSPTagHelperTooltipFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultVSLSPTagHelperTooltipFactory.cs
@@ -418,9 +418,19 @@ internal class DefaultVSLSPTagHelperTooltipFactory : VSLSPTagHelperTooltipFactor
 
     private static ContainerElement CombineClassifiedTextRuns(IReadOnlyList<DescriptionClassification> descriptionClassifications, ImageElement glyph)
     {
+        var isFirstElement = true;
         var classifiedElementContainer = new List<ContainerElement>();
         foreach (var classification in descriptionClassifications)
         {
+            if (isFirstElement)
+            {
+                isFirstElement = false;
+            }
+            else
+            {
+                classifiedElementContainer.Add(new ContainerElement(ContainerElementStyle.Wrapped, new ClassifiedTextElement(s_newLine)));
+            }
+
             classifiedElementContainer.Add(new ContainerElement(ContainerElementStyle.Wrapped, glyph, new ClassifiedTextElement(classification.Type)));
 
             if (classification.Documentation.Count > 0)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultVSLSPTagHelperTooltipFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultVSLSPTagHelperTooltipFactoryTest.cs
@@ -490,7 +490,7 @@ End summary description.";
         //     [Class Glyph] Microsoft.AspNetCore.OtherTagHelper
         //     Also uses List<string>s
         Assert.Equal(ContainerElementStyle.Stacked, container.Style);
-        Assert.Equal(4, containerElements.Count);
+        Assert.Equal(5, containerElements.Count);
 
         // [Class Glyph] Microsoft.AspNetCore.SomeTagHelper
         var innerContainer = ((ContainerElement)containerElements[0]).Elements.ToList();
@@ -516,8 +516,14 @@ End summary description.";
             run => AssertExpectedClassification(run, ">", VSPredefinedClassificationTypeNames.Punctuation),
             run => AssertExpectedClassification(run, "s", VSPredefinedClassificationTypeNames.Text));
 
-        // [Class Glyph] Microsoft.AspNetCore.OtherTagHelper
+        // new line
         innerContainer = ((ContainerElement)containerElements[2]).Elements.ToList();
+        classifiedTextElement = (ClassifiedTextElement)innerContainer[0];
+        Assert.Single(innerContainer);
+        Assert.Empty(classifiedTextElement.Runs);
+
+        // [Class Glyph] Microsoft.AspNetCore.OtherTagHelper
+        innerContainer = ((ContainerElement)containerElements[3]).Elements.ToList();
         classifiedTextElement = (ClassifiedTextElement)innerContainer[1];
         Assert.Equal(2, innerContainer.Count);
         Assert.Equal(ClassGlyph, innerContainer[0]);
@@ -529,7 +535,7 @@ End summary description.";
             run => AssertExpectedClassification(run, "OtherTagHelper", VSPredefinedClassificationTypeNames.Type));
 
         // Also uses List<string>s
-        innerContainer = ((ContainerElement)containerElements[3]).Elements.ToList();
+        innerContainer = ((ContainerElement)containerElements[4]).Elements.ToList();
         classifiedTextElement = (ClassifiedTextElement)innerContainer[0];
         Assert.Single(innerContainer);
         Assert.Collection(classifiedTextElement.Runs,
@@ -590,7 +596,7 @@ End summary description.";
         //     [Property Glyph] bool? Microsoft.AspNetCore.SomeTagHelpers.AnotherTypeName.AnotherProperty
         //     Uses List<string>s
         Assert.Equal(ContainerElementStyle.Stacked, container.Style);
-        Assert.Equal(4, containerElements.Count);
+        Assert.Equal(5, containerElements.Count);
 
         // [TagHelper Glyph] string Microsoft.AspNetCore.SomeTagHelpers.SomeTypeName.SomeProperty
         var innerContainer = ((ContainerElement)containerElements[0]).Elements.ToList();
@@ -622,8 +628,14 @@ End summary description.";
             run => AssertExpectedClassification(run, ">", VSPredefinedClassificationTypeNames.Punctuation),
             run => AssertExpectedClassification(run, "s", VSPredefinedClassificationTypeNames.Text));
 
-        // [TagHelper Glyph] bool? Microsoft.AspNetCore.SomeTagHelpers.AnotherTypeName.AnotherProperty
+        // new line
         innerContainer = ((ContainerElement)containerElements[2]).Elements.ToList();
+        classifiedTextElement = (ClassifiedTextElement)innerContainer[0];
+        Assert.Single(innerContainer);
+        Assert.Empty(classifiedTextElement.Runs);
+
+        // [TagHelper Glyph] bool? Microsoft.AspNetCore.SomeTagHelpers.AnotherTypeName.AnotherProperty
+        innerContainer = ((ContainerElement)containerElements[3]).Elements.ToList();
         classifiedTextElement = (ClassifiedTextElement)innerContainer[1];
         Assert.Equal(2, innerContainer.Count);
         Assert.Equal(PropertyGlyph, innerContainer[0]);
@@ -642,7 +654,7 @@ End summary description.";
             run => AssertExpectedClassification(run, "AnotherProperty", VSPredefinedClassificationTypeNames.Identifier));
 
         // Uses List<string>s
-        innerContainer = ((ContainerElement)containerElements[3]).Elements.ToList();
+        innerContainer = ((ContainerElement)containerElements[4]).Elements.ToList();
         classifiedTextElement = (ClassifiedTextElement)innerContainer[0];
         Assert.Single(innerContainer);
         Assert.Collection(classifiedTextElement.Runs,


### PR DESCRIPTION
Fixes #6998

### Summary of the changes

The actual behavior:
![IFzLurRJ0s](https://user-images.githubusercontent.com/70431552/196397622-74f7c06f-d422-4bb4-b4cc-c8866c5977cc.png)

The expected behavior:
![51VqKTRMin](https://user-images.githubusercontent.com/70431552/196397739-85c631f7-1c76-4915-98aa-58b0f78a88cb.png)

The fix:
The changes in this PR helps to add a line of padding in between summaries.
![image](https://user-images.githubusercontent.com/5897654/206558400-078eb760-1abb-46d4-89d6-76e9111ae04e.png)

It somehow seems like it is adding two new lines. So I need to figure our why this is happening.

Fixes: #6998
