### PR TITLE
Don't include Microsoft.Extensions.ObjectPool.dll in our mpack

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Properties/_Manifest.addin.xml
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Properties/_Manifest.addin.xml
@@ -17,7 +17,6 @@
     <Import assembly="Microsoft.AspNetCore.Razor.LanguageServer.dll" />
     <Import assembly="Microsoft.AspNetCore.Razor.LanguageServer.Common.dll" />
     <Import assembly="Microsoft.AspNetCore.Razor.LanguageServer.Protocol.dll" />
-    <Import assembly="Microsoft.Extensions.ObjectPool.dll" />
     <Import assembly="Microsoft.Extensions.Options.dll" />
     <Import assembly="Microsoft.Extensions.Primitives.dll" />
     <Import assembly="Microsoft.Extensions.DependencyInjection.dll" />
@@ -28,6 +27,7 @@
     <!--
         Purposefully not including these actual dependencies because VS4Mac ships them for us on our behalf. This differs from VisualStudio windows.
 
+        <Import assembly="Microsoft.Extensions.ObjectPool.dll" />
         <Import assembly="Microsoft.Extensions.Logging.dll" />
         <Import assembly="Microsoft.Extensions.Logging.Abstractions.dll" />
         <Import assembly="System.IO.Pipelines.dll" />

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/mpack/addin.info
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/mpack/addin.info
@@ -17,7 +17,6 @@
     <Import assembly="Microsoft.AspNetCore.Razor.LanguageServer.dll" />
     <Import assembly="Microsoft.AspNetCore.Razor.LanguageServer.Common.dll" />
     <Import assembly="Microsoft.AspNetCore.Razor.LanguageServer.Protocol.dll" />
-    <Import assembly="Microsoft.Extensions.ObjectPool.dll" />
     <Import assembly="Microsoft.Extensions.Options.dll" />
     <Import assembly="Microsoft.Extensions.Primitives.dll" />
     <Import assembly="Microsoft.Extensions.DependencyInjection.dll" />
@@ -28,6 +27,7 @@
     <!--
         Purposefully not including these actual dependencies because VS4Mac ships them for us on our behalf. This differs from VisualStudio windows.
 
+        <Import assembly="Microsoft.Extensions.ObjectPool.dll" />
         <Import assembly="Microsoft.Extensions.Logging.dll" />
         <Import assembly="Microsoft.Extensions.Logging.Abstractions.dll" />
         <Import assembly="System.IO.Pipelines.dll" />


### PR DESCRIPTION
Turns out VS Mac already ships this itself, so we don't need to.

https://github.com/xamarin/vsmac/blob/main/main/src/core/MonoDevelop.Core/MonoDevelop.Core.addin.xml#L4