### PR TITLE
Truly exclude Microsoft.Extensions.ObjectPool.dll from mpack

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Microsoft.VisualStudio.Mac.RazorAddin.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.RazorAddin/Microsoft.VisualStudio.Mac.RazorAddin.csproj
@@ -81,7 +81,6 @@
     <MPackFile Include="$(ArtifactsBinDir)Microsoft.AspNetCore.Razor.LanguageServer.Common\$(Configuration)\net472\Microsoft.AspNetCore.Razor.LanguageServer.Common.dll" />
     <MPackFile Include="$(ArtifactsBinDir)Microsoft.AspNetCore.Razor.LanguageServer.Protocol\$(Configuration)\net472\Microsoft.AspNetCore.Razor.LanguageServer.Protocol.dll" />
     <MPackFile Include="$(ArtifactsBinDir)Microsoft.AspNetCore.Razor.LanguageServer\$(Configuration)\net472\Microsoft.AspNetCore.Razor.LanguageServer.dll" />
-    <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Mac.RazorAddin\$(Configuration)\net472\Microsoft.Extensions.ObjectPool.dll" />
     <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Mac.RazorAddin\$(Configuration)\net472\Microsoft.Extensions.Options.dll" />
     <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Mac.RazorAddin\$(Configuration)\net472\Microsoft.Extensions.Primitives.dll" />
     <MPackFile Include="$(ArtifactsBinDir)Microsoft.VisualStudio.Mac.RazorAddin\$(Configuration)\net472\Microsoft.Extensions.DependencyInjection.dll" />


### PR DESCRIPTION
Follow-up to https://github.com/dotnet/razor/pull/8009.

If Razor's LSP server was a separate process like WebTools, we would leave the duplicate files in there and resolve this issue using symlinks. But that's not the case here.