### PR TITLE
Implement new logger interface method without dependency upgrade

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
@@ -107,6 +107,10 @@ public class RazorLanguageServerBenchmarkBase : ProjectSnapshotManagerBenchmarkB
         {
         }
 
+        public void LogDebug(string _, params object[] _2)
+        {
+        }
+
         public void LogError(string message, params object[] @params)
         {
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LoggerAdapter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LoggerAdapter.cs
@@ -53,6 +53,11 @@ public class LoggerAdapter : IRazorLogger
         _logger.LogInformation(message, @params);
     }
 
+    public void LogDebug(string message, params object[] @params)
+    {
+        _logger.LogDebug(message, @params);
+    }
+
     public void LogStartContext(string message, params object[] @params)
     {
         _logger.LogInformation("Entering: {}", message);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LspLogger.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LspLogger.cs
@@ -103,6 +103,11 @@ internal class LspLogger : IRazorLogger
     {
         ((ILogger)this).LogWarning(message, @params);
     }
+
+    public void LogDebug(string message, params object[] @params)
+    {
+        ((ILogger)this).LogDebug(message, @params);
+    }
 #pragma warning restore CA2254 // Template should be a static expression
 
     private class Disposable : IDisposable

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/Logging/LoggerExtensions.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/Logging/LoggerExtensions.cs
@@ -35,6 +35,9 @@ internal static class LoggerExtensions
         public void LogWarning(string? message, params object?[] @params)
             => _logger.LogWarning(message, @params);
 
+        public void LogDebug(string message, params object[] @params)
+            => _logger.LogDebug(message, @params);
+
         public void LogStartContext(string message, params object?[] @params)
         {
             lock (_gate)


### PR DESCRIPTION
### Summary of the changes

-

Alternative attempt to https://github.com/dotnet/razor/pull/8016 to respond to breaking changes without updating dependencies (and therefore breaking integration tests)

Fixes:
