### PR TITLE
Diagnostic translate flag

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultLanguageServerFeatureOptions.cs
@@ -19,6 +19,4 @@ internal class DefaultLanguageServerFeatureOptions : LanguageServerFeatureOption
     public override bool SingleServerCompletionSupport => false;
 
     public override bool SingleServerSupport => false;
-
-    public override bool SingleServerDiagnosticsSupport => false;
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorPullDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorPullDiagnosticsEndpoint.cs
@@ -52,7 +52,7 @@ internal class RazorPullDiagnosticsEndpoint
 
     public async Task<IEnumerable<VSInternalDiagnosticReport>?> HandleRequestAsync(VSInternalDocumentDiagnosticsParams request, RazorRequestContext context, CancellationToken cancellationToken)
     {
-        if (!_languageServerFeatureOptions.SingleServerDiagnosticsSupport)
+        if (!_languageServerFeatureOptions.SingleServerSupport)
         {
             return default;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorTranslateDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorTranslateDiagnosticsEndpoint.cs
@@ -2,49 +2,30 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.AspNetCore.Razor.Language.Syntax;
-using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
-using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
-using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
-using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
-using DiagnosticSeverity = Microsoft.VisualStudio.LanguageServer.Protocol.DiagnosticSeverity;
-using RazorDiagnosticFactory = Microsoft.AspNetCore.Razor.Language.RazorDiagnosticFactory;
-using SourceText = Microsoft.CodeAnalysis.Text.SourceText;
-using SyntaxNode = Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxNode;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics;
 
 internal class RazorTranslateDiagnosticsEndpoint :
     IRazorTranslateDiagnosticsEndpoint
 {
-    // Internal for testing
-    internal static readonly IReadOnlyCollection<string> CSharpDiagnosticsToIgnore = new HashSet<string>()
-    {
-        "RemoveUnnecessaryImportsFixable",
-        "IDE0005_gen", // Using directive is unnecessary
-    };
-
-    private readonly RazorDocumentMappingService _documentMappingService;
     private readonly ILogger _logger;
+    private readonly RazorTranslateDiagnosticsService _translateDiagnosticsService;
 
     public bool MutatesSolutionState { get; } = false;
 
     public RazorTranslateDiagnosticsEndpoint(
-        RazorDocumentMappingService documentMappingService,
+        RazorTranslateDiagnosticsService translateDiagnosticsService,
         ILoggerFactory loggerFactory)
     {
-        if (documentMappingService is null)
+        if (translateDiagnosticsService is null)
         {
-            throw new ArgumentNullException(nameof(documentMappingService));
+            throw new ArgumentNullException(nameof(translateDiagnosticsService));
         }
 
         if (loggerFactory is null)
@@ -52,7 +33,7 @@ internal class RazorTranslateDiagnosticsEndpoint :
             throw new ArgumentNullException(nameof(loggerFactory));
         }
 
-        _documentMappingService = documentMappingService;
+        _translateDiagnosticsService = translateDiagnosticsService;
         _logger = loggerFactory.CreateLogger<RazorTranslateDiagnosticsEndpoint>();
     }
 
@@ -81,502 +62,36 @@ internal class RazorTranslateDiagnosticsEndpoint :
             };
         }
 
-        var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
-        if (codeDocument.IsUnsupported() != false)
-        {
-            _logger.LogInformation("Unsupported code document.");
-            return new RazorDiagnosticsResponse()
-            {
-                Diagnostics = Array.Empty<VSDiagnostic>(),
-                HostDocumentVersion = documentContext.Version
-            };
-        }
-
-        var sourceText = await documentContext.GetSourceTextAsync(cancellationToken);
-        var unmappedDiagnostics = request.Diagnostics;
-        var filteredDiagnostics = request.Kind == RazorLanguageKind.CSharp
-            ? FilterCSharpDiagnostics(unmappedDiagnostics, codeDocument, sourceText)
-            : FilterHTMLDiagnostics(unmappedDiagnostics, codeDocument, sourceText, _logger);
-        if (!filteredDiagnostics.Any())
-        {
-            _logger.LogInformation("No diagnostics remaining after filtering.");
-
-            return new RazorDiagnosticsResponse()
-            {
-                Diagnostics = Array.Empty<VSDiagnostic>(),
-                HostDocumentVersion = documentContext.Version,
-            };
-        }
-
-        _logger.LogInformation("{filteredDiagnosticsLength}/{unmappedDiagnosticsLength} diagnostics remain after filtering.", filteredDiagnostics.Length, unmappedDiagnostics.Length);
-
-        var mappedDiagnostics = MapDiagnostics(
-            request.Kind,
-            filteredDiagnostics,
-            codeDocument,
-            sourceText);
+        var mappedDiagnostics = await _translateDiagnosticsService.TranslateAsync(request.Kind, request.Diagnostics, documentContext, cancellationToken);
 
         _logger.LogInformation("Returning {mappedDiagnosticsLength} mapped diagnostics.", mappedDiagnostics.Length);
 
         return new RazorDiagnosticsResponse()
         {
-            Diagnostics = mappedDiagnostics,
+            Diagnostics = mappedDiagnostics.Select(ToVSDiagnostic).ToArray(),
             HostDocumentVersion = documentContext.Version,
         };
-    }
-
-    private static VSDiagnostic[] FilterHTMLDiagnostics(
-        VSDiagnostic[] unmappedDiagnostics,
-        RazorCodeDocument codeDocument,
-        SourceText sourceText,
-        ILogger logger)
-    {
-        var syntaxTree = codeDocument.GetSyntaxTree();
-
-        var processedAttributes = new Dictionary<TextSpan, bool>();
-
-        var filteredDiagnostics = unmappedDiagnostics
-            .Where(d =>
-                !InCSharpLiteral(d, sourceText, syntaxTree, logger) &&
-                !InAttributeContainingCSharp(d, sourceText, syntaxTree, processedAttributes, logger) &&
-                !AppliesToTagHelperTagName(d, sourceText, syntaxTree, logger) &&
-                !ShouldFilterHtmlDiagnosticBasedOnErrorCode(d, sourceText, syntaxTree, logger))
-            .ToArray();
-
-        return filteredDiagnostics;
-    }
-
-    private static bool InCSharpLiteral(
-        VSDiagnostic d,
-        SourceText sourceText,
-        RazorSyntaxTree syntaxTree,
-        ILogger logger)
-    {
-        if (d.Range is null)
-        {
-            return false;
-        }
-
-        var owner = syntaxTree.GetOwner(sourceText, d.Range.End, logger);
-        if (owner is null)
-        {
-            return false;
-        }
-
-        var isCSharp = owner.Kind is SyntaxKind.CSharpExpressionLiteral or SyntaxKind.CSharpStatementLiteral or SyntaxKind.CSharpEphemeralTextLiteral;
-
-        return isCSharp;
-    }
-
-    private static bool AppliesToTagHelperTagName(
-        VSDiagnostic diagnostic,
-        SourceText sourceText,
-        RazorSyntaxTree syntaxTree,
-        ILogger logger)
-    {
-        // Goal of this method is to filter diagnostics that touch TagHelper tag names. Reason being is TagHelpers can output anything. Meaning
-        // If you have a TagHelper like:
-        //
-        // <Input>
-        // </Input>
-        //
-        // HTML would see this as an error because the input element can't have a body; however, a TagHelper could respect this in a totally valid
-        // way.
-
-        if (diagnostic.Range is null)
-        {
-            return false;
-        }
-
-        var owner = syntaxTree.GetOwner(sourceText, diagnostic.Range.End, logger);
-
-        var startOrEndTag = owner?.FirstAncestorOrSelf<RazorSyntaxNode>(n => n is MarkupTagHelperStartTagSyntax || n is MarkupTagHelperEndTagSyntax);
-        if (startOrEndTag is null)
-        {
-            return false;
-        }
-
-        var tagName = startOrEndTag is MarkupTagHelperStartTagSyntax startTag ? startTag.Name : ((MarkupTagHelperEndTagSyntax)startOrEndTag).Name;
-        var tagNameRange = tagName.GetRange(syntaxTree.Source);
-
-        if (!tagNameRange.IntersectsOrTouches(diagnostic.Range))
-        {
-            // The diagnostic doesn't touch the tag name
-            return false;
-        }
-
-        // Diagnostic is touching the start or end tag name range
-        return true;
-    }
-
-    private static bool ShouldFilterHtmlDiagnosticBasedOnErrorCode(VSDiagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
-    {
-        if (!diagnostic.Code.HasValue)
-        {
-            return false;
-        }
-
-        diagnostic.Code.Value.TryGetSecond(out var str);
-
-        return str switch
-        {
-            CSSErrorCodes.MissingOpeningBrace => IsCSharpInStyleBlock(diagnostic, sourceText, syntaxTree, logger),
-            CSSErrorCodes.MissingSelectorAfterCombinator => IsCSharpInStyleBlock(diagnostic, sourceText, syntaxTree, logger),
-            CSSErrorCodes.MissingSelectorBeforeCombinatorCode => IsCSharpInStyleBlock(diagnostic, sourceText, syntaxTree, logger),
-            HtmlErrorCodes.UnexpectedEndTagErrorCode => IsHtmlWithBangAndMatchingTags(diagnostic, sourceText, syntaxTree, logger),
-            HtmlErrorCodes.InvalidNestingErrorCode => IsAnyFilteredInvalidNestingError(diagnostic, sourceText, syntaxTree, logger),
-            HtmlErrorCodes.MissingEndTagErrorCode => FileKinds.IsComponent(syntaxTree.Options.FileKind), // Redundant with RZ9980 in Components
-            HtmlErrorCodes.TooFewElementsErrorCode => IsAnyFilteredTooFewElementsError(diagnostic, sourceText, syntaxTree, logger),
-            _ => false,
-        };
-
-        static bool IsCSharpInStyleBlock(VSDiagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
-        {
-            // C# in a style block causes diagnostics because the HTML background document replaces C# with "~"
-            var owner = syntaxTree.GetOwner(sourceText, diagnostic.Range.Start, logger);
-            if (owner is null)
-            {
-                return false;
-            }
-
-            var element = owner.FirstAncestorOrSelf<MarkupElementSyntax>(n => n.StartTag?.Name.Content == "style");
-            var csharp = owner.FirstAncestorOrSelf<CSharpCodeBlockSyntax>();
-
-            return element.Body.Any(c => c is CSharpCodeBlockSyntax) || csharp is not null;
-        }
-
-        // Ideally this would be solved instead by not emitting the "!" at the HTML backing file,
-        // but we don't currently have a system to accomplish that
-        static bool IsAnyFilteredTooFewElementsError(VSDiagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
-        {
-            var owner = syntaxTree.GetOwner(sourceText, diagnostic.Range.Start, logger);
-            if (owner is null)
-            {
-                return false;
-            }
-
-            var element = owner.FirstAncestorOrSelf<MarkupElementSyntax>();
-
-            if (element.StartTag?.Name.Content != "html")
-            {
-                return false;
-            }
-
-            var bodyElement = element
-                .ChildNodes()
-                .SingleOrDefault(c => c is MarkupElementSyntax tag && tag.StartTag?.Name.Content == "body") as MarkupElementSyntax;
-
-            return bodyElement is not null &&
-                   bodyElement.StartTag?.Bang is not null;
-        }
-
-        // Ideally this would be solved instead by not emitting the "!" at the HTML backing file,
-        // but we don't currently have a system to accomplish that
-        static bool IsHtmlWithBangAndMatchingTags(VSDiagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
-        {
-            var owner = syntaxTree.GetOwner(sourceText, diagnostic.Range.Start, logger);
-            if (owner is null)
-            {
-                return false;
-            }
-
-            var element = owner.FirstAncestorOrSelf<MarkupElementSyntax>();
-            var startNode = element.StartTag;
-            var endNode = element.EndTag;
-
-            if (startNode is null || endNode is null)
-            {
-                // We only care about tags with a start and an end because we want to exclude diagnostics from their children
-                return false;
-            }
-
-            var haveBang = startNode.Bang is not null && endNode.Bang is not null;
-            var namesEquivilant = startNode.Name.Content == endNode.Name.Content;
-
-            return haveBang && namesEquivilant;
-        }
-
-        static bool IsAnyFilteredInvalidNestingError(VSDiagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
-            => IsInvalidNestingWarningWithinComponent(diagnostic, sourceText, syntaxTree, logger) ||
-               IsInvalidNestingFromBody(diagnostic, sourceText, syntaxTree, logger);
-
-        static bool IsInvalidNestingWarningWithinComponent(VSDiagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
-        {
-            var owner = syntaxTree.GetOwner(sourceText, diagnostic.Range.Start, logger);
-            if (owner is null)
-            {
-                return false;
-            }
-
-            var taghelperNode = owner.FirstAncestorOrSelf<MarkupTagHelperElementSyntax>();
-
-            return taghelperNode is not null;
-        }
-
-        // Ideally this would be solved instead by not emitting the "!" at the HTML backing file,
-        // but we don't currently have a system to accomplish that
-        static bool IsInvalidNestingFromBody(VSDiagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
-        {
-            var owner = syntaxTree.GetOwner(sourceText, diagnostic.Range.Start, logger);
-            if (owner is null)
-            {
-                return false;
-            }
-
-            var body = owner.FirstAncestorOrSelf<MarkupElementSyntax>(n => n.StartTag?.Name.Content.Equals("body", StringComparison.Ordinal) == true);
-
-            if (ReferenceEquals(body, owner))
-            {
-                return false;
-            }
-
-            if (diagnostic.Message is null)
-            {
-                return false;
-            }
-
-            return diagnostic.Message.EndsWith("cannot be nested inside element 'html'.") && body.StartTag?.Bang is not null;
-        }
-    }
-
-    private static bool InAttributeContainingCSharp(
-        VSDiagnostic diagnostic,
-        SourceText sourceText,
-        RazorSyntaxTree syntaxTree,
-        Dictionary<TextSpan, bool> processedAttributes,
-        ILogger logger)
-    {
-        // Examine the _end_ of the diagnostic to see if we're at the
-        // start of an (im/ex)plicit expression. Looking at the start
-        // of the diagnostic isn't sufficient.
-        if (diagnostic.Range is null)
-        {
-            return false;
-        }
-
-        var owner = syntaxTree.GetOwner(sourceText, diagnostic.Range.End, logger);
-        if (owner is null)
-        {
-            return false;
-        }
-
-        var markupAttributeNode = owner.FirstAncestorOrSelf<RazorSyntaxNode>(n =>
-            n is MarkupAttributeBlockSyntax ||
-            n is MarkupTagHelperAttributeSyntax ||
-            n is MarkupMiscAttributeContentSyntax);
-
-        if (markupAttributeNode is not null)
-        {
-            if (!processedAttributes.TryGetValue(markupAttributeNode.FullSpan, out var doesAttributeContainNonMarkup))
-            {
-                doesAttributeContainNonMarkup = CheckIfAttributeContainsNonMarkupNodes(markupAttributeNode);
-                processedAttributes.Add(markupAttributeNode.FullSpan, doesAttributeContainNonMarkup);
-            }
-
-            return doesAttributeContainNonMarkup;
-        }
-
-        return false;
-
-        static bool CheckIfAttributeContainsNonMarkupNodes(RazorSyntaxNode attributeNode)
-        {
-            // Only allow markup, generic & (non-razor comment) token nodes
-            var containsNonMarkupNodes = attributeNode.DescendantNodes()
-                .Any(n => !(n is MarkupBlockSyntax ||
-                    n is MarkupSyntaxNode ||
-                    n is GenericBlockSyntax ||
-                    (n is SyntaxNode sn && sn.IsToken && sn.Kind != SyntaxKind.RazorCommentTransition)));
-
-            return containsNonMarkupNodes;
-        }
-    }
-
-    private VSDiagnostic[] FilterCSharpDiagnostics(VSDiagnostic[] unmappedDiagnostics, RazorCodeDocument codeDocument, SourceText sourceText)
-    {
-        return unmappedDiagnostics.Where(d =>
-            !ShouldFilterCSharpDiagnosticBasedOnErrorCode(d, codeDocument, sourceText)).ToArray();
-    }
-
-    private bool ShouldFilterCSharpDiagnosticBasedOnErrorCode(VSDiagnostic diagnostic, RazorCodeDocument codeDocument, SourceText sourceText)
-    {
-        if (!diagnostic.Code.HasValue)
-        {
-            return false;
-        }
-
-        diagnostic.Code.Value.TryGetSecond(out var str);
-
-        return str switch
-        {
-            "CS1525" => ShouldIgnoreCS1525(diagnostic, codeDocument, sourceText),
-            _ => CSharpDiagnosticsToIgnore.Contains(str) &&
-                    diagnostic.Severity != DiagnosticSeverity.Error,
-        };
-
-        bool ShouldIgnoreCS1525(VSDiagnostic diagnostic, RazorCodeDocument codeDocument, SourceText sourceText)
-        {
-            if (CheckIfDocumentHasRazorDiagnostic(codeDocument, RazorDiagnosticFactory.TagHelper_EmptyBoundAttribute.Id) &&
-                TryGetOriginalDiagnosticRange(diagnostic, codeDocument, sourceText, out var originalRange) &&
-                originalRange.IsUndefined())
-            {
-                // Empty attribute values will take the following form in the generated C# document:
-                // __o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.ProgressEventArgs>(this, );
-                // The trailing `)` with no value preceding it, will lead to a C# error which doesn't make sense within the razor file.
-                // The empty attribute value is not directly mappable to Razor, hence we check if the diagnostic has an undefined range.
-                // Note; Error RZ2008 informs the user that the empty attribute value is not allowed.
-                // https://github.com/dotnet/aspnetcore/issues/30480
-                return true;
-            }
-
-            return false;
-        }
-    }
-
-    // Internal & virtual for testing
-    internal virtual bool CheckIfDocumentHasRazorDiagnostic(RazorCodeDocument codeDocument, string razorDiagnosticCode)
-    {
-        return codeDocument.GetSyntaxTree().Diagnostics.Any(d => d.Id.Equals(razorDiagnosticCode, StringComparison.Ordinal));
-    }
-
-    private VSDiagnostic[] MapDiagnostics(
-        RazorLanguageKind languageKind,
-        IReadOnlyList<VSDiagnostic> diagnostics,
-        RazorCodeDocument codeDocument,
-        SourceText sourceText)
-    {
-        if (languageKind != RazorLanguageKind.CSharp)
-        {
-            // All other non-C# requests map directly to where they are in the document.
-            return diagnostics.ToArray();
-        }
-
-        var mappedDiagnostics = new List<VSDiagnostic>();
-
-        for (var i = 0; i < diagnostics.Count; i++)
-        {
-            var diagnostic = diagnostics[i];
-
-            if (!TryGetOriginalDiagnosticRange(diagnostic, codeDocument, sourceText, out var originalRange))
-            {
-                continue;
-            }
-
-            diagnostic.Range = originalRange;
-            mappedDiagnostics.Add(diagnostic);
-        }
-
-        return mappedDiagnostics.ToArray();
-    }
-
-    private static bool IsRudeEditDiagnostic(VSDiagnostic diagnostic)
-    {
-        return diagnostic.Code.HasValue &&
-            diagnostic.Code.Value.TryGetSecond(out var str) &&
-            str.StartsWith("ENC");
-    }
-
-    private bool TryRemapRudeEditRange(Range diagnosticRange, RazorCodeDocument codeDocument, SourceText sourceText, [NotNullWhen(true)] out Range? remappedRange)
-    {
-        // This is a rude edit diagnostic that has already been mapped to the Razor document. The mapping isn't absolutely correct though,
-        // it's based on the runtime code generation of the Razor document therefore we need to re-map the already mapped diagnostic in a
-        // semi-intelligent way.
-
-        var syntaxTree = codeDocument.GetSyntaxTree();
-        var owner = syntaxTree.GetOwner(sourceText, diagnosticRange, logger: _logger);
-
-        switch (owner?.Kind)
-        {
-            case SyntaxKind.CSharpStatementLiteral: // Simple C# in @code block, @{ ... } etc.
-            case SyntaxKind.CSharpExpressionLiteral: // Referenced simple C# in an implicit expression @Foo((abc) => {....})
-                // Good as is, we were able to find a known leaf-node that fully contains the diagnostic range. Therefore we can
-                // return the diagnostic range as is.
-                remappedRange = diagnosticRange;
-                return true;
-
-            default:
-                // Unsupported owner of rude diagnostic, lets map to the entirety of the diagnostic range to be sure the diagnostic can be presented
-
-                _logger.LogInformation("Failed to remap rude edit for SyntaxTree owner '{ownerKind}'.", owner?.Kind);
-
-                var startLineIndex = diagnosticRange.Start.Line;
-                if (startLineIndex >= sourceText.Lines.Count)
-                {
-                    // Documents aren't sync'd we can't remap the ranges correctly, drop the diagnostic.
-                    remappedRange = null;
-                    return false;
-                }
-
-                var startLine = sourceText.Lines[startLineIndex];
-
-                // Look for the first non-whitespace character so we're not squiggling random whitespace at the start of the diagnostic
-                var firstNonWhitespaceCharacterOffset = sourceText.GetFirstNonWhitespaceOffset(startLine.Span, out _);
-                var diagnosticStartCharacter = firstNonWhitespaceCharacterOffset ?? 0;
-                var startLinePosition = new Position(startLineIndex, diagnosticStartCharacter);
-
-                var endLineIndex = diagnosticRange.End.Line;
-                if (endLineIndex >= sourceText.Lines.Count)
-                {
-                    // Documents aren't sync'd we can't remap the ranges correctly, drop the diagnostic.
-                    remappedRange = null;
-                    return false;
-                }
-
-                var endLine = sourceText.Lines[endLineIndex];
-
-                // Look for the last non-whitespace character so we're not squiggling random whitespace at the end of the diagnostic
-                var lastNonWhitespaceCharacterOffset = sourceText.GetLastNonWhitespaceOffset(endLine.Span, out _);
-                var diagnosticEndCharacter = lastNonWhitespaceCharacterOffset ?? 0;
-                var diagnosticEndWhitespaceOffset = diagnosticEndCharacter + 1;
-                var endLinePosition = new Position(endLineIndex, diagnosticEndWhitespaceOffset);
-
-                remappedRange = new Range
-                {
-                    Start = startLinePosition,
-                    End = endLinePosition
-                };
-                return true;
-        }
-    }
-
-    private bool TryGetOriginalDiagnosticRange(VSDiagnostic diagnostic, RazorCodeDocument codeDocument, SourceText sourceText, [NotNullWhen(true)] out Range? originalRange)
-    {
-        if (IsRudeEditDiagnostic(diagnostic))
-        {
-            if (TryRemapRudeEditRange(diagnostic.Range, codeDocument, sourceText, out originalRange))
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        if (!_documentMappingService.TryMapFromProjectedDocumentRange(
-            codeDocument,
-            diagnostic.Range,
-            MappingBehavior.Inferred,
-            out originalRange))
-        {
-            // Couldn't remap the range correctly.
-            // If this isn't an `Error` Severity Diagnostic we can discard it.
-            if (diagnostic.Severity != DiagnosticSeverity.Error)
-            {
-                return false;
-            }
-
-            // For `Error` Severity diagnostics we still show the diagnostics to
-            // the user, however we set the range to an undefined range to ensure
-            // clicking on the diagnostic doesn't cause errors.
-            originalRange = RangeExtensions.UndefinedRange;
-        }
-
-        return true;
     }
 
     public TextDocumentIdentifier GetTextDocumentIdentifier(RazorDiagnosticsParams request)
     {
         return new TextDocumentIdentifier
         {
-            Uri = request.RazorDocumentUri
+            Uri = request.RazorDocumentUri,
+        };
+    }
+
+    private static VSDiagnostic ToVSDiagnostic(Diagnostic diagnostic)
+    {
+        return new VSDiagnostic
+        {
+            Code = diagnostic.Code,
+            CodeDescription = diagnostic.CodeDescription,
+            Message = diagnostic.Message,
+            Range = diagnostic.Range,
+            Severity = diagnostic.Severity,
+            Source = diagnostic.Source,
+            Tags = diagnostic.Tags,
         };
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorTranslateDiagnosticsService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorTranslateDiagnosticsService.cs
@@ -1,0 +1,537 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
+using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
+using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging;
+using Diagnostic = Microsoft.VisualStudio.LanguageServer.Protocol.Diagnostic;
+using DiagnosticSeverity = Microsoft.VisualStudio.LanguageServer.Protocol.DiagnosticSeverity;
+using Position = Microsoft.VisualStudio.LanguageServer.Protocol.Position;
+using RazorDiagnosticFactory = Microsoft.AspNetCore.Razor.Language.RazorDiagnosticFactory;
+using SourceText = Microsoft.CodeAnalysis.Text.SourceText;
+using SyntaxNode = Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxNode;
+using TextSpan = Microsoft.AspNetCore.Razor.Language.Syntax.TextSpan;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics;
+
+internal class RazorTranslateDiagnosticsService
+{
+    private readonly ILogger _logger;
+    private readonly RazorDocumentMappingService _documentMappingService;
+
+    // Internal for testing
+    internal static readonly IReadOnlyCollection<string> CSharpDiagnosticsToIgnore = new HashSet<string>()
+    {
+        "RemoveUnnecessaryImportsFixable",
+        "IDE0005_gen", // Using directive is unnecessary
+    };
+
+    public RazorTranslateDiagnosticsService(RazorDocumentMappingService documentMappingService, ILoggerFactory loggerFactory)
+    {
+        if (documentMappingService is null)
+        {
+            throw new ArgumentNullException(nameof(documentMappingService));
+        }
+
+        if (loggerFactory is null)
+        {
+            throw new ArgumentNullException(nameof(loggerFactory));
+        }
+
+        _documentMappingService = documentMappingService;
+        _logger = loggerFactory.CreateLogger<RazorTranslateDiagnosticsService>();
+    }
+
+    internal async Task<Diagnostic[]> TranslateAsync(
+        RazorLanguageKind diagnosticKind,
+        Diagnostic[] diagnostics,
+        DocumentContext documentContext,
+        CancellationToken cancellationToken)
+    {
+        var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        if (codeDocument.IsUnsupported() != false)
+        {
+            _logger.LogInformation("Unsupported code document.");
+            return Array.Empty<Diagnostic>();
+        }
+
+        var sourceText = await documentContext.GetSourceTextAsync(cancellationToken);
+
+        var filteredDiagnostics = diagnosticKind == RazorLanguageKind.CSharp
+        ? FilterCSharpDiagnostics(diagnostics, codeDocument, sourceText)
+            : FilterHTMLDiagnostics(diagnostics, codeDocument, sourceText, _logger);
+        if (!filteredDiagnostics.Any())
+        {
+            _logger.LogInformation("No diagnostics remaining after filtering.");
+
+            return Array.Empty<Diagnostic>();
+        }
+
+        _logger.LogInformation("{filteredDiagnosticsLength}/{unmappedDiagnosticsLength} diagnostics remain after filtering.", filteredDiagnostics.Length, diagnostics.Length);
+
+        var mappedDiagnostics = MapDiagnostics(
+            diagnosticKind,
+            filteredDiagnostics,
+            codeDocument,
+            sourceText);
+
+        return mappedDiagnostics;
+    }
+
+    private Diagnostic[] FilterCSharpDiagnostics(Diagnostic[] unmappedDiagnostics, RazorCodeDocument codeDocument, SourceText sourceText)
+    {
+        return unmappedDiagnostics.Where(d =>
+            !ShouldFilterCSharpDiagnosticBasedOnErrorCode(d, codeDocument, sourceText)).ToArray();
+    }
+
+    private static Diagnostic[] FilterHTMLDiagnostics(
+        Diagnostic[] unmappedDiagnostics,
+        RazorCodeDocument codeDocument,
+        SourceText sourceText,
+        ILogger logger)
+    {
+        var syntaxTree = codeDocument.GetSyntaxTree();
+
+        var processedAttributes = new Dictionary<TextSpan, bool>();
+
+        var filteredDiagnostics = unmappedDiagnostics
+            .Where(d =>
+                !InCSharpLiteral(d, sourceText, syntaxTree, logger) &&
+                !InAttributeContainingCSharp(d, sourceText, syntaxTree, processedAttributes, logger) &&
+                !AppliesToTagHelperTagName(d, sourceText, syntaxTree, logger) &&
+                !ShouldFilterHtmlDiagnosticBasedOnErrorCode(d, sourceText, syntaxTree, logger))
+            .ToArray();
+
+        return filteredDiagnostics;
+    }
+
+    private Diagnostic[] MapDiagnostics(
+        RazorLanguageKind languageKind,
+        IReadOnlyList<Diagnostic> diagnostics,
+        RazorCodeDocument codeDocument,
+        SourceText sourceText)
+    {
+        if (languageKind != RazorLanguageKind.CSharp)
+        {
+            // All other non-C# requests map directly to where they are in the document.
+            return diagnostics.ToArray();
+        }
+
+        var mappedDiagnostics = new List<Diagnostic>();
+
+        for (var i = 0; i < diagnostics.Count; i++)
+        {
+            var diagnostic = diagnostics[i];
+
+            if (!TryGetOriginalDiagnosticRange(diagnostic, codeDocument, sourceText, out var originalRange))
+            {
+                continue;
+            }
+
+            diagnostic.Range = originalRange;
+            mappedDiagnostics.Add(diagnostic);
+        }
+
+        return mappedDiagnostics.ToArray();
+    }
+
+    private static bool InCSharpLiteral(
+        Diagnostic d,
+        SourceText sourceText,
+        RazorSyntaxTree syntaxTree,
+        ILogger logger)
+    {
+        if (d.Range is null)
+        {
+            return false;
+        }
+
+        var owner = syntaxTree.GetOwner(sourceText, d.Range.End, logger);
+        if (owner is null)
+        {
+            return false;
+        }
+
+        var isCSharp = owner.Kind is SyntaxKind.CSharpExpressionLiteral or SyntaxKind.CSharpStatementLiteral or SyntaxKind.CSharpEphemeralTextLiteral;
+
+        return isCSharp;
+    }
+
+    private static bool AppliesToTagHelperTagName(
+        Diagnostic diagnostic,
+        SourceText sourceText,
+        RazorSyntaxTree syntaxTree,
+        ILogger logger)
+    {
+        // Goal of this method is to filter diagnostics that touch TagHelper tag names. Reason being is TagHelpers can output anything. Meaning
+        // If you have a TagHelper like:
+        //
+        // <Input>
+        // </Input>
+        //
+        // HTML would see this as an error because the input element can't have a body; however, a TagHelper could respect this in a totally valid
+        // way.
+
+        if (diagnostic.Range is null)
+        {
+            return false;
+        }
+
+        var owner = syntaxTree.GetOwner(sourceText, diagnostic.Range.End, logger);
+
+        var startOrEndTag = owner?.FirstAncestorOrSelf<RazorSyntaxNode>(n => n is MarkupTagHelperStartTagSyntax || n is MarkupTagHelperEndTagSyntax);
+        if (startOrEndTag is null)
+        {
+            return false;
+        }
+
+        var tagName = startOrEndTag is MarkupTagHelperStartTagSyntax startTag ? startTag.Name : ((MarkupTagHelperEndTagSyntax)startOrEndTag).Name;
+        var tagNameRange = tagName.GetRange(syntaxTree.Source);
+
+        if (!tagNameRange.IntersectsOrTouches(diagnostic.Range))
+        {
+            // The diagnostic doesn't touch the tag name
+            return false;
+        }
+
+        // Diagnostic is touching the start or end tag name range
+        return true;
+    }
+
+    private static bool ShouldFilterHtmlDiagnosticBasedOnErrorCode(Diagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
+    {
+        if (!diagnostic.Code.HasValue)
+        {
+            return false;
+        }
+
+        diagnostic.Code.Value.TryGetSecond(out var str);
+
+        return str switch
+        {
+            CSSErrorCodes.MissingOpeningBrace => IsCSharpInStyleBlock(diagnostic, sourceText, syntaxTree, logger),
+            CSSErrorCodes.MissingSelectorAfterCombinator => IsCSharpInStyleBlock(diagnostic, sourceText, syntaxTree, logger),
+            CSSErrorCodes.MissingSelectorBeforeCombinatorCode => IsCSharpInStyleBlock(diagnostic, sourceText, syntaxTree, logger),
+            HtmlErrorCodes.UnexpectedEndTagErrorCode => IsHtmlWithBangAndMatchingTags(diagnostic, sourceText, syntaxTree, logger),
+            HtmlErrorCodes.InvalidNestingErrorCode => IsAnyFilteredInvalidNestingError(diagnostic, sourceText, syntaxTree, logger),
+            HtmlErrorCodes.MissingEndTagErrorCode => FileKinds.IsComponent(syntaxTree.Options.FileKind), // Redundant with RZ9980 in Components
+            HtmlErrorCodes.TooFewElementsErrorCode => IsAnyFilteredTooFewElementsError(diagnostic, sourceText, syntaxTree, logger),
+            _ => false,
+        };
+
+        static bool IsCSharpInStyleBlock(Diagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
+        {
+            // C# in a style block causes diagnostics because the HTML background document replaces C# with "~"
+            var owner = syntaxTree.GetOwner(sourceText, diagnostic.Range.Start, logger);
+            if (owner is null)
+            {
+                return false;
+            }
+
+            var element = owner.FirstAncestorOrSelf<MarkupElementSyntax>(n => n.StartTag?.Name.Content == "style");
+            var csharp = owner.FirstAncestorOrSelf<CSharpCodeBlockSyntax>();
+
+            return element.Body.Any(c => c is CSharpCodeBlockSyntax) || csharp is not null;
+        }
+
+        // Ideally this would be solved instead by not emitting the "!" at the HTML backing file,
+        // but we don't currently have a system to accomplish that
+        static bool IsAnyFilteredTooFewElementsError(Diagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
+        {
+            var owner = syntaxTree.GetOwner(sourceText, diagnostic.Range.Start, logger);
+            if (owner is null)
+            {
+                return false;
+            }
+
+            var element = owner.FirstAncestorOrSelf<MarkupElementSyntax>();
+
+            if (element.StartTag?.Name.Content != "html")
+            {
+                return false;
+            }
+
+            var bodyElement = element
+                .ChildNodes()
+                .SingleOrDefault(c => c is MarkupElementSyntax tag && tag.StartTag?.Name.Content == "body") as MarkupElementSyntax;
+
+            return bodyElement is not null &&
+                   bodyElement.StartTag?.Bang is not null;
+        }
+
+        // Ideally this would be solved instead by not emitting the "!" at the HTML backing file,
+        // but we don't currently have a system to accomplish that
+        static bool IsHtmlWithBangAndMatchingTags(Diagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
+        {
+            var owner = syntaxTree.GetOwner(sourceText, diagnostic.Range.Start, logger);
+            if (owner is null)
+            {
+                return false;
+            }
+
+            var element = owner.FirstAncestorOrSelf<MarkupElementSyntax>();
+            var startNode = element.StartTag;
+            var endNode = element.EndTag;
+
+            if (startNode is null || endNode is null)
+            {
+                // We only care about tags with a start and an end because we want to exclude diagnostics from their children
+                return false;
+            }
+
+            var haveBang = startNode.Bang is not null && endNode.Bang is not null;
+            var namesEquivilant = startNode.Name.Content == endNode.Name.Content;
+
+            return haveBang && namesEquivilant;
+        }
+
+        static bool IsAnyFilteredInvalidNestingError(Diagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
+            => IsInvalidNestingWarningWithinComponent(diagnostic, sourceText, syntaxTree, logger) ||
+               IsInvalidNestingFromBody(diagnostic, sourceText, syntaxTree, logger);
+
+        static bool IsInvalidNestingWarningWithinComponent(Diagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
+        {
+            var owner = syntaxTree.GetOwner(sourceText, diagnostic.Range.Start, logger);
+            if (owner is null)
+            {
+                return false;
+            }
+
+            var taghelperNode = owner.FirstAncestorOrSelf<MarkupTagHelperElementSyntax>();
+
+            return taghelperNode is not null;
+        }
+
+        // Ideally this would be solved instead by not emitting the "!" at the HTML backing file,
+        // but we don't currently have a system to accomplish that
+        static bool IsInvalidNestingFromBody(Diagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
+        {
+            var owner = syntaxTree.GetOwner(sourceText, diagnostic.Range.Start, logger);
+            if (owner is null)
+            {
+                return false;
+            }
+
+            var body = owner.FirstAncestorOrSelf<MarkupElementSyntax>(n => n.StartTag?.Name.Content.Equals("body", StringComparison.Ordinal) == true);
+
+            if (ReferenceEquals(body, owner))
+            {
+                return false;
+            }
+
+            if (diagnostic.Message is null)
+            {
+                return false;
+            }
+
+            return diagnostic.Message.EndsWith("cannot be nested inside element 'html'.") && body.StartTag?.Bang is not null;
+        }
+    }
+
+    private static bool InAttributeContainingCSharp(
+        Diagnostic diagnostic,
+        SourceText sourceText,
+        RazorSyntaxTree syntaxTree,
+        Dictionary<TextSpan, bool> processedAttributes,
+        ILogger logger)
+    {
+        // Examine the _end_ of the diagnostic to see if we're at the
+        // start of an (im/ex)plicit expression. Looking at the start
+        // of the diagnostic isn't sufficient.
+        if (diagnostic.Range is null)
+        {
+            return false;
+        }
+
+        var owner = syntaxTree.GetOwner(sourceText, diagnostic.Range.End, logger);
+        if (owner is null)
+        {
+            return false;
+        }
+
+        var markupAttributeNode = owner.FirstAncestorOrSelf<RazorSyntaxNode>(n =>
+            n is MarkupAttributeBlockSyntax ||
+            n is MarkupTagHelperAttributeSyntax ||
+            n is MarkupMiscAttributeContentSyntax);
+
+        if (markupAttributeNode is not null)
+        {
+            if (!processedAttributes.TryGetValue(markupAttributeNode.FullSpan, out var doesAttributeContainNonMarkup))
+            {
+                doesAttributeContainNonMarkup = CheckIfAttributeContainsNonMarkupNodes(markupAttributeNode);
+                processedAttributes.Add(markupAttributeNode.FullSpan, doesAttributeContainNonMarkup);
+            }
+
+            return doesAttributeContainNonMarkup;
+        }
+
+        return false;
+
+        static bool CheckIfAttributeContainsNonMarkupNodes(RazorSyntaxNode attributeNode)
+        {
+            // Only allow markup, generic & (non-razor comment) token nodes
+            var containsNonMarkupNodes = attributeNode.DescendantNodes()
+                .Any(n => !(n is MarkupBlockSyntax ||
+                    n is MarkupSyntaxNode ||
+                    n is GenericBlockSyntax ||
+                    (n is SyntaxNode sn && sn.IsToken && sn.Kind != SyntaxKind.RazorCommentTransition)));
+
+            return containsNonMarkupNodes;
+        }
+    }
+
+    private bool ShouldFilterCSharpDiagnosticBasedOnErrorCode(Diagnostic diagnostic, RazorCodeDocument codeDocument, SourceText sourceText)
+    {
+        if (!diagnostic.Code.HasValue)
+        {
+            return false;
+        }
+
+        diagnostic.Code.Value.TryGetSecond(out var str);
+
+        return str switch
+        {
+            "CS1525" => ShouldIgnoreCS1525(diagnostic, codeDocument, sourceText),
+            _ => CSharpDiagnosticsToIgnore.Contains(str) &&
+                    diagnostic.Severity != DiagnosticSeverity.Error,
+        };
+
+        bool ShouldIgnoreCS1525(Diagnostic diagnostic, RazorCodeDocument codeDocument, SourceText sourceText)
+        {
+            if (CheckIfDocumentHasRazorDiagnostic(codeDocument, RazorDiagnosticFactory.TagHelper_EmptyBoundAttribute.Id) &&
+                TryGetOriginalDiagnosticRange(diagnostic, codeDocument, sourceText, out var originalRange) &&
+                originalRange.IsUndefined())
+            {
+                // Empty attribute values will take the following form in the generated C# document:
+                // __o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.ProgressEventArgs>(this, );
+                // The trailing `)` with no value preceding it, will lead to a C# error which doesn't make sense within the razor file.
+                // The empty attribute value is not directly mappable to Razor, hence we check if the diagnostic has an undefined range.
+                // Note; Error RZ2008 informs the user that the empty attribute value is not allowed.
+                // https://github.com/dotnet/aspnetcore/issues/30480
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    // Internal & virtual for testing
+    internal virtual bool CheckIfDocumentHasRazorDiagnostic(RazorCodeDocument codeDocument, string razorDiagnosticCode)
+    {
+        return codeDocument.GetSyntaxTree().Diagnostics.Any(d => d.Id.Equals(razorDiagnosticCode, StringComparison.Ordinal));
+    }
+
+    private bool TryGetOriginalDiagnosticRange(Diagnostic diagnostic, RazorCodeDocument codeDocument, SourceText sourceText, [NotNullWhen(true)] out Range? originalRange)
+    {
+        if (IsRudeEditDiagnostic(diagnostic))
+        {
+            if (TryRemapRudeEditRange(diagnostic.Range, codeDocument, sourceText, out originalRange))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        if (!_documentMappingService.TryMapFromProjectedDocumentRange(
+            codeDocument,
+            diagnostic.Range,
+            MappingBehavior.Inferred,
+            out originalRange))
+        {
+            // Couldn't remap the range correctly.
+            // If this isn't an `Error` Severity Diagnostic we can discard it.
+            if (diagnostic.Severity != DiagnosticSeverity.Error)
+            {
+                return false;
+            }
+
+            // For `Error` Severity diagnostics we still show the diagnostics to
+            // the user, however we set the range to an undefined range to ensure
+            // clicking on the diagnostic doesn't cause errors.
+            originalRange = RangeExtensions.UndefinedRange;
+        }
+
+        return true;
+    }
+
+    private static bool IsRudeEditDiagnostic(Diagnostic diagnostic)
+    {
+        return diagnostic.Code.HasValue &&
+            diagnostic.Code.Value.TryGetSecond(out var str) &&
+            str.StartsWith("ENC");
+    }
+
+    private bool TryRemapRudeEditRange(Range diagnosticRange, RazorCodeDocument codeDocument, SourceText sourceText, [NotNullWhen(true)] out Range? remappedRange)
+    {
+        // This is a rude edit diagnostic that has already been mapped to the Razor document. The mapping isn't absolutely correct though,
+        // it's based on the runtime code generation of the Razor document therefore we need to re-map the already mapped diagnostic in a
+        // semi-intelligent way.
+
+        var syntaxTree = codeDocument.GetSyntaxTree();
+        var owner = syntaxTree.GetOwner(sourceText, diagnosticRange, logger: _logger);
+
+        switch (owner?.Kind)
+        {
+            case SyntaxKind.CSharpStatementLiteral: // Simple C# in @code block, @{ ... } etc.
+            case SyntaxKind.CSharpExpressionLiteral: // Referenced simple C# in an implicit expression @Foo((abc) => {....})
+                // Good as is, we were able to find a known leaf-node that fully contains the diagnostic range. Therefore we can
+                // return the diagnostic range as is.
+                remappedRange = diagnosticRange;
+                return true;
+
+            default:
+                // Unsupported owner of rude diagnostic, lets map to the entirety of the diagnostic range to be sure the diagnostic can be presented
+
+                _logger.LogInformation("Failed to remap rude edit for SyntaxTree owner '{ownerKind}'.", owner?.Kind);
+
+                var startLineIndex = diagnosticRange.Start.Line;
+                if (startLineIndex >= sourceText.Lines.Count)
+                {
+                    // Documents aren't sync'd we can't remap the ranges correctly, drop the diagnostic.
+                    remappedRange = null;
+                    return false;
+                }
+
+                var startLine = sourceText.Lines[startLineIndex];
+
+                // Look for the first non-whitespace character so we're not squiggling random whitespace at the start of the diagnostic
+                var firstNonWhitespaceCharacterOffset = sourceText.GetFirstNonWhitespaceOffset(startLine.Span, out _);
+                var diagnosticStartCharacter = firstNonWhitespaceCharacterOffset ?? 0;
+                var startLinePosition = new Position(startLineIndex, diagnosticStartCharacter);
+
+                var endLineIndex = diagnosticRange.End.Line;
+                if (endLineIndex >= sourceText.Lines.Count)
+                {
+                    // Documents aren't sync'd we can't remap the ranges correctly, drop the diagnostic.
+                    remappedRange = null;
+                    return false;
+                }
+
+                var endLine = sourceText.Lines[endLineIndex];
+
+                // Look for the last non-whitespace character so we're not squiggling random whitespace at the end of the diagnostic
+                var lastNonWhitespaceCharacterOffset = sourceText.GetLastNonWhitespaceOffset(endLine.Span, out _);
+                var diagnosticEndCharacter = lastNonWhitespaceCharacterOffset ?? 0;
+                var diagnosticEndWhitespaceOffset = diagnosticEndCharacter + 1;
+                var endLinePosition = new Position(endLineIndex, diagnosticEndWhitespaceOffset);
+
+                remappedRange = new Range
+                {
+                    Start = startLinePosition,
+                    End = endLinePosition
+                };
+                return true;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
@@ -101,6 +101,7 @@ internal static class IServiceCollectionExtensions
     {
         services.AddHandler<RazorTranslateDiagnosticsEndpoint>();
         services.AddRegisteringHandler<RazorPullDiagnosticsEndpoint>();
+        services.AddSingleton<RazorTranslateDiagnosticsService>();
     }
 
     public static void AddHoverServices(this IServiceCollection services)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
@@ -19,8 +19,6 @@ internal abstract class LanguageServerFeatureOptions
 
     public abstract bool SingleServerSupport { get; }
 
-    public abstract bool SingleServerDiagnosticsSupport { get; }
-
     public string GetRazorCSharpFilePath(string razorFilePath) => razorFilePath + CSharpVirtualDocumentSuffix;
 
     public string GetRazorHtmlFilePath(string razorFilePath) => razorFilePath + HtmlVirtualDocumentSuffix;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
@@ -115,10 +115,6 @@ internal class InitializeHandler : IRequestHandler<InitializeParams, InitializeR
             _initializeResult.Capabilities.ImplementationProvider = false;
 
             ((VSInternalServerCapabilities)_initializeResult.Capabilities).OnAutoInsertProvider = null;
-        }
-
-        if (_languageServerFeatureOptions.SingleServerDiagnosticsSupport)
-        {
             ((VSInternalServerCapabilities)_initializeResult.Capabilities).SupportsDiagnosticRequests = false;
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
@@ -14,12 +14,10 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
 {
     private const string SingleServerCompletionFeatureFlag = "Razor.LSP.SingleServerCompletion";
     private const string SingleServerFeatureFlag = "Razor.LSP.SingleServer";
-    private const string SingleServerDiagnosticsFeatureFlag = "Razor.LSP.SingleServerDiagnostics";
 
     private readonly LSPEditorFeatureDetector _lspEditorFeatureDetector;
     private readonly Lazy<bool> _singleServerCompletionSupport;
     private readonly Lazy<bool> _singleServerSupport;
-    private readonly Lazy<bool> _singleServerDiagnosticsSupport;
 
     [ImportingConstructor]
     public VisualStudioWindowsLanguageServerFeatureOptions(LSPEditorFeatureDetector lspEditorFeatureDetector)
@@ -44,13 +42,6 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
             var singleServerEnabled = featureFlags.IsFeatureEnabled(SingleServerFeatureFlag, defaultValue: false);
             return singleServerEnabled;
         });
-
-        _singleServerDiagnosticsSupport = new Lazy<bool>(() =>
-        {
-            var featureFlags = (IVsFeatureFlags)AsyncPackage.GetGlobalService(typeof(SVsFeatureFlags));
-            var singleServerDiagnosticsEnabled = featureFlags.IsFeatureEnabled(SingleServerDiagnosticsFeatureFlag, defaultValue: false);
-            return singleServerDiagnosticsEnabled;
-        });
     }
 
     // We don't currently support file creation operations on VS Codespaces or VS Liveshare
@@ -66,8 +57,6 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
     public override bool SingleServerCompletionSupport => _singleServerCompletionSupport.Value;
 
     public override bool SingleServerSupport => _singleServerSupport.Value;
-
-    public override bool SingleServerDiagnosticsSupport => _singleServerDiagnosticsSupport.Value;
 
     private bool IsCodespacesOrLiveshare => _lspEditorFeatureDetector.IsRemoteClient() || _lspEditorFeatureDetector.IsLiveShareHost();
 }

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacLanguageServerFeatureOptions.cs
@@ -37,8 +37,6 @@ internal class VisualStudioMacLanguageServerFeatureOptions : LanguageServerFeatu
 
     public override bool SingleServerSupport => false;
 
-    public override bool SingleServerDiagnosticsSupport => false;
-
     private bool IsCodespacesOrLiveshare => _lspEditorFeatureDetector.IsRemoteClient() || _lspEditorFeatureDetector.IsLiveShareHost();
 
 }

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
@@ -54,9 +54,3 @@
 "Value"=dword:00000001
 "Title"="Enable enhanced Razor LSP server (requires restart)"
 "PreviewPaneChannels"="IntPreview,int.main"
-
-[$RootKey$\FeatureFlags\Razor\LSP\SingleServerDiagnostics]
-"Description"="Enable single server diagnostics support when editing Razor (ASP.NET Core)."
-"Value"=dword:00000000
-"Title"="Enable enhanced Razor LSP diagnostics (requires restart)"
-"PreviewPaneChannels"="IntPreview,int.main"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorTranslateDiagnosticsEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorTranslateDiagnosticsEndpointTest.cs
@@ -37,7 +37,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
         // Arrange
         var documentPath = new Uri("C:/path/to/document.cshtml");
 
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.CSharp,
@@ -65,7 +66,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
             });
         var documentContext = (DocumentContext?)null;
 
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.CSharp,
@@ -97,7 +99,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(10, 12))
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.CSharp,
@@ -130,7 +133,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(2, 15))
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.CSharp,
@@ -165,7 +169,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(6, 25))
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.CSharp,
@@ -205,7 +210,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(15, 13))
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.CSharp,
@@ -239,7 +245,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(10, 12))
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
@@ -277,7 +284,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(10, 12))
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
@@ -314,7 +322,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(10, 12))
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
@@ -352,14 +361,15 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(10, 12))
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.CSharp,
             Diagnostics = new[] {
                 new VSDiagnostic() {
                     Range = new Range { Start = new Position(0, 10), End = new Position(0, 22)},
-                    Code = RazorTranslateDiagnosticsEndpoint.CSharpDiagnosticsToIgnore.First(),
+                    Code = RazorTranslateDiagnosticsService.CSharpDiagnosticsToIgnore.First(),
                     Severity = DiagnosticSeverity.Warning
                 }
             },
@@ -391,13 +401,14 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(10, 12))
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
             Diagnostics = new[] {
                 new VSDiagnostic() {
-                    Code = RazorTranslateDiagnosticsEndpoint.CSharpDiagnosticsToIgnore.First(),
+                    Code = RazorTranslateDiagnosticsService.CSharpDiagnosticsToIgnore.First(),
                     Severity = DiagnosticSeverity.Error
                 }
             },
@@ -427,14 +438,15 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(10, 12))
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.CSharp,
             Diagnostics = new[] {
                 new VSDiagnostic() {
                     Range = new Range { Start = new Position(0, 10),End =  new Position(0, 22)},
-                    Code = RazorTranslateDiagnosticsEndpoint.CSharpDiagnosticsToIgnore.First(),
+                    Code = RazorTranslateDiagnosticsService.CSharpDiagnosticsToIgnore.First(),
                     Severity = DiagnosticSeverity.Error
                 }
             },
@@ -465,7 +477,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(10, 12))
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.CSharp,
@@ -502,7 +515,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(10, 12))
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.CSharp,
@@ -534,7 +548,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
             "__o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.ProgressEventArgs>(this, );",
             sourceMappings: Array.Empty<SourceMapping>());
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new TestRazorDiagnosticsEndpointWithoutRazorDiagnostic(_mappingService, LoggerFactory);
+        var diagnosticsService = new TestRazorDiagnosticsServiceWithoutRazorDiagnostic(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.CSharp,
@@ -567,7 +582,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
             "__o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.ProgressEventArgs>(this, );",
             sourceMappings: Array.Empty<SourceMapping>());
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new TestRazorDiagnosticsEndpointWithRazorDiagnostic(_mappingService, LoggerFactory);
+        var diagnosticsService = new TestRazorDiagnosticsServiceWithRazorDiagnostic(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.CSharp,
@@ -605,7 +621,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(10, 13))
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.CSharp,
@@ -636,7 +653,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
         var documentPath = new Uri("C:/path/to/document.cshtml");
         var codeDocument = CreateCodeDocument("<p>@DateTime.Now</p>");
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
@@ -660,7 +678,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
         var documentPath = new Uri("C:/path/to/document.cshtml");
         var codeDocument = CreateCodeDocument("<p>@DateTime.Now</p>");
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Razor,
@@ -692,7 +711,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
             });
         codeDocument.SetUnsupported();
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.CSharp,
@@ -723,7 +743,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                 GetButtonTagHelperDescriptor().Build()
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
@@ -754,7 +775,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                 GetButtonTagHelperDescriptor().Build()
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
@@ -786,7 +808,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(10, 14))
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
@@ -818,7 +841,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(10, 14))
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
@@ -870,7 +894,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                 descriptor.Build()
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
@@ -918,7 +943,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                 descriptor.Build()
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
@@ -956,7 +982,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
         var documentPath = new Uri("C:/path/to/document.cshtml");
         var codeDocument = CreateCodeDocument("<p>@DateTime.Now");
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
@@ -990,7 +1017,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
         var documentPath = new Uri("C:/path/to/document.razor");
         var codeDocument = CreateCodeDocument("<p>@DateTime.Now", kind: FileKinds.Component);
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
@@ -1021,7 +1049,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
         var documentPath = new Uri("C:/path/to/document.razor");
         var codeDocument = CreateCodeDocument("<!body></body>", kind: FileKinds.Component);
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
@@ -1055,7 +1084,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
         var documentPath = new Uri("C:/path/to/document.razor");
         var codeDocument = CreateCodeDocument("<html><!body><div></div></!body></html>", kind: FileKinds.Component);
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
@@ -1097,7 +1127,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
         var documentPath = new Uri("C:/path/to/document.razor");
         var codeDocument = CreateCodeDocument("<!body></!body>", kind: FileKinds.Component);
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
@@ -1160,9 +1191,9 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
         return codeDocument;
     }
 
-    class TestRazorDiagnosticsEndpointWithRazorDiagnostic : RazorTranslateDiagnosticsEndpoint
+    class TestRazorDiagnosticsServiceWithRazorDiagnostic : RazorTranslateDiagnosticsService
     {
-        public TestRazorDiagnosticsEndpointWithRazorDiagnostic(
+        public TestRazorDiagnosticsServiceWithRazorDiagnostic(
             RazorDocumentMappingService documentMappingService,
             ILoggerFactory loggerFactory)
             : base(documentMappingService, loggerFactory)
@@ -1175,9 +1206,9 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
         }
     }
 
-    class TestRazorDiagnosticsEndpointWithoutRazorDiagnostic : RazorTranslateDiagnosticsEndpoint
+    class TestRazorDiagnosticsServiceWithoutRazorDiagnostic : RazorTranslateDiagnosticsService
     {
-        public TestRazorDiagnosticsEndpointWithoutRazorDiagnostic(
+        public TestRazorDiagnosticsServiceWithoutRazorDiagnostic(
             RazorDocumentMappingService documentMappingService,
             ILoggerFactory loggerFactory)
             : base(documentMappingService, loggerFactory)

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common/TestLanguageServerFeatureOptions.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common/TestLanguageServerFeatureOptions.cs
@@ -24,6 +24,4 @@ internal class TestLanguageServerFeatureOptions : LanguageServerFeatureOptions
     public override bool SingleServerCompletionSupport => false;
 
     public override bool SingleServerSupport => false;
-
-    public override bool SingleServerDiagnosticsSupport => false;
 }

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/DiagnosticTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/DiagnosticTests.cs
@@ -47,4 +47,36 @@ public class DiagnosticTests : AbstractRazorEditorTest
                 Assert.Equal("Counter.razor(7, 9): error CS0127: Since 'Counter.Function()' returns void, a return keyword must not be followed by an object expression", error);
             });
     }
+
+    [IdeFact]
+    public async Task Diagnostics_ShowErrors_cshtml()
+    {
+        // Arrange
+        await TestServices.SolutionExplorer.OpenFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.ErrorCshtmlFile, ControlledHangMitigatingCancellationToken);
+
+        await TestServices.Editor.SetTextAsync(@"
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+<!DOCTYPE html>
+<html lang=""en"">
+<head>
+</head>
+
+<body>
+    <input asp-for=""Test"" />
+</body>
+</html>
+
+", ControlledHangMitigatingCancellationToken);
+
+        // Act
+        var errors = await TestServices.ErrorList.WaitForErrorsAsync("Error.cshtml", expectedCount: 1, ControlledHangMitigatingCancellationToken);
+
+        // Assert
+        Assert.Collection(errors,
+            (error) =>
+            {
+                Assert.Equal("Error.cshtml(10, 21): error CS1963: An expression tree may not contain a dynamic operation", error);
+            });
+    }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/DiagnosticTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/DiagnosticTests.cs
@@ -49,7 +49,7 @@ public class DiagnosticTests : AbstractRazorEditorTest
             });
     }
 
-    [IdeFact]
+    [IdeFact(Skip = "https://github.com/dotnet/razor/issues/8023")]
     public async Task Diagnostics_ShowErrors_HtmlDiagnostics()
     {
         // Arrange
@@ -64,7 +64,7 @@ public class DiagnosticTests : AbstractRazorEditorTest
 </head>
 
 <body>
-    <li>
+    <p
 </body>
 </html>
 
@@ -77,7 +77,7 @@ public class DiagnosticTests : AbstractRazorEditorTest
         Assert.Collection(errors,
             (error) =>
             {
-                Assert.Equal("Error.cshtml(10, 5): error HTML0204: Element 'li' cannot be nested inside element 'body'.", error);
+                Assert.Equal("Error.cshtml(10, 5): error HTML0001: Element start tag is missing closing angle bracket.", error);
             });
     }
 

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/DiagnosticTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/DiagnosticTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -49,7 +50,39 @@ public class DiagnosticTests : AbstractRazorEditorTest
     }
 
     [IdeFact]
-    public async Task Diagnostics_ShowErrors_cshtml()
+    public async Task Diagnostics_ShowErrors_HtmlDiagnostics()
+    {
+        // Arrange
+        await TestServices.SolutionExplorer.OpenFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.ErrorCshtmlFile, ControlledHangMitigatingCancellationToken);
+
+        await TestServices.Editor.SetTextAsync(@"
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+<!DOCTYPE html>
+<html lang=""en"">
+<head>
+</head>
+
+<body>
+    <li>
+</body>
+</html>
+
+", ControlledHangMitigatingCancellationToken);
+
+        // Act
+        var errors = await TestServices.ErrorList.WaitForErrorsAsync("Error.cshtml", expectedCount: 1, ControlledHangMitigatingCancellationToken);
+
+        // Assert
+        Assert.Collection(errors,
+            (error) =>
+            {
+                Assert.Equal("Error.cshtml(10, 5): error HTML0204: Element 'li' cannot be nested inside element 'body'.", error);
+            });
+    }
+
+    [IdeFact]
+    public async Task Diagnostics_ShowErrors_CSHtml()
     {
         // Arrange
         await TestServices.SolutionExplorer.OpenFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.ErrorCshtmlFile, ControlledHangMitigatingCancellationToken);


### PR DESCRIPTION
### Summary of the changes

- Start running pull diagnostics through translate.
  - Break diagnostics translate out into a service to keep the multi-location use clean
  - Create an Integration test which covers the diagnostics scenario that was missed.
  - Remove SingleServerDiagnostics flag (if people feel strongly or there's some policy I'm unaware of this can be left in).

Fixes: Reversion of https://github.com/dotnet/razor/pull/7986.
