### PR TITLE
Use the scouting queue

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,10 +77,10 @@ stages:
           pool:
             ${{ if eq(variables['System.TeamProject'], 'public') }}:
               name: NetCore-Public
-              demands: ImageOverride -equals windows.vs2022preview.amd64.open
+              demands: ImageOverride -equals windows.vs2022preview.scout.amd64.open
             ${{ if ne(variables['System.TeamProject'], 'public') }}:
               name: NetCore1ESPool-Internal
-              demands: ImageOverride -equals windows.vs2022preview.amd64
+              demands: ImageOverride -equals windows.vs2022preview.scout.amd64
           steps:
           - task: NodeTool@0
             displayName: Install Node 10.x


### PR DESCRIPTION
### Summary of the changes

- Scouting queue moves faster, so we should be broken for less time.

Fixes: Point in time VS Integration tests issue. 
