### PR TITLE
Switch Html to pull diagnostics

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultLanguageServerFeatureOptions.cs
@@ -19,6 +19,4 @@ internal class DefaultLanguageServerFeatureOptions : LanguageServerFeatureOption
     public override bool SingleServerCompletionSupport => false;
 
     public override bool SingleServerSupport => false;
-
-    public override bool SingleServerDiagnosticsSupport => false;
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorPullDiagnosticResponse.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorPullDiagnosticResponse.cs
@@ -1,0 +1,8 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics;
+
+internal record RazorPullDiagnosticResponse(VSInternalDiagnosticReport[] CSharpDiagnostics, VSInternalDiagnosticReport[] HtmlDiagnostics);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorPullDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorPullDiagnosticsEndpoint.cs
@@ -52,7 +52,7 @@ internal class RazorPullDiagnosticsEndpoint
 
     public async Task<IEnumerable<VSInternalDiagnosticReport>?> HandleRequestAsync(VSInternalDocumentDiagnosticsParams request, RazorRequestContext context, CancellationToken cancellationToken)
     {
-        if (!_languageServerFeatureOptions.SingleServerDiagnosticsSupport)
+        if (!_languageServerFeatureOptions.SingleServerSupport)
         {
             return default;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorTranslateDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorTranslateDiagnosticsEndpoint.cs
@@ -2,49 +2,30 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.AspNetCore.Razor.Language.Syntax;
-using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
-using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
-using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
-using Microsoft.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
-using DiagnosticSeverity = Microsoft.VisualStudio.LanguageServer.Protocol.DiagnosticSeverity;
-using RazorDiagnosticFactory = Microsoft.AspNetCore.Razor.Language.RazorDiagnosticFactory;
-using SourceText = Microsoft.CodeAnalysis.Text.SourceText;
-using SyntaxNode = Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxNode;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics;
 
 internal class RazorTranslateDiagnosticsEndpoint :
     IRazorTranslateDiagnosticsEndpoint
 {
-    // Internal for testing
-    internal static readonly IReadOnlyCollection<string> CSharpDiagnosticsToIgnore = new HashSet<string>()
-    {
-        "RemoveUnnecessaryImportsFixable",
-        "IDE0005_gen", // Using directive is unnecessary
-    };
-
-    private readonly RazorDocumentMappingService _documentMappingService;
     private readonly ILogger _logger;
+    private readonly RazorTranslateDiagnosticsService _translateDiagnosticsService;
 
     public bool MutatesSolutionState { get; } = false;
 
     public RazorTranslateDiagnosticsEndpoint(
-        RazorDocumentMappingService documentMappingService,
+        RazorTranslateDiagnosticsService translateDiagnosticsService,
         ILoggerFactory loggerFactory)
     {
-        if (documentMappingService is null)
+        if (translateDiagnosticsService is null)
         {
-            throw new ArgumentNullException(nameof(documentMappingService));
+            throw new ArgumentNullException(nameof(translateDiagnosticsService));
         }
 
         if (loggerFactory is null)
@@ -52,7 +33,7 @@ internal class RazorTranslateDiagnosticsEndpoint :
             throw new ArgumentNullException(nameof(loggerFactory));
         }
 
-        _documentMappingService = documentMappingService;
+        _translateDiagnosticsService = translateDiagnosticsService;
         _logger = loggerFactory.CreateLogger<RazorTranslateDiagnosticsEndpoint>();
     }
 
@@ -81,502 +62,36 @@ internal class RazorTranslateDiagnosticsEndpoint :
             };
         }
 
-        var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
-        if (codeDocument.IsUnsupported() != false)
-        {
-            _logger.LogInformation("Unsupported code document.");
-            return new RazorDiagnosticsResponse()
-            {
-                Diagnostics = Array.Empty<VSDiagnostic>(),
-                HostDocumentVersion = documentContext.Version
-            };
-        }
-
-        var sourceText = await documentContext.GetSourceTextAsync(cancellationToken);
-        var unmappedDiagnostics = request.Diagnostics;
-        var filteredDiagnostics = request.Kind == RazorLanguageKind.CSharp
-            ? FilterCSharpDiagnostics(unmappedDiagnostics, codeDocument, sourceText)
-            : FilterHTMLDiagnostics(unmappedDiagnostics, codeDocument, sourceText, _logger);
-        if (!filteredDiagnostics.Any())
-        {
-            _logger.LogInformation("No diagnostics remaining after filtering.");
-
-            return new RazorDiagnosticsResponse()
-            {
-                Diagnostics = Array.Empty<VSDiagnostic>(),
-                HostDocumentVersion = documentContext.Version,
-            };
-        }
-
-        _logger.LogInformation("{filteredDiagnosticsLength}/{unmappedDiagnosticsLength} diagnostics remain after filtering.", filteredDiagnostics.Length, unmappedDiagnostics.Length);
-
-        var mappedDiagnostics = MapDiagnostics(
-            request.Kind,
-            filteredDiagnostics,
-            codeDocument,
-            sourceText);
+        var mappedDiagnostics = await _translateDiagnosticsService.TranslateAsync(request.Kind, request.Diagnostics, documentContext, cancellationToken);
 
         _logger.LogInformation("Returning {mappedDiagnosticsLength} mapped diagnostics.", mappedDiagnostics.Length);
 
         return new RazorDiagnosticsResponse()
         {
-            Diagnostics = mappedDiagnostics,
+            Diagnostics = mappedDiagnostics.Select(ToVSDiagnostic).ToArray(),
             HostDocumentVersion = documentContext.Version,
         };
-    }
-
-    private static VSDiagnostic[] FilterHTMLDiagnostics(
-        VSDiagnostic[] unmappedDiagnostics,
-        RazorCodeDocument codeDocument,
-        SourceText sourceText,
-        ILogger logger)
-    {
-        var syntaxTree = codeDocument.GetSyntaxTree();
-
-        var processedAttributes = new Dictionary<TextSpan, bool>();
-
-        var filteredDiagnostics = unmappedDiagnostics
-            .Where(d =>
-                !InCSharpLiteral(d, sourceText, syntaxTree, logger) &&
-                !InAttributeContainingCSharp(d, sourceText, syntaxTree, processedAttributes, logger) &&
-                !AppliesToTagHelperTagName(d, sourceText, syntaxTree, logger) &&
-                !ShouldFilterHtmlDiagnosticBasedOnErrorCode(d, sourceText, syntaxTree, logger))
-            .ToArray();
-
-        return filteredDiagnostics;
-    }
-
-    private static bool InCSharpLiteral(
-        VSDiagnostic d,
-        SourceText sourceText,
-        RazorSyntaxTree syntaxTree,
-        ILogger logger)
-    {
-        if (d.Range is null)
-        {
-            return false;
-        }
-
-        var owner = syntaxTree.GetOwner(sourceText, d.Range.End, logger);
-        if (owner is null)
-        {
-            return false;
-        }
-
-        var isCSharp = owner.Kind is SyntaxKind.CSharpExpressionLiteral or SyntaxKind.CSharpStatementLiteral or SyntaxKind.CSharpEphemeralTextLiteral;
-
-        return isCSharp;
-    }
-
-    private static bool AppliesToTagHelperTagName(
-        VSDiagnostic diagnostic,
-        SourceText sourceText,
-        RazorSyntaxTree syntaxTree,
-        ILogger logger)
-    {
-        // Goal of this method is to filter diagnostics that touch TagHelper tag names. Reason being is TagHelpers can output anything. Meaning
-        // If you have a TagHelper like:
-        //
-        // <Input>
-        // </Input>
-        //
-        // HTML would see this as an error because the input element can't have a body; however, a TagHelper could respect this in a totally valid
-        // way.
-
-        if (diagnostic.Range is null)
-        {
-            return false;
-        }
-
-        var owner = syntaxTree.GetOwner(sourceText, diagnostic.Range.End, logger);
-
-        var startOrEndTag = owner?.FirstAncestorOrSelf<RazorSyntaxNode>(n => n is MarkupTagHelperStartTagSyntax || n is MarkupTagHelperEndTagSyntax);
-        if (startOrEndTag is null)
-        {
-            return false;
-        }
-
-        var tagName = startOrEndTag is MarkupTagHelperStartTagSyntax startTag ? startTag.Name : ((MarkupTagHelperEndTagSyntax)startOrEndTag).Name;
-        var tagNameRange = tagName.GetRange(syntaxTree.Source);
-
-        if (!tagNameRange.IntersectsOrTouches(diagnostic.Range))
-        {
-            // The diagnostic doesn't touch the tag name
-            return false;
-        }
-
-        // Diagnostic is touching the start or end tag name range
-        return true;
-    }
-
-    private static bool ShouldFilterHtmlDiagnosticBasedOnErrorCode(VSDiagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
-    {
-        if (!diagnostic.Code.HasValue)
-        {
-            return false;
-        }
-
-        diagnostic.Code.Value.TryGetSecond(out var str);
-
-        return str switch
-        {
-            CSSErrorCodes.MissingOpeningBrace => IsCSharpInStyleBlock(diagnostic, sourceText, syntaxTree, logger),
-            CSSErrorCodes.MissingSelectorAfterCombinator => IsCSharpInStyleBlock(diagnostic, sourceText, syntaxTree, logger),
-            CSSErrorCodes.MissingSelectorBeforeCombinatorCode => IsCSharpInStyleBlock(diagnostic, sourceText, syntaxTree, logger),
-            HtmlErrorCodes.UnexpectedEndTagErrorCode => IsHtmlWithBangAndMatchingTags(diagnostic, sourceText, syntaxTree, logger),
-            HtmlErrorCodes.InvalidNestingErrorCode => IsAnyFilteredInvalidNestingError(diagnostic, sourceText, syntaxTree, logger),
-            HtmlErrorCodes.MissingEndTagErrorCode => FileKinds.IsComponent(syntaxTree.Options.FileKind), // Redundant with RZ9980 in Components
-            HtmlErrorCodes.TooFewElementsErrorCode => IsAnyFilteredTooFewElementsError(diagnostic, sourceText, syntaxTree, logger),
-            _ => false,
-        };
-
-        static bool IsCSharpInStyleBlock(VSDiagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
-        {
-            // C# in a style block causes diagnostics because the HTML background document replaces C# with "~"
-            var owner = syntaxTree.GetOwner(sourceText, diagnostic.Range.Start, logger);
-            if (owner is null)
-            {
-                return false;
-            }
-
-            var element = owner.FirstAncestorOrSelf<MarkupElementSyntax>(n => n.StartTag?.Name.Content == "style");
-            var csharp = owner.FirstAncestorOrSelf<CSharpCodeBlockSyntax>();
-
-            return element.Body.Any(c => c is CSharpCodeBlockSyntax) || csharp is not null;
-        }
-
-        // Ideally this would be solved instead by not emitting the "!" at the HTML backing file,
-        // but we don't currently have a system to accomplish that
-        static bool IsAnyFilteredTooFewElementsError(VSDiagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
-        {
-            var owner = syntaxTree.GetOwner(sourceText, diagnostic.Range.Start, logger);
-            if (owner is null)
-            {
-                return false;
-            }
-
-            var element = owner.FirstAncestorOrSelf<MarkupElementSyntax>();
-
-            if (element.StartTag?.Name.Content != "html")
-            {
-                return false;
-            }
-
-            var bodyElement = element
-                .ChildNodes()
-                .SingleOrDefault(c => c is MarkupElementSyntax tag && tag.StartTag?.Name.Content == "body") as MarkupElementSyntax;
-
-            return bodyElement is not null &&
-                   bodyElement.StartTag?.Bang is not null;
-        }
-
-        // Ideally this would be solved instead by not emitting the "!" at the HTML backing file,
-        // but we don't currently have a system to accomplish that
-        static bool IsHtmlWithBangAndMatchingTags(VSDiagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
-        {
-            var owner = syntaxTree.GetOwner(sourceText, diagnostic.Range.Start, logger);
-            if (owner is null)
-            {
-                return false;
-            }
-
-            var element = owner.FirstAncestorOrSelf<MarkupElementSyntax>();
-            var startNode = element.StartTag;
-            var endNode = element.EndTag;
-
-            if (startNode is null || endNode is null)
-            {
-                // We only care about tags with a start and an end because we want to exclude diagnostics from their children
-                return false;
-            }
-
-            var haveBang = startNode.Bang is not null && endNode.Bang is not null;
-            var namesEquivilant = startNode.Name.Content == endNode.Name.Content;
-
-            return haveBang && namesEquivilant;
-        }
-
-        static bool IsAnyFilteredInvalidNestingError(VSDiagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
-            => IsInvalidNestingWarningWithinComponent(diagnostic, sourceText, syntaxTree, logger) ||
-               IsInvalidNestingFromBody(diagnostic, sourceText, syntaxTree, logger);
-
-        static bool IsInvalidNestingWarningWithinComponent(VSDiagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
-        {
-            var owner = syntaxTree.GetOwner(sourceText, diagnostic.Range.Start, logger);
-            if (owner is null)
-            {
-                return false;
-            }
-
-            var taghelperNode = owner.FirstAncestorOrSelf<MarkupTagHelperElementSyntax>();
-
-            return taghelperNode is not null;
-        }
-
-        // Ideally this would be solved instead by not emitting the "!" at the HTML backing file,
-        // but we don't currently have a system to accomplish that
-        static bool IsInvalidNestingFromBody(VSDiagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
-        {
-            var owner = syntaxTree.GetOwner(sourceText, diagnostic.Range.Start, logger);
-            if (owner is null)
-            {
-                return false;
-            }
-
-            var body = owner.FirstAncestorOrSelf<MarkupElementSyntax>(n => n.StartTag?.Name.Content.Equals("body", StringComparison.Ordinal) == true);
-
-            if (ReferenceEquals(body, owner))
-            {
-                return false;
-            }
-
-            if (diagnostic.Message is null)
-            {
-                return false;
-            }
-
-            return diagnostic.Message.EndsWith("cannot be nested inside element 'html'.") && body.StartTag?.Bang is not null;
-        }
-    }
-
-    private static bool InAttributeContainingCSharp(
-        VSDiagnostic diagnostic,
-        SourceText sourceText,
-        RazorSyntaxTree syntaxTree,
-        Dictionary<TextSpan, bool> processedAttributes,
-        ILogger logger)
-    {
-        // Examine the _end_ of the diagnostic to see if we're at the
-        // start of an (im/ex)plicit expression. Looking at the start
-        // of the diagnostic isn't sufficient.
-        if (diagnostic.Range is null)
-        {
-            return false;
-        }
-
-        var owner = syntaxTree.GetOwner(sourceText, diagnostic.Range.End, logger);
-        if (owner is null)
-        {
-            return false;
-        }
-
-        var markupAttributeNode = owner.FirstAncestorOrSelf<RazorSyntaxNode>(n =>
-            n is MarkupAttributeBlockSyntax ||
-            n is MarkupTagHelperAttributeSyntax ||
-            n is MarkupMiscAttributeContentSyntax);
-
-        if (markupAttributeNode is not null)
-        {
-            if (!processedAttributes.TryGetValue(markupAttributeNode.FullSpan, out var doesAttributeContainNonMarkup))
-            {
-                doesAttributeContainNonMarkup = CheckIfAttributeContainsNonMarkupNodes(markupAttributeNode);
-                processedAttributes.Add(markupAttributeNode.FullSpan, doesAttributeContainNonMarkup);
-            }
-
-            return doesAttributeContainNonMarkup;
-        }
-
-        return false;
-
-        static bool CheckIfAttributeContainsNonMarkupNodes(RazorSyntaxNode attributeNode)
-        {
-            // Only allow markup, generic & (non-razor comment) token nodes
-            var containsNonMarkupNodes = attributeNode.DescendantNodes()
-                .Any(n => !(n is MarkupBlockSyntax ||
-                    n is MarkupSyntaxNode ||
-                    n is GenericBlockSyntax ||
-                    (n is SyntaxNode sn && sn.IsToken && sn.Kind != SyntaxKind.RazorCommentTransition)));
-
-            return containsNonMarkupNodes;
-        }
-    }
-
-    private VSDiagnostic[] FilterCSharpDiagnostics(VSDiagnostic[] unmappedDiagnostics, RazorCodeDocument codeDocument, SourceText sourceText)
-    {
-        return unmappedDiagnostics.Where(d =>
-            !ShouldFilterCSharpDiagnosticBasedOnErrorCode(d, codeDocument, sourceText)).ToArray();
-    }
-
-    private bool ShouldFilterCSharpDiagnosticBasedOnErrorCode(VSDiagnostic diagnostic, RazorCodeDocument codeDocument, SourceText sourceText)
-    {
-        if (!diagnostic.Code.HasValue)
-        {
-            return false;
-        }
-
-        diagnostic.Code.Value.TryGetSecond(out var str);
-
-        return str switch
-        {
-            "CS1525" => ShouldIgnoreCS1525(diagnostic, codeDocument, sourceText),
-            _ => CSharpDiagnosticsToIgnore.Contains(str) &&
-                    diagnostic.Severity != DiagnosticSeverity.Error,
-        };
-
-        bool ShouldIgnoreCS1525(VSDiagnostic diagnostic, RazorCodeDocument codeDocument, SourceText sourceText)
-        {
-            if (CheckIfDocumentHasRazorDiagnostic(codeDocument, RazorDiagnosticFactory.TagHelper_EmptyBoundAttribute.Id) &&
-                TryGetOriginalDiagnosticRange(diagnostic, codeDocument, sourceText, out var originalRange) &&
-                originalRange.IsUndefined())
-            {
-                // Empty attribute values will take the following form in the generated C# document:
-                // __o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.ProgressEventArgs>(this, );
-                // The trailing `)` with no value preceding it, will lead to a C# error which doesn't make sense within the razor file.
-                // The empty attribute value is not directly mappable to Razor, hence we check if the diagnostic has an undefined range.
-                // Note; Error RZ2008 informs the user that the empty attribute value is not allowed.
-                // https://github.com/dotnet/aspnetcore/issues/30480
-                return true;
-            }
-
-            return false;
-        }
-    }
-
-    // Internal & virtual for testing
-    internal virtual bool CheckIfDocumentHasRazorDiagnostic(RazorCodeDocument codeDocument, string razorDiagnosticCode)
-    {
-        return codeDocument.GetSyntaxTree().Diagnostics.Any(d => d.Id.Equals(razorDiagnosticCode, StringComparison.Ordinal));
-    }
-
-    private VSDiagnostic[] MapDiagnostics(
-        RazorLanguageKind languageKind,
-        IReadOnlyList<VSDiagnostic> diagnostics,
-        RazorCodeDocument codeDocument,
-        SourceText sourceText)
-    {
-        if (languageKind != RazorLanguageKind.CSharp)
-        {
-            // All other non-C# requests map directly to where they are in the document.
-            return diagnostics.ToArray();
-        }
-
-        var mappedDiagnostics = new List<VSDiagnostic>();
-
-        for (var i = 0; i < diagnostics.Count; i++)
-        {
-            var diagnostic = diagnostics[i];
-
-            if (!TryGetOriginalDiagnosticRange(diagnostic, codeDocument, sourceText, out var originalRange))
-            {
-                continue;
-            }
-
-            diagnostic.Range = originalRange;
-            mappedDiagnostics.Add(diagnostic);
-        }
-
-        return mappedDiagnostics.ToArray();
-    }
-
-    private static bool IsRudeEditDiagnostic(VSDiagnostic diagnostic)
-    {
-        return diagnostic.Code.HasValue &&
-            diagnostic.Code.Value.TryGetSecond(out var str) &&
-            str.StartsWith("ENC");
-    }
-
-    private bool TryRemapRudeEditRange(Range diagnosticRange, RazorCodeDocument codeDocument, SourceText sourceText, [NotNullWhen(true)] out Range? remappedRange)
-    {
-        // This is a rude edit diagnostic that has already been mapped to the Razor document. The mapping isn't absolutely correct though,
-        // it's based on the runtime code generation of the Razor document therefore we need to re-map the already mapped diagnostic in a
-        // semi-intelligent way.
-
-        var syntaxTree = codeDocument.GetSyntaxTree();
-        var owner = syntaxTree.GetOwner(sourceText, diagnosticRange, logger: _logger);
-
-        switch (owner?.Kind)
-        {
-            case SyntaxKind.CSharpStatementLiteral: // Simple C# in @code block, @{ ... } etc.
-            case SyntaxKind.CSharpExpressionLiteral: // Referenced simple C# in an implicit expression @Foo((abc) => {....})
-                // Good as is, we were able to find a known leaf-node that fully contains the diagnostic range. Therefore we can
-                // return the diagnostic range as is.
-                remappedRange = diagnosticRange;
-                return true;
-
-            default:
-                // Unsupported owner of rude diagnostic, lets map to the entirety of the diagnostic range to be sure the diagnostic can be presented
-
-                _logger.LogInformation("Failed to remap rude edit for SyntaxTree owner '{ownerKind}'.", owner?.Kind);
-
-                var startLineIndex = diagnosticRange.Start.Line;
-                if (startLineIndex >= sourceText.Lines.Count)
-                {
-                    // Documents aren't sync'd we can't remap the ranges correctly, drop the diagnostic.
-                    remappedRange = null;
-                    return false;
-                }
-
-                var startLine = sourceText.Lines[startLineIndex];
-
-                // Look for the first non-whitespace character so we're not squiggling random whitespace at the start of the diagnostic
-                var firstNonWhitespaceCharacterOffset = sourceText.GetFirstNonWhitespaceOffset(startLine.Span, out _);
-                var diagnosticStartCharacter = firstNonWhitespaceCharacterOffset ?? 0;
-                var startLinePosition = new Position(startLineIndex, diagnosticStartCharacter);
-
-                var endLineIndex = diagnosticRange.End.Line;
-                if (endLineIndex >= sourceText.Lines.Count)
-                {
-                    // Documents aren't sync'd we can't remap the ranges correctly, drop the diagnostic.
-                    remappedRange = null;
-                    return false;
-                }
-
-                var endLine = sourceText.Lines[endLineIndex];
-
-                // Look for the last non-whitespace character so we're not squiggling random whitespace at the end of the diagnostic
-                var lastNonWhitespaceCharacterOffset = sourceText.GetLastNonWhitespaceOffset(endLine.Span, out _);
-                var diagnosticEndCharacter = lastNonWhitespaceCharacterOffset ?? 0;
-                var diagnosticEndWhitespaceOffset = diagnosticEndCharacter + 1;
-                var endLinePosition = new Position(endLineIndex, diagnosticEndWhitespaceOffset);
-
-                remappedRange = new Range
-                {
-                    Start = startLinePosition,
-                    End = endLinePosition
-                };
-                return true;
-        }
-    }
-
-    private bool TryGetOriginalDiagnosticRange(VSDiagnostic diagnostic, RazorCodeDocument codeDocument, SourceText sourceText, [NotNullWhen(true)] out Range? originalRange)
-    {
-        if (IsRudeEditDiagnostic(diagnostic))
-        {
-            if (TryRemapRudeEditRange(diagnostic.Range, codeDocument, sourceText, out originalRange))
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        if (!_documentMappingService.TryMapFromProjectedDocumentRange(
-            codeDocument,
-            diagnostic.Range,
-            MappingBehavior.Inferred,
-            out originalRange))
-        {
-            // Couldn't remap the range correctly.
-            // If this isn't an `Error` Severity Diagnostic we can discard it.
-            if (diagnostic.Severity != DiagnosticSeverity.Error)
-            {
-                return false;
-            }
-
-            // For `Error` Severity diagnostics we still show the diagnostics to
-            // the user, however we set the range to an undefined range to ensure
-            // clicking on the diagnostic doesn't cause errors.
-            originalRange = RangeExtensions.UndefinedRange;
-        }
-
-        return true;
     }
 
     public TextDocumentIdentifier GetTextDocumentIdentifier(RazorDiagnosticsParams request)
     {
         return new TextDocumentIdentifier
         {
-            Uri = request.RazorDocumentUri
+            Uri = request.RazorDocumentUri,
+        };
+    }
+
+    private static VSDiagnostic ToVSDiagnostic(Diagnostic diagnostic)
+    {
+        return new VSDiagnostic
+        {
+            Code = diagnostic.Code,
+            CodeDescription = diagnostic.CodeDescription,
+            Message = diagnostic.Message,
+            Range = diagnostic.Range,
+            Severity = diagnostic.Severity,
+            Source = diagnostic.Source,
+            Tags = diagnostic.Tags,
         };
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorTranslateDiagnosticsService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorTranslateDiagnosticsService.cs
@@ -1,0 +1,537 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
+using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
+using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging;
+using Diagnostic = Microsoft.VisualStudio.LanguageServer.Protocol.Diagnostic;
+using DiagnosticSeverity = Microsoft.VisualStudio.LanguageServer.Protocol.DiagnosticSeverity;
+using Position = Microsoft.VisualStudio.LanguageServer.Protocol.Position;
+using RazorDiagnosticFactory = Microsoft.AspNetCore.Razor.Language.RazorDiagnosticFactory;
+using SourceText = Microsoft.CodeAnalysis.Text.SourceText;
+using SyntaxNode = Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxNode;
+using TextSpan = Microsoft.AspNetCore.Razor.Language.Syntax.TextSpan;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics;
+
+internal class RazorTranslateDiagnosticsService
+{
+    private readonly ILogger _logger;
+    private readonly RazorDocumentMappingService _documentMappingService;
+
+    // Internal for testing
+    internal static readonly IReadOnlyCollection<string> CSharpDiagnosticsToIgnore = new HashSet<string>()
+    {
+        "RemoveUnnecessaryImportsFixable",
+        "IDE0005_gen", // Using directive is unnecessary
+    };
+
+    public RazorTranslateDiagnosticsService(RazorDocumentMappingService documentMappingService, ILoggerFactory loggerFactory)
+    {
+        if (documentMappingService is null)
+        {
+            throw new ArgumentNullException(nameof(documentMappingService));
+        }
+
+        if (loggerFactory is null)
+        {
+            throw new ArgumentNullException(nameof(loggerFactory));
+        }
+
+        _documentMappingService = documentMappingService;
+        _logger = loggerFactory.CreateLogger<RazorTranslateDiagnosticsService>();
+    }
+
+    internal async Task<Diagnostic[]> TranslateAsync(
+        RazorLanguageKind diagnosticKind,
+        Diagnostic[] diagnostics,
+        DocumentContext documentContext,
+        CancellationToken cancellationToken)
+    {
+        var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        if (codeDocument.IsUnsupported() != false)
+        {
+            _logger.LogInformation("Unsupported code document.");
+            return Array.Empty<Diagnostic>();
+        }
+
+        var sourceText = await documentContext.GetSourceTextAsync(cancellationToken);
+
+        var filteredDiagnostics = diagnosticKind == RazorLanguageKind.CSharp
+        ? FilterCSharpDiagnostics(diagnostics, codeDocument, sourceText)
+            : FilterHTMLDiagnostics(diagnostics, codeDocument, sourceText, _logger);
+        if (!filteredDiagnostics.Any())
+        {
+            _logger.LogInformation("No diagnostics remaining after filtering.");
+
+            return Array.Empty<Diagnostic>();
+        }
+
+        _logger.LogInformation("{filteredDiagnosticsLength}/{unmappedDiagnosticsLength} diagnostics remain after filtering.", filteredDiagnostics.Length, diagnostics.Length);
+
+        var mappedDiagnostics = MapDiagnostics(
+            diagnosticKind,
+            filteredDiagnostics,
+            codeDocument,
+            sourceText);
+
+        return mappedDiagnostics;
+    }
+
+    private Diagnostic[] FilterCSharpDiagnostics(Diagnostic[] unmappedDiagnostics, RazorCodeDocument codeDocument, SourceText sourceText)
+    {
+        return unmappedDiagnostics.Where(d =>
+            !ShouldFilterCSharpDiagnosticBasedOnErrorCode(d, codeDocument, sourceText)).ToArray();
+    }
+
+    private static Diagnostic[] FilterHTMLDiagnostics(
+        Diagnostic[] unmappedDiagnostics,
+        RazorCodeDocument codeDocument,
+        SourceText sourceText,
+        ILogger logger)
+    {
+        var syntaxTree = codeDocument.GetSyntaxTree();
+
+        var processedAttributes = new Dictionary<TextSpan, bool>();
+
+        var filteredDiagnostics = unmappedDiagnostics
+            .Where(d =>
+                !InCSharpLiteral(d, sourceText, syntaxTree, logger) &&
+                !InAttributeContainingCSharp(d, sourceText, syntaxTree, processedAttributes, logger) &&
+                !AppliesToTagHelperTagName(d, sourceText, syntaxTree, logger) &&
+                !ShouldFilterHtmlDiagnosticBasedOnErrorCode(d, sourceText, syntaxTree, logger))
+            .ToArray();
+
+        return filteredDiagnostics;
+    }
+
+    private Diagnostic[] MapDiagnostics(
+        RazorLanguageKind languageKind,
+        IReadOnlyList<Diagnostic> diagnostics,
+        RazorCodeDocument codeDocument,
+        SourceText sourceText)
+    {
+        if (languageKind != RazorLanguageKind.CSharp)
+        {
+            // All other non-C# requests map directly to where they are in the document.
+            return diagnostics.ToArray();
+        }
+
+        var mappedDiagnostics = new List<Diagnostic>();
+
+        for (var i = 0; i < diagnostics.Count; i++)
+        {
+            var diagnostic = diagnostics[i];
+
+            if (!TryGetOriginalDiagnosticRange(diagnostic, codeDocument, sourceText, out var originalRange))
+            {
+                continue;
+            }
+
+            diagnostic.Range = originalRange;
+            mappedDiagnostics.Add(diagnostic);
+        }
+
+        return mappedDiagnostics.ToArray();
+    }
+
+    private static bool InCSharpLiteral(
+        Diagnostic d,
+        SourceText sourceText,
+        RazorSyntaxTree syntaxTree,
+        ILogger logger)
+    {
+        if (d.Range is null)
+        {
+            return false;
+        }
+
+        var owner = syntaxTree.GetOwner(sourceText, d.Range.End, logger);
+        if (owner is null)
+        {
+            return false;
+        }
+
+        var isCSharp = owner.Kind is SyntaxKind.CSharpExpressionLiteral or SyntaxKind.CSharpStatementLiteral or SyntaxKind.CSharpEphemeralTextLiteral;
+
+        return isCSharp;
+    }
+
+    private static bool AppliesToTagHelperTagName(
+        Diagnostic diagnostic,
+        SourceText sourceText,
+        RazorSyntaxTree syntaxTree,
+        ILogger logger)
+    {
+        // Goal of this method is to filter diagnostics that touch TagHelper tag names. Reason being is TagHelpers can output anything. Meaning
+        // If you have a TagHelper like:
+        //
+        // <Input>
+        // </Input>
+        //
+        // HTML would see this as an error because the input element can't have a body; however, a TagHelper could respect this in a totally valid
+        // way.
+
+        if (diagnostic.Range is null)
+        {
+            return false;
+        }
+
+        var owner = syntaxTree.GetOwner(sourceText, diagnostic.Range.End, logger);
+
+        var startOrEndTag = owner?.FirstAncestorOrSelf<RazorSyntaxNode>(n => n is MarkupTagHelperStartTagSyntax || n is MarkupTagHelperEndTagSyntax);
+        if (startOrEndTag is null)
+        {
+            return false;
+        }
+
+        var tagName = startOrEndTag is MarkupTagHelperStartTagSyntax startTag ? startTag.Name : ((MarkupTagHelperEndTagSyntax)startOrEndTag).Name;
+        var tagNameRange = tagName.GetRange(syntaxTree.Source);
+
+        if (!tagNameRange.IntersectsOrTouches(diagnostic.Range))
+        {
+            // The diagnostic doesn't touch the tag name
+            return false;
+        }
+
+        // Diagnostic is touching the start or end tag name range
+        return true;
+    }
+
+    private static bool ShouldFilterHtmlDiagnosticBasedOnErrorCode(Diagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
+    {
+        if (!diagnostic.Code.HasValue)
+        {
+            return false;
+        }
+
+        diagnostic.Code.Value.TryGetSecond(out var str);
+
+        return str switch
+        {
+            CSSErrorCodes.MissingOpeningBrace => IsCSharpInStyleBlock(diagnostic, sourceText, syntaxTree, logger),
+            CSSErrorCodes.MissingSelectorAfterCombinator => IsCSharpInStyleBlock(diagnostic, sourceText, syntaxTree, logger),
+            CSSErrorCodes.MissingSelectorBeforeCombinatorCode => IsCSharpInStyleBlock(diagnostic, sourceText, syntaxTree, logger),
+            HtmlErrorCodes.UnexpectedEndTagErrorCode => IsHtmlWithBangAndMatchingTags(diagnostic, sourceText, syntaxTree, logger),
+            HtmlErrorCodes.InvalidNestingErrorCode => IsAnyFilteredInvalidNestingError(diagnostic, sourceText, syntaxTree, logger),
+            HtmlErrorCodes.MissingEndTagErrorCode => FileKinds.IsComponent(syntaxTree.Options.FileKind), // Redundant with RZ9980 in Components
+            HtmlErrorCodes.TooFewElementsErrorCode => IsAnyFilteredTooFewElementsError(diagnostic, sourceText, syntaxTree, logger),
+            _ => false,
+        };
+
+        static bool IsCSharpInStyleBlock(Diagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
+        {
+            // C# in a style block causes diagnostics because the HTML background document replaces C# with "~"
+            var owner = syntaxTree.GetOwner(sourceText, diagnostic.Range.Start, logger);
+            if (owner is null)
+            {
+                return false;
+            }
+
+            var element = owner.FirstAncestorOrSelf<MarkupElementSyntax>(n => n.StartTag?.Name.Content == "style");
+            var csharp = owner.FirstAncestorOrSelf<CSharpCodeBlockSyntax>();
+
+            return element.Body.Any(c => c is CSharpCodeBlockSyntax) || csharp is not null;
+        }
+
+        // Ideally this would be solved instead by not emitting the "!" at the HTML backing file,
+        // but we don't currently have a system to accomplish that
+        static bool IsAnyFilteredTooFewElementsError(Diagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
+        {
+            var owner = syntaxTree.GetOwner(sourceText, diagnostic.Range.Start, logger);
+            if (owner is null)
+            {
+                return false;
+            }
+
+            var element = owner.FirstAncestorOrSelf<MarkupElementSyntax>();
+
+            if (element.StartTag?.Name.Content != "html")
+            {
+                return false;
+            }
+
+            var bodyElement = element
+                .ChildNodes()
+                .SingleOrDefault(c => c is MarkupElementSyntax tag && tag.StartTag?.Name.Content == "body") as MarkupElementSyntax;
+
+            return bodyElement is not null &&
+                   bodyElement.StartTag?.Bang is not null;
+        }
+
+        // Ideally this would be solved instead by not emitting the "!" at the HTML backing file,
+        // but we don't currently have a system to accomplish that
+        static bool IsHtmlWithBangAndMatchingTags(Diagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
+        {
+            var owner = syntaxTree.GetOwner(sourceText, diagnostic.Range.Start, logger);
+            if (owner is null)
+            {
+                return false;
+            }
+
+            var element = owner.FirstAncestorOrSelf<MarkupElementSyntax>();
+            var startNode = element.StartTag;
+            var endNode = element.EndTag;
+
+            if (startNode is null || endNode is null)
+            {
+                // We only care about tags with a start and an end because we want to exclude diagnostics from their children
+                return false;
+            }
+
+            var haveBang = startNode.Bang is not null && endNode.Bang is not null;
+            var namesEquivilant = startNode.Name.Content == endNode.Name.Content;
+
+            return haveBang && namesEquivilant;
+        }
+
+        static bool IsAnyFilteredInvalidNestingError(Diagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
+            => IsInvalidNestingWarningWithinComponent(diagnostic, sourceText, syntaxTree, logger) ||
+               IsInvalidNestingFromBody(diagnostic, sourceText, syntaxTree, logger);
+
+        static bool IsInvalidNestingWarningWithinComponent(Diagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
+        {
+            var owner = syntaxTree.GetOwner(sourceText, diagnostic.Range.Start, logger);
+            if (owner is null)
+            {
+                return false;
+            }
+
+            var taghelperNode = owner.FirstAncestorOrSelf<MarkupTagHelperElementSyntax>();
+
+            return taghelperNode is not null;
+        }
+
+        // Ideally this would be solved instead by not emitting the "!" at the HTML backing file,
+        // but we don't currently have a system to accomplish that
+        static bool IsInvalidNestingFromBody(Diagnostic diagnostic, SourceText sourceText, RazorSyntaxTree syntaxTree, ILogger logger)
+        {
+            var owner = syntaxTree.GetOwner(sourceText, diagnostic.Range.Start, logger);
+            if (owner is null)
+            {
+                return false;
+            }
+
+            var body = owner.FirstAncestorOrSelf<MarkupElementSyntax>(n => n.StartTag?.Name.Content.Equals("body", StringComparison.Ordinal) == true);
+
+            if (ReferenceEquals(body, owner))
+            {
+                return false;
+            }
+
+            if (diagnostic.Message is null)
+            {
+                return false;
+            }
+
+            return diagnostic.Message.EndsWith("cannot be nested inside element 'html'.") && body.StartTag?.Bang is not null;
+        }
+    }
+
+    private static bool InAttributeContainingCSharp(
+        Diagnostic diagnostic,
+        SourceText sourceText,
+        RazorSyntaxTree syntaxTree,
+        Dictionary<TextSpan, bool> processedAttributes,
+        ILogger logger)
+    {
+        // Examine the _end_ of the diagnostic to see if we're at the
+        // start of an (im/ex)plicit expression. Looking at the start
+        // of the diagnostic isn't sufficient.
+        if (diagnostic.Range is null)
+        {
+            return false;
+        }
+
+        var owner = syntaxTree.GetOwner(sourceText, diagnostic.Range.End, logger);
+        if (owner is null)
+        {
+            return false;
+        }
+
+        var markupAttributeNode = owner.FirstAncestorOrSelf<RazorSyntaxNode>(n =>
+            n is MarkupAttributeBlockSyntax ||
+            n is MarkupTagHelperAttributeSyntax ||
+            n is MarkupMiscAttributeContentSyntax);
+
+        if (markupAttributeNode is not null)
+        {
+            if (!processedAttributes.TryGetValue(markupAttributeNode.FullSpan, out var doesAttributeContainNonMarkup))
+            {
+                doesAttributeContainNonMarkup = CheckIfAttributeContainsNonMarkupNodes(markupAttributeNode);
+                processedAttributes.Add(markupAttributeNode.FullSpan, doesAttributeContainNonMarkup);
+            }
+
+            return doesAttributeContainNonMarkup;
+        }
+
+        return false;
+
+        static bool CheckIfAttributeContainsNonMarkupNodes(RazorSyntaxNode attributeNode)
+        {
+            // Only allow markup, generic & (non-razor comment) token nodes
+            var containsNonMarkupNodes = attributeNode.DescendantNodes()
+                .Any(n => !(n is MarkupBlockSyntax ||
+                    n is MarkupSyntaxNode ||
+                    n is GenericBlockSyntax ||
+                    (n is SyntaxNode sn && sn.IsToken && sn.Kind != SyntaxKind.RazorCommentTransition)));
+
+            return containsNonMarkupNodes;
+        }
+    }
+
+    private bool ShouldFilterCSharpDiagnosticBasedOnErrorCode(Diagnostic diagnostic, RazorCodeDocument codeDocument, SourceText sourceText)
+    {
+        if (!diagnostic.Code.HasValue)
+        {
+            return false;
+        }
+
+        diagnostic.Code.Value.TryGetSecond(out var str);
+
+        return str switch
+        {
+            "CS1525" => ShouldIgnoreCS1525(diagnostic, codeDocument, sourceText),
+            _ => CSharpDiagnosticsToIgnore.Contains(str) &&
+                    diagnostic.Severity != DiagnosticSeverity.Error,
+        };
+
+        bool ShouldIgnoreCS1525(Diagnostic diagnostic, RazorCodeDocument codeDocument, SourceText sourceText)
+        {
+            if (CheckIfDocumentHasRazorDiagnostic(codeDocument, RazorDiagnosticFactory.TagHelper_EmptyBoundAttribute.Id) &&
+                TryGetOriginalDiagnosticRange(diagnostic, codeDocument, sourceText, out var originalRange) &&
+                originalRange.IsUndefined())
+            {
+                // Empty attribute values will take the following form in the generated C# document:
+                // __o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.ProgressEventArgs>(this, );
+                // The trailing `)` with no value preceding it, will lead to a C# error which doesn't make sense within the razor file.
+                // The empty attribute value is not directly mappable to Razor, hence we check if the diagnostic has an undefined range.
+                // Note; Error RZ2008 informs the user that the empty attribute value is not allowed.
+                // https://github.com/dotnet/aspnetcore/issues/30480
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    // Internal & virtual for testing
+    internal virtual bool CheckIfDocumentHasRazorDiagnostic(RazorCodeDocument codeDocument, string razorDiagnosticCode)
+    {
+        return codeDocument.GetSyntaxTree().Diagnostics.Any(d => d.Id.Equals(razorDiagnosticCode, StringComparison.Ordinal));
+    }
+
+    private bool TryGetOriginalDiagnosticRange(Diagnostic diagnostic, RazorCodeDocument codeDocument, SourceText sourceText, [NotNullWhen(true)] out Range? originalRange)
+    {
+        if (IsRudeEditDiagnostic(diagnostic))
+        {
+            if (TryRemapRudeEditRange(diagnostic.Range, codeDocument, sourceText, out originalRange))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        if (!_documentMappingService.TryMapFromProjectedDocumentRange(
+            codeDocument,
+            diagnostic.Range,
+            MappingBehavior.Inferred,
+            out originalRange))
+        {
+            // Couldn't remap the range correctly.
+            // If this isn't an `Error` Severity Diagnostic we can discard it.
+            if (diagnostic.Severity != DiagnosticSeverity.Error)
+            {
+                return false;
+            }
+
+            // For `Error` Severity diagnostics we still show the diagnostics to
+            // the user, however we set the range to an undefined range to ensure
+            // clicking on the diagnostic doesn't cause errors.
+            originalRange = RangeExtensions.UndefinedRange;
+        }
+
+        return true;
+    }
+
+    private static bool IsRudeEditDiagnostic(Diagnostic diagnostic)
+    {
+        return diagnostic.Code.HasValue &&
+            diagnostic.Code.Value.TryGetSecond(out var str) &&
+            str.StartsWith("ENC");
+    }
+
+    private bool TryRemapRudeEditRange(Range diagnosticRange, RazorCodeDocument codeDocument, SourceText sourceText, [NotNullWhen(true)] out Range? remappedRange)
+    {
+        // This is a rude edit diagnostic that has already been mapped to the Razor document. The mapping isn't absolutely correct though,
+        // it's based on the runtime code generation of the Razor document therefore we need to re-map the already mapped diagnostic in a
+        // semi-intelligent way.
+
+        var syntaxTree = codeDocument.GetSyntaxTree();
+        var owner = syntaxTree.GetOwner(sourceText, diagnosticRange, logger: _logger);
+
+        switch (owner?.Kind)
+        {
+            case SyntaxKind.CSharpStatementLiteral: // Simple C# in @code block, @{ ... } etc.
+            case SyntaxKind.CSharpExpressionLiteral: // Referenced simple C# in an implicit expression @Foo((abc) => {....})
+                // Good as is, we were able to find a known leaf-node that fully contains the diagnostic range. Therefore we can
+                // return the diagnostic range as is.
+                remappedRange = diagnosticRange;
+                return true;
+
+            default:
+                // Unsupported owner of rude diagnostic, lets map to the entirety of the diagnostic range to be sure the diagnostic can be presented
+
+                _logger.LogInformation("Failed to remap rude edit for SyntaxTree owner '{ownerKind}'.", owner?.Kind);
+
+                var startLineIndex = diagnosticRange.Start.Line;
+                if (startLineIndex >= sourceText.Lines.Count)
+                {
+                    // Documents aren't sync'd we can't remap the ranges correctly, drop the diagnostic.
+                    remappedRange = null;
+                    return false;
+                }
+
+                var startLine = sourceText.Lines[startLineIndex];
+
+                // Look for the first non-whitespace character so we're not squiggling random whitespace at the start of the diagnostic
+                var firstNonWhitespaceCharacterOffset = sourceText.GetFirstNonWhitespaceOffset(startLine.Span, out _);
+                var diagnosticStartCharacter = firstNonWhitespaceCharacterOffset ?? 0;
+                var startLinePosition = new Position(startLineIndex, diagnosticStartCharacter);
+
+                var endLineIndex = diagnosticRange.End.Line;
+                if (endLineIndex >= sourceText.Lines.Count)
+                {
+                    // Documents aren't sync'd we can't remap the ranges correctly, drop the diagnostic.
+                    remappedRange = null;
+                    return false;
+                }
+
+                var endLine = sourceText.Lines[endLineIndex];
+
+                // Look for the last non-whitespace character so we're not squiggling random whitespace at the end of the diagnostic
+                var lastNonWhitespaceCharacterOffset = sourceText.GetLastNonWhitespaceOffset(endLine.Span, out _);
+                var diagnosticEndCharacter = lastNonWhitespaceCharacterOffset ?? 0;
+                var diagnosticEndWhitespaceOffset = diagnosticEndCharacter + 1;
+                var endLinePosition = new Position(endLineIndex, diagnosticEndWhitespaceOffset);
+
+                remappedRange = new Range
+                {
+                    Start = startLinePosition,
+                    End = endLinePosition
+                };
+                return true;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
@@ -101,6 +101,7 @@ internal static class IServiceCollectionExtensions
     {
         services.AddHandler<RazorTranslateDiagnosticsEndpoint>();
         services.AddRegisteringHandler<RazorPullDiagnosticsEndpoint>();
+        services.AddSingleton<RazorTranslateDiagnosticsService>();
     }
 
     public static void AddHoverServices(this IServiceCollection services)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
@@ -19,8 +19,6 @@ internal abstract class LanguageServerFeatureOptions
 
     public abstract bool SingleServerSupport { get; }
 
-    public abstract bool SingleServerDiagnosticsSupport { get; }
-
     public string GetRazorCSharpFilePath(string razorFilePath) => razorFilePath + CSharpVirtualDocumentSuffix;
 
     public string GetRazorHtmlFilePath(string razorFilePath) => razorFilePath + HtmlVirtualDocumentSuffix;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
+using Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics;
 using Microsoft.AspNetCore.Razor.LanguageServer.DocumentColor;
 using Microsoft.AspNetCore.Razor.LanguageServer.DocumentPresentation;
 using Microsoft.AspNetCore.Razor.LanguageServer.Folding;
@@ -35,1164 +36,1187 @@ using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor;
 
-    [Export(typeof(RazorLanguageServerCustomMessageTarget))]
-    internal class DefaultRazorLanguageServerCustomMessageTarget : RazorLanguageServerCustomMessageTarget
+[Export(typeof(RazorLanguageServerCustomMessageTarget))]
+internal class DefaultRazorLanguageServerCustomMessageTarget : RazorLanguageServerCustomMessageTarget
+{
+    private readonly TrackingLSPDocumentManager _documentManager;
+    private readonly JoinableTaskFactory _joinableTaskFactory;
+    private readonly LSPRequestInvoker _requestInvoker;
+    private readonly FormattingOptionsProvider _formattingOptionsProvider;
+    private readonly EditorSettingsManager _editorSettingsManager;
+    private readonly LSPDocumentSynchronizer _documentSynchronizer;
+
+    [ImportingConstructor]
+    public DefaultRazorLanguageServerCustomMessageTarget(
+        LSPDocumentManager documentManager,
+        JoinableTaskContext joinableTaskContext,
+        LSPRequestInvoker requestInvoker,
+        FormattingOptionsProvider formattingOptionsProvider,
+        EditorSettingsManager editorSettingsManager,
+        LSPDocumentSynchronizer documentSynchronizer)
     {
-        private readonly TrackingLSPDocumentManager _documentManager;
-        private readonly JoinableTaskFactory _joinableTaskFactory;
-        private readonly LSPRequestInvoker _requestInvoker;
-        private readonly FormattingOptionsProvider _formattingOptionsProvider;
-        private readonly EditorSettingsManager _editorSettingsManager;
-        private readonly LSPDocumentSynchronizer _documentSynchronizer;
-
-        [ImportingConstructor]
-        public DefaultRazorLanguageServerCustomMessageTarget(
-            LSPDocumentManager documentManager,
-            JoinableTaskContext joinableTaskContext,
-            LSPRequestInvoker requestInvoker,
-            FormattingOptionsProvider formattingOptionsProvider,
-            EditorSettingsManager editorSettingsManager,
-            LSPDocumentSynchronizer documentSynchronizer)
+        if (documentManager is null)
         {
-            if (documentManager is null)
-            {
-                throw new ArgumentNullException(nameof(documentManager));
-            }
-
-            if (joinableTaskContext is null)
-            {
-                throw new ArgumentNullException(nameof(joinableTaskContext));
-            }
-
-            if (requestInvoker is null)
-            {
-                throw new ArgumentNullException(nameof(requestInvoker));
-            }
-
-            if (formattingOptionsProvider is null)
-            {
-                throw new ArgumentNullException(nameof(formattingOptionsProvider));
-            }
-
-            if (editorSettingsManager is null)
-            {
-                throw new ArgumentNullException(nameof(editorSettingsManager));
-            }
-
-            if (documentSynchronizer is null)
-            {
-                throw new ArgumentNullException(nameof(documentSynchronizer));
-            }
-
-            _documentManager = (TrackingLSPDocumentManager)documentManager;
-
-            if (_documentManager is null)
-            {
-                throw new ArgumentException("The LSP document manager should be of type " + typeof(TrackingLSPDocumentManager).FullName, nameof(_documentManager));
-            }
-
-            _joinableTaskFactory = joinableTaskContext.Factory;
-            _requestInvoker = requestInvoker;
-            _formattingOptionsProvider = formattingOptionsProvider;
-            _editorSettingsManager = editorSettingsManager;
-            _documentSynchronizer = documentSynchronizer;
+            throw new ArgumentNullException(nameof(documentManager));
         }
 
-        // Testing constructor
+        if (joinableTaskContext is null)
+        {
+            throw new ArgumentNullException(nameof(joinableTaskContext));
+        }
+
+        if (requestInvoker is null)
+        {
+            throw new ArgumentNullException(nameof(requestInvoker));
+        }
+
+        if (formattingOptionsProvider is null)
+        {
+            throw new ArgumentNullException(nameof(formattingOptionsProvider));
+        }
+
+        if (editorSettingsManager is null)
+        {
+            throw new ArgumentNullException(nameof(editorSettingsManager));
+        }
+
+        if (documentSynchronizer is null)
+        {
+            throw new ArgumentNullException(nameof(documentSynchronizer));
+        }
+
+        _documentManager = (TrackingLSPDocumentManager)documentManager;
+
+        if (_documentManager is null)
+        {
+            throw new ArgumentException("The LSP document manager should be of type " + typeof(TrackingLSPDocumentManager).FullName, nameof(_documentManager));
+        }
+
+        _joinableTaskFactory = joinableTaskContext.Factory;
+        _requestInvoker = requestInvoker;
+        _formattingOptionsProvider = formattingOptionsProvider;
+        _editorSettingsManager = editorSettingsManager;
+        _documentSynchronizer = documentSynchronizer;
+    }
+
+    // Testing constructor
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-        internal DefaultRazorLanguageServerCustomMessageTarget(TrackingLSPDocumentManager documentManager,
-            LSPDocumentSynchronizer documentSynchronizer)
+    internal DefaultRazorLanguageServerCustomMessageTarget(TrackingLSPDocumentManager documentManager,
+        LSPDocumentSynchronizer documentSynchronizer)
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+    {
+        _documentManager = documentManager;
+        _documentSynchronizer = documentSynchronizer;
+    }
+
+    public override async Task UpdateCSharpBufferAsync(UpdateBufferRequest request, CancellationToken cancellationToken)
+    {
+        if (request is null)
         {
-            _documentManager = documentManager;
-            _documentSynchronizer = documentSynchronizer;
+            throw new ArgumentNullException(nameof(request));
         }
 
-        public override async Task UpdateCSharpBufferAsync(UpdateBufferRequest request, CancellationToken cancellationToken)
+        await _joinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+        UpdateCSharpBuffer(request);
+    }
+
+    // Internal for testing
+    internal void UpdateCSharpBuffer(UpdateBufferRequest request)
+    {
+        if (request is null || request.HostDocumentFilePath is null || request.HostDocumentVersion is null)
         {
-            if (request is null)
-            {
-                throw new ArgumentNullException(nameof(request));
-            }
-
-            await _joinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
-            UpdateCSharpBuffer(request);
+            return;
         }
 
-        // Internal for testing
-        internal void UpdateCSharpBuffer(UpdateBufferRequest request)
-        {
-            if (request is null || request.HostDocumentFilePath is null || request.HostDocumentVersion is null)
-            {
-                return;
-            }
+        var hostDocumentUri = new Uri(request.HostDocumentFilePath);
+        _documentManager.UpdateVirtualDocument<CSharpVirtualDocument>(
+            hostDocumentUri,
+            request.Changes.Select(change => change.ToVisualStudioTextChange()).ToArray(),
+            request.HostDocumentVersion.Value,
+            state: null);
+    }
 
-            var hostDocumentUri = new Uri(request.HostDocumentFilePath);
-            _documentManager.UpdateVirtualDocument<CSharpVirtualDocument>(
-                hostDocumentUri,
-                request.Changes.Select(change => change.ToVisualStudioTextChange()).ToArray(),
-                request.HostDocumentVersion.Value,
-                state: null);
+    public override async Task UpdateHtmlBufferAsync(UpdateBufferRequest request, CancellationToken cancellationToken)
+    {
+        if (request is null)
+        {
+            throw new ArgumentNullException(nameof(request));
         }
 
-        public override async Task UpdateHtmlBufferAsync(UpdateBufferRequest request, CancellationToken cancellationToken)
+        await _joinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+        UpdateHtmlBuffer(request);
+    }
+
+    // Internal for testing
+    internal void UpdateHtmlBuffer(UpdateBufferRequest request)
+    {
+        if (request is null || request.HostDocumentFilePath is null || request.HostDocumentVersion is null)
         {
-            if (request is null)
-            {
-                throw new ArgumentNullException(nameof(request));
-            }
-
-            await _joinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
-            UpdateHtmlBuffer(request);
+            return;
         }
 
-        // Internal for testing
-        internal void UpdateHtmlBuffer(UpdateBufferRequest request)
-        {
-            if (request is null || request.HostDocumentFilePath is null || request.HostDocumentVersion is null)
-            {
-                return;
-            }
+        var hostDocumentUri = new Uri(request.HostDocumentFilePath);
+        _documentManager.UpdateVirtualDocument<HtmlVirtualDocument>(
+            hostDocumentUri,
+            request.Changes.Select(change => change.ToVisualStudioTextChange()).ToArray(),
+            request.HostDocumentVersion.Value,
+            state: null);
+    }
 
-            var hostDocumentUri = new Uri(request.HostDocumentFilePath);
-            _documentManager.UpdateVirtualDocument<HtmlVirtualDocument>(
-                hostDocumentUri,
-                request.Changes.Select(change => change.ToVisualStudioTextChange()).ToArray(),
-                request.HostDocumentVersion.Value,
-                state: null);
+    public override async Task<RazorDocumentRangeFormattingResponse> RazorDocumentFormattingAsync(VersionedDocumentFormattingParams request, CancellationToken cancellationToken)
+    {
+        var response = new RazorDocumentRangeFormattingResponse() { Edits = Array.Empty<TextEdit>() };
+
+        await _joinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+        var (synchronized, htmlDocument) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<HtmlVirtualDocumentSnapshot>(
+            request.HostDocumentVersion,
+            request.TextDocument.Uri,
+            cancellationToken);
+
+        var languageServerName = RazorLSPConstants.HtmlLanguageServerName;
+        var projectedUri = htmlDocument.Uri;
+
+        if (!synchronized)
+        {
+            Debug.Fail("RangeFormatting not synchronized.");
+            return response;
         }
 
-        public override async Task<RazorDocumentRangeFormattingResponse> RazorDocumentFormattingAsync(VersionedDocumentFormattingParams request, CancellationToken cancellationToken)
+        var formattingParams = new DocumentFormattingParams()
         {
-            var response = new RazorDocumentRangeFormattingResponse() { Edits = Array.Empty<TextEdit>() };
+            TextDocument = new TextDocumentIdentifier() { Uri = projectedUri },
+            Options = request.Options
+        };
 
-            await _joinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+        var textBuffer = htmlDocument.Snapshot.TextBuffer;
+        var edits = await _requestInvoker.ReinvokeRequestOnServerAsync<DocumentFormattingParams, TextEdit[]>(
+            textBuffer,
+            Methods.TextDocumentFormattingName,
+            languageServerName,
+            formattingParams,
+            cancellationToken).ConfigureAwait(false);
 
-            var (synchronized, htmlDocument) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<HtmlVirtualDocumentSnapshot>(
-                request.HostDocumentVersion,
-                request.TextDocument.Uri,
+        response.Edits = edits?.Response ?? Array.Empty<TextEdit>();
+
+        return response;
+    }
+
+    public override async Task<RazorDocumentRangeFormattingResponse> HtmlOnTypeFormattingAsync(RazorDocumentOnTypeFormattingParams request, CancellationToken cancellationToken)
+    {
+        var response = new RazorDocumentRangeFormattingResponse() { Edits = Array.Empty<TextEdit>() };
+
+        var hostDocumentUri = request.TextDocument.Uri;
+
+        var languageServerName = RazorLSPConstants.HtmlLanguageServerName;
+        var (synchronized, htmlDocument) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<HtmlVirtualDocumentSnapshot>(
+            request.HostDocumentVersion, hostDocumentUri, cancellationToken);
+
+        if (!synchronized)
+        {
+            return response;
+        }
+
+        var formattingParams = new DocumentOnTypeFormattingParams()
+        {
+            Character = request.Character,
+            Position = request.Position,
+            TextDocument = new TextDocumentIdentifier() { Uri = htmlDocument.Uri },
+            Options = request.Options
+        };
+
+        var textBuffer = htmlDocument.Snapshot.TextBuffer;
+        var edits = await _requestInvoker.ReinvokeRequestOnServerAsync<DocumentOnTypeFormattingParams, TextEdit[]>(
+            textBuffer,
+            Methods.TextDocumentOnTypeFormattingName,
+            languageServerName,
+            formattingParams,
+            cancellationToken).ConfigureAwait(false);
+
+        response.Edits = edits?.Response ?? Array.Empty<TextEdit>();
+
+        return response;
+    }
+
+    public override async Task<RazorDocumentRangeFormattingResponse> RazorRangeFormattingAsync(RazorDocumentRangeFormattingParams request, CancellationToken cancellationToken)
+    {
+        var response = new RazorDocumentRangeFormattingResponse() { Edits = Array.Empty<TextEdit>() };
+
+        if (request.Kind == RazorLanguageKind.Razor)
+        {
+            return response;
+        }
+
+        await _joinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+        var hostDocumentUri = new Uri(request.HostDocumentFilePath);
+        var (synchronized, csharpDocument) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<CSharpVirtualDocumentSnapshot>(
+            request.HostDocumentVersion,
+            hostDocumentUri,
+            cancellationToken);
+
+        string languageServerName;
+        Uri projectedUri;
+
+        if (!synchronized)
+        {
+            // Document could not be synchronized
+            return response;
+        }
+
+        if (request.Kind == RazorLanguageKind.CSharp)
+        {
+            languageServerName = RazorLSPConstants.RazorCSharpLanguageServerName;
+            projectedUri = csharpDocument.Uri;
+        }
+        else
+        {
+            Debug.Fail("Unexpected RazorLanguageKind. This can't really happen in a real scenario.");
+            return response;
+        }
+
+        var formattingParams = new DocumentRangeFormattingParams()
+        {
+            TextDocument = new TextDocumentIdentifier() { Uri = projectedUri },
+            Range = request.ProjectedRange,
+            Options = request.Options
+        };
+
+        var textBuffer = csharpDocument.Snapshot.TextBuffer;
+        var edits = await _requestInvoker.ReinvokeRequestOnServerAsync<DocumentRangeFormattingParams, TextEdit[]>(
+            textBuffer,
+            Methods.TextDocumentRangeFormattingName,
+            languageServerName,
+            formattingParams,
+            cancellationToken).ConfigureAwait(false);
+
+        response.Edits = edits?.Response ?? Array.Empty<TextEdit>();
+
+        return response;
+    }
+
+    public override async Task<IReadOnlyList<VSInternalCodeAction>?> ProvideCodeActionsAsync(DelegatedCodeActionParams codeActionParams, CancellationToken cancellationToken)
+    {
+        if (codeActionParams is null)
+        {
+            throw new ArgumentNullException(nameof(codeActionParams));
+        }
+
+        bool synchronized;
+        VirtualDocumentSnapshot virtualDocumentSnapshot;
+        if (codeActionParams.LanguageKind == RazorLanguageKind.Html)
+        {
+            (synchronized, virtualDocumentSnapshot) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<HtmlVirtualDocumentSnapshot>(
+                codeActionParams.HostDocumentVersion,
+                codeActionParams.CodeActionParams.TextDocument.Uri,
                 cancellationToken);
-
-            var languageServerName = RazorLSPConstants.HtmlLanguageServerName;
-            var projectedUri = htmlDocument.Uri;
-
-            if (!synchronized)
-            {
-                Debug.Fail("RangeFormatting not synchronized.");
-                return response;
-            }
-
-            var formattingParams = new DocumentFormattingParams()
-            {
-                TextDocument = new TextDocumentIdentifier() { Uri = projectedUri },
-                Options = request.Options
-            };
-
-            var textBuffer = htmlDocument.Snapshot.TextBuffer;
-            var edits = await _requestInvoker.ReinvokeRequestOnServerAsync<DocumentFormattingParams, TextEdit[]>(
-                textBuffer,
-                Methods.TextDocumentFormattingName,
-                languageServerName,
-                formattingParams,
-                cancellationToken).ConfigureAwait(false);
-
-            response.Edits = edits?.Response ?? Array.Empty<TextEdit>();
-
-            return response;
         }
-
-        public override async Task<RazorDocumentRangeFormattingResponse> HtmlOnTypeFormattingAsync(RazorDocumentOnTypeFormattingParams request, CancellationToken cancellationToken)
+        else if (codeActionParams.LanguageKind == RazorLanguageKind.CSharp)
         {
-            var response = new RazorDocumentRangeFormattingResponse() { Edits = Array.Empty<TextEdit>() };
-
-            var hostDocumentUri = request.TextDocument.Uri;
-
-            var languageServerName = RazorLSPConstants.HtmlLanguageServerName;
-            var (synchronized, htmlDocument) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<HtmlVirtualDocumentSnapshot>(
-                request.HostDocumentVersion, hostDocumentUri, cancellationToken);
-
-            if (!synchronized)
-            {
-                return response;
-            }
-
-            var formattingParams = new DocumentOnTypeFormattingParams()
-            {
-                Character = request.Character,
-                Position = request.Position,
-                TextDocument = new TextDocumentIdentifier() { Uri = htmlDocument.Uri },
-                Options = request.Options
-            };
-
-            var textBuffer = htmlDocument.Snapshot.TextBuffer;
-            var edits = await _requestInvoker.ReinvokeRequestOnServerAsync<DocumentOnTypeFormattingParams, TextEdit[]>(
-                textBuffer,
-                Methods.TextDocumentOnTypeFormattingName,
-                languageServerName,
-                formattingParams,
-                cancellationToken).ConfigureAwait(false);
-
-            response.Edits = edits?.Response ?? Array.Empty<TextEdit>();
-
-            return response;
-        }
-
-        public override async Task<RazorDocumentRangeFormattingResponse> RazorRangeFormattingAsync(RazorDocumentRangeFormattingParams request, CancellationToken cancellationToken)
-        {
-            var response = new RazorDocumentRangeFormattingResponse() { Edits = Array.Empty<TextEdit>() };
-
-            if (request.Kind == RazorLanguageKind.Razor)
-            {
-                return response;
-            }
-
-            await _joinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
-            var hostDocumentUri = new Uri(request.HostDocumentFilePath);
-            var (synchronized, csharpDocument) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<CSharpVirtualDocumentSnapshot>(
-                request.HostDocumentVersion,
-                hostDocumentUri,
+            (synchronized, virtualDocumentSnapshot) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<CSharpVirtualDocumentSnapshot>(
+                codeActionParams.HostDocumentVersion,
+                codeActionParams.CodeActionParams.TextDocument.Uri,
                 cancellationToken);
-
-            string languageServerName;
-            Uri projectedUri;
-
-            if (!synchronized)
-            {
-                // Document could not be synchronized
-                return response;
-            }
-
-            if (request.Kind == RazorLanguageKind.CSharp)
-            {
-                languageServerName = RazorLSPConstants.RazorCSharpLanguageServerName;
-                projectedUri = csharpDocument.Uri;
-            }
-            else
-            {
-                Debug.Fail("Unexpected RazorLanguageKind. This can't really happen in a real scenario.");
-                return response;
-            }
-
-            var formattingParams = new DocumentRangeFormattingParams()
-            {
-                TextDocument = new TextDocumentIdentifier() { Uri = projectedUri },
-                Range = request.ProjectedRange,
-                Options = request.Options
-            };
-
-            var textBuffer = csharpDocument.Snapshot.TextBuffer;
-            var edits = await _requestInvoker.ReinvokeRequestOnServerAsync<DocumentRangeFormattingParams, TextEdit[]>(
-                textBuffer,
-                Methods.TextDocumentRangeFormattingName,
-                languageServerName,
-                formattingParams,
-                cancellationToken).ConfigureAwait(false);
-
-            response.Edits = edits?.Response ?? Array.Empty<TextEdit>();
-
-            return response;
         }
-
-        public override async Task<IReadOnlyList<VSInternalCodeAction>?> ProvideCodeActionsAsync(DelegatedCodeActionParams codeActionParams, CancellationToken cancellationToken)
+        else
         {
-            if (codeActionParams is null)
-            {
-                throw new ArgumentNullException(nameof(codeActionParams));
-            }
-
-            bool synchronized;
-            VirtualDocumentSnapshot virtualDocumentSnapshot;
-            if (codeActionParams.LanguageKind == RazorLanguageKind.Html)
-            {
-                (synchronized, virtualDocumentSnapshot) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<HtmlVirtualDocumentSnapshot>(
-                    codeActionParams.HostDocumentVersion,
-                    codeActionParams.CodeActionParams.TextDocument.Uri,
-                    cancellationToken);
-            }
-            else if (codeActionParams.LanguageKind == RazorLanguageKind.CSharp)
-            {
-                (synchronized, virtualDocumentSnapshot) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<CSharpVirtualDocumentSnapshot>(
-                    codeActionParams.HostDocumentVersion,
-                    codeActionParams.CodeActionParams.TextDocument.Uri,
-                    cancellationToken);
-            }
-            else
-            {
-                Debug.Fail("Unexpected RazorLanguageKind. This shouldn't really happen in a real scenario.");
-                return null;
-            }
-
-            if (!synchronized || virtualDocumentSnapshot is null)
-            {
-                // Document could not synchronize
-                return null;
-            }
-
-            codeActionParams.CodeActionParams.TextDocument.Uri = virtualDocumentSnapshot.Uri;
-
-            var textBuffer = virtualDocumentSnapshot.Snapshot.TextBuffer;
-            var requests = _requestInvoker.ReinvokeRequestOnMultipleServersAsync<CodeActionParams, IReadOnlyList<VSInternalCodeAction>>(
-                textBuffer,
-                Methods.TextDocumentCodeActionName,
-                SupportsCodeActionResolve,
-                codeActionParams.CodeActionParams,
-                cancellationToken).ConfigureAwait(false);
-
-            var codeActions = new List<VSInternalCodeAction>();
-            await foreach (var response in requests)
-            {
-                if (response.Response != null)
-                {
-                    codeActions.AddRange(response.Response);
-                }
-            }
-
-            return codeActions;
-        }
-
-        public override async Task<VSInternalCodeAction?> ResolveCodeActionsAsync(RazorResolveCodeActionParams resolveCodeActionParams, CancellationToken cancellationToken)
-        {
-            if (resolveCodeActionParams is null)
-            {
-                throw new ArgumentNullException(nameof(resolveCodeActionParams));
-            }
-
-            if (!_documentManager.TryGetDocument(resolveCodeActionParams.Uri, out var documentSnapshot))
-            {
-                // Couldn't resolve the document associated with the code action bail out.
-                return null;
-            }
-
-            bool synchronized;
-            VirtualDocumentSnapshot virtualDocumentSnapshot;
-            if (resolveCodeActionParams.LanguageKind == RazorLanguageKind.Html)
-            {
-                (synchronized, virtualDocumentSnapshot) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<HtmlVirtualDocumentSnapshot>(
-                    resolveCodeActionParams.HostDocumentVersion,
-                    resolveCodeActionParams.Uri,
-                    cancellationToken);
-            }
-            else if (resolveCodeActionParams.LanguageKind == RazorLanguageKind.CSharp)
-            {
-                (synchronized, virtualDocumentSnapshot) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<CSharpVirtualDocumentSnapshot>(
-                    resolveCodeActionParams.HostDocumentVersion,
-                    resolveCodeActionParams.Uri,
-                    cancellationToken);
-            }
-            else
-            {
-                Debug.Fail("Unexpected RazorLanguageKind. This shouldn't really happen in a real scenario.");
-                return null;
-            }
-
-            if (!synchronized || virtualDocumentSnapshot is null)
-            {
-                // Document could not synchronize
-                return null;
-            }
-
-            var textBuffer = virtualDocumentSnapshot.Snapshot.TextBuffer;
-            var codeAction = resolveCodeActionParams.CodeAction;
-            var requests = _requestInvoker.ReinvokeRequestOnMultipleServersAsync<CodeAction, VSInternalCodeAction?>(
-                textBuffer,
-                Methods.CodeActionResolveName,
-                SupportsCodeActionResolve,
-                codeAction,
-                cancellationToken).ConfigureAwait(false);
-
-            await foreach (var response in requests)
-            {
-                if (response.Response is not null)
-                {
-                    // Only take the first response from a resolution
-                    return response.Response;
-                }
-            }
-
+            Debug.Fail("Unexpected RazorLanguageKind. This shouldn't really happen in a real scenario.");
             return null;
         }
 
-        public override async Task<ProvideSemanticTokensResponse?> ProvideSemanticTokensRangeAsync(
-            ProvideSemanticTokensRangeParams semanticTokensParams,
-            CancellationToken cancellationToken)
+        if (!synchronized || virtualDocumentSnapshot is null)
         {
-            if (semanticTokensParams is null)
-            {
-                throw new ArgumentNullException(nameof(semanticTokensParams));
-            }
-
-            if (semanticTokensParams.Range is null)
-            {
-                throw new ArgumentNullException(nameof(semanticTokensParams.Range));
-            }
-
-            var (synchronized, csharpDoc) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<CSharpVirtualDocumentSnapshot>(
-                (int)semanticTokensParams.RequiredHostDocumentVersion, semanticTokensParams.TextDocument.Uri, cancellationToken);
-
-            if (csharpDoc is null)
-            {
-                return null;
-            }
-
-            if (!synchronized)
-            {
-                // If we're unable to synchronize we won't produce useful results, but we have to indicate
-                // it's due to out of sync by providing the old version
-                return new ProvideSemanticTokensResponse(tokens: null, hostDocumentSyncVersion: -1);
-            }
-
-            semanticTokensParams.TextDocument.Uri = csharpDoc.Uri;
-
-            var newParams = new SemanticTokensRangeParams
-            {
-                TextDocument = semanticTokensParams.TextDocument,
-                PartialResultToken = semanticTokensParams.PartialResultToken,
-                Range = semanticTokensParams.Range,
-            };
-
-            var textBuffer = csharpDoc.Snapshot.TextBuffer;
-            var csharpResults = await _requestInvoker.ReinvokeRequestOnServerAsync<SemanticTokensRangeParams, VSSemanticTokensResponse>(
-                textBuffer,
-                Methods.TextDocumentSemanticTokensRangeName,
-                RazorLSPConstants.RazorCSharpLanguageServerName,
-                newParams,
-                cancellationToken).ConfigureAwait(false);
-
-            var result = csharpResults?.Response;
-            if (result is null)
-            {
-                // Weren't able to re-invoke C# semantic tokens but we have to indicate it's due to out of sync by providing the old version
-                return new ProvideSemanticTokensResponse(tokens: null, hostDocumentSyncVersion: csharpDoc.HostDocumentSyncVersion);
-            }
-
-            var response = new ProvideSemanticTokensResponse(result.Data, semanticTokensParams.RequiredHostDocumentVersion);
-
-            return response;
+            // Document could not synchronize
+            return null;
         }
+
+        codeActionParams.CodeActionParams.TextDocument.Uri = virtualDocumentSnapshot.Uri;
+
+        var textBuffer = virtualDocumentSnapshot.Snapshot.TextBuffer;
+        var requests = _requestInvoker.ReinvokeRequestOnMultipleServersAsync<CodeActionParams, IReadOnlyList<VSInternalCodeAction>>(
+            textBuffer,
+            Methods.TextDocumentCodeActionName,
+            SupportsCodeActionResolve,
+            codeActionParams.CodeActionParams,
+            cancellationToken).ConfigureAwait(false);
+
+        var codeActions = new List<VSInternalCodeAction>();
+        await foreach (var response in requests)
+        {
+            if (response.Response != null)
+            {
+                codeActions.AddRange(response.Response);
+            }
+        }
+
+        return codeActions;
+    }
+
+    public override async Task<VSInternalCodeAction?> ResolveCodeActionsAsync(RazorResolveCodeActionParams resolveCodeActionParams, CancellationToken cancellationToken)
+    {
+        if (resolveCodeActionParams is null)
+        {
+            throw new ArgumentNullException(nameof(resolveCodeActionParams));
+        }
+
+        if (!_documentManager.TryGetDocument(resolveCodeActionParams.Uri, out var documentSnapshot))
+        {
+            // Couldn't resolve the document associated with the code action bail out.
+            return null;
+        }
+
+        bool synchronized;
+        VirtualDocumentSnapshot virtualDocumentSnapshot;
+        if (resolveCodeActionParams.LanguageKind == RazorLanguageKind.Html)
+        {
+            (synchronized, virtualDocumentSnapshot) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<HtmlVirtualDocumentSnapshot>(
+                resolveCodeActionParams.HostDocumentVersion,
+                resolveCodeActionParams.Uri,
+                cancellationToken);
+        }
+        else if (resolveCodeActionParams.LanguageKind == RazorLanguageKind.CSharp)
+        {
+            (synchronized, virtualDocumentSnapshot) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<CSharpVirtualDocumentSnapshot>(
+                resolveCodeActionParams.HostDocumentVersion,
+                resolveCodeActionParams.Uri,
+                cancellationToken);
+        }
+        else
+        {
+            Debug.Fail("Unexpected RazorLanguageKind. This shouldn't really happen in a real scenario.");
+            return null;
+        }
+
+        if (!synchronized || virtualDocumentSnapshot is null)
+        {
+            // Document could not synchronize
+            return null;
+        }
+
+        var textBuffer = virtualDocumentSnapshot.Snapshot.TextBuffer;
+        var codeAction = resolveCodeActionParams.CodeAction;
+        var requests = _requestInvoker.ReinvokeRequestOnMultipleServersAsync<CodeAction, VSInternalCodeAction?>(
+            textBuffer,
+            Methods.CodeActionResolveName,
+            SupportsCodeActionResolve,
+            codeAction,
+            cancellationToken).ConfigureAwait(false);
+
+        await foreach (var response in requests)
+        {
+            if (response.Response is not null)
+            {
+                // Only take the first response from a resolution
+                return response.Response;
+            }
+        }
+
+        return null;
+    }
+
+    public override async Task<ProvideSemanticTokensResponse?> ProvideSemanticTokensRangeAsync(
+        ProvideSemanticTokensRangeParams semanticTokensParams,
+        CancellationToken cancellationToken)
+    {
+        if (semanticTokensParams is null)
+        {
+            throw new ArgumentNullException(nameof(semanticTokensParams));
+        }
+
+        if (semanticTokensParams.Range is null)
+        {
+            throw new ArgumentNullException(nameof(semanticTokensParams.Range));
+        }
+
+        var (synchronized, csharpDoc) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<CSharpVirtualDocumentSnapshot>(
+            (int)semanticTokensParams.RequiredHostDocumentVersion, semanticTokensParams.TextDocument.Uri, cancellationToken);
+
+        if (csharpDoc is null)
+        {
+            return null;
+        }
+
+        if (!synchronized)
+        {
+            // If we're unable to synchronize we won't produce useful results, but we have to indicate
+            // it's due to out of sync by providing the old version
+            return new ProvideSemanticTokensResponse(tokens: null, hostDocumentSyncVersion: -1);
+        }
+
+        semanticTokensParams.TextDocument.Uri = csharpDoc.Uri;
+
+        var newParams = new SemanticTokensRangeParams
+        {
+            TextDocument = semanticTokensParams.TextDocument,
+            PartialResultToken = semanticTokensParams.PartialResultToken,
+            Range = semanticTokensParams.Range,
+        };
+
+        var textBuffer = csharpDoc.Snapshot.TextBuffer;
+        var csharpResults = await _requestInvoker.ReinvokeRequestOnServerAsync<SemanticTokensRangeParams, VSSemanticTokensResponse>(
+            textBuffer,
+            Methods.TextDocumentSemanticTokensRangeName,
+            RazorLSPConstants.RazorCSharpLanguageServerName,
+            newParams,
+            cancellationToken).ConfigureAwait(false);
+
+        var result = csharpResults?.Response;
+        if (result is null)
+        {
+            // Weren't able to re-invoke C# semantic tokens but we have to indicate it's due to out of sync by providing the old version
+            return new ProvideSemanticTokensResponse(tokens: null, hostDocumentSyncVersion: csharpDoc.HostDocumentSyncVersion);
+        }
+
+        var response = new ProvideSemanticTokensResponse(result.Data, semanticTokensParams.RequiredHostDocumentVersion);
+
+        return response;
+    }
 
     public override async Task<IReadOnlyList<ColorInformation>?> ProvideHtmlDocumentColorAsync(DelegatedDocumentColorParams documentColorParams, CancellationToken cancellationToken)
+    {
+        if (documentColorParams is null)
         {
-            if (documentColorParams is null)
-            {
-                throw new ArgumentNullException(nameof(documentColorParams));
-            }
-
-            var (synchronized, htmlDoc) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<HtmlVirtualDocumentSnapshot>(
-                documentColorParams.HostDocumentVersion, documentColorParams.TextDocument.Uri, cancellationToken);
-
-            documentColorParams.TextDocument.Uri = htmlDoc.Uri;
-            var htmlTextBuffer = htmlDoc.Snapshot.TextBuffer;
-            var requests = _requestInvoker.ReinvokeRequestOnMultipleServersAsync<DocumentColorParams, ColorInformation[]>(
-                htmlTextBuffer,
-                Methods.DocumentColorRequest.Name,
-                SupportsDocumentColor,
-                documentColorParams,
-                cancellationToken).ConfigureAwait(false);
-
-            var colorInformation = new List<ColorInformation>();
-            await foreach (var response in requests)
-            {
-                if (response.Response is not null)
-                {
-                    colorInformation.AddRange(response.Response);
-                }
-            }
-
-            return colorInformation;
+            throw new ArgumentNullException(nameof(documentColorParams));
         }
 
-        private static bool SupportsCodeActionResolve(JToken token)
+        var (synchronized, htmlDoc) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<HtmlVirtualDocumentSnapshot>(
+            documentColorParams.HostDocumentVersion, documentColorParams.TextDocument.Uri, cancellationToken);
+
+        documentColorParams.TextDocument.Uri = htmlDoc.Uri;
+        var htmlTextBuffer = htmlDoc.Snapshot.TextBuffer;
+        var requests = _requestInvoker.ReinvokeRequestOnMultipleServersAsync<DocumentColorParams, ColorInformation[]>(
+            htmlTextBuffer,
+            Methods.DocumentColorRequest.Name,
+            SupportsDocumentColor,
+            documentColorParams,
+            cancellationToken).ConfigureAwait(false);
+
+        var colorInformation = new List<ColorInformation>();
+        await foreach (var response in requests)
         {
-            var serverCapabilities = token.ToObject<ServerCapabilities>();
-
-            var (providesCodeActions, resolvesCodeActions) = serverCapabilities?.CodeActionProvider?.Match(
-                boolValue => (boolValue, false),
-                options => (true, options.ResolveProvider)) ?? (false, false);
-
-            return providesCodeActions && resolvesCodeActions;
+            if (response.Response is not null)
+            {
+                colorInformation.AddRange(response.Response);
+            }
         }
 
-        private static bool SupportsDocumentColor(JToken token)
+        return colorInformation;
+    }
+
+    private static bool SupportsCodeActionResolve(JToken token)
+    {
+        var serverCapabilities = token.ToObject<ServerCapabilities>();
+
+        var (providesCodeActions, resolvesCodeActions) = serverCapabilities?.CodeActionProvider?.Match(
+            boolValue => (boolValue, false),
+            options => (true, options.ResolveProvider)) ?? (false, false);
+
+        return providesCodeActions && resolvesCodeActions;
+    }
+
+    private static bool SupportsDocumentColor(JToken token)
+    {
+        var serverCapabilities = token.ToObject<ServerCapabilities>();
+
+        var supportsDocumentColor = serverCapabilities?.DocumentColorProvider?.Match(
+            boolValue => boolValue,
+            options => options != null) ?? false;
+
+        return supportsDocumentColor;
+    }
+
+    // NOTE: This method is a polyfill for VS. We only intend to do it this way until VS formally
+    // supports sending workspace configuration requests.
+    public override Task<object[]> WorkspaceConfigurationAsync(
+        ConfigurationParams configParams,
+        CancellationToken cancellationToken)
+    {
+        if (configParams is null)
         {
-            var serverCapabilities = token.ToObject<ServerCapabilities>();
-
-            var supportsDocumentColor = serverCapabilities?.DocumentColorProvider?.Match(
-                boolValue => boolValue,
-                options => options != null) ?? false;
-
-            return supportsDocumentColor;
+            throw new ArgumentNullException(nameof(configParams));
         }
 
-        // NOTE: This method is a polyfill for VS. We only intend to do it this way until VS formally
-        // supports sending workspace configuration requests.
-        public override Task<object[]> WorkspaceConfigurationAsync(
-            ConfigurationParams configParams,
-            CancellationToken cancellationToken)
+        var result = new List<object>();
+        foreach (var item in configParams.Items)
         {
-            if (configParams is null)
-            {
-                throw new ArgumentNullException(nameof(configParams));
-            }
-
-            var result = new List<object>();
-            foreach (var item in configParams.Items)
-            {
-                // Right now in VS we only care about editor settings, but we should update this logic later if
-                // we want to support Razor and HTML settings as well.
-                var setting = item.Section == "vs.editor.razor"
-                    ? _editorSettingsManager.Current
-                    : new object();
-                result.Add(setting);
-            }
-
-            return Task.FromResult(result.ToArray());
+            // Right now in VS we only care about editor settings, but we should update this logic later if
+            // we want to support Razor and HTML settings as well.
+            var setting = item.Section == "vs.editor.razor"
+                ? _editorSettingsManager.Current
+                : new object();
+            result.Add(setting);
         }
 
-        public override async Task<VSInternalWrapWithTagResponse> RazorWrapWithTagAsync(VSInternalWrapWithTagParams wrapWithParams, CancellationToken cancellationToken)
+        return Task.FromResult(result.ToArray());
+    }
+
+    public override async Task<VSInternalWrapWithTagResponse> RazorWrapWithTagAsync(VSInternalWrapWithTagParams wrapWithParams, CancellationToken cancellationToken)
+    {
+        // Same as in LanguageServerConstants, and in Web Tools
+        const string HtmlWrapWithTagEndpoint = "textDocument/_vsweb_wrapWithTag";
+
+        var response = new VSInternalWrapWithTagResponse(wrapWithParams.Range, Array.Empty<TextEdit>());
+
+        var (synchronized, htmlDocument) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<HtmlVirtualDocumentSnapshot>(
+            wrapWithParams.TextDocument.Version,
+            wrapWithParams.TextDocument.Uri,
+            cancellationToken);
+
+        if (!synchronized)
         {
-            // Same as in LanguageServerConstants, and in Web Tools
-            const string HtmlWrapWithTagEndpoint = "textDocument/_vsweb_wrapWithTag";
-
-            var response = new VSInternalWrapWithTagResponse(wrapWithParams.Range, Array.Empty<TextEdit>());
-
-            var (synchronized, htmlDocument) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<HtmlVirtualDocumentSnapshot>(
-                wrapWithParams.TextDocument.Version,
-                wrapWithParams.TextDocument.Uri,
-                cancellationToken);
-
-            if (!synchronized)
-            {
-                Debug.Fail("Document was not synchronized");
-                return response;
-            }
-
-            var languageServerName = RazorLSPConstants.HtmlLanguageServerName;
-            var projectedUri = htmlDocument.Uri;
-
-            // We call the Html language server to do the actual work here, now that we have the vitrual document that they know about
-            var request = new VSInternalWrapWithTagParams(
-                wrapWithParams.Range,
-                wrapWithParams.TagName,
-                wrapWithParams.Options,
-                new VersionedTextDocumentIdentifier() { Uri = projectedUri, });
-
-            var textBuffer = htmlDocument.Snapshot.TextBuffer;
-            var result = await _requestInvoker.ReinvokeRequestOnServerAsync<VSInternalWrapWithTagParams, VSInternalWrapWithTagResponse>(
-                textBuffer,
-                HtmlWrapWithTagEndpoint,
-                languageServerName,
-                request,
-                cancellationToken).ConfigureAwait(false);
-
-            if (result?.Response is not null)
-            {
-                response = result.Response;
-            }
-
+            Debug.Fail("Document was not synchronized");
             return response;
         }
 
-        public override async Task<VSInternalInlineCompletionList?> ProvideInlineCompletionAsync(RazorInlineCompletionRequest inlineCompletionParams, CancellationToken cancellationToken)
+        var languageServerName = RazorLSPConstants.HtmlLanguageServerName;
+        var projectedUri = htmlDocument.Uri;
+
+        // We call the Html language server to do the actual work here, now that we have the vitrual document that they know about
+        var request = new VSInternalWrapWithTagParams(
+            wrapWithParams.Range,
+            wrapWithParams.TagName,
+            wrapWithParams.Options,
+            new VersionedTextDocumentIdentifier() { Uri = projectedUri, });
+
+        var textBuffer = htmlDocument.Snapshot.TextBuffer;
+        var result = await _requestInvoker.ReinvokeRequestOnServerAsync<VSInternalWrapWithTagParams, VSInternalWrapWithTagResponse>(
+            textBuffer,
+            HtmlWrapWithTagEndpoint,
+            languageServerName,
+            request,
+            cancellationToken).ConfigureAwait(false);
+
+        if (result?.Response is not null)
         {
-            if (inlineCompletionParams is null)
-            {
-                throw new ArgumentNullException(nameof(inlineCompletionParams));
-            }
+            response = result.Response;
+        }
 
-            var hostDocumentUri = inlineCompletionParams.TextDocument.Uri;
-            if (!_documentManager.TryGetDocument(hostDocumentUri, out var documentSnapshot))
-            {
-                return null;
-            }
+        return response;
+    }
 
-            if (!documentSnapshot.TryGetVirtualDocument<CSharpVirtualDocumentSnapshot>(out var csharpDoc))
-            {
-                return null;
-            }
+    public override async Task<VSInternalInlineCompletionList?> ProvideInlineCompletionAsync(RazorInlineCompletionRequest inlineCompletionParams, CancellationToken cancellationToken)
+    {
+        if (inlineCompletionParams is null)
+        {
+            throw new ArgumentNullException(nameof(inlineCompletionParams));
+        }
 
-            var csharpRequest = new VSInternalInlineCompletionRequest
+        var hostDocumentUri = inlineCompletionParams.TextDocument.Uri;
+        if (!_documentManager.TryGetDocument(hostDocumentUri, out var documentSnapshot))
+        {
+            return null;
+        }
+
+        if (!documentSnapshot.TryGetVirtualDocument<CSharpVirtualDocumentSnapshot>(out var csharpDoc))
+        {
+            return null;
+        }
+
+        var csharpRequest = new VSInternalInlineCompletionRequest
+        {
+            Context = inlineCompletionParams.Context,
+            Position = inlineCompletionParams.Position,
+            TextDocument = new TextDocumentIdentifier { Uri = csharpDoc.Uri, },
+            Options = inlineCompletionParams.Options,
+        };
+
+        var textBuffer = csharpDoc.Snapshot.TextBuffer;
+        var request = await _requestInvoker.ReinvokeRequestOnServerAsync<VSInternalInlineCompletionRequest, VSInternalInlineCompletionList?>(
+            textBuffer,
+            VSInternalMethods.TextDocumentInlineCompletionName,
+            RazorLSPConstants.RazorCSharpLanguageServerName,
+            csharpRequest,
+            cancellationToken).ConfigureAwait(false);
+
+        return request?.Response;
+    }
+
+    public override async Task<RazorFoldingRangeResponse?> ProvideFoldingRangesAsync(RazorFoldingRangeRequestParam foldingRangeParams, CancellationToken cancellationToken)
+    {
+        if (foldingRangeParams is null)
+        {
+            throw new ArgumentNullException(nameof(foldingRangeParams));
+        }
+
+        var csharpRanges = new List<FoldingRange>();
+        var csharpTask = Task.Run(async () =>
+        {
+            var (synchronized, csharpSnapshot) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<CSharpVirtualDocumentSnapshot>(
+                foldingRangeParams.HostDocumentVersion, foldingRangeParams.TextDocument.Uri, cancellationToken);
+
+            if (synchronized)
             {
-                Context = inlineCompletionParams.Context,
-                Position = inlineCompletionParams.Position,
-                TextDocument = new TextDocumentIdentifier { Uri = csharpDoc.Uri, },
-                Options = inlineCompletionParams.Options,
+                var csharpRequestParams = new FoldingRangeParams()
+                {
+                    TextDocument = new()
+                    {
+                        Uri = csharpSnapshot.Uri
+                    }
+                };
+
+                var request = await _requestInvoker.ReinvokeRequestOnServerAsync<FoldingRangeParams, IEnumerable<FoldingRange>?>(
+                    csharpSnapshot.Snapshot.TextBuffer,
+                    Methods.TextDocumentFoldingRange.Name,
+                    RazorLSPConstants.RazorCSharpLanguageServerName,
+                    SupportsFoldingRange,
+                    csharpRequestParams,
+                    cancellationToken).ConfigureAwait(false);
+
+                var result = request?.Response;
+                if (result is null)
+                {
+                    csharpRanges = null;
+                }
+                else
+                {
+                    csharpRanges.AddRange(result);
+                }
+            }
+        }, cancellationToken);
+
+        var htmlRanges = new List<FoldingRange>();
+        var htmlTask = Task.CompletedTask;
+        htmlTask = Task.Run(async () =>
+        {
+            var (synchronized, htmlDocument) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<HtmlVirtualDocumentSnapshot>(
+                foldingRangeParams.HostDocumentVersion, foldingRangeParams.TextDocument.Uri, cancellationToken);
+
+            if (synchronized)
+            {
+                var htmlRequestParams = new FoldingRangeParams()
+                {
+                    TextDocument = new()
+                    {
+                        Uri = htmlDocument.Uri
+                    }
+                };
+
+                var request = await _requestInvoker.ReinvokeRequestOnServerAsync<FoldingRangeParams, IEnumerable<FoldingRange>?>(
+                    htmlDocument.Snapshot.TextBuffer,
+                    Methods.TextDocumentFoldingRange.Name,
+                    RazorLSPConstants.HtmlLanguageServerName,
+                    SupportsFoldingRange,
+                    htmlRequestParams,
+                    cancellationToken).ConfigureAwait(false);
+
+                var result = request?.Response;
+                if (result is null)
+                {
+                    htmlRanges = null;
+                }
+                else
+                {
+                    htmlRanges.AddRange(result);
+                }
+            }
+        }, cancellationToken);
+
+        var allTasks = Task.WhenAll(htmlTask, csharpTask);
+
+        try
+        {
+            await allTasks.ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            // Return null if any of the tasks getting folding ranges
+            // results in an error
+            return null;
+        }
+
+        return new(htmlRanges.ToImmutableArray(), csharpRanges.ToImmutableArray());
+    }
+
+    private static bool SupportsFoldingRange(JToken token)
+    {
+        var serverCapabilities = token.ToObject<ServerCapabilities>();
+
+        var supportsFoldingRange = serverCapabilities?.FoldingRangeProvider?.Match(
+            boolValue => boolValue,
+            options => options is not null) ?? false;
+
+        return supportsFoldingRange;
+    }
+
+    public override Task<WorkspaceEdit?> ProvideTextPresentationAsync(RazorTextPresentationParams presentationParams, CancellationToken cancellationToken)
+    {
+        return ProvidePresentationAsync(presentationParams, presentationParams.TextDocument.Uri, presentationParams.HostDocumentVersion, presentationParams.Kind, VSInternalMethods.TextDocumentTextPresentationName, cancellationToken);
+    }
+
+    public override Task<WorkspaceEdit?> ProvideUriPresentationAsync(RazorUriPresentationParams presentationParams, CancellationToken cancellationToken)
+    {
+        return ProvidePresentationAsync(presentationParams, presentationParams.TextDocument.Uri, presentationParams.HostDocumentVersion, presentationParams.Kind, VSInternalMethods.TextDocumentUriPresentationName, cancellationToken);
+    }
+
+    public async Task<WorkspaceEdit?> ProvidePresentationAsync<TParams>(TParams presentationParams, Uri hostDocumentUri, int hostDocumentVersion, RazorLanguageKind kind, string methodName, CancellationToken cancellationToken)
+        where TParams : notnull, IPresentationParams
+    {
+        string languageServerName;
+        VirtualDocumentSnapshot document;
+        if (kind == RazorLanguageKind.CSharp)
+        {
+            var syncResult = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<CSharpVirtualDocumentSnapshot>(
+                hostDocumentVersion,
+                hostDocumentUri,
+                cancellationToken);
+            languageServerName = RazorLSPConstants.RazorCSharpLanguageServerName;
+            presentationParams.TextDocument = new TextDocumentIdentifier
+            {
+                Uri = syncResult.VirtualSnapshot.Uri,
             };
+            document = syncResult.VirtualSnapshot;
+        }
+        else if (kind == RazorLanguageKind.Html)
+        {
+            var syncResult = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<HtmlVirtualDocumentSnapshot>(
+                hostDocumentVersion,
+                hostDocumentUri,
+                cancellationToken);
+            languageServerName = RazorLSPConstants.HtmlLanguageServerName;
+            presentationParams.TextDocument = new TextDocumentIdentifier
+            {
+                Uri = syncResult.VirtualSnapshot.Uri,
+            };
+            document = syncResult.VirtualSnapshot;
+        }
+        else
+        {
+            Debug.Fail("Unexpected RazorLanguageKind. This can't really happen in a real scenario.");
+            return null;
+        }
 
-            var textBuffer = csharpDoc.Snapshot.TextBuffer;
-            var request = await _requestInvoker.ReinvokeRequestOnServerAsync<VSInternalInlineCompletionRequest, VSInternalInlineCompletionList?>(
+        var textBuffer = document.Snapshot.TextBuffer;
+        var result = await _requestInvoker.ReinvokeRequestOnServerAsync<TParams, WorkspaceEdit?>(
+            textBuffer,
+            methodName,
+            languageServerName,
+            presentationParams,
+            cancellationToken).ConfigureAwait(false);
+
+        return result?.Response;
+    }
+
+    // JToken returning because there's no value in converting the type into its final type because this method serves entirely as a delegation point (immedaitely re-serializes).
+    public override async Task<JToken?> ProvideCompletionsAsync(
+        DelegatedCompletionParams request,
+        CancellationToken cancellationToken)
+    {
+        var hostDocumentUri = request.HostDocument.Uri;
+
+        string languageServerName;
+        Uri projectedUri;
+        bool synchronized;
+        VirtualDocumentSnapshot virtualDocumentSnapshot;
+        if (request.ProjectedKind == RazorLanguageKind.Html)
+        {
+            (synchronized, virtualDocumentSnapshot) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<HtmlVirtualDocumentSnapshot>(
+                request.HostDocument.Version,
+                request.HostDocument.Uri,
+                cancellationToken);
+            languageServerName = RazorLSPConstants.HtmlLanguageServerName;
+            projectedUri = virtualDocumentSnapshot.Uri;
+        }
+        else if (request.ProjectedKind == RazorLanguageKind.CSharp)
+        {
+            (synchronized, virtualDocumentSnapshot) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<CSharpVirtualDocumentSnapshot>(
+                request.HostDocument.Version,
+                hostDocumentUri,
+                cancellationToken);
+            languageServerName = RazorLSPConstants.RazorCSharpLanguageServerName;
+            projectedUri = virtualDocumentSnapshot.Uri;
+        }
+        else
+        {
+            Debug.Fail("Unexpected RazorLanguageKind. This shouldn't really happen in a real scenario.");
+            return null;
+        }
+
+        if (!synchronized)
+        {
+            return null;
+        }
+
+        var completionParams = new CompletionParams()
+        {
+            Context = request.Context,
+            Position = request.ProjectedPosition,
+            TextDocument = new TextDocumentIdentifier()
+            {
+                Uri = projectedUri,
+            },
+        };
+
+        var continueOnCapturedContext = false;
+        var provisionalTextEdit = request.ProvisionalTextEdit;
+        if (provisionalTextEdit is not null)
+        {
+            await _joinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+            var provisionalChange = new VisualStudioTextChange(provisionalTextEdit, virtualDocumentSnapshot.Snapshot);
+            UpdateVirtualDocument(provisionalChange, request.ProjectedKind, request.HostDocument.Version, hostDocumentUri);
+
+            // We want the delegation to continue on the captured context because we're currently on the `main` thread and we need to get back to the
+            // main thread in order to update the virtual buffer with the reverted text edit.
+            continueOnCapturedContext = true;
+        }
+
+        try
+        {
+            var textBuffer = virtualDocumentSnapshot.Snapshot.TextBuffer;
+            var response = await _requestInvoker.ReinvokeRequestOnServerAsync<CompletionParams, JToken?>(
                 textBuffer,
-                VSInternalMethods.TextDocumentInlineCompletionName,
-                RazorLSPConstants.RazorCSharpLanguageServerName,
-                csharpRequest,
-                cancellationToken).ConfigureAwait(false);
-
-            return request?.Response;
-        }
-
-        public override async Task<RazorFoldingRangeResponse?> ProvideFoldingRangesAsync(RazorFoldingRangeRequestParam foldingRangeParams, CancellationToken cancellationToken)
-        {
-            if (foldingRangeParams is null)
-            {
-                throw new ArgumentNullException(nameof(foldingRangeParams));
-            }
-
-            var csharpRanges = new List<FoldingRange>();
-            var csharpTask = Task.Run(async () =>
-            {
-                var (synchronized, csharpSnapshot) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<CSharpVirtualDocumentSnapshot>(
-                    foldingRangeParams.HostDocumentVersion, foldingRangeParams.TextDocument.Uri, cancellationToken);
-
-                if (synchronized)
-                {
-                    var csharpRequestParams = new FoldingRangeParams()
-                    {
-                        TextDocument = new()
-                        {
-                            Uri = csharpSnapshot.Uri
-                        }
-                    };
-
-                    var request = await _requestInvoker.ReinvokeRequestOnServerAsync<FoldingRangeParams, IEnumerable<FoldingRange>?>(
-                        csharpSnapshot.Snapshot.TextBuffer,
-                        Methods.TextDocumentFoldingRange.Name,
-                        RazorLSPConstants.RazorCSharpLanguageServerName,
-                        SupportsFoldingRange,
-                        csharpRequestParams,
-                        cancellationToken).ConfigureAwait(false);
-
-                    var result = request?.Response;
-                    if (result is null)
-                    {
-                        csharpRanges = null;
-                    }
-                    else
-                    {
-                        csharpRanges.AddRange(result);
-                    }
-                }
-            }, cancellationToken);
-
-            var htmlRanges = new List<FoldingRange>();
-            var htmlTask = Task.CompletedTask;
-            htmlTask = Task.Run(async () =>
-            {
-                var (synchronized, htmlDocument) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<HtmlVirtualDocumentSnapshot>(
-                    foldingRangeParams.HostDocumentVersion, foldingRangeParams.TextDocument.Uri, cancellationToken);
-
-                if (synchronized)
-                {
-                    var htmlRequestParams = new FoldingRangeParams()
-                    {
-                        TextDocument = new()
-                        {
-                            Uri = htmlDocument.Uri
-                        }
-                    };
-
-                    var request = await _requestInvoker.ReinvokeRequestOnServerAsync<FoldingRangeParams, IEnumerable<FoldingRange>?>(
-                        htmlDocument.Snapshot.TextBuffer,
-                        Methods.TextDocumentFoldingRange.Name,
-                        RazorLSPConstants.HtmlLanguageServerName,
-                        SupportsFoldingRange,
-                        htmlRequestParams,
-                        cancellationToken).ConfigureAwait(false);
-
-                    var result = request?.Response;
-                    if (result is null)
-                    {
-                        htmlRanges = null;
-                    }
-                    else
-                    {
-                        htmlRanges.AddRange(result);
-                    }
-                }
-            }, cancellationToken);
-
-            var allTasks = Task.WhenAll(htmlTask, csharpTask);
-
-            try
-            {
-                await allTasks.ConfigureAwait(false);
-            }
-            catch (Exception)
-            {
-                // Return null if any of the tasks getting folding ranges
-                // results in an error
-                return null;
-            }
-
-            return new(htmlRanges.ToImmutableArray(), csharpRanges.ToImmutableArray());
-        }
-
-        private static bool SupportsFoldingRange(JToken token)
-        {
-            var serverCapabilities = token.ToObject<ServerCapabilities>();
-
-            var supportsFoldingRange = serverCapabilities?.FoldingRangeProvider?.Match(
-                boolValue => boolValue,
-                options => options is not null) ?? false;
-
-            return supportsFoldingRange;
-        }
-
-        public override Task<WorkspaceEdit?> ProvideTextPresentationAsync(RazorTextPresentationParams presentationParams, CancellationToken cancellationToken)
-        {
-            return ProvidePresentationAsync(presentationParams, presentationParams.TextDocument.Uri, presentationParams.HostDocumentVersion, presentationParams.Kind, VSInternalMethods.TextDocumentTextPresentationName, cancellationToken);
-        }
-
-        public override Task<WorkspaceEdit?> ProvideUriPresentationAsync(RazorUriPresentationParams presentationParams, CancellationToken cancellationToken)
-        {
-            return ProvidePresentationAsync(presentationParams, presentationParams.TextDocument.Uri, presentationParams.HostDocumentVersion, presentationParams.Kind, VSInternalMethods.TextDocumentUriPresentationName, cancellationToken);
-        }
-
-        public async Task<WorkspaceEdit?> ProvidePresentationAsync<TParams>(TParams presentationParams, Uri hostDocumentUri, int hostDocumentVersion, RazorLanguageKind kind, string methodName, CancellationToken cancellationToken)
-            where TParams : notnull, IPresentationParams
-        {
-            string languageServerName;
-            VirtualDocumentSnapshot document;
-            if (kind == RazorLanguageKind.CSharp)
-            {
-                var syncResult = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<CSharpVirtualDocumentSnapshot>(
-                    hostDocumentVersion,
-                    hostDocumentUri,
-                    cancellationToken);
-                languageServerName = RazorLSPConstants.RazorCSharpLanguageServerName;
-                presentationParams.TextDocument = new TextDocumentIdentifier
-                {
-                    Uri = syncResult.VirtualSnapshot.Uri,
-                };
-                document = syncResult.VirtualSnapshot;
-            }
-            else if (kind == RazorLanguageKind.Html)
-            {
-                var syncResult = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<HtmlVirtualDocumentSnapshot>(
-                    hostDocumentVersion,
-                    hostDocumentUri,
-                    cancellationToken);
-                languageServerName = RazorLSPConstants.HtmlLanguageServerName;
-                presentationParams.TextDocument = new TextDocumentIdentifier
-                {
-                    Uri = syncResult.VirtualSnapshot.Uri,
-                };
-                document = syncResult.VirtualSnapshot;
-            }
-            else
-            {
-                Debug.Fail("Unexpected RazorLanguageKind. This can't really happen in a real scenario.");
-                return null;
-            }
-
-            var textBuffer = document.Snapshot.TextBuffer;
-            var result = await _requestInvoker.ReinvokeRequestOnServerAsync<TParams, WorkspaceEdit?>(
-                textBuffer,
-                methodName,
+                Methods.TextDocumentCompletion.Name,
                 languageServerName,
-                presentationParams,
-                cancellationToken).ConfigureAwait(false);
-
-            return result?.Response;
+                completionParams,
+                cancellationToken).ConfigureAwait(continueOnCapturedContext);
+            return response?.Response;
         }
-
-        // JToken returning because there's no value in converting the type into its final type because this method serves entirely as a delegation point (immedaitely re-serializes).
-        public override async Task<JToken?> ProvideCompletionsAsync(
-            DelegatedCompletionParams request,
-            CancellationToken cancellationToken)
+        finally
         {
-            var hostDocumentUri = request.HostDocument.Uri;
-
-            string languageServerName;
-            Uri projectedUri;
-            bool synchronized;
-            VirtualDocumentSnapshot virtualDocumentSnapshot;
-            if (request.ProjectedKind == RazorLanguageKind.Html)
-            {
-                (synchronized, virtualDocumentSnapshot) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<HtmlVirtualDocumentSnapshot>(
-                    request.HostDocument.Version,
-                    request.HostDocument.Uri,
-                    cancellationToken);
-                languageServerName = RazorLSPConstants.HtmlLanguageServerName;
-                projectedUri = virtualDocumentSnapshot.Uri;
-            }
-            else if (request.ProjectedKind == RazorLanguageKind.CSharp)
-            {
-                (synchronized, virtualDocumentSnapshot) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<CSharpVirtualDocumentSnapshot>(
-                    request.HostDocument.Version,
-                    hostDocumentUri,
-                    cancellationToken);
-                languageServerName = RazorLSPConstants.RazorCSharpLanguageServerName;
-                projectedUri = virtualDocumentSnapshot.Uri;
-            }
-            else
-            {
-                Debug.Fail("Unexpected RazorLanguageKind. This shouldn't really happen in a real scenario.");
-                return null;
-            }
-
-            if (!synchronized)
-            {
-                return null;
-            }
-
-            var completionParams = new CompletionParams()
-            {
-                Context = request.Context,
-                Position = request.ProjectedPosition,
-                TextDocument = new TextDocumentIdentifier()
-                {
-                    Uri = projectedUri,
-                },
-            };
-
-            var continueOnCapturedContext = false;
-            var provisionalTextEdit = request.ProvisionalTextEdit;
             if (provisionalTextEdit is not null)
             {
-                await _joinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
-
-                var provisionalChange = new VisualStudioTextChange(provisionalTextEdit, virtualDocumentSnapshot.Snapshot);
-                UpdateVirtualDocument(provisionalChange, request.ProjectedKind, request.HostDocument.Version, hostDocumentUri);
-
-                // We want the delegation to continue on the captured context because we're currently on the `main` thread and we need to get back to the
-                // main thread in order to update the virtual buffer with the reverted text edit.
-                continueOnCapturedContext = true;
-            }
-
-            try
-            {
-                var textBuffer = virtualDocumentSnapshot.Snapshot.TextBuffer;
-                var response = await _requestInvoker.ReinvokeRequestOnServerAsync<CompletionParams, JToken?>(
-                    textBuffer,
-                    Methods.TextDocumentCompletion.Name,
-                    languageServerName,
-                    completionParams,
-                    cancellationToken).ConfigureAwait(continueOnCapturedContext);
-                return response?.Response;
-            }
-            finally
-            {
-                if (provisionalTextEdit is not null)
-                {
-                    var revertedProvisionalTextEdit = BuildRevertedEdit(provisionalTextEdit);
-                    var revertedProvisionalChange = new VisualStudioTextChange(revertedProvisionalTextEdit, virtualDocumentSnapshot.Snapshot);
-                    UpdateVirtualDocument(revertedProvisionalChange, request.ProjectedKind, request.HostDocument.Version, hostDocumentUri);
-                }
+                var revertedProvisionalTextEdit = BuildRevertedEdit(provisionalTextEdit);
+                var revertedProvisionalChange = new VisualStudioTextChange(revertedProvisionalTextEdit, virtualDocumentSnapshot.Snapshot);
+                UpdateVirtualDocument(revertedProvisionalChange, request.ProjectedKind, request.HostDocument.Version, hostDocumentUri);
             }
         }
+    }
 
-        private static TextEdit BuildRevertedEdit(TextEdit provisionalTextEdit)
-        {
-            TextEdit? revertedProvisionalTextEdit;
-            if (provisionalTextEdit.Range.Start == provisionalTextEdit.Range.End)
-            {
-                // Insertion
-                revertedProvisionalTextEdit = new TextEdit()
-                {
-                    Range = new Range()
-                    {
-                        Start = provisionalTextEdit.Range.Start,
-
-                        // We're making an assumption that provisional text edits do not span more than 1 line.
-                        End = new Position(provisionalTextEdit.Range.End.Line, provisionalTextEdit.Range.End.Character + provisionalTextEdit.NewText.Length),
-                    },
-                    NewText = string.Empty
-                };
-            }
-            else
-            {
-                // Replace
-                revertedProvisionalTextEdit = new TextEdit()
-                {
-                    Range = provisionalTextEdit.Range,
-                    NewText = string.Empty
-                };
-            }
-
-            return revertedProvisionalTextEdit;
-        }
-
-        private void UpdateVirtualDocument(
-            VisualStudioTextChange textChange,
-            RazorLanguageKind virtualDocumentKind,
-            int hostDocumentVersion,
-            Uri documentSnapshotUri)
-        {
-            if (_documentManager is not TrackingLSPDocumentManager trackingDocumentManager)
-            {
-                return;
-            }
-
-            if (virtualDocumentKind == RazorLanguageKind.CSharp)
-            {
-                trackingDocumentManager.UpdateVirtualDocument<CSharpVirtualDocument>(
-                    documentSnapshotUri,
-                    new[] { textChange },
-                    hostDocumentVersion,
-                    state: null);
-            }
-            else if (virtualDocumentKind == RazorLanguageKind.Html)
-            {
-                trackingDocumentManager.UpdateVirtualDocument<HtmlVirtualDocument>(
-                    documentSnapshotUri,
-                    new[] { textChange },
-                    hostDocumentVersion,
-                    state: null);
-            }
-        }
-
-        public override async Task<JToken?> ProvideResolvedCompletionItemAsync(DelegatedCompletionItemResolveParams request, CancellationToken cancellationToken)
-        {
-            string languageServerName;
-            bool synchronized;
-            VirtualDocumentSnapshot virtualDocumentSnapshot;
-            if (request.OriginatingKind == RazorLanguageKind.Html)
-            {
-                (synchronized, virtualDocumentSnapshot) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<HtmlVirtualDocumentSnapshot>(
-                    request.HostDocument.Version,
-                    request.HostDocument.Uri,
-                    cancellationToken);
-                languageServerName = RazorLSPConstants.HtmlLanguageServerName;
-            }
-            else if (request.OriginatingKind == RazorLanguageKind.CSharp)
-            {
-                (synchronized, virtualDocumentSnapshot) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<CSharpVirtualDocumentSnapshot>(
-                    request.HostDocument.Version,
-                    request.HostDocument.Uri,
-                    cancellationToken);
-                languageServerName = RazorLSPConstants.RazorCSharpLanguageServerName;
-            }
-            else
-            {
-                Debug.Fail("Unexpected RazorLanguageKind. This can't really happen in a real scenario.");
-                return null;
-            }
-
-            if (!synchronized)
-            {
-                // Document was not synchronized
-                return null;
-            }
-
-            var completionResolveParams = request.CompletionItem;
-
-            var textBuffer = virtualDocumentSnapshot.Snapshot.TextBuffer;
-            var response = await _requestInvoker.ReinvokeRequestOnServerAsync<VSInternalCompletionItem, JToken?>(
-                textBuffer,
-                Methods.TextDocumentCompletionResolve.Name,
-                languageServerName,
-                completionResolveParams,
-                cancellationToken).ConfigureAwait(false);
-            return response?.Response;
-        }
-
-        public override Task<FormattingOptions?> GetFormattingOptionsAsync(TextDocumentIdentifier document, CancellationToken cancellationToken)
-        {
-            var formattingOptions = _formattingOptionsProvider.GetOptions(document.Uri);
-            return Task.FromResult(formattingOptions);
-        }
-
-        public override async Task<WorkspaceEdit?> RenameAsync(DelegatedRenameParams request, CancellationToken cancellationToken)
-        {
-            var delegationDetails = await GetProjectedRequestDetailsAsync(request, cancellationToken).ConfigureAwait(false);
-            if (delegationDetails is null)
-            {
-                return null;
-            }
-
-            var renameParams = new RenameParams()
-            {
-                TextDocument = new TextDocumentIdentifier()
-                {
-                    Uri = delegationDetails.Value.ProjectedUri,
-                },
-                Position = request.ProjectedPosition,
-                NewName = request.NewName,
-            };
-
-            var textBuffer = delegationDetails.Value.TextBuffer;
-            var response = await _requestInvoker.ReinvokeRequestOnServerAsync<RenameParams, WorkspaceEdit?>(
-                textBuffer,
-                Methods.TextDocumentRenameName,
-                delegationDetails.Value.LanguageServerName,
-                renameParams,
-                cancellationToken).ConfigureAwait(false);
-            return response?.Response;
-        }
-
-        public override async Task<VSInternalDocumentOnAutoInsertResponseItem?> OnAutoInsertAsync(DelegatedOnAutoInsertParams request, CancellationToken cancellationToken)
-        {
-            var delegationDetails = await GetProjectedRequestDetailsAsync(request, cancellationToken).ConfigureAwait(false);
-            if (delegationDetails is null)
-            {
-                return default;
-            }
-
-            var onAutoInsertParams = new VSInternalDocumentOnAutoInsertParams
-            {
-                TextDocument = new TextDocumentIdentifier()
-                {
-                    Uri = delegationDetails.Value.ProjectedUri,
-                },
-                Position = request.ProjectedPosition,
-                Character = request.Character,
-                Options = request.Options
-            };
-
-            var response = await _requestInvoker.ReinvokeRequestOnServerAsync<VSInternalDocumentOnAutoInsertParams, VSInternalDocumentOnAutoInsertResponseItem?>(
-               delegationDetails.Value.TextBuffer,
-               VSInternalMethods.OnAutoInsertName,
-               delegationDetails.Value.LanguageServerName,
-               onAutoInsertParams,
-               cancellationToken).ConfigureAwait(false);
-            return response?.Response;
-        }
-
-        public override async Task<Range?> ValidateBreakpointRangeAsync(DelegatedValidateBreakpointRangeParams request, CancellationToken cancellationToken)
-        {
-            var delegationDetails = await GetProjectedRequestDetailsAsync(request, cancellationToken).ConfigureAwait(false);
-            if (delegationDetails is null)
-            {
-                return default;
-            }
-
-            var validateBreakpointRangeParams = new VSInternalValidateBreakableRangeParams
-            {
-                TextDocument = new TextDocumentIdentifier()
-                {
-                    Uri = delegationDetails.Value.ProjectedUri,
-                },
-                Range = request.ProjectedRange
-            };
-
-            var response = await _requestInvoker.ReinvokeRequestOnServerAsync<VSInternalValidateBreakableRangeParams, Range?>(
-                delegationDetails.Value.TextBuffer,
-                VSInternalMethods.TextDocumentValidateBreakableRangeName,
-                delegationDetails.Value.LanguageServerName,
-                validateBreakpointRangeParams,
-                cancellationToken).ConfigureAwait(false);
-            return response?.Response;
-        }
-
-        public override Task<VSInternalHover?> HoverAsync(DelegatedPositionParams request, CancellationToken cancellationToken)
-            => DelegateTextDocumentPositionRequestAsync<VSInternalHover>(request, Methods.TextDocumentHoverName, cancellationToken);
-
-        public override Task<Location[]?> DefinitionAsync(DelegatedPositionParams request, CancellationToken cancellationToken)
-            => DelegateTextDocumentPositionRequestAsync<Location[]>(request, Methods.TextDocumentDefinitionName, cancellationToken);
-
-        public override Task<DocumentHighlight[]?> DocumentHighlightAsync(DelegatedPositionParams request, CancellationToken cancellationToken)
-            => DelegateTextDocumentPositionRequestAsync<DocumentHighlight[]>(request, Methods.TextDocumentDocumentHighlightName, cancellationToken);
-
-        public override Task<SignatureHelp?> SignatureHelpAsync(DelegatedPositionParams request, CancellationToken cancellationToken)
-            => DelegateTextDocumentPositionRequestAsync<SignatureHelp>(request, Methods.TextDocumentSignatureHelpName, cancellationToken);
-
-        public override Task<ImplementationResult> ImplementationAsync(DelegatedPositionParams request, CancellationToken cancellationToken)
-            => DelegateTextDocumentPositionRequestAsync<ImplementationResult>(request, Methods.TextDocumentImplementationName, cancellationToken);
-
-    public override async Task<IEnumerable<VSInternalDiagnosticReport>?> DiagnosticsAsync(DelegatedDiagnosticParams request, CancellationToken cancellationToken)
+    private static TextEdit BuildRevertedEdit(TextEdit provisionalTextEdit)
     {
-        var (synchronized, csharpVirtualDocument) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<CSharpVirtualDocumentSnapshot>(
-            request.HostDocument.Version,
-            request.HostDocument.Uri,
+        TextEdit? revertedProvisionalTextEdit;
+        if (provisionalTextEdit.Range.Start == provisionalTextEdit.Range.End)
+        {
+            // Insertion
+            revertedProvisionalTextEdit = new TextEdit()
+            {
+                Range = new Range()
+                {
+                    Start = provisionalTextEdit.Range.Start,
+
+                    // We're making an assumption that provisional text edits do not span more than 1 line.
+                    End = new Position(provisionalTextEdit.Range.End.Line, provisionalTextEdit.Range.End.Character + provisionalTextEdit.NewText.Length),
+                },
+                NewText = string.Empty
+            };
+        }
+        else
+        {
+            // Replace
+            revertedProvisionalTextEdit = new TextEdit()
+            {
+                Range = provisionalTextEdit.Range,
+                NewText = string.Empty
+            };
+        }
+
+        return revertedProvisionalTextEdit;
+    }
+
+    private void UpdateVirtualDocument(
+        VisualStudioTextChange textChange,
+        RazorLanguageKind virtualDocumentKind,
+        int hostDocumentVersion,
+        Uri documentSnapshotUri)
+    {
+        if (_documentManager is not TrackingLSPDocumentManager trackingDocumentManager)
+        {
+            return;
+        }
+
+        if (virtualDocumentKind == RazorLanguageKind.CSharp)
+        {
+            trackingDocumentManager.UpdateVirtualDocument<CSharpVirtualDocument>(
+                documentSnapshotUri,
+                new[] { textChange },
+                hostDocumentVersion,
+                state: null);
+        }
+        else if (virtualDocumentKind == RazorLanguageKind.Html)
+        {
+            trackingDocumentManager.UpdateVirtualDocument<HtmlVirtualDocument>(
+                documentSnapshotUri,
+                new[] { textChange },
+                hostDocumentVersion,
+                state: null);
+        }
+    }
+
+    public override async Task<JToken?> ProvideResolvedCompletionItemAsync(DelegatedCompletionItemResolveParams request, CancellationToken cancellationToken)
+    {
+        string languageServerName;
+        bool synchronized;
+        VirtualDocumentSnapshot virtualDocumentSnapshot;
+        if (request.OriginatingKind == RazorLanguageKind.Html)
+        {
+            (synchronized, virtualDocumentSnapshot) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<HtmlVirtualDocumentSnapshot>(
+                request.HostDocument.Version,
+                request.HostDocument.Uri,
+                cancellationToken);
+            languageServerName = RazorLSPConstants.HtmlLanguageServerName;
+        }
+        else if (request.OriginatingKind == RazorLanguageKind.CSharp)
+        {
+            (synchronized, virtualDocumentSnapshot) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<CSharpVirtualDocumentSnapshot>(
+                request.HostDocument.Version,
+                request.HostDocument.Uri,
+                cancellationToken);
+            languageServerName = RazorLSPConstants.RazorCSharpLanguageServerName;
+        }
+        else
+        {
+            Debug.Fail("Unexpected RazorLanguageKind. This can't really happen in a real scenario.");
+            return null;
+        }
+
+        if (!synchronized)
+        {
+            // Document was not synchronized
+            return null;
+        }
+
+        var completionResolveParams = request.CompletionItem;
+
+        var textBuffer = virtualDocumentSnapshot.Snapshot.TextBuffer;
+        var response = await _requestInvoker.ReinvokeRequestOnServerAsync<VSInternalCompletionItem, JToken?>(
+            textBuffer,
+            Methods.TextDocumentCompletionResolve.Name,
+            languageServerName,
+            completionResolveParams,
+            cancellationToken).ConfigureAwait(false);
+        return response?.Response;
+    }
+
+    public override Task<FormattingOptions?> GetFormattingOptionsAsync(TextDocumentIdentifier document, CancellationToken cancellationToken)
+    {
+        var formattingOptions = _formattingOptionsProvider.GetOptions(document.Uri);
+        return Task.FromResult(formattingOptions);
+    }
+
+    public override async Task<WorkspaceEdit?> RenameAsync(DelegatedRenameParams request, CancellationToken cancellationToken)
+    {
+        var delegationDetails = await GetProjectedRequestDetailsAsync(request, cancellationToken).ConfigureAwait(false);
+        if (delegationDetails is null)
+        {
+            return null;
+        }
+
+        var renameParams = new RenameParams()
+        {
+            TextDocument = new TextDocumentIdentifier()
+            {
+                Uri = delegationDetails.Value.ProjectedUri,
+            },
+            Position = request.ProjectedPosition,
+            NewName = request.NewName,
+        };
+
+        var textBuffer = delegationDetails.Value.TextBuffer;
+        var response = await _requestInvoker.ReinvokeRequestOnServerAsync<RenameParams, WorkspaceEdit?>(
+            textBuffer,
+            Methods.TextDocumentRenameName,
+            delegationDetails.Value.LanguageServerName,
+            renameParams,
+            cancellationToken).ConfigureAwait(false);
+        return response?.Response;
+    }
+
+    public override async Task<VSInternalDocumentOnAutoInsertResponseItem?> OnAutoInsertAsync(DelegatedOnAutoInsertParams request, CancellationToken cancellationToken)
+    {
+        var delegationDetails = await GetProjectedRequestDetailsAsync(request, cancellationToken).ConfigureAwait(false);
+        if (delegationDetails is null)
+        {
+            return default;
+        }
+
+        var onAutoInsertParams = new VSInternalDocumentOnAutoInsertParams
+        {
+            TextDocument = new TextDocumentIdentifier()
+            {
+                Uri = delegationDetails.Value.ProjectedUri,
+            },
+            Position = request.ProjectedPosition,
+            Character = request.Character,
+            Options = request.Options
+        };
+
+        var response = await _requestInvoker.ReinvokeRequestOnServerAsync<VSInternalDocumentOnAutoInsertParams, VSInternalDocumentOnAutoInsertResponseItem?>(
+           delegationDetails.Value.TextBuffer,
+           VSInternalMethods.OnAutoInsertName,
+           delegationDetails.Value.LanguageServerName,
+           onAutoInsertParams,
+           cancellationToken).ConfigureAwait(false);
+        return response?.Response;
+    }
+
+    public override async Task<Range?> ValidateBreakpointRangeAsync(DelegatedValidateBreakpointRangeParams request, CancellationToken cancellationToken)
+    {
+        var delegationDetails = await GetProjectedRequestDetailsAsync(request, cancellationToken).ConfigureAwait(false);
+        if (delegationDetails is null)
+        {
+            return default;
+        }
+
+        var validateBreakpointRangeParams = new VSInternalValidateBreakableRangeParams
+        {
+            TextDocument = new TextDocumentIdentifier()
+            {
+                Uri = delegationDetails.Value.ProjectedUri,
+            },
+            Range = request.ProjectedRange
+        };
+
+        var response = await _requestInvoker.ReinvokeRequestOnServerAsync<VSInternalValidateBreakableRangeParams, Range?>(
+            delegationDetails.Value.TextBuffer,
+            VSInternalMethods.TextDocumentValidateBreakableRangeName,
+            delegationDetails.Value.LanguageServerName,
+            validateBreakpointRangeParams,
+            cancellationToken).ConfigureAwait(false);
+        return response?.Response;
+    }
+
+    public override Task<VSInternalHover?> HoverAsync(DelegatedPositionParams request, CancellationToken cancellationToken)
+        => DelegateTextDocumentPositionRequestAsync<VSInternalHover>(request, Methods.TextDocumentHoverName, cancellationToken);
+
+    public override Task<Location[]?> DefinitionAsync(DelegatedPositionParams request, CancellationToken cancellationToken)
+        => DelegateTextDocumentPositionRequestAsync<Location[]>(request, Methods.TextDocumentDefinitionName, cancellationToken);
+
+    public override Task<DocumentHighlight[]?> DocumentHighlightAsync(DelegatedPositionParams request, CancellationToken cancellationToken)
+        => DelegateTextDocumentPositionRequestAsync<DocumentHighlight[]>(request, Methods.TextDocumentDocumentHighlightName, cancellationToken);
+
+    public override Task<SignatureHelp?> SignatureHelpAsync(DelegatedPositionParams request, CancellationToken cancellationToken)
+        => DelegateTextDocumentPositionRequestAsync<SignatureHelp>(request, Methods.TextDocumentSignatureHelpName, cancellationToken);
+
+    public override Task<ImplementationResult> ImplementationAsync(DelegatedPositionParams request, CancellationToken cancellationToken)
+        => DelegateTextDocumentPositionRequestAsync<ImplementationResult>(request, Methods.TextDocumentImplementationName, cancellationToken);
+
+    public override async Task<RazorPullDiagnosticResponse?> DiagnosticsAsync(DelegatedDiagnosticParams request, CancellationToken cancellationToken)
+    {
+        var csharpTask = Task.Run(() => GetVirtualDocumentPullDiagnosticsAsync<CSharpVirtualDocumentSnapshot>(request.HostDocument, RazorLSPConstants.RazorCSharpLanguageServerName, cancellationToken), cancellationToken);
+        var htmlTask = Task.Run(() => GetVirtualDocumentPullDiagnosticsAsync<HtmlVirtualDocumentSnapshot>(request.HostDocument, RazorLSPConstants.HtmlLanguageServerName, cancellationToken), cancellationToken);
+
+        var allTasks = Task.WhenAll(htmlTask, csharpTask);
+
+        try
+        {
+            await allTasks.ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            // Return null if any of the tasks getting diagnostics results in an error
+            return null;
+        }
+
+        var csharpDiagnostics = await csharpTask.ConfigureAwait(false) ?? Array.Empty<VSInternalDiagnosticReport>();
+        var htmlDiagnostics = await htmlTask.ConfigureAwait(false) ?? Array.Empty<VSInternalDiagnosticReport>();
+
+        return new RazorPullDiagnosticResponse(csharpDiagnostics, htmlDiagnostics);
+    }
+
+    private async Task<VSInternalDiagnosticReport[]?> GetVirtualDocumentPullDiagnosticsAsync<TVirtualDocumentSnapshot>(VersionedTextDocumentIdentifier hostDocument, string delegatedLanguageServerName, CancellationToken cancellationToken)
+        where TVirtualDocumentSnapshot : VirtualDocumentSnapshot
+    {
+        var (synchronized, virtualDocument) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<TVirtualDocumentSnapshot>(
+            hostDocument.Version,
+            hostDocument.Uri,
             cancellationToken).ConfigureAwait(false);
         if (!synchronized)
         {
             return null;
         }
 
-        var csharpRequest = new VSInternalDocumentDiagnosticsParams
+        var request = new VSInternalDocumentDiagnosticsParams
         {
             TextDocument = new TextDocumentIdentifier
             {
-                Uri = csharpVirtualDocument.Uri,
+                Uri = virtualDocument.Uri,
             },
         };
-        var csharpResponse = await _requestInvoker.ReinvokeRequestOnServerAsync<VSInternalDocumentDiagnosticsParams, VSInternalDiagnosticReport[]?>(
-            csharpVirtualDocument.Snapshot.TextBuffer,
+        var response = await _requestInvoker.ReinvokeRequestOnServerAsync<VSInternalDocumentDiagnosticsParams, VSInternalDiagnosticReport[]?>(
+            virtualDocument.Snapshot.TextBuffer,
             VSInternalMethods.DocumentPullDiagnosticName,
-            RazorLSPConstants.RazorCSharpLanguageServerName,
-            csharpRequest,
+            delegatedLanguageServerName,
+            request,
             cancellationToken).ConfigureAwait(false);
 
-        if (csharpResponse is null)
+        if (response is null)
+        {
+            return null;
+        }
+
+        return response.Response;
+    }
+    private async Task<TResult?> DelegateTextDocumentPositionRequestAsync<TResult>(DelegatedPositionParams request, string methodName, CancellationToken cancellationToken)
+    {
+        var delegationDetails = await GetProjectedRequestDetailsAsync(request, cancellationToken).ConfigureAwait(false);
+        if (delegationDetails is null)
         {
             return default;
         }
 
-        return csharpResponse.Response;
-    }
-
-        private async Task<TResult?> DelegateTextDocumentPositionRequestAsync<TResult>(DelegatedPositionParams request, string methodName, CancellationToken cancellationToken)
+        var positionParams = new TextDocumentPositionParams()
         {
-            var delegationDetails = await GetProjectedRequestDetailsAsync(request, cancellationToken).ConfigureAwait(false);
-            if (delegationDetails is null)
+            TextDocument = new TextDocumentIdentifier()
             {
-                return default;
-            }
+                Uri = delegationDetails.Value.ProjectedUri,
+            },
+            Position = request.ProjectedPosition,
+        };
 
-            var positionParams = new TextDocumentPositionParams()
-            {
-                TextDocument = new TextDocumentIdentifier()
-                {
-                    Uri = delegationDetails.Value.ProjectedUri,
-                },
-                Position = request.ProjectedPosition,
-            };
+        var response = await _requestInvoker.ReinvokeRequestOnServerAsync<TextDocumentPositionParams, TResult?>(
+            delegationDetails.Value.TextBuffer,
+            methodName,
+            delegationDetails.Value.LanguageServerName,
+            positionParams,
+            cancellationToken).ConfigureAwait(false);
 
-            var response = await _requestInvoker.ReinvokeRequestOnServerAsync<TextDocumentPositionParams, TResult?>(
-                delegationDetails.Value.TextBuffer,
-                methodName,
-                delegationDetails.Value.LanguageServerName,
-                positionParams,
-                cancellationToken).ConfigureAwait(false);
-
-            if (response is null)
-            {
-                return default;
-            }
-
-            return response.Response;
+        if (response is null)
+        {
+            return default;
         }
 
-        private async Task<DelegationRequestDetails?> GetProjectedRequestDetailsAsync(IDelegatedParams request, CancellationToken cancellationToken)
+        return response.Response;
+    }
+
+    private async Task<DelegationRequestDetails?> GetProjectedRequestDetailsAsync(IDelegatedParams request, CancellationToken cancellationToken)
+    {
+        string languageServerName;
+
+        bool synchronized;
+        VirtualDocumentSnapshot virtualDocumentSnapshot;
+        if (request.ProjectedKind == RazorLanguageKind.Html)
         {
-            string languageServerName;
-
-            bool synchronized;
-            VirtualDocumentSnapshot virtualDocumentSnapshot;
-            if (request.ProjectedKind == RazorLanguageKind.Html)
-            {
-                (synchronized, virtualDocumentSnapshot) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<HtmlVirtualDocumentSnapshot>(
-                    request.HostDocument.Version,
-                    request.HostDocument.Uri,
-                    rejectOnNewerParallelRequest: false,
-                    cancellationToken);
-                languageServerName = RazorLSPConstants.HtmlLanguageServerName;
-            }
-            else if (request.ProjectedKind == RazorLanguageKind.CSharp)
-            {
-                (synchronized, virtualDocumentSnapshot) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<CSharpVirtualDocumentSnapshot>(
-                    request.HostDocument.Version,
-                    request.HostDocument.Uri,
-                    rejectOnNewerParallelRequest: false,
-                    cancellationToken);
-                languageServerName = RazorLSPConstants.RazorCSharpLanguageServerName;
-            }
-            else
-            {
-                Debug.Fail("Unexpected RazorLanguageKind. This shouldn't really happen in a real scenario.");
-                return null;
-            }
-
-            if (!synchronized)
-            {
-                return null;
-            }
-
-            return new DelegationRequestDetails(languageServerName, virtualDocumentSnapshot.Uri, virtualDocumentSnapshot.Snapshot.TextBuffer);
+            (synchronized, virtualDocumentSnapshot) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<HtmlVirtualDocumentSnapshot>(
+                request.HostDocument.Version,
+                request.HostDocument.Uri,
+                rejectOnNewerParallelRequest: false,
+                cancellationToken);
+            languageServerName = RazorLSPConstants.HtmlLanguageServerName;
+        }
+        else if (request.ProjectedKind == RazorLanguageKind.CSharp)
+        {
+            (synchronized, virtualDocumentSnapshot) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<CSharpVirtualDocumentSnapshot>(
+                request.HostDocument.Version,
+                request.HostDocument.Uri,
+                rejectOnNewerParallelRequest: false,
+                cancellationToken);
+            languageServerName = RazorLSPConstants.RazorCSharpLanguageServerName;
+        }
+        else
+        {
+            Debug.Fail("Unexpected RazorLanguageKind. This shouldn't really happen in a real scenario.");
+            return null;
         }
 
-        private record struct DelegationRequestDetails(string LanguageServerName, Uri ProjectedUri, ITextBuffer TextBuffer);
+        if (!synchronized)
+        {
+            return null;
+        }
+
+        return new DelegationRequestDetails(languageServerName, virtualDocumentSnapshot.Uri, virtualDocumentSnapshot.Snapshot.TextBuffer);
     }
+
+    private record struct DelegationRequestDetails(string LanguageServerName, Uri ProjectedUri, ITextBuffer TextBuffer);
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
@@ -115,10 +115,6 @@ internal class InitializeHandler : IRequestHandler<InitializeParams, InitializeR
             _initializeResult.Capabilities.ImplementationProvider = false;
 
             ((VSInternalServerCapabilities)_initializeResult.Capabilities).OnAutoInsertProvider = null;
-        }
-
-        if (_languageServerFeatureOptions.SingleServerDiagnosticsSupport)
-        {
             ((VSInternalServerCapabilities)_initializeResult.Capabilities).SupportsDiagnosticRequests = false;
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerCustomMessageTarget.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics;
 using Microsoft.AspNetCore.Razor.LanguageServer.DocumentColor;
 using Microsoft.AspNetCore.Razor.LanguageServer.DocumentPresentation;
 using Microsoft.AspNetCore.Razor.LanguageServer.Folding;
@@ -25,103 +26,103 @@ using ImplementationResult = Microsoft.VisualStudio.LanguageServer.Protocol.SumT
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor;
 
-    internal abstract class RazorLanguageServerCustomMessageTarget
-    {
-        // Called by the Razor Language Server to retrieve the user's latest settings.
-        // NOTE: This method is a polyfill for VS. We only intend to do it this way until VS formally
-        // supports sending workspace configuration requests.
-        [JsonRpcMethod(Methods.WorkspaceConfigurationName, UseSingleObjectParameterDeserialization = true)]
-        public abstract Task<object[]> WorkspaceConfigurationAsync(ConfigurationParams configParams, CancellationToken cancellationToken);
+internal abstract class RazorLanguageServerCustomMessageTarget
+{
+    // Called by the Razor Language Server to retrieve the user's latest settings.
+    // NOTE: This method is a polyfill for VS. We only intend to do it this way until VS formally
+    // supports sending workspace configuration requests.
+    [JsonRpcMethod(Methods.WorkspaceConfigurationName, UseSingleObjectParameterDeserialization = true)]
+    public abstract Task<object[]> WorkspaceConfigurationAsync(ConfigurationParams configParams, CancellationToken cancellationToken);
 
-        // Called by the Razor Language Server to update the contents of the virtual CSharp buffer.
-        [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorUpdateCSharpBufferEndpoint, UseSingleObjectParameterDeserialization = true)]
-        public abstract Task UpdateCSharpBufferAsync(UpdateBufferRequest token, CancellationToken cancellationToken);
+    // Called by the Razor Language Server to update the contents of the virtual CSharp buffer.
+    [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorUpdateCSharpBufferEndpoint, UseSingleObjectParameterDeserialization = true)]
+    public abstract Task UpdateCSharpBufferAsync(UpdateBufferRequest token, CancellationToken cancellationToken);
 
-        // Called by the Razor Language Server to update the contents of the virtual Html buffer.
-        [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorUpdateHtmlBufferEndpoint, UseSingleObjectParameterDeserialization = true)]
-        public abstract Task UpdateHtmlBufferAsync(UpdateBufferRequest token, CancellationToken cancellationToken);
+    // Called by the Razor Language Server to update the contents of the virtual Html buffer.
+    [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorUpdateHtmlBufferEndpoint, UseSingleObjectParameterDeserialization = true)]
+    public abstract Task UpdateHtmlBufferAsync(UpdateBufferRequest token, CancellationToken cancellationToken);
 
-        // Called by the Razor Language Server to invoke a textDocument/formatting request
-        // on the virtual Html/CSharp buffer.
-        [JsonRpcMethod(LanguageServerConstants.RazorDocumentFormattingEndpoint, UseSingleObjectParameterDeserialization = true)]
-        public abstract Task<RazorDocumentRangeFormattingResponse> RazorDocumentFormattingAsync(VersionedDocumentFormattingParams token, CancellationToken cancellationToken);
+    // Called by the Razor Language Server to invoke a textDocument/formatting request
+    // on the virtual Html/CSharp buffer.
+    [JsonRpcMethod(LanguageServerConstants.RazorDocumentFormattingEndpoint, UseSingleObjectParameterDeserialization = true)]
+    public abstract Task<RazorDocumentRangeFormattingResponse> RazorDocumentFormattingAsync(VersionedDocumentFormattingParams token, CancellationToken cancellationToken);
 
-        // Called by the Razor Language Server to invoke a textDocument/onTypeFormatting  request
-        // on the virtual Html buffer.
-        [JsonRpcMethod(LanguageServerConstants.RazorDocumentOnTypeFormattingEndpoint, UseSingleObjectParameterDeserialization = true)]
-        public abstract Task<RazorDocumentRangeFormattingResponse> HtmlOnTypeFormattingAsync(RazorDocumentOnTypeFormattingParams token, CancellationToken cancellationToken);
+    // Called by the Razor Language Server to invoke a textDocument/onTypeFormatting  request
+    // on the virtual Html buffer.
+    [JsonRpcMethod(LanguageServerConstants.RazorDocumentOnTypeFormattingEndpoint, UseSingleObjectParameterDeserialization = true)]
+    public abstract Task<RazorDocumentRangeFormattingResponse> HtmlOnTypeFormattingAsync(RazorDocumentOnTypeFormattingParams token, CancellationToken cancellationToken);
 
-        // Called by the Razor Language Server to invoke a textDocument/rangeFormatting request
-        // on the virtual Html/CSharp buffer.
-        [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorRangeFormattingEndpoint, UseSingleObjectParameterDeserialization = true)]
-        public abstract Task<RazorDocumentRangeFormattingResponse> RazorRangeFormattingAsync(RazorDocumentRangeFormattingParams token, CancellationToken cancellationToken);
+    // Called by the Razor Language Server to invoke a textDocument/rangeFormatting request
+    // on the virtual Html/CSharp buffer.
+    [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorRangeFormattingEndpoint, UseSingleObjectParameterDeserialization = true)]
+    public abstract Task<RazorDocumentRangeFormattingResponse> RazorRangeFormattingAsync(RazorDocumentRangeFormattingParams token, CancellationToken cancellationToken);
 
-        // Called by the Razor Language Server to provide code actions from the platform.
-        [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorProvideCodeActionsEndpoint, UseSingleObjectParameterDeserialization = true)]
-        public abstract Task<IReadOnlyList<VSInternalCodeAction>?> ProvideCodeActionsAsync(DelegatedCodeActionParams codeActionParams, CancellationToken cancellationToken);
+    // Called by the Razor Language Server to provide code actions from the platform.
+    [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorProvideCodeActionsEndpoint, UseSingleObjectParameterDeserialization = true)]
+    public abstract Task<IReadOnlyList<VSInternalCodeAction>?> ProvideCodeActionsAsync(DelegatedCodeActionParams codeActionParams, CancellationToken cancellationToken);
 
-        // Called by the Razor Language Server to resolve code actions from the platform.
-        [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorResolveCodeActionsEndpoint, UseSingleObjectParameterDeserialization = true)]
-        public abstract Task<VSInternalCodeAction?> ResolveCodeActionsAsync(RazorResolveCodeActionParams codeAction, CancellationToken cancellationToken);
+    // Called by the Razor Language Server to resolve code actions from the platform.
+    [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorResolveCodeActionsEndpoint, UseSingleObjectParameterDeserialization = true)]
+    public abstract Task<VSInternalCodeAction?> ResolveCodeActionsAsync(RazorResolveCodeActionParams codeAction, CancellationToken cancellationToken);
 
-        // Called by the Razor Language Server to provide ranged semantic tokens from the platform.
-        [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorProvideSemanticTokensRangeEndpoint, UseSingleObjectParameterDeserialization = true)]
-        public abstract Task<ProvideSemanticTokensResponse?> ProvideSemanticTokensRangeAsync(ProvideSemanticTokensRangeParams semanticTokensParams, CancellationToken cancellationToken);
+    // Called by the Razor Language Server to provide ranged semantic tokens from the platform.
+    [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorProvideSemanticTokensRangeEndpoint, UseSingleObjectParameterDeserialization = true)]
+    public abstract Task<ProvideSemanticTokensResponse?> ProvideSemanticTokensRangeAsync(ProvideSemanticTokensRangeParams semanticTokensParams, CancellationToken cancellationToken);
 
-        // Called by Visual Studio to wrap the current selection with a tag
-        [JsonRpcMethod(LanguageServerConstants.RazorWrapWithTagEndpoint, UseSingleObjectParameterDeserialization = true)]
-        public abstract Task<VSInternalWrapWithTagResponse> RazorWrapWithTagAsync(VSInternalWrapWithTagParams wrapWithParams, CancellationToken cancellationToken);
+    // Called by Visual Studio to wrap the current selection with a tag
+    [JsonRpcMethod(LanguageServerConstants.RazorWrapWithTagEndpoint, UseSingleObjectParameterDeserialization = true)]
+    public abstract Task<VSInternalWrapWithTagResponse> RazorWrapWithTagAsync(VSInternalWrapWithTagParams wrapWithParams, CancellationToken cancellationToken);
 
-        // Called by the Razor Language Server to provide inline completions from the platform.
-        [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorInlineCompletionEndpoint, UseSingleObjectParameterDeserialization = true)]
-        public abstract Task<VSInternalInlineCompletionList?> ProvideInlineCompletionAsync(RazorInlineCompletionRequest inlineCompletionParams, CancellationToken cancellationToken);
+    // Called by the Razor Language Server to provide inline completions from the platform.
+    [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorInlineCompletionEndpoint, UseSingleObjectParameterDeserialization = true)]
+    public abstract Task<VSInternalInlineCompletionList?> ProvideInlineCompletionAsync(RazorInlineCompletionRequest inlineCompletionParams, CancellationToken cancellationToken);
 
-        // Called by the Razor Language Server to provide document colors from the platform.
-        [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorProvideHtmlDocumentColorEndpoint, UseSingleObjectParameterDeserialization = true)]
+    // Called by the Razor Language Server to provide document colors from the platform.
+    [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorProvideHtmlDocumentColorEndpoint, UseSingleObjectParameterDeserialization = true)]
     public abstract Task<IReadOnlyList<ColorInformation>?> ProvideHtmlDocumentColorAsync(DelegatedDocumentColorParams documentColorParams, CancellationToken cancellationToken);
 
-        [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorFoldingRangeEndpoint, UseSingleObjectParameterDeserialization = true)]
-        public abstract Task<RazorFoldingRangeResponse?> ProvideFoldingRangesAsync(RazorFoldingRangeRequestParam foldingRangeParams, CancellationToken cancellationToken);
+    [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorFoldingRangeEndpoint, UseSingleObjectParameterDeserialization = true)]
+    public abstract Task<RazorFoldingRangeResponse?> ProvideFoldingRangesAsync(RazorFoldingRangeRequestParam foldingRangeParams, CancellationToken cancellationToken);
 
-        [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorTextPresentationEndpoint, UseSingleObjectParameterDeserialization = true)]
-        public abstract Task<WorkspaceEdit?> ProvideTextPresentationAsync(RazorTextPresentationParams presentationParams, CancellationToken cancellationToken);
+    [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorTextPresentationEndpoint, UseSingleObjectParameterDeserialization = true)]
+    public abstract Task<WorkspaceEdit?> ProvideTextPresentationAsync(RazorTextPresentationParams presentationParams, CancellationToken cancellationToken);
 
-        [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorUriPresentationEndpoint, UseSingleObjectParameterDeserialization = true)]
-        public abstract Task<WorkspaceEdit?> ProvideUriPresentationAsync(RazorUriPresentationParams presentationParams, CancellationToken cancellationToken);
+    [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorUriPresentationEndpoint, UseSingleObjectParameterDeserialization = true)]
+    public abstract Task<WorkspaceEdit?> ProvideUriPresentationAsync(RazorUriPresentationParams presentationParams, CancellationToken cancellationToken);
 
-        [JsonRpcMethod(LanguageServerConstants.RazorCompletionEndpointName, UseSingleObjectParameterDeserialization = true)]
-        public abstract Task<JToken?> ProvideCompletionsAsync(DelegatedCompletionParams completionParams, CancellationToken cancellationToken);
+    [JsonRpcMethod(LanguageServerConstants.RazorCompletionEndpointName, UseSingleObjectParameterDeserialization = true)]
+    public abstract Task<JToken?> ProvideCompletionsAsync(DelegatedCompletionParams completionParams, CancellationToken cancellationToken);
 
-        [JsonRpcMethod(LanguageServerConstants.RazorCompletionResolveEndpointName, UseSingleObjectParameterDeserialization = true)]
-        public abstract Task<JToken?> ProvideResolvedCompletionItemAsync(DelegatedCompletionItemResolveParams completionResolveParams, CancellationToken cancellationToken);
+    [JsonRpcMethod(LanguageServerConstants.RazorCompletionResolveEndpointName, UseSingleObjectParameterDeserialization = true)]
+    public abstract Task<JToken?> ProvideResolvedCompletionItemAsync(DelegatedCompletionItemResolveParams completionResolveParams, CancellationToken cancellationToken);
 
-        [JsonRpcMethod(LanguageServerConstants.RazorGetFormattingOptionsEndpointName, UseSingleObjectParameterDeserialization = true)]
-        public abstract Task<FormattingOptions?> GetFormattingOptionsAsync(TextDocumentIdentifier document, CancellationToken cancellationToken);
+    [JsonRpcMethod(LanguageServerConstants.RazorGetFormattingOptionsEndpointName, UseSingleObjectParameterDeserialization = true)]
+    public abstract Task<FormattingOptions?> GetFormattingOptionsAsync(TextDocumentIdentifier document, CancellationToken cancellationToken);
 
-        [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorRenameEndpointName, UseSingleObjectParameterDeserialization = true)]
-        public abstract Task<WorkspaceEdit?> RenameAsync(DelegatedRenameParams request, CancellationToken cancellationToken);
+    [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorRenameEndpointName, UseSingleObjectParameterDeserialization = true)]
+    public abstract Task<WorkspaceEdit?> RenameAsync(DelegatedRenameParams request, CancellationToken cancellationToken);
 
-        [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorHoverEndpointName, UseSingleObjectParameterDeserialization = true)]
-        public abstract Task<VSInternalHover?> HoverAsync(DelegatedPositionParams request, CancellationToken cancellationToken);
+    [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorHoverEndpointName, UseSingleObjectParameterDeserialization = true)]
+    public abstract Task<VSInternalHover?> HoverAsync(DelegatedPositionParams request, CancellationToken cancellationToken);
 
-        [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorDefinitionEndpointName, UseSingleObjectParameterDeserialization = true)]
-        public abstract Task<Location[]?> DefinitionAsync(DelegatedPositionParams request, CancellationToken cancellationToken);
+    [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorDefinitionEndpointName, UseSingleObjectParameterDeserialization = true)]
+    public abstract Task<Location[]?> DefinitionAsync(DelegatedPositionParams request, CancellationToken cancellationToken);
 
-        [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorDocumentHighlightEndpointName, UseSingleObjectParameterDeserialization = true)]
-        public abstract Task<DocumentHighlight[]?> DocumentHighlightAsync(DelegatedPositionParams request, CancellationToken cancellationToken);
+    [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorDocumentHighlightEndpointName, UseSingleObjectParameterDeserialization = true)]
+    public abstract Task<DocumentHighlight[]?> DocumentHighlightAsync(DelegatedPositionParams request, CancellationToken cancellationToken);
 
-        [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorSignatureHelpEndpointName, UseSingleObjectParameterDeserialization = true)]
-        public abstract Task<SignatureHelp?> SignatureHelpAsync(DelegatedPositionParams request, CancellationToken cancellationToken);
+    [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorSignatureHelpEndpointName, UseSingleObjectParameterDeserialization = true)]
+    public abstract Task<SignatureHelp?> SignatureHelpAsync(DelegatedPositionParams request, CancellationToken cancellationToken);
 
-        [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorImplementationEndpointName, UseSingleObjectParameterDeserialization = true)]
-        public abstract Task<ImplementationResult> ImplementationAsync(DelegatedPositionParams request, CancellationToken cancellationToken);
+    [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorImplementationEndpointName, UseSingleObjectParameterDeserialization = true)]
+    public abstract Task<ImplementationResult> ImplementationAsync(DelegatedPositionParams request, CancellationToken cancellationToken);
 
-        [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorOnAutoInsertEndpointName, UseSingleObjectParameterDeserialization = true)]
-        public abstract Task<VSInternalDocumentOnAutoInsertResponseItem?> OnAutoInsertAsync(DelegatedOnAutoInsertParams request, CancellationToken cancellationToken);
+    [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorOnAutoInsertEndpointName, UseSingleObjectParameterDeserialization = true)]
+    public abstract Task<VSInternalDocumentOnAutoInsertResponseItem?> OnAutoInsertAsync(DelegatedOnAutoInsertParams request, CancellationToken cancellationToken);
 
-        [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorValidateBreakpointRangeName, UseSingleObjectParameterDeserialization = true)]
-        public abstract Task<Range?> ValidateBreakpointRangeAsync(DelegatedValidateBreakpointRangeParams request, CancellationToken cancellationToken);
+    [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorValidateBreakpointRangeName, UseSingleObjectParameterDeserialization = true)]
+    public abstract Task<Range?> ValidateBreakpointRangeAsync(DelegatedValidateBreakpointRangeParams request, CancellationToken cancellationToken);
 
     [JsonRpcMethod(RazorLanguageServerCustomMessageTargets.RazorPullDiagnosticEndpointName, UseSingleObjectParameterDeserialization = true)]
-    public abstract Task<IEnumerable<VSInternalDiagnosticReport>?> DiagnosticsAsync(DelegatedDiagnosticParams request, CancellationToken cancellationToken);
+    public abstract Task<RazorPullDiagnosticResponse?> DiagnosticsAsync(DelegatedDiagnosticParams request, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
@@ -14,12 +14,10 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
 {
     private const string SingleServerCompletionFeatureFlag = "Razor.LSP.SingleServerCompletion";
     private const string SingleServerFeatureFlag = "Razor.LSP.SingleServer";
-    private const string SingleServerDiagnosticsFeatureFlag = "Razor.LSP.SingleServerDiagnostics";
 
     private readonly LSPEditorFeatureDetector _lspEditorFeatureDetector;
     private readonly Lazy<bool> _singleServerCompletionSupport;
     private readonly Lazy<bool> _singleServerSupport;
-    private readonly Lazy<bool> _singleServerDiagnosticsSupport;
 
     [ImportingConstructor]
     public VisualStudioWindowsLanguageServerFeatureOptions(LSPEditorFeatureDetector lspEditorFeatureDetector)
@@ -44,13 +42,6 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
             var singleServerEnabled = featureFlags.IsFeatureEnabled(SingleServerFeatureFlag, defaultValue: false);
             return singleServerEnabled;
         });
-
-        _singleServerDiagnosticsSupport = new Lazy<bool>(() =>
-        {
-            var featureFlags = (IVsFeatureFlags)AsyncPackage.GetGlobalService(typeof(SVsFeatureFlags));
-            var singleServerDiagnosticsEnabled = featureFlags.IsFeatureEnabled(SingleServerDiagnosticsFeatureFlag, defaultValue: false);
-            return singleServerDiagnosticsEnabled;
-        });
     }
 
     // We don't currently support file creation operations on VS Codespaces or VS Liveshare
@@ -66,8 +57,6 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
     public override bool SingleServerCompletionSupport => _singleServerCompletionSupport.Value;
 
     public override bool SingleServerSupport => _singleServerSupport.Value;
-
-    public override bool SingleServerDiagnosticsSupport => _singleServerDiagnosticsSupport.Value;
 
     private bool IsCodespacesOrLiveshare => _lspEditorFeatureDetector.IsRemoteClient() || _lspEditorFeatureDetector.IsLiveShareHost();
 }

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacLanguageServerFeatureOptions.cs
@@ -37,8 +37,6 @@ internal class VisualStudioMacLanguageServerFeatureOptions : LanguageServerFeatu
 
     public override bool SingleServerSupport => false;
 
-    public override bool SingleServerDiagnosticsSupport => false;
-
     private bool IsCodespacesOrLiveshare => _lspEditorFeatureDetector.IsRemoteClient() || _lspEditorFeatureDetector.IsLiveShareHost();
 
 }

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
@@ -54,9 +54,3 @@
 "Value"=dword:00000001
 "Title"="Enable enhanced Razor LSP server (requires restart)"
 "PreviewPaneChannels"="IntPreview,int.main"
-
-[$RootKey$\FeatureFlags\Razor\LSP\SingleServerDiagnostics]
-"Description"="Enable single server diagnostics support when editing Razor (ASP.NET Core)."
-"Value"=dword:00000000
-"Title"="Enable enhanced Razor LSP diagnostics (requires restart)"
-"PreviewPaneChannels"="IntPreview,int.main"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorTranslateDiagnosticsEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorTranslateDiagnosticsEndpointTest.cs
@@ -37,7 +37,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
         // Arrange
         var documentPath = new Uri("C:/path/to/document.cshtml");
 
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.CSharp,
@@ -65,7 +66,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
             });
         var documentContext = (DocumentContext?)null;
 
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.CSharp,
@@ -97,7 +99,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(10, 12))
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.CSharp,
@@ -130,7 +133,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(2, 15))
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.CSharp,
@@ -165,7 +169,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(6, 25))
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.CSharp,
@@ -205,7 +210,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(15, 13))
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.CSharp,
@@ -239,7 +245,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(10, 12))
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
@@ -277,7 +284,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(10, 12))
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
@@ -314,7 +322,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(10, 12))
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
@@ -352,14 +361,15 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(10, 12))
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.CSharp,
             Diagnostics = new[] {
                 new VSDiagnostic() {
                     Range = new Range { Start = new Position(0, 10), End = new Position(0, 22)},
-                    Code = RazorTranslateDiagnosticsEndpoint.CSharpDiagnosticsToIgnore.First(),
+                    Code = RazorTranslateDiagnosticsService.CSharpDiagnosticsToIgnore.First(),
                     Severity = DiagnosticSeverity.Warning
                 }
             },
@@ -391,13 +401,14 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(10, 12))
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
             Diagnostics = new[] {
                 new VSDiagnostic() {
-                    Code = RazorTranslateDiagnosticsEndpoint.CSharpDiagnosticsToIgnore.First(),
+                    Code = RazorTranslateDiagnosticsService.CSharpDiagnosticsToIgnore.First(),
                     Severity = DiagnosticSeverity.Error
                 }
             },
@@ -427,14 +438,15 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(10, 12))
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.CSharp,
             Diagnostics = new[] {
                 new VSDiagnostic() {
                     Range = new Range { Start = new Position(0, 10),End =  new Position(0, 22)},
-                    Code = RazorTranslateDiagnosticsEndpoint.CSharpDiagnosticsToIgnore.First(),
+                    Code = RazorTranslateDiagnosticsService.CSharpDiagnosticsToIgnore.First(),
                     Severity = DiagnosticSeverity.Error
                 }
             },
@@ -465,7 +477,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(10, 12))
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.CSharp,
@@ -502,7 +515,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(10, 12))
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.CSharp,
@@ -534,7 +548,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
             "__o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.ProgressEventArgs>(this, );",
             sourceMappings: Array.Empty<SourceMapping>());
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new TestRazorDiagnosticsEndpointWithoutRazorDiagnostic(_mappingService, LoggerFactory);
+        var diagnosticsService = new TestRazorDiagnosticsServiceWithoutRazorDiagnostic(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.CSharp,
@@ -567,7 +582,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
             "__o = Microsoft.AspNetCore.Components.EventCallback.Factory.Create<Microsoft.AspNetCore.Components.Web.ProgressEventArgs>(this, );",
             sourceMappings: Array.Empty<SourceMapping>());
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new TestRazorDiagnosticsEndpointWithRazorDiagnostic(_mappingService, LoggerFactory);
+        var diagnosticsService = new TestRazorDiagnosticsServiceWithRazorDiagnostic(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.CSharp,
@@ -605,7 +621,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(10, 13))
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.CSharp,
@@ -636,7 +653,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
         var documentPath = new Uri("C:/path/to/document.cshtml");
         var codeDocument = CreateCodeDocument("<p>@DateTime.Now</p>");
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
@@ -660,7 +678,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
         var documentPath = new Uri("C:/path/to/document.cshtml");
         var codeDocument = CreateCodeDocument("<p>@DateTime.Now</p>");
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Razor,
@@ -692,7 +711,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
             });
         codeDocument.SetUnsupported();
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.CSharp,
@@ -723,7 +743,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                 GetButtonTagHelperDescriptor().Build()
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
@@ -754,7 +775,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                 GetButtonTagHelperDescriptor().Build()
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
@@ -786,7 +808,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(10, 14))
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
@@ -818,7 +841,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(10, 14))
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
@@ -870,7 +894,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                 descriptor.Build()
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
@@ -918,7 +943,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                 descriptor.Build()
             });
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
@@ -956,7 +982,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
         var documentPath = new Uri("C:/path/to/document.cshtml");
         var codeDocument = CreateCodeDocument("<p>@DateTime.Now");
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
@@ -990,7 +1017,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
         var documentPath = new Uri("C:/path/to/document.razor");
         var codeDocument = CreateCodeDocument("<p>@DateTime.Now", kind: FileKinds.Component);
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
@@ -1021,7 +1049,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
         var documentPath = new Uri("C:/path/to/document.razor");
         var codeDocument = CreateCodeDocument("<!body></body>", kind: FileKinds.Component);
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
@@ -1055,7 +1084,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
         var documentPath = new Uri("C:/path/to/document.razor");
         var codeDocument = CreateCodeDocument("<html><!body><div></div></!body></html>", kind: FileKinds.Component);
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
@@ -1097,7 +1127,8 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
         var documentPath = new Uri("C:/path/to/document.razor");
         var codeDocument = CreateCodeDocument("<!body></!body>", kind: FileKinds.Component);
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(_mappingService, LoggerFactory);
+        var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
+        var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);
         var request = new RazorDiagnosticsParams()
         {
             Kind = RazorLanguageKind.Html,
@@ -1160,9 +1191,9 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
         return codeDocument;
     }
 
-    class TestRazorDiagnosticsEndpointWithRazorDiagnostic : RazorTranslateDiagnosticsEndpoint
+    class TestRazorDiagnosticsServiceWithRazorDiagnostic : RazorTranslateDiagnosticsService
     {
-        public TestRazorDiagnosticsEndpointWithRazorDiagnostic(
+        public TestRazorDiagnosticsServiceWithRazorDiagnostic(
             RazorDocumentMappingService documentMappingService,
             ILoggerFactory loggerFactory)
             : base(documentMappingService, loggerFactory)
@@ -1175,9 +1206,9 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
         }
     }
 
-    class TestRazorDiagnosticsEndpointWithoutRazorDiagnostic : RazorTranslateDiagnosticsEndpoint
+    class TestRazorDiagnosticsServiceWithoutRazorDiagnostic : RazorTranslateDiagnosticsService
     {
-        public TestRazorDiagnosticsEndpointWithoutRazorDiagnostic(
+        public TestRazorDiagnosticsServiceWithoutRazorDiagnostic(
             RazorDocumentMappingService documentMappingService,
             ILoggerFactory loggerFactory)
             : base(documentMappingService, loggerFactory)

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common/TestLanguageServerFeatureOptions.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common/TestLanguageServerFeatureOptions.cs
@@ -24,6 +24,4 @@ internal class TestLanguageServerFeatureOptions : LanguageServerFeatureOptions
     public override bool SingleServerCompletionSupport => false;
 
     public override bool SingleServerSupport => false;
-
-    public override bool SingleServerDiagnosticsSupport => false;
 }

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/DiagnosticTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/DiagnosticTests.cs
@@ -77,7 +77,7 @@ public class DiagnosticTests : AbstractRazorEditorTest
         Assert.Collection(errors,
             (error) =>
             {
-                Assert.Equal("Error.cshtml(10, 5): error HTML0001: Element start tag is missing closing angle bracket.", error);
+                Assert.Equal("Error.cshtml(10, 6): warning HTML0001: Element start tag is missing closing angle bracket.", error);
             });
     }
 

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/DiagnosticTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/DiagnosticTests.cs
@@ -47,4 +47,36 @@ public class DiagnosticTests : AbstractRazorEditorTest
                 Assert.Equal("Counter.razor(7, 9): error CS0127: Since 'Counter.Function()' returns void, a return keyword must not be followed by an object expression", error);
             });
     }
+
+    [IdeFact]
+    public async Task Diagnostics_ShowErrors_cshtml()
+    {
+        // Arrange
+        await TestServices.SolutionExplorer.OpenFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.ErrorCshtmlFile, ControlledHangMitigatingCancellationToken);
+
+        await TestServices.Editor.SetTextAsync(@"
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+<!DOCTYPE html>
+<html lang=""en"">
+<head>
+</head>
+
+<body>
+    <input asp-for=""Test"" />
+</body>
+</html>
+
+", ControlledHangMitigatingCancellationToken);
+
+        // Act
+        var errors = await TestServices.ErrorList.WaitForErrorsAsync("Error.cshtml", expectedCount: 1, ControlledHangMitigatingCancellationToken);
+
+        // Assert
+        Assert.Collection(errors,
+            (error) =>
+            {
+                Assert.Equal("Error.cshtml(10, 21): error CS1963: An expression tree may not contain a dynamic operation", error);
+            });
+    }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/DiagnosticTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/DiagnosticTests.cs
@@ -49,7 +49,7 @@ public class DiagnosticTests : AbstractRazorEditorTest
             });
     }
 
-    [IdeFact]
+    [IdeFact(Skip = "https://github.com/dotnet/razor/issues/8023")]
     public async Task Diagnostics_ShowErrors_HtmlDiagnostics()
     {
         // Arrange
@@ -64,7 +64,7 @@ public class DiagnosticTests : AbstractRazorEditorTest
 </head>
 
 <body>
-    <li>
+    <p
 </body>
 </html>
 
@@ -77,7 +77,7 @@ public class DiagnosticTests : AbstractRazorEditorTest
         Assert.Collection(errors,
             (error) =>
             {
-                Assert.Equal("Error.cshtml(10, 5): error HTML0204: Element 'li' cannot be nested inside element 'body'.", error);
+                Assert.Equal("Error.cshtml(10, 5): error HTML0001: Element start tag is missing closing angle bracket.", error);
             });
     }
 

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/DiagnosticTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/DiagnosticTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -49,7 +50,39 @@ public class DiagnosticTests : AbstractRazorEditorTest
     }
 
     [IdeFact]
-    public async Task Diagnostics_ShowErrors_cshtml()
+    public async Task Diagnostics_ShowErrors_HtmlDiagnostics()
+    {
+        // Arrange
+        await TestServices.SolutionExplorer.OpenFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.ErrorCshtmlFile, ControlledHangMitigatingCancellationToken);
+
+        await TestServices.Editor.SetTextAsync(@"
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+<!DOCTYPE html>
+<html lang=""en"">
+<head>
+</head>
+
+<body>
+    <li>
+</body>
+</html>
+
+", ControlledHangMitigatingCancellationToken);
+
+        // Act
+        var errors = await TestServices.ErrorList.WaitForErrorsAsync("Error.cshtml", expectedCount: 1, ControlledHangMitigatingCancellationToken);
+
+        // Assert
+        Assert.Collection(errors,
+            (error) =>
+            {
+                Assert.Equal("Error.cshtml(10, 5): error HTML0204: Element 'li' cannot be nested inside element 'body'.", error);
+            });
+    }
+
+    [IdeFact]
+    public async Task Diagnostics_ShowErrors_CSHtml()
     {
         // Arrange
         await TestServices.SolutionExplorer.OpenFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.ErrorCshtmlFile, ControlledHangMitigatingCancellationToken);


### PR DESCRIPTION
Fixes #8023

Nerd sniped myself. Looks like Web Tools changed to pull diagnostics for Html so we need to respond in kind.

Includes https://github.com/dotnet/razor/pull/8018 so just review [the last commit](https://github.com/dotnet/razor/pull/8024/commits/0f44ec5f70f1c241fab32609ce159d8a4d530aa6?w=1) (with whitespace off). @ryanbrandenburg if you think this is okay, and see this message before you merge your PR, feel free to just approve and merge this instead :)