### PR TITLE
Mark source gen as shipping

### DIFF
--- a/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.csproj
+++ b/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.csproj
@@ -4,9 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
 
-    <!-- This is not a package, it is part of Razor SDK. -->
+    <!-- This is not a package, it is part of Razor SDK, but it does ship in the VSIX. -->
     <IsPackable>false</IsPackable>
-    <IsShipping>false</IsShipping>
     <NoWarn>$(NoWarn);RS2008</NoWarn>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.csproj
+++ b/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators/Microsoft.NET.Sdk.Razor.SourceGenerators.csproj
@@ -6,6 +6,9 @@
 
     <!-- This is not a package, it is part of Razor SDK, but it does ship in the VSIX. -->
     <IsPackable>false</IsPackable>
+    <IsShipping>false</IsShipping>
+    <!-- setting IsShippingAssembly because we want symbols stored for this DLL, since it ships in the VSIX -->
+    <IsShippingAssembly>true</IsShippingAssembly>
     <NoWarn>$(NoWarn);RS2008</NoWarn>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
The latest build has the source gen as the only DLL missing symbols, and I think letting it be marked as a shipping should fix that. And it does ship in the VSIX after all.

Hopefully this can't break anything else 🤷‍♂️