### PR TITLE
UI thread handling outside of initialize request

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
@@ -144,7 +144,7 @@ internal class InitializeHandler : IRequestHandler<InitializeParams, InitializeR
     {
         _ = Task.Run(async () =>
         {
-            var containedLanguageServerClients = await EnsureContainedLanguageServersInitializedAsync().ConfigureAwait(false);
+            var containedLanguageServerClients = GetContainedLanguageClients();
 
             var mergedCapabilities = GetMergedServerCapabilities(containedLanguageServerClients);
 
@@ -480,10 +480,9 @@ internal class InitializeHandler : IRequestHandler<InitializeParams, InitializeR
     }
 
     // Ensures all contained language servers that we rely on are started.
-    private async Task<List<ILanguageClient>> EnsureContainedLanguageServersInitializedAsync()
+    private List<ILanguageClient> GetContainedLanguageClients()
     {
         var relevantLanguageClients = new List<ILanguageClient>();
-        var clientLoadTasks = new List<Task>();
 
 #pragma warning disable CS0618 // Type or member is obsolete
         foreach (var languageClientAndMetadata in _languageServiceBroker.LanguageClients)
@@ -504,13 +503,8 @@ internal class InitializeHandler : IRequestHandler<InitializeParams, InitializeR
                 metadata.ContentTypes.Contains(RazorLSPConstants.HtmlLSPDelegationContentTypeName))
             {
                 relevantLanguageClients.Add(languageClientAndMetadata.Value);
-
-                var loadAsyncTask = _languageClientBroker.LoadAsync(metadata, languageClientAndMetadata.Value);
-                clientLoadTasks.Add(loadAsyncTask);
             }
         }
-
-        await Task.WhenAll(clientLoadTasks).ConfigureAwait(false);
 
         return relevantLanguageClients;
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlCSharp/InitializeHandler.cs
@@ -484,34 +484,13 @@ internal class InitializeHandler : IRequestHandler<InitializeParams, InitializeR
     {
         var relevantLanguageClients = new List<ILanguageClient>();
 
-#pragma warning disable CS0618 // Type or member is obsolete
-        foreach (var languageClientAndMetadata in _languageServiceBroker.LanguageClients)
-#pragma warning restore CS0618 // Type or member is obsolete
+        var releventatClientsAndMetadata = RazorLanguageServerClient.GetReleventContainedLanguageClientsAndMetadata(_languageServiceBroker);
+
+        foreach (var languageClientAndMetadata in releventatClientsAndMetadata)
         {
-            if (languageClientAndMetadata.Metadata is not ILanguageClientMetadata metadata)
-            {
-                continue;
-            }
-
-            if (metadata is IIsUserExperienceDisabledMetadata userExperienceDisabledMetadata &&
-                userExperienceDisabledMetadata.IsUserExperienceDisabled)
-            {
-                continue;
-            }
-
-            if (IsCSharpApplicable(metadata) ||
-                metadata.ContentTypes.Contains(RazorLSPConstants.HtmlLSPDelegationContentTypeName))
-            {
-                relevantLanguageClients.Add(languageClientAndMetadata.Value);
-            }
+            relevantLanguageClients.Add(languageClientAndMetadata.Value);
         }
 
         return relevantLanguageClients;
-
-        static bool IsCSharpApplicable(ILanguageClientMetadata metadata)
-        {
-            return metadata.ContentTypes.Contains(RazorLSPConstants.CSharpContentTypeName) &&
-                metadata.ClientName == CSharpVirtualDocumentFactory.CSharpClientName;
-        }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
@@ -162,6 +162,7 @@ internal class RazorLanguageServerClient : ILanguageClient, ILanguageClientCusto
         var logHubLogger = _loggerProvider.CreateLogger("Razor");
         var razorLogger = new LoggerAdapter(logHubLogger);
         _server = RazorLanguageServerWrapper.Create(serverStream, serverStream, razorLogger, _projectSnapshotManagerDispatcher, ConfigureLanguageServer, _languageServerFeatureOptions);
+        // This must not happen on an RPC endpoint due to UIThread concerns, so ActivateAsync was chosen.
         await EnsureContainedLanguageServersInitializedAsync();
         var connection = new Connection(clientStream, clientStream);
         return connection;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer;
@@ -33,6 +34,8 @@ internal class RazorLanguageServerClient : ILanguageClient, ILanguageClientCusto
 {
     private const string LogFileIdentifier = "Razor.RazorLanguageServerClient";
 
+    private readonly ILanguageClientBroker _languageClientBroker;
+    private readonly ILanguageServiceBroker2 _languageServiceBroker;
     private readonly RazorLanguageServerCustomMessageTarget _customMessageTarget;
     private readonly ILanguageClientMiddleLayer _middleLayer;
     private readonly LSPRequestInvoker _requestInvoker;
@@ -62,6 +65,8 @@ internal class RazorLanguageServerClient : ILanguageClient, ILanguageClientCusto
         RazorLanguageServerLogHubLoggerProviderFactory logHubLoggerProviderFactory,
         LanguageServerFeatureOptions languageServerFeatureOptions,
         ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,
+        ILanguageClientBroker languageClientBroker,
+        ILanguageServiceBroker2 languageServiceBroker,
         [Import(AllowDefault = true)] VisualStudioHostServicesProvider? vsHostWorkspaceServicesProvider)
     {
         if (customTarget is null)
@@ -99,6 +104,16 @@ internal class RazorLanguageServerClient : ILanguageClient, ILanguageClientCusto
             throw new ArgumentNullException(nameof(languageServerFeatureOptions));
         }
 
+        if (languageClientBroker is null)
+        {
+            throw new ArgumentNullException(nameof(languageClientBroker));
+        }
+
+        if (languageServiceBroker is null)
+        {
+            throw new ArgumentNullException(nameof(languageServiceBroker));
+        }
+
         _customMessageTarget = customTarget;
         _middleLayer = middleLayer;
         _requestInvoker = requestInvoker;
@@ -106,6 +121,8 @@ internal class RazorLanguageServerClient : ILanguageClient, ILanguageClientCusto
         _logHubLoggerProviderFactory = logHubLoggerProviderFactory;
         _languageServerFeatureOptions = languageServerFeatureOptions;
         _vsHostWorkspaceServicesProvider = vsHostWorkspaceServicesProvider;
+        _languageClientBroker = languageClientBroker;
+        _languageServiceBroker = languageServiceBroker;
         _projectSnapshotManagerDispatcher = projectSnapshotManagerDispatcher;
     }
 
@@ -145,9 +162,45 @@ internal class RazorLanguageServerClient : ILanguageClient, ILanguageClientCusto
         var logHubLogger = _loggerProvider.CreateLogger("Razor");
         var razorLogger = new LoggerAdapter(logHubLogger);
         _server = RazorLanguageServerWrapper.Create(serverStream, serverStream, razorLogger, _projectSnapshotManagerDispatcher, ConfigureLanguageServer, _languageServerFeatureOptions);
-
+        await EnsureContainedLanguageServersInitializedAsync();
         var connection = new Connection(clientStream, clientStream);
         return connection;
+    }
+
+    private async Task EnsureContainedLanguageServersInitializedAsync()
+    {
+        var clientLoadTasks = new List<Task>();
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        foreach (var languageClientAndMetadata in _languageServiceBroker.LanguageClients)
+#pragma warning restore CS0618 // Type or member is obsolete
+        {
+            if (languageClientAndMetadata.Metadata is not ILanguageClientMetadata metadata)
+            {
+                continue;
+            }
+
+            if (metadata is IIsUserExperienceDisabledMetadata userExperienceDisabledMetadata &&
+                userExperienceDisabledMetadata.IsUserExperienceDisabled)
+            {
+                continue;
+            }
+
+            if (IsCSharpApplicable(metadata) ||
+                metadata.ContentTypes.Contains(RazorLSPConstants.HtmlLSPDelegationContentTypeName))
+            {
+                var loadAsyncTask = _languageClientBroker.LoadAsync(metadata, languageClientAndMetadata.Value);
+                clientLoadTasks.Add(loadAsyncTask);
+            }
+        }
+
+        await Task.WhenAll(clientLoadTasks).ConfigureAwait(false);
+
+        static bool IsCSharpApplicable(ILanguageClientMetadata metadata)
+        {
+            return metadata.ContentTypes.Contains(RazorLSPConstants.CSharpContentTypeName) &&
+                metadata.ClientName == CSharpVirtualDocumentFactory.CSharpClientName;
+        }
     }
 
     private void ConfigureLanguageServer(IServiceCollection serviceCollection)


### PR DESCRIPTION
### Summary of the changes

- This moves contained LS initialization out of the initialize handler for HTMLCSharp to avoid some UIThread dangers. It's also a good pre-emptive fix since HTMLCSharp is on the way out.

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1391983

CC @gundermanc 