### PR TITLE
Use a singleton for MarkupChunkGenerator

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorIntermediateNodeLoweringPhase.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorIntermediateNodeLoweringPhase.cs
@@ -1095,7 +1095,7 @@ internal class DefaultRazorIntermediateNodeLoweringPhase : RazorEnginePhaseBase,
             var originalContext = rewritten.GetSpanContext();
             if (originalContext != null)
             {
-                rewritten = rewritten.WithSpanContext(new SpanContext(new MarkupChunkGenerator(), originalContext.EditHandler));
+                rewritten = rewritten.WithSpanContext(new SpanContext(MarkupChunkGenerator.Instance, originalContext.EditHandler));
             }
 
             return rewritten;
@@ -2083,7 +2083,7 @@ internal class DefaultRazorIntermediateNodeLoweringPhase : RazorEnginePhaseBase,
             var originalContext = rewritten.GetSpanContext();
             if (originalContext != null)
             {
-                rewritten = rewritten.WithSpanContext(new SpanContext(new MarkupChunkGenerator(), originalContext.EditHandler));
+                rewritten = rewritten.WithSpanContext(new SpanContext(MarkupChunkGenerator.Instance, originalContext.EditHandler));
             }
 
             return rewritten;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/CSharpCodeParser.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/CSharpCodeParser.cs
@@ -550,7 +550,7 @@ internal class CSharpCodeParser : TokenizerBackedParser<CSharpTokenizer>
             }
 
             EnsureCurrent();
-            SpanContext.ChunkGenerator = new StatementChunkGenerator();
+            SpanContext.ChunkGenerator = StatementChunkGenerator.Instance;
             AcceptMarkerTokenIfNecessary();
             if (!At(SyntaxKind.RightBrace))
             {
@@ -1609,7 +1609,7 @@ internal class CSharpCodeParser : TokenizerBackedParser<CSharpTokenizer>
                                 Balance(childBuilder, BalancingModes.NoErrorOnFailure, SyntaxKind.LeftBrace, SyntaxKind.RightBrace, startingBraceLocation);
                             }
 
-                            SpanContext.ChunkGenerator = new StatementChunkGenerator();
+                            SpanContext.ChunkGenerator = StatementChunkGenerator.Instance;
 
                             AcceptMarkerTokenIfNecessary();
 
@@ -2519,7 +2519,7 @@ internal class CSharpCodeParser : TokenizerBackedParser<CSharpTokenizer>
     private void DefaultSpanContextConfig(SpanContextBuilder spanContext)
     {
         spanContext.EditHandler = SpanEditHandler.CreateDefault(LanguageTokenizeString);
-        spanContext.ChunkGenerator = new StatementChunkGenerator();
+        spanContext.ChunkGenerator = StatementChunkGenerator.Instance;
     }
 
     private void ExplicitExpressionSpanContextConfig(SpanContextBuilder spanContext)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/HtmlMarkupParser.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/HtmlMarkupParser.cs
@@ -2156,7 +2156,7 @@ internal class HtmlMarkupParser : TokenizerBackedParser<HtmlTokenizer>
 
     private void DefaultMarkupSpanContext(SpanContextBuilder spanContext)
     {
-        spanContext.ChunkGenerator = new MarkupChunkGenerator();
+        spanContext.ChunkGenerator = MarkupChunkGenerator.Instance;
         spanContext.EditHandler = new SpanEditHandler(LanguageTokenizeString, AcceptedCharactersInternal.Any);
     }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/MarkupChunkGenerator.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/MarkupChunkGenerator.cs
@@ -7,6 +7,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy;
 
 internal class MarkupChunkGenerator : SpanChunkGenerator
 {
+    public static readonly MarkupChunkGenerator Instance = new();
+
+    private MarkupChunkGenerator() { }
+
     public override string ToString()
     {
         return "Markup";

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/MarkupChunkGenerator.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/MarkupChunkGenerator.cs
@@ -3,9 +3,11 @@
 
 #nullable disable
 
+using System.Runtime.CompilerServices;
+
 namespace Microsoft.AspNetCore.Razor.Language.Legacy;
 
-internal class MarkupChunkGenerator : SpanChunkGenerator
+internal sealed class MarkupChunkGenerator : SpanChunkGenerator
 {
     public static readonly MarkupChunkGenerator Instance = new();
 
@@ -14,5 +16,15 @@ internal class MarkupChunkGenerator : SpanChunkGenerator
     public override string ToString()
     {
         return "Markup";
+    }
+
+    public override bool Equals(object obj)
+    {
+        return ReferenceEquals(this, obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return RuntimeHelpers.GetHashCode(this);
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/StatementChunkGenerator.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/StatementChunkGenerator.cs
@@ -3,12 +3,28 @@
 
 #nullable disable
 
+using System.Runtime.CompilerServices;
+
 namespace Microsoft.AspNetCore.Razor.Language.Legacy;
 
 internal class StatementChunkGenerator : SpanChunkGenerator
 {
+    public static readonly StatementChunkGenerator Instance = new();
+
+    private StatementChunkGenerator() { }
+
     public override string ToString()
     {
         return "Stmt";
+    }
+
+    public override bool Equals(object obj)
+    {
+        return ReferenceEquals(this, obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return RuntimeHelpers.GetHashCode(this);
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/StatementChunkGenerator.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/StatementChunkGenerator.cs
@@ -7,7 +7,7 @@ using System.Runtime.CompilerServices;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy;
 
-internal class StatementChunkGenerator : SpanChunkGenerator
+internal sealed class StatementChunkGenerator : SpanChunkGenerator
 {
     public static readonly StatementChunkGenerator Instance = new();
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/TagHelperBlockRewriter.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/TagHelperBlockRewriter.cs
@@ -576,7 +576,7 @@ internal static class TagHelperBlockRewriter
             {
                 // Change to a MarkupChunkGenerator so that the '@' \ parenthesis is generated as part of the output.
                 var context = node.GetSpanContext();
-                var newContext = new SpanContext(new MarkupChunkGenerator(), context.EditHandler);
+                var newContext = new SpanContext(MarkupChunkGenerator.Instance, context.EditHandler);
 
                 var expression = SyntaxFactory.CSharpExpressionLiteral(new SyntaxList<SyntaxToken>(node.Transition)).WithSpanContext(newContext);
 
@@ -596,7 +596,7 @@ internal static class TagHelperBlockRewriter
                 // Convert transition.
                 // Change to a MarkupChunkGenerator so that the '@' \ parenthesis is generated as part of the output.
                 var context = node.GetSpanContext();
-                var newContext = new SpanContext(new MarkupChunkGenerator(), context?.EditHandler ?? SpanEditHandler.CreateDefault((content) => Enumerable.Empty<Syntax.InternalSyntax.SyntaxToken>()));
+                var newContext = new SpanContext(MarkupChunkGenerator.Instance, context?.EditHandler ?? SpanEditHandler.CreateDefault((content) => Enumerable.Empty<Syntax.InternalSyntax.SyntaxToken>()));
 
                 var expression = SyntaxFactory.CSharpExpressionLiteral(new SyntaxList<SyntaxToken>(node.Transition.Transition)).WithSpanContext(newContext);
                 expression = (CSharpExpressionLiteralSyntax)VisitCSharpExpressionLiteral(expression);
@@ -624,7 +624,7 @@ internal static class TagHelperBlockRewriter
                 // Convert transition.
                 // Change to a MarkupChunkGenerator so that the '@' \ parenthesis is generated as part of the output.
                 var context = node.GetSpanContext();
-                var newContext = new SpanContext(new MarkupChunkGenerator(), context?.EditHandler ?? SpanEditHandler.CreateDefault((content) => Enumerable.Empty<Syntax.InternalSyntax.SyntaxToken>()));
+                var newContext = new SpanContext(MarkupChunkGenerator.Instance, context?.EditHandler ?? SpanEditHandler.CreateDefault((content) => Enumerable.Empty<Syntax.InternalSyntax.SyntaxToken>()));
 
                 var expression = SyntaxFactory.CSharpExpressionLiteral(new SyntaxList<SyntaxToken>(node.Transition.Transition)).WithSpanContext(newContext);
                 expression = (CSharpExpressionLiteralSyntax)VisitCSharpExpressionLiteral(expression);
@@ -671,7 +671,7 @@ internal static class TagHelperBlockRewriter
             {
                 // Change to a MarkupChunkGenerator so that the '@' \ parenthesis is generated as part of the output.
                 var context = node.GetSpanContext();
-                var newContext = new SpanContext(new MarkupChunkGenerator(), context.EditHandler);
+                var newContext = new SpanContext(MarkupChunkGenerator.Instance, context.EditHandler);
 
                 var expression = SyntaxFactory.CSharpExpressionLiteral(new SyntaxList<SyntaxToken>(node.MetaCode)).WithSpanContext(newContext);
 


### PR DESCRIPTION
Contributes to https://github.com/dotnet/razor/issues/7893. MarkupChunkGenerator is a stateless marker entity, and shows up 16 million times in the trace in the linked bug.

![image](https://user-images.githubusercontent.com/2371880/209885896-965d77ae-2ab9-4aef-8453-7e413b6ee7e1.png)

