### PR TITLE
[VS Code] Re-enable source build in VS Code feature branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -110,7 +110,7 @@ stages:
       enablePublishBuildArtifacts: true
       enablePublishTestResults: true
       enableTelemetry: true
-      enableSourcebuild: false
+      enableSourcebuild: true
       helixRepo: dotnet/razor
       helixType: build.product/
       # enableMicrobuild can't be read from a user-defined variable (Azure DevOps limitation)

--- a/eng/AfterSigning.targets
+++ b/eng/AfterSigning.targets
@@ -9,7 +9,7 @@
       Condition="!Exists('$(VSSetupDir)$(Configuration)\$(RazorExtensionVSIXName)')" />
   </Target>
 
-  <Target Name="_ZipLanguageServerBinaries" AfterTargets="Pack">
+  <Target Name="_ZipLanguageServerBinaries" AfterTargets="Pack" Condition="'$(DotNetBuildFromSource)' != 'true'">
     <!-- This target is defined in eng/targets/Packaging.targets and included in every project. -->
     <MSBuild Projects="$(RepoRoot)src\Razor\src\Microsoft.AspNetCore.Razor.LanguageServer\Microsoft.AspNetCore.Razor.LanguageServer.csproj"
         Targets="_GetPackageVersionInfo"

--- a/eng/AfterSolutionBuild.targets
+++ b/eng/AfterSolutionBuild.targets
@@ -1,6 +1,6 @@
 <Project>
 
-  <Target Name="_PublishLanguageServerRids" AfterTargets="Pack">
+  <Target Name="_PublishLanguageServerRids" AfterTargets="Pack" Condition="'$(DotNetBuildFromSource)' != 'true'">
     <PropertyGroup>
       <LanguageServerProject>$(MSBuildThisFileDirectory)..\src\Razor\src\rzls\rzls.csproj</LanguageServerProject>
       <RazorSolutionPath>$(MSBuildThisFileDirectory)..\Razor.sln</RazorSolutionPath>


### PR DESCRIPTION
### Summary of the changes
- Previously disabled source build in the VS Code feature branch (via https://github.com/dotnet/razor/pull/8049) since I couldn't determine how to prevent it from building `rzls.csproj`. After talking to Fred, this should hopefully be the solution.
