### PR TITLE
Fix md file warnings

### DIFF
--- a/README_compiler.md
+++ b/README_compiler.md
@@ -1,5 +1,4 @@
-Razor-Compiler
-=====
+# Razor-Compiler
 
 The Razor syntax provides a fast, terse, clean and lightweight way to combine server code with HTML to create dynamic web content. This repo contains the parser and the C# code generator for the Razor syntax.
 

--- a/docs/ProjectsAndLayering.md
+++ b/docs/ProjectsAndLayering.md
@@ -92,7 +92,7 @@ target the broadest set of frameworks.
 - Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X (`net7.0`;`net472`)
 - Microsoft.AspNetCore.Razor.Test.MvcShim.Version2_X (`net7.0`;`net4720`)
 
-### Tooling Core TEsts
+### Tooling Core Tests
 
 - Microsoft.CodeAnalysis.Razor.Workspaces.Test (`net7.0`;`net472` - only on Windows)
 - Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common (`net7.0`;`net472`)

--- a/docs/ProjectsAndLayering.md
+++ b/docs/ProjectsAndLayering.md
@@ -1,6 +1,8 @@
-# Product Layers
+# Layers
 
-## Shared
+## Product Layers
+
+### Shared
 
 This project is shared between all layers (both compiler and tooling) to provide language support types for modern C# language features.
 
@@ -8,7 +10,7 @@ This project is shared between all layers (both compiler and tooling) to provide
 - Projects:
   - Microsoft.AspNetCore.Razor.LanguageSupport
 
-## Compiler
+### Compiler
 
 - Target Framework: `netstandard2.0`
 - Projects:
@@ -19,7 +21,7 @@ This project is shared between all layers (both compiler and tooling) to provide
   - Microsoft.CodeAnalysis.Razor
   - Microsoft.NET.Sdk.Razor.SourceGenerators
 
-## Tooling Core
+### Tooling Core
 
 These projects are referenced by most Razor tooling projects. Because of this, they
 target the broadest set of frameworks.
@@ -29,7 +31,7 @@ target the broadest set of frameworks.
   - Microsoft.AspNetCore.Razor.Common
   - Microsoft.CodeAnalysis.Razor.Workspaces
 
-## Razor Language Server
+### Razor Language Server
 
 - Target Framework: `net7.0;net472`
 - Projects:
@@ -37,20 +39,20 @@ target the broadest set of frameworks.
   - Microsoft.AspNetCore.Razor.LanguageServer.Common
   - Microsoft.AspNetCore.Razor.LanguageServer.Protocol
 
-## Razor Language Server (rzls)
+### Razor Language Server (rzls)
 
 - Target Framework: `net7.0`
 - Projects:
   - rzls
 
-## Roslyn OOP (for Visual Studio)
+### Roslyn OOP (for Visual Studio)
 
 - Target Framework: `netstandard2.0`
 - Projects:
   - Microsoft.CodeAnalysis.Remote.Razor
   - Microsoft.CodeAnalysis.Remote.Razor.CoreComponents
 
-## Visual Studio (Windows)
+### Visual Studio (Windows)
 
 - Target Framework: `net472`
 - Projects:
@@ -62,27 +64,27 @@ target the broadest set of frameworks.
   - Microsoft.VisualStudio.RazorExtension.Dependencies
   - RazorDeployment
 
-## Visual Studio (Mac)
+### Visual Studio (Mac)
 
 - Target Framework: `net472`
 - Projects:
   - Microsoft.VisualStudio.Mac.LanguageServices.Razor
   - Microsoft.VisualStudio.Mac.RazorAddin
 
-## Visual Studio Code (OmniSharp Plug-in)
+### Visual Studio Code (OmniSharp Plug-in)
 
 - Target Framework: `net472`
 - Projects:
   - Microsoft.AspNetCore.Razor.OmniSharpPlugin
   - Microsoft.AspNetCore.Razor.OmniSHarpPlugin.StrongNamed
 
-# Testing Layers
+## Testing Layers
 
-## Shared
+### Shared test infra
 
 - Microsoft.AspNetCore.Razor.Test.Common (`net7.0`;`net472`)
 
-## API Shims
+### API Shims
 
 - Microsoft.AspNetCore.Razor.Test.ComponentShim (`netstandard2.0`)
 - Microsoft.AspNetCore.Razor.Test.MvcShim (`net7.0`;`net472`)
@@ -90,22 +92,22 @@ target the broadest set of frameworks.
 - Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X (`net7.0`;`net472`)
 - Microsoft.AspNetCore.Razor.Test.MvcShim.Version2_X (`net7.0`;`net4720`)
 
-## Tooling Core
+### Tooling Core TEsts
 
 - Microsoft.CodeAnalysis.Razor.Workspaces.Test (`net7.0`;`net472` - only on Windows)
 - Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common (`net7.0`;`net472`)
 
-## Language Server
+### Language Server
 
 - Microsoft.AspNetCore.Razor.LanguageServer.Common.Test (`net7.0`)
 - Microsoft.AspNetCore.Razor.LanguageServer.Test (`net7.0-windows`)
 - Microsoft.AspNetCore.Razor.LanguageServer.Test.Common (`net7.0`;`net472`)
 
-## Roslyn OOP (for Visual Studio)
+### Roslyn OOP (for Visual Studio) Tests
 
 - Microsoft.CodeAnalysis.Remote.Razor.Test (`net7.0`;`net472` - only on Windows)
 
-## Visual Studio Code (Windows)
+### Visual Studio Code (Windows)
 
 - Microsoft.VisualStudio.Editor.Razor.Test (`net472`)
 - Microsoft.VisualStudio.Editor.Razor.Test.Common (`net472`)
@@ -116,10 +118,10 @@ target the broadest set of frameworks.
 - Microsoft.VisualStudio.LiveShare.Razor.Test (`net472`)
 - Microsoft.VisualStudio.Razor.IntegrationTests (`net472`)
 
-## Visual Studio (Mac)
+### Visual Studio (Mac) Tests
 
 - Microsoft.VisualStudio.Mac.LanguageServices.Razor.Test (`net472`)
 
-## Visual Studio Code (OmniSharp Plug-in)
+### Visual Studio Code (OmniSharp Plug-in) Tests
 
 - Microsoft.AspNetCore.Razor.OmniSharpPlugin.Test (`net472`)


### PR DESCRIPTION
### Summary of the changes

- Mostly I just am annoyed by the warnings that show in VSCode, but I'm told that clean header usage helps screen-readers 
