### PR TITLE
Fix benchmarks to produce correct documents

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/ProjectSystem/ProjectSnapshotManagerBenchmarkBase.StaticProjectSnapshotProjectEngineFactory.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/ProjectSystem/ProjectSnapshotManagerBenchmarkBase.StaticProjectSnapshotProjectEngineFactory.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Mvc.Razor.Extensions;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+namespace Microsoft.AspNetCore.Razor.Microbenchmarks;
+
+public abstract partial class ProjectSnapshotManagerBenchmarkBase
+{
+    private class StaticProjectSnapshotProjectEngineFactory : ProjectSnapshotProjectEngineFactory
+    {
+        public override IProjectEngineFactory FindFactory(ProjectSnapshot project)
+            => throw new NotImplementedException();
+
+        public override IProjectEngineFactory FindSerializableFactory(ProjectSnapshot project)
+            => throw new NotImplementedException();
+
+        public override RazorProjectEngine Create(
+            RazorConfiguration configuration,
+            RazorProjectFileSystem fileSystem,
+            Action<RazorProjectEngineBuilder> configure)
+            => RazorProjectEngine.Create(configuration, fileSystem, RazorExtensions.Register);
+    }
+}

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/ProjectSystem/ProjectSnapshotManagerBenchmarkBase.StaticTagHelperResolver.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/ProjectSystem/ProjectSnapshotManagerBenchmarkBase.StaticTagHelperResolver.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Telemetry;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+namespace Microsoft.AspNetCore.Razor.Microbenchmarks;
+
+public abstract partial class ProjectSnapshotManagerBenchmarkBase
+{
+    private class StaticTagHelperResolver : TagHelperResolver
+    {
+        private readonly IReadOnlyList<TagHelperDescriptor> _tagHelpers;
+
+        public StaticTagHelperResolver(IReadOnlyList<TagHelperDescriptor> tagHelpers, ITelemetryReporter telemetryReporter)
+            : base(telemetryReporter)
+        {
+            _tagHelpers = tagHelpers;
+        }
+
+        public override Task<TagHelperResolutionResult> GetTagHelpersAsync(
+            Project project,
+            ProjectSnapshot projectSnapshot,
+            CancellationToken cancellationToken = default)
+            => Task.FromResult(new TagHelperResolutionResult(_tagHelpers, Array.Empty<RazorDiagnostic>()));
+    }
+}

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/ProjectSystem/ProjectSnapshotManagerBenchmarkBase.TestErrorReporter.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/ProjectSystem/ProjectSnapshotManagerBenchmarkBase.TestErrorReporter.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+namespace Microsoft.AspNetCore.Razor.Microbenchmarks;
+
+public abstract partial class ProjectSnapshotManagerBenchmarkBase
+{
+    private class TestErrorReporter : ErrorReporter
+    {
+        public override void ReportError(Exception exception)
+        {
+        }
+
+        public override void ReportError(Exception exception, ProjectSnapshot? project)
+        {
+        }
+
+        public override void ReportError(Exception exception, Project workspaceProject)
+        {
+        }
+    }
+}

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/ProjectSystem/ProjectSnapshotManagerBenchmarkBase.TestProjectSnapshotManagerDispatcher.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/ProjectSystem/ProjectSnapshotManagerBenchmarkBase.TestProjectSnapshotManagerDispatcher.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Razor;
+
+namespace Microsoft.AspNetCore.Razor.Microbenchmarks;
+
+public abstract partial class ProjectSnapshotManagerBenchmarkBase
+{
+    private class TestProjectSnapshotManagerDispatcher : ProjectSnapshotManagerDispatcher
+    {
+        public override bool IsDispatcherThread => true;
+
+        public override TaskScheduler DispatcherScheduler => TaskScheduler.Default;
+    }
+}

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/ProjectSystem/ProjectSnapshotManagerBenchmarkBase.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/ProjectSystem/ProjectSnapshotManagerBenchmarkBase.cs
@@ -1,16 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc.Razor.Extensions;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.AspNetCore.Razor.Telemetry;
+using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Razor;
@@ -22,47 +18,53 @@ using Newtonsoft.Json;
 
 namespace Microsoft.AspNetCore.Razor.Microbenchmarks;
 
-public class ProjectSnapshotManagerBenchmarkBase
+public abstract partial class ProjectSnapshotManagerBenchmarkBase
 {
-    public ProjectSnapshotManagerBenchmarkBase()
+    internal HostProject HostProject { get; }
+    internal ImmutableArray<HostDocument> Documents { get; }
+    internal ImmutableArray<TextLoader> TextLoaders { get; }
+    internal TagHelperResolver TagHelperResolver { get; }
+
+    protected ProjectSnapshotManagerBenchmarkBase()
     {
         var current = new DirectoryInfo(AppContext.BaseDirectory);
-        while (current != null && !File.Exists(Path.Combine(current.FullName, "Razor.sln")))
+        while (current is not null && !File.Exists(Path.Combine(current.FullName, "Razor.sln")))
         {
             current = current.Parent;
         }
 
-        var root = current;
+        var root = current ?? throw new InvalidOperationException("Could not find Razor.sln");
         var projectRoot = Path.Combine(root.FullName, "src", "Razor", "test", "testapps", "LargeProject");
 
         HostProject = new HostProject(Path.Combine(projectRoot, "LargeProject.csproj"), FallbackRazorConfiguration.MVC_2_1, rootNamespace: null);
 
-        TextLoaders = new TextLoader[4];
+        using var _1 = ArrayBuilderPool<TextLoader>.GetPooledObject(out var textLoaders);
+
         for (var i = 0; i < 4; i++)
         {
             var filePath = Path.Combine(projectRoot, "Views", "Home", $"View00{i % 4}.cshtml");
-            var text = SourceText.From(filePath, encoding: null);
-            TextLoaders[i] = TextLoader.From(TextAndVersion.Create(text, VersionStamp.Create()));
+            var fileText = File.ReadAllText(filePath);
+            var text = SourceText.From(fileText);
+            textLoaders.Add(
+                TextLoader.From(TextAndVersion.Create(text, VersionStamp.Create(), filePath)));
         }
 
-        Documents = new HostDocument[100];
-        for (var i = 0; i < Documents.Length; i++)
+        TextLoaders = textLoaders.ToImmutable();
+
+        using var _2 = ArrayBuilderPool<HostDocument>.GetPooledObject(out var documents);
+
+        for (var i = 0; i < 100; i++)
         {
             var filePath = Path.Combine(projectRoot, "Views", "Home", $"View00{i % 4}.cshtml");
-            Documents[i] = new HostDocument(filePath, $"/Views/Home/View00{i}.cshtml", FileKinds.Legacy);
+            documents.Add(
+                new HostDocument(filePath, $"/Views/Home/View00{i}.cshtml", FileKinds.Legacy));
         }
+
+        Documents = documents.ToImmutable();
 
         var tagHelpers = Path.Combine(root.FullName, "src", "Razor", "benchmarks", "Microsoft.AspNetCore.Razor.Microbenchmarks", "taghelpers.json");
         TagHelperResolver = new StaticTagHelperResolver(ReadTagHelpers(tagHelpers), NoOpTelemetryReporter.Instance);
     }
-
-    internal HostProject HostProject { get; }
-
-    internal HostDocument[] Documents { get; }
-
-    internal TextLoader[] TextLoaders { get; }
-
-    internal TagHelperResolver TagHelperResolver { get; }
 
     internal DefaultProjectSnapshotManager CreateProjectSnapshotManager()
     {
@@ -86,68 +88,10 @@ public class ProjectSnapshotManagerBenchmarkBase
     private static IReadOnlyList<TagHelperDescriptor> ReadTagHelpers(string filePath)
     {
         var serializer = new JsonSerializer();
-        serializer.Converters.Add(new RazorDiagnosticJsonConverter());
+        serializer.Converters.Add(RazorDiagnosticJsonConverter.Instance);
         serializer.Converters.Add(TagHelperDescriptorJsonConverter.Instance);
 
-        using (var reader = new JsonTextReader(File.OpenText(filePath)))
-        {
-            return serializer.Deserialize<IReadOnlyList<TagHelperDescriptor>>(reader);
-        }
-    }
-
-    private class TestProjectSnapshotManagerDispatcher : ProjectSnapshotManagerDispatcher
-    {
-        public override bool IsDispatcherThread => true;
-
-        public override TaskScheduler DispatcherScheduler => TaskScheduler.Default;
-    }
-
-    private class TestErrorReporter : ErrorReporter
-    {
-        public override void ReportError(Exception exception)
-        {
-        }
-
-        public override void ReportError(Exception exception, ProjectSnapshot project)
-        {
-        }
-
-        public override void ReportError(Exception exception, Project workspaceProject)
-        {
-        }
-    }
-
-    private class StaticTagHelperResolver : TagHelperResolver
-    {
-        private readonly IReadOnlyList<TagHelperDescriptor> _tagHelpers;
-
-        public StaticTagHelperResolver(IReadOnlyList<TagHelperDescriptor> tagHelpers, ITelemetryReporter telemetryReporter)
-            : base(telemetryReporter)
-        {
-            _tagHelpers = tagHelpers;
-        }
-
-        public override Task<TagHelperResolutionResult> GetTagHelpersAsync(Project project, ProjectSnapshot projectSnapshot, CancellationToken cancellationToken = default)
-        {
-            return Task.FromResult(new TagHelperResolutionResult(_tagHelpers, Array.Empty<RazorDiagnostic>()));
-        }
-    }
-
-    private class StaticProjectSnapshotProjectEngineFactory : ProjectSnapshotProjectEngineFactory
-    {
-        public override IProjectEngineFactory FindFactory(ProjectSnapshot project)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override IProjectEngineFactory FindSerializableFactory(ProjectSnapshot project)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override RazorProjectEngine Create(RazorConfiguration configuration, RazorProjectFileSystem fileSystem, Action<RazorProjectEngineBuilder> configure)
-        {
-            return RazorProjectEngine.Create(configuration, fileSystem, b => RazorExtensions.Register(b));
-        }
+        using var reader = new JsonTextReader(File.OpenText(filePath));
+        return serializer.Deserialize<IReadOnlyList<TagHelperDescriptor>>(reader) ?? Array.Empty<TagHelperDescriptor>();
     }
 }


### PR DESCRIPTION
This change cleans up `ProjectSnapshotManagerBenchmarkBase` a bit, which is the base class of several of the tooling benchmarks. While cleaning this up, I was surprised to find a bug where several documents with initialized with a file path as the text, rather than the actual file text. This results in some benchmarks, notably `BackgroundCodeGenerationBenchmark`, being completely invalid.