### PR TITLE
Fix benchmarks that use RazorLanguageServer

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
@@ -16,6 +16,7 @@ using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Nerdbank.Streams;
 
 namespace Microsoft.AspNetCore.Razor.Microbenchmarks.LanguageServer;
 
@@ -31,9 +32,9 @@ public class RazorLanguageServerBenchmarkBase : ProjectSnapshotManagerBenchmarkB
 
         RepoRoot = current.FullName;
 
-        using var memoryStream = new MemoryStream();
+        var (_, serverStream) = FullDuplexStream.CreatePair();
         var logger = new NoopLogger();
-        RazorLanguageServer = RazorLanguageServerWrapper.Create(memoryStream, memoryStream, logger, configure: (collection) => {
+        RazorLanguageServer = RazorLanguageServerWrapper.Create(serverStream, serverStream, logger, configure: (collection) => {
             collection.AddSingleton<ClientNotifierServiceBase, NoopClientNotifierService>();
             Builder(collection);
         });


### PR DESCRIPTION
The stream used for input/output with the language server shouldn't be disposed before the language server is used.