### PR TITLE
Fix diagnostics when only C# diagnostics exists

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -1140,7 +1140,11 @@ internal class DefaultRazorLanguageServerCustomMessageTarget : RazorLanguageServ
             request,
             cancellationToken).ConfigureAwait(false);
 
-        if (response is null)
+        // Sometimes web tools will respond with a non-null response, of an array of diagnostics with a single element
+        // in it, but the actual diagnostics (and every other property) in that element are null. This confuses VS, and
+        // means we don't get squiggles for C# diagnostics, unless there are also Html diagnostics.
+        // This check ensures we catch that, and just return an empty result for Html diagnostics.
+        if (response?.Response is null or [{ Diagnostics: null }, ..])
         {
             return null;
         }

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/DiagnosticTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/DiagnosticTests.cs
@@ -114,6 +114,46 @@ public class DiagnosticTests : AbstractRazorEditorTest
     }
 
     [IdeFact]
+    public async Task Diagnostics_ShowErrors_CSharp_NoDocType()
+    {
+        // Why this test, when we have the above test, and they seem so similar, and we also have Diagnostics_ShowErrors_CSharpAndHtml you ask? Well I'll tell you!
+        //
+        // In the above test, with a doctype, the Html LSP server returns a diagnostic result containing one item, which has an empty array of actual diagnostics within it.
+        // In Diagnostics_ShowErrors_CSharpAndHtml, the Html LSP server returns a diagnostic result containing one item, which has one actual diagnostic inside it.
+        // In this test, with no doctype, the Html LSP server returns a diagnostic result containing one item, which has null for the actual diagnostics within it.
+        //
+        // The Visual Studio error system (squiggles and error list) didn't like that last case, so given that quirkiness and the slight differences in results, there
+        // is value in having a range of tests to make sure nothing regresses.
+
+        // Arrange
+        await TestServices.SolutionExplorer.OpenFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.ErrorCshtmlFile, ControlledHangMitigatingCancellationToken);
+
+        await TestServices.Editor.SetTextAsync(@"
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+
+<html lang=""en"">
+<head>
+</head>
+
+<body>
+    <input asp-for=""Test"" />
+</body>
+</html>
+
+", ControlledHangMitigatingCancellationToken);
+
+        // Act
+        var errors = await TestServices.ErrorList.WaitForErrorsAsync("Error.cshtml", expectedCount: 1, ControlledHangMitigatingCancellationToken);
+
+        // Assert
+        Assert.Collection(errors,
+            (error) =>
+            {
+                Assert.Equal("Error.cshtml(10, 21): error CS1963: An expression tree may not contain a dynamic operation", error);
+            });
+    }
+
+    [IdeFact]
     public async Task Diagnostics_ShowErrors_CSharpAndHtml()
     {
         // Arrange

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/DiagnosticTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/DiagnosticTests.cs
@@ -149,7 +149,7 @@ public class DiagnosticTests : AbstractRazorEditorTest
         Assert.Collection(errors,
             (error) =>
             {
-                Assert.Equal("Error.cshtml(10, 21): error CS1963: An expression tree may not contain a dynamic operation", error);
+                Assert.Equal("Error.cshtml(9, 21): error CS1963: An expression tree may not contain a dynamic operation", error);
             });
     }
 


### PR DESCRIPTION
... and when there is no doctype.

I _think_ this might fix the integration test failures we're seeing in CI.