### PR TITLE
Show position owner info in Syntax Visualizer

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/SyntaxVisualizer/SyntaxVisualizerControl.xaml
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/SyntaxVisualizer/SyntaxVisualizerControl.xaml
@@ -21,6 +21,7 @@
         </ResourceDictionary>
     </UserControl.Resources>
     <DockPanel>
+        <Label x:Name="infoLabel" AutomationProperties.Name="Info" DockPanel.Dock="Top" Content="&lt;info&gt;" />
         <TreeView x:Name="treeView" AutomationProperties.Name="Nodes" KeyUp="treeView_KeyUp">
             <TreeView.Resources>
                 <!-- Style the inactive selection the same as active -->


### PR DESCRIPTION
In preparing for a meeting with the compiler folks, I thought this might be a useful addition (and helps illustrate some quirks).

Looks like this (above the treeview):
<img width="348" alt="image" src="https://user-images.githubusercontent.com/754264/210876484-b245dcf0-981a-4db2-968a-89bf4e4b5eca.png">
