### PR TITLE
Conditionally deploy Roslyn dependencies

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -210,6 +210,7 @@ stages:
             $(_BuildArgs)
             $(_PublishArgs)
             $(_InternalRuntimeDownloadArgs)
+            /p:IncludeRoslynDeps=true
           name: Build
           displayName: Build and Deploy
           condition: succeeded()

--- a/docs/contributing/BuildFromSource.md
+++ b/docs/contributing/BuildFromSource.md
@@ -59,7 +59,15 @@ Before opening the `Razor.sln` file in Visual Studio or VS Code, you need to per
    in PowerShell. For more information on execution policies, you can read the [execution policy docs](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy).
 
 2. Use the `.\startvs.cmd Razor.sln` script to open Visual Studio with the Razor solution. This script first sets the required
-environment variables.
+environment variables. In addition, the following switches can be specified:
+
+   * `-chooseVS`: When specified, displays a list of the installed Visual Studio instances and prompts to
+     pick an instance to launch. By default, the newest recently installed instance of Visual Studio is
+     launched.
+   * `-includeRoslynDeps`: When specified, sets an environment variable that causes the Roslyn dependences
+     of Razor to be deployed. This can be useful if the latest Razor bits depend on a breaking change in
+     Roslyn that isn't available in the version of Visual Studio being targeted. If you encounter errors
+     when debugging the Razor bits that you've built and deployed, setting this switch _might_ fix them.
 
 3. Set `Microsoft.VisualStudio.RazorExtension` as the startup project.
 

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension.Dependencies/AssemblyCodeBases.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension.Dependencies/AssemblyCodeBases.cs
@@ -3,6 +3,11 @@
 
 using Microsoft.VisualStudio.Shell;
 
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.VisualStudio.LanguageServer.Protocol.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.VisualStudio.LanguageServer.Protocol.Internal.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.VisualStudio.LanguageServer.Protocol.Extensions.dll")]
+
+#if INCLUDE_ROSLYN_DEPS
 [assembly: ProvideBindingRedirection(
     AssemblyName = "Microsoft.CodeAnalysis",
     GenerateCodeBase = true,
@@ -95,6 +100,4 @@ using Microsoft.VisualStudio.Shell;
     NewVersion = "4.5.0.0")]
 
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.CodeAnalysis.Workspaces.dll")]
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.VisualStudio.LanguageServer.Protocol.dll")]
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.VisualStudio.LanguageServer.Protocol.Internal.dll")]
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.VisualStudio.LanguageServer.Protocol.Extensions.dll")]
+#endif

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension.Dependencies/Microsoft.VisualStudio.RazorExtension.Dependencies.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension.Dependencies/Microsoft.VisualStudio.RazorExtension.Dependencies.csproj
@@ -25,6 +25,7 @@
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
+    <DefineConstants Condition="'$(IncludeRoslynDeps)' == 'true'">$(DefineConstants);INCLUDE_ROSLYN_DEPS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -42,22 +43,30 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="$(MicrosoftVisualStudioShell150PackageVersion)" />
   </ItemGroup>
 
+  <!-- Reference the LSP protocol dlls so that we can include them in the code base and output them with the VSIX. -->
   <ItemGroup>
-    <!-- Reference the Roslyn dependencies so that Preview builds work -->
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="$(Tooling_MicrosoftCodeAnalysisCSharpFeaturesPackageVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.EditorFeatures" Version="$(RoslynPackageVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.EditorFeatures.Wpf" Version="$(RoslynPackageVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.ExternalAccess.Razor" Version="$(Tooling_MicrosoftCodeAnalysisExternalAccessRazorPackageVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.ExternalAccess.FSharp" Version="$(Tooling_MicrosoftCodeAnalysisExternalAccessRazorPackageVersion)" />
-    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="$(Tooling_MicrosoftVisualStudioLanguageServicesPackageVersion)" />
-
-    <!-- Reference the LSP protocol dlls so that we can include them in the code base and output them with the VSIX. -->
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="$(MicrosoftVisualStudioLanguageServerProtocolPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol.Extensions" Version="$(MicrosoftVisualStudioLanguageServerProtocolExtensionsPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol.Internal" Version="$(MicrosoftVisualStudioLanguageServerProtocolInternalPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>
+    <VSIXSourceItem Include="$(OutputPath)Microsoft.VisualStudio.LanguageServer.Protocol.dll" />
+    <VSIXSourceItem Include="$(OutputPath)Microsoft.VisualStudio.LanguageServer.Protocol.Extensions.dll" />
+    <VSIXSourceItem Include="$(OutputPath)Microsoft.VisualStudio.LanguageServer.Protocol.Internal.dll" />
+  </ItemGroup>
+
+  <!-- Reference the Roslyn dependencies so that Preview builds work -->
+  <ItemGroup Condition="'$(IncludeRoslynDeps)' == 'true'">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="$(Tooling_MicrosoftCodeAnalysisCSharpFeaturesPackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.EditorFeatures" Version="$(RoslynPackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.EditorFeatures.Wpf" Version="$(RoslynPackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.ExternalAccess.Razor" Version="$(Tooling_MicrosoftCodeAnalysisExternalAccessRazorPackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.ExternalAccess.FSharp" Version="$(Tooling_MicrosoftCodeAnalysisExternalAccessRazorPackageVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="$(Tooling_MicrosoftVisualStudioLanguageServicesPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IncludeRoslynDeps)' == 'true'">
     <VSIXSourceItem Include="$(OutputPath)Microsoft.CodeAnalysis.dll" />
     <VSIXSourceItem Include="$(OutputPath)Microsoft.CodeAnalysis.CSharp.dll" />
     <VSIXSourceItem Include="$(OutputPath)Microsoft.CodeAnalysis.CSharp.Features.dll" />
@@ -72,8 +81,5 @@
     <VSIXSourceItem Include="$(OutputPath)Microsoft.CodeAnalysis.Remote.Workspaces.dll" />
     <VSIXSourceItem Include="$(OutputPath)Microsoft.CodeAnalysis.Workspaces.dll" />
     <VSIXSourceItem Include="$(OutputPath)Microsoft.VisualStudio.LanguageServices.dll" />
-    <VSIXSourceItem Include="$(OutputPath)Microsoft.VisualStudio.LanguageServer.Protocol.dll" />
-    <VSIXSourceItem Include="$(OutputPath)Microsoft.VisualStudio.LanguageServer.Protocol.Extensions.dll" />
-    <VSIXSourceItem Include="$(OutputPath)Microsoft.VisualStudio.LanguageServer.Protocol.Internal.dll" />
   </ItemGroup>
 </Project>

--- a/startvs.cmd
+++ b/startvs.cmd
@@ -1,27 +1,4 @@
-﻿@ECHO OFF
-SETLOCAL
+@echo off
+setlocal
 
-:: This command launches a Visual Studio solution with environment variables required to use a local version of the .NET Core SDK.
-
-:: This tells .NET Core to use the same dotnet.exe that build scripts use
-SET DOTNET_ROOT=%~dp0.dotnet
-SET DOTNET_ROOT(x86)=%~dp0.dotnet\x86
-
-:: This tells .NET Core not to go looking for .NET Core in other places
-SET DOTNET_MULTILEVEL_LOOKUP=0
-
-:: Put our local dotnet.exe on PATH first so Visual Studio knows which one to use
-SET PATH=%DOTNET_ROOT%;%PATH%
-
-SET sln=%~1
-
-IF "%sln%"=="" (
-    SET sln=%~dp0\Razor.sln
-)
-
-IF NOT EXIST "%DOTNET_ROOT%\dotnet.exe" (
-    echo .NET Core has not yet been installed. Run `%~dp0restore.cmd` to install tools
-    exit /b 1
-)
-
-start "" "%sln%"
+powershell -ExecutionPolicy ByPass -NoProfile -Command "& '%~dp0startvs.ps1'" %*

--- a/startvs.ps1
+++ b/startvs.ps1
@@ -1,0 +1,75 @@
+[CmdletBinding(PositionalBinding=$true)]
+Param(
+    [Parameter(
+        Position=0,
+        Mandatory=$false,
+        HelpMessage="Solution file to open. The default is 'Razor.sln'.")]
+    [string]$solutionFile=$null,
+
+    [Parameter(
+        Mandatory=$false,
+        HelpMessage="If specified, choose the Visual Studio version from a list before laucnhing. By default the newest and last installed Visual Studio instance will be launched.")]
+    [Switch]$chooseVS,
+
+    [Parameter(
+        Mandatory=$false,
+        HelpMessage="If specified, Roslyn dependencies will be included in the Razor extension when deployed.")]
+    [Switch]$includeRoslynDeps
+)
+
+if ($solutionFile -eq "") {
+    $solutionFile = "Razor.sln"
+}
+
+if ($includeRoslynDeps) {
+    # Setting this environment variable ensures that the MSBuild will see it when
+    # building from inside Visual Studio.
+    $env:IncludeRoslynDeps = $true
+}
+
+$dotnetPath = Join-Path (Get-Location) ".dotnet"
+
+# This tells .NET Core to use the same dotnet.exe that build scripts use
+$env:DOTNET_ROOT = $dotnetPath
+${env:DOTNET_ROOT(x86)} = Join-Path $dotnetPath "x86"
+
+# This tells .NET Core not to go looking for .NET Core in other places
+$env:DOTNET_MULTILEVEL_LOOKUP = 0
+
+# Put our local dotnet.exe on PATH first so Visual Studio knows which one to use
+$env:PATH = $env:DOTNET_ROOT + ";" + $env:PATH
+
+$vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+
+if ($chooseVS) {
+    # Launch vswhere.exe to retrieve a list of installed Visual Studio instances
+    $vsInstallsJson = &$vswhere -prerelease -format json
+    $vsInstalls = $vsInstallsJson | ConvertFrom-Json
+
+    # Display a menu of Visual Studio instances to the user
+    Write-Host ""
+
+    $index = 1
+
+    foreach ($vsInstall in $vsInstalls) {
+        $channelId = $vsInstall.installedChannelId
+        $lastDotIndex = $channelId.LastIndexOf(".")
+        $channelName = $channelId.Substring($lastDotIndex + 1);
+
+        Write-Host "    $($index) - $($vsInstall.displayName) ($($vsInstall.installationVersion) - $($channelName))"
+        $index += 1
+    }
+
+    Write-Host ""
+    $choice = [int](Read-Host "Choose a Visual Studio version to launch")
+
+    $vsBasePath = $vsInstalls[$choice - 1].installationPath
+}
+else {
+    # Launch vswhere.exe to retrieve the newest, last installed Visual Studio instance
+    $vsBasePath = &$vswhere -prerelease -latest -property installationPath
+}
+
+$vsPath = Join-Path $vsBasePath "Common7\IDE\devenv.exe"
+
+Start-Process $vsPath -ArgumentList $solutionFile


### PR DESCRIPTION
Razor tooling deploys Roslyn dependencies to allow integration tests and VS hive debugging to function against VS preview builds. However, on local dev boxes, where VS IntPreview should be used for dogfooding, this can result in hard-to-diagnose problems when some Roslyn dependencies are loaded from the Razor tooling deployment and others are loaded from the VS install.

This change only deploys Roslyn dependencies if the `IncludeRoslynDeps` MSBuild property is set to true. This is needed for running integration tests in CI, so the job has been updated to set that property.
