### PR TITLE
Reduce allocations and O(n) lookup in completion

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.Common/ListExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.Common/ListExtensions.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor;
+
+internal static class ListExtensions
+{
+    /// <summary>
+    ///  Set the <paramref name="list"/>'s capacity if it is less than <paramref name="newCapacity"/>.
+    /// </summary>
+    public static void SetCapacityIfLarger<T>(this List<T> list, int newCapacity)
+    {
+        if (list.Capacity < newCapacity)
+        {
+            list.Capacity = newCapacity;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Protocol/DebuggerDisplay.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Protocol/DebuggerDisplay.cs
@@ -1,0 +1,7 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+[assembly: DebuggerDisplay("{Label} ({Kind})", Target = typeof(CompletionItem))]

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ClientNotifierServiceBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ClientNotifierServiceBase.cs
@@ -8,7 +8,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
 // The VSCode OmniSharp client starts the RazorServer before all of its handlers are registered
-// because of this we need to wait until everthing is initialized to make some client requests.
+// because of this we need to wait until everything is initialized to make some client requests.
 // This class takes a TCS which will complete when everything is initialized
 // ensuring that no requests are sent before the client is ready.
 internal abstract class ClientNotifierServiceBase : IOnInitialized

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/CompletionListCache.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/CompletionListCache.cs
@@ -2,28 +2,30 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion;
 
 internal sealed class CompletionListCache
 {
+    private record struct Slot(
+        int Id,
+        VSInternalCompletionList CompletionList,
+        object? Context,
+        bool Used = true);
+
     // Internal for testing
-    internal static readonly int MaxCacheSize = 10;
+    internal const int MaxCacheSize = 10;
 
-    private readonly object _accessLock;
-    private readonly List<CacheEntry> _resultIdToCacheEntry;
-    private int _nextResultId;
+    private readonly object _accessLock = new();
 
-    public CompletionListCache()
-    {
-        _accessLock = new object();
-        _resultIdToCacheEntry = new List<CacheEntry>();
-    }
+    // This is used as a circular buffer.
+    private readonly Slot[] _items = new Slot[MaxCacheSize];
 
-    public int Set(VSInternalCompletionList completionList, object? context)
+    private int _nextIndex;
+    private int _nextId;
+
+    public int Add(VSInternalCompletionList completionList, object? context)
     {
         if (completionList is null)
         {
@@ -32,41 +34,58 @@ internal sealed class CompletionListCache
 
         lock (_accessLock)
         {
-            // If cache exceeds maximum size, remove the oldest list in the cache
-            if (_resultIdToCacheEntry.Count >= MaxCacheSize)
+            var index = _nextIndex++;
+            var id = _nextId++;
+
+            _items[index] = new Slot(id, completionList, context);
+
+            if (_nextIndex == MaxCacheSize)
             {
-                _resultIdToCacheEntry.RemoveAt(0);
+                _nextIndex = 0;
             }
 
-            var resultId = _nextResultId++;
-            var cacheEntry = new CacheEntry(resultId, completionList, context);
-            _resultIdToCacheEntry.Add(cacheEntry);
-
-            // Return generated resultId so completion list can later be retrieved from cache
-            return resultId;
+            // Return generated id so the completion list can be retrieved later.
+            return id;
         }
     }
 
-    public bool TryGet(int resultId, [NotNullWhen(returnValue: true)] out CacheEntry? cachedEntry)
+    public bool TryGet(int id, out (VSInternalCompletionList CompletionList, object? Context) result)
     {
         lock (_accessLock)
         {
-            // Search back -> front because the items in the back are the most recently added which are most frequently accessed.
-            for (var i = _resultIdToCacheEntry.Count - 1; i >= 0; i--)
+            var index = _nextIndex;
+            var count = MaxCacheSize;
+
+            // Search back to front because the items in the back are the most recently added
+            // which are most frequently accessed.
+            while (count > 0)
             {
-                var entry = _resultIdToCacheEntry[i];
-                if (entry.ResultId == resultId)
+                index--;
+
+                if (index < 0)
                 {
-                    cachedEntry = entry;
+                    index = MaxCacheSize - 1;
+                }
+
+                var slot = _items[index];
+
+                if (!slot.Used)
+                {
+                    break;
+                }
+
+                if (slot.Id == id)
+                {
+                    result = (slot.CompletionList, slot.Context);
                     return true;
                 }
+
+                count--;
             }
 
-            // A cache entry associated with the given resultId was not found
-            cachedEntry = null;
+            // A cache entry associated with the given id was not found.
+            result = default;
             return false;
         }
     }
-
-    public record CacheEntry(int ResultId, VSInternalCompletionList CompletionList, object? Context);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/CompletionListCache.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/CompletionListCache.cs
@@ -39,6 +39,9 @@ internal sealed class CompletionListCache
 
             _items[index] = new Slot(id, completionList, context);
 
+            // _nextIndex should always point to the index where we'll access the next element
+            // in the circular buffer. Here, we check to see if it is after the last index.
+            // If it is, we change it to the first index to properly "wrap around" the array.
             if (_nextIndex == MaxCacheSize)
             {
                 _nextIndex = 0;
@@ -62,6 +65,8 @@ internal sealed class CompletionListCache
             {
                 index--;
 
+                // If we're before the first index in the array, switch to the last index to
+                // "wrap around" the array.
                 if (index < 0)
                 {
                     index = MaxCacheSize - 1;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionItemResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionItemResolver.cs
@@ -29,7 +29,7 @@ internal class DelegatedCompletionItemResolver : CompletionItemResolver
 
     public override async Task<VSInternalCompletionItem?> ResolveAsync(
         VSInternalCompletionItem item,
-        VSInternalCompletionList containingCompletionlist,
+        VSInternalCompletionList containingCompletionList,
         object? originalRequestContext,
         VSInternalClientCapabilities? clientCapabilities,
         CancellationToken cancellationToken)
@@ -41,7 +41,7 @@ internal class DelegatedCompletionItemResolver : CompletionItemResolver
         }
 
         var labelQuery = item.Label;
-        var associatedDelegatedCompletion = containingCompletionlist.Items.FirstOrDefault(completion => string.Equals(labelQuery, completion.Label, StringComparison.Ordinal));
+        var associatedDelegatedCompletion = containingCompletionList.Items.FirstOrDefault(completion => string.Equals(labelQuery, completion.Label, StringComparison.Ordinal));
         if (associatedDelegatedCompletion is null)
         {
             return null;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DesignTimeHelperResponseRewriter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DesignTimeHelperResponseRewriter.cs
@@ -1,24 +1,25 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
-using Microsoft.CodeAnalysis;
+using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using RazorSyntaxNode = Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxNode;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation;
 
+/// <summary>
+///  Removes Razor design-time helpers from a C# completion list.
+/// </summary>
 internal class DesignTimeHelperResponseRewriter : DelegatedCompletionResponseRewriter
 {
-    private static readonly IReadOnlyList<string> s_designTimeHelpers = new string[]
+    private static readonly ImmutableHashSet<string> s_designTimeHelpers = new[]
     {
         "__builder",
         "__o",
@@ -28,12 +29,7 @@ internal class DesignTimeHelperResponseRewriter : DelegatedCompletionResponseRew
         "__typeHelper",
         "_Imports",
         "BuildRenderTree"
-    };
-
-    private static readonly IReadOnlyList<CompletionItem> s_designTimeHelpersCompletionItems =
-        s_designTimeHelpers
-            .Select(item => new CompletionItem { Label = item })
-            .ToArray();
+    }.ToImmutableHashSet();
 
     public override int Order => ExecutionBehaviorOrder.FiltersCompletionItems;
 
@@ -59,57 +55,49 @@ internal class DesignTimeHelperResponseRewriter : DelegatedCompletionResponseRew
 
         var sourceText = await hostDocumentContext.GetSourceTextAsync(cancellationToken).ConfigureAwait(false);
 
-        // We should remove Razor design time helpers from C#'s completion list. If the current identifier being targeted does not start with a double
-        // underscore, we trim out all items starting with "__" from the completion list. If the current identifier does start with a double underscore
-        // (e.g. "__ab[||]"), we only trim out common design time helpers from the completion list.
+        // We should remove Razor design-time helpers from C#'s completion list. If the current identifier
+        // being targeted does not start with a double underscore, we trim out all items starting with "__"
+        // from the completion list. If the current identifier does start with a double underscore (e.g. "__ab[||]"),
+        // we only trim out common design time helpers from the completion list.
 
-        var filteredItems = completionList.Items.Except(s_designTimeHelpersCompletionItems, CompletionItemComparer.Instance).ToArray();
+        using var _ = ListPool<CompletionItem>.GetPooledObject(out var filteredItems);
 
-        if (ShouldRemoveAllDesignTimeItems(owner, sourceText))
+        var items = completionList.Items;
+        filteredItems.SetCapacityIfLarger(items.Length);
+
+        var shouldRemoveAllDesignTimeItems = StartsWithDoubleUnderscore(owner, sourceText);
+
+        foreach (var item in items)
         {
-            filteredItems = filteredItems.Where(item => item.Label != null && !item.Label.StartsWith("__", StringComparison.Ordinal)).ToArray();
+            if (s_designTimeHelpers.Contains(item.Label) || (shouldRemoveAllDesignTimeItems && item.Label.StartsWith("__")))
+            {
+                continue;
+            }
+
+            filteredItems.Add(item);
         }
 
-        completionList.Items = filteredItems;
+        // Avoid allocating array if nothing was filtered.
+        if (items.Length != filteredItems.Count)
+        {
+            completionList.Items = filteredItems.ToArray();
+        }
+
         return completionList;
     }
 
-    // If the current identifier starts with "__", only trim out common design time helpers from the list.
-    // In all other cases, trim out both common design time helpers and all completion items starting with "__".
-    private static bool ShouldRemoveAllDesignTimeItems(RazorSyntaxNode owner, SourceText sourceText)
+    private static bool StartsWithDoubleUnderscore(RazorSyntaxNode owner, SourceText sourceText)
     {
-        if (owner.Span.Length < 2)
+        // If the current identifier starts with "__", only trim out common design time helpers from the list.
+        // In all other cases, trim out both common design-time helpers and all completion items starting with "__".
+
+        var span = owner.Span;
+        if (span.Length < 2)
         {
             return true;
         }
 
-        if (sourceText[owner.Span.Start] == '_' && sourceText[owner.Span.Start + 1] == '_')
-        {
-            return false;
-        }
-
-        return true;
-    }
-
-    private class CompletionItemComparer : IEqualityComparer<CompletionItem>
-    {
-        public static CompletionItemComparer Instance = new();
-
-        public bool Equals(CompletionItem? x, CompletionItem? y)
-        {
-            if (x is null)
-            {
-                return y is null;
-            }
-            else if (y is null)
-            {
-                return false;
-            }
-
-            return x.Label == y.Label;
-        }
-
-        public int GetHashCode(CompletionItem obj)
-            => obj?.Label?.GetHashCode() ?? 0;
+        var start = span.Start;
+        return sourceText[start] != '_' || sourceText[start + 1] != '_';
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/TextEditResponseRewriter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/TextEditResponseRewriter.cs
@@ -31,9 +31,9 @@ internal class TextEditResponseRewriter : DelegatedCompletionResponseRewriter
         var hostDocumentPosition = new Position(lineNumber, characterOffset);
         completionList = TranslateTextEdits(hostDocumentPosition, delegatedParameters.ProjectedPosition, completionList);
 
-        if (completionList.ItemDefaults?.EditRange != null)
+        if (completionList.ItemDefaults?.EditRange is { } editRange)
         {
-            completionList.ItemDefaults.EditRange = TranslateRange(hostDocumentPosition, delegatedParameters.ProjectedPosition, completionList.ItemDefaults.EditRange);
+            completionList.ItemDefaults.EditRange = TranslateRange(hostDocumentPosition, delegatedParameters.ProjectedPosition, editRange);
         }
 
         return completionList;
@@ -53,12 +53,12 @@ internal class TextEditResponseRewriter : DelegatedCompletionResponseRewriter
 
         foreach (var item in completionList.Items)
         {
-            if (item.TextEdit != null)
+            if (item.TextEdit is { } textEdit)
             {
-                var translatedRange = TranslateRange(hostDocumentPosition, projectedPosition, item.TextEdit.Range);
-                item.TextEdit.Range = translatedRange;
+                var translatedRange = TranslateRange(hostDocumentPosition, projectedPosition, textEdit.Range);
+                textEdit.Range = translatedRange;
             }
-            else if (item.AdditionalTextEdits != null)
+            else if (item.AdditionalTextEdits is not null)
             {
                 // Additional text edits should typically only be provided at resolve time. We don't support them in the normal completion flow.
                 item.AdditionalTextEdits = null;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LegacyRazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LegacyRazorCompletionEndpoint.cs
@@ -118,7 +118,7 @@ internal class LegacyRazorCompletionEndpoint : IVSCompletionEndpoint
         var completionCapability = _clientCapabilities?.TextDocument?.Completion as VSInternalCompletionSetting;
 
         // The completion items are cached and can be retrieved via this result id to enable the "resolve" completion functionality.
-        var resultId = _completionListCache.Set(completionList, razorCompletionItems);
+        var resultId = _completionListCache.Add(completionList, razorCompletionItems);
         completionList.SetResultId(resultId, completionCapability);
 
         return completionList;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionListProvider.cs
@@ -86,7 +86,7 @@ internal class RazorCompletionListProvider
         var completionCapability = clientCapabilities?.TextDocument?.Completion as VSInternalCompletionSetting;
 
         // The completion list is cached and can be retrieved via this result id to enable the resolve completion functionality.
-        var resultId = _completionListCache.Set(completionList, razorCompletionItems);
+        var resultId = _completionListCache.Add(completionList, razorCompletionItems);
         completionList.SetResultId(resultId, completionCapability);
 
         return completionList;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionResolveEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionResolveEndpoint.cs
@@ -36,7 +36,6 @@ internal class RazorCompletionResolveEndpoint : IVSCompletionResolveEndpoint, IO
 
     public async Task<VSInternalCompletionItem> HandleRequestAsync(VSInternalCompletionItem completionItem, RazorRequestContext requestContext, CancellationToken cancellationToken)
     {
-
         if (!completionItem.TryGetCompletionListResultIds(out var resultIds))
         {
             // Unable to lookup completion item result info
@@ -44,7 +43,7 @@ internal class RazorCompletionResolveEndpoint : IVSCompletionResolveEndpoint, IO
         }
 
         object? originalRequestContext = null;
-        VSInternalCompletionList? containingCompletionlist = null;
+        VSInternalCompletionList? containingCompletionList = null;
         foreach (var resultId in resultIds)
         {
             if (!_completionListCache.TryGet(resultId, out var cacheEntry))
@@ -57,20 +56,20 @@ internal class RazorCompletionResolveEndpoint : IVSCompletionResolveEndpoint, IO
             if (cacheEntry.CompletionList.Items.Any(completion => string.Equals(completionItem.Label, completion.Label, StringComparison.Ordinal)))
             {
                 originalRequestContext = cacheEntry.Context;
-                containingCompletionlist = cacheEntry.CompletionList;
+                containingCompletionList = cacheEntry.CompletionList;
                 break;
             }
         }
 
-        if (containingCompletionlist is null)
+        if (containingCompletionList is null)
         {
-            // Couldn't find an assocaited completion list
+            // Couldn't find an associated completion list
             return completionItem;
         }
 
         var resolvedCompletionItem = await _completionItemResolver.ResolveAsync(
             completionItem,
-            containingCompletionlist,
+            containingCompletionList,
             originalRequestContext,
             _clientCapabilities,
             cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/VSInternalCompletionListExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/VSInternalCompletionListExtensions.cs
@@ -26,6 +26,7 @@ internal static class VSInternalCompletionListExtensions
         {
             [ResultIdKey] = resultId,
         };
+
         if (completionSetting?.CompletionList?.Data == true)
         {
             // Can set data at the completion list level

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/LegacyRazorCompletionResolveEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/LegacyRazorCompletionResolveEndpointTest.cs
@@ -242,7 +242,7 @@ public class LegacyRazorCompletionResolveEndpointTest : LanguageServerTestBase
     private VSInternalCompletionList CreateLSPCompletionList(IReadOnlyList<RazorCompletionItem> razorCompletionItems)
     {
         var completionList = LegacyRazorCompletionEndpoint.CreateLSPCompletionList(razorCompletionItems, _defaultClientCapability);
-        var resultId = _completionListCache.Set(completionList, razorCompletionItems);
+        var resultId = _completionListCache.Add(completionList, razorCompletionItems);
         completionList.SetResultId(resultId, completionSetting: null);
         return completionList;
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionResolveEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionResolveEndpointTest.cs
@@ -74,7 +74,7 @@ public class RazorCompletionResolveEndpointTest : LanguageServerTestBase
         // Arrange
         var completionItem = new VSInternalCompletionItem() { Label = "Test" };
         var completionList = new VSInternalCompletionList() { Items = new[] { completionItem } };
-        var resultId = _completionListCache.Set(completionList, context: null);
+        var resultId = _completionListCache.Add(completionList, context: null);
         completionList.SetResultId(resultId, completionSetting: null);
         var parameters = ConvertToBridgedItem(completionItem);
         var requestContext = CreateRazorRequestContext(documentContext: null);
@@ -94,7 +94,7 @@ public class RazorCompletionResolveEndpointTest : LanguageServerTestBase
         var completionItem = new VSInternalCompletionItem() { Label = "Test" };
         var completionList = new VSInternalCompletionList() { Items = new[] { completionItem } };
         completionList.SetResultId(/* Invalid */ 1337, completionSetting: null);
-        var resultId = _completionListCache.Set(completionList, context: null);
+        var resultId = _completionListCache.Add(completionList, context: null);
         completionList.SetResultId(resultId, completionSetting: null);
         var parameters = ConvertToBridgedItem(completionItem);
         var requestContext = CreateRazorRequestContext(documentContext: null);
@@ -114,13 +114,13 @@ public class RazorCompletionResolveEndpointTest : LanguageServerTestBase
         var completionSetting = new VSInternalCompletionSetting() { CompletionList = new VSInternalCompletionListSetting() { Data = true } };
         var completionList1 = new VSInternalCompletionList() { Items = Array.Empty<CompletionItem>() };
         var completion1Context = new object();
-        var resultId1 = _completionListCache.Set(completionList1, completion1Context);
+        var resultId1 = _completionListCache.Add(completionList1, completion1Context);
         completionList1.SetResultId(resultId1, completionSetting);
 
         var completionItem = new VSInternalCompletionItem() { Label = "Test" };
         var completionList2 = new VSInternalCompletionList() { Items = new[] { completionItem } };
         var completion2Context = new object();
-        var resultId2 = _completionListCache.Set(completionList2, completion2Context);
+        var resultId2 = _completionListCache.Add(completionList2, completion2Context);
         completionList2.SetResultId(resultId2, completionSetting);
         var mergedCompletionList = CompletionListMerger.Merge(completionList1, completionList2);
         var mergedCompletionItem = mergedCompletionList.Items.Single();


### PR DESCRIPTION
This is a series of tweaks in completion to improve performance at an algorithmic level. This won't make much difference in the grand scheme of completion, since most of the time spent bringing up a completion list is currently within Roslyn. However, there is some low-hanging fruit that can be easily addressed:

* `CompletionListCache` now uses a circular buffer rather than a `List<T>`. Previously, it called `List<T>.RemoveAt(0)` when something would be evicted from the cache, which results in all remaining items in the array being copied. This change avoids the copy entirely.
* Lookup for completion trigger characters was O(n) because it was calling `Contains(...)` on string arrays. This has been updated to use `ImmutableHashSet<string>` for O(1) lookup.
* Filtering design-time helpers out of the C# completion list now uses a pooled list with a single `ToArray()` at the end. Previously, it used LINQ methods with a custom comparer and multiple `ToArray()` calls.

In addition, there's a few other bits of clean up and spelling fixes.