### PR TITLE
Warnings as errors only in CI

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,7 +21,7 @@
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors Condition="'$(CI)' == 'true'">true</TreatWarningsAsErrors>
     <GenerateResxSource>true</GenerateResxSource>
     <GenerateResxSourceEmitFormatMethods>true</GenerateResxSourceEmitFormatMethods>
     <ExcludeFromSourceBuild Condition="'$(IsUnitTestProject)' == 'true'">true</ExcludeFromSourceBuild>

--- a/build.cmd
+++ b/build.cmd
@@ -1,7 +1,7 @@
 @echo off
 setlocal
 
-set _args=-restore -build %*
+set _args=-restore -build /p:TreatWarningsAsErrors=true %*
 if "%~1"=="-?" set _args=-help
 
 powershell -ExecutionPolicy ByPass -NoProfile -Command "& '%~dp0eng\common\build.ps1'" %_args%

--- a/src/Razor/src/Directory.Build.props
+++ b/src/Razor/src/Directory.Build.props
@@ -6,6 +6,7 @@
     <IsPackable>true</IsPackable>
     <IsShipping>true</IsShipping>
     <IncludeSymbols>true</IncludeSymbols>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 
     <!-- In theory we want to have this property set, but our pipeline doesn't set the access tokens yet -->
     <PublishWindowsPdb Condition="'$(DotNetSymbolServerTokenMsdl)'!='' and '$(DotNetSymbolServerTokenSymWeb)'!=''">true</PublishWindowsPdb>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Microsoft.CodeAnalysis.Razor.Workspaces.csproj
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Microsoft.CodeAnalysis.Razor.Workspaces.csproj
@@ -6,6 +6,11 @@
     <EnableApiCheck>false</EnableApiCheck>
     <IsShippingPackage>false</IsShippingPackage>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <!--
+      The NonCapturingTimer package is a source package, and the source files in there don't conform to our header
+      poilcy, so we have to ignore that error code for this project.
+    -->
+    <NoWarn>$(NoWarn);IDE0073</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Let me know if this is controversial, in particular @ryanbrandenburg, but our "warnings as errors" policy really annoys me in the IDE, because it interupts me about inane things when I'm just trying to get my hacky code changes in. I think by coding and debugging, so often don't have fully-formed thoughts, and having unused variables, or uncalled private members, is not uncommon for me.

I do, however, understand the desire for a clean codebase, and I have the same desire, so having this on in CI makes sense. This does mean you could get a local build pass, which fails in CI, so perhaps that will annoy people more than I get annoyed by having to comment out unused locals, I don't know, but I'm open to all feedback.