### PR TITLE
Remove BOM from batch files

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,4 +1,4 @@
-﻿@echo off
+@echo off
 setlocal
 
 set _args=-restore -build %*

--- a/clean.cmd
+++ b/clean.cmd
@@ -1,3 +1,3 @@
-﻿@ECHO OFF
+@ECHO OFF
 SETLOCAL
 PowerShell -NoProfile -NoLogo -ExecutionPolicy ByPass -Command "[System.Threading.Thread]::CurrentThread.CurrentCulture = ''; [System.Threading.Thread]::CurrentThread.CurrentUICulture = ''; try { & '%~dp0clean.ps1' %*; exit $LASTEXITCODE } catch { write-host $_; exit 1 }"

--- a/restore.cmd
+++ b/restore.cmd
@@ -1,3 +1,3 @@
-﻿@echo off
+@echo off
 powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0eng\common\Build.ps1""" -restore %*"
 exit /b %ErrorLevel%


### PR DESCRIPTION
This is a follow up to #8099 to remove the BOM from out batch files to allow them to run properly.