### PR TITLE
[17.4] Update PublishData.json path

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -483,6 +483,6 @@ stages:
           componentPassword: $(dn-bot-dnceng-build-e-code-full-release-e-packaging-r)
           componentBuildProjectName: internal
           sourceBranch: "$(ComponentBranchName)"
-          publishDataURI: "https://dev.azure.com/dnceng/internal/_apis/git/repositories/dotnet-razor/items?path=/eng/config/PublishData.json&api-version=6.0"
+          publishDataURI: "https://dev.azure.com/dnceng/internal/_apis/git/repositories/dotnet-razor/items?path=/eng/config/PublishData.json&version=release/17.4&api-version=6.0"
           publishDataAccessToken: "$(System.AccessToken)"
           dropPath: '$(Pipeline.Workspace)\VSSetup'


### PR DESCRIPTION
﻿### Summary of the changes
- The 17.4 branch should be pointing to the 17.4-specific PublishData.json.

cc @Cosifne 