### PR TITLE
Add link to instructions on inserting Razor into O#

### DIFF
--- a/docs/InsertingRazorIntoOmniSharp.md
+++ b/docs/InsertingRazorIntoOmniSharp.md
@@ -1,0 +1,1 @@
+See [here](https://github.com/dotnet/aspnetcore-internal/blob/main/docs/release/InsertingRazorIntoOmniSharp.md) (MSFT internal) for instructions on inserting Razor into O#.


### PR DESCRIPTION
﻿### Summary of the changes
- The instructions for inserting Razor into O# are located somewhere fairly obscure, so I thought it'd be helpful to link directly to the instructions from our repo.
