### PR TITLE
Lookup some types by name

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentsApi.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentsApi.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentsApi.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentsApi.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -62,6 +62,7 @@ internal static class ComponentsApi
         public const string Namespace = "Microsoft.AspNetCore.Components";
         public const string FullTypeName = Namespace + ".RenderFragment<>";
         public const string MetadataName = Namespace + ".RenderFragment`1";
+        public const string DisplayName = Namespace + ".RenderFragment<TValue>";
     }
 
     public static class RenderTreeBuilder
@@ -149,6 +150,7 @@ internal static class ComponentsApi
     public static class EventCallbackOfT
     {
         public const string MetadataName = "Microsoft.AspNetCore.Components.EventCallback`1";
+        public const string DisplayName = "Microsoft.AspNetCore.Components.EventCallback<TValue>";
     }
 
     public static class EventCallbackFactory

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentDetectionConventions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentDetectionConventions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentDetectionConventions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentDetectionConventions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable enable

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentDetectionConventions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentDetectionConventions.cs
@@ -1,9 +1,10 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
 
 using System;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.Razor;
 
@@ -25,5 +26,23 @@ internal static class ComponentDetectionConventions
             symbol.DeclaredAccessibility == Accessibility.Public &&
             !symbol.IsAbstract &&
             symbol.AllInterfaces.Contains(icomponentSymbol);
+    }
+
+    public static bool IsComponent(INamedTypeSymbol symbol, string icomponentSymbolName)
+    {
+        if (symbol is null)
+        {
+            throw new ArgumentNullException(nameof(symbol));
+        }
+
+        if (icomponentSymbolName is null)
+        {
+            throw new ArgumentNullException(nameof(icomponentSymbolName));
+        }
+
+        return
+            symbol.DeclaredAccessibility == Accessibility.Public &&
+            !symbol.IsAbstract &&
+            symbol.AllInterfaces.Any(s => SymbolExtensions.HasFullName(s, icomponentSymbolName));
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentDetectionConventions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentDetectionConventions.cs
@@ -1,7 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
+#nullable enable
 
 using System;
 using System.Linq;
@@ -43,6 +43,6 @@ internal static class ComponentDetectionConventions
         return
             symbol.DeclaredAccessibility == Accessibility.Public &&
             !symbol.IsAbstract &&
-            symbol.AllInterfaces.Any(s => SymbolExtensions.HasFullName(s, icomponentSymbolName));
+            symbol.AllInterfaces.Any(s => s.HasFullName(icomponentSymbolName));
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentTagHelperDescriptorProvider.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/DefaultTagHelperDescriptorFactory.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/DefaultTagHelperDescriptorFactory.cs
@@ -121,7 +121,7 @@ internal class DefaultTagHelperDescriptorFactory
 
     private void AddAllowedChildren(INamedTypeSymbol type, TagHelperDescriptorBuilder builder)
     {
-        var restrictChildrenAttribute = type.GetAttributes().Where(a => a.AttributeClass.HasFullName(TagHelperTypes.RestrictChildrenAttribute)).FirstOrDefault();
+        var restrictChildrenAttribute = type.GetAttributes().FirstOrDefault(a => a.AttributeClass.HasFullName(TagHelperTypes.RestrictChildrenAttribute));
         if (restrictChildrenAttribute == null)
         {
             return;
@@ -156,7 +156,7 @@ internal class DefaultTagHelperDescriptorFactory
     private void AddTagOutputHint(INamedTypeSymbol type, TagHelperDescriptorBuilder builder)
     {
         string outputElementHint = null;
-        var outputElementHintAttribute = type.GetAttributes().Where(a => a.AttributeClass.HasFullName(TagHelperTypes.OutputElementHintAttribute)).FirstOrDefault();
+        var outputElementHintAttribute = type.GetAttributes().FirstOrDefault(a => a.AttributeClass.HasFullName(TagHelperTypes.OutputElementHintAttribute));
         if (outputElementHintAttribute != null)
         {
             outputElementHint = (string)(outputElementHintAttribute.ConstructorArguments[0]).Value;

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/DefaultTagHelperDescriptorFactory.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/DefaultTagHelperDescriptorFactory.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -171,8 +171,7 @@ internal class DefaultTagHelperDescriptorFactory
     {
         var attributeNameAttribute = property
             .GetAttributes()
-            .Where(a => a.AttributeClass.HasFullName(TagHelperTypes.HtmlAttributeNameAttribute))
-            .FirstOrDefault();
+            .FirstOrDefault(a => a.AttributeClass.HasFullName(TagHelperTypes.HtmlAttributeNameAttribute));
 
         bool hasExplicitName;
         string attributeName;

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/DefaultTagHelperDescriptorFactory.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/DefaultTagHelperDescriptorFactory.cs
@@ -378,7 +378,7 @@ internal class DefaultTagHelperDescriptorFactory
                     property.Parameters.Length == 0 &&
                     property.GetMethod != null &&
                     property.GetMethod.DeclaredAccessibility == Accessibility.Public &&
-                    property.GetAttributes().Where(a => a.AttributeClass.HasFullName(TagHelperTypes.HtmlAttributeNotBoundAttribute)).FirstOrDefault() == null &&
+                    property.GetAttributes().FirstOrDefault(a => a.AttributeClass.HasFullName(TagHelperTypes.HtmlAttributeNotBoundAttribute)) == null &&
                     (property.GetAttributes().Any(a => a.AttributeClass.HasFullName(TagHelperTypes.HtmlAttributeNameAttribute)) ||
                     property.SetMethod != null && property.SetMethod.DeclaredAccessibility == Accessibility.Public ||
                     IsPotentialDictionaryProperty(property)) &&
@@ -399,7 +399,7 @@ internal class DefaultTagHelperDescriptorFactory
     {
         if (ExcludeHidden)
         {
-            var editorBrowsableAttribute = symbol.GetAttributes().Where(a => a.AttributeClass.HasFullName(typeof(EditorBrowsableAttribute).FullName)).FirstOrDefault();
+            var editorBrowsableAttribute = symbol.GetAttributes().FirstOrDefault(a => a.AttributeClass.HasFullName(typeof(EditorBrowsableAttribute).FullName));
 
             if (editorBrowsableAttribute == null)
             {

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/SymbolExtensions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/SymbolExtensions.cs
@@ -14,6 +14,6 @@ internal static class SymbolExtensions
 
     internal static bool HasFullName(this ISymbol symbol, string fullName)
     {
-        return symbol.ToDisplayString(FullNameTypeDisplayFormat).Equals(fullName, StringComparison.OrdinalIgnoreCase);
+        return symbol.ToDisplayString(FullNameTypeDisplayFormat).Equals(fullName, StringComparison.Ordinal);
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/SymbolExtensions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/SymbolExtensions.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.Razor;
+
+internal static class SymbolExtensions
+{
+    internal static readonly SymbolDisplayFormat FullNameTypeDisplayFormat =
+        SymbolDisplayFormat.FullyQualifiedFormat
+            .WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted)
+            .WithMiscellaneousOptions(SymbolDisplayFormat.FullyQualifiedFormat.MiscellaneousOptions & (~SymbolDisplayMiscellaneousOptions.UseSpecialTypes));
+
+    internal static bool HasFullName(this ISymbol symbol, string fullName)
+    {
+        return symbol.ToDisplayString(FullNameTypeDisplayFormat).Equals(fullName, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/SymbolExtensions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/SymbolExtensions.cs
@@ -10,7 +10,7 @@ internal static class SymbolExtensions
     internal static readonly SymbolDisplayFormat FullNameTypeDisplayFormat =
         SymbolDisplayFormat.FullyQualifiedFormat
             .WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted)
-            .WithMiscellaneousOptions(SymbolDisplayFormat.FullyQualifiedFormat.MiscellaneousOptions & (~SymbolDisplayMiscellaneousOptions.UseSpecialTypes));
+            .RemoveMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
 
     internal static bool HasFullName(this ISymbol symbol, string fullName)
     {

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/TagHelperTypes.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/TagHelperTypes.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/TagHelperTypes.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/TagHelperTypes.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -11,7 +11,7 @@ internal static class TagHelperTypes
 
     public const string IComponent = "Microsoft.AspNetCore.Components.IComponent";
 
-    public const string IDictionary = "System.Collections.Generic.IDictionary`2";
+    public const string IDictionary = "System.Collections.Generic.IDictionary<TKey, TValue>";
 
     public const string HtmlAttributeNameAttribute = "Microsoft.AspNetCore.Razor.TagHelpers.HtmlAttributeNameAttribute";
 


### PR DESCRIPTION
The general pattern for tag helper lookup is to use `compilation.GetTypeByMetadataName()` and then compare if a given type is equal. Generally, this is fine, but for some operations the source generator calls into these methods many times per compilation. Looking at traces this became a significant performance bottleneck. 

This PR replaces that logic by instead comparing the full names of the types which is significantly faster. I don't *think* this changes the lookup rules if a user has defined their own copy of the attribute, as `GetTypeByMetadataName` checks the declaring compilation first anyway.

This is honestly one of the changes I'm _least_ happy with, although we tell people to use the approach in source generators, so I think its sound. I also looked if it would be possible to just do the lookup once and either cache the results (doesn't work because the compilation changes) or pass them into the factories so we can at least do the lookup just once per compilation, but that proved be to fairly complex. Happy to investigate it more though