### PR TITLE
Cherry-pick all the infra changes to 17.4.x branch

### DIFF
--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -32,7 +32,7 @@ stages:
       - job: Windows
         pool:
           name: NetCore-Public
-          demands: ImageOverride -equals build.windows.10.amd64.vs2019.pre.open
+          demands: ImageOverride -equals windows.vs2019preview.amd64.open
 
         steps:
         - task: NodeTool@0

--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -32,7 +32,7 @@ stages:
       - job: Windows
         pool:
           name: NetCore-Public
-          demands: ImageOverride -equals windows.vs2019preview.amd64.open
+          demands: ImageOverride -equals windows.vs2019.amd64.open
 
         steps:
         - task: NodeTool@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -363,7 +363,7 @@ stages:
           options: --init # This ensures all the stray defunct processes are reaped.
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            vmImage: ubuntu-18.04
+            vmImage: ubuntu-latest
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
             name: NetCore1ESPool-Internal
             demands: ImageOverride -equals Build.Ubuntu.1804.Amd64

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -486,31 +486,3 @@ stages:
           publishDataURI: "https://dev.azure.com/dnceng/internal/_apis/git/repositories/dotnet-razor/items?path=/eng/config/PublishData.json&api-version=6.0"
           publishDataAccessToken: "$(System.AccessToken)"
           dropPath: '$(Pipeline.Workspace)\VSSetup'
-
-  - stage: insert
-    dependsOn: publish_using_darc
-    displayName: Insert to VS
-    jobs:
-    - job: insert
-      displayName: Insert to VS
-      pool:
-        name: NetCore1ESPool-Svc-Internal
-        demands: ImageOverride -equals windows.vs2022.amd64
-      steps:
-      - download: current
-        artifact: VSSetup
-      - powershell: |
-          $branchName = "$(Build.SourceBranch)".Substring("refs/heads/".Length)
-          Write-Host "##vso[task.setvariable variable=ComponentBranchName]$branchName"
-        displayName: Get Branch Name
-      - template: eng/pipelines/insert.yml
-        parameters:
-          buildUserName: "dn-bot@microsoft.com"
-          buildPassword: $(dn-bot-devdiv-build-e-code-full-release-e-packaging-r)
-          componentUserName: "dn-bot@microsoft.com"
-          componentPassword: $(dn-bot-dnceng-build-e-code-full-release-e-packaging-r)
-          componentBuildProjectName: internal
-          sourceBranch: "$(ComponentBranchName)"
-          publishDataURI: "https://dev.azure.com/dnceng/internal/_apis/git/repositories/dotnet-razor/items?path=/eng/config/PublishData.json&versionType=commit&version=507dd3c0c9af56897c7d9f2830c82d690e0ef3d4&api-version=6.0"
-          publishDataAccessToken: "$(System.AccessToken)"
-          dropPath: '$(Pipeline.Workspace)\VSSetup'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,7 +65,7 @@ stages:
           pool:
             ${{ if eq(variables['System.TeamProject'], 'public') }}:
               name: NetCore-Public
-              demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
+              demands: ImageOverride -equals windows.vs2022preview.amd64.open
             ${{ if ne(variables['System.TeamProject'], 'public') }}:
               name: NetCore1ESPool-Internal
               demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Main
@@ -111,10 +111,10 @@ stages:
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: NetCore-Public
-            demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre.Open
+            demands: ImageOverride -equals windows.vs2022preview.amd64.open
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
             name: NetCore1ESPool-Internal
-            demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Pre
+            demands: ImageOverride -equals windows.vs2022preview.amd64
         strategy:
           matrix:
             ${{ if eq(variables['System.TeamProject'], 'public') }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,7 +68,7 @@ stages:
               demands: ImageOverride -equals windows.vs2022preview.amd64.open
             ${{ if ne(variables['System.TeamProject'], 'public') }}:
               name: NetCore1ESPool-Internal
-              demands: ImageOverride -equals Build.Windows.Amd64.VS2022.Main
+              demands: ImageOverride -equals windows.vs2022preview.amd64
           steps:
           - task: NodeTool@0
             displayName: Install Node 10.x

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,24 @@ variables:
   - name: _InternalRuntimeDownloadArgs
     value: /p:DotNetRuntimeSourceFeed=https://dotnetclimsrc.blob.core.windows.net/dotnet
            /p:DotNetRuntimeSourceFeedKey=$(dotnetclimsrc-read-sas-token-base64)
+
+  - group: DotNet-DevDiv-Insertion-Workflow-Variables
+  - name: _DevDivDropAccessToken
+    value: $(dn-bot-devdiv-drop-rw-code-rw)
+
+  - group: DotNet-Roslyn-Insertion-Variables
+  - name: Razor.GitHubEmail
+    value: dotnet-build-bot@microsoft.com
+  - name: Razor.GitHubToken
+    value: $(AccessToken-dotnet-build-bot-public-repo)
+  - name: Razor.GitHubUserName
+    value: dotnet-build-bot
+  - name: Insertion.CreateDraftPR
+    value: true
+  - name: Insertion.TitlePrefix
+    value: '[Auto Insertion]'
+  - name: Insertion.TitleSuffix
+    value: ''
 - ${{ if eq(variables['System.TeamProject'], 'public') }}:
   - name: _InternalRuntimeDownloadArgs
     value: ''
@@ -153,7 +171,7 @@ stages:
               /p:OfficialBuildId=$(Build.BuildNumber)
               /p:ManifestBuildBranch=$(Build.SourceBranchName)
               /p:ManifestBuildNumber=$(Build.BuildNumber)
-              /p:VisualStudioDropName=Products/dotnet/razor-tooling/$(Build.SourceBranchName)/$(Build.BuildNumber)
+              /p:VisualStudioDropName=Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)
               /p:GenerateSbom=true
 
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
@@ -285,38 +303,51 @@ stages:
         #     searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults/$(_BuildConfig)'
         #   continueOnError: true
         #   condition: always()
+
+        # Publish an artifact that the RoslynInsertionTool is able to find by its name.
         - task: PublishBuildArtifacts@1
-          displayName: Publish VSIX Artifacts
+          displayName: Publish Artifact VSSetup
           inputs:
-            PathtoPublish: '$(Build.SourcesDirectory)/artifacts/VSSetup/$(_BuildConfig)'
-            PublishLocation: Container
-            ArtifactName: VSIX_$(Agent.Os)_$(_BuildConfig)
+            PathtoPublish: 'artifacts\VSSetup\$(_BuildConfig)'
+            ArtifactName: 'VSSetup'
           continueOnError: true
           condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
         - task: PublishBuildArtifacts@1
           displayName: Publish VS for Mac Artifacts
           inputs:
-            PathtoPublish: '$(Build.SourcesDirectory)/artifacts/MPack/$(_BuildConfig)'
-            PublishLocation: Container
+            PathtoPublish: 'artifacts\MPack\$(_BuildConfig)'
             ArtifactName: MPack_$(Agent.Os)_$(_BuildConfig)
           continueOnError: true
           condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
         - task: PublishBuildArtifacts@1
           displayName: Publish package artifacts
           inputs:
-            PathtoPublish: $(Build.SourcesDirectory)/artifacts/packages/$(_BuildConfig)
-            PublishLocation: Container
+            PathtoPublish: 'artifacts\packages\$(_BuildConfig)'
             ArtifactName: Packages_$(Agent.Os)_$(_BuildConfig)
           continueOnError: true
           condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
         - task: PublishBuildArtifacts@1
           displayName: Publish VS Code extension artifacts
           inputs:
-            PathtoPublish: $(Build.SourcesDirectory)/artifacts/packages/VSCode/$(_BuildConfig)
-            PublishLocation: Container
+            PathtoPublish: 'artifacts\packages\VSCode\$(_BuildConfig)'
             ArtifactName: BlazorWasmDebuggingExtension
           continueOnError: true
           condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
+
+        - powershell: Write-Host "##vso[task.setvariable variable=VisualStudio.DropName]Products/$(System.TeamProject)/$(Build.Repository.Name)/$(Build.SourceBranchName)/$(Build.BuildNumber)"
+          displayName: Setting VisualStudio.DropName variable
+
+        # Publishes setup VSIXes to a drop.
+        # Note: The insertion tool looks for the display name of this task in the logs.
+        - ${{ if ne(variables['System.TeamProject'], 'public') }}:
+          - task: ms-vseng.MicroBuildTasks.4305a8de-ba66-4d8b-b2d1-0dc4ecbbf5e8.MicroBuildUploadVstsDropFolder@1
+            displayName: Upload VSTS Drop
+            inputs:
+              DropName: $(VisualStudio.DropName)
+              DropFolder: 'artifacts\VSSetup\$(_BuildConfig)\Insertion'
+              AccessToken: $(_DevDivDropAccessToken)
+            continueOnError: true
+            condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
 
       - job: macOS
         pool:
@@ -427,3 +458,59 @@ stages:
           -TsaRepositoryName "Razor-Tooling"
           -TsaCodebaseName "Razor-Tooling"
           -TsaPublish $True
+
+  - stage: insert
+    dependsOn: publish_using_darc
+    displayName: Insert to VS
+    jobs:
+    - job: insert
+      displayName: Insert to VS
+      pool:
+        name: NetCore1ESPool-Svc-Internal
+        demands: ImageOverride -equals windows.vs2022.amd64
+      steps:
+      - download: current
+        artifact: VSSetup
+      - powershell: |
+          $branchName = "$(Build.SourceBranch)".Substring("refs/heads/".Length)
+          Write-Host "##vso[task.setvariable variable=ComponentBranchName]$branchName"
+        displayName: Get Branch Name
+      - template: eng/pipelines/insert.yml
+        parameters:
+          buildUserName: "dn-bot@microsoft.com"
+          buildPassword: $(dn-bot-devdiv-build-e-code-full-release-e-packaging-r)
+          componentUserName: "dn-bot@microsoft.com"
+          componentPassword: $(dn-bot-dnceng-build-e-code-full-release-e-packaging-r)
+          componentBuildProjectName: internal
+          sourceBranch: "$(ComponentBranchName)"
+          publishDataURI: "https://dev.azure.com/dnceng/internal/_apis/git/repositories/dotnet-razor/items?path=/eng/config/PublishData.json&api-version=6.0"
+          publishDataAccessToken: "$(System.AccessToken)"
+          dropPath: '$(Pipeline.Workspace)\VSSetup'
+
+  - stage: insert
+    dependsOn: publish_using_darc
+    displayName: Insert to VS
+    jobs:
+    - job: insert
+      displayName: Insert to VS
+      pool:
+        name: NetCore1ESPool-Svc-Internal
+        demands: ImageOverride -equals windows.vs2022.amd64
+      steps:
+      - download: current
+        artifact: VSSetup
+      - powershell: |
+          $branchName = "$(Build.SourceBranch)".Substring("refs/heads/".Length)
+          Write-Host "##vso[task.setvariable variable=ComponentBranchName]$branchName"
+        displayName: Get Branch Name
+      - template: eng/pipelines/insert.yml
+        parameters:
+          buildUserName: "dn-bot@microsoft.com"
+          buildPassword: $(dn-bot-devdiv-build-e-code-full-release-e-packaging-r)
+          componentUserName: "dn-bot@microsoft.com"
+          componentPassword: $(dn-bot-dnceng-build-e-code-full-release-e-packaging-r)
+          componentBuildProjectName: internal
+          sourceBranch: "$(ComponentBranchName)"
+          publishDataURI: "https://dev.azure.com/dnceng/internal/_apis/git/repositories/dotnet-razor/items?path=/eng/config/PublishData.json&versionType=commit&version=507dd3c0c9af56897c7d9f2830c82d690e0ef3d4&api-version=6.0"
+          publishDataAccessToken: "$(System.AccessToken)"
+          dropPath: '$(Pipeline.Workspace)\VSSetup'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -483,6 +483,6 @@ stages:
           componentPassword: $(dn-bot-dnceng-build-e-code-full-release-e-packaging-r)
           componentBuildProjectName: internal
           sourceBranch: "$(ComponentBranchName)"
-          publishDataURI: "https://dev.azure.com/dnceng/internal/_apis/git/repositories/dotnet-razor/items?path=/eng/config/PublishData.json&api-version=6.0"
+          publishDataURI: "https://dev.azure.com/dnceng/internal/_apis/git/repositories/dotnet-razor/items?path=/eng/config/PublishData.json&version=release/17.4&api-version=6.0"
           publishDataAccessToken: "$(System.AccessToken)"
           dropPath: '$(Pipeline.Workspace)\VSSetup'

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -35,8 +35,8 @@
     imported. This OK because we want to just have an obvious salt for a local build.
   -->
   <PropertyGroup>
-    <VsixVersionPrefix>17.0.0</VsixVersionPrefix>
-    <AddinMajorVersion>17.3</AddinMajorVersion>
+    <VsixVersionPrefix>17.4.5</VsixVersionPrefix>
+    <AddinMajorVersion>17.4</AddinMajorVersion>
     <AddinVersion>$(AddinMajorVersion)</AddinVersion>
     <AddinVersion Condition="'$(OfficialBuildId)' != ''">$(AddinVersion).$(OfficialBuildId)</AddinVersion>
     <AddinVersion Condition="'$(OfficialBuildId)' == ''">$(AddinVersion).42424242.42</AddinVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -73,7 +73,7 @@
     <!-- Several packages from the editor are used for testing HTML support, and share the following version. -->
     <Tooling_HtmlEditorPackageVersion>16.10.57-preview1</Tooling_HtmlEditorPackageVersion>
     <!-- Several packages share the MS.CA.Testing version -->
-    <Tooling_MicrosoftCodeAnalysisTestingVersion>1.1.2-beta1.22109.1</Tooling_MicrosoftCodeAnalysisTestingVersion>
+    <Tooling_MicrosoftCodeAnalysisTestingVersion>1.1.2-beta1.22512.1</Tooling_MicrosoftCodeAnalysisTestingVersion>
     <MicrosoftVisualStudioShellPackagesVersion>17.2.32330.158</MicrosoftVisualStudioShellPackagesVersion>
     <MicrosoftVisualStudioPackagesVersion>17.3.133-preview</MicrosoftVisualStudioPackagesVersion>
     <RoslynPackageVersion>4.4.0-2.22424.2</RoslynPackageVersion>

--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -1,0 +1,14 @@
+{
+  "branches": {
+    "release/17.4": {
+      "nugetKind": [
+        "Shipping",
+        "NonShipping"
+      ],
+      "vsBranch": "rel/d17.4",
+      "vsMajorVersion": 17,
+      "insertionCreateDraftPR": false,
+      "insertionTitlePrefix": "[17.4]"
+    }
+  }
+}

--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -1,6 +1,6 @@
 {
   "branches": {
-    "release/17.4": {
+    "release/17.4.x": {
       "nugetKind": [
         "Shipping",
         "NonShipping"

--- a/eng/pipelines/insert.yml
+++ b/eng/pipelines/insert.yml
@@ -1,0 +1,198 @@
+parameters:
+  # These are actually booleans but must be defined as string.
+  # Parameters are evaluated at compile time, but all variables are strings at compile time.
+  # So in order to pass a parameter that comes from a variable these must be typed as string.
+  - name: createDraftPR
+    type: string
+    default: ''
+  - name: autoComplete
+    type: string
+    default: ''
+  - name: queueSpeedometerValidation
+    type: string
+    default: 'false'
+
+  - name: buildUserName
+    type: string
+  - name: buildPassword
+    type: string
+  - name: componentUserName
+    type: string
+  - name: componentPassword
+    type: string
+  
+  - name: publishDataURI
+    type: string
+  - name: publishDataAccessToken
+    type: string
+    default: ''
+
+  - name: vsBranchName
+    type: string
+    default: ''
+  - name: componentBuildProjectName
+    type: string
+    default: ''
+  - name: titlePrefix
+    type: string
+    default: ''
+
+  - name: sourceBranch
+    type: string
+
+  - name: dropPath
+    type: string
+    default: ''
+
+steps:
+  - checkout: none
+
+  - task: NuGetCommand@2
+    displayName: 'Install RIT from Azure Artifacts'
+    inputs:
+      command: custom
+      arguments: 'install RoslynTools.VisualStudioInsertionTool -PreRelease -Source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
+
+  - powershell: |
+      $authorization = if ("" -ne $Env:PublishDataAccessToken) { "Bearer $Env:PublishDataAccessToken" } else { "" }
+      $response = Invoke-RestMethod -Headers @{Authorization = $authorization} "${{ parameters.publishDataURI }}"
+      $branchName = "${{ parameters.sourceBranch }}"
+      $branchData = $response.branches.$branchName
+      if (!$branchData)
+      {
+        Write-Host "No PublishData found for branch '$branchName'. Using PublishData for branch 'main'."
+        $branchData = $response.branches.main
+      }
+
+      # Set our template variables to reasonable defaults
+      Write-Host "##vso[task.setvariable variable=Template.CreateDraftPR]$($true)"
+      Write-Host "##vso[task.setvariable variable=Template.AutoComplete]$($false)"
+      Write-Host "##vso[task.setvariable variable=Template.TitlePrefix]$('')"
+      Write-Host "##vso[task.setvariable variable=Template.TitleSuffix]$('')"
+      Write-Host "##vso[task.setvariable variable=Template.ComponentAzdoUri]$('')"
+      Write-Host "##vso[task.setvariable variable=Template.ComponentProjectName]$('')"
+      Write-Host "##vso[task.setvariable variable=Template.DropPath]$('(default)')"
+
+      Write-Host "##vso[task.setvariable variable=Template.ComponentBranchName]$branchName"
+      Write-Host "##vso[task.setvariable variable=Template.VSBranchName]$($branchData.vsBranch)"
+
+      # Overwrite the default template variables with the values from PublishData for this sourceBranch
+      if ($null -ne $branchData.insertionCreateDraftPR)
+      {
+        Write-Host "##vso[task.setvariable variable=Template.CreateDraftPR]$($branchData.insertionCreateDraftPR)"
+      }
+
+      if ($null -ne $branchData.insertionCreateDraftPR)
+      {
+        Write-Host "##vso[task.setvariable variable=Template.AutoComplete]$(-not $branchData.insertionCreateDraftPR)"
+      }
+
+      if ($null -ne $branchData.insertionTitlePrefix)
+      {
+        Write-Host "##vso[task.setvariable variable=Template.TitlePrefix]$($branchData.insertionTitlePrefix)"
+      }
+
+    displayName: Set Variables from PublishData
+    env:
+      PublishDataAccessToken: ${{ parameters.publishDataAccessToken }}
+
+  - powershell: |
+      # Set AzDO authorization template variables
+      Write-Host "Setting BuildUserName to $Env:BuildUserName"
+      Write-Host "##vso[task.setvariable variable=Template.BuildUserName]$Env:BuildUserName"
+      Write-Host "##vso[task.setvariable variable=Template.BuildPassword]$Env:BuildPassword"
+
+      Write-Host "Setting ComponentUserName to $Env:ComponentUserName"
+      Write-Host "##vso[task.setvariable variable=Template.ComponentUserName]$Env:ComponentUserName"
+      Write-Host "##vso[task.setvariable variable=Template.ComponentPassword]$Env:ComponentPassword"
+
+      # Overwrite template variables with values passed into this template as parameters
+      if ("" -ne $Env:CreateDraftPR)
+      {
+        Write-Host "Setting CreateDraftPR to $Env:CreateDraftPR"
+        Write-Host "##vso[task.setvariable variable=Template.CreateDraftPR]$Env:CreateDraftPR"
+      }
+
+      if ("" -ne $Env:AutoComplete)
+      {
+        Write-Host "Setting AutoComplete to $Env:AutoComplete"
+        Write-Host "##vso[task.setvariable variable=Template.AutoComplete]$Env:AutoComplete"
+      }
+
+      if ("" -ne $Env:TitlePrefix)
+      {
+        Write-Host "Setting TitlePrefix to $Env:TitlePrefix"
+        Write-Host "##vso[task.setvariable variable=Template.TitlePrefix]$Env:TitlePrefix"
+      }
+
+      # Workaround for pipeline parameters not supporting optional empty parameters.
+      if ("" -ne $Env:VSBranchName -and "default" -ne $Env:VSBranchName)
+      {
+        Write-Host "Setting VSBranchName to $Env:VSBranchName"
+        Write-Host "##vso[task.setvariable variable=Template.VSBranchName]$Env:VSBranchName"
+      }
+
+      if ("" -ne $Env:ComponentBuildProjectName)
+      {
+        Write-Host "Setting component Azdo parameters $('$(System.CollectionUri)') and $Env:ComponentBuildProjectName"
+        Write-Host "##vso[task.setvariable variable=Template.ComponentAzdoUri]$('$(System.CollectionUri)')"
+        Write-Host "##vso[task.setvariable variable=Template.ComponentProjectName]$Env:ComponentBuildProjectName"
+      }
+
+      if ("" -ne $Env:DropPath)
+      {
+        Write-Host "Setting DropPath to $Env:DropPath"
+        Write-Host "##vso[task.setvariable variable=Template.DropPath]$Env:DropPath"
+      }
+
+    displayName: Set Variables from Input Parameters
+    env:
+      BuildUserName: ${{ parameters.buildUserName }}
+      BuildPassword: ${{ parameters.buildPassword }}
+      ComponentUserName: ${{ parameters.componentUserName }}
+      ComponentPassword: ${{ parameters.componentPassword }}
+      CreateDraftPR: ${{ parameters.createDraftPR }}
+      AutoComplete: ${{ parameters.autoComplete }}
+      TitlePrefix: ${{ parameters.titlePrefix }}
+      VSBranchName: ${{ parameters.vsBranchName }}
+      ComponentBuildProjectName: ${{ parameters.componentBuildProjectName }}
+      DropPath: ${{ parameters.dropPath }}
+
+  # Now that everything is set, actually perform the insertion.
+  - powershell: |
+      mv RoslynTools.VisualStudioInsertionTool.* RIT
+      .\RIT\tools\net46\OneOffInsertion.ps1 `
+        -autoComplete "$(Template.AutoComplete)" `
+        -buildQueueName "$(Build.DefinitionName)" `
+        -cherryPick "(default)" `
+        -userName "$(Template.BuildUserName)" `
+        -password "$(Template.BuildPassword)" `
+        -componentUserName "$(Template.ComponentUserName)" `
+        -componentPassword "$(Template.ComponentPassword)" `
+        -componentAzdoUri "$(Template.ComponentAzdoUri)" `
+        -componentProjectName "$(Template.ComponentProjectName)" `
+        -componentName "Razor" `
+        -componentGitHubRepoName "dotnet/razor" `
+        -componentBranchName "$(Template.ComponentBranchName)" `
+        -createDraftPR "$(Template.CreateDraftPR)" `
+        -defaultValueSentinel "(default)" `
+        -dropPath "$(Template.DropPath)" `
+        -insertCore "false" `
+        -insertDevDiv "(default)" `
+        -insertionCount "1" `
+        -insertToolset "false" `
+        -titlePrefix "$(Template.TitlePrefix)" `
+        -titleSuffix "$(Template.TitleSuffix)" `
+        -queueValidation "true" `
+        -requiredValueSentinel "REQUIRED" `
+        -reviewerGUID "6c25b447-1d90-4840-8fde-d8b22cb8733e" `
+        -specificBuild "$(Build.BuildNumber)" `
+        -updateAssemblyVersions "false" `
+        -updateCoreXTLibraries "false" `
+        -visualStudioBranchName "$(Template.VSBranchName)" `
+        -writePullRequest "prid.txt" `
+        -queueSpeedometerValidation "${{ parameters.queueSpeedometerValidation }}"
+    displayName: 'Run OneOffInsertion.ps1'
+
+  - script: 'echo. && echo. && type "prid.txt" && echo. && echo.'
+    displayName: 'Report PR URL'


### PR DESCRIPTION
Long story short:
Razor miss the insertion due in 17.4 P3, so right now, everything in release/17.4 branch after https://github.com/dotnet/razor/commit/61cc048d36a3fc9246d2f04625988b19a18ab8f0 is not in VS.

Now there is a servicing fix need to come to 17.4.
And QB would not be happy to accept so many change one time,
So we need to create a new branch based on https://github.com/dotnet/razor/commit/61cc048d36a3fc9246d2f04625988b19a18ab8f0 , use this as the 17.4 branch, then ship things from there.

This PR, cherry-picking the infra change listed here https://devdiv.visualstudio.com/DevDiv/_git/VS/pullrequest/445017
I believe it would include
https://github.com/dotnet/razor/pull/6910
https://github.com/dotnet/razor/pull/6912
https://github.com/dotnet/razor/pull/8097
https://github.com/dotnet/razor/pull/8100
https://github.com/dotnet/razor/pull/8101
https://github.com/dotnet/razor/pull/8104

And the last commit is changing the branch name