### PR TITLE
[VS Code] Normalize directories

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ComponentAccessibilityCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ComponentAccessibilityCodeActionProvider.cs
@@ -65,7 +65,7 @@ internal class ComponentAccessibilityCodeActionProvider : RazorCodeActionProvide
         if (IsTagUnknown(startTag, context))
         {
             AddComponentAccessFromTag(context, startTag, codeActions);
-            AddCreateComponentFromTag(context, startTag, codeActions);
+            ComponentAccessibilityCodeActionProvider.AddCreateComponentFromTag(context, startTag, codeActions);
         }
 
         return Task.FromResult<IReadOnlyList<RazorVSInternalCodeAction>?>(codeActions);
@@ -82,7 +82,7 @@ internal class ComponentAccessibilityCodeActionProvider : RazorCodeActionProvide
         return true;
     }
 
-    private void AddCreateComponentFromTag(RazorCodeActionContext context, MarkupStartTagSyntax startTag, List<RazorVSInternalCodeAction> container)
+    private static void AddCreateComponentFromTag(RazorCodeActionContext context, MarkupStartTagSyntax startTag, List<RazorVSInternalCodeAction> container)
     {
         if (context is null)
         {
@@ -99,6 +99,7 @@ internal class ComponentAccessibilityCodeActionProvider : RazorCodeActionProvide
 
         var directoryName = Path.GetDirectoryName(path);
         Assumes.NotNull(directoryName);
+        directoryName = FilePathNormalizer.NormalizeDirectory(directoryName);
 
         var newComponentPath = Path.Combine(directoryName, $"{startTag.Name.Content}.razor");
         if (File.Exists(newComponentPath))

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ComponentAccessibilityCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ComponentAccessibilityCodeActionProvider.cs
@@ -65,7 +65,7 @@ internal class ComponentAccessibilityCodeActionProvider : RazorCodeActionProvide
         if (IsTagUnknown(startTag, context))
         {
             AddComponentAccessFromTag(context, startTag, codeActions);
-            ComponentAccessibilityCodeActionProvider.AddCreateComponentFromTag(context, startTag, codeActions);
+            AddCreateComponentFromTag(context, startTag, codeActions);
         }
 
         return Task.FromResult<IReadOnlyList<RazorVSInternalCodeAction>?>(codeActions);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
@@ -68,7 +68,7 @@ internal class ExtractToCodeBehindCodeActionResolver : RazorCodeActionResolver
             return null;
         }
 
-        var codeBehindPath = ExtractToCodeBehindCodeActionResolver.GenerateCodeBehindPath(path);
+        var codeBehindPath = GenerateCodeBehindPath(path);
         var codeBehindUri = new UriBuilder
         {
             Scheme = Uri.UriSchemeFile,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
@@ -76,8 +76,6 @@ internal class ExtractToCodeBehindCodeActionResolver : RazorCodeActionResolver
             Host = string.Empty,
         }.Uri;
 
-        codeBehindUri = new Uri(codeBehindUri.AbsoluteUri);
-
         var text = await documentContext.GetSourceTextAsync(cancellationToken).ConfigureAwait(false);
         if (text is null)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
@@ -68,13 +68,15 @@ internal class ExtractToCodeBehindCodeActionResolver : RazorCodeActionResolver
             return null;
         }
 
-        var codeBehindPath = GenerateCodeBehindPath(path);
+        var codeBehindPath = ExtractToCodeBehindCodeActionResolver.GenerateCodeBehindPath(path);
         var codeBehindUri = new UriBuilder
         {
             Scheme = Uri.UriSchemeFile,
             Path = codeBehindPath,
             Host = string.Empty,
         }.Uri;
+
+        codeBehindUri = new Uri(codeBehindUri.AbsoluteUri);
 
         var text = await documentContext.GetSourceTextAsync(cancellationToken).ConfigureAwait(false);
         if (text is null)
@@ -139,7 +141,7 @@ internal class ExtractToCodeBehindCodeActionResolver : RazorCodeActionResolver
     /// </summary>
     /// <param name="path">The origin file path.</param>
     /// <returns>A non-existent file path with the same base name and a codebehind extension.</returns>
-    private string GenerateCodeBehindPath(string path)
+    private static string GenerateCodeBehindPath(string path)
     {
         var n = 0;
         string codeBehindPath;
@@ -148,6 +150,7 @@ internal class ExtractToCodeBehindCodeActionResolver : RazorCodeActionResolver
             var identifier = n > 0 ? n.ToString(CultureInfo.InvariantCulture) : string.Empty;  // Make it look nice
             var directoryName = Path.GetDirectoryName(path);
             Assumes.NotNull(directoryName);
+            directoryName = FilePathNormalizer.NormalizeDirectory(directoryName);
 
             codeBehindPath = Path.Combine(
                 directoryName,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
@@ -215,6 +215,7 @@ internal class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenameParamsBrid
         var newFileName = $"{newName}{Path.GetExtension(originalPath)}";
         var directoryName = Path.GetDirectoryName(originalPath);
         Assumes.NotNull(directoryName);
+        directoryName = FilePathNormalizer.NormalizeDirectory(directoryName);
         var newPath = Path.Combine(directoryName, newFileName);
         return newPath;
     }


### PR DESCRIPTION
﻿### Summary of the changes

- VS Code wouldn't apply some renames or Razor code actions (just in Windows - surprisingly worked in Mac) due to us not normalizing file path directories correctly. This PR resolves the issue.