### PR TITLE
Exclude analyzers from source-build to eliminate prebuilts

### DIFF
--- a/src/Compiler/Directory.Build.props
+++ b/src/Compiler/Directory.Build.props
@@ -37,7 +37,7 @@
     <WarningsNotAsErrors>$(WarningsNotAsErrors);xUnit1004</WarningsNotAsErrors>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" NoWarn="NU1608" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" NoWarn="NU1608" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" PrivateAssets="All" />


### PR DESCRIPTION
Fixes #8035 
