### PR TITLE
[VS Code] Fix code action and rename file paths

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultLanguageServerFeatureOptions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Runtime.InteropServices;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 
@@ -21,4 +22,9 @@ internal class DefaultLanguageServerFeatureOptions : LanguageServerFeatureOption
     public override bool SingleServerSupport => false;
 
     public override bool SupportsDelegatedCodeActions => false;
+
+    // Code action and rename paths in Windows VS Code need to be prefixed with '/':
+    // https://github.com/dotnet/razor/issues/8131
+    public override bool ReturnCodeActionAndRenamePathsWithPrefixedSlash
+        => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/CreateComponentCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/CreateComponentCodeActionResolver.cs
@@ -62,7 +62,7 @@ internal class CreateComponentCodeActionResolver : RazorCodeActionResolver
         }
 
 		// VS code expects path to start with '/'
-        var updatedPath = _languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash && actionParams.Path.StartsWith("/")
+        var updatedPath = !_languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash || actionParams.Path.StartsWith("/")
 			? actionParams.Path
 			: '/' + actionParams.Path;
         var newComponentUri = new UriBuilder()

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/CreateComponentCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/CreateComponentCodeActionResolver.cs
@@ -61,7 +61,7 @@ internal class CreateComponentCodeActionResolver : RazorCodeActionResolver
             return null;
         }
 
-		// VS code expects path to start with '/'
+        // VS Code in Windows expects path to start with '/'
         var updatedPath = _languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash && !actionParams.Path.StartsWith("/")
 			? '/' + actionParams.Path
 			: actionParams.Path;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/CreateComponentCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/CreateComponentCodeActionResolver.cs
@@ -61,7 +61,8 @@ internal class CreateComponentCodeActionResolver : RazorCodeActionResolver
         var newComponentUri = new UriBuilder()
         {
             Scheme = Uri.UriSchemeFile,
-            Path = actionParams.Path,
+			// VS code expects path to start with '/'
+			Path = actionParams.Path.StartsWith("/") ? actionParams.Path : '/' + actionParams.Path,
             Host = string.Empty,
         }.Uri;
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/CreateComponentCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/CreateComponentCodeActionResolver.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Newtonsoft.Json.Linq;
 
@@ -20,10 +21,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
 internal class CreateComponentCodeActionResolver : RazorCodeActionResolver
 {
     private readonly DocumentContextFactory _documentContextFactory;
+    private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
 
-    public CreateComponentCodeActionResolver(DocumentContextFactory documentContextFactory)
+    public CreateComponentCodeActionResolver(DocumentContextFactory documentContextFactory, LanguageServerFeatureOptions languageServerFeatureOptions)
     {
         _documentContextFactory = documentContextFactory ?? throw new ArgumentNullException(nameof(documentContextFactory));
+        _languageServerFeatureOptions = languageServerFeatureOptions ?? throw new ArgumentException(nameof(languageServerFeatureOptions));
     }
 
     public override string Action => LanguageServerConstants.CodeActions.CreateComponentFromTag;
@@ -58,11 +61,14 @@ internal class CreateComponentCodeActionResolver : RazorCodeActionResolver
             return null;
         }
 
+		// VS code expects path to start with '/'
+        var updatedPath = _languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash && actionParams.Path.StartsWith("/")
+			? actionParams.Path
+			: '/' + actionParams.Path;
         var newComponentUri = new UriBuilder()
         {
             Scheme = Uri.UriSchemeFile,
-			// VS code expects path to start with '/'
-			Path = actionParams.Path.StartsWith("/") ? actionParams.Path : '/' + actionParams.Path,
+			Path = updatedPath,
             Host = string.Empty,
         }.Uri;
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/CreateComponentCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/CreateComponentCodeActionResolver.cs
@@ -62,9 +62,9 @@ internal class CreateComponentCodeActionResolver : RazorCodeActionResolver
         }
 
 		// VS code expects path to start with '/'
-        var updatedPath = !_languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash || actionParams.Path.StartsWith("/")
-			? actionParams.Path
-			: '/' + actionParams.Path;
+        var updatedPath = _languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash && !actionParams.Path.StartsWith("/")
+			? '/' + actionParams.Path
+			: actionParams.Path;
         var newComponentUri = new UriBuilder()
         {
             Scheme = Uri.UriSchemeFile,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
@@ -76,7 +76,7 @@ internal class ExtractToCodeBehindCodeActionResolver : RazorCodeActionResolver
         var codeBehindPath = GenerateCodeBehindPath(path);
 
         // VS Code in Windows expects path to start with '/'
-        var updatedCodeBehindPath = _languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash && codeBehindPath.StartsWith("/")
+        var updatedCodeBehindPath = !_languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash || codeBehindPath.StartsWith("/")
             ? codeBehindPath
             : '/' + codeBehindPath;
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
@@ -72,7 +72,8 @@ internal class ExtractToCodeBehindCodeActionResolver : RazorCodeActionResolver
         var codeBehindUri = new UriBuilder
         {
             Scheme = Uri.UriSchemeFile,
-            Path = codeBehindPath,
+            // VS Code expects path to start with '/'
+            Path = codeBehindPath.StartsWith("/") ? codeBehindPath : '/' + codeBehindPath,
             Host = string.Empty,
         }.Uri;
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
@@ -18,6 +18,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Newtonsoft.Json.Linq;
 using CSharpSyntaxFactory = Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
@@ -28,10 +29,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
 internal class ExtractToCodeBehindCodeActionResolver : RazorCodeActionResolver
 {
     private readonly DocumentContextFactory _documentContextFactory;
+    private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
 
-    public ExtractToCodeBehindCodeActionResolver(DocumentContextFactory documentContextFactory)
+    public ExtractToCodeBehindCodeActionResolver(
+        DocumentContextFactory documentContextFactory,
+        LanguageServerFeatureOptions languageServerFeatureOptions)
     {
         _documentContextFactory = documentContextFactory ?? throw new ArgumentNullException(nameof(documentContextFactory));
+        _languageServerFeatureOptions = languageServerFeatureOptions;
     }
 
     public override string Action => LanguageServerConstants.CodeActions.ExtractToCodeBehindAction;
@@ -69,11 +74,16 @@ internal class ExtractToCodeBehindCodeActionResolver : RazorCodeActionResolver
         }
 
         var codeBehindPath = GenerateCodeBehindPath(path);
+
+        // VS Code in Windows expects path to start with '/'
+        var updatedCodeBehindPath = _languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash && codeBehindPath.StartsWith("/")
+            ? codeBehindPath
+            : '/' + codeBehindPath;
+
         var codeBehindUri = new UriBuilder
         {
             Scheme = Uri.UriSchemeFile,
-            // VS Code expects path to start with '/'
-            Path = codeBehindPath.StartsWith("/") ? codeBehindPath : '/' + codeBehindPath,
+            Path = updatedCodeBehindPath,
             Host = string.Empty,
         }.Uri;
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
@@ -76,9 +76,9 @@ internal class ExtractToCodeBehindCodeActionResolver : RazorCodeActionResolver
         var codeBehindPath = GenerateCodeBehindPath(path);
 
         // VS Code in Windows expects path to start with '/'
-        var updatedCodeBehindPath = !_languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash || codeBehindPath.StartsWith("/")
-            ? codeBehindPath
-            : '/' + codeBehindPath;
+        var updatedCodeBehindPath = _languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash && !codeBehindPath.StartsWith("/")
+            ? '/' + codeBehindPath
+            : codeBehindPath;
 
         var codeBehindUri = new UriBuilder
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
@@ -191,7 +191,7 @@ internal class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenameParamsBrid
     public void AddFileRenameForComponent(List<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>> documentChanges, DocumentSnapshot documentSnapshot, string newPath)
     {
         // VS code expects path to start with '/'
-        var updatedOldPath = _languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash && documentSnapshot.FilePath.StartsWith("/")
+        var updatedOldPath = !_languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash || documentSnapshot.FilePath.StartsWith("/")
             ? documentSnapshot.FilePath
             : '/' + documentSnapshot.FilePath;
         var oldUri = new UriBuilder
@@ -203,7 +203,7 @@ internal class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenameParamsBrid
         }.Uri;
 
         // VS code expects path to start with '/'
-        var updatedNewPath = _languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash && newPath.StartsWith("/")
+        var updatedNewPath = !_languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash || newPath.StartsWith("/")
             ? newPath
             : '/' + newPath;
         var newUri = new UriBuilder
@@ -252,7 +252,7 @@ internal class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenameParamsBrid
             return;
         }
 
-        var updatedPath = _languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash && documentSnapshot.FilePath.StartsWith("/")
+        var updatedPath = !_languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash || documentSnapshot.FilePath.StartsWith("/")
             ? documentSnapshot.FilePath
             : "/" + documentSnapshot.FilePath;
         var uri = new UriBuilder

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
@@ -190,7 +190,7 @@ internal class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenameParamsBrid
 
     public void AddFileRenameForComponent(List<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>> documentChanges, DocumentSnapshot documentSnapshot, string newPath)
     {
-        // VS code expects path to start with '/'
+        // VS Code in Windows expects path to start with '/'
         var updatedOldPath = _languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash && !documentSnapshot.FilePath.StartsWith("/")
             ? '/' + documentSnapshot.FilePath
             : documentSnapshot.FilePath;
@@ -201,7 +201,7 @@ internal class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenameParamsBrid
             Scheme = Uri.UriSchemeFile,
         }.Uri;
 
-        // VS code expects path to start with '/'
+        // VS Code in Windows expects path to start with '/'
         var updatedNewPath = _languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash && !newPath.StartsWith("/")
             ? '/' + newPath
             : newPath;
@@ -251,12 +251,12 @@ internal class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenameParamsBrid
             return;
         }
 
+        // VS Code in Windows expects path to start with '/'
         var updatedPath = _languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash && !documentSnapshot.FilePath.StartsWith("/")
             ? "/" + documentSnapshot.FilePath
             : documentSnapshot.FilePath;
         var uri = new UriBuilder
         {
-            // VS code expects path to start with '/'
             Path = updatedPath,
             Host = string.Empty,
             Scheme = Uri.UriSchemeFile,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
@@ -188,19 +188,28 @@ internal class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenameParamsBrid
         }
     }
 
-    public static void AddFileRenameForComponent(List<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>> documentChanges, DocumentSnapshot documentSnapshot, string newPath)
+    public void AddFileRenameForComponent(List<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>> documentChanges, DocumentSnapshot documentSnapshot, string newPath)
     {
+        // VS code expects path to start with '/'
+        var updatedOldPath = _languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash && documentSnapshot.FilePath.StartsWith("/")
+            ? documentSnapshot.FilePath
+            : '/' + documentSnapshot.FilePath;
         var oldUri = new UriBuilder
         {
-            // VS code expects path to start with '/'
-            Path = documentSnapshot.FilePath.StartsWith("/") ? documentSnapshot.FilePath : '/' + documentSnapshot.FilePath,
+
+            Path = updatedOldPath,
             Host = string.Empty,
             Scheme = Uri.UriSchemeFile,
         }.Uri;
+
+        // VS code expects path to start with '/'
+        var updatedNewPath = _languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash && newPath.StartsWith("/")
+            ? newPath
+            : '/' + newPath;
         var newUri = new UriBuilder
         {
-            // VS code expects path to start with '/'
-            Path = newPath.StartsWith("/") ? newPath : '/' + newPath,
+
+            Path = updatedNewPath,
             Host = string.Empty,
             Scheme = Uri.UriSchemeFile,
         }.Uri;
@@ -221,7 +230,7 @@ internal class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenameParamsBrid
         return newPath;
     }
 
-    private static async Task AddEditsForCodeDocumentAsync(
+    private async Task AddEditsForCodeDocumentAsync(
         List<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>> documentChanges,
         IReadOnlyList<TagHelperDescriptor> originTagHelpers,
         string newName,
@@ -243,10 +252,13 @@ internal class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenameParamsBrid
             return;
         }
 
+        var updatedPath = _languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash && documentSnapshot.FilePath.StartsWith("/")
+            ? documentSnapshot.FilePath
+            : "/" + documentSnapshot.FilePath;
         var uri = new UriBuilder
         {
             // VS code expects path to start with '/'
-            Path = documentSnapshot.FilePath.StartsWith("/") ? documentSnapshot.FilePath : "/" + documentSnapshot.FilePath,
+            Path = updatedPath,
             Host = string.Empty,
             Scheme = Uri.UriSchemeFile,
         }.Uri;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
@@ -192,13 +192,15 @@ internal class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenameParamsBrid
     {
         var oldUri = new UriBuilder
         {
-            Path = documentSnapshot.FilePath,
+            // VS code expects path to start with '/'
+            Path = documentSnapshot.FilePath.StartsWith("/") ? documentSnapshot.FilePath : '/' + documentSnapshot.FilePath,
             Host = string.Empty,
             Scheme = Uri.UriSchemeFile,
         }.Uri;
         var newUri = new UriBuilder
         {
-            Path = newPath,
+            // VS code expects path to start with '/'
+            Path = newPath.StartsWith("/") ? newPath : '/' + newPath,
             Host = string.Empty,
             Scheme = Uri.UriSchemeFile,
         }.Uri;
@@ -243,7 +245,8 @@ internal class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenameParamsBrid
 
         var uri = new UriBuilder
         {
-            Path = documentSnapshot.FilePath,
+            // VS code expects path to start with '/'
+            Path = documentSnapshot.FilePath.StartsWith("/") ? documentSnapshot.FilePath : "/" + documentSnapshot.FilePath,
             Host = string.Empty,
             Scheme = Uri.UriSchemeFile,
         }.Uri;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
@@ -191,21 +191,20 @@ internal class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenameParamsBrid
     public void AddFileRenameForComponent(List<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>> documentChanges, DocumentSnapshot documentSnapshot, string newPath)
     {
         // VS code expects path to start with '/'
-        var updatedOldPath = !_languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash || documentSnapshot.FilePath.StartsWith("/")
-            ? documentSnapshot.FilePath
-            : '/' + documentSnapshot.FilePath;
+        var updatedOldPath = _languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash && !documentSnapshot.FilePath.StartsWith("/")
+            ? '/' + documentSnapshot.FilePath
+            : documentSnapshot.FilePath;
         var oldUri = new UriBuilder
         {
-
             Path = updatedOldPath,
             Host = string.Empty,
             Scheme = Uri.UriSchemeFile,
         }.Uri;
 
         // VS code expects path to start with '/'
-        var updatedNewPath = !_languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash || newPath.StartsWith("/")
-            ? newPath
-            : '/' + newPath;
+        var updatedNewPath = _languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash && !newPath.StartsWith("/")
+            ? '/' + newPath
+            : newPath;
         var newUri = new UriBuilder
         {
 
@@ -252,9 +251,9 @@ internal class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenameParamsBrid
             return;
         }
 
-        var updatedPath = !_languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash || documentSnapshot.FilePath.StartsWith("/")
-            ? documentSnapshot.FilePath
-            : "/" + documentSnapshot.FilePath;
+        var updatedPath = _languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash && !documentSnapshot.FilePath.StartsWith("/")
+            ? "/" + documentSnapshot.FilePath
+            : documentSnapshot.FilePath;
         var uri = new UriBuilder
         {
             // VS code expects path to start with '/'

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
@@ -21,6 +21,10 @@ internal abstract class LanguageServerFeatureOptions
 
     public abstract bool SupportsDelegatedCodeActions { get; }
 
+    // Code action and rename paths in Windows VS Code need to be prefixed with '/':
+    // https://github.com/dotnet/razor/issues/8131
+    public abstract bool ReturnCodeActionAndRenamePathsWithPrefixedSlash { get; }
+
     public string GetRazorCSharpFilePath(string razorFilePath) => razorFilePath + CSharpVirtualDocumentSuffix;
 
     public string GetRazorHtmlFilePath(string razorFilePath) => razorFilePath + HtmlVirtualDocumentSuffix;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
@@ -60,5 +60,7 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
 
     public override bool SupportsDelegatedCodeActions => true;
 
+    public override bool ReturnCodeActionAndRenamePathsWithPrefixedSlash => false;
+
     private bool IsCodespacesOrLiveshare => _lspEditorFeatureDetector.IsRemoteClient() || _lspEditorFeatureDetector.IsLiveShareHost();
 }

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacLanguageServerFeatureOptions.cs
@@ -39,6 +39,8 @@ internal class VisualStudioMacLanguageServerFeatureOptions : LanguageServerFeatu
 
     public override bool SupportsDelegatedCodeActions => true;
 
+    public override bool ReturnCodeActionAndRenamePathsWithPrefixedSlash => false;
+
     private bool IsCodespacesOrLiveshare => _lspEditorFeatureDetector.IsRemoteClient() || _lspEditorFeatureDetector.IsLiveShareHost();
 
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/CreateComponentCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/CreateComponentCodeActionResolverTest.cs
@@ -36,7 +36,7 @@ public class CreateComponentCodeActionResolverTest : LanguageServerTestBase
     public async Task Handle_MissingFile()
     {
         // Arrange
-        var resolver = new CreateComponentCodeActionResolver(_emptyDocumentContextFactory);
+        var resolver = new CreateComponentCodeActionResolver(_emptyDocumentContextFactory, TestLanguageServerFeatureOptions.Instance);
         var data = JObject.FromObject(new CreateComponentCodeActionParams()
         {
             Uri = new Uri("c:/Test.razor"),
@@ -59,7 +59,7 @@ public class CreateComponentCodeActionResolverTest : LanguageServerTestBase
         var codeDocument = CreateCodeDocument(contents);
         codeDocument.SetUnsupported();
 
-        var resolver = new CreateComponentCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument));
+        var resolver = new CreateComponentCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance);
         var data = JObject.FromObject(new CreateComponentCodeActionParams()
         {
             Uri = documentPath,
@@ -82,7 +82,7 @@ public class CreateComponentCodeActionResolverTest : LanguageServerTestBase
         var codeDocument = CreateCodeDocument(contents);
         codeDocument.SetFileKind(FileKinds.Legacy);
 
-        var resolver = new CreateComponentCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument));
+        var resolver = new CreateComponentCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance);
         var data = JObject.FromObject(new CreateComponentCodeActionParams()
         {
             Uri = documentPath,
@@ -104,7 +104,7 @@ public class CreateComponentCodeActionResolverTest : LanguageServerTestBase
         var contents = $"@page \"/test\"";
         var codeDocument = CreateCodeDocument(contents);
 
-        var resolver = new CreateComponentCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument));
+        var resolver = new CreateComponentCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance);
         var actionParams = new CreateComponentCodeActionParams
         {
             Uri = documentPath,
@@ -132,7 +132,7 @@ public class CreateComponentCodeActionResolverTest : LanguageServerTestBase
         var contents = $"@page \"/test\"{Environment.NewLine}@namespace Another.Namespace";
         var codeDocument = CreateCodeDocument(contents);
 
-        var resolver = new CreateComponentCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument));
+        var resolver = new CreateComponentCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance);
         var actionParams = new CreateComponentCodeActionParams
         {
             Uri = documentPath,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
@@ -39,7 +39,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
     public async Task Handle_MissingFile()
     {
         // Arrange
-        var resolver = new ExtractToCodeBehindCodeActionResolver(_emptyDocumentContextFactory);
+        var resolver = new ExtractToCodeBehindCodeActionResolver(_emptyDocumentContextFactory, TestLanguageServerFeatureOptions.Instance);
         var data = JObject.FromObject(new ExtractToCodeBehindCodeActionParams()
         {
             Uri = new Uri("c:/Test.razor"),
@@ -66,7 +66,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
         var codeDocument = CreateCodeDocument(contents);
         codeDocument.SetUnsupported();
 
-        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument));
+        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance);
         var data = JObject.FromObject(new ExtractToCodeBehindCodeActionParams()
         {
             Uri = new Uri("c:/Test.razor"),
@@ -93,7 +93,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
         var codeDocument = CreateCodeDocument(contents);
         codeDocument.SetFileKind(FileKinds.Legacy);
 
-        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument));
+        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance);
         var data = JObject.FromObject(new ExtractToCodeBehindCodeActionParams()
         {
             Uri = new Uri("c:/Test.razor"),
@@ -120,7 +120,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
         var codeDocument = CreateCodeDocument(contents);
         Assert.True(codeDocument.TryComputeNamespace(fallbackToRootNamespace: true, out var @namespace));
 
-        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument));
+        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance);
         var actionParams = new ExtractToCodeBehindCodeActionParams
         {
             Uri = documentPath,
@@ -169,7 +169,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
         var codeDocument = CreateCodeDocument(contents);
         Assert.True(codeDocument.TryComputeNamespace(fallbackToRootNamespace: true, out var @namespace));
 
-        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument));
+        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance);
         var actionParams = new ExtractToCodeBehindCodeActionParams
         {
             Uri = documentPath,
@@ -218,7 +218,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
         var codeDocument = CreateCodeDocument(contents);
         Assert.True(codeDocument.TryComputeNamespace(fallbackToRootNamespace: true, out var @namespace));
 
-        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument));
+        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance);
         var actionParams = new ExtractToCodeBehindCodeActionParams
         {
             Uri = documentPath,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
@@ -47,7 +47,7 @@ public class RenameEndpointTest : LanguageServerTestBase
     public async Task Handle_Rename_FileManipulationNotSupported_ReturnsNull()
     {
         // Arrange
-        var languageServerFeatureOptions = Mock.Of<LanguageServerFeatureOptions>(options => options.SupportsFileManipulation == false, MockBehavior.Strict);
+        var languageServerFeatureOptions = Mock.Of<LanguageServerFeatureOptions>(options => options.SupportsFileManipulation == false && options.ReturnCodeActionAndRenamePathsWithPrefixedSlash == false, MockBehavior.Strict);
         var endpoint = CreateEndpoint(languageServerFeatureOptions);
         var uri = new Uri("file:///c:/First/Component1.razor");
         var request = new RenameParamsBridge
@@ -421,7 +421,8 @@ public class RenameEndpointTest : LanguageServerTestBase
     public async Task Handle_Rename_SingleServer_CallsDelegatedLanguageServer()
     {
         // Arrange
-        var languageServerFeatureOptions = Mock.Of<LanguageServerFeatureOptions>(options => options.SupportsFileManipulation == true && options.SingleServerSupport == true, MockBehavior.Strict);
+        var languageServerFeatureOptions = Mock.Of<LanguageServerFeatureOptions>(
+            options => options.SupportsFileManipulation == true && options.SingleServerSupport == true && options.ReturnCodeActionAndRenamePathsWithPrefixedSlash == false, MockBehavior.Strict);
 
         var delegatedEdit = new WorkspaceEdit();
 
@@ -469,7 +470,8 @@ public class RenameEndpointTest : LanguageServerTestBase
     public async Task Handle_Rename_SingleServer_DoesntDelegateForRazor()
     {
         // Arrange
-        var languageServerFeatureOptions = Mock.Of<LanguageServerFeatureOptions>(options => options.SupportsFileManipulation == true && options.SingleServerSupport == true, MockBehavior.Strict);
+        var languageServerFeatureOptions = Mock.Of<LanguageServerFeatureOptions>(
+            options => options.SupportsFileManipulation == true && options.SingleServerSupport == true && options.ReturnCodeActionAndRenamePathsWithPrefixedSlash == false, MockBehavior.Strict);
         var languageServerMock = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
         var documentMappingServiceMock = new Mock<RazorDocumentMappingService>(MockBehavior.Strict);
         documentMappingServiceMock
@@ -640,7 +642,8 @@ public class RenameEndpointTest : LanguageServerTestBase
             d.TryCreateAsync(new Uri(itemDirectory2.FilePath), It.IsAny<CancellationToken>()) == Task.FromResult(directory2Component), MockBehavior.Strict);
 
         var searchEngine = new DefaultRazorComponentSearchEngine(Dispatcher, projectSnapshotManagerAccessor, LoggerFactory);
-        languageServerFeatureOptions ??= Mock.Of<LanguageServerFeatureOptions>(options => options.SupportsFileManipulation == true && options.SingleServerSupport == false, MockBehavior.Strict);
+        languageServerFeatureOptions ??= Mock.Of<LanguageServerFeatureOptions>(
+            options => options.SupportsFileManipulation == true && options.SingleServerSupport == false && options.ReturnCodeActionAndRenamePathsWithPrefixedSlash == false, MockBehavior.Strict);
 
         var documentMappingServiceMock = new Mock<RazorDocumentMappingService>(MockBehavior.Strict);
         documentMappingServiceMock

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common/TestLanguageServerFeatureOptions.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common/TestLanguageServerFeatureOptions.cs
@@ -26,4 +26,6 @@ internal class TestLanguageServerFeatureOptions : LanguageServerFeatureOptions
     public override bool SingleServerSupport => false;
 
     public override bool SupportsDelegatedCodeActions => false;
+
+    public override bool ReturnCodeActionAndRenamePathsWithPrefixedSlash => false;
 }


### PR DESCRIPTION
﻿### Summary of the changes

- VS Code expects returned file paths to be prefixed with `/`. We aren't doing this in code actions or rename, and instead we [remove](https://github.com/dotnet/razor/blob/b2d15be01c8b9615b819fb8cffed4ccd02cdff2f/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/FilePathNormalizer.cs#L37) any leading `/` in `FilePathNormalizer` on Windows machines. This has resulted in broken code actions and rename. Unfortunately, we can't alter the logic in `FilePathNormalizer` as doing so would break other parts of the world. As an alternative, I've hacked a fix specifically in our rename/code actions logic.
- Manually verified these changes work in both VS and VS Code.
