### PR TITLE
[VS Code] Fix version numbers

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -367,6 +367,7 @@ stages:
               --prepareMachine
               /p:DotNetSignType=real
               /p:DotNetPublishUsingPipelines=true
+              /p:OfficialBuildId=$(Build.BuildNumber)
               $(_InternalRuntimeDownloadArgs)
             name: Build
             displayName: Build
@@ -439,6 +440,7 @@ stages:
               --prepareMachine
               /p:DotNetSignType=real
               /p:DotNetPublishUsingPipelines=true
+              /p:OfficialBuildId=$(Build.BuildNumber)
               $(_InternalRuntimeDownloadArgs)
             name: Build
             displayName: Build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -360,12 +360,10 @@ stages:
           - script: eng/common/cibuild.sh
               --restore
               --build
-              --sign
               --pack
               --publish
               --configuration $(_BuildConfig)
               --prepareMachine
-              /p:DotNetSignType=real
               /p:DotNetPublishUsingPipelines=true
               /p:OfficialBuildId=$(Build.BuildNumber)
               $(_InternalRuntimeDownloadArgs)
@@ -433,12 +431,10 @@ stages:
           - script: eng/common/cibuild.sh
               --restore
               --build
-              --sign
               --pack
               --publish
               --configuration $(_BuildConfig)
               --prepareMachine
-              /p:DotNetSignType=real
               /p:DotNetPublishUsingPipelines=true
               /p:OfficialBuildId=$(Build.BuildNumber)
               $(_InternalRuntimeDownloadArgs)


### PR DESCRIPTION
﻿### Summary of the changes

- We weren't producing the proper build #s on Linux and Mac builds. We also don't need to sign those builds since (1) the Windows build already signs, and (2) the only unique component of the Linux/Mac builds are the produced language servers, which are "signed" through a separate pipeline.
