### PR TITLE
Remove BOM from .cmd files in eng folder

### DIFF
--- a/eng/CIBuild.cmd
+++ b/eng/CIBuild.cmd
@@ -1,2 +1,2 @@
-﻿@echo off
+@echo off
 powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0\common\Build.ps1""" -ci %*"

--- a/eng/common/CIBuild.cmd
+++ b/eng/common/CIBuild.cmd
@@ -1,2 +1,2 @@
-﻿@echo off
+@echo off
 powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0Build.ps1""" -restore -build -test -sign -pack -publish -ci %*"

--- a/eng/common/dotnet-install.cmd
+++ b/eng/common/dotnet-install.cmd
@@ -1,2 +1,2 @@
-﻿@echo off
+@echo off
 powershell -ExecutionPolicy ByPass -NoProfile -command "& """%~dp0dotnet-install.ps1""" %*"

--- a/eng/common/init-tools-native.cmd
+++ b/eng/common/init-tools-native.cmd
@@ -1,3 +1,3 @@
-﻿@echo off
+@echo off
 powershell -NoProfile -NoLogo -ExecutionPolicy ByPass -command "& """%~dp0init-tools-native.ps1""" %*"
 exit /b %ErrorLevel%


### PR DESCRIPTION
This change removes the BOM added by #8099 from `.cmd` files in the `eng` and `eng/common` folders. These scripts have continued to work, since the first line of each starts with `@echo off`. However, an error gets printed to the console for the first line before the scripts continue on.