### PR TITLE
Skip Diagnostic tests for now

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/DiagnosticTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/DiagnosticTests.cs
@@ -8,7 +8,7 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests;
 
 public class DiagnosticTests : AbstractRazorEditorTest
 {
-    [IdeFact]
+    [IdeFact(Skip = "https://github.com/dotnet/razor/issues/8150")]
     public async Task Diagnostics_ShowErrors_Razor()
     {
         // Arrange
@@ -48,7 +48,7 @@ public class DiagnosticTests : AbstractRazorEditorTest
             });
     }
 
-    [IdeFact]
+    [IdeFact(Skip = "https://github.com/dotnet/razor/issues/8150")]
     public async Task Diagnostics_ShowErrors_Html()
     {
         // Arrange
@@ -80,7 +80,7 @@ public class DiagnosticTests : AbstractRazorEditorTest
             });
     }
 
-    [IdeFact]
+    [IdeFact(Skip = "https://github.com/dotnet/razor/issues/8150")]
     public async Task Diagnostics_ShowErrors_CSharp()
     {
         // Arrange
@@ -112,7 +112,7 @@ public class DiagnosticTests : AbstractRazorEditorTest
             });
     }
 
-    [IdeFact]
+    [IdeFact(Skip = "https://github.com/dotnet/razor/issues/8150")]
     public async Task Diagnostics_ShowErrors_CSharp_NoDocType()
     {
         // Why this test, when we have the above test, and they seem so similar, and we also have Diagnostics_ShowErrors_CSharpAndHtml you ask? Well I'll tell you!
@@ -152,7 +152,7 @@ public class DiagnosticTests : AbstractRazorEditorTest
             });
     }
 
-    [IdeFact]
+    [IdeFact(Skip = "https://github.com/dotnet/razor/issues/8150")]
     public async Task Diagnostics_ShowErrors_CSharpAndHtml()
     {
         // Arrange


### PR DESCRIPTION
﻿### Summary of the changes

- The new VS Preview version seems to have stirred up [some instability](https://dev.azure.com/dnceng/internal/_build/results?buildId=2091222&view=artifacts&pathAsName=false&type=publishedArtifacts) that we already knew about.
- Turning these back on is tracked by https://github.com/dotnet/razor/issues/8150.

CC @DustinCampbell and @jaredpar who we talked about this with.