### PR TITLE
Fix broken tooling micro benchmarks

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensBenchmark.cs
@@ -22,7 +22,7 @@ namespace Microsoft.AspNetCore.Razor.Microbenchmarks.LanguageServer;
 
 public class RazorSemanticTokensBenchmark : RazorLanguageServerBenchmarkBase
 {
-    private DefaultRazorSemanticTokensInfoService RazorSemanticTokenService { get; set; }
+    private RazorSemanticTokensInfoService RazorSemanticTokenService { get; set; }
 
     private DocumentVersionCache VersionCache { get; set; }
 
@@ -116,14 +116,17 @@ public class RazorSemanticTokensBenchmark : RazorLanguageServerBenchmarkBase
     private void EnsureServicesInitialized()
     {
         var languageServer = RazorLanguageServer.GetInnerLanguageServerForTesting();
-        RazorSemanticTokenService = languageServer.GetRequiredService<RazorSemanticTokensInfoService>() as TestRazorSemanticTokensInfoService;
+        RazorSemanticTokenService = languageServer.GetRequiredService<RazorSemanticTokensInfoService>();
         VersionCache = languageServer.GetRequiredService<DocumentVersionCache>();
         ProjectSnapshotManagerDispatcher = languageServer.GetRequiredService<ProjectSnapshotManagerDispatcher>();
     }
 
     internal class TestRazorSemanticTokensInfoService : DefaultRazorSemanticTokensInfoService
     {
-        public TestRazorSemanticTokensInfoService(ClientNotifierServiceBase languageServer, RazorDocumentMappingService documentMappingService, LoggerFactory loggerFactory)
+        public TestRazorSemanticTokensInfoService(
+            ClientNotifierServiceBase languageServer,
+            RazorDocumentMappingService documentMappingService,
+            ILoggerFactory loggerFactory)
             : base(languageServer, documentMappingService, loggerFactory)
         {
         }

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensScrollingBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensScrollingBenchmark.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNetCore.Razor.Microbenchmarks.LanguageServer;
 
 public class RazorSemanticTokensScrollingBenchmark : RazorLanguageServerBenchmarkBase
 {
-    private DefaultRazorSemanticTokensInfoService RazorSemanticTokenService { get; set; }
+    private RazorSemanticTokensInfoService RazorSemanticTokenService { get; set; }
 
     private DocumentVersionCache VersionCache { get; set; }
 
@@ -129,7 +129,7 @@ public class RazorSemanticTokensScrollingBenchmark : RazorLanguageServerBenchmar
     private void EnsureServicesInitialized()
     {
         var languageServer = RazorLanguageServer.GetInnerLanguageServerForTesting();
-        RazorSemanticTokenService = (languageServer.GetRequiredService<RazorSemanticTokensInfoService>() as TestRazorSemanticTokensInfoService)!;
+        RazorSemanticTokenService = languageServer.GetRequiredService<RazorSemanticTokensInfoService>();
         VersionCache = languageServer.GetRequiredService<DocumentVersionCache>();
         ProjectSnapshotManagerDispatcher = languageServer.GetRequiredService<ProjectSnapshotManagerDispatcher>();
     }

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/ProjectSystem/ProjectSnapshotSerializationBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/ProjectSystem/ProjectSnapshotSerializationBenchmark.cs
@@ -37,7 +37,7 @@ public class ProjectSnapshotSerializationBenchmark : ProjectSnapshotManagerBench
         using (originalStream = new MemoryStream())
         using (var writer = new StreamWriter(originalStream, Encoding.UTF8, bufferSize: 4096))
         {
-            Serializer.Serialize(writer, ProjectSnapshot);
+            Serializer.Serialize(writer, new ProjectSnapshotHandle(ProjectSnapshot));
         }
 
         ProjectSnapshotHandle deserializedResult;

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Serialization/CompletionListSerializationBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Serialization/CompletionListSerializationBenchmark.cs
@@ -27,12 +27,12 @@ public class CompletionListSerializationBenchmark : TagHelperBenchmarkBase
         var htmlFactsService = new DefaultHtmlFactsService();
         var tagHelperCompletionProvider = new TagHelperCompletionProvider(completionService, htmlFactsService, tagHelperFactsService);
 
+        Serializer = JsonSerializer.Create();
+
         var documentContent = "<";
         var queryIndex = 1;
         CompletionList = GenerateCompletionList(documentContent, queryIndex, tagHelperCompletionProvider);
         _completionListBuffer = GenerateBuffer(CompletionList);
-
-        Serializer = JsonSerializer.Create();
     }
 
     private JsonSerializer Serializer { get; }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
@@ -20,6 +20,7 @@ using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.Editor.Razor;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -118,7 +119,9 @@ internal static class IServiceCollectionExtensions
 
         services.AddSingleton<WorkspaceSemanticTokensRefreshPublisher, DefaultWorkspaceSemanticTokensRefreshPublisher>();
         services.AddSingleton<ProjectSnapshotChangeTrigger, DefaultWorkspaceSemanticTokensRefreshTrigger>();
-        services.AddSingleton<RazorSemanticTokensInfoService, DefaultRazorSemanticTokensInfoService>();
+
+        // Ensure that we don't add the default service if something else has added one.
+        services.TryAddSingleton<RazorSemanticTokensInfoService, DefaultRazorSemanticTokensInfoService>();
     }
 
     public static void AddCodeActionsServices(this IServiceCollection services)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Serialization/ProjectSnapshotHandle.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Serialization/ProjectSnapshotHandle.cs
@@ -8,6 +8,11 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 internal sealed class ProjectSnapshotHandle
 {
+    public ProjectSnapshotHandle(ProjectSnapshot snapshot)
+        : this(snapshot.FilePath, snapshot.Configuration, snapshot.RootNamespace)
+    {
+    }
+
     public ProjectSnapshotHandle(
         string filePath,
         RazorConfiguration? configuration,


### PR DESCRIPTION
Fixes #8073

There were a handful of tooling micro benchmarks that failed when run. This change fixes each of them.

* `ProjectSnapshotSerializationBenchmark`: Tried to serialize a `ProjectSnapshot` and then deserialize it as a `ProjectSnapshotHandle`. Since `ProjectSnapshot` isn't actually an object that can be serialized, I assume that the original intent was to serialize a `ProjectSnapshotHandle`.
* `RazorSemanticTokensBenchmark` and `RazorSemanticTokenScrollingBenchmark`: Both of these benchmarks add a `TestRazorSemanticTokensInfoService` into the language server's service collection. However, the language server would add a `DefaultRazorSemanticTokensInfoService` afterward, causing the benchmarks to fail. The fix is to use `TryAddSingleton` in the language server to avoid allowing two services to be added.
* `CompletionListSerializationBenchmark`: Tried to serialize before the serializer was created.

Admittedly, these might not be the best fixes. These benchmarks all seem to be a written a bit haphazardly and could use some refactoring. However, I think it's probably better to get them running first.