### PR TITLE
Add UTF-8 encoding to `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-﻿* text=auto
+﻿* text=auto encoding=UTF-8
 
 # Collapse these files in PRs by default
 *.xlf linguist-generated=true


### PR DESCRIPTION
This change was originally added to PR #8099 in [commit](https://github.com/dotnet/razor/commit/7c7cce2b663c6f86e2b46bda608a6f53637c1ea4#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393e) by @333fred, but subsequently got accidently removed with his first force push.

See [comment](https://github.com/dotnet/razor/pull/8099#issuecomment-1376904265).

This PR adds that same encoding back into the `.gitattributes` file.

**N.B.** I've not seen this attribute `encoding` in the official [git documentation](https://git-scm.com/docs/gitattributes), but assume @333fred knows what he's doing :smiley:.