### PR TITLE
Allow `DocumentContextFactory` to be used for closed files

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCSharpFormattingBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCSharpFormattingBenchmark.cs
@@ -118,7 +118,7 @@ public class RazorCSharpFormattingBenchmark : RazorLanguageServerBenchmarkBase
             InsertSpaces = true
         };
 
-        var documentContext = new DocumentContext(DocumentUri, DocumentSnapshot, version: 1);
+        var documentContext = new VersionedDocumentContext(DocumentUri, DocumentSnapshot, version: 1);
 
         var edits = await RazorFormattingService.FormatAsync(documentContext, range: null, options, CancellationToken.None);
 

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCodeActionsBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCodeActionsBenchmark.cs
@@ -79,7 +79,7 @@ public class RazorCodeActionsBenchmark : RazorLanguageServerBenchmarkBase
         CSharpCodeActionRange = ToRange(csharpCodeActionIndex);
         HtmlCodeActionRange = ToRange(htmlCodeActionIndex);
 
-        var documentContext = new DocumentContext(DocumentUri, DocumentSnapshot, 1);
+        var documentContext = new VersionedDocumentContext(DocumentUri, DocumentSnapshot, 1);
 
         var codeDocument = await documentContext.GetCodeDocumentAsync(CancellationToken.None);
         // Need a root namespace for the Extract to Code Behind light bulb to be happy

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCompletionBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCompletionBenchmark.cs
@@ -74,7 +74,7 @@ public class RazorCompletionBenchmark : RazorLanguageServerBenchmarkBase
 
         RazorPosition = ToPosition(razorCodeActionIndex);
 
-        var documentContext = new DocumentContext(DocumentUri, DocumentSnapshot, 1);
+        var documentContext = new VersionedDocumentContext(DocumentUri, DocumentSnapshot, 1);
         RazorRequestContext = new RazorRequestContext(documentContext, Logger, languageServer.GetLspServices());
 
         Position ToPosition(int index)
@@ -147,7 +147,7 @@ public class RazorCompletionBenchmark : RazorLanguageServerBenchmarkBase
         {
         }
 
-        public override Task<VSInternalCompletionList?> GetCompletionListAsync(int absoluteIndex, VSInternalCompletionContext completionContext, DocumentContext documentContext, VSInternalClientCapabilities clientCapabilities, CancellationToken cancellationToken)
+        public override Task<VSInternalCompletionList?> GetCompletionListAsync(int absoluteIndex, VSInternalCompletionContext completionContext, VersionedDocumentContext documentContext, VSInternalClientCapabilities clientCapabilities, CancellationToken cancellationToken)
         {
             return Task.FromResult<VSInternalCompletionList?>(
                 new VSInternalCompletionList

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensBenchmark.cs
@@ -30,7 +30,7 @@ public class RazorSemanticTokensBenchmark : RazorLanguageServerBenchmarkBase
 
     private DocumentSnapshot DocumentSnapshot => DocumentContext.Snapshot;
 
-    private DocumentContext DocumentContext { get; set; }
+    private VersionedDocumentContext DocumentContext { get; set; }
 
     private Range Range { get; set; }
 
@@ -56,7 +56,7 @@ public class RazorSemanticTokensBenchmark : RazorLanguageServerBenchmarkBase
         var documentUri = new Uri(filePath);
         var documentSnapshot = GetDocumentSnapshot(ProjectFilePath, filePath, TargetPath);
         var version = 1;
-        DocumentContext = new DocumentContext(documentUri, documentSnapshot, version);
+        DocumentContext = new VersionedDocumentContext(documentUri, documentSnapshot, version);
 
         var text = await DocumentContext.GetSourceTextAsync(CancellationToken.None).ConfigureAwait(false);
         Range = new Range

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensScrollingBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensScrollingBenchmark.cs
@@ -24,7 +24,7 @@ public class RazorSemanticTokensScrollingBenchmark : RazorLanguageServerBenchmar
 
     private DocumentVersionCache VersionCache { get; set; }
 
-    private DocumentContext DocumentContext { get; set; }
+    private VersionedDocumentContext DocumentContext { get; set; }
 
     private Uri DocumentUri => DocumentContext.Uri;
 
@@ -53,7 +53,7 @@ public class RazorSemanticTokensScrollingBenchmark : RazorLanguageServerBenchmar
 
         var documentUri = new Uri(filePath);
         var documentSnapshot = GetDocumentSnapshot(ProjectFilePath, filePath, TargetPath);
-        DocumentContext = new DocumentContext(documentUri, documentSnapshot, version: 1);
+        DocumentContext = new VersionedDocumentContext(documentUri, documentSnapshot, version: 1);
 
         var text = await DocumentSnapshot.GetTextAsync().ConfigureAwait(false);
         Range = new Range

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/AddUsingsCSharpCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/AddUsingsCSharpCodeActionResolver.cs
@@ -51,7 +51,7 @@ internal class AddUsingsCSharpCodeActionResolver : CSharpCodeActionResolver
 
         cancellationToken.ThrowIfCancellationRequested();
 
-        var documentContext = await _documentContextFactory.TryCreateAsync(csharpParams.RazorFileUri, cancellationToken).ConfigureAwait(false);
+        var documentContext = await _documentContextFactory.TryCreateForOpenDocumentAsync(csharpParams.RazorFileUri, cancellationToken).ConfigureAwait(false);
         if (documentContext is null || cancellationToken.IsCancellationRequested)
         {
             return codeAction;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/DefaultCSharpCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/DefaultCSharpCodeActionResolver.cs
@@ -72,7 +72,7 @@ internal class DefaultCSharpCodeActionResolver : CSharpCodeActionResolver
             throw new ArgumentNullException(nameof(codeAction));
         }
 
-        var documentContext = await _documentContextFactory.TryCreateAsync(csharpParams.RazorFileUri, cancellationToken).ConfigureAwait(false);
+        var documentContext = await _documentContextFactory.TryCreateForOpenDocumentAsync(csharpParams.RazorFileUri, cancellationToken).ConfigureAwait(false);
         if (documentContext is null)
         {
             return codeAction;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/UnformattedRemappingCSharpCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/UnformattedRemappingCSharpCodeActionResolver.cs
@@ -52,7 +52,7 @@ internal class UnformattedRemappingCSharpCodeActionResolver : CSharpCodeActionRe
 
         cancellationToken.ThrowIfCancellationRequested();
 
-        var documentContext = await _documentContextFactory.TryCreateAsync(csharpParams.RazorFileUri, cancellationToken).ConfigureAwait(false);
+        var documentContext = await _documentContextFactory.TryCreateForOpenDocumentAsync(csharpParams.RazorFileUri, cancellationToken).ConfigureAwait(false);
         if (documentContext is null)
         {
             return codeAction;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
@@ -181,7 +181,7 @@ internal class CodeActionEndpoint : IVSCodeActionEndpoint
         return context;
     }
 
-    private async Task<ImmutableArray<RazorVSInternalCodeAction>> GetDelegatedCodeActionsAsync(DocumentContext documentContext, RazorCodeActionContext context, CancellationToken cancellationToken)
+    private async Task<ImmutableArray<RazorVSInternalCodeAction>> GetDelegatedCodeActionsAsync(VersionedDocumentContext documentContext, RazorCodeActionContext context, CancellationToken cancellationToken)
     {
         var languageKind = _documentMappingService.GetLanguageKind(context.CodeDocument, context.Location.AbsoluteIndex, rightAssociative: false);
 
@@ -263,7 +263,7 @@ internal class CodeActionEndpoint : IVSCodeActionEndpoint
     }
 
     // Internal for testing
-    internal async Task<RazorVSInternalCodeAction[]> GetCodeActionsFromLanguageServerAsync(RazorLanguageKind languageKind, DocumentContext documentContext, RazorCodeActionContext context, CancellationToken cancellationToken)
+    internal async Task<RazorVSInternalCodeAction[]> GetCodeActionsFromLanguageServerAsync(RazorLanguageKind languageKind, VersionedDocumentContext documentContext, RazorCodeActionContext context, CancellationToken cancellationToken)
     {
         if (languageKind == RazorLanguageKind.CSharp)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Html/DefaultHtmlCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Html/DefaultHtmlCodeActionResolver.cs
@@ -53,7 +53,7 @@ internal class DefaultHtmlCodeActionResolver : HtmlCodeActionResolver
             throw new ArgumentNullException(nameof(codeAction));
         }
 
-        var documentContext = await _documentContextFactory.TryCreateAsync(resolveParams.RazorFileUri, cancellationToken).ConfigureAwait(false);
+        var documentContext = await _documentContextFactory.TryCreateForOpenDocumentAsync(resolveParams.RazorFileUri, cancellationToken).ConfigureAwait(false);
         if (documentContext is null)
         {
             return codeAction;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/CompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/CompletionListProvider.cs
@@ -31,7 +31,7 @@ internal class CompletionListProvider
     public async Task<VSInternalCompletionList?> GetCompletionListAsync(
         int absoluteIndex,
         VSInternalCompletionContext completionContext,
-        DocumentContext documentContext,
+        VersionedDocumentContext documentContext,
         VSInternalClientCapabilities clientCapabilities,
         CancellationToken cancellationToken)
     {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionItemResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionItemResolver.cs
@@ -88,7 +88,7 @@ internal class DelegatedCompletionItemResolver : CompletionItemResolver
         }
 
         var hostDocumentUri = context.OriginalRequestParams.HostDocument.Uri;
-        var documentContext = await _documentContextFactory.TryCreateAsync(hostDocumentUri, cancellationToken).ConfigureAwait(false);
+        var documentContext = await _documentContextFactory.TryCreateForOpenDocumentAsync(hostDocumentUri, cancellationToken).ConfigureAwait(false);
         if (documentContext is null)
         {
             return resolvedCompletionItem;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionListProvider.cs
@@ -46,7 +46,7 @@ internal class DelegatedCompletionListProvider
     public virtual async Task<VSInternalCompletionList?> GetCompletionListAsync(
         int absoluteIndex,
         VSInternalCompletionContext completionContext,
-        DocumentContext documentContext,
+        VersionedDocumentContext documentContext,
         VSInternalClientCapabilities clientCapabilities,
         CancellationToken cancellationToken)
     {
@@ -144,7 +144,7 @@ internal class DelegatedCompletionListProvider
     }
 
     private async Task<ProvisionalCompletionInfo?> TryGetProvisionalCompletionInfoAsync(
-        DocumentContext documentContext,
+        VersionedDocumentContext documentContext,
         VSInternalCompletionContext completionContext,
         Projection projection,
         CancellationToken cancellationToken)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionListProvider.cs
@@ -46,7 +46,7 @@ internal class RazorCompletionListProvider
     public virtual async Task<VSInternalCompletionList?> GetCompletionListAsync(
         int absoluteIndex,
         VSInternalCompletionContext completionContext,
-        DocumentContext documentContext,
+        VersionedDocumentContext documentContext,
         VSInternalClientCapabilities clientCapabilities,
         HashSet<string>? existingCompletions,
         CancellationToken cancellationToken)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultDocumentContextFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultDocumentContextFactory.cs
@@ -32,10 +32,10 @@ internal class DefaultDocumentContextFactory : DocumentContextFactory
     }
 
     public override Task<DocumentContext?> TryCreateAsync(Uri documentUri, CancellationToken cancellationToken)
-     => TryCreateCoreAsync(documentUri, versioned: false, cancellationToken);
+        => TryCreateCoreAsync(documentUri, versioned: false, cancellationToken);
 
     public async override Task<VersionedDocumentContext?> TryCreateForOpenDocumentAsync(Uri documentUri, CancellationToken cancellationToken)
-     => (VersionedDocumentContext?)await TryCreateCoreAsync(documentUri, versioned: true, cancellationToken).ConfigureAwait(false);
+        => (VersionedDocumentContext?)await TryCreateCoreAsync(documentUri, versioned: true, cancellationToken).ConfigureAwait(false);
 
     private async Task<DocumentContext?> TryCreateCoreAsync(Uri documentUri, bool versioned, CancellationToken cancellationToken)
     {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
@@ -809,7 +809,7 @@ internal class DefaultRazorDocumentMappingService : RazorDocumentMappingService
             }
 
             var razorDocumentUri = _languageServerFeatureOptions.GetRazorDocumentUri(virtualDocumentUri);
-            var documentContext = await _documentContextFactory.TryCreateAsync(razorDocumentUri, cancellationToken).ConfigureAwait(false);
+            var documentContext = await _documentContextFactory.TryCreateForOpenDocumentAsync(razorDocumentUri, cancellationToken).ConfigureAwait(false);
             if (documentContext is null)
             {
                 continue;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentContext.cs
@@ -14,26 +14,22 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
-internal record DocumentContext
+internal class DocumentContext
 {
     private RazorCodeDocument? _codeDocument;
     private SourceText? _sourceText;
 
     public DocumentContext(
         Uri uri,
-        DocumentSnapshot snapshot,
-        int version)
+        DocumentSnapshot snapshot)
     {
         Uri = uri;
         Snapshot = snapshot;
-        Version = version;
     }
 
     public virtual Uri Uri { get; }
 
     public virtual DocumentSnapshot Snapshot { get; }
-
-    public virtual int Version { get; }
 
     public virtual string FilePath => Snapshot.FilePath;
 
@@ -41,10 +37,9 @@ internal record DocumentContext
 
     public virtual ProjectSnapshot Project => Snapshot.Project;
 
-    public virtual VersionedTextDocumentIdentifier Identifier => new VersionedTextDocumentIdentifier()
+    public virtual TextDocumentIdentifier Identifier => new VersionedTextDocumentIdentifier()
     {
-        Uri = Uri,
-        Version = Version,
+        Uri = Uri
     };
 
     public virtual async Task<RazorCodeDocument> GetCodeDocumentAsync(CancellationToken cancellationToken)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentContextFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentContextFactory.cs
@@ -10,4 +10,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer;
 internal abstract class DocumentContextFactory
 {
     public abstract Task<DocumentContext?> TryCreateAsync(Uri documentUri, CancellationToken cancellationToken);
+
+    public abstract Task<VersionedDocumentContext?> TryCreateForOpenDocumentAsync(Uri documentUri, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/RazorRequestContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/RazorRequestContext.cs
@@ -8,12 +8,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 
 internal readonly struct RazorRequestContext
 {
-    public readonly DocumentContext? DocumentContext;
+    public readonly VersionedDocumentContext? DocumentContext;
     public readonly IRazorLogger Logger;
     public readonly ILspServices LspServices;
 
     public RazorRequestContext(
-        DocumentContext? documentContext,
+        VersionedDocumentContext? documentContext,
         IRazorLogger logger,
         ILspServices lspServices)
     {
@@ -22,7 +22,7 @@ internal readonly struct RazorRequestContext
         Logger = logger;
     }
 
-    public DocumentContext GetRequiredDocumentContext()
+    public VersionedDocumentContext GetRequiredDocumentContext()
     {
         if (DocumentContext is null)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DefaultRazorFormattingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DefaultRazorFormattingService.cs
@@ -48,7 +48,7 @@ internal class DefaultRazorFormattingService : RazorFormattingService
     }
 
     public override async Task<TextEdit[]> FormatAsync(
-        DocumentContext documentContext,
+        VersionedDocumentContext documentContext,
         Range? range,
         FormattingOptions options,
         CancellationToken cancellationToken)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingService.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 internal abstract class RazorFormattingService
 {
     public abstract Task<TextEdit[]> FormatAsync(
-        DocumentContext documentContext,
+        VersionedDocumentContext documentContext,
         Range? range,
         FormattingOptions options,
         CancellationToken cancellationToken);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorRequestContextFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorRequestContextFactory.cs
@@ -21,7 +21,7 @@ internal class RazorRequestContextFactory : IRequestContextFactory<RazorRequestC
 
     public async Task<RazorRequestContext> CreateRequestContextAsync<TRequestParams>(IQueueItem<RazorRequestContext> queueItem, TRequestParams @params, CancellationToken cancellationToken)
     {
-        DocumentContext? documentContext = null;
+        VersionedDocumentContext? documentContext = null;
         var textDocumentHandler = queueItem.MethodHandler as ITextDocumentIdentifierHandler;
 
         Uri? uri = null;
@@ -45,7 +45,7 @@ internal class RazorRequestContextFactory : IRequestContextFactory<RazorRequestC
         if (uri is not null)
         {
             var documentContextFactory = _lspServices.GetRequiredService<DocumentContextFactory>();
-            documentContext = await documentContextFactory.TryCreateAsync(uri, cancellationToken);
+            documentContext = await documentContextFactory.TryCreateForOpenDocumentAsync(uri, cancellationToken);
         }
 
         var loggerAdapter = _lspServices.GetRequiredService<LoggerAdapter>();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/DefaultRazorSemanticTokensInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/DefaultRazorSemanticTokensInfoService.cs
@@ -47,7 +47,7 @@ internal class DefaultRazorSemanticTokensInfoService : RazorSemanticTokensInfoSe
     public override async Task<SemanticTokens?> GetSemanticTokensAsync(
         TextDocumentIdentifier textDocumentIdentifier,
         Range range,
-        DocumentContext documentContext,
+        VersionedDocumentContext documentContext,
         CancellationToken cancellationToken)
     {
         var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/RazorSemanticTokenInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/RazorSemanticTokenInfoService.cs
@@ -9,5 +9,5 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
 
 internal abstract class RazorSemanticTokensInfoService
 {
-    public abstract Task<SemanticTokens?> GetSemanticTokensAsync(TextDocumentIdentifier textDocumentIdentifier, Range range, DocumentContext documentContext, CancellationToken cancellationToken);
+    public abstract Task<SemanticTokens?> GetSemanticTokensAsync(TextDocumentIdentifier textDocumentIdentifier, Range range, VersionedDocumentContext documentContext, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/VersionedDocumentContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/VersionedDocumentContext.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer;
+
+internal class VersionedDocumentContext : DocumentContext
+{
+    public virtual int Version { get; }
+
+    public VersionedDocumentContext(Uri uri, DocumentSnapshot snapshot, int version)
+        : base(uri, snapshot)
+    {
+        Version = version;
+    }
+
+    // Sadly we target net472 which doesn't support covariant return types, so this can't override.
+    public new VersionedTextDocumentIdentifier Identifier => new VersionedTextDocumentIdentifier()
+    {
+        Uri = Uri,
+        Version = Version,
+    };
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/LanguageServerTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/LanguageServerTestBase.cs
@@ -58,7 +58,7 @@ public abstract class LanguageServerTestBase : TestBase
         Serializer.AddVSExtensionConverters();
     }
 
-    internal RazorRequestContext CreateRazorRequestContext(DocumentContext? documentContext, ILspServices? lspServices = null)
+    internal RazorRequestContext CreateRazorRequestContext(VersionedDocumentContext? documentContext, ILspServices? lspServices = null)
     {
         lspServices ??= new Mock<ILspServices>(MockBehavior.Strict).Object;
 
@@ -90,7 +90,7 @@ public abstract class LanguageServerTestBase : TestBase
         return CreateDocumentContextFactory(documentPath, codeDocument);
     }
 
-    internal static DocumentContext CreateDocumentContext(Uri documentPath, RazorCodeDocument codeDocument)
+    internal static VersionedDocumentContext CreateDocumentContext(Uri documentPath, RazorCodeDocument codeDocument)
     {
         return TestDocumentContext.From(documentPath.GetAbsoluteOrUNCPath(), codeDocument, hostDocumentVersion: 1337);
     }
@@ -115,9 +115,9 @@ public abstract class LanguageServerTestBase : TestBase
         return documentContextFactory;
     }
 
-    internal static DocumentContext CreateDocumentContext(Uri uri, DocumentSnapshot snapshot)
+    internal static VersionedDocumentContext CreateDocumentContext(Uri uri, DocumentSnapshot snapshot)
     {
-        return new DocumentContext(uri, snapshot, version: 0);
+        return new VersionedDocumentContext(uri, snapshot, version: 0);
     }
 
     [Obsolete("Use " + nameof(LSPProjectSnapshotManagerDispatcher))]

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestDocumentContext.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestDocumentContext.cs
@@ -44,4 +44,12 @@ internal static class TestDocumentContext
         var codeDocument = RazorCodeDocument.Create(sourceDocument);
         return From(filePath, codeDocument);
     }
+
+    public static VersionedDocumentContext From(string filePath, int hostDocumentVersion)
+    {
+        var properties = new RazorSourceDocumentProperties(filePath, filePath);
+        var sourceDocument = RazorSourceDocument.Create(content: string.Empty, properties);
+        var codeDocument = RazorCodeDocument.Create(sourceDocument);
+        return From(filePath, codeDocument, hostDocumentVersion);
+    }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestDocumentContext.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestDocumentContext.cs
@@ -13,24 +13,28 @@ internal static class TestDocumentContext
 {
     public static DocumentContext Create(Uri uri) => Create(uri, string.Empty);
 
-    public static DocumentContext Create(Uri uri, string text, int version = 0)
+    public static DocumentContext Create(Uri uri, string text)
     {
         var snapshot = TestDocumentSnapshot.Create(uri.GetAbsoluteOrUNCPath(), text);
-        return new DocumentContext(uri, snapshot, version);
+        return new DocumentContext(uri, snapshot);
     }
 
-    public static DocumentContext From(string filePath, RazorCodeDocument codeDocument, int hostDocumentVersion)
+    public static VersionedDocumentContext From(string filePath, RazorCodeDocument codeDocument, int hostDocumentVersion)
     {
         var content = codeDocument.GetSourceText().ToString();
         var documentSnapshot = TestDocumentSnapshot.Create(filePath, content);
         documentSnapshot.With(codeDocument);
         var uri = new Uri(filePath);
-        return new DocumentContext(uri, documentSnapshot, hostDocumentVersion);
+        return new VersionedDocumentContext(uri, documentSnapshot, hostDocumentVersion);
     }
 
     public static DocumentContext From(string filePath, RazorCodeDocument codeDocument)
     {
-        return From(filePath, codeDocument, hostDocumentVersion: 0);
+        var content = codeDocument.GetSourceText().ToString();
+        var documentSnapshot = TestDocumentSnapshot.Create(filePath, content);
+        documentSnapshot.With(codeDocument);
+        var uri = new Uri(filePath);
+        return new DocumentContext(uri, documentSnapshot);
     }
 
     public static DocumentContext From(string filePath)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestDocumentContextFactory.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestDocumentContextFactory.cs
@@ -32,7 +32,16 @@ internal class TestDocumentContextFactory : DocumentContextFactory
             return Task.FromResult<DocumentContext?>(null);
         }
 
-        var documentContext = _version is null ? TestDocumentContext.From(_filePath, _codeDocument) : TestDocumentContext.From(_filePath, _codeDocument, _version.Value);
-        return Task.FromResult<DocumentContext?>(documentContext);
+        return Task.FromResult<DocumentContext?>(TestDocumentContext.From(_filePath, _codeDocument));
+    }
+
+    public override Task<VersionedDocumentContext?> TryCreateForOpenDocumentAsync(Uri documentUri, CancellationToken cancellationToken)
+    {
+        if (_filePath is null || _codeDocument is null || _version is null)
+        {
+            return Task.FromResult<VersionedDocumentContext?>(null);
+        }
+
+        return Task.FromResult<VersionedDocumentContext?>(TestDocumentContext.From(_filePath, _codeDocument, _version.Value));
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/OnAutoInsertEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/OnAutoInsertEndpointTest.cs
@@ -386,7 +386,7 @@ public class OnAutoInsertEndpointTest : SingleServerDelegatingEndpointTestBase
         await VerifyCSharpOnAutoInsertAsync(input, expected, character);
     }
 
-    private async Task<RazorRequestContext> CreateOnAutoInsertRequestContextAsync(DocumentContext? documentContext)
+    private async Task<RazorRequestContext> CreateOnAutoInsertRequestContextAsync(VersionedDocumentContext? documentContext)
     {
         var lspServices = new Mock<ILspServices>(MockBehavior.Strict);
         lspServices
@@ -425,7 +425,7 @@ public class OnAutoInsertEndpointTest : SingleServerDelegatingEndpointTestBase
                 InsertSpaces = true
             },
         };
-        var documentContext = await DocumentContextFactory.TryCreateAsync(@params.TextDocument.Uri, DisposalToken);
+        var documentContext = await DocumentContextFactory.TryCreateForOpenDocumentAsync(@params.TextDocument.Uri, DisposalToken);
 
         var requestContext = await CreateOnAutoInsertRequestContextAsync(documentContext);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/CompletionListProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/CompletionListProviderTest.cs
@@ -27,7 +27,7 @@ public class CompletionListProviderTest : LanguageServerTestBase
     private readonly RazorCompletionListProvider _razorCompletionProvider;
     private readonly DelegatedCompletionListProvider _delegatedCompletionProvider;
     private readonly VSInternalCompletionContext _completionContext;
-    private readonly DocumentContext _documentContext;
+    private readonly VersionedDocumentContext _documentContext;
     private readonly VSInternalClientCapabilities _clientCapabilities;
 
     public CompletionListProviderTest(ITestOutputHelper testOutput)
@@ -38,7 +38,7 @@ public class CompletionListProviderTest : LanguageServerTestBase
         _razorCompletionProvider = new TestRazorCompletionListProvider(_completionList1, new[] { SharedTriggerCharacter, }, LoggerFactory);
         _delegatedCompletionProvider = new TestDelegatedCompletionListProvider(_completionList2, new[] { SharedTriggerCharacter, CompletionList2OnlyTriggerCharacter });
         _completionContext = new VSInternalCompletionContext();
-        _documentContext = TestDocumentContext.From("C:/path/to/file.cshtml");
+        _documentContext = TestDocumentContext.From("C:/path/to/file.cshtml", hostDocumentVersion: 0);
         _clientCapabilities = new VSInternalClientCapabilities();
     }
 
@@ -89,7 +89,7 @@ public class CompletionListProviderTest : LanguageServerTestBase
         public override Task<VSInternalCompletionList> GetCompletionListAsync(
             int absoluteIndex,
             VSInternalCompletionContext completionContext,
-            DocumentContext documentContext,
+            VersionedDocumentContext documentContext,
             VSInternalClientCapabilities clientCapabilities,
             CancellationToken cancellationToken)
         {
@@ -116,7 +116,7 @@ public class CompletionListProviderTest : LanguageServerTestBase
         public override Task<VSInternalCompletionList> GetCompletionListAsync(
             int absoluteIndex,
             VSInternalCompletionContext completionContext,
-            DocumentContext documentContext,
+            VersionedDocumentContext documentContext,
             VSInternalClientCapabilities clientCapabilities,
             HashSet<string> existingCompletions,
             CancellationToken cancellationToken)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionItemResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionItemResolverTest.cs
@@ -55,7 +55,7 @@ public class DelegatedCompletionItemResolverTest : LanguageServerTestBase
             }
         };
 
-        var documentContext = TestDocumentContext.From("C:/path/to/file.cshtml");
+        var documentContext = TestDocumentContext.From("C:/path/to/file.cshtml", hostDocumentVersion: 0);
         _csharpCompletionParams = new DelegatedCompletionParams(documentContext.Identifier, new Position(10, 6), RazorLanguageKind.CSharp, new VSInternalCompletionContext(), ProvisionalTextEdit: null);
         _htmlCompletionParams = new DelegatedCompletionParams(documentContext.Identifier, new Position(0, 0), RazorLanguageKind.Html, new VSInternalCompletionContext(), ProvisionalTextEdit: null);
         _documentContextFactory = new TestDocumentContextFactory();
@@ -211,7 +211,7 @@ public class DelegatedCompletionItemResolverTest : LanguageServerTestBase
         await using var csharpServer = await CreateCSharpServerAsync(codeDocument);
 
         var server = TestDelegatedCompletionItemResolverServer.Create(csharpServer, DisposalToken);
-        var documentContextFactory = new TestDocumentContextFactory("C:/path/to/file.razor", codeDocument);
+        var documentContextFactory = new TestDocumentContextFactory("C:/path/to/file.razor", codeDocument, version: 123);
         var resolver = new DelegatedCompletionItemResolver(documentContextFactory, _formattingService.GetValue(), server);
         var (containingCompletionList, csharpCompletionParams) = await GetCompletionListAndOriginalParamsAsync(
             cursorPosition, codeDocument, csharpServer);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionListProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionListProviderTest.cs
@@ -38,7 +38,7 @@ public class DelegatedCompletionListProviderTest : LanguageServerTestBase
         // Arrange
         var completionContext = new VSInternalCompletionContext();
         var codeDocument = CreateCodeDocument("<");
-        var documentContext = TestDocumentContext.From("C:/path/to/file.cshtml", codeDocument);
+        var documentContext = TestDocumentContext.From("C:/path/to/file.cshtml", codeDocument, hostDocumentVersion: 0);
         var rewriter1 = new TestResponseRewriter(order: 100);
         var rewriter2 = new TestResponseRewriter(order: 20);
         var provider = TestDelegatedCompletionListProvider.Create(LoggerFactory, rewriter1, rewriter2);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/ResponseRewriterTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/ResponseRewriterTestBase.cs
@@ -28,7 +28,7 @@ public abstract class ResponseRewriterTestBase : LanguageServerTestBase
     {
         var completionContext = new VSInternalCompletionContext();
         var codeDocument = CreateCodeDocument(documentContent);
-        var documentContext = TestDocumentContext.From("C:/path/to/file.cshtml", codeDocument);
+        var documentContext = TestDocumentContext.From("C:/path/to/file.cshtml", codeDocument, hostDocumentVersion: 0);
         var provider = TestDelegatedCompletionListProvider.Create(initialCompletionList, LoggerFactory, Rewriter);
         var clientCapabilities = new VSInternalClientCapabilities();
         var completionList = await provider.GetCompletionListAsync(absoluteIndex, completionContext, documentContext, clientCapabilities, DisposalToken);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionListProvierTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionListProvierTest.cs
@@ -347,7 +347,7 @@ public class RazorCompletionListProvierTest : LanguageServerTestBase
         // Arrange
         var documentPath = "C:/path/to/document.cshtml";
         var codeDocument = CreateCodeDocument("@");
-        var documentContext = TestDocumentContext.From(documentPath, codeDocument);
+        var documentContext = TestDocumentContext.From(documentPath, codeDocument, hostDocumentVersion: 0);
         var provider = new RazorCompletionListProvider(_completionFactsService, _completionListCache, LoggerFactory);
 
         // Act
@@ -373,7 +373,7 @@ public class RazorCompletionListProvierTest : LanguageServerTestBase
         // Arrange
         var documentPath = "C:/path/to/document.cshtml";
         var codeDocument = CreateCodeDocument("@");
-        var documentContext = TestDocumentContext.From(documentPath, codeDocument);
+        var documentContext = TestDocumentContext.From(documentPath, codeDocument, hostDocumentVersion: 0);
         var completionContext = new VSInternalCompletionContext()
         {
             TriggerKind = CompletionTriggerKind.TriggerForIncompleteCompletions,
@@ -406,7 +406,7 @@ public class RazorCompletionListProvierTest : LanguageServerTestBase
         var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, new[] { tagHelper });
         var codeDocument = CreateCodeDocument("@in");
         codeDocument.SetTagHelperContext(tagHelperContext);
-        var documentContext = TestDocumentContext.From(documentPath, codeDocument);
+        var documentContext = TestDocumentContext.From(documentPath, codeDocument, hostDocumentVersion: 0);
         var provider = new RazorCompletionListProvider(_completionFactsService, _completionListCache, LoggerFactory);
         var completionContext = new VSInternalCompletionContext()
         {
@@ -440,7 +440,7 @@ public class RazorCompletionListProvierTest : LanguageServerTestBase
         var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, new[] { tagHelper });
         var codeDocument = CreateCodeDocument("@inje");
         codeDocument.SetTagHelperContext(tagHelperContext);
-        var documentContext = TestDocumentContext.From(documentPath, codeDocument);
+        var documentContext = TestDocumentContext.From(documentPath, codeDocument, hostDocumentVersion: 0);
         var provider = new RazorCompletionListProvider(_completionFactsService, _completionListCache, LoggerFactory);
         var completionContext = new VSInternalCompletionContext()
         {
@@ -468,7 +468,7 @@ public class RazorCompletionListProvierTest : LanguageServerTestBase
         var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, new[] { tagHelper });
         var codeDocument = CreateCodeDocument("@inje");
         codeDocument.SetTagHelperContext(tagHelperContext);
-        var documentContext = TestDocumentContext.From(documentPath, codeDocument);
+        var documentContext = TestDocumentContext.From(documentPath, codeDocument, hostDocumentVersion: 0);
         var provider = new RazorCompletionListProvider(_completionFactsService, _completionListCache, LoggerFactory);
         var completionContext = new VSInternalCompletionContext()
         {
@@ -503,7 +503,7 @@ public class RazorCompletionListProvierTest : LanguageServerTestBase
         var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, new[] { tagHelper });
         var codeDocument = CreateCodeDocument("<");
         codeDocument.SetTagHelperContext(tagHelperContext);
-        var documentContext = TestDocumentContext.From(documentPath, codeDocument);
+        var documentContext = TestDocumentContext.From(documentPath, codeDocument, hostDocumentVersion: 0);
         var provider = new RazorCompletionListProvider(_completionFactsService, _completionListCache, LoggerFactory);
 
         // Act
@@ -533,7 +533,7 @@ public class RazorCompletionListProvierTest : LanguageServerTestBase
         var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, new[] { tagHelper });
         var codeDocument = CreateCodeDocument("<test  ");
         codeDocument.SetTagHelperContext(tagHelperContext);
-        var documentContext = TestDocumentContext.From(documentPath, codeDocument);
+        var documentContext = TestDocumentContext.From(documentPath, codeDocument, hostDocumentVersion: 0);
         var provider = new RazorCompletionListProvider(_completionFactsService, _completionListCache, LoggerFactory);
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperServiceTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperServiceTestBase.cs
@@ -212,14 +212,14 @@ public abstract class TagHelperServiceTestBase : LanguageServerTestBase
         };
     }
 
-    internal static (Queue<DocumentContext>, Queue<TextDocumentIdentifier>) CreateDocumentContext(
+    internal static (Queue<VersionedDocumentContext>, Queue<TextDocumentIdentifier>) CreateDocumentContext(
         DocumentContentVersion[] textArray,
         bool[] isRazorArray,
         TagHelperDescriptor[] tagHelpers,
         VersionStamp projectVersion = default,
         int? documentVersion = null)
     {
-        var documentContexts = new Queue<DocumentContext>();
+        var documentContexts = new Queue<VersionedDocumentContext>();
         var identifiers = new Queue<TextDocumentIdentifier>();
         foreach (var (text, isRazorFile) in textArray.Zip(isRazorArray, (t, r) => (t, r)))
         {
@@ -231,7 +231,7 @@ public abstract class TagHelperServiceTestBase : LanguageServerTestBase
                 .Returns(projectVersion);
 
             var documentSnapshot = Mock.Of<DocumentSnapshot>(MockBehavior.Strict);
-            var documentContext = new Mock<DocumentContext>(MockBehavior.Strict, new Uri("c:/path/to/file.razor"), documentSnapshot, 0);
+            var documentContext = new Mock<VersionedDocumentContext>(MockBehavior.Strict, new Uri("c:/path/to/file.razor"), documentSnapshot, 0);
             documentContext.Setup(d => d.GetCodeDocumentAsync(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(document);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Debugging/ValidateBreakpointRangeEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Debugging/ValidateBreakpointRangeEndpointTest.cs
@@ -127,13 +127,13 @@ public class ValidateBreakpointRangeEndpointTest : SingleServerDelegatingEndpoin
             Range = breakpointSpan.AsRange(codeDocument.GetSourceText())
         };
 
-        var documentContext = await DocumentContextFactory.TryCreateAsync(request.TextDocument.Uri, DisposalToken);
+        var documentContext = await DocumentContextFactory.TryCreateForOpenDocumentAsync(request.TextDocument.Uri, DisposalToken);
         var requestContext = CreateValidateBreakpointRangeRequestContext(documentContext);
 
         return await endpoint.HandleRequestAsync(request, requestContext, DisposalToken);
     }
 
-    private RazorRequestContext CreateValidateBreakpointRangeRequestContext(DocumentContext documentContext)
+    private RazorRequestContext CreateValidateBreakpointRangeRequestContext(VersionedDocumentContext documentContext)
     {
         var lspServices = new Mock<ILspServices>(MockBehavior.Strict);
         //lspServices

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/RazorDefinitionEndpointDelegationTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/RazorDefinitionEndpointDelegationTest.cs
@@ -129,7 +129,7 @@ public class RazorDefinitionEndpointDelegationTest : SingleServerDelegatingEndpo
         var searchEngine = new DefaultRazorComponentSearchEngine(Dispatcher, projectSnapshotManagerAccessor, LoggerFactory);
 
         var razorUri = new Uri(razorFilePath);
-        var documentContext = await DocumentContextFactory.TryCreateAsync(razorUri, DisposalToken);
+        var documentContext = await DocumentContextFactory.TryCreateForOpenDocumentAsync(razorUri, DisposalToken);
         var requestContext = CreateRazorRequestContext(documentContext);
 
         var endpoint = new RazorDefinitionEndpoint(searchEngine, DocumentMappingService, LanguageServerFeatureOptions, LanguageServer, LoggerFactory);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorTranslateDiagnosticsEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorTranslateDiagnosticsEndpointTest.cs
@@ -64,7 +64,7 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
                     new SourceSpan(4, 12),
                     new SourceSpan(10, 12))
             });
-        var documentContext = (DocumentContext?)null;
+        var documentContext = (VersionedDocumentContext?)null;
 
         var diagnosticsService = new RazorTranslateDiagnosticsService(_mappingService, LoggerFactory);
         var diagnosticsEndpoint = new RazorTranslateDiagnosticsEndpoint(diagnosticsService, LoggerFactory);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentPresentation/TextDocumentUriPresentationEndpointTests.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentPresentation/TextDocumentUriPresentationEndpointTests.cs
@@ -42,8 +42,7 @@ public class TextDocumentUriPresentationEndpointTests : LanguageServerTestBase
         var uri = new Uri("file://path/test.razor");
 
         var documentSnapshot = Mock.Of<DocumentSnapshot>(s => s.GetGeneratedOutputAsync() == Task.FromResult(componentCodeDocument), MockBehavior.Strict);
-        var documentResolver = Mock.Of<DocumentResolver>(
-            s => s.TryResolveDocument(It.IsAny<string>(), out documentSnapshot) == true, MockBehavior.Strict);
+        var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
 
         var documentContext = CreateDocumentContext(uri, codeDocument);
         var searchEngine = Mock.Of<RazorComponentSearchEngine>(
@@ -57,7 +56,7 @@ public class TextDocumentUriPresentationEndpointTests : LanguageServerTestBase
             searchEngine,
             languageServer.Object,
             TestLanguageServerFeatureOptions.Instance,
-            documentResolver,
+            documentContextFactory,
             Dispatcher,
             LoggerFactory);
 
@@ -102,10 +101,9 @@ public class TextDocumentUriPresentationEndpointTests : LanguageServerTestBase
         var tagHelperDescriptor = builder.Build();
 
         var documentSnapshot = Mock.Of<DocumentSnapshot>(s => s.GetGeneratedOutputAsync() == Task.FromResult(componentCodeDocument), MockBehavior.Strict);
-        var documentResolver = Mock.Of<DocumentResolver>(
-            s => s.TryResolveDocument(It.IsAny<string>(), out documentSnapshot) == true, MockBehavior.Strict);
 
         var uri = new Uri("file://path/test.razor");
+        var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
         var documentContext = CreateDocumentContext(uri, codeDocument);
         var searchEngine = Mock.Of<RazorComponentSearchEngine>(
             s => s.TryGetTagHelperDescriptorAsync(It.IsAny<DocumentSnapshot>(), It.IsAny<CancellationToken>()) == Task.FromResult(tagHelperDescriptor),
@@ -118,7 +116,7 @@ public class TextDocumentUriPresentationEndpointTests : LanguageServerTestBase
             searchEngine,
             languageServer.Object,
             TestLanguageServerFeatureOptions.Instance,
-            documentResolver,
+            documentContextFactory,
             Dispatcher,
             LoggerFactory);
 
@@ -171,10 +169,9 @@ public class TextDocumentUriPresentationEndpointTests : LanguageServerTestBase
         var tagHelperDescriptor = builder.Build();
 
         var documentSnapshot = Mock.Of<DocumentSnapshot>(s => s.GetGeneratedOutputAsync() == Task.FromResult(componentCodeDocument), MockBehavior.Strict);
-        var documentResolver = Mock.Of<DocumentResolver>(
-            s => s.TryResolveDocument(It.IsAny<string>(), out documentSnapshot) == true, MockBehavior.Strict);
 
         var uri = new Uri("file://path/test.razor");
+        var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
         var documentContext = CreateDocumentContext(uri, codeDocument);
         var searchEngine = Mock.Of<RazorComponentSearchEngine>(
             s => s.TryGetTagHelperDescriptorAsync(It.IsAny<DocumentSnapshot>(), It.IsAny<CancellationToken>()) == Task.FromResult(tagHelperDescriptor),
@@ -187,7 +184,7 @@ public class TextDocumentUriPresentationEndpointTests : LanguageServerTestBase
             searchEngine,
             languageServer.Object,
             TestLanguageServerFeatureOptions.Instance,
-            documentResolver,
+            documentContextFactory,
             Dispatcher,
             LoggerFactory);
 
@@ -231,10 +228,9 @@ public class TextDocumentUriPresentationEndpointTests : LanguageServerTestBase
         var tagHelperDescriptor = builder.Build();
 
         var documentSnapshot = Mock.Of<DocumentSnapshot>(s => s.GetGeneratedOutputAsync() == Task.FromResult(componentCodeDocument), MockBehavior.Strict);
-        var documentResolver = Mock.Of<DocumentResolver>(
-            s => s.TryResolveDocument(It.IsAny<string>(), out documentSnapshot) == true, MockBehavior.Strict);
 
         var uri = new Uri("file://path/test.razor");
+        var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
         var documentContext = CreateDocumentContext(uri, codeDocument);
         var searchEngine = Mock.Of<RazorComponentSearchEngine>(
             s => s.TryGetTagHelperDescriptorAsync(It.IsAny<DocumentSnapshot>(), It.IsAny<CancellationToken>()) == Task.FromResult(tagHelperDescriptor),
@@ -252,7 +248,7 @@ public class TextDocumentUriPresentationEndpointTests : LanguageServerTestBase
             searchEngine,
             languageServer.Object,
             TestLanguageServerFeatureOptions.Instance,
-            documentResolver,
+            documentContextFactory,
             Dispatcher,
             LoggerFactory);
 
@@ -290,10 +286,9 @@ public class TextDocumentUriPresentationEndpointTests : LanguageServerTestBase
             s => s.GetLanguageKind(codeDocument, It.IsAny<int>(), It.IsAny<bool>()) == RazorLanguageKind.Html, MockBehavior.Strict);
 
         var documentSnapshot = Mock.Of<DocumentSnapshot>(s => s.GetGeneratedOutputAsync() == Task.FromResult(codeDocument), MockBehavior.Strict);
-        var documentResolver = Mock.Of<DocumentResolver>(
-            s => s.TryResolveDocument(It.IsAny<string>(), out documentSnapshot) == true, MockBehavior.Strict);
 
         var uri = new Uri("file://path/test.razor");
+        var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
         var documentContext = CreateDocumentContext(uri, codeDocument);
         var searchEngine = Mock.Of<RazorComponentSearchEngine>(MockBehavior.Strict);
 
@@ -309,7 +304,7 @@ public class TextDocumentUriPresentationEndpointTests : LanguageServerTestBase
             searchEngine,
             languageServer.Object,
             TestLanguageServerFeatureOptions.Instance,
-            documentResolver,
+            documentContextFactory,
             Dispatcher,
             LoggerFactory);
 
@@ -349,11 +344,10 @@ public class TextDocumentUriPresentationEndpointTests : LanguageServerTestBase
             s => s.GetLanguageKind(codeDocument, It.IsAny<int>(), It.IsAny<bool>()) == RazorLanguageKind.Html, MockBehavior.Strict);
 
         var documentSnapshot = Mock.Of<DocumentSnapshot>(s => s.GetGeneratedOutputAsync() == Task.FromResult(codeDocument), MockBehavior.Strict);
-        var documentResolver = Mock.Of<DocumentResolver>(
-            s => s.TryResolveDocument(It.IsAny<string>(), out documentSnapshot) == true, MockBehavior.Strict);
 
         var droppedUri = new Uri("file:///c:/path/MyTagHelper.cshtml");
         var uri = new Uri("file://path/test.razor");
+        var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
         var documentContext = CreateDocumentContext(uri, codeDocument);
         var searchEngine = Mock.Of<RazorComponentSearchEngine>(MockBehavior.Strict);
 
@@ -369,7 +363,7 @@ public class TextDocumentUriPresentationEndpointTests : LanguageServerTestBase
             searchEngine,
             languageServer.Object,
             TestLanguageServerFeatureOptions.Instance,
-            documentResolver,
+            documentContextFactory,
             Dispatcher,
             LoggerFactory);
 
@@ -412,8 +406,7 @@ public class TextDocumentUriPresentationEndpointTests : LanguageServerTestBase
         var searchEngine = Mock.Of<RazorComponentSearchEngine>(MockBehavior.Strict);
 
         var documentSnapshot = Mock.Of<DocumentSnapshot>(s => s.GetGeneratedOutputAsync() == Task.FromResult(codeDocument), MockBehavior.Strict);
-        var documentResolver = Mock.Of<DocumentResolver>(
-            s => s.TryResolveDocument(It.IsAny<string>(), out documentSnapshot) == true, MockBehavior.Strict);
+        var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
 
         var response = (WorkspaceEdit?)null;
 
@@ -427,7 +420,7 @@ public class TextDocumentUriPresentationEndpointTests : LanguageServerTestBase
             searchEngine,
             languageServer.Object,
             TestLanguageServerFeatureOptions.Instance,
-            documentResolver,
+            documentContextFactory,
             Dispatcher,
             LoggerFactory);
 
@@ -464,8 +457,7 @@ public class TextDocumentUriPresentationEndpointTests : LanguageServerTestBase
         var searchEngine = Mock.Of<RazorComponentSearchEngine>(MockBehavior.Strict);
 
         var documentSnapshot = Mock.Of<DocumentSnapshot>(s => s.GetGeneratedOutputAsync() == Task.FromResult(codeDocument), MockBehavior.Strict);
-        var documentResolver = Mock.Of<DocumentResolver>(
-            s => s.TryResolveDocument(It.IsAny<string>(), out documentSnapshot) == true, MockBehavior.Strict);
+        var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
 
         var response = (WorkspaceEdit?)null;
 
@@ -479,7 +471,7 @@ public class TextDocumentUriPresentationEndpointTests : LanguageServerTestBase
             searchEngine,
             languageServer.Object,
             TestLanguageServerFeatureOptions.Instance,
-            documentResolver,
+            documentContextFactory,
             Dispatcher,
             LoggerFactory);
 
@@ -517,8 +509,7 @@ public class TextDocumentUriPresentationEndpointTests : LanguageServerTestBase
         var searchEngine = Mock.Of<RazorComponentSearchEngine>(MockBehavior.Strict);
 
         var documentSnapshot = Mock.Of<DocumentSnapshot>(s => s.GetGeneratedOutputAsync() == Task.FromResult(codeDocument), MockBehavior.Strict);
-        var documentResolver = Mock.Of<DocumentResolver>(
-            s => s.TryResolveDocument(It.IsAny<string>(), out documentSnapshot) == true, MockBehavior.Strict);
+        var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
 
         var response = new WorkspaceEdit();
 
@@ -532,7 +523,7 @@ public class TextDocumentUriPresentationEndpointTests : LanguageServerTestBase
             searchEngine,
             languageServer.Object,
             TestLanguageServerFeatureOptions.Instance,
-            documentResolver,
+            documentContextFactory,
             Dispatcher,
             LoggerFactory);
 
@@ -569,8 +560,7 @@ public class TextDocumentUriPresentationEndpointTests : LanguageServerTestBase
         var searchEngine = Mock.Of<RazorComponentSearchEngine>(MockBehavior.Strict);
 
         var documentSnapshot = Mock.Of<DocumentSnapshot>(s => s.GetGeneratedOutputAsync() == Task.FromResult(codeDocument), MockBehavior.Strict);
-        var documentResolver = Mock.Of<DocumentResolver>(
-            s => s.TryResolveDocument(It.IsAny<string>(), out documentSnapshot) == true, MockBehavior.Strict);
+        var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
 
         var response = (WorkspaceEdit?)null;
 
@@ -584,7 +574,7 @@ public class TextDocumentUriPresentationEndpointTests : LanguageServerTestBase
             searchEngine,
             languageServer.Object,
             TestLanguageServerFeatureOptions.Instance,
-            documentResolver,
+            documentContextFactory,
             Dispatcher,
             LoggerFactory);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/FindReferences/FindReferencesEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/FindReferences/FindReferencesEndpointTest.cs
@@ -81,7 +81,7 @@ public class FindReferencesEndpointTest : SingleServerDelegatingEndpointTestBase
             },
             Position = new Position(line, offset)
         };
-        var documentContext = await DocumentContextFactory.TryCreateAsync(request.TextDocument.Uri, DisposalToken);
+        var documentContext = await DocumentContextFactory.TryCreateForOpenDocumentAsync(request.TextDocument.Uri, DisposalToken);
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingLanguageServerTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingLanguageServerTestBase.cs
@@ -55,7 +55,7 @@ public abstract class FormattingLanguageServerTestBase : LanguageServerTestBase
     {
         public bool Called { get; private set; }
 
-        public override Task<TextEdit[]> FormatAsync(DocumentContext documentContext, Range? range, FormattingOptions options, CancellationToken cancellationToken)
+        public override Task<TextEdit[]> FormatAsync(VersionedDocumentContext documentContext, Range? range, FormattingOptions options, CancellationToken cancellationToken)
         {
             Called = true;
             return Task.FromResult(Array.Empty<TextEdit>());

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
@@ -88,7 +88,7 @@ public class FormattingTestBase : RazorIntegrationTestBase
         };
 
         var formattingService = await TestRazorFormattingService.CreateWithFullSupportAsync(codeDocument, documentSnapshot, LoggerFactory);
-        var documentContext = new DocumentContext(uri, documentSnapshot, version: 1);
+        var documentContext = new VersionedDocumentContext(uri, documentSnapshot, version: 1);
 
         // Act
         var edits = await formattingService.FormatAsync(documentContext, range, options, DisposalToken);
@@ -134,7 +134,7 @@ public class FormattingTestBase : RazorIntegrationTestBase
             TabSize = tabSize,
             InsertSpaces = insertSpaces,
         };
-        var documentContext = new DocumentContext(uri, documentSnapshot, version: 1);
+        var documentContext = new VersionedDocumentContext(uri, documentSnapshot, version: 1);
 
         // Act
         var edits = await formattingService.FormatOnTypeAsync(documentContext, languageKind, Array.Empty<TextEdit>(), options, hostDocumentIndex: positionAfterTrigger, triggerCharacter: triggerCharacter, DisposalToken);
@@ -202,7 +202,7 @@ public class FormattingTestBase : RazorIntegrationTestBase
             TabSize = tabSize,
             InsertSpaces = insertSpaces,
         };
-        var documentContext = new DocumentContext(uri, documentSnapshot, version: 1);
+        var documentContext = new VersionedDocumentContext(uri, documentSnapshot, version: 1);
 
         // Act
         var edits = await formattingService.FormatCodeActionAsync(documentContext, languageKind, codeActionEdits, options, DisposalToken);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorDocumentOnTypeFormattingEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorDocumentOnTypeFormattingEndpointTest.cs
@@ -210,7 +210,7 @@ public class RazorDocumentOnTypeFormattingEndpointTest : FormattingLanguageServe
             Position = new Position(2, 11),
             Options = new FormattingOptions { InsertSpaces = true, TabSize = 4 }
         };
-        var documentContext = await documentResolver.TryCreateAsync(uri, DisposalToken);
+        var documentContext = await documentResolver.TryCreateForOpenDocumentAsync(uri, DisposalToken);
         var requestContext = CreateRazorRequestContext(documentContext!);
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/DefaultRazorHoverInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/DefaultRazorHoverInfoServiceTest.cs
@@ -765,7 +765,7 @@ public class DefaultRazorHoverInfoServiceTest : TagHelperServiceTestBase
         return await endpoint.HandleRequestAsync(request, requestContext, DisposalToken);
     }
 
-    private DocumentContext CreateDefaultDocumentContext()
+    private VersionedDocumentContext CreateDefaultDocumentContext()
     {
         var txt = """
                 @addTagHelper *, TestAssembly
@@ -788,7 +788,7 @@ public class DefaultRazorHoverInfoServiceTest : TagHelperServiceTestBase
             d.GetTextAsync() == Task.FromResult(sourceText) &&
             d.Project == projectSnapshot, MockBehavior.Strict);
 
-        var documentContext = new DocumentContext(new Uri(path), snapshot, 1337);
+        var documentContext = new VersionedDocumentContext(new Uri(path), snapshot, 1337);
 
         return documentContext;
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Implementation/ImplementationEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Implementation/ImplementationEndpointTest.cs
@@ -113,7 +113,7 @@ public class ImplementationEndpointTest : SingleServerDelegatingEndpointTestBase
             },
             Position = new Position(line, offset)
         };
-        var documentContext = await DocumentContextFactory.TryCreateAsync(request.TextDocument.Uri, DisposalToken);
+        var documentContext = await DocumentContextFactory.TryCreateForOpenDocumentAsync(request.TextDocument.Uri, DisposalToken);
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointDelegationTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointDelegationTest.cs
@@ -85,7 +85,7 @@ public class RenameEndpointDelegationTest: SingleServerDelegatingEndpointTestBas
             Position = new Position(line, offset),
             NewName = newName
         };
-        var documentContext = await DocumentContextFactory.TryCreateAsync(request.TextDocument.Uri, DisposalToken);
+        var documentContext = await DocumentContextFactory.TryCreateForOpenDocumentAsync(request.TextDocument.Uri, DisposalToken);
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/DefaultRazorSemanticTokenInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/DefaultRazorSemanticTokenInfoServiceTest.cs
@@ -684,7 +684,7 @@ public class DefaultRazorSemanticTokenInfoServiceTest : SemanticTokenTestBase
     }
 
     private RazorSemanticTokensInfoService GetDefaultRazorSemanticTokenInfoService(
-        Queue<DocumentContext> documentSnapshots,
+        Queue<VersionedDocumentContext> documentSnapshots,
         ProvideSemanticTokensResponse? csharpTokens = null)
     {
         var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
@@ -744,18 +744,23 @@ public class DefaultRazorSemanticTokenInfoServiceTest : SemanticTokenTestBase
 
     private class TestDocumentContextFactory : DocumentContextFactory
     {
-        private readonly Queue<DocumentContext> _documentContexts;
+        private readonly Queue<VersionedDocumentContext> _documentContexts;
 
-        public TestDocumentContextFactory(Queue<DocumentContext> documentContexts)
+        public TestDocumentContextFactory(Queue<VersionedDocumentContext> documentContexts)
         {
             _documentContexts = documentContexts;
         }
 
-        public override Task<DocumentContext?> TryCreateAsync(Uri documentFilePath, CancellationToken _)
+        public override Task<VersionedDocumentContext?> TryCreateForOpenDocumentAsync(Uri documentFilePath, CancellationToken _)
         {
             var document = _documentContexts.Count == 1 ? _documentContexts.Peek() : _documentContexts.Dequeue();
 
-            return Task.FromResult<DocumentContext?>(document);
+            return Task.FromResult<VersionedDocumentContext?>(document);
+        }
+
+        public override Task<DocumentContext?> TryCreateAsync(Uri documentUri, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SignatureHelp/SignatureHelpEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SignatureHelp/SignatureHelpEndpointTest.cs
@@ -92,7 +92,7 @@ public class SignatureHelpEndpointTest : SingleServerDelegatingEndpointTestBase
             Position = new Position(line, offset)
         };
 
-        var documentContext = await DocumentContextFactory.TryCreateAsync(request.TextDocument.Uri, DisposalToken);
+        var documentContext = await DocumentContextFactory.TryCreateForOpenDocumentAsync(request.TextDocument.Uri, DisposalToken);
 
         var requestContext = CreateRazorRequestContext(documentContext);
 


### PR DESCRIPTION
Fixes #6960

Previously `DocumentContextFactory` would only work for open files, but the API was temptingly named, and convenient to use, which could lead people into a trap. This updates it so that it can be used for closed documents too, allowing for the convenient API in more places, and making the use of open documents much more explicit.

Reviewing commit-at-a-time probably makes the most sense.

Please note, this was 99% coded in airport lounges, so it may not be as clear as my usual work.