### PR TITLE
[Infra] Disallow pre-release SDK versions

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -18,7 +18,6 @@
     <MajorVersion>7</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
-    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <!--
         When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages
     -->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -18,6 +18,7 @@
     <MajorVersion>7</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
+    <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>
     <!--
         When StabilizePackageVersion is set to 'true', this branch will produce stable outputs for 'Shipping' packages
     -->

--- a/global.json
+++ b/global.json
@@ -17,7 +17,7 @@
   },
   "sdk": {
     "version": "7.0.101",
-    "allowPrerelease": true,
+    "allowPrerelease": false,
     "rollForward": "latestPatch"
   },
   "msbuild-sdks": {


### PR DESCRIPTION
﻿### Summary of the changes
- This matches Roslyn's behavior: https://github.com/dotnet/roslyn/blob/fde6782ee30efa6f408b64085ba6ebdeb36dace1/global.json#L4
- It also addresses some user concerns of Razor releasing VS Code updates using pre-release versions of .NET SDK (see https://github.com/dotnet/razor/issues/6241)