### PR TITLE
Ensure we use the unedited syntax tree before re-writing occurs

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorParsingPhase.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorParsingPhase.cs
@@ -18,7 +18,7 @@ internal class DefaultRazorParsingPhase : RazorEnginePhaseBase, IRazorParsingPha
     {
         var options = codeDocument.GetParserOptions() ?? _optionsFeature.GetOptions();
         var syntaxTree = RazorSyntaxTree.Parse(codeDocument.Source, options);
-        codeDocument.SetSyntaxTree(syntaxTree);
+        codeDocument.SetPreTagHelperSyntaxTree(syntaxTree);
 
         var importSyntaxTrees = new RazorSyntaxTree[codeDocument.Imports.Count];
         for (var i = 0; i < codeDocument.Imports.Count; i++)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorSyntaxTreePhase.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorSyntaxTreePhase.cs
@@ -18,7 +18,7 @@ internal class DefaultRazorSyntaxTreePhase : RazorEnginePhaseBase, IRazorSyntaxT
 
     protected override void ExecuteCore(RazorCodeDocument codeDocument)
     {
-        var syntaxTree = codeDocument.GetSyntaxTree();
+        var syntaxTree = codeDocument.GetPreTagHelperSyntaxTree();
         ThrowForMissingDocumentDependency(syntaxTree);
 
         foreach (var pass in Passes)
@@ -26,6 +26,6 @@ internal class DefaultRazorSyntaxTreePhase : RazorEnginePhaseBase, IRazorSyntaxT
             syntaxTree = pass.Execute(codeDocument, syntaxTree);
         }
 
-        codeDocument.SetSyntaxTree(syntaxTree);
+        codeDocument.SetPreTagHelperSyntaxTree(syntaxTree);
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorTagHelperContextDiscoveryPhase.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorTagHelperContextDiscoveryPhase.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorTagHelperContextDiscoveryPhase.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorTagHelperContextDiscoveryPhase.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -17,7 +17,7 @@ internal sealed class DefaultRazorTagHelperContextDiscoveryPhase : RazorEnginePh
 {
     protected override void ExecuteCore(RazorCodeDocument codeDocument)
     {
-        var syntaxTree = codeDocument.GetSyntaxTree();
+        var syntaxTree = codeDocument.GetPreTagHelperSyntaxTree();
         ThrowForMissingDocumentDependency(syntaxTree);
 
         var descriptors = codeDocument.GetTagHelpers();
@@ -69,7 +69,6 @@ internal sealed class DefaultRazorTagHelperContextDiscoveryPhase : RazorEnginePh
 
         var context = TagHelperDocumentContext.Create(tagHelperPrefix, descriptors);
         codeDocument.SetTagHelperContext(context);
-        codeDocument.SetPreTagHelperSyntaxTree(syntaxTree);
     }
 
     private static bool MatchesDirective(TagHelperDescriptor descriptor, string typePattern, string assemblyName)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorTagHelperRewritePhase.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorTagHelperRewritePhase.cs
@@ -1,23 +1,28 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 #nullable enable
 
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 
 namespace Microsoft.AspNetCore.Razor.Language;
+
 internal sealed class DefaultRazorTagHelperRewritePhase : RazorEnginePhaseBase
 {
+    private static readonly ISet<TagHelperDescriptor> EmptyTagHelperSet = new HashSet<TagHelperDescriptor>();
+
     protected override void ExecuteCore(RazorCodeDocument codeDocument)
     {
         var syntaxTree = codeDocument.GetPreTagHelperSyntaxTree();
         var context = codeDocument.GetTagHelperContext();
-        if (syntaxTree is null || context.TagHelpers.Count == 0)
-        {
-            // No descriptors, no-op.
-            return;
-        }
 
-        var rewrittenSyntaxTree = TagHelperParseTreeRewriter.Rewrite(syntaxTree, context.Prefix, context.TagHelpers, out var usedHelpers);
+        var rewrittenSyntaxTree = syntaxTree;
+        var usedHelpers = EmptyTagHelperSet;
+
+        if (syntaxTree is not null && context?.TagHelpers.Count > 0)
+        {
+            rewrittenSyntaxTree = TagHelperParseTreeRewriter.Rewrite(syntaxTree, context.Prefix, context.TagHelpers, out usedHelpers);
+        }
 
         codeDocument.SetReferencedTagHelpers(usedHelpers);
         codeDocument.SetSyntaxTree(rewrittenSyntaxTree);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorTagHelperRewritePhase.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorTagHelperRewritePhase.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 #nullable enable
 
@@ -9,7 +9,6 @@ namespace Microsoft.AspNetCore.Razor.Language;
 
 internal sealed class DefaultRazorTagHelperRewritePhase : RazorEnginePhaseBase
 {
-    private static readonly ISet<TagHelperDescriptor> EmptyTagHelperSet = new HashSet<TagHelperDescriptor>();
 
     protected override void ExecuteCore(RazorCodeDocument codeDocument)
     {
@@ -17,7 +16,7 @@ internal sealed class DefaultRazorTagHelperRewritePhase : RazorEnginePhaseBase
         var context = codeDocument.GetTagHelperContext();
 
         var rewrittenSyntaxTree = syntaxTree;
-        var usedHelpers = EmptyTagHelperSet;
+        ISet<TagHelperDescriptor> usedHelpers = new HashSet<TagHelperDescriptor>();
 
         if (syntaxTree is not null && context?.TagHelpers.Count > 0)
         {


### PR DESCRIPTION
Only use the 'pre-tag helper syntax tree' for operations before we re-write the syntax tree. This ensures we don't see TagHelper nodes in earlier phases.

Unconditionally set the SyntaxTree in the re-write phase, even if we didn't re-write it.
