### PR TITLE
Upgrade BlazorWasmDebugging to 1.1.3

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/package.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/package.json
@@ -2,7 +2,7 @@
   "name": "blazorwasm-companion",
   "displayName": "Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension",
   "description": "A companion extension for debugging Blazor WebAssembly applications in VS Code. Must be installed alongside the C# extension.",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/dotnet/razor-tooling.git"

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/package.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/package.json
@@ -5,7 +5,7 @@
   "version": "1.1.3",
   "repository": {
     "type": "git",
-    "url": "https://github.com/dotnet/razor-tooling.git"
+    "url": "https://github.com/dotnet/razor.git"
   },
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
It's been a while since we've published a new version (currently 1.1.0 is the most recent). Incrementing the version because of the addition of #7929, then will walk through publishing on resolution of this PR.

My understanding of the publishing process is from the guide written by @captainsafia [here](https://github.com/dotnet/razor/blob/main/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/README.dev.md#publishing-the-extension). Please correct me if this process is no longer correct.
