### PR TITLE
Account for Syntax colors

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/EditorInProcess_Classification.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/EditorInProcess_Classification.cs
@@ -94,16 +94,22 @@ internal partial class EditorInProcess
         var actualClassifications = await GetClassificationsAsync(cancellationToken);
         var actualArray = actualClassifications.ToArray();
         var expectedArray = expectedClassifications.ToArray();
+        var actualOffset = 0;
 
         for (var i = 0; i < actualArray.Length; i++)
         {
-            var actualClassification = actualArray[i];
+            var actualClassification = actualArray[i+actualOffset];
             var expectedClassification = expectedArray[i];
+
+            if (actualClassification.ClassificationType.BaseTypes.Count() == 1 && actualClassification.ClassificationType.BaseTypes.Any(t => t is ILayeredClassificationType layered && layered.Layer == ClassificationLayer.Syntactic))
+            {
+                actualOffset++;
+                actualClassification = actualArray[i+ actualOffset];
+            }
 
             if (actualClassification.ClassificationType.BaseTypes.Count() > 1)
             {
                 Assert.Equal(expectedClassification, actualClassification, ClassificationTypeComparer.Instance);
-
             }
             else if (!expectedClassification.Span.Span.Equals(actualClassification.Span.Span)
                 || !string.Equals(expectedClassification.ClassificationType.Classification, actualClassification.ClassificationType.Classification))

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Semantic/TestFiles/RazorSemanticTokensTests/GenericTypeParameters_Work.txt
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Semantic/TestFiles/RazorSemanticTokensTests/GenericTypeParameters_Work.txt
@@ -22,7 +22,6 @@
 101,1,operator,
 102,7,identifier,
 109,1,HTML Attribute Value,
-110,1,HTML Tag Delimiter,
 111,1,HTML Tag Delimiter,
 112,1,HTML Tag Delimiter,
 115,1,HTML Tag Delimiter,

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Semantic/TestFiles/RazorSemanticTokensTests/GenericTypeParameters_Work.txt
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Semantic/TestFiles/RazorSemanticTokensTests/GenericTypeParameters_Work.txt
@@ -22,6 +22,7 @@
 101,1,operator,
 102,7,identifier,
 109,1,HTML Attribute Value,
+110,1,HTML Tag Delimiter,
 111,1,HTML Tag Delimiter,
 112,1,HTML Tag Delimiter,
 115,1,HTML Tag Delimiter,


### PR DESCRIPTION
﻿### Summary of the changes

- So in VSMain we fixed a TextMate issue causing additional colors to show up in the results, but now that that's available in VSMain (but not VSPreview) our Integration tests are failing due to an additional classification span.