### PR TITLE
Update PublishData.json after 17.6 P1 snap

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -7,8 +7,8 @@
       ],
       "vsBranch": "main",
       "vsMajorVersion": 17,
-      "insertionCreateDraftPR": false,
-      "insertionTitlePrefix": "[17.5p3]"
+      "insertionCreateDraftPR": true,
+      "insertionTitlePrefix": "[17.6P2]"
     },
     "release/dev17.5": {
       "nugetKind": [
@@ -17,8 +17,16 @@
       ],
       "vsBranch": "rel/d17.5",
       "vsMajorVersion": 17,
-      "insertionCreateDraftPR": false,
-      "insertionTitlePrefix": "[17.5p2]"
+      "insertionTitlePrefix": "[17.5]"
+    },
+    "release/dev17.6": {
+      "nugetKind": [
+        "Shipping",
+        "NonShipping"
+      ],
+      "vsBranch": "main",
+      "vsMajorVersion": 17,
+      "insertionTitlePrefix": "[17.6P1]"
     }
   }
 }


### PR DESCRIPTION
Add 17.6 P1 in PublishData.json after snap.
Razor 17.6 branch would still point to VS main, after this Fri. it should be changed to the release branch.
Let me know if there are other config file need to be changed.
@davidwengier  @allisonchou 