### PR TITLE
Use a custom CodeActionParams to prevent NRE in Web Tools

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCodeActionsBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCodeActionsBenchmark.cs
@@ -141,11 +141,11 @@ public class RazorCodeActionsBenchmark : RazorLanguageServerBenchmarkBase
     [Benchmark(Description = "Lightbulbs")]
     public async Task RazorLightbulbAsync()
     {
-        var request = new CodeActionParams
+        var request = new VSCodeActionParams
         {
             Range = RazorCodeActionRange!,
             Context = new VSInternalCodeActionContext(),
-            TextDocument = new TextDocumentIdentifier
+            TextDocument = new VSTextDocumentIdentifier
             {
                 Uri = DocumentUri!
             },

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
@@ -58,7 +58,7 @@ internal class CodeActionEndpoint : IVSCodeActionEndpoint
         _allAvailableCodeActionNames = GetAllAvailableCodeActionNames();
     }
 
-    public async Task<SumType<Command, CodeAction>[]?> HandleRequestAsync(CodeActionParams request, RazorRequestContext requestContext, CancellationToken cancellationToken)
+    public async Task<SumType<Command, CodeAction>[]?> HandleRequestAsync(VSCodeActionParams request, RazorRequestContext requestContext, CancellationToken cancellationToken)
     {
         if (request is null)
         {
@@ -140,7 +140,7 @@ internal class CodeActionEndpoint : IVSCodeActionEndpoint
     }
 
     // internal for testing
-    internal async Task<RazorCodeActionContext?> GenerateRazorCodeActionContextAsync(CodeActionParams request, DocumentSnapshot documentSnapshot)
+    internal async Task<RazorCodeActionContext?> GenerateRazorCodeActionContextAsync(VSCodeActionParams request, DocumentSnapshot documentSnapshot)
     {
         var codeDocument = await documentSnapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
         if (codeDocument.IsUnsupported())
@@ -358,7 +358,7 @@ internal class CodeActionEndpoint : IVSCodeActionEndpoint
         return availableCodeActionNames.ToImmutableHashSet();
     }
 
-    public TextDocumentIdentifier GetTextDocumentIdentifier(CodeActionParams request)
+    public TextDocumentIdentifier GetTextDocumentIdentifier(VSCodeActionParams request)
     {
         return request.TextDocument;
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/DelegatedCodeActionParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/DelegatedCodeActionParams.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Runtime.Serialization;
+using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
-using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
 
@@ -14,7 +14,7 @@ internal class DelegatedCodeActionParams
     public int HostDocumentVersion { get; set; }
 
     [DataMember(Name = "codeActionParams")]
-    public required CodeActionParams CodeActionParams { get; set; }
+    public required VSCodeActionParams CodeActionParams { get; set; }
 
     [DataMember(Name = "languageKind")]
     public RazorLanguageKind LanguageKind { get; set; }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/RazorCodeActionContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/RazorCodeActionContext.cs
@@ -3,16 +3,16 @@
 
 using System;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
 
 internal sealed class RazorCodeActionContext
 {
     public RazorCodeActionContext(
-        CodeActionParams request,
+        VSCodeActionParams request,
         DocumentSnapshot documentSnapshot,
         RazorCodeDocument codeDocument,
         SourceLocation location,
@@ -29,7 +29,7 @@ internal sealed class RazorCodeActionContext
         SupportsCodeActionResolve = supportsCodeActionResolve;
     }
 
-    public CodeActionParams Request { get; }
+    public VSCodeActionParams Request { get; }
     public DocumentSnapshot DocumentSnapshot { get; }
     public RazorCodeDocument CodeDocument { get; }
     public SourceLocation Location { get; }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/IVSCodeActionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/IVSCodeActionEndpoint.cs
@@ -7,6 +7,6 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 
 [LanguageServerEndpoint(Methods.TextDocumentCodeActionName)]
-internal interface IVSCodeActionEndpoint : IRazorRequestHandler<CodeActionParams, SumType<Command, CodeAction>[]?>, IRegistrationExtension
+internal interface IVSCodeActionEndpoint : IRazorRequestHandler<VSCodeActionParams, SumType<Command, CodeAction>[]?>, IRegistrationExtension
 {
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/VSCodeActionParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/EndpointContracts/VSCodeActionParams.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Runtime.Serialization;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
+
+/// <summary>
+/// We can't use the CodeActionParams defined in MS.VS.LS.Protocol, so need our own version, because the platform only
+/// converts on read, not write. ie, if it gets a request for a CodeActionParams, it will happily deserialize the Context
+/// property to VSInternalCodeActionContext, but in our case we need to send a request to our CustomMessageTarget, and so
+/// we need the Context property serialized as the internal type.
+/// </summary>
+[DataContract]
+internal class VSCodeActionParams
+{
+    //
+    // Summary:
+    //     Gets or sets the document identifier indicating where the command was invoked.
+    [DataMember(Name = "textDocument")]
+    public required VSTextDocumentIdentifier TextDocument { get; set; }
+
+    //
+    // Summary:
+    //     Gets or sets the range in the document for which the command was invoked.
+    [DataMember(Name = "range")]
+    public required Range Range { get; set; }
+
+    //
+    // Summary:
+    //     Gets or sets the additional diagnostic information about the code action context.
+    [DataMember(Name = "context")]
+    public required VSInternalCodeActionContext Context { get; set; }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -10,12 +10,13 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer;
-using Microsoft.AspNetCore.Razor.LanguageServer.ColorPresentation;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
+using Microsoft.AspNetCore.Razor.LanguageServer.ColorPresentation;
 using Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics;
 using Microsoft.AspNetCore.Razor.LanguageServer.DocumentColor;
 using Microsoft.AspNetCore.Razor.LanguageServer.DocumentPresentation;
+using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Folding;
 using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
@@ -346,7 +347,7 @@ internal class DefaultRazorLanguageServerCustomMessageTarget : RazorLanguageServ
         codeActionParams.CodeActionParams.TextDocument.Uri = virtualDocumentSnapshot.Uri;
 
         var textBuffer = virtualDocumentSnapshot.Snapshot.TextBuffer;
-        var requests = _requestInvoker.ReinvokeRequestOnMultipleServersAsync<CodeActionParams, IReadOnlyList<VSInternalCodeAction>>(
+        var requests = _requestInvoker.ReinvokeRequestOnMultipleServersAsync<VSCodeActionParams, IReadOnlyList<VSInternalCodeAction>>(
             textBuffer,
             Methods.TextDocumentCodeActionName,
             SupportsCodeActionResolve,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/DefaultCSharpCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/DefaultCSharpCodeActionProviderTest.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
+using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -46,11 +47,11 @@ public class DefaultCSharpCodeActionProviderTest : LanguageServerTestBase
         var contents = "@code { $$Path; }";
         TestFileMarkupParser.GetPosition(contents, out contents, out var cursorPosition);
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
-            Context = new CodeActionContext()
+            Context = new VSInternalCodeActionContext()
         };
 
         var location = new SourceLocation(cursorPosition, -1, -1);
@@ -78,11 +79,11 @@ public class DefaultCSharpCodeActionProviderTest : LanguageServerTestBase
         var contents = "@code { $$Path; }";
         TestFileMarkupParser.GetPosition(contents, out contents, out var cursorPosition);
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
-            Context = new CodeActionContext()
+            Context = new VSInternalCodeActionContext()
         };
 
         var location = new SourceLocation(cursorPosition, -1, -1);
@@ -107,11 +108,11 @@ public class DefaultCSharpCodeActionProviderTest : LanguageServerTestBase
         var contents = "@functions { $$Path; }";
         TestFileMarkupParser.GetPosition(contents, out contents, out var cursorPosition);
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
-            Context = new CodeActionContext()
+            Context = new VSInternalCodeActionContext()
         };
 
         var location = new SourceLocation(cursorPosition, -1, -1);
@@ -141,11 +142,11 @@ $$Path;
 }";
         TestFileMarkupParser.GetPosition(contents, out contents, out var cursorPosition);
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
-            Context = new CodeActionContext()
+            Context = new VSInternalCodeActionContext()
         };
 
         var location = new SourceLocation(cursorPosition, -1, -1);
@@ -176,11 +177,11 @@ $$Path;
 }";
         TestFileMarkupParser.GetPosition(contents, out contents, out var cursorPosition);
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
-            Context = new CodeActionContext()
+            Context = new VSInternalCodeActionContext()
         };
 
         var location = new SourceLocation(cursorPosition, -1, -1);
@@ -208,11 +209,11 @@ $$Path;
         var contents = "@code { $$Path; }";
         TestFileMarkupParser.GetPosition(contents, out contents, out var cursorPosition);
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
-            Context = new CodeActionContext()
+            Context = new VSInternalCodeActionContext()
         };
 
         var location = new SourceLocation(cursorPosition, -1, -1);
@@ -254,11 +255,11 @@ $$Path;
                 """;
         TestFileMarkupParser.GetPosition(contents, out contents, out var cursorPosition);
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
-            Context = new CodeActionContext()
+            Context = new VSInternalCodeActionContext()
         };
 
         var location = new SourceLocation(cursorPosition, -1, -1);
@@ -279,7 +280,7 @@ $$Path;
     }
 
     private static RazorCodeActionContext CreateRazorCodeActionContext(
-        CodeActionParams request,
+        VSCodeActionParams request,
         SourceLocation location,
         string filePath,
         string text,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/TypeAccessibilityCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/TypeAccessibilityCodeActionProviderTest.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
@@ -33,11 +34,11 @@ public class TypeAccessibilityCodeActionProviderTest : LanguageServerTestBase
         // Arrange
         var documentPath = "c:/Test.razor";
         var contents = "";
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
-            Context = new CodeActionContext()
+            Context = new VSInternalCodeActionContext()
             {
                 // Even though the DTO declares this as non-null, we want to make sure we behave
                 Diagnostics = null!
@@ -70,11 +71,11 @@ public class TypeAccessibilityCodeActionProviderTest : LanguageServerTestBase
         // Arrange
         var documentPath = "c:/Test.razor";
         var contents = "";
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
-            Context = new CodeActionContext()
+            Context = new VSInternalCodeActionContext()
             {
                 Diagnostics = new Diagnostic[] {
                     new Diagnostic()
@@ -126,11 +127,11 @@ public class TypeAccessibilityCodeActionProviderTest : LanguageServerTestBase
         // Arrange
         var documentPath = "c:/Test.razor";
         var contents = "";
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
-            Context = new CodeActionContext()
+            Context = new VSInternalCodeActionContext()
             {
                 Diagnostics = new Diagnostic[] {
                     new Diagnostic()
@@ -167,11 +168,11 @@ public class TypeAccessibilityCodeActionProviderTest : LanguageServerTestBase
         // Arrange
         var documentPath = "c:/Test.razor";
         var contents = "@code { Path; }";
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
-            Context = new CodeActionContext()
+            Context = new VSInternalCodeActionContext()
             {
                 Diagnostics = new Diagnostic[] {
                     new Diagnostic()
@@ -246,11 +247,11 @@ public class TypeAccessibilityCodeActionProviderTest : LanguageServerTestBase
         // Arrange
         var documentPath = "c:/Test.razor";
         var contents = "@inject Path";
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
-            Context = new CodeActionContext()
+            Context = new VSInternalCodeActionContext()
             {
                 Diagnostics = Array.Empty<Diagnostic>()
             }
@@ -298,11 +299,11 @@ public class TypeAccessibilityCodeActionProviderTest : LanguageServerTestBase
         // Arrange
         var documentPath = "c:/Test.razor";
         var contents = "@code { Path; }";
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
-            Context = new CodeActionContext()
+            Context = new VSInternalCodeActionContext()
             {
                 Diagnostics = Array.Empty<Diagnostic>()
             }
@@ -356,11 +357,11 @@ public class TypeAccessibilityCodeActionProviderTest : LanguageServerTestBase
         // Arrange
         var documentPath = "c:/Test.razor";
         var contents = "@code { Path; }";
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
-            Context = new CodeActionContext()
+            Context = new VSInternalCodeActionContext()
             {
                 Diagnostics = new Diagnostic[] {
                     new Diagnostic()
@@ -444,7 +445,7 @@ public class TypeAccessibilityCodeActionProviderTest : LanguageServerTestBase
     }
 
     private static RazorCodeActionContext CreateRazorCodeActionContext(
-        CodeActionParams request,
+        VSCodeActionParams request,
         SourceLocation location,
         string filePath,
         string text,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
+using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.AspNetCore.Razor.Test.Common;
@@ -63,11 +64,11 @@ public class CodeActionEndpointTest : LanguageServerTestBase
         {
             _supportsCodeActionResolve = false
         };
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            TextDocument = new VSTextDocumentIdentifier { Uri = documentPath },
             Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
-            Context = new CodeActionContext()
+            Context = new VSInternalCodeActionContext()
         };
 
         var requestContext = CreateRazorRequestContext(documentContext: null);
@@ -97,9 +98,9 @@ public class CodeActionEndpointTest : LanguageServerTestBase
         {
             _supportsCodeActionResolve = false
         };
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            TextDocument = new VSTextDocumentIdentifier { Uri = documentPath },
             Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
             Context = new VSInternalCodeActionContext()
         };
@@ -129,9 +130,9 @@ public class CodeActionEndpointTest : LanguageServerTestBase
         {
             _supportsCodeActionResolve = false
         };
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            TextDocument = new VSTextDocumentIdentifier { Uri = documentPath },
             Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
             Context = new VSInternalCodeActionContext()
         };
@@ -164,9 +165,9 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             _supportsCodeActionResolve = false
         };
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            TextDocument = new VSTextDocumentIdentifier { Uri = documentPath },
             Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
             Context = new VSInternalCodeActionContext()
         };
@@ -202,9 +203,9 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             _supportsCodeActionResolve = false
         };
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            TextDocument = new VSTextDocumentIdentifier { Uri = documentPath },
             Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
             Context = new VSInternalCodeActionContext()
         };
@@ -238,9 +239,9 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             _supportsCodeActionResolve = false
         };
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            TextDocument = new VSTextDocumentIdentifier { Uri = documentPath },
             Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
             Context = new VSInternalCodeActionContext()
         };
@@ -281,9 +282,9 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             _supportsCodeActionResolve = false
         };
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            TextDocument = new VSTextDocumentIdentifier { Uri = documentPath },
             Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
             Context = new VSInternalCodeActionContext()
         };
@@ -324,9 +325,9 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             _supportsCodeActionResolve = false
         };
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            TextDocument = new VSTextDocumentIdentifier { Uri = documentPath },
             Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
             Context = new VSInternalCodeActionContext()
         };
@@ -360,9 +361,9 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             _supportsCodeActionResolve = false
         };
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            TextDocument = new VSTextDocumentIdentifier { Uri = documentPath },
             Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
             Context = new VSInternalCodeActionContext()
         };
@@ -403,9 +404,9 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             _supportsCodeActionResolve = false
         };
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            TextDocument = new VSTextDocumentIdentifier { Uri = documentPath },
             Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
             Context = new VSInternalCodeActionContext()
         };
@@ -441,9 +442,9 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             _supportsCodeActionResolve = true
         };
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            TextDocument = new VSTextDocumentIdentifier { Uri = documentPath },
             Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
             Context = new VSInternalCodeActionContext()
         };
@@ -489,9 +490,9 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             _supportsCodeActionResolve = false
         };
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            TextDocument = new VSTextDocumentIdentifier { Uri = documentPath },
             Range = new Range { Start = new Position(0, 1), End = new Position(0, 1) },
             Context = new VSInternalCodeActionContext()
         };
@@ -537,9 +538,9 @@ public class CodeActionEndpointTest : LanguageServerTestBase
 
         var initialRange = new Range { Start = new Position(0, 1), End = new Position(0, 1) };
         var selectionRange = new Range { Start = new Position(0, 5), End = new Position(0, 5) };
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            TextDocument = new VSTextDocumentIdentifier { Uri = documentPath },
             Range = initialRange,
             Context = new VSInternalCodeActionContext()
             {
@@ -576,9 +577,9 @@ public class CodeActionEndpointTest : LanguageServerTestBase
         };
 
         var initialRange = new Range { Start = new Position(0, 1), End = new Position(0, 1) };
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            TextDocument = new VSTextDocumentIdentifier { Uri = documentPath },
             Range = initialRange,
             Context = new VSInternalCodeActionContext()
             {
@@ -619,9 +620,9 @@ public class CodeActionEndpointTest : LanguageServerTestBase
         };
 
         var initialRange = new Range { Start = new Position(0, 1), End = new Position(0, 1) };
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            TextDocument = new VSTextDocumentIdentifier { Uri = documentPath },
             Range = initialRange,
             Context = new VSInternalCodeActionContext()
         };
@@ -661,9 +662,9 @@ public class CodeActionEndpointTest : LanguageServerTestBase
         };
 
         var initialRange = new Range { Start = new Position(0, 1), End = new Position(0, 1) };
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = documentPath },
+            TextDocument = new VSTextDocumentIdentifier { Uri = documentPath },
             Range = initialRange,
             Context = new VSInternalCodeActionContext()
             {
@@ -801,7 +802,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             }
 
             if (@params is not DelegatedCodeActionParams delegatedCodeActionParams ||
-                delegatedCodeActionParams.CodeActionParams is not CodeActionParams codeActionParams ||
+                delegatedCodeActionParams.CodeActionParams is not VSCodeActionParams codeActionParams ||
                 codeActionParams.Context is not VSInternalCodeActionContext codeActionContext)
             {
                 throw new InvalidOperationException(@params!.GetType().FullName);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Html/DefaultHtmlCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Html/DefaultHtmlCodeActionProviderTest.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
+using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -34,11 +35,11 @@ public class DefaultHtmlCodeActionProviderTest : LanguageServerTestBase
         TestFileMarkupParser.GetPosition(contents, out contents, out var cursorPosition);
 
         var documentPath = "c:/Test.razor";
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
-            Context = new CodeActionContext()
+            Context = new VSInternalCodeActionContext()
         };
 
         var location = new SourceLocation(cursorPosition, -1, -1);
@@ -68,11 +69,11 @@ public class DefaultHtmlCodeActionProviderTest : LanguageServerTestBase
         TestFileMarkupParser.GetPositionAndSpan(contents, out contents, out var cursorPosition, out var span);
 
         var documentPath = "c:/Test.razor";
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
-            Context = new CodeActionContext()
+            Context = new VSInternalCodeActionContext()
         };
 
         var location = new SourceLocation(cursorPosition, -1, -1);
@@ -145,7 +146,7 @@ public class DefaultHtmlCodeActionProviderTest : LanguageServerTestBase
     }
 
     private static RazorCodeActionContext CreateRazorCodeActionContext(
-        CodeActionParams request,
+        VSCodeActionParams request,
         SourceLocation location,
         string filePath,
         string text,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ComponentAccessibilityCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ComponentAccessibilityCodeActionProviderTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Components;
+using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
@@ -36,10 +37,11 @@ public class ComponentAccessibilityCodeActionProviderTest : LanguageServerTestBa
             """;
         TestFileMarkupParser.GetPosition(contents, out contents, out var cursorPosition);
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range{ Start = new Position(0, 1), End = new Position(0, 1), },
+            Context = new VSInternalCodeActionContext()
         };
 
         var location = new SourceLocation(cursorPosition, -1, -1);
@@ -64,10 +66,11 @@ public class ComponentAccessibilityCodeActionProviderTest : LanguageServerTestBa
             """;
         TestFileMarkupParser.GetPosition(contents, out contents, out var cursorPosition);
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
+            Context = new VSInternalCodeActionContext()
         };
 
         var location = new SourceLocation(cursorPosition, -1, -1);
@@ -93,10 +96,11 @@ public class ComponentAccessibilityCodeActionProviderTest : LanguageServerTestBa
             """;
         TestFileMarkupParser.GetPosition(contents, out contents, out var cursorPosition);
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range { Start = new Position(0, 0), End = new Position(0, 0) },
+            Context = new VSInternalCodeActionContext()
         };
 
         var location = new SourceLocation(cursorPosition, -1, -1);
@@ -121,10 +125,11 @@ public class ComponentAccessibilityCodeActionProviderTest : LanguageServerTestBa
             """;
         TestFileMarkupParser.GetPosition(contents, out contents, out var cursorPosition);
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range { Start = new Position(0, 0), End = new Position(0, 0) },
+            Context = new VSInternalCodeActionContext()
         };
 
         var location = new SourceLocation(cursorPosition, -1, -1);
@@ -169,10 +174,11 @@ public class ComponentAccessibilityCodeActionProviderTest : LanguageServerTestBa
             """;
         TestFileMarkupParser.GetPosition(contents, out contents, out var cursorPosition);
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range { Start = new Position(0, 0), End = new Position(0, 0) },
+            Context = new VSInternalCodeActionContext()
         };
 
         var location = new SourceLocation(cursorPosition, -1, -1);
@@ -200,10 +206,11 @@ public class ComponentAccessibilityCodeActionProviderTest : LanguageServerTestBa
             """;
         TestFileMarkupParser.GetPosition(contents, out contents, out var cursorPosition);
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range { Start = new Position(0, 0), End = new Position(0, 0) },
+            Context = new VSInternalCodeActionContext()
         };
 
         var location = new SourceLocation(cursorPosition, -1, -1);
@@ -231,10 +238,11 @@ public class ComponentAccessibilityCodeActionProviderTest : LanguageServerTestBa
             """;
         TestFileMarkupParser.GetPosition(contents, out contents, out var cursorPosition);
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range { Start = new Position(0, 0), End = new Position(0, 0) },
+            Context = new VSInternalCodeActionContext()
         };
 
         var location = new SourceLocation(cursorPosition, -1, -1);
@@ -260,10 +268,11 @@ public class ComponentAccessibilityCodeActionProviderTest : LanguageServerTestBa
             """;
         TestFileMarkupParser.GetPosition(contents, out contents, out var cursorPosition);
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range { Start = new Position(0, 0), End = new Position(0, 0) },
+            Context = new VSInternalCodeActionContext()
         };
 
         var location = new SourceLocation(cursorPosition, -1, -1);
@@ -292,7 +301,7 @@ public class ComponentAccessibilityCodeActionProviderTest : LanguageServerTestBa
             });
     }
 
-    private static RazorCodeActionContext CreateRazorCodeActionContext(CodeActionParams request, SourceLocation location, string filePath, string text, SourceSpan componentSourceSpan, bool supportsFileCreation = true)
+    private static RazorCodeActionContext CreateRazorCodeActionContext(VSCodeActionParams request, SourceLocation location, string filePath, string text, SourceSpan componentSourceSpan, bool supportsFileCreation = true)
     {
         var shortComponent = TagHelperDescriptorBuilder.Create(ComponentMetadata.Component.TagHelperKind, "Fully.Qualified.Component", "TestAssembly");
         shortComponent.TagMatchingRule(rule => rule.TagName = "Component");

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionProviderTest.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
+using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
@@ -38,10 +39,11 @@ public class ExtractToCodeBehindCodeActionProviderTest : LanguageServerTestBase
             """;
         TestFileMarkupParser.GetPosition(contents, out contents, out var cursorPosition);
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
+            Context = new VSInternalCodeActionContext()
         };
 
         var location = new SourceLocation(cursorPosition, -1, -1);
@@ -68,10 +70,11 @@ public class ExtractToCodeBehindCodeActionProviderTest : LanguageServerTestBase
             """;
         TestFileMarkupParser.GetPosition(contents, out contents, out var cursorPosition);
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
+            Context = new VSInternalCodeActionContext()
         };
 
         var location = new SourceLocation(cursorPosition, -1, -1);
@@ -97,10 +100,11 @@ public class ExtractToCodeBehindCodeActionProviderTest : LanguageServerTestBase
             """;
         TestFileMarkupParser.GetPosition(contents, out contents, out var cursorPosition);
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
+            Context = new VSInternalCodeActionContext()
         };
 
         var location = new SourceLocation(cursorPosition, -1, -1);
@@ -126,10 +130,11 @@ public class ExtractToCodeBehindCodeActionProviderTest : LanguageServerTestBase
             """;
         TestFileMarkupParser.GetPosition(contents, out contents, out var cursorPosition);
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
+            Context = new VSInternalCodeActionContext()
         };
 
         var location = new SourceLocation(cursorPosition, -1, -1);
@@ -160,10 +165,11 @@ public class ExtractToCodeBehindCodeActionProviderTest : LanguageServerTestBase
             """;
         TestFileMarkupParser.GetPosition(contents, out contents, out var cursorPosition);
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
+            Context = new VSInternalCodeActionContext()
         };
 
         var location = new SourceLocation(cursorPosition, -1, -1);
@@ -194,10 +200,11 @@ public class ExtractToCodeBehindCodeActionProviderTest : LanguageServerTestBase
             """;
         TestFileMarkupParser.GetPosition(contents, out contents, out var cursorPosition);
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
+            Context = new VSInternalCodeActionContext()
         };
 
         var location = new SourceLocation(cursorPosition, -1, -1);
@@ -232,10 +239,11 @@ public class ExtractToCodeBehindCodeActionProviderTest : LanguageServerTestBase
             """;
         TestFileMarkupParser.GetPosition(contents, out contents, out var cursorPosition);
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
+            Context = new VSInternalCodeActionContext()
         };
 
         var location = new SourceLocation(cursorPosition, -1, -1);
@@ -270,10 +278,11 @@ public class ExtractToCodeBehindCodeActionProviderTest : LanguageServerTestBase
             """;
         TestFileMarkupParser.GetPosition(contents, out contents, out var cursorPosition);
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
+            Context = new VSInternalCodeActionContext()
         };
 
         var location = new SourceLocation(cursorPosition, -1, -1);
@@ -299,10 +308,11 @@ public class ExtractToCodeBehindCodeActionProviderTest : LanguageServerTestBase
             """;
         TestFileMarkupParser.GetPosition(contents, out contents, out var cursorPosition);
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
+            Context = new VSInternalCodeActionContext()
         };
 
         var location = new SourceLocation(cursorPosition, -1, -1);
@@ -337,10 +347,11 @@ public class ExtractToCodeBehindCodeActionProviderTest : LanguageServerTestBase
             """;
         TestFileMarkupParser.GetPosition(contents, out contents, out var cursorPosition);
 
-        var request = new CodeActionParams()
+        var request = new VSCodeActionParams()
         {
-            TextDocument = new TextDocumentIdentifier { Uri = new Uri(documentPath) },
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
             Range = new Range(),
+            Context = null!
         };
 
         var location = new SourceLocation(cursorPosition, -1, -1);
@@ -355,10 +366,10 @@ public class ExtractToCodeBehindCodeActionProviderTest : LanguageServerTestBase
         Assert.Null(commandOrCodeActionContainer);
     }
 
-    private static RazorCodeActionContext CreateRazorCodeActionContext(CodeActionParams request, SourceLocation location, string filePath, string text, bool supportsFileCreation = true)
+    private static RazorCodeActionContext CreateRazorCodeActionContext(VSCodeActionParams request, SourceLocation location, string filePath, string text, bool supportsFileCreation = true)
         => CreateRazorCodeActionContext(request, location, filePath, text, relativePath: filePath, supportsFileCreation: supportsFileCreation);
 
-    private static RazorCodeActionContext CreateRazorCodeActionContext(CodeActionParams request, SourceLocation location, string filePath, string text, string? relativePath, bool supportsFileCreation = true)
+    private static RazorCodeActionContext CreateRazorCodeActionContext(VSCodeActionParams request, SourceLocation location, string filePath, string text, string? relativePath, bool supportsFileCreation = true)
     {
         var sourceDocument = RazorSourceDocument.Create(text, new RazorSourceDocumentProperties(filePath, relativePath));
         var options = RazorParserOptions.Create(o =>

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
+using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
 using Microsoft.AspNetCore.Razor.LanguageServer.Semantic.Models;
@@ -242,12 +243,14 @@ public class DefaultRazorLanguageServerCustomMessageTargetTest : TestBase
         {
             HostDocumentVersion = 1,
             LanguageKind = RazorLanguageKind.CSharp,
-            CodeActionParams = new CodeActionParams()
+            CodeActionParams = new VSCodeActionParams()
             {
-                TextDocument = new TextDocumentIdentifier()
+                TextDocument = new VSTextDocumentIdentifier()
                 {
                     Uri = new Uri("C:/path/to/file.razor")
-                }
+                },
+                Range = new Range(),
+                Context = new VSInternalCodeActionContext()
             }
         };
 
@@ -289,11 +292,11 @@ public class DefaultRazorLanguageServerCustomMessageTargetTest : TestBase
         var expectedResults = GetExpectedResultsAsync();
         var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
         requestInvoker
-            .Setup(invoker => invoker.ReinvokeRequestOnMultipleServersAsync<CodeActionParams, IReadOnlyList<VSInternalCodeAction>>(
+            .Setup(invoker => invoker.ReinvokeRequestOnMultipleServersAsync<VSCodeActionParams, IReadOnlyList<VSInternalCodeAction>>(
                 _textBuffer,
                 Methods.TextDocumentCodeActionName,
                 It.IsAny<Func<JToken, bool>>(),
-                It.IsAny<CodeActionParams>(),
+                It.IsAny<VSCodeActionParams>(),
                 It.IsAny<CancellationToken>()))
             .Returns(expectedResults);
 
@@ -308,12 +311,14 @@ public class DefaultRazorLanguageServerCustomMessageTargetTest : TestBase
         {
             HostDocumentVersion = 1,
             LanguageKind = RazorLanguageKind.CSharp,
-            CodeActionParams = new CodeActionParams()
+            CodeActionParams = new VSCodeActionParams()
             {
-                TextDocument = new TextDocumentIdentifier()
+                TextDocument = new VSTextDocumentIdentifier()
                 {
                     Uri = testDocUri
-                }
+                },
+                Range = new Range(),
+                Context = new VSInternalCodeActionContext()
             }
         };
 


### PR DESCRIPTION
We're losing data between our endpoint and middleware (custom message target) because the platform converters aren't used for writing.

Poiinting this to release/dev17.6 on the assumption web tools wants it for M2.  @ToddGrun @jimmylewis let me know if P2 is okay.