### PR TITLE
fix-text-differ

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TextDifferencing/TextDiffer.IntArray.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TextDifferencing/TextDiffer.IntArray.cs
@@ -118,7 +118,7 @@ internal abstract partial class TextDiffer
                 // Does this index fall within page? If not, acquire the appropriate page.
                 if (index < page.Start || index >= page.Start + page.Length)
                 {
-                    page = _pages[index % PageSize];
+                    page = _pages[index / PageSize];
                     _page = page;
                 }
 


### PR DESCRIPTION
Encountered an IndexOutOfRange Exception here, when formatting a large .razor file.

The debugger showed that the pages array had 3 entries, the expression `index % PageSize` evaluated to some high values like 23300 % 20480.

I think this should be an integer division instead of a modulo operation.