### PR TITLE
Handle UnauthorizedAccessExceptions in DirectoryHelper

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DirectoryHelper.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DirectoryHelper.cs
@@ -64,6 +64,11 @@ internal static class DirectoryHelper
             // This can also happen if the directory is too long for windows.
             files = Array.Empty<string>();
         }
+        catch (UnauthorizedAccessException ex)
+        {
+            logger?.LogWarning("UnauthorizedAccess: {exception}", ex.Message);
+            yield break;
+        }
         catch (PathTooLongException ex)
         {
             logger?.LogWarning("PathTooLong: {exception}", ex.Message);
@@ -90,6 +95,11 @@ internal static class DirectoryHelper
             // The filesystem may have deleted the directory between us finding it and searching for directories in it.
             // This can also happen if the directory is too long for windows.
             directories = Array.Empty<string>();
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            logger?.LogWarning("UnauthorizedAccess: {exception}", ex.Message);
+            yield break;
         }
         catch (PathTooLongException ex)
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationFileChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationFileChangeDetectorTest.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 using Xunit.Abstractions;
@@ -40,7 +41,8 @@ public class ProjectConfigurationFileChangeDetectorTest : LanguageServerTestBase
             cts,
             Dispatcher,
             new[] { listener1.Object, listener2.Object },
-            existingConfigurationFiles);
+            existingConfigurationFiles,
+            LoggerFactory);
 
         // Act
         await detector.StartAsync("/some/workspace+directory", cts.Token);
@@ -77,10 +79,11 @@ public class ProjectConfigurationFileChangeDetectorTest : LanguageServerTestBase
 
         public TestProjectConfigurationFileChangeDetector(
             CancellationTokenSource cancellationTokenSource,
-            ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,
+            ProjectSnapshotManagerDispatcher dispatcher,
             IEnumerable<IProjectConfigurationFileChangeListener> listeners,
-            IReadOnlyList<string> existingConfigurationFiles)
-            : base(projectSnapshotManagerDispatcher, listeners, TestLanguageServerFeatureOptions.Instance)
+            IReadOnlyList<string> existingConfigurationFiles,
+            ILoggerFactory loggerFactory)
+            : base(dispatcher, listeners, TestLanguageServerFeatureOptions.Instance, loggerFactory)
         {
             _cancellationTokenSource = cancellationTokenSource;
             _existingConfigurationFiles = existingConfigurationFiles;


### PR DESCRIPTION
When recursively digging through directories to find project configuration files (i.e. `project.razor.json`), we didn't handle any `UnauthorizedAccessExceptions` that might be thrown. So, if some sub-directory fails due to permissions access, the entire search would fail, even if a configuration file had already been found.

Beyond the bug fix (which is small), I did a bit of clean up.