### PR TITLE
Release BlazorWasmDebugging 1.1.4

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/package.json
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension/package.json
@@ -2,7 +2,7 @@
   "name": "blazorwasm-companion",
   "displayName": "Microsoft.AspNetCore.Razor.VSCode.BlazorWasmDebuggingExtension",
   "description": "A companion extension for debugging Blazor WebAssembly applications in VS Code. Must be installed alongside the C# extension.",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/dotnet/razor.git"


### PR DESCRIPTION
It looks like the .vsix artifact for publishing isn't created unless this changes. Includes fix for dotnet/aspnetcore#46429

FYI @thaystg 
