### PR TITLE
Don't NotImplemented in OutputwindowLogger

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Logging/OutputWindowLogger.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Logging/OutputWindowLogger.cs
@@ -31,10 +31,7 @@ internal class OutputWindowLogger : ILogger
     {
     }
 
-    public IDisposable BeginScope<TState>(TState state)
-    {
-        throw new NotImplementedException();
-    }
+    public IDisposable BeginScope<TState>(TState state) => Scope.Instance;
 
     public bool IsEnabled(LogLevel logLevel)
     {
@@ -132,6 +129,15 @@ internal class OutputWindowLogger : ILogger
             }
 
             return null;
+        }
+    }
+
+    private class Scope : IDisposable
+    {
+        public static readonly Scope Instance = new();
+
+        public void Dispose()
+        {
         }
     }
 }


### PR DESCRIPTION
﻿### Summary of the changes

- It was silly of me to make this an exception just because we weren't using scopes at the time, especially given that apparently we already had a pattern to do this without the underlying stores having to understand (NoOps).