### PR TITLE
Turn on windows targeting

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,6 +26,7 @@
     <GenerateResxSourceEmitFormatMethods>true</GenerateResxSourceEmitFormatMethods>
     <ExcludeFromSourceBuild Condition="'$(IsUnitTestProject)' == 'true'">true</ExcludeFromSourceBuild>
     <RepositoryRoot>$(MSBuildThisFileDirectory)</RepositoryRoot>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
 
     <SharedSourceRoot>$(MSBuildThisFileDirectory)src\Shared\</SharedSourceRoot>
 


### PR DESCRIPTION
Allows linux machines to build the complete solution, without errors about WPF frameworks being missing.
