### PR TITLE
[VS Code] Update Razor repo link

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Diagnostics/ReportIssuePanel.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Diagnostics/ReportIssuePanel.ts
@@ -111,7 +111,7 @@ export class ReportIssuePanel {
     <li>Press <button onclick="startIssue()">Start</button></li>
     <li>Perform the actions (or no action) that resulted in your Razor issue</li>
     <li>Click <button onclick="stopIssue()">Stop</button>. This will copy all relevant issue information.</li>
-    <li><a href="https://github.com/dotnet/razor-tooling/issues/new?template=bug_report.md&labels=vscode%2C+bug">Go to GitHub</a>, paste your issue contents as the body of the issue. Don't forget to fill out any details left unfilled.</li>
+    <li><a href="https://github.com/dotnet/razor/issues/new?template=bug_report.md&labels=vscode%2C+bug">Go to GitHub</a>, paste your issue contents as the body of the issue. Don't forget to fill out any details left unfilled.</li>
 </ol>
 
 <p><em>Privacy Alert! The contents copied to your clipboard may contain personal data. Prior to posting to


### PR DESCRIPTION
﻿### Summary of the changes
- The GitHub link in the "Report a Razor issue" command automatically re-directs to the Razor repo, but Phil brought up a good point that we should probably explicitly change this to "razor" (from "razor-tooling").

