### PR TITLE
Fix UTF-8 BOM settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,7 @@ trim_trailing_whitespace = true
 [*.{cs,csx,vb,vbx}]
 indent_size = 4
 insert_final_newline = true
-encoding = utf-8-bom
+charset = utf-8-bom
 
 file_header_template = Copyright (c) .NET Foundation. All rights reserved.\nLicensed under the MIT license. See License.txt in the project root for license information.
 

--- a/src/Compiler/.editorconfig
+++ b/src/Compiler/.editorconfig
@@ -21,6 +21,7 @@ insert_final_newline = true
 
 [*.cs]
 indent_size = 4
+charset = utf-8-bom
 dotnet_sort_system_directives_first = true
 dotnet_separate_import_directive_groups = false
 

--- a/src/Compiler/test/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/RazorBaselineIntegrationTestBase.cs
+++ b/src/Compiler/test/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/RazorBaselineIntegrationTestBase.cs
@@ -6,6 +6,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Xunit;
@@ -17,6 +18,9 @@ namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests;
 public abstract class RazorBaselineIntegrationTestBase : RazorIntegrationTestBase
 {
     private static readonly AsyncLocal<string> _directoryPath = new AsyncLocal<string>();
+
+    // UTF-8 with BOM
+    private static readonly Encoding _baselineEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
 
     protected RazorBaselineIntegrationTestBase(bool? generateBaselines = null)
     {
@@ -36,7 +40,7 @@ public abstract class RazorBaselineIntegrationTestBase : RazorIntegrationTestBas
     }
 
 #if GENERATE_BASELINES
-        protected bool GenerateBaselines { get; } = true;
+    protected bool GenerateBaselines { get; } = true;
 #else
     protected bool GenerateBaselines { get; } = false;
 #endif
@@ -250,12 +254,12 @@ public abstract class RazorBaselineIntegrationTestBase : RazorIntegrationTestBas
     private static void WriteBaseline(string text, string filePath)
     {
         var lines = text.Replace("\r", "").Replace("\n", "\r\n");
-        File.WriteAllText(filePath, text);
+        File.WriteAllText(filePath, text, _baselineEncoding);
     }
 
     private static void WriteBaseline(string[] lines, string filePath)
     {
-        using (var writer = new StreamWriter(File.Open(filePath, FileMode.Create)))
+        using (var writer = new StreamWriter(File.Open(filePath, FileMode.Create), _baselineEncoding))
         {
             // Force windows-style line endings so that we're consistent. This isn't
             // required for correctness, but will prevent churn when developing on OSX.


### PR DESCRIPTION
Follow up on #8099.

- Fixes EditorConfig settings.
- Emits baselines in UTF-8 with BOM.

Tested locally with Visual Studio.