### PR TITLE
Fix TextMate missing item

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/EditorInProcess_Classification.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/EditorInProcess_Classification.cs
@@ -96,15 +96,19 @@ internal partial class EditorInProcess
         var expectedArray = expectedClassifications.ToArray();
         var actualOffset = 0;
 
-        for (var i = 0; i < actualArray.Length; i++)
+        for (var i = 0; i < expectedArray.Length; i++)
         {
             var actualClassification = actualArray[i+actualOffset];
             var expectedClassification = expectedArray[i];
 
-            if (actualClassification.ClassificationType.BaseTypes.Count() == 1 && actualClassification.ClassificationType.BaseTypes.Any(t => t is ILayeredClassificationType layered && layered.Layer == ClassificationLayer.Syntactic))
+            if (actualClassification.ClassificationType.BaseTypes.Count() == 0 &&
+                actualClassification.ClassificationType is ILayeredClassificationType layeredClassificationType &&
+                layeredClassificationType.Layer == ClassificationLayer.Syntactic)
             {
+                // Don't check purely syntactic classifications, we're gonna try this again.
                 actualOffset++;
-                actualClassification = actualArray[i+ actualOffset];
+                i--;
+                continue;
             }
 
             if (actualClassification.ClassificationType.BaseTypes.Count() > 1)
@@ -124,7 +128,7 @@ internal partial class EditorInProcess
             }
         }
 
-        Assert.Equal(expectedArray.Length, actualArray.Length);
+        Assert.Equal(expectedArray.Length, actualArray.Length - actualOffset);
     }
 
     public async Task<IEnumerable<ClassificationSpan>> GetClassificationsAsync(CancellationToken cancellationToken)

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Semantic/TestFiles/RazorSemanticTokensTests/GenericTypeParameters_Work.txt
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Semantic/TestFiles/RazorSemanticTokensTests/GenericTypeParameters_Work.txt
@@ -22,7 +22,6 @@
 101,1,operator,
 102,7,identifier,
 109,1,HTML Attribute Value,
-110,1,HTML Tag Delimiter,
 111,1,HTML Tag Delimiter,
 112,1,HTML Tag Delimiter,
 115,1,HTML Tag Delimiter,

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Semantic/TestFiles/RazorSemanticTokensTests/GenericTypeParameters_Work.txt
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Semantic/TestFiles/RazorSemanticTokensTests/GenericTypeParameters_Work.txt
@@ -22,6 +22,7 @@
 101,1,operator,
 102,7,identifier,
 109,1,HTML Attribute Value,
+110,1,HTML Tag Delimiter,
 111,1,HTML Tag Delimiter,
 112,1,HTML Tag Delimiter,
 115,1,HTML Tag Delimiter,


### PR DESCRIPTION
﻿### Summary of the changes

- Seen when running locally, the TextMate colorization was missing from the baseline file.
