### PR TITLE
Don't try and de-dup tag helper descriptors

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperBinder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperBinder.cs
@@ -132,8 +132,6 @@ internal sealed class TagHelperBinder
 
     private void Register(TagHelperDescriptor descriptor)
     {
-        bool descriptorAdded = false;
-
         var count = descriptor.TagMatchingRules.Count;
         for (var i = 0; i < count; i++)
         {
@@ -150,12 +148,7 @@ internal sealed class TagHelperBinder
                 _registrations[registrationKey] = descriptorSet;
             }
 
-            // We don't need to keep trying to add the same Descriptor to the HashSet for each matching rule.
-            if (!descriptorAdded)
-            {
-                _ = descriptorSet.Add(descriptor);
-                descriptorAdded = true;
-            }
+            _ = descriptorSet.Add(descriptor);
         }
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TagHelperBinderTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TagHelperBinderTest.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable


### PR DESCRIPTION
Partially reverts https://github.com/dotnet/razor/pull/8135

Unfortunately, it isn't valid to short circuit in all cases. It's possible for a descriptor to have multiple registration keys. We also can't just add it when we create the hash set, because it could be created by a different provider. 

We could probably track which sets a descriptor has been added to, so as to not try and add it multiple times, but I'm not convinced it would be all that much faster (we can benchmark this in another PR if we're interested).

