### PR TITLE
Avoid killing the process when a login window is closed.

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/TerminateDebugHandler.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/TerminateDebugHandler.ts
@@ -12,7 +12,8 @@ export const isValidEvent = (name: string) => {
 
   // The name can be of the form: `Debug Blazor Web Assembly in Browser: https://localhost:7291`
   // hence we have to examine what the name **startsWith**
-  // we cannot use startsWith otherwise when we close a login window we will receive a name like this `'Debug Blazor Web Assembly in Browser: https://localhost:5001/authentication/login-callback#state=eyJpZCI6ImEwYjQ5MDMzL` and will kill the app
+  // we cannot use startsWith otherwise when we close a login window we will receive a name like this
+  // `Debug Blazor Web Assembly in Browser: https://localhost:5001/authentication/login-callback#state=eyJpZCI6ImEwYjQ5MDMzL` and will kill the app
   return name === JS_DEBUG_NAME || name === SERVER_APP_NAME;
 };
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/TerminateDebugHandler.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/BlazorDebug/TerminateDebugHandler.ts
@@ -12,7 +12,8 @@ export const isValidEvent = (name: string) => {
 
   // The name can be of the form: `Debug Blazor Web Assembly in Browser: https://localhost:7291`
   // hence we have to examine what the name **startsWith**
-  return name.startsWith(JS_DEBUG_NAME) || name === SERVER_APP_NAME;
+  // we cannot use startsWith otherwise when we close a login window we will receive a name like this `'Debug Blazor Web Assembly in Browser: https://localhost:5001/authentication/login-callback#state=eyJpZCI6ImEwYjQ5MDMzL` and will kill the app
+  return name === JS_DEBUG_NAME || name === SERVER_APP_NAME;
 };
 
 const killProcess = (targetPid: number | undefined, logger: RazorLogger) => {


### PR DESCRIPTION
We cannot use startsWith because if we use it we will kill the process when we close a login window.

When we stop the debugging session we receive 2 event names:
- `Debug Blazor Web Assembly in Browser: https://localhost:7291`
- `Debug Blazor Web Assembly in Browser`

So I think it's okay to keep without the startsWith as it was done before this commit: https://github.com/dotnet/razor/pull/5885 

Fixes: https://github.com/aspnet/AspNetCore-ManualTests/issues/1834
