### PR TITLE
Don't set always-auth

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/.npmrc
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/.npmrc
@@ -1,3 +1,2 @@
 ﻿# Auto generated file from Gardener Plugin CentralFeedServiceAdoptionPlugin
 registry=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
-always-auth=true

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/.npmrc
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.VSCode.Grammar.Test/.npmrc
@@ -1,3 +1,2 @@
 ﻿# Auto generated file from Gardener Plugin CentralFeedServiceAdoptionPlugin
 registry=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/
-always-auth=true


### PR DESCRIPTION
This was introduced by yarn when I updated various packages, and because I refuse to acknowledge the existence of the JavaScript ecosystem, I blindly committed it assuming it was correct. What this actually did was ensure that on every build, npm would auth to the package registry, which means my build broke when a PAT expired. This is objectively stupid.