### PR TITLE
Fix formatting of lines that start with component attributes

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPassBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPassBase.cs
@@ -167,7 +167,7 @@ internal abstract class CSharpFormattingPassBase : FormattingPassBase
             var line = context.SourceText.Lines[i];
             var lineStart = line.GetFirstNonWhitespacePosition() ?? line.Start;
             var lineStartSpan = new TextSpan(lineStart, 0);
-            if (!ShouldFormat(context, lineStartSpan, allowImplicitStatements: true))
+            if (!ShouldFormatLine(context, lineStartSpan, allowImplicitStatements: true))
             {
                 // We don't care about this line as it lies in an area we don't want to format.
                 continue;
@@ -280,6 +280,16 @@ internal abstract class CSharpFormattingPassBase : FormattingPassBase
 
     protected static bool ShouldFormat(FormattingContext context, TextSpan mappingSpan, bool allowImplicitStatements, out SyntaxNode? foundOwner)
     {
+        return ShouldFormatCore(context, mappingSpan, allowImplicitStatements, isLineRequest: false, out foundOwner);
+    }
+
+    private static bool ShouldFormatLine(FormattingContext context, TextSpan mappingSpan, bool allowImplicitStatements)
+    {
+        return ShouldFormatCore(context, mappingSpan, allowImplicitStatements, isLineRequest: true, out _);
+    }
+
+    private static bool ShouldFormatCore(FormattingContext context, TextSpan mappingSpan, bool allowImplicitStatements, bool isLineRequest, out SyntaxNode? foundOwner)
+    {
         // We should be called with the range of various C# SourceMappings.
 
         if (mappingSpan.Start == 0)
@@ -323,7 +333,7 @@ internal abstract class CSharpFormattingPassBase : FormattingPassBase
         }
 
         if (IsRazorComment() ||
-            IsInHtmlAttributeName() ||
+            IsInBoundComponentAttributeName() ||
             IsInHtmlAttributeValue() ||
             IsInDirectiveWithNoKind() ||
             IsInSingleLineDirective() ||
@@ -367,18 +377,31 @@ internal abstract class CSharpFormattingPassBase : FormattingPassBase
             return false;
         }
 
-        bool IsInHtmlAttributeName()
+        bool IsInBoundComponentAttributeName()
         {
             // E.g, (| is position)
             //
             // `<p |csharpattr="Variable">` - true
             //
             // Because we map attributes, so rename and FAR works, there could be C# mapping for them,
-            // but only if they're actually bound attributes
+            // but only if they're actually bound attributes. We don't want the mapping to throw make the
+            // formatting engine think it needs to apply C# indentation rules.
+            //
+            // The exception here is if we're being asked whether to format the line of code at all,
+            // then we want to pretend it's not a component attribute, because we do still want the line
+            // formatted. ie, given this:
+            //
+            // `<p
+            //     |csharpattr="Variable">`
+            //
+            // We want to return false when being asked to format the line, so the line gets indented, but
+            // return true if we're just being asked "should we format this according to C# rules".
 
-            return owner.AncestorsAndSelf().Any(
-                n => n is MarkupTagHelperAttributeSyntax { TagHelperAttributeInfo: { Bound: true } } or
-                          MarkupTagHelperDirectiveAttributeSyntax { TagHelperAttributeInfo: { Bound: true } });
+            return owner is MarkupTextLiteralSyntax
+            {
+                Parent: MarkupTagHelperAttributeSyntax { TagHelperAttributeInfo: { Bound: true } } or
+                        MarkupTagHelperDirectiveAttributeSyntax { TagHelperAttributeInfo: { Bound: true } }
+            } && !isLineRequest;
         }
 
         bool IsInHtmlAttributeValue()

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingVisitor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingVisitor.cs
@@ -341,7 +341,14 @@ internal class FormattingVisitor : SyntaxWalker
 
     public override void VisitMarkupTagHelperAttribute(MarkupTagHelperAttributeSyntax node)
     {
-        Visit(node.Value);
+        WriteBlock(node, FormattingBlockKind.Tag, n =>
+        {
+            var equalsSyntax = SyntaxFactory.MarkupTextLiteral(new SyntaxList<SyntaxToken>(node.EqualsToken));
+            var mergedAttributePrefix = SyntaxUtilities.MergeTextLiterals(node.NamePrefix, node.Name, node.NameSuffix, equalsSyntax, node.ValuePrefix);
+            Visit(mergedAttributePrefix);
+            Visit(node.Value);
+            Visit(node.ValueSuffix);
+        });
     }
 
     public override void VisitMarkupTagHelperDirectiveAttribute(MarkupTagHelperDirectiveAttributeSyntax node)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
@@ -749,7 +749,7 @@ public class HtmlFormattingTest : FormattingTestBase
             tagHelpers: GetComponents());
     }
 
-    [Fact(Skip = "Requires fix")]
+    [Fact]
     [WorkItem("https://github.com/dotnet/razor/issues/8227")]
     public async Task FormatNestedComponents3()
     {
@@ -767,6 +767,19 @@ public class HtmlFormattingTest : FormattingTestBase
                                 </Frag>
                                 </Component1>
                     }
+
+                    @if (true)
+                    {
+                        <a_really_long_tag_name Id="comp1"
+                                Caption="Title" />
+                    <a_really_long_tag_name Id="comp2"
+                                Caption="Title">
+                                <a_really_long_tag_name>
+                    <a_really_long_tag_name Id="comp3"
+                                Caption="Title" />
+                                </a_really_long_tag_name>
+                                </a_really_long_tag_name>
+                    }
                     """,
             expected: """
                     @if (true)
@@ -780,6 +793,19 @@ public class HtmlFormattingTest : FormattingTestBase
                                             Caption="Title" />
                             </Frag>
                         </Component1>
+                    }
+
+                    @if (true)
+                    {
+                        <a_really_long_tag_name Id="comp1"
+                                                Caption="Title" />
+                        <a_really_long_tag_name Id="comp2"
+                                                Caption="Title">
+                            <a_really_long_tag_name>
+                                <a_really_long_tag_name Id="comp3"
+                                                        Caption="Title" />
+                            </a_really_long_tag_name>
+                        </a_really_long_tag_name>
                     }
                     """,
             tagHelpers: GetComponents());

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
@@ -835,7 +835,7 @@ public class HtmlFormattingTest : FormattingTestBase
             tagHelpers: GetComponents());
     }
 
-    [Fact(Skip = "Requires fix")]
+    [Fact]
     [WorkItem("https://github.com/dotnet/razor/issues/8229")]
     public async Task FormatNestedComponents5()
     {


### PR DESCRIPTION
To celebrate finally being able to build on my machine, I took a break from firefighting to write some code.

Fixes https://github.com/dotnet/razor/issues/8227
Fixes https://github.com/dotnet/razor/issues/8229

I cannot explain why this doesn't fix the third skipped test, but I wanted to timebox the work so I did.

Thanks @LunicLynx for creating the tests for these, made it much easier