### PR TITLE
Update SourceGenerator.Tooling.Internal with Utilities.Shared

### DIFF
--- a/src/Compiler/Directory.Packages.props
+++ b/src/Compiler/Directory.Packages.props
@@ -30,5 +30,6 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="$(Tooling_MicrosoftCodeAnalysisBannedApiAnalyzersPackageVersion)" />
     <PackageVersion Include="Roslyn.Diagnostics.Analyzers" Version="$(Tooling_RoslynDiagnosticsAnalyzersPackageVersion)" />
     <PackageVersion Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutablePackageVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="$(MicrosoftExtensionsPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/src/Compiler/tools/Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal/Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal.csproj
+++ b/src/Compiler/tools/Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal/Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal.csproj
@@ -25,11 +25,15 @@
     <EmbeddedResource Include="..\..\Microsoft.AspNetCore.Mvc.Razor.Extensions\src\RazorExtensionsResources.resx"
       ClassName="Microsoft.AspNetCore.Mvc.Razor.Extensions.RazorExtensionsResources" />
 
-    <Compile Include="$(SharedSourceRoot)\Microsoft.AspNetCore.Razor.Utilities.Shared\LanguageSupport\NullableAttributes.cs" LinkBase="LanguageSupport" />
+    <Compile Include="$(SharedSourceRoot)\Microsoft.AspNetCore.Razor.Utilities.Shared\**\*.cs" LinkBase="Utilities" />
+    <EmbeddedResource Include="$(SharedSourceRoot)\Microsoft.AspNetCore.Razor.Utilities.Shared\Resources\SR.resx"
+      ClassName="Microsoft.AspNetCore.Razor.Utilities.Shared.Resources.SR"/>
+    <Using Include="Microsoft.AspNetCore.Razor.Utilities.Shared.Resources" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This change links all of the files from `Microsoft.AspNetCore.Razor.Utilities.Shared` into `Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal`, now that `Utilities.Shared` is referenced by `Microsoft.AspNetCore.Razor.Language`. Otherwise, `SourceGenerators.Tooling.Internal` will fail to build if anything from `Utilities.Shared` is actually used.

@333fred: I noticed that `Microsoft.AspNetCore.Razor.SourceGenerator.Tooling.Internal` does not directly reference `System.Collections.Immutable`, so it's transitively referencing it through its reference to `Microsoft.CodeAnalysis.CSharp`. Would it make sense to add a direct reference in `SourceGenerator.Tooling.Internal` to ensure that it builds with the same version as `Microsoft.AspNetCore.Razor.Language`?