### PR TITLE
Avoid allocating when comparing type names

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/SymbolExtensions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/SymbolExtensions.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -12,18 +12,27 @@ internal static class SymbolExtensions
             .WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted)
             .RemoveMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes);
 
+    /// <summary>
+    /// Checks if <paramref name="symbol"/> has the same fully qualified name as <paramref name="fullName"/>.
+    /// </summary>
+    /// <remarks>
+    /// This is a *very* simple implementation that doesn't handle all cases. It's only intended to be used
+    /// for a small set of known types. If you add a new type to be looked up by this function you must ensure
+    /// the simple check works correctly for it. 
+    /// </remarks>
+    /// <returns>true if the type has the specified full name</returns>
     internal static bool HasFullName(this ISymbol symbol, string fullName)
     {
         // generally we expect this call to fail, so try and match on the simple name first, before
-        // checking the fully qualified name, to prevent unnecesary string allocation from ToDisplayString 
+        // checking the fully qualified name, to prevent unnecessary string allocation from ToDisplayString 
         if (symbol.Name.Length > fullName.Length)
         {
             return false;
         }
 
         // the simple name doesn't include generic type params, so skip over them in the full name if they are present
-        int fullNameEndIndex = fullName[^1] == '>' ? fullName.LastIndexOf('<') : fullName.Length;
-        int fullNameStartIndex = fullName.LastIndexOf('.', fullNameEndIndex - 1) + 1;
+        var fullNameEndIndex = fullName[^1] == '>' ? fullName.LastIndexOf('<') : fullName.Length;
+        var fullNameStartIndex = fullName.LastIndexOf('.', fullNameEndIndex - 1) + 1;
 
         if (!fullName.AsSpan(fullNameStartIndex, fullNameEndIndex - fullNameStartIndex).Equals(symbol.Name.AsSpan(), StringComparison.Ordinal))
         {

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/SymbolExtensions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/SymbolExtensions.cs
@@ -14,6 +14,23 @@ internal static class SymbolExtensions
 
     internal static bool HasFullName(this ISymbol symbol, string fullName)
     {
+        // generally we expect this call to fail, so try and match on the simple name first, before
+        // checking the fully qualified name, to prevent unnecesary string allocation from ToDisplayString 
+        if (symbol.Name.Length > fullName.Length)
+        {
+            return false;
+        }
+
+        // the simple name doesn't include generic type params, so skip over them in the full name if they are present
+        int fullNameEndIndex = fullName[^1] == '>' ? fullName.LastIndexOf('<') : fullName.Length;
+        int fullNameStartIndex = fullName.LastIndexOf('.', fullNameEndIndex - 1) + 1;
+
+        if (!fullName.AsSpan(fullNameStartIndex, fullNameEndIndex - fullNameStartIndex).Equals(symbol.Name.AsSpan(), StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        // The simple name matched, do a fully qualified comparison
         return symbol.ToDisplayString(FullNameTypeDisplayFormat).Equals(fullName, StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
Check the type simple name first, to avoid allocating a lot of strings via `ToDisplayString()`

In the cold benchmark we see a drop of about 6MB

```
Previous:
|           Method |     Mean |   Error |  StdDev |      Gen0 |      Gen1 | Allocated |
|----------------- |---------:|--------:|--------:|----------:|----------:|----------:|
| Cold_Compilation | 254.5 ms | 4.80 ms | 4.25 ms | 3000.0000 | 1000.0000 |  95.29 MB |

After:
|           Method |     Mean |   Error |  StdDev |      Gen0 |      Gen1 | Allocated |
|----------------- |---------:|--------:|--------:|----------:|----------:|----------:|
| Cold_Compilation | 251.6 ms | 2.77 ms | 2.31 ms | 3000.0000 | 1000.0000 |  89.25 MB |

```

We also see a drop of a 100kb or so on the hot benchmarks, but they already allocated very little.