### PR TITLE
Load Advanced Settings On Server Start

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
@@ -164,11 +164,18 @@ internal static class IServiceCollectionExtensions
         services.AddHandler<RazorLanguageQueryEndpoint>();
     }
 
-    public static void AddOptionsServices(this IServiceCollection services)
+    public static void AddOptionsServices(this IServiceCollection services, RazorLSPOptions currentOptions)
     {
         services.AddSingleton<IConfigurationSyncService, DefaultRazorConfigurationService>();
-        services.AddSingleton<RazorLSPOptionsMonitor>();
-        services.AddSingleton<IOptionsMonitor<RazorLSPOptions>, RazorLSPOptionsMonitor>();
+        services.AddSingleton(s =>
+        {
+            return new RazorLSPOptionsMonitor(
+                s.GetRequiredService<IConfigurationSyncService>(),
+                s.GetRequiredService<IOptionsMonitorCache<RazorLSPOptions>>(),
+                currentOptions);
+        });
+
+        services.AddSingleton<IOptionsMonitor<RazorLSPOptions>, RazorLSPOptionsMonitor>(s => s.GetRequiredService<RazorLSPOptionsMonitor>());
     }
 
     public static void AddDocumentManagmentServices(this IServiceCollection services)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLSPOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLSPOptions.cs
@@ -31,4 +31,7 @@ public record RazorLSPOptions(
             Trace.Verbose => LogLevel.Trace,
             _ => LogLevel.None,
         };
+
+    internal RazorLSPOptions With(ClientSettings clientSettings)
+        => new(Trace, EnableFormatting, AutoClosingTags, clientSettings);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLSPOptionsMonitor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLSPOptionsMonitor.cs
@@ -15,7 +15,7 @@ internal class RazorLSPOptionsMonitor : IOptionsMonitor<RazorLSPOptions>
     private event Action<RazorLSPOptions, string>? OnChangeEvent;
     private RazorLSPOptions _currentValue;
 
-    public RazorLSPOptionsMonitor(IConfigurationSyncService configurationService, IOptionsMonitorCache<RazorLSPOptions> cache)
+    public RazorLSPOptionsMonitor(IConfigurationSyncService configurationService, IOptionsMonitorCache<RazorLSPOptions> cache, RazorLSPOptions currentOptions)
     {
         if (configurationService is null)
         {
@@ -29,7 +29,7 @@ internal class RazorLSPOptionsMonitor : IOptionsMonitor<RazorLSPOptions>
 
         _configurationService = configurationService;
         _cache = cache;
-        _currentValue = RazorLSPOptions.Default;
+        _currentValue = currentOptions;
     }
 
     public RazorLSPOptions CurrentValue => Get(Options.DefaultName);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -38,6 +38,8 @@ internal class RazorLanguageServer : AbstractLanguageServer<RazorRequestContext>
     private readonly LanguageServerFeatureOptions? _featureOptions;
     private readonly ProjectSnapshotManagerDispatcher? _projectSnapshotManagerDispatcher;
     private readonly Action<IServiceCollection>? _configureServer;
+    private readonly RazorLSPOptions _lspOptions;
+
     // Cached for testing
     private IHandlerProvider? _handlerProvider;
 
@@ -46,13 +48,15 @@ internal class RazorLanguageServer : AbstractLanguageServer<RazorRequestContext>
         ILspLogger logger,
         ProjectSnapshotManagerDispatcher? projectSnapshotManagerDispatcher,
         LanguageServerFeatureOptions? featureOptions,
-        Action<IServiceCollection>? configureServer)
+        Action<IServiceCollection>? configureServer,
+        RazorLSPOptions? lspOptions)
         : base(jsonRpc, logger)
     {
         _jsonRpc = jsonRpc;
         _featureOptions = featureOptions;
         _projectSnapshotManagerDispatcher = projectSnapshotManagerDispatcher;
         _configureServer = configureServer;
+        _lspOptions = lspOptions ?? RazorLSPOptions.Default;
 
         Initialize();
     }
@@ -124,7 +128,7 @@ internal class RazorLanguageServer : AbstractLanguageServer<RazorRequestContext>
         services.AddCompletionServices(featureOptions);
         services.AddFormattingServices();
         services.AddCodeActionsServices();
-        services.AddOptionsServices();
+        services.AddOptionsServices(_lspOptions);
         services.AddHoverServices();
         services.AddTextDocumentServices();
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServerWrapper.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServerWrapper.cs
@@ -38,7 +38,8 @@ internal sealed class RazorLanguageServerWrapper : IDisposable
         IRazorLogger razorLogger,
         ProjectSnapshotManagerDispatcher? projectSnapshotManagerDispatcher = null,
         Action<IServiceCollection>? configure = null,
-        LanguageServerFeatureOptions? featureOptions = null)
+        LanguageServerFeatureOptions? featureOptions = null,
+        RazorLSPOptions? razorLSPOptions = null)
     {
         var jsonRpc = CreateJsonRpc(input, output);
 
@@ -47,7 +48,8 @@ internal sealed class RazorLanguageServerWrapper : IDisposable
             razorLogger,
             projectSnapshotManagerDispatcher,
             featureOptions,
-            configure);
+            configure,
+            razorLSPOptions);
 
         var razorLanguageServer = new RazorLanguageServerWrapper(server);
         jsonRpc.StartListening();

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/ClientSettingsManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/ClientSettingsManager.cs
@@ -48,6 +48,7 @@ internal class ClientSettingsManager : EditorSettingsManager, IClientSettingsMan
 
         if (_advancedSettingsStorage is not null)
         {
+            Update(_advancedSettingsStorage.GetAdvancedSettings());
             _advancedSettingsStorage.Changed += AdvancedSettingsChanged;
         }
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLSPOptionsMonitorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLSPOptionsMonitorTest.cs
@@ -94,7 +94,7 @@ public class RazorLSPOptionsMonitorTest : TestBase
     }
 
     [Fact]
-    public async Task InitializedOptionsAreCurrent()
+    public void InitializedOptionsAreCurrent()
     {
         // Arrange
         var expectedOptions = new RazorLSPOptions(Trace.Messages, EnableFormatting: false, AutoClosingTags: true, InsertSpaces: true, TabSize: 4, FormatOnType: true);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLSPOptionsMonitorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLSPOptionsMonitorTest.cs
@@ -33,7 +33,7 @@ public class RazorLSPOptionsMonitorTest : TestBase
         var configService = Mock.Of<IConfigurationSyncService>(
             f => f.GetLatestOptionsAsync(DisposalToken) == Task.FromResult(expectedOptions),
             MockBehavior.Strict);
-        var optionsMonitor = new RazorLSPOptionsMonitor(configService, _cache);
+        var optionsMonitor = new RazorLSPOptionsMonitor(configService, _cache, RazorLSPOptions.Default);
         var called = false;
 
         // Act & Assert
@@ -55,7 +55,7 @@ public class RazorLSPOptionsMonitorTest : TestBase
         var configService = Mock.Of<IConfigurationSyncService>(
             f => f.GetLatestOptionsAsync(DisposalToken) == Task.FromResult(expectedOptions),
             MockBehavior.Strict);
-        var optionsMonitor = new RazorLSPOptionsMonitor(configService, _cache);
+        var optionsMonitor = new RazorLSPOptionsMonitor(configService, _cache, RazorLSPOptions.Default);
         var called = false;
         var onChangeToken = optionsMonitor.OnChange(options => called = true);
 
@@ -82,7 +82,7 @@ public class RazorLSPOptionsMonitorTest : TestBase
         Mock.Get(configService)
             .Setup(s => s.GetLatestOptionsAsync(DisposalToken))
             .ReturnsAsync(value: null);
-        var optionsMonitor = new RazorLSPOptionsMonitor(configService, _cache);
+        var optionsMonitor = new RazorLSPOptionsMonitor(configService, _cache, RazorLSPOptions.Default);
         var called = false;
         var onChangeToken = optionsMonitor.OnChange(options => called = true);
 
@@ -91,5 +91,19 @@ public class RazorLSPOptionsMonitorTest : TestBase
 
         // Assert
         Assert.False(called, "Registered callback called even when GetLatestOptionsAsync() returns null.");
+    }
+
+    [Fact]
+    public async Task InitializedOptionsAreCurrent()
+    {
+        // Arrange
+        var expectedOptions = new RazorLSPOptions(Trace.Messages, EnableFormatting: false, AutoClosingTags: true, InsertSpaces: true, TabSize: 4, FormatOnType: true);
+        var configService = Mock.Of<IConfigurationSyncService>(
+            f => f.GetLatestOptionsAsync(DisposalToken) == Task.FromResult(expectedOptions),
+            MockBehavior.Strict);
+        var optionsMonitor = new RazorLSPOptionsMonitor(configService, _cache, expectedOptions);
+
+        // Act & Assert
+        Assert.Same(expectedOptions, optionsMonitor.CurrentValue);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestRazorLSPOptionsMonitor.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestRazorLSPOptionsMonitor.cs
@@ -12,7 +12,7 @@ internal class TestRazorLSPOptionsMonitor : RazorLSPOptionsMonitor
     public TestRazorLSPOptionsMonitor(
         IConfigurationSyncService configurationService,
         IOptionsMonitorCache<RazorLSPOptions> cache)
-        : base(configurationService, cache)
+        : base(configurationService, cache, RazorLSPOptions.Default)
     {
     }
 

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/ClientSettingsManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/ClientSettingsManagerTest.cs
@@ -147,7 +147,9 @@ public class ClientSettingsManagerTest : ProjectSnapshotManagerDispatcherTestBas
             _settings = settings;
         }
 
+#pragma warning disable CS0067 // The event 'ClientSettingsManagerTest.AdvancedSettingsStorage.Changed' is never used
         public event EventHandler<ClientAdvancedSettingsChangedEventArgs> Changed;
+#pragma warning restore CS0067 // The event 'ClientSettingsManagerTest.AdvancedSettingsStorage.Changed' is never used
 
         public ClientAdvancedSettings GetAdvancedSettings()
         {

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/ClientSettingsManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/ClientSettingsManagerTest.cs
@@ -11,11 +11,11 @@ using Xunit.Abstractions;
 
 namespace Microsoft.VisualStudio.Editor.Razor;
 
-public class DefaultEditorSettingsManagerTest : ProjectSnapshotManagerDispatcherTestBase
+public class ClientSettingsManagerTest : ProjectSnapshotManagerDispatcherTestBase
 {
     private readonly IEnumerable<ClientSettingsChangedTrigger> _editorSettingsChangeTriggers;
 
-    public DefaultEditorSettingsManagerTest(ITestOutputHelper testOutput)
+    public ClientSettingsManagerTest(ITestOutputHelper testOutput)
         : base(testOutput)
     {
         _editorSettingsChangeTriggers = Array.Empty<ClientSettingsChangedTrigger>();
@@ -114,6 +114,20 @@ public class DefaultEditorSettingsManagerTest : ProjectSnapshotManagerDispatcher
         Assert.Same(originalSettings, manager.GetClientSettings());
     }
 
+    [Fact]
+    public void InitialSettingsStored()
+    {
+        var defaultSettings = ClientAdvancedSettings.Default;
+        var expectedSettings = defaultSettings with
+        {
+            FormatOnType = !defaultSettings.FormatOnType
+        };
+
+        var manager = new ClientSettingsManager(_editorSettingsChangeTriggers, new AdvancedSettingsStorage(expectedSettings));
+
+        Assert.Same(expectedSettings, manager.GetClientSettings());
+    }
+
     private class TestChangeTrigger : ClientSettingsChangedTrigger
     {
         public bool Initialized { get; private set; }
@@ -121,6 +135,23 @@ public class DefaultEditorSettingsManagerTest : ProjectSnapshotManagerDispatcher
         public override void Initialize(IClientSettingsManager clientSettingsManager)
         {
             Initialized = true;
+        }
+    }
+
+    private class AdvancedSettingsStorage : IAdvancedSettingsStorage
+    {
+        private readonly ClientAdvancedSettings _settings;
+
+        public AdvancedSettingsStorage(ClientAdvancedSettings settings)
+        {
+            _settings = settings;
+        }
+
+        public event EventHandler<ClientAdvancedSettingsChangedEventArgs> Changed;
+
+        public ClientAdvancedSettings GetAdvancedSettings()
+        {
+            return _settings;
         }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/ClientSettingsManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/ClientSettingsManagerTest.cs
@@ -125,7 +125,7 @@ public class ClientSettingsManagerTest : ProjectSnapshotManagerDispatcherTestBas
 
         var manager = new ClientSettingsManager(_editorSettingsChangeTriggers, new AdvancedSettingsStorage(expectedSettings));
 
-        Assert.Same(expectedSettings, manager.GetClientSettings());
+        Assert.Same(expectedSettings, manager.GetClientSettings().AdvancedSettings);
     }
 
     private class TestChangeTrigger : ClientSettingsChangedTrigger


### PR DESCRIPTION
When Razor LSP Server starts, provide the advanced settings available in the ClientSettingsManager