### PR TITLE
Move OutputWindowLogger to a VS Windows only project

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Logging/IOutputWindowLogger.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Logging/IOutputWindowLogger.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.VisualStudio.Editor.Razor.Logging;
+
+internal interface IOutputWindowLogger : ILogger
+{
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -50,7 +50,7 @@ internal class DefaultRazorLanguageServerCustomMessageTarget : RazorLanguageServ
     private readonly FormattingOptionsProvider _formattingOptionsProvider;
     private readonly IClientSettingsManager _editorSettingsManager;
     private readonly LSPDocumentSynchronizer _documentSynchronizer;
-    private readonly ILogger? _logger;
+    private readonly IOutputWindowLogger? _outputWindowLogger;
 
     [ImportingConstructor]
     public DefaultRazorLanguageServerCustomMessageTarget(
@@ -60,7 +60,7 @@ internal class DefaultRazorLanguageServerCustomMessageTarget : RazorLanguageServ
         FormattingOptionsProvider formattingOptionsProvider,
         IClientSettingsManager editorSettingsManager,
         LSPDocumentSynchronizer documentSynchronizer,
-        [Import(AllowDefault = true)] IOutputWindowLogger? logger)
+        [Import(AllowDefault = true)] IOutputWindowLogger? outputWindowLogger)
     {
         if (documentManager is null)
         {
@@ -104,7 +104,7 @@ internal class DefaultRazorLanguageServerCustomMessageTarget : RazorLanguageServ
         _formattingOptionsProvider = formattingOptionsProvider;
         _editorSettingsManager = editorSettingsManager;
         _documentSynchronizer = documentSynchronizer;
-        _logger = logger;
+        _outputWindowLogger = outputWindowLogger;
     }
 
     // Testing constructor
@@ -1160,7 +1160,7 @@ internal class DefaultRazorLanguageServerCustomMessageTarget : RazorLanguageServ
         }
         catch (Exception e)
         {
-            _logger?.LogError(e, "Exception thrown in PullDiagnostic delegation");
+            _outputWindowLogger?.LogError(e, "Exception thrown in PullDiagnostic delegation");
             // Return null if any of the tasks getting diagnostics results in an error
             return null;
         }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -24,6 +24,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
 using Microsoft.AspNetCore.Razor.LanguageServer.Semantic.Models;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.Editor.Razor;
+using Microsoft.VisualStudio.Editor.Razor.Logging;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.LanguageServerClient.Razor.Extensions;
@@ -49,7 +50,7 @@ internal class DefaultRazorLanguageServerCustomMessageTarget : RazorLanguageServ
     private readonly FormattingOptionsProvider _formattingOptionsProvider;
     private readonly IClientSettingsManager _editorSettingsManager;
     private readonly LSPDocumentSynchronizer _documentSynchronizer;
-    private readonly ILogger _logger;
+    private readonly ILogger? _logger;
 
     [ImportingConstructor]
     public DefaultRazorLanguageServerCustomMessageTarget(
@@ -59,7 +60,7 @@ internal class DefaultRazorLanguageServerCustomMessageTarget : RazorLanguageServ
         FormattingOptionsProvider formattingOptionsProvider,
         IClientSettingsManager editorSettingsManager,
         LSPDocumentSynchronizer documentSynchronizer,
-        OutputWindowLogger logger)
+        [Import(AllowDefault = true)] IOutputWindowLogger? logger)
     {
         if (documentManager is null)
         {
@@ -89,11 +90,6 @@ internal class DefaultRazorLanguageServerCustomMessageTarget : RazorLanguageServ
         if (documentSynchronizer is null)
         {
             throw new ArgumentNullException(nameof(documentSynchronizer));
-        }
-
-        if (logger is null)
-        {
-            throw new ArgumentNullException(nameof(logger));
         }
 
         _documentManager = (TrackingLSPDocumentManager)documentManager;
@@ -1164,7 +1160,7 @@ internal class DefaultRazorLanguageServerCustomMessageTarget : RazorLanguageServ
         }
         catch (Exception e)
         {
-            _logger.LogError(e, "Exception thrown in PullDiagnostic delegation");
+            _logger?.LogError(e, "Exception thrown in PullDiagnostic delegation");
             // Return null if any of the tasks getting diagnostics results in an error
             return null;
         }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
@@ -44,7 +44,7 @@ internal class RazorLanguageServerClient : ILanguageClient, ILanguageClientCusto
     private readonly LSPRequestInvoker _requestInvoker;
     private readonly ProjectConfigurationFilePathStore _projectConfigurationFilePathStore;
     private readonly RazorLanguageServerLogHubLoggerProviderFactory _logHubLoggerProviderFactory;
-    private readonly ILogger? _outputWindowLogger;
+    private readonly IOutputWindowLogger? _outputWindowLogger;
     private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
     private readonly VisualStudioHostServicesProvider? _vsHostWorkspaceServicesProvider;
     private RazorLanguageServerWrapper? _server;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/OutputWindowLogger.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/OutputWindowLogger.cs
@@ -5,15 +5,16 @@ using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.Editor.Razor.Logging;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
 
-namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Logging;
+namespace Microsoft.VisualStudio.LanguageServices.Razor.Logging;
 
 [Shared]
-[Export(typeof(OutputWindowLogger))]
-internal class OutputWindowLogger : ILogger
+[Export(typeof(IOutputWindowLogger))]
+internal class OutputWindowLogger : IOutputWindowLogger
 {
     private const LogLevel MinimumLogLevel = LogLevel.Warning;
     private readonly OutputPane _outputPane;

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.Editor.Razor;
+using Microsoft.VisualStudio.Editor.Razor.Logging;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.LanguageServerClient.Razor.HtmlCSharp;
@@ -100,7 +101,7 @@ public class DefaultRazorLanguageServerCustomMessageTargetTest : TestBase
         // Arrange
         var documentManager = Mock.Of<TrackingLSPDocumentManager>(MockBehavior.Strict);
         var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
-        var outputWindowLogger = Mock.Of<OutputWindowLogger>(MockBehavior.Strict);
+        var outputWindowLogger = Mock.Of<IOutputWindowLogger>(MockBehavior.Strict);
 
         var documentSynchronizer = new Mock<LSPDocumentSynchronizer>(MockBehavior.Strict);
 
@@ -139,7 +140,7 @@ public class DefaultRazorLanguageServerCustomMessageTargetTest : TestBase
                 out It.Ref<LSPDocumentSnapshot>.IsAny))
             .Returns(false);
         var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
-        var outputWindowLogger = Mock.Of<OutputWindowLogger>(MockBehavior.Strict);
+        var outputWindowLogger = Mock.Of<IOutputWindowLogger>(MockBehavior.Strict);
 
         var documentSynchronizer = GetDocumentSynchronizer();
 
@@ -195,7 +196,7 @@ public class DefaultRazorLanguageServerCustomMessageTargetTest : TestBase
                 It.IsAny<DocumentRangeFormattingParams>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new ReinvocationResponse<TextEdit[]>("languageClient", new[] { expectedEdit }));
-        var outputWindowLogger = Mock.Of<OutputWindowLogger>(MockBehavior.Strict);
+        var outputWindowLogger = Mock.Of<IOutputWindowLogger>(MockBehavior.Strict);
 
         var documentSynchronizer = GetDocumentSynchronizer(GetCSharpSnapshot(uri, hostDocumentSyncVersion: 1));
 
@@ -301,7 +302,7 @@ public class DefaultRazorLanguageServerCustomMessageTargetTest : TestBase
             .Returns(expectedResults);
 
         var documentSynchronizer = GetDocumentSynchronizer(GetCSharpSnapshot());
-        var outputWindowLogger = Mock.Of<OutputWindowLogger>(MockBehavior.Strict);
+        var outputWindowLogger = Mock.Of<IOutputWindowLogger>(MockBehavior.Strict);
 
         var target = new DefaultRazorLanguageServerCustomMessageTarget(
                 documentManager.Object, JoinableTaskContext, requestInvoker.Object,
@@ -376,7 +377,7 @@ public class DefaultRazorLanguageServerCustomMessageTargetTest : TestBase
                 It.IsAny<Uri>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new DefaultLSPDocumentSynchronizer.SynchronizedResult<CSharpVirtualDocumentSnapshot>(true, csharpVirtualDocument));
-        var outputWindowLogger = Mock.Of<OutputWindowLogger>(MockBehavior.Strict);
+        var outputWindowLogger = Mock.Of<IOutputWindowLogger>(MockBehavior.Strict);
 
         var target = new DefaultRazorLanguageServerCustomMessageTarget(
             documentManager, JoinableTaskContext, requestInvoker.Object,
@@ -485,7 +486,7 @@ public class DefaultRazorLanguageServerCustomMessageTargetTest : TestBase
                 It.IsAny<Uri>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new DefaultLSPDocumentSynchronizer.SynchronizedResult<CSharpVirtualDocumentSnapshot>(true, csharpVirtualDocument));
-        var outputWindowLogger = Mock.Of<OutputWindowLogger>(MockBehavior.Strict);
+        var outputWindowLogger = Mock.Of<IOutputWindowLogger>(MockBehavior.Strict);
 
         var target = new DefaultRazorLanguageServerCustomMessageTarget(
             documentManager.Object, JoinableTaskContext, requestInvoker.Object,


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/8261

Unfortunately the LSP client packages bring in windows only packages as transitive dependencies, so its hard to notice when adding these things, that we're breaking VS Mac. Hopefully that will be fixed soon on the platform side.

Thanks to @sandyarmstrong for doing the work to find the offending class here.