### PR TITLE
Update contributing docs

### DIFF
--- a/docs/contributing/ASPNetCore-Debugging.md
+++ b/docs/contributing/ASPNetCore-Debugging.md
@@ -9,12 +9,12 @@ Sometimes it may be necessary to make changes in [`dotnet/aspnetcore`](https://g
 1. Make the desired changes in `dotnet/aspnetcore`.
 1. `./eng/build.cmd -pack`. The `-pack` option causes the creation of NuGet packages.
 1. You should see the generated packages in the `aspnetcore\artifacts\packages\Debug\NonShipping` directory. The packages should end with `x.0.0-dev.nupkg` where `x` is the current .NET version.
-1. Open `razor-tooling/NuGet.config` and add the local package sources:
+1. Open `razor/NuGet.config` and add the local package sources:
 
    - `<add key="ASPNETCORE_SHIPPING" value="<PATH_TO_ASPNET_CORE_REPO>\artifacts\packages\Debug\Shipping\" />`
    - `<add key="ASPNETCORE_NONSHIPPING" value="<PATH_TO_ASPNET_CORE_REPO>\artifacts\packages\Debug\NonShipping\" />`
 
-1. Open `razor-tooling/eng/Versions.props` and note the version for `MicrosoftCodeAnalysisRazorPackageVersion`. Ex. `5.0.0-rc.1.20380.7`.
+1. Open `razor/eng/Versions.props` and note the version for `MicrosoftCodeAnalysisRazorPackageVersion`. Ex. `5.0.0-rc.1.20380.7`.
 1. Do a find in `Versions.props` for the version in step 7 and replace with `x.0.0-dev`.
 1. Get the assembly version of the `aspnetcore` packages.
    1. Assembly version can be found by openning the `.dll` in `ILSpy`
@@ -24,6 +24,6 @@ Sometimes it may be necessary to make changes in [`dotnet/aspnetcore`](https://g
 
 ## Notes
 
-- ⚠️ Ensure you do not commit the changes to `razor-tooling/NuGet.config` & `razor-tooling/eng/Versions.props`!
-- If you're still seeing build errors after performing the above steps, you may have to temporarily modify `OldVersionUpperBound` and `NewVersion` of the first five assemblies in [AssemblyBindingRedirects.cs](https://github.com/dotnet/razor-tooling/blob/main/src/Razor/src/Microsoft.VisualStudio.RazorExtension/AssemblyBindingRedirects.cs) to match the assembly version of the aspnetcore packages above. You can find the assembly version by opening one of the packages with [ILSpy](https://github.com/icsharpcode/ILSpy/releases) or similar tool.
+- ⚠️ Ensure you do not commit the changes to `razor/NuGet.config` & `razor/eng/Versions.props`!
+- If you're still seeing build errors after performing the above steps, you may have to temporarily modify `OldVersionUpperBound` and `NewVersion` of the first five assemblies in [AssemblyBindingRedirects.cs](https://github.com/dotnet/razor/blob/main/src/Razor/src/Microsoft.VisualStudio.RazorExtension/AssemblyBindingRedirects.cs) to match the assembly version of the aspnetcore packages above. You can find the assembly version by opening one of the packages with [ILSpy](https://github.com/icsharpcode/ILSpy/releases) or similar tool.
 - If you find the old packages are still being used after this change, purge the nuget cache here: `~\.nuget\packages`

--- a/docs/contributing/BuildFromSource.md
+++ b/docs/contributing/BuildFromSource.md
@@ -85,10 +85,10 @@ In most cases, this is because the option _Use previews of the .NET Core SDK_ in
 Note, the [Visual Studio Code C# Extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) is required.
 
 1. Run `Restore.cmd` on the command line.
-1. Launch the `razor-tooling` repo in VS Code.
+1. Launch the `razor` repo in VS Code.
 2. Open VS Code settings (`CTRL+,`) and navigate to the `Razor > Plugin: Path` setting:
 ![image](https://user-images.githubusercontent.com/16968319/192892840-ae2b102c-a282-472f-b1f1-ef3dad671874.png)
-3. Set path to `C:\path_to_razor_repo\razor-tooling\artifacts\bin\Microsoft.AspNetCore.Razor.OmniSharpPlugin\Debug\net472\Microsoft.AspNetCore.Razor.OmniSharpPlugin.dll`.
+3. Set path to `C:\path_to_razor_repo\artifacts\bin\Microsoft.AspNetCore.Razor.OmniSharpPlugin\Debug\net472\Microsoft.AspNetCore.Razor.OmniSharpPlugin.dll`.
 4. Launch extension via `Run and Debug -> Run Extension`.
 5. Install missing assets if prompted.
 

--- a/docs/contributing/Roslyn-Debugging.md
+++ b/docs/contributing/Roslyn-Debugging.md
@@ -9,8 +9,14 @@ Sometimes it may be necessary to make changes in [`dotnet/roslyn`](https://githu
 3. Make the desired changes in `dotnet/roslyn`.
 4. `./Build.cmd -pack`. The `-pack` option causes the creation of NuGet packages.
 5. You should see the generated packages in the `roslyn\artifacts\packages\Debug\Release` directory. Take note of the package versions (ie. `Microsoft.CodeAnalysis.Workspaces.Common.3.8.0.nupkg` => `3.8.0`).
-6. Open `razor-tooling/NuGet.config` and add the local package source `<add key="Roslyn Local Package source" value="<PATH_TO_ROSLYN_REPO>\artifacts\packages\Debug\Release" />`.
-7. Open `razor-tooling/eng/Versions.props` and update all the `Tooling_*` versions to the version noted in step 5.
+6. Open `razor/NuGet.config` and add the local package source `<add key="Roslyn Local Package source" value="<PATH_TO_ROSLYN_REPO>\artifacts\packages\Debug\Release" />` and package source mapping
+   ```xml
+   <packageSource key="Roslyn Local Package source">
+     <package pattern="microsoft.*" />
+     <package pattern="microsoft.commonlanguageserverProtocol.*" />
+   </packageSource>
+   ```
+7. Open `razor/eng/Versions.props` and update `<RoslynPackageVersion>` version to the version noted in step 5.
 
 ## Notes
 


### PR DESCRIPTION
Fixes #5996.

- Replaced references to `razor-tooling` with `razor`.
- Updated "Debugging with experimental Roslyn bits" to what actually worked for me.