### PR TITLE
Update documentation for razor/roslyn debugging

### DIFF
--- a/docs/contributing/Roslyn-Debugging.md
+++ b/docs/contributing/Roslyn-Debugging.md
@@ -1,6 +1,6 @@
 ﻿# Debugging with experimental Roslyn bits
 
-Sometimes it may be necessary to make changes in [`dotnet/roslyn`](https://github.com/dotnet/roslyn), and react to the changes in this repo. The following are steps which outline the general process in using Roslyn development `dll`s with Razor Tooling.
+Sometimes it may be necessary to make changes in [`dotnet/roslyn`](https://github.com/dotnet/roslyn), and react to the changes in this repo. The following are steps which outline the general process in using Roslyn development `dll`s and binaries with Razor Tooling.
 
 ## Steps
 
@@ -8,15 +8,18 @@ Sometimes it may be necessary to make changes in [`dotnet/roslyn`](https://githu
 2. `./Restore.cmd`
 3. Make the desired changes in `dotnet/roslyn`.
 4. `./Build.cmd -pack`. The `-pack` option causes the creation of NuGet packages.
-5. You should see the generated packages in the `roslyn\artifacts\packages\Debug\Release` directory. Take note of the package versions (ie. `Microsoft.CodeAnalysis.Workspaces.Common.3.8.0.nupkg` => `3.8.0`).
-6. Open `razor/NuGet.config` and add the local package source `<add key="Roslyn Local Package source" value="<PATH_TO_ROSLYN_REPO>\artifacts\packages\Debug\Release" />` and package source mapping
-   ```xml
-   <packageSource key="Roslyn Local Package source">
-     <package pattern="microsoft.*" />
-     <package pattern="microsoft.commonlanguageserverProtocol.*" />
-   </packageSource>
-   ```
-7. Open `razor/eng/Versions.props` and update `<RoslynPackageVersion>` version to the version noted in step 5.
+5. You should see the generated packages in the `<PATH_TO_ROSLYN_REPO>\artifacts\packages\Debug\Debug` directory. Take note of the package versions (ie. `Microsoft.CodeAnalysis.Workspaces.Common.3.8.0-dev.nupkg` => `3.8.0-dev`).
+6. Open `NuGet.config` and add the local package source `<add key="Roslyn Local Package source" value="<PATH_TO_ROSLYN_REPO>\artifacts\packages\Debug\Debug" />` and package source below under the `packageSourceMapping` tag:
+
+```xml
+    <packageSource key="Roslyn Local Package source">
+      <package pattern="microsoft.*" />
+      <package pattern="microsoft.commonlanguageserverProtocol.*" />
+    </packageSource>
+```
+
+7. Open `eng/Versions.props` and update `RoslynPackageVersion` to the version noted in step 5.
+8. To get the end-to-end local debugging working, running `./Build.cmd -deploy` script from roslyn repository. this will copy over the right binaries from roslyn to the shared local roslyn/razor hive.
 
 ## Notes
 

--- a/docs/contributing/Roslyn-Debugging.md
+++ b/docs/contributing/Roslyn-Debugging.md
@@ -21,6 +21,25 @@ Sometimes it may be necessary to make changes in [`dotnet/roslyn`](https://githu
 7. Open `eng/Versions.props` and update `RoslynPackageVersion` to the version noted in step 5.
 8. To get the end-to-end local debugging working, running `./Build.cmd -deploy` script from roslyn repository. this will copy over the right binaries from roslyn to the shared local roslyn/razor hive.
 
+## Troubleshooting
+
+Use the steps below to do a clean build if the dlls/binaries need to get cleaned out:
+
+- Shut down all instances of VS.
+- Run the following scripts to kill processes running in a bad state:
+```
+> TASKKILL /IM devenv.exe /F
+> TASKKILL /IM dotnet.exe /F
+> TASKKILL /IM MSBuild.exe /F
+```
+- Delete your hives completely
+- Delete your artifacts folder
+- Launch VS with the Razor solution
+- Make sure `Microsoft.VisualStudio.RazorExtension` is set as the start up project.
+- Build and Rebuild Solution from the menu.
+- Check to make sure the hive is there
+- F5 the razor solution.
+
 ## Notes
 
 - If you're familiar with _Visual Studio Hives_ the `dotnet/roslyn` project uses the `RoslynDev` root suffix .


### PR DESCRIPTION
﻿### Summary of the changes


A few steps were missing in the doc guide for locally debugging razor/roslyn together. This PR adds the missing steps.
Also adding steps to troubleshoot when bits get into a bad state

Fixes: https://github.com/dotnet/razor/issues/8305
