### PR TITLE
[VS Code] Fix various formatting issues

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Folding/FoldingRangeHandler.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Folding/FoldingRangeHandler.ts
@@ -38,13 +38,16 @@ export class FoldingRangeHandler {
                 return this.emptyFoldingRangeReponse;
             }
 
-            const virtualCSharpUri = razorDocument.csharpDocument.uri;
             const virtualHtmlUri = razorDocument.htmlDocument.uri;
+            const virtualCSharpUri = razorDocument.csharpDocument.uri;
 
-            const csharpFoldingRanges = await vscode.commands.executeCommand<vscode.FoldingRange[]>('vscode.executeFoldingRangeProvider', virtualCSharpUri);
             const htmlFoldingRanges = await vscode.commands.executeCommand<vscode.FoldingRange[]>('vscode.executeFoldingRangeProvider', virtualHtmlUri);
+            const csharpFoldingRanges = await vscode.commands.executeCommand<vscode.FoldingRange[]>('vscode.executeFoldingRangeProvider', virtualCSharpUri);
 
-            const response = new SerializableFoldingRangeResponse(this.convertFoldingRanges(htmlFoldingRanges), this.convertFoldingRanges(csharpFoldingRanges));
+            const convertedHtmlFoldingRanges = htmlFoldingRanges === undefined ? new Array<FoldingRange>() : this.convertFoldingRanges(htmlFoldingRanges);
+            const convertedCSharpFoldingRanges = csharpFoldingRanges === undefined ? new Array<FoldingRange>() : this.convertFoldingRanges(csharpFoldingRanges);
+
+            const response = new SerializableFoldingRangeResponse(convertedHtmlFoldingRanges, convertedCSharpFoldingRanges);
             return response;
         } catch (error) {
             this.logger.logWarning(`${FoldingRangeHandler.provideFoldingRange} failed with ${error}`);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Formatting/FormattingHandler.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Formatting/FormattingHandler.ts
@@ -90,7 +90,7 @@ export class FormattingHandler {
     private getLastLineLength(text: string) {
         let currentLineLength = 0;
         for (let i = 0; i < text.length; i++) {
-            // Take into account different line ending types ('\r\n' vs. '\r')
+            // Take into account different line ending types ('\r\n' vs. '\n')
             if (i + 1 < text.length && text[i] === '\r' && text[i + 1] === '\n') {
                 currentLineLength = 0;
                 i++;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Formatting/FormattingHandler.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Formatting/FormattingHandler.ts
@@ -46,8 +46,24 @@ export class FormattingHandler {
                 virtualHtmlUri,
                 formattingParams.options);
 
+            if (textEdits === undefined) {
+                return this.emptyFormattingResponse;
+            }
+
+            const htmlDocText = razorDocument.htmlDocument.getContent();
+            const lineCount = this.countLines(htmlDocText);
             const serializableTextEdits = Array<SerializableTextEdit>();
-            for (const textEdit of textEdits) {
+            for (let textEdit of textEdits) {
+                // The below workaround is needed due to a bug on the HTML side where
+                // they'll sometimes send us an end position that exceeds the length
+                // of the document. Tracked by https://github.com/microsoft/vscode/issues/175298.
+                if (textEdit.range.end.line > lineCount) {
+                    const lastLineLength = this.getLastLineLength(htmlDocText);
+                    const updatedEndPosition = new vscode.Position(lineCount, lastLineLength);
+                    const updatedRange = new vscode.Range(textEdit.range.start, updatedEndPosition);
+                    textEdit = new vscode.TextEdit(updatedRange, textEdit.newText);
+                }
+
                 const serializableTextEdit = convertTextEditToSerializable(textEdit);
                 serializableTextEdits.push(serializableTextEdit);
             }
@@ -58,5 +74,33 @@ export class FormattingHandler {
         }
 
         return this.emptyFormattingResponse;
+    }
+
+    private countLines(text: string) {
+        let lineCount = 0;
+        for (const i of text) {
+            if (i === '\n') {
+                lineCount++;
+            }
+        }
+
+        return lineCount;
+    }
+
+    private getLastLineLength(text: string) {
+        let currentLineLength = 0;
+        for (let i = 0; i < text.length; i++) {
+            // Take into account different line ending types ('\r\n' vs. '\r')
+            if (i + 1 < text.length && text[i] === '\r' && text[i + 1] === '\n') {
+                currentLineLength = 0;
+                i++;
+            } else if (text[i] === '\n') {
+                currentLineLength = 0;
+            } else {
+                currentLineLength++;
+            }
+        }
+
+        return currentLineLength;
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Formatting/FormattingHandler.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Formatting/FormattingHandler.ts
@@ -51,15 +51,15 @@ export class FormattingHandler {
             }
 
             const htmlDocText = razorDocument.htmlDocument.getContent();
-            const lineCount = this.countLines(htmlDocText);
+            const zeroBasedLineCount = this.countLines(htmlDocText);
             const serializableTextEdits = Array<SerializableTextEdit>();
             for (let textEdit of textEdits) {
                 // The below workaround is needed due to a bug on the HTML side where
                 // they'll sometimes send us an end position that exceeds the length
                 // of the document. Tracked by https://github.com/microsoft/vscode/issues/175298.
-                if (textEdit.range.end.line > lineCount) {
+                if (textEdit.range.end.line > zeroBasedLineCount) {
                     const lastLineLength = this.getLastLineLength(htmlDocText);
-                    const updatedEndPosition = new vscode.Position(lineCount, lastLineLength);
+                    const updatedEndPosition = new vscode.Position(zeroBasedLineCount, lastLineLength);
                     const updatedRange = new vscode.Range(textEdit.range.start, updatedEndPosition);
                     textEdit = new vscode.TextEdit(updatedRange, textEdit.newText);
                 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Formatting/RazorFormatOnTypeProvider.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Formatting/RazorFormatOnTypeProvider.ts
@@ -1,0 +1,19 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import * as vscode from 'vscode';
+
+export class RazorFormatOnTypeProvider
+    implements vscode.OnTypeFormattingEditProvider {
+
+    public provideOnTypeFormattingEdits(
+        document: vscode.TextDocument,
+        position: vscode.Position,
+        character: string,
+        formattingOptions: vscode.FormattingOptions,
+        cancellationToken: vscode.CancellationToken): vscode.ProviderResult<vscode.TextEdit[]> {
+        return new Array<vscode.TextEdit>();
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServiceClient.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServiceClient.ts
@@ -60,11 +60,6 @@ export class RazorLanguageServiceClient {
         }
     }
 
-    public async onTypeFormatting() {
-        await this.ensureStarted;
-
-    }
-
     private async ensureStarted() {
         // If the server is already started this will instantly return.
         await this.serverClient.start();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServiceClient.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/RazorLanguageServiceClient.ts
@@ -60,6 +60,11 @@ export class RazorLanguageServiceClient {
         }
     }
 
+    public async onTypeFormatting() {
+        await this.ensureStarted;
+
+    }
+
     private async ensureStarted() {
         // If the server is already started this will instantly return.
         await this.serverClient.start();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/extension.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/extension.ts
@@ -23,6 +23,7 @@ import { RazorDocumentHighlightProvider } from './DocumentHighlight/RazorDocumen
 import { reportTelemetryForDocuments } from './DocumentTelemetryListener';
 import { FoldingRangeHandler } from './Folding/FoldingRangeHandler';
 import { FormattingHandler } from './Formatting/FormattingHandler';
+import { RazorFormatOnTypeProvider } from './Formatting/RazorFormatOnTypeProvider';
 import { RazorFormattingFeature } from './Formatting/RazorFormattingFeature';
 import { HostEventStream } from './HostEventStream';
 import { RazorHoverProvider } from './Hover/RazorHoverProvider';
@@ -144,6 +145,7 @@ export async function activate(vscodeType: typeof vscodeapi, context: ExtensionC
                 documentManager,
                 languageServiceClient,
                 logger);
+            const onTypeFormattingEditProvider = new RazorFormatOnTypeProvider();
 
             localRegistrations.push(
                 languageConfiguration.register(),
@@ -177,6 +179,13 @@ export async function activate(vscodeType: typeof vscodeapi, context: ExtensionC
                 vscodeType.languages.registerDocumentHighlightProvider(
                     RazorLanguage.id,
                     documentHighlightProvider),
+                // Our OnTypeFormatter doesn't do anything at the moment, but it's needed so
+                // VS Code doesn't throw an exception when it tries to send us an
+                // OnTypeFormatting request.
+                vscodeType.languages.registerOnTypeFormattingEditProvider(
+                    RazorLanguage.documentSelector,
+                    onTypeFormattingEditProvider,
+                    ''),
                 documentManager.register(),
                 csharpFeature.register(),
                 htmlFeature.register(),


### PR DESCRIPTION
﻿### Summary of the changes

- This PR fixes several formatting bugs:
- https://github.com/dotnet/razor/issues/8175: If the user had onTypeFormatting enabled, VS Code would try to send us a request that we didn't support. This change adds an empty handler for the time being so we stop throwing the exception.
- https://github.com/OmniSharp/omnisharp-vscode/issues/5561: This is due a bug presumably on VS Code's side where
they'll sometimes send us an end position that exceeds the length of the document. I've filed a bug on them (https://github.com/microsoft/vscode/issues/175298) and have implemented a workaround for the time being.
- (Possibly) https://github.com/dotnet/razor/issues/7038: Wasn't able to directly repro this one, but improved error handling that could potentially resolve the issue.
