### PR TITLE
Have *.Razor.Utilities.Shared package created

### DIFF
--- a/src/Shared/Directory.Build.props
+++ b/src/Shared/Directory.Build.props
@@ -1,0 +1,15 @@
+﻿<Project>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props"  />
+
+  <PropertyGroup>
+    <PackageTags>aspnetcore;cshtml;razor</PackageTags>
+    <IsPackable>true</IsPackable>
+    <IsShipping>true</IsShipping>
+    <IncludeSymbols>true</IncludeSymbols>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+
+    <!-- In theory we want to have this property set, but our pipeline doesn't set the access tokens yet -->
+    <PublishWindowsPdb Condition="'$(DotNetSymbolServerTokenMsdl)'!='' and '$(DotNetSymbolServerTokenSymWeb)'!=''">true</PublishWindowsPdb>
+  </PropertyGroup>
+
+</Project>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.csproj
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netstandard2.0;$(DefaultNetCoreTargetFramework);$(DefaultNetFxTargetFramework)</TargetFrameworks>
     <Description>Razor is a markup syntax for adding server-side logic to web pages. This package contains the language server library assets.</Description>
     <EnableApiCheck>false</EnableApiCheck>
+    <IsShippingPackage>false</IsShippingPackage>
     <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
     <RootNamespace>Microsoft.AspNetCore.Razor</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
ISSUE:  
In order for consumption of Microsoft.VisualStudio.LanguageServer.ContainedLanguage to work, the upstream Microsoft.AspNetCore.Razor.Utilities.Shared needs to be available.

FIX:
Using the build properties that are used heavily in the src\Razor directories, apply to src\Shared.

VALIDATION:
Validated that in local build, the package is produced in the Debug\NonShipping directory and the package contains the correct binary in three different TFMs.