### PR TITLE
Fix drag/drop

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentPresentation/TextDocumentUriPresentationEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentPresentation/TextDocumentUriPresentationEndpoint.cs
@@ -88,7 +88,14 @@ internal class TextDocumentUriPresentationEndpoint : AbstractTextDocumentPresent
         if (!fileName.EndsWith(".razor", FilePathComparison.Instance))
         {
             _logger.LogInformation("Last file in the drop was not a single razor file URI.");
-            return null;
+            razorFileUri = request.Uris
+                .Where(x => Path.GetFileName(x.GetAbsoluteOrUNCPath()).EndsWith(".razor", FilePathComparison.Instance))
+                .LastOrDefault();
+
+            if (razorFileUri == null)
+            {
+                return null;
+            }
         }
 
         if (request.Uris.Any(uri => !Path.GetFileName(uri.GetAbsoluteOrUNCPath()).StartsWith(fileName, FilePathComparison.Instance)))

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentPresentation/TextDocumentUriPresentationEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentPresentation/TextDocumentUriPresentationEndpoint.cs
@@ -81,7 +81,7 @@ internal class TextDocumentUriPresentationEndpoint : AbstractTextDocumentPresent
         }
 
         var razorFileUri = request.Uris.Where(
-            x => Path.GetFileName(x.GetAbsoluteOrUNCPath()).EndsWith(".razor", FilePathComparison.Instance)).LastOrDefault();
+            x => Path.GetFileName(x.GetAbsoluteOrUNCPath()).EndsWith(".razor", FilePathComparison.Instance)).FirstOrDefault();
 
         // We only want to handle requests for a single .razor file, but when there are files nested under a .razor
         // file (for example, Goo.razor.css, Goo.razor.cs etc.) then we'll get all of those files as well, when the user
@@ -92,14 +92,14 @@ internal class TextDocumentUriPresentationEndpoint : AbstractTextDocumentPresent
             return null;
         }
 
-        var fileName = Path.GetFileName(razorFileUri!.GetAbsoluteOrUNCPath());
+        var fileName = Path.GetFileName(razorFileUri.GetAbsoluteOrUNCPath());
         if (request.Uris.Any(uri => !Path.GetFileName(uri.GetAbsoluteOrUNCPath()).StartsWith(fileName, FilePathComparison.Instance)))
         {
             _logger.LogInformation("One or more URIs were not a child file of the main .razor file.");
             return null;
         }
 
-        var componentTagText = await TryGetComponentTagAsync(razorFileUri!, cancellationToken).ConfigureAwait(false);
+        var componentTagText = await TryGetComponentTagAsync(razorFileUri, cancellationToken).ConfigureAwait(false);
         if (componentTagText is null)
         {
             return null;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentPresentation/TextDocumentUriPresentationEndpointTests.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentPresentation/TextDocumentUriPresentationEndpointTests.cs
@@ -394,7 +394,7 @@ public class TextDocumentUriPresentationEndpointTests : LanguageServerTestBase
     }
 
     [Fact]
-    public async Task Handle_ComponentWithNestedFiles_Success()
+    public async Task Handle_ComponentWithNestedFiles_ReturnsResult()
     {
         // Arrange
         var codeDocument = TestRazorCodeDocument.Create(@"<FetchData\>");


### PR DESCRIPTION
﻿### Summary of the changes

- Drag & drop a .razor file with a code-behind file (.razor.cs) creates anchor tags for both files instead of a component tag. This provides a fix for this issue.

### Steps to repro

- Add a file like below with a code-behind file:

```cs
using BlazorApp6.Data;
using Microsoft.AspNetCore.Components;
using System;
using System.Threading.Tasks;

namespace BlazorApp6.Data
{
    public class FetchDataBase : ComponentBase
    {
        [Inject] WeatherForecastService ForecastService { get; set; }

        protected WeatherForecast[]? forecasts;
        protected override async Task OnInitializedAsync()
        {
            forecasts = await ForecastService.GetForecastAsync(DateTime.Now);
        }
    }
}
```

By commenting out the C# code block in its corresponding razor file below;

```razor
@inherits FetchDataBase
@page "/fetchdata"

<PageTitle>Weather forecast</PageTitle>

@using BlazorApp6.Data
@inject WeatherForecastService ForecastService

<h1>Weather forecast</h1>

<p>This component demonstrates fetching data from a service.</p>

@if (forecasts == null)
{
    <p><em>Loading...</em></p>
}
else
{
    <table class="table">
        <thead>
            <tr>
                <th>Date</th>
                <th>Temp. (C)</th>
                <th>Temp. (F)</th>
                <th>Summary</th>
            </tr>
        </thead>
        <tbody>
            @foreach (var f in forecasts)
            {
                <tr>
                    <td>@f.TemperatureC</td>
                    <td>@f.TemperatureF</td>
                    <td>@f.Summary</td>
                    <td>@f.Music</td>
                </tr>
            }
        </tbody>
    </table>
}

@code {
@*    private WeatherForecast[]? forecasts;

    protected override async Task OnInitializedAsync()
    {
        forecasts = await ForecastService.GetForecastAsync(DateTime.Now);
    }*@
}
```

Then follow the steps in the issue page #8254 to test the fix.

Fixes: https://github.com/dotnet/razor/issues/8254
