### PR TITLE
Deploy to RazorDev instead of RoslynDev

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -212,7 +212,6 @@ stages:
             $(_BuildArgs)
             $(_PublishArgs)
             $(_InternalRuntimeDownloadArgs)
-            /p:IncludeRoslynDeps=true
           name: Build
           displayName: Build and Deploy
           condition: succeeded()

--- a/eng/SetupVSHive.ps1
+++ b/eng/SetupVSHive.ps1
@@ -9,7 +9,7 @@ $vsDir = $vsInfo.installationPath.TrimEnd("\")
 
 $vsRegEdit = Join-Path (Join-Path (Join-Path $vsDir 'Common7') 'IDE') 'VSRegEdit.exe'
 
-$hive = "RoslynDev"
+$hive = "RazorDev"
 &$vsRegEdit set "$vsDir" $hive HKCU "Roslyn\Internal\OnOff\Features" OOP64Bit dword 0
 
 Write-Host "-- VS Info --"

--- a/eng/pipelines/test-integration-job.yml
+++ b/eng/pipelines/test-integration-job.yml
@@ -30,7 +30,6 @@ steps:
       -build
       -pack
       -publish
-      /p:BuildDependencyVsix=false
     name: Build
     displayName: Build
     condition: succeeded()
@@ -51,7 +50,6 @@ steps:
       -configuration ${{ parameters.configuration }}
       -msbuildEngine vs
       -prepareMachine
-      /p:BuildDependencyVsix=false
       /p:BuildProjectReferences=false
     name: BuildVSIX
     displayName: Build and Deploy VSIX
@@ -72,7 +70,6 @@ steps:
       -msbuildEngine vs
       -prepareMachine
       -integrationTest
-      /p:BuildDependencyVsix=false
       /p:BuildProjectReferences=false
     name: RunIntegrationTests
     displayName: Run Integration Tests

--- a/eng/pipelines/test-integration-job.yml
+++ b/eng/pipelines/test-integration-job.yml
@@ -18,7 +18,7 @@ steps:
   # We explicitly pass the VS install directory in azure-pipelines-integration-dartlab.yml
   # We manually create the Hive before deployment to avoid a race condition
   - powershell: eng\scripts\CreateVSHive.ps1
-      -rootSuffix RoslynDev
+      -rootSuffix RazorDev
       -devenvExepath C:\\Test\\VisualStudio\\Common7\\IDE\\devenv.exe
     displayName: Create and Verify hive
 

--- a/eng/scripts/CreateVSHive.ps1
+++ b/eng/scripts/CreateVSHive.ps1
@@ -19,9 +19,9 @@ $success=$false
 for($i=0; $i -le 3; $i++)
 {
   & $devenvExePath /rootsuffix $rootSuffix /updateConfiguration
-  if(Test-Path -Path $env:LocalAppData\Microsoft\VisualStudio\17.0*RoslynDev)
+  if(Test-Path -Path $env:LocalAppData\Microsoft\VisualStudio\17.0*RazorDev)
   {
-    Write-Host "The hive 'RoslynDev' exists"
+    Write-Host "The hive 'RazorDev' exists"
     $success=$true
     break
   }

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension.Dependencies/AssemblyCodeBases.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension.Dependencies/AssemblyCodeBases.cs
@@ -7,115 +7,93 @@ using Microsoft.VisualStudio.Shell;
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.VisualStudio.LanguageServer.Protocol.Internal.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.VisualStudio.LanguageServer.Protocol.Extensions.dll")]
 
-#if INCLUDE_ROSLYN_DEPS
 [assembly: ProvideBindingRedirection(
     AssemblyName = "Microsoft.CodeAnalysis",
     GenerateCodeBase = true,
     OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
+    OldVersionUpperBound = "Current")]
 [assembly: ProvideBindingRedirection(
     AssemblyName = "Microsoft.CodeAnalysis.CSharp",
     GenerateCodeBase = true,
     OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
+    OldVersionUpperBound = "Current")]
 [assembly: ProvideBindingRedirection(
     AssemblyName = "Microsoft.CodeAnalysis.CSharp.Features",
     GenerateCodeBase = true,
     OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
+    OldVersionUpperBound = "Current")]
 [assembly: ProvideBindingRedirection(
     AssemblyName = "Microsoft.CodeAnalysis.CSharp.Workspaces",
     GenerateCodeBase = true,
     OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
+    OldVersionUpperBound = "Current")]
 [assembly: ProvideBindingRedirection(
     AssemblyName = "Microsoft.CodeAnalysis.EditorFeatures",
     GenerateCodeBase = true,
     OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
+    OldVersionUpperBound = "Current")]
 [assembly: ProvideBindingRedirection(
     AssemblyName = "Microsoft.CodeAnalysis.EditorFeatures.Text",
     GenerateCodeBase = true,
     OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
+    OldVersionUpperBound = "Current")]
 [assembly: ProvideBindingRedirection(
     AssemblyName = "Microsoft.CodeAnalysis.EditorFeatures.Wpf",
     GenerateCodeBase = true,
     OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
+    OldVersionUpperBound = "Current")]
 [assembly: ProvideBindingRedirection(
     AssemblyName = "Microsoft.CodeAnalysis.ExternalAccess.Razor",
     GenerateCodeBase = true,
     OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
+    OldVersionUpperBound = "Current")]
 [assembly: ProvideBindingRedirection(
     AssemblyName = "Microsoft.CodeAnalysis.InteractiveHost",
     GenerateCodeBase = true,
     OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
+    OldVersionUpperBound = "Current")]
 [assembly: ProvideBindingRedirection(
     AssemblyName = "Microsoft.CodeAnalysis.Features",
     GenerateCodeBase = true,
     OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
+    OldVersionUpperBound = "Current")]
 [assembly: ProvideBindingRedirection(
     AssemblyName = "Microsoft.CodeAnalysis.LanguageServer.Protocol",
     GenerateCodeBase = true,
     OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
+    OldVersionUpperBound = "Current")]
 [assembly: ProvideBindingRedirection(
     AssemblyName = "Microsoft.CodeAnalysis.Remote.Workspaces",
     GenerateCodeBase = true,
     OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
+    OldVersionUpperBound = "Current")]
 [assembly: ProvideBindingRedirection(
     AssemblyName = "Microsoft.CodeAnalysis.VisualBasic.Features",
     GenerateCodeBase = true,
     OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
+    OldVersionUpperBound = "Current")]
 [assembly: ProvideBindingRedirection(
     AssemblyName = "Microsoft.CodeAnalysis.Workspaces",
     GenerateCodeBase = true,
     OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
+    OldVersionUpperBound = "Current")]
 [assembly: ProvideBindingRedirection(
     AssemblyName = "Microsoft.VisualStudio.Threading",
     GenerateCodeBase = true,
     OldVersionLowerBound = "17.4.0.0",
-    OldVersionUpperBound = "17.5.0.0",
-    NewVersion = "17.5.0.0")]
+    OldVersionUpperBound = "Current")]
 [assembly: ProvideBindingRedirection(
     AssemblyName = "Microsoft.VisualStudio.LanguageServices",
     GenerateCodeBase = true,
     OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
+    OldVersionUpperBound = "Current")]
 [assembly: ProvideBindingRedirection(
     AssemblyName = "Microsoft.VisualStudio.LanguageServices.Implementation",
     GenerateCodeBase = true,
     OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
+    OldVersionUpperBound = "Current")]
 [assembly: ProvideBindingRedirection(
     AssemblyName = "Microsoft.VisualStudio.LanguageServices.CSharp",
     GenerateCodeBase = true,
     OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
-
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.CodeAnalysis.Workspaces.dll")]
-#endif
+    OldVersionUpperBound = "Current")]

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension.Dependencies/Microsoft.VisualStudio.RazorExtension.Dependencies.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension.Dependencies/Microsoft.VisualStudio.RazorExtension.Dependencies.csproj
@@ -19,13 +19,15 @@
     <!-- Don't automatically include dependencies -->
     <IncludePackageReferencesInVSIXContainer>false</IncludePackageReferencesInVSIXContainer>
 
-    <CreateVsixContainer Condition="'$(BuildDependencyVsix)' == 'true'">true</CreateVsixContainer>
+    <CreateVsixContainer>true</CreateVsixContainer>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
-    <DeployExtension Condition="'$(BuildDependencyVsix)' == 'true' OR '$(BuildDependencyVsix)' == ''" >true</DeployExtension>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
     <DefineConstants Condition="'$(IncludeRoslynDeps)' == 'true'">$(DefineConstants);INCLUDE_ROSLYN_DEPS</DefineConstants>
+
+    <!-- This extension will be deployed on demand by the integration test harness -->
+    <DeployExtension>false</DeployExtension>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension.Dependencies/Microsoft.VisualStudio.RazorExtension.Dependencies.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension.Dependencies/Microsoft.VisualStudio.RazorExtension.Dependencies.csproj
@@ -10,7 +10,7 @@
 
     <TargetFramework>$(DefaultNetFxTargetFramework)</TargetFramework>
 
-    <VSSDKTargetPlatformRegRootSuffix>RoslynDev</VSSDKTargetPlatformRegRootSuffix>
+    <VSSDKTargetPlatformRegRootSuffix>RazorDev</VSSDKTargetPlatformRegRootSuffix>
 
     <IsShipping>false</IsShipping>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension.Dependencies/Microsoft.VisualStudio.RazorExtension.Dependencies.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension.Dependencies/Microsoft.VisualStudio.RazorExtension.Dependencies.csproj
@@ -24,7 +24,6 @@
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
-    <DefineConstants Condition="'$(IncludeRoslynDeps)' == 'true'">$(DefineConstants);INCLUDE_ROSLYN_DEPS</DefineConstants>
 
     <!-- This extension will be deployed on demand by the integration test harness -->
     <DeployExtension>false</DeployExtension>
@@ -59,7 +58,7 @@
   </ItemGroup>
 
   <!-- Reference the Roslyn dependencies so that Preview builds work -->
-  <ItemGroup Condition="'$(IncludeRoslynDeps)' == 'true'">
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="$(MicrosoftCodeAnalysisCSharpFeaturesPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.EditorFeatures" Version="$(RoslynPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.EditorFeatures.Wpf" Version="$(RoslynPackageVersion)" />
@@ -70,7 +69,7 @@
     <PackageReference Include="Microsoft.VisualStudio.LanguageServices.Implementation.Symbols" Version="$(Tooling_MicrosoftVisualStudioLanguageServicesPackageVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(IncludeRoslynDeps)' == 'true'">
+  <ItemGroup>
     <VSIXSourceItem Include="$(OutputPath)Microsoft.CodeAnalysis.dll" />
     <VSIXSourceItem Include="$(OutputPath)Microsoft.CodeAnalysis.CSharp.dll" />
     <VSIXSourceItem Include="$(OutputPath)Microsoft.CodeAnalysis.CSharp.Features.dll" />

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension.Dependencies/source.extension.vsixmanifest
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension.Dependencies/source.extension.vsixmanifest
@@ -8,7 +8,7 @@
     <!-- This is needed to mark this extension as cloud compliant. -->
     <AllowClientRole>true</AllowClientRole>
   </Metadata>
-  <Installation AllUsers="true" Experimental="true">
+  <Installation>
     <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,)">
       <ProductArchitecture>amd64</ProductArchitecture>
     </InstallationTarget>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultNetFxTargetFramework)</TargetFramework>
 
-    <VSSDKTargetPlatformRegRootSuffix>RoslynDev</VSSDKTargetPlatformRegRootSuffix>
+    <VSSDKTargetPlatformRegRootSuffix>RazorDev</VSSDKTargetPlatformRegRootSuffix>
 
     <!-- Required to run the project localy -->
     <StartArguments>/rootsuffix $(VSSDKTargetPlatformRegRootSuffix) /log</StartArguments>

--- a/src/Razor/src/RazorDeployment/RazorDeployment.csproj
+++ b/src/Razor/src/RazorDeployment/RazorDeployment.csproj
@@ -8,7 +8,7 @@
 
     <TargetFramework>$(DefaultNetFxTargetFramework)</TargetFramework>
 
-    <VSSDKTargetPlatformRegRootSuffix>RoslynDev</VSSDKTargetPlatformRegRootSuffix>
+    <VSSDKTargetPlatformRegRootSuffix>RazorDev</VSSDKTargetPlatformRegRootSuffix>
   </PropertyGroup>
   <ItemGroup>
     <!-- References the main RazorExtension vsix to ensure all the actual code is deployed to the hive. -->

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractIntegrationTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests;
 /// <item><description><see cref="IDisposable.Dispose"/></description></item>
 /// </list>
 /// </remarks>
-[IdeSettings(MinVersion = VisualStudioVersion.VS2022, RootSuffix = "RoslynDev", MaxAttempts = 2)]
+[IdeSettings(MinVersion = VisualStudioVersion.VS2022, RootSuffix = "RazorDev", MaxAttempts = 2)]
 public abstract class AbstractIntegrationTest : AbstractIdeIntegrationTest
 {
     protected const string ProjectName = "TestProj";

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Microsoft.VisualStudio.Razor.IntegrationTests.csproj
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Microsoft.VisualStudio.Razor.IntegrationTests.csproj
@@ -15,11 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\RazorDeployment\RazorDeployment.csproj" Private="False" Condition="'$(BuildDependencyVsix)' == 'true'">
-      <PrivateAssets>All</PrivateAssets>
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-      <CopyLocalSatelliteAssemblies>False</CopyLocalSatelliteAssemblies>
-    </ProjectReference>
+    <ProjectReference Include="..\..\src\Microsoft.VisualStudio.RazorExtension.Dependencies\Microsoft.VisualStudio.RazorExtension.Dependencies.csproj" Private="false" ReferenceOutputAssembly="false" CopyVsix="true" />
+    <ProjectReference Include="..\..\src\Microsoft.VisualStudio.RazorExtension\Microsoft.VisualStudio.RazorExtension.csproj" Private="false" ReferenceOutputAssembly="false" CopyVsix="true" />
     <ProjectReference Include="..\Microsoft.AspNetCore.Razor.Test.Common\Microsoft.AspNetCore.Razor.Test.Common.csproj" />
     <ProjectReference Include="..\Microsoft.VisualStudio.Editor.Razor.Test.Common\Microsoft.VisualStudio.Editor.Razor.Test.Common.csproj" />
   </ItemGroup>
@@ -39,4 +36,35 @@
   <ItemGroup>
     <EmbeddedResource Include="**\TestFiles\**\*" />
   </ItemGroup>
+
+  <ItemGroup>
+    <!-- Microsoft.VisualStudio.RazorExtension.vsix cannot be installed without elevation due to a bug in the experimental extension installation logic. -->
+    <!--<AssemblyAttribute Include="Xunit.Harness.RequireExtensionAttribute">
+      <_Parameter1>Microsoft.VisualStudio.RazorExtension.vsix</_Parameter1>
+    </AssemblyAttribute>-->
+    <AssemblyAttribute Include="Xunit.Harness.RequireExtensionAttribute">
+      <_Parameter1>Microsoft.VisualStudio.RazorExtension.Dependencies.vsix</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <Target Name="PrepareVsixProjectReferences"
+          BeforeTargets="ResolveProjectReferences"
+          DependsOnTargets="PrepareProjectReferences">
+    <MSBuild
+      Projects="@(_MSBuildProjectReferenceExistent)"
+      Targets="VSIXContainerProjectOutputGroup"
+      BuildInParallel="$(BuildInParallel)"
+      Properties="%(_MSBuildProjectReferenceExistent.SetConfiguration); %(_MSBuildProjectReferenceExistent.SetPlatform); %(_MSBuildProjectReferenceExistent.SetTargetFramework); CreateVsixContainer=true"
+      Condition="'%(_MSBuildProjectReferenceExistent.CopyVsix)' == 'true'"
+      ContinueOnError="!$(BuildingProject)"
+      RemoveProperties="%(_MSBuildProjectReferenceExistent.GlobalPropertiesToRemove)">
+
+      <Output TaskParameter="TargetOutputs" ItemName="_ProjectReferenceVsixOutputs" />
+    </MSBuild>
+
+    <ItemGroup>
+      <ReferenceCopyLocalPaths Include="@(_ProjectReferenceVsixOutputs)" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/VisualStudioLogging.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/VisualStudioLogging.cs
@@ -127,7 +127,7 @@ internal static class VisualStudioLogging
 
     internal static string GetHiveDirectory()
     {
-        // There could be multiple copies of visual studio installed, each with their own RoslynDev hive
+        // There could be multiple copies of visual studio installed, each with their own RazorDev hive
         // so to make sure we find the one for the instance of VS we are actually running, we need to find
         // the installation ID for this install. This is stored in an ini file, next to devenv.exe, and the
         // ID itself is pre-pended to the hive name in the file system.
@@ -150,9 +150,9 @@ internal static class VisualStudioLogging
 
         // Just in case the enterprise grade ini file parsing above didn't work, or VS changes how they
         // store things, the following is written to work even if installationId is an empty string. In
-        // that case it will fall back to the previous behavior of expecting a single RoslynDev hive to
+        // that case it will fall back to the previous behavior of expecting a single RazorDev hive to
         // exist, or fail.
-        var directories = Directory.GetDirectories(vsLocalDir, $"17*{installationId}RoslynDev", SearchOption.TopDirectoryOnly);
+        var directories = Directory.GetDirectories(vsLocalDir, $"17*{installationId}RazorDev", SearchOption.TopDirectoryOnly);
         var hiveDirectories = directories.Where(d => !d.Contains("$")).ToList();
 
         Assert.True(hiveDirectories.Count == 1, $"Could not find the hive path for InstallationID '{installationId}'. Found instead:{Environment.NewLine}{string.Join(Environment.NewLine, hiveDirectories)}");

--- a/startvs.ps1
+++ b/startvs.ps1
@@ -9,22 +9,11 @@ Param(
     [Parameter(
         Mandatory=$false,
         HelpMessage="If specified, choose the Visual Studio version from a list before laucnhing. By default the newest and last installed Visual Studio instance will be launched.")]
-    [Switch]$chooseVS,
-
-    [Parameter(
-        Mandatory=$false,
-        HelpMessage="If specified, Roslyn dependencies will be included in the Razor extension when deployed.")]
-    [Switch]$includeRoslynDeps
+    [Switch]$chooseVS
 )
 
 if ($solutionFile -eq "") {
     $solutionFile = "Razor.sln"
-}
-
-if ($includeRoslynDeps) {
-    # Setting this environment variable ensures that the MSBuild will see it when
-    # building from inside Visual Studio.
-    $env:IncludeRoslynDeps = $true
 }
 
 $dotnetPath = Join-Path (Get-Location) ".dotnet"


### PR DESCRIPTION
* Deploy to `RazorDev` experimental instance instead of `RoslynDev` to avoid conflicts with Roslyn
* Let the integration test harness deploy the dependencies VSIX on demand, instead of relying on the VS SDK to do it as part of the build
* Always include Roslyn dependencies for integration test deployment