### PR TITLE
Allow formatting service to ignore the OnTypeFormatting option

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/OnAutoInsertEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/OnAutoInsertEndpoint.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.AutoInsert;
@@ -26,6 +27,7 @@ internal class OnAutoInsertEndpoint : AbstractRazorDelegatingEndpoint<VSInternal
     private static readonly HashSet<string> s_cSharpAllowedTriggerCharacters = new(StringComparer.Ordinal) { "'", "/", "\n" };
 
     private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
+    private readonly IOptionsMonitor<RazorLSPOptions> _optionsMonitor;
     private readonly IReadOnlyList<IOnAutoInsertProvider> _onAutoInsertProviders;
 
     public OnAutoInsertEndpoint(
@@ -33,10 +35,12 @@ internal class OnAutoInsertEndpoint : AbstractRazorDelegatingEndpoint<VSInternal
         RazorDocumentMappingService documentMappingService,
         ClientNotifierServiceBase languageServer,
         IEnumerable<IOnAutoInsertProvider> onAutoInsertProvider,
+        IOptionsMonitor<RazorLSPOptions> optionsMonitor,
         ILoggerFactory loggerFactory)
         : base(languageServerFeatureOptions, documentMappingService, languageServer, loggerFactory.CreateLogger<OnAutoInsertEndpoint>())
     {
         _languageServerFeatureOptions = languageServerFeatureOptions ?? throw new ArgumentNullException(nameof(languageServerFeatureOptions));
+        _optionsMonitor = optionsMonitor ?? throw new ArgumentNullException(nameof(optionsMonitor));
         _onAutoInsertProviders = onAutoInsertProvider?.ToList() ?? throw new ArgumentNullException(nameof(onAutoInsertProvider));
     }
 
@@ -123,11 +127,30 @@ internal class OnAutoInsertEndpoint : AbstractRazorDelegatingEndpoint<VSInternal
             Logger.LogInformation("Inapplicable HTML trigger char {request.Character}.", request.Character);
             return Task.FromResult<IDelegatedParams?>(null);
         }
-        else if (projection.LanguageKind == RazorLanguageKind.CSharp &&
-            !s_cSharpAllowedTriggerCharacters.Contains(request.Character))
+        else if (projection.LanguageKind == RazorLanguageKind.CSharp)
         {
-            Logger.LogInformation("Inapplicable C# trigger char {request.Character}.", request.Character);
-            return Task.FromResult<IDelegatedParams?>(null);
+            if (!s_cSharpAllowedTriggerCharacters.Contains(request.Character))
+            {
+                Logger.LogInformation("Inapplicable C# trigger char {request.Character}.", request.Character);
+                return Task.FromResult<IDelegatedParams?>(null);
+            }
+
+            // Special case for C# where we use AutoInsert for two purposes:
+            // 1. For XML documentation comments (filling out the template when typing "///")
+            // 2. For "on type formatting" style behaviour, like adjusting indentation when pressing Enter inside empty braces
+            //
+            // If users have turned off on-type formatting, they don't want the behaviour of number 2, but its impossible to separate
+            // that out from number 1. Typing "///" could just as easily adjust indentation on some unrelated code higher up in the
+            // file, which is exactly the behaviour users complain about.
+            //
+            // Therefore we are just going to no-op if the user has turned off on type formatting. Maybe one day we can make this
+            // smarter, but at least the user can always turn the setting back on, type their "///", and turn it back off, without
+            // having to restart VS. Not the worst compromise (hopefully!)
+            if (!_optionsMonitor.CurrentValue.FormatOnType)
+            {
+                requestContext.Logger.LogInformation("Formatting on type disabled, so auto insert is a no-op for C#.");
+                return Task.FromResult<IDelegatedParams?>(null);
+            }
         }
 
         return Task.FromResult<IDelegatedParams?>(new DelegatedOnAutoInsertParams(

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpOnTypeFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpOnTypeFormattingPass.cs
@@ -50,7 +50,7 @@ internal class CSharpOnTypeFormattingPass : CSharpFormattingPassBase
 
     public async override Task<FormattingResult> ExecuteAsync(FormattingContext context, FormattingResult result, CancellationToken cancellationToken)
     {
-        if (!context.IsFormatOnType || result.Kind != RazorLanguageKind.CSharp || !_optionsMonitor.CurrentValue.FormatOnType)
+        if (!context.IsFormatOnType || result.Kind != RazorLanguageKind.CSharp)
         {
             // We don't want to handle regular formatting or non-C# on type formatting here.
             return result;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormattingPass.cs
@@ -56,7 +56,7 @@ internal class HtmlFormattingPass : FormattingPassBase
 
         TextEdit[] htmlEdits;
 
-        if (context.IsFormatOnType && result.Kind == RazorLanguageKind.Html && _optionsMonitor.CurrentValue.FormatOnType)
+        if (context.IsFormatOnType && result.Kind == RazorLanguageKind.Html)
         {
             htmlEdits = await HtmlFormatter.FormatOnTypeAsync(context, cancellationToken).ConfigureAwait(false);
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/LanguageServerTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/LanguageServerTestBase.cs
@@ -20,6 +20,7 @@ using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CommonLanguageServerProtocol.Framework;
+using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Moq;
 using Newtonsoft.Json;
@@ -118,6 +119,13 @@ public abstract class LanguageServerTestBase : TestBase
     internal static VersionedDocumentContext CreateDocumentContext(Uri uri, IDocumentSnapshot snapshot)
     {
         return new VersionedDocumentContext(uri, snapshot, version: 0);
+    }
+
+    internal static IOptionsMonitor<RazorLSPOptions> GetOptionsMonitor(bool enableFormatting = true, bool formatOnType = true)
+    {
+        var monitor = new Mock<IOptionsMonitor<RazorLSPOptions>>(MockBehavior.Strict);
+        monitor.SetupGet(m => m.CurrentValue).Returns(new RazorLSPOptions(default, enableFormatting, true, InsertSpaces: true, TabSize: 4, formatOnType));
+        return monitor.Object;
     }
 
     [Obsolete("Use " + nameof(LSPProjectSnapshotManagerDispatcher))]

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/OnAutoInsertEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/OnAutoInsertEndpointTest.cs
@@ -36,8 +36,9 @@ public class OnAutoInsertEndpointTest : SingleServerDelegatingEndpointTestBase
         var uri = new Uri(razorFilePath);
         await CreateLanguageServerAsync(codeDocument, razorFilePath);
         var documentContext = CreateDocumentContext(uri, codeDocument);
+        var optionsMonitor = GetOptionsMonitor();
         var insertProvider = new TestOnAutoInsertProvider(">", canResolve: true);
-        var endpoint = new OnAutoInsertEndpoint(LanguageServerFeatureOptions, DocumentMappingService, LanguageServer, new[] { insertProvider }, LoggerFactory);
+        var endpoint = new OnAutoInsertEndpoint(LanguageServerFeatureOptions, DocumentMappingService, LanguageServer, new[] { insertProvider }, optionsMonitor, LoggerFactory);
         var @params = new VSInternalDocumentOnAutoInsertParams()
         {
             TextDocument = new TextDocumentIdentifier { Uri = uri, },
@@ -69,6 +70,7 @@ public class OnAutoInsertEndpointTest : SingleServerDelegatingEndpointTestBase
         var uri = new Uri(razorFilePath);
         await CreateLanguageServerAsync(codeDocument, razorFilePath);
         var documentContext = CreateDocumentContext(uri, codeDocument);
+        var optionsMonitor = GetOptionsMonitor();
         var insertProvider1 = new TestOnAutoInsertProvider(">", canResolve: false)
         {
             ResolvedTextEdit = new TextEdit()
@@ -77,7 +79,7 @@ public class OnAutoInsertEndpointTest : SingleServerDelegatingEndpointTestBase
         {
             ResolvedTextEdit = new TextEdit()
         };
-        var endpoint = new OnAutoInsertEndpoint(LanguageServerFeatureOptions, DocumentMappingService, LanguageServer, new[] { insertProvider1, insertProvider2 }, LoggerFactory);
+        var endpoint = new OnAutoInsertEndpoint(LanguageServerFeatureOptions, DocumentMappingService, LanguageServer, new[] { insertProvider1, insertProvider2 }, optionsMonitor, LoggerFactory);
         var @params = new VSInternalDocumentOnAutoInsertParams()
         {
             TextDocument = new TextDocumentIdentifier { Uri = uri, },
@@ -112,6 +114,7 @@ public class OnAutoInsertEndpointTest : SingleServerDelegatingEndpointTestBase
         var uri = new Uri(razorFilePath);
         await CreateLanguageServerAsync(codeDocument, razorFilePath);
         var documentContext = CreateDocumentContext(uri, codeDocument);
+        var optionsMonitor = GetOptionsMonitor();
         var insertProvider1 = new TestOnAutoInsertProvider(">", canResolve: true)
         {
             ResolvedTextEdit = new TextEdit()
@@ -120,7 +123,7 @@ public class OnAutoInsertEndpointTest : SingleServerDelegatingEndpointTestBase
         {
             ResolvedTextEdit = new TextEdit()
         };
-        var endpoint = new OnAutoInsertEndpoint(LanguageServerFeatureOptions, DocumentMappingService, LanguageServer, new[] { insertProvider1, insertProvider2 }, LoggerFactory);
+        var endpoint = new OnAutoInsertEndpoint(LanguageServerFeatureOptions, DocumentMappingService, LanguageServer, new[] { insertProvider1, insertProvider2 }, optionsMonitor, LoggerFactory);
         var @params = new VSInternalDocumentOnAutoInsertParams()
         {
             TextDocument = new TextDocumentIdentifier { Uri = uri, },
@@ -154,9 +157,10 @@ public class OnAutoInsertEndpointTest : SingleServerDelegatingEndpointTestBase
         var uri = new Uri(razorFilePath);
         await CreateLanguageServerAsync(codeDocument, razorFilePath);
         var documentContext = CreateDocumentContext(uri, codeDocument);
+        var optionsMonitor = GetOptionsMonitor();
         var insertProvider1 = new TestOnAutoInsertProvider(">", canResolve: true);
         var insertProvider2 = new TestOnAutoInsertProvider("<", canResolve: true);
-        var endpoint = new OnAutoInsertEndpoint(LanguageServerFeatureOptions, DocumentMappingService, LanguageServer, new[] { insertProvider1, insertProvider2 }, LoggerFactory);
+        var endpoint = new OnAutoInsertEndpoint(LanguageServerFeatureOptions, DocumentMappingService, LanguageServer, new[] { insertProvider1, insertProvider2 }, optionsMonitor, LoggerFactory);
         var @params = new VSInternalDocumentOnAutoInsertParams()
         {
             TextDocument = new TextDocumentIdentifier { Uri = uri, },
@@ -188,8 +192,9 @@ public class OnAutoInsertEndpointTest : SingleServerDelegatingEndpointTestBase
         var razorFilePath = "file://path/test.razor";
         await CreateLanguageServerAsync(codeDocument, razorFilePath);
 
+        var optionsMonitor = GetOptionsMonitor();
         var insertProvider = new TestOnAutoInsertProvider(">", canResolve: true);
-        var endpoint = new OnAutoInsertEndpoint(LanguageServerFeatureOptions, DocumentMappingService, LanguageServer, new[] { insertProvider }, LoggerFactory);
+        var endpoint = new OnAutoInsertEndpoint(LanguageServerFeatureOptions, DocumentMappingService, LanguageServer, new[] { insertProvider }, optionsMonitor, LoggerFactory);
         var uri = new Uri("file://path/test.razor");
         var @params = new VSInternalDocumentOnAutoInsertParams()
         {
@@ -223,8 +228,9 @@ public class OnAutoInsertEndpointTest : SingleServerDelegatingEndpointTestBase
         var uri = new Uri(razorFilePath);
         await CreateLanguageServerAsync(codeDocument, razorFilePath);
         var documentContext = CreateDocumentContext(uri, codeDocument);
+        var optionsMonitor = GetOptionsMonitor();
         var insertProvider = new TestOnAutoInsertProvider(">", canResolve: true);
-        var endpoint = new OnAutoInsertEndpoint(LanguageServerFeatureOptions, DocumentMappingService, LanguageServer, new[] { insertProvider }, LoggerFactory);
+        var endpoint = new OnAutoInsertEndpoint(LanguageServerFeatureOptions, DocumentMappingService, LanguageServer, new[] { insertProvider }, optionsMonitor, LoggerFactory);
         var @params = new VSInternalDocumentOnAutoInsertParams()
         {
             TextDocument = new TextDocumentIdentifier { Uri = uri, },
@@ -256,8 +262,9 @@ public class OnAutoInsertEndpointTest : SingleServerDelegatingEndpointTestBase
         var uri = new Uri(razorFilePath);
         await CreateLanguageServerAsync(codeDocument, razorFilePath);
         var documentContext = CreateDocumentContext(uri, codeDocument);
+        var optionsMonitor = GetOptionsMonitor();
         var insertProvider = new TestOnAutoInsertProvider(">", canResolve: false);
-        var endpoint = new OnAutoInsertEndpoint(LanguageServerFeatureOptions, DocumentMappingService, LanguageServer, new[] { insertProvider }, LoggerFactory);
+        var endpoint = new OnAutoInsertEndpoint(LanguageServerFeatureOptions, DocumentMappingService, LanguageServer, new[] { insertProvider }, optionsMonitor, LoggerFactory);
         var @params = new VSInternalDocumentOnAutoInsertParams()
         {
             TextDocument = new TextDocumentIdentifier { Uri = uri, },
@@ -278,6 +285,71 @@ public class OnAutoInsertEndpointTest : SingleServerDelegatingEndpointTestBase
         Assert.Null(result);
         Assert.True(insertProvider.Called);
         Assert.Equal(0, LanguageServer.RequestCount);
+    }
+
+    [Fact]
+    public async Task Handle_OnTypeFormattingOff_CSharp_ReturnsNull()
+    {
+        // Arrange
+        var codeDocument = CreateCodeDocument();
+        var razorFilePath = "file://path/test.razor";
+        var uri = new Uri(razorFilePath);
+        await CreateLanguageServerAsync(codeDocument, razorFilePath);
+        var documentContext = CreateDocumentContext(uri, codeDocument);
+        var optionsMonitor = GetOptionsMonitor(formatOnType: false);
+        var insertProvider = new TestOnAutoInsertProvider(">", canResolve: false);
+        var endpoint = new OnAutoInsertEndpoint(LanguageServerFeatureOptions, DocumentMappingService, LanguageServer, new[] { insertProvider }, optionsMonitor, LoggerFactory);
+        var @params = new VSInternalDocumentOnAutoInsertParams()
+        {
+            TextDocument = new TextDocumentIdentifier { Uri = uri, },
+            Position = new Position(1, 3),
+            Character = "/",
+            Options = new FormattingOptions
+            {
+                TabSize = 4,
+                InsertSpaces = true
+            },
+        };
+        var requestContext = CreateRazorRequestContext(documentContext);
+
+        // Act
+        var result = await endpoint.HandleRequestAsync(@params, requestContext, DisposalToken);
+
+        // Assert
+        Assert.Null(result);
+        Assert.Equal(0, LanguageServer.RequestCount);
+    }
+
+    [Fact]
+    public async Task Handle_OnTypeFormattingOff_Html_CallsLanguageServer()
+    {
+        // Arrange
+        var codeDocument = CreateCodeDocument();
+        var razorFilePath = "file://path/test.razor";
+        var uri = new Uri(razorFilePath);
+        await CreateLanguageServerAsync(codeDocument, razorFilePath);
+        var documentContext = CreateDocumentContext(uri, codeDocument);
+        var optionsMonitor = GetOptionsMonitor(formatOnType: false);
+        var insertProvider = new TestOnAutoInsertProvider("<", canResolve: false);
+        var endpoint = new OnAutoInsertEndpoint(LanguageServerFeatureOptions, DocumentMappingService, LanguageServer, new[] { insertProvider }, optionsMonitor, LoggerFactory);
+        var @params = new VSInternalDocumentOnAutoInsertParams()
+        {
+            TextDocument = new TextDocumentIdentifier { Uri = uri, },
+            Position = new Position(0, 0),
+            Character = "=",
+            Options = new FormattingOptions
+            {
+                TabSize = 4,
+                InsertSpaces = true
+            },
+        };
+        var requestContext = await CreateOnAutoInsertRequestContextAsync(documentContext);
+
+        // Act
+        var result = await endpoint.HandleRequestAsync(@params, requestContext, DisposalToken);
+
+        // Assert
+        Assert.Equal(1, LanguageServer.RequestCount);
     }
 
     [Fact]
@@ -409,9 +481,10 @@ public class OnAutoInsertEndpointTest : SingleServerDelegatingEndpointTestBase
         var razorFilePath = "file://path/test.razor";
         await CreateLanguageServerAsync(codeDocument, razorFilePath);
 
+        var optionsMonitor = GetOptionsMonitor();
         var insertProvider = new TestOnAutoInsertProvider("!!!", canResolve: false);
         var providers = new[] { insertProvider };
-        var endpoint = new OnAutoInsertEndpoint(LanguageServerFeatureOptions, DocumentMappingService, LanguageServer, providers, LoggerFactory);
+        var endpoint = new OnAutoInsertEndpoint(LanguageServerFeatureOptions, DocumentMappingService, LanguageServer, providers, optionsMonitor, LoggerFactory);
 
         codeDocument.GetSourceText().GetLineAndOffset(cursorPosition, out var line, out var offset);
         var @params = new VSInternalDocumentOnAutoInsertParams()
@@ -470,6 +543,9 @@ public class OnAutoInsertEndpointTest : SingleServerDelegatingEndpointTestBase
 
     private static RazorCodeDocument CreateCodeDocument()
     {
-        return CreateCodeDocument("");
+        return CreateCodeDocument("""
+
+            @{ }
+            """);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingLanguageServerTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingLanguageServerTestBase.cs
@@ -44,13 +44,6 @@ public abstract class FormattingLanguageServerTestBase : LanguageServerTestBase
         return codeDocument;
     }
 
-    internal static IOptionsMonitor<RazorLSPOptions> GetOptionsMonitor(bool enableFormatting)
-    {
-        var monitor = new Mock<IOptionsMonitor<RazorLSPOptions>>(MockBehavior.Strict);
-        monitor.SetupGet(m => m.CurrentValue).Returns(new RazorLSPOptions(default, enableFormatting, true, InsertSpaces: true, TabSize: 4, FormatOnType: true));
-        return monitor.Object;
-    }
-
     internal class DummyRazorFormattingService : RazorFormattingService
     {
         public bool Called { get; private set; }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
@@ -106,35 +106,6 @@ public class HtmlFormattingTest : FormattingTestBase
     }
 
     [Fact]
-    public async Task FormatsSimpleHtmlTag_OnTypeDisabled()
-    {
-        await RunOnTypeFormattingTestAsync(
-            input: """
-                    <html>
-                    <head>
-                        <title>Hello</title>
-                            <script>
-                                var x = 2;$$
-                            </script>
-                    </head>
-                    </html>
-                    """,
-            expected: """
-                    <html>
-                    <head>
-                        <title>Hello</title>
-                            <script>
-                                var x = 2;
-                            </script>
-                    </head>
-                    </html>
-                    """,
-            triggerCharacter: ';',
-            fileKind: FileKinds.Legacy,
-            razorLSPOptions: RazorLSPOptions.Default with { FormatOnType = false });
-    }
-
-    [Fact]
     public async Task FormatsRazorHtmlBlock()
     {
         await RunFormattingTestAsync(

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingTest.cs
@@ -578,32 +578,6 @@ public class RazorFormattingTest : FormattingTestBase
     }
 
     [Fact]
-    public async Task OnTypeFormatting_Disabled()
-    {
-        await RunOnTypeFormattingTestAsync(
-            input: """
-            @functions {
-            	private int currentCount = 0;
-            
-            	private void IncrementCount (){
-            		currentCount++;
-            	}$$
-            }
-            """,
-            expected: """
-            @functions {
-            	private int currentCount = 0;
-            
-            	private void IncrementCount (){
-            		currentCount++;
-            	}
-            }
-            """,
-            triggerCharacter: '}',
-            razorLSPOptions: RazorLSPOptions.Default with { FormatOnType = false });
-    }
-
-    [Fact]
     public async Task OnTypeFormatting_Enabled()
     {
         await RunOnTypeFormattingTestAsync(


### PR DESCRIPTION
This was a lot more complicated than I thought, so after chatting with @ryzngard this is taking the easy way out, since the hard way would require big changes to formatting.

With this change the actual formatting service doesn't check the on type formatting setting, just the LSP endpoints do, with this PR specifically adding that check to the auto insert endpoint. This means the setting will also turn off XML doc comment completion, but I think thats a reasonable compromise for now. It also means the setting has no effect if Single Server is turned off, but we have no reason to think anyone has done that anyway.

There is a comment explaining that, and a bit more, in the code.

Closes https://github.com/dotnet/razor/issues/4336

@phil-allen-msft I think we should take this for M2