### PR TITLE
Update versions to 17.6.P3

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -24,7 +24,7 @@
         "Shipping",
         "NonShipping"
       ],
-      "vsBranch": "rel/d17.6",
+      "vsBranch": "main",
       "vsMajorVersion": 17,
       "insertionTitlePrefix": "[17.6P2]"
     }

--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -8,7 +8,7 @@
       "vsBranch": "main",
       "vsMajorVersion": 17,
       "insertionCreateDraftPR": true,
-      "insertionTitlePrefix": "[17.6P2]"
+      "insertionTitlePrefix": "[17.6P3]"
     },
     "release/dev17.5": {
       "nugetKind": [
@@ -26,7 +26,7 @@
       ],
       "vsBranch": "rel/d17.6",
       "vsMajorVersion": 17,
-      "insertionTitlePrefix": "[17.6P1]"
+      "insertionTitlePrefix": "[17.6P2]"
     }
   }
 }


### PR DESCRIPTION
I checked the [OneNote](https://microsoft.sharepoint.com/teams/managedlanguages/_layouts/OneNote.aspx?id=%2Fteams%2Fmanagedlanguages%2Ffiles%2FTeam%20Notebook%2FRoslyn%20Team%20Notebook%20-%20New&wd=target%28Infrastructure.one%7C0E3C75FE-0827-41BF-9696-F5CD7105BC9A%2FSnapping%20Razor%20-%20LoaT%7C9C7582B1-F81D-44B0-9DB7-1078696B9A53%2F%29) for this step and it looks like we update PublishData but not Versions.props here. I think the only update needed is the PR title for informational purposes.

Does this change look right @allisonchou?