### PR TITLE
Fix `RepositoryUrl` MSBuild property

### DIFF
--- a/src/Compiler/Directory.Build.props
+++ b/src/Compiler/Directory.Build.props
@@ -6,7 +6,7 @@
     <!-- $(RepoRoot) is normally set globally and Arcade overrides it to ensure a trailing slash. -->
     <RepoRoot Condition=" '$(RepoRoot)' == '' OR !HasTrailingSlash('$(RepoRoot)') ">$(MSBuildThisFileDirectory)</RepoRoot>
 
-    <RepositoryUrl>https://github.com/dotnet/razor-compiler</RepositoryUrl>
+    <RepositoryUrl>https://github.com/dotnet/razor</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 


### PR DESCRIPTION
It was pointing to `razor-compiler`. It's an informative property for NuGet listings.