### PR TITLE
[17.5] Cache classified spans and tag helper spans

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -227,12 +227,13 @@ stages:
         - powershell: eng\SetupVSHive.ps1
           displayName: Setup VS Hive
 
+          # https://github.com/dotnet/razor/issues/8378
+          # Restore the following flag to the below script to re-enable integration tests.
+          # -integrationTest
         - script: eng\CIBuild.cmd
             -configuration $(_BuildConfig)
             -prepareMachine
             -test
-            # https://github.com/dotnet/razor/issues/8378
-            # -integrationTest
             /p:BuildProjectReferences=false
           name: Run_Tests
           # displayName: Run Unit and Integration tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -231,10 +231,12 @@ stages:
             -configuration $(_BuildConfig)
             -prepareMachine
             -test
-            -integrationTest
+            # https://github.com/dotnet/razor/issues/8378
+            # -integrationTest
             /p:BuildProjectReferences=false
           name: Run_Tests
-          displayName: Run Unit and Integration tests
+          # displayName: Run Unit and Integration tests
+          displayName: Run Unit tests
           condition: succeeded()
 
         - task: PublishBuildArtifacts@1

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
@@ -418,10 +418,9 @@ internal class DefaultRazorDocumentMappingService : RazorDocumentMappingService
             throw new ArgumentNullException(nameof(codeDocument));
         }
 
-        var syntaxTree = codeDocument.GetSyntaxTree();
-        var classifiedSpans = syntaxTree.GetClassifiedSpans();
-        var tagHelperSpans = syntaxTree.GetTagHelperSpans();
-        var documentLength = codeDocument.GetSourceText().Length;
+        var classifiedSpans = GetClassifiedSpans(codeDocument);
+        var tagHelperSpans = GetTagHelperSpans(codeDocument);
+        var documentLength = codeDocument.Source.Length;
         var languageKind = GetLanguageKindCore(classifiedSpans, tagHelperSpans, originalIndex, documentLength, rightAssociative);
 
         return languageKind;
@@ -902,5 +901,45 @@ internal class DefaultRazorDocumentMappingService : RazorDocumentMappingService
         }
 
         return edits;
+    }
+
+    private static IReadOnlyList<ClassifiedSpanInternal> GetClassifiedSpans(RazorCodeDocument document)
+    {
+        // Since this service is called so often, we get a good performance improvement by caching these values
+        // for this code document. If the document changes, as the user types, then the document instance will be
+        // different, so we don't need to worry about invalidating the cache.
+        var classifiedSpans = (IReadOnlyList<ClassifiedSpanInternal>)document.Items[typeof(ClassifiedSpanInternal)];
+        if (classifiedSpans is null)
+        {
+            var syntaxTree = document.GetSyntaxTree();
+
+            var visitor = new ClassifiedSpanVisitor(syntaxTree.Source);
+            visitor.Visit(syntaxTree.Root);
+            classifiedSpans = visitor.ClassifiedSpans;
+
+            document.Items[typeof(ClassifiedSpanInternal)] = classifiedSpans;
+        }
+
+        return classifiedSpans;
+    }
+
+    private static IReadOnlyList<TagHelperSpanInternal> GetTagHelperSpans(RazorCodeDocument document)
+    {
+        // Since this service is called so often, we get a good performance improvement by caching these values
+        // for this code document. If the document changes, as the user types, then the document instance will be
+        // different, so we don't need to worry about invalidating the cache.
+        var tagHelperSpans = (IReadOnlyList<TagHelperSpanInternal>)document.Items[typeof(TagHelperSpanInternal)];
+        if (tagHelperSpans is null)
+        {
+            var syntaxTree = document.GetSyntaxTree();
+
+            var visitor = new TagHelperSpanVisitor(syntaxTree.Source);
+            visitor.Visit(syntaxTree.Root);
+            tagHelperSpans = visitor.TagHelperSpans;
+
+            document.Items[typeof(TagHelperSpanInternal)] = tagHelperSpans;
+        }
+
+        return tagHelperSpans;
     }
 }


### PR DESCRIPTION
Pulled out of #8133 in case we want to take this for servicing.
|  | Method | Job | RunStrategy|FileType |Mean|Error|StdDev|Op/s|Gen 0|Gen 1|Gen 2|Allocated |
|-------|------------|--------------|---------|------|----------|---------|--------|-------------|--------|---|---|------|
|Before| Lightbulbs| Job-GKMZJP|Default| Small| 378.0 us| 2.41 us| 1.88 us|2,645.85	|19.5313| -|-|	 40 KB |
|After	 |Lightbulbs	 |Job-GKMZJP	  |   Default|Small	|   137.5 us|  1.65 us	|  1.38 us	|7,270.60	|5.8594|-|-|12 KB |
|Before	 |Lightbulbs	  |InProcess	  |Throughput|  Small	|    380.1 us|	  1.27 us	|  1.13 us	|2,630.64	|19.5313|-|-|40 KB |
|After	 |Lightbulbs	 | InProcess	  |Throughput|   Small	|   138.1 us|	  1.87 us	|  2.00 us	|7,239.20	|5.8594|-|-|12 KB |
|Before	 |Lightbulbs	 |Job-GKMZJP	  |   Default|  Large	| 10,078.1 us| 90.48 us	 |75.55 us	|99.23	|406.25	|31.25	|15.625	  |1,006 KB |
|After	 |Lightbulbs	 |Job-GKMZJP	  |   Default| Large	| 2,245.1 us|	 29.68 us	| 23.17 us	|445.4	|3.9063	     |-|-|12 KB |
|Before	 |Lightbulbs	  |InProcess	  |Throughput| Large	| 10,079.9 us|	 67.40 us	| 56.28 us	|99.21	|406.25	|31.25	|15.625	  1,009 KB| 
|After	 |Lightbulbs	  |InProcess	  |Throughput| Large	| 2,247.9 us|	 31.42 us	| 26.23 us	|444.9	|3.9063	 |    -	     |-	     |12 KB |


FYI @phil-allen-msft 