### PR TITLE
Simplify assembly code bases

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension.Dependencies/AssemblyCodeBases.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension.Dependencies/AssemblyCodeBases.cs
@@ -8,126 +8,27 @@ using Microsoft.VisualStudio.Shell;
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.VisualStudio.LanguageServer.Protocol.Extensions.dll")]
 
 #if INCLUDE_ROSLYN_DEPS
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis",
-    GenerateCodeBase = true,
-    OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.CSharp",
-    GenerateCodeBase = true,
-    OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.CSharp.Features",
-    GenerateCodeBase = true,
-    OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.CSharp.Workspaces",
-    GenerateCodeBase = true,
-    OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.EditorFeatures",
-    GenerateCodeBase = true,
-    OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.EditorFeatures.Text",
-    GenerateCodeBase = true,
-    OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.EditorFeatures.Wpf",
-    GenerateCodeBase = true,
-    OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.ExternalAccess.Razor",
-    GenerateCodeBase = true,
-    OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.InteractiveHost",
-    GenerateCodeBase = true,
-    OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.Features",
-    GenerateCodeBase = true,
-    OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.LanguageServer.Protocol",
-    GenerateCodeBase = true,
-    OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.Remote.Workspaces",
-    GenerateCodeBase = true,
-    OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.VisualBasic",
-    GenerateCodeBase = true,
-    OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.VisualBasic.Features",
-    GenerateCodeBase = true,
-    OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.VisualBasic.Workspaces",
-    GenerateCodeBase = true,
-    OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.CodeAnalysis.Workspaces",
-    GenerateCodeBase = true,
-    OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.VisualStudio.Threading",
-    GenerateCodeBase = true,
-    OldVersionLowerBound = "17.4.0.0",
-    OldVersionUpperBound = "17.5.0.0",
-    NewVersion = "17.5.0.0")]
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.VisualStudio.LanguageServices",
-    GenerateCodeBase = true,
-    OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.VisualStudio.LanguageServices.Implementation",
-    GenerateCodeBase = true,
-    OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
-[assembly: ProvideBindingRedirection(
-    AssemblyName = "Microsoft.VisualStudio.LanguageServices.CSharp",
-    GenerateCodeBase = true,
-    OldVersionLowerBound = "4.4.0.0",
-    OldVersionUpperBound = "4.6.0.0",
-    NewVersion = "4.6.0.0")]
+[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
+[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis.CSharp", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
+[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis.CSharp.Features", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
+[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis.CSharp.Workspaces", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
+[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis.EditorFeatures", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
+[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis.EditorFeatures.Text", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
+[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis.EditorFeatures.Wpf", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
+[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis.ExternalAccess.Razor", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
+[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis.InteractiveHost", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
+[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis.Features", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
+[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis.LanguageServer.Protocol", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
+[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis.Remote.Workspaces", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
+[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis.VisualBasic", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
+[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis.VisualBasic.Features", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
+[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis.VisualBasic.Workspaces", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
+[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.CodeAnalysis.Workspaces", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
+[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.VisualStudio.LanguageServices", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
+[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.VisualStudio.LanguageServices.Implementation", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
+[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.VisualStudio.LanguageServices.CSharp", GenerateCodeBase = true, OldVersionLowerBound = "4.4.0.0", OldVersionUpperBound = "Current")]
+
+[assembly: ProvideBindingRedirection(AssemblyName = "Microsoft.VisualStudio.Threading", GenerateCodeBase = true, OldVersionLowerBound = "17.4.0.0", OldVersionUpperBound = "Current")]
 
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.CodeAnalysis.Workspaces.dll")]
 #endif


### PR DESCRIPTION
Pulled from #8349

Removal of upper bound will remove most of the maintenance burden.
Shrinking to a single line makes it must easier to identify which assemblies are missing in future.