### PR TITLE
Move OptionsStorage down to avoid image load

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/ClientSettingsManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/ClientSettingsManager.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Razor.Editor;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+
 namespace Microsoft.VisualStudio.Editor.Razor;
 
 [System.Composition.Shared]

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Options/OptionsStorage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Options/OptionsStorage.cs
@@ -10,11 +10,11 @@ using Microsoft.VisualStudio.Settings;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Settings;
 
-namespace Microsoft.VisualStudio.RazorExtension.Options;
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Options;
 
+[Shared]
 [Export(typeof(OptionsStorage))]
 [Export(typeof(IAdvancedSettingsStorage))]
-[Shared]
 internal class OptionsStorage : IAdvancedSettingsStorage
 {
     private readonly WritableSettingsStore _writableSettingsStore;

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Options/AdvancedOptionPage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Options/AdvancedOptionPage.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.ComponentModelHost;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.Options;
 using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.RazorExtension.Options;
@@ -12,7 +13,7 @@ namespace Microsoft.VisualStudio.RazorExtension.Options;
 [ComVisible(true)]
 internal class AdvancedOptionPage : DialogPage
 {
-    private Lazy<OptionsStorage> _optionsStorage;
+    private readonly Lazy<OptionsStorage> _optionsStorage;
 
     public AdvancedOptionPage()
     {


### PR DESCRIPTION
The OptionsStorage is exported as part of the MEF composition but is defined in Microsoft.VisualStudio.RazorExtension project. This causes Microsoft.VisualStudio.RazorExtension.dll to be loaded in typing scenarios, though it really shouldn't be. To address that, this change moves the OptionsStorage type into LanguageServerClient.

This should address part of https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1752820.
