### PR TITLE
Check Closing Brace for Directives During ExtractToCodeBehind

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
@@ -202,6 +202,11 @@ internal class ExtractToCodeBehindCodeActionResolver : RazorCodeActionResolver
             .AddModifiers(CSharpSyntaxFactory.Token(CSharpSyntaxKind.PublicKeyword), CSharpSyntaxFactory.Token(CSharpSyntaxKind.PartialKeyword))
             .AddMembers(mock.Members.ToArray());
 
+        if (mock.CloseBraceToken.ContainsDirectives)
+        {
+            @class = @class.WithCloseBraceToken(mock.CloseBraceToken);
+        }
+
         var @namespace = CSharpSyntaxFactory
             .NamespaceDeclaration(CSharpSyntaxFactory.ParseName(namespaceName))
             .AddMembers(@class);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
@@ -200,12 +200,8 @@ internal class ExtractToCodeBehindCodeActionResolver : RazorCodeActionResolver
         var @class = CSharpSyntaxFactory
             .ClassDeclaration(className)
             .AddModifiers(CSharpSyntaxFactory.Token(CSharpSyntaxKind.PublicKeyword), CSharpSyntaxFactory.Token(CSharpSyntaxKind.PartialKeyword))
-            .AddMembers(mock.Members.ToArray());
-
-        if (mock.CloseBraceToken.ContainsDirectives)
-        {
-            @class = @class.WithCloseBraceToken(mock.CloseBraceToken);
-        }
+            .AddMembers(mock.Members.ToArray())
+            .WithCloseBraceToken(mock.CloseBraceToken);
 
         var @namespace = CSharpSyntaxFactory
             .NamespaceDeclaration(CSharpSyntaxFactory.ParseName(namespaceName))

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
@@ -67,15 +67,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
         codeDocument.SetUnsupported();
 
         var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance);
-        var data = JObject.FromObject(new ExtractToCodeBehindCodeActionParams()
-        {
-            Uri = new Uri("c:/Test.razor"),
-            RemoveStart = 14,
-            ExtractStart = 20,
-            ExtractEnd = 41,
-            RemoveEnd = 41,
-            Namespace = "Test"
-        });
+        var data = JObject.FromObject(CreateExtractToCodeBehindCodeActionParams(new Uri("c:/Test.razor"), contents, "@code", "Test"));
 
         // Act
         var workspaceEdit = await resolver.ResolveAsync(data, default);
@@ -94,15 +86,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
         codeDocument.SetFileKind(FileKinds.Legacy);
 
         var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance);
-        var data = JObject.FromObject(new ExtractToCodeBehindCodeActionParams()
-        {
-            Uri = new Uri("c:/Test.razor"),
-            RemoveStart = 14,
-            ExtractStart = 20,
-            ExtractEnd = 41,
-            RemoveEnd = 41,
-            Namespace = "Test"
-        });
+        var data = JObject.FromObject(CreateExtractToCodeBehindCodeActionParams(new Uri("c:/Test.razor"), contents, "@code", "Test"));
 
         // Act
         var workspaceEdit = await resolver.ResolveAsync(data, default);
@@ -121,15 +105,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
         Assert.True(codeDocument.TryComputeNamespace(fallbackToRootNamespace: true, out var @namespace));
 
         var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance);
-        var actionParams = new ExtractToCodeBehindCodeActionParams
-        {
-            Uri = documentPath,
-            RemoveStart = contents.IndexOf("@code", StringComparison.Ordinal),
-            ExtractStart = contents.IndexOf("{", StringComparison.Ordinal),
-            ExtractEnd = contents.IndexOf("}", StringComparison.Ordinal) + 1,
-            RemoveEnd = contents.IndexOf("}", StringComparison.Ordinal) + 1,
-            Namespace = @namespace,
-        };
+        var actionParams = CreateExtractToCodeBehindCodeActionParams(documentPath, contents, "@code", @namespace);
         var data = JObject.FromObject(actionParams);
 
         // Act
@@ -170,15 +146,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
         Assert.True(codeDocument.TryComputeNamespace(fallbackToRootNamespace: true, out var @namespace));
 
         var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance);
-        var actionParams = new ExtractToCodeBehindCodeActionParams
-        {
-            Uri = documentPath,
-            RemoveStart = contents.IndexOf("@functions", StringComparison.Ordinal),
-            ExtractStart = contents.IndexOf("{", StringComparison.Ordinal),
-            ExtractEnd = contents.IndexOf("}", StringComparison.Ordinal) + 1,
-            RemoveEnd = contents.IndexOf("}", StringComparison.Ordinal) + 1,
-            Namespace = @namespace,
-        };
+        var actionParams = CreateExtractToCodeBehindCodeActionParams(documentPath, contents, "@functions", @namespace);
         var data = JObject.FromObject(actionParams);
 
         // Act
@@ -219,15 +187,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
         Assert.True(codeDocument.TryComputeNamespace(fallbackToRootNamespace: true, out var @namespace));
 
         var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance);
-        var actionParams = new ExtractToCodeBehindCodeActionParams
-        {
-            Uri = documentPath,
-            RemoveStart = contents.IndexOf("@code", StringComparison.Ordinal),
-            ExtractStart = contents.IndexOf("{", StringComparison.Ordinal),
-            ExtractEnd = contents.IndexOf("}", StringComparison.Ordinal) + 1,
-            RemoveEnd = contents.IndexOf("}", StringComparison.Ordinal) + 1,
-            Namespace = @namespace,
-        };
+        var actionParams = CreateExtractToCodeBehindCodeActionParams(documentPath, contents, "@code", @namespace);
         var data = JObject.FromObject(actionParams);
 
         // Act
@@ -269,15 +229,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
         Assert.True(codeDocument.TryComputeNamespace(fallbackToRootNamespace: true, out var @namespace));
 
         var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance);
-        var actionParams = new ExtractToCodeBehindCodeActionParams
-        {
-            Uri = documentPath,
-            RemoveStart = contents.IndexOf("@code", StringComparison.Ordinal),
-            ExtractStart = contents.IndexOf("{", StringComparison.Ordinal),
-            ExtractEnd = contents.IndexOf("}", StringComparison.Ordinal) + 1,
-            RemoveEnd = contents.IndexOf("}", StringComparison.Ordinal) + 1,
-            Namespace = @namespace,
-        };
+        var actionParams = CreateExtractToCodeBehindCodeActionParams(documentPath, contents, "@code", @namespace);
         var data = JObject.FromObject(actionParams);
 
         // Act
@@ -319,5 +271,20 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
         codeDocument.SetFileKind(FileKinds.Component);
 
         return codeDocument;
+    }
+
+    private static ExtractToCodeBehindCodeActionParams CreateExtractToCodeBehindCodeActionParams(Uri uri, string contents, string removeStart, string @namespace)
+    {
+        // + 1 to ensure we do not cut off the '}'.
+        var endIndex = contents.IndexOf("}", StringComparison.Ordinal) + 1;
+        return new ExtractToCodeBehindCodeActionParams
+        {
+            Uri = uri,
+            RemoveStart = contents.IndexOf(removeStart, StringComparison.Ordinal),
+            ExtractStart = contents.IndexOf("{", StringComparison.Ordinal),
+            ExtractEnd = endIndex,
+            RemoveEnd = endIndex,
+            Namespace = @namespace
+        };
     }
 }


### PR DESCRIPTION
﻿### Summary of the changes

- `#endregion` was being attached to the closing brace of generated class upon parsing the c# and we were losing that information when creating our `ClassDeclarationSyntax`. The change adds a check to see if the closing brace contains a directive and update our created `ClassDeclarationSyntax` before proceeding
- Add unit test to ensure we correctly extract code with directives
- Small change to fix the code contents of other unit tests since we end up accidentally cutting off the end "}"

Fixes: #8294
Before: 
![before](https://user-images.githubusercontent.com/30007367/224848037-0b558284-68d4-4d1f-ac70-c87d6d133fcd.gif)

After:
![after](https://user-images.githubusercontent.com/30007367/224848078-f6b71be5-3016-443e-a3e0-af5d2b26817b.gif)