### PR TITLE
Use an alternate approach to publishing nupkgs only on Windows

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -2,17 +2,17 @@
 <Project>
   <PropertyGroup>
     <PublishingVersion>3</PublishingVersion>
-    <PublishDependsOnTargets>$(PublishDependsOnTargets);_PublishingBlobItems</PublishDependsOnTargets>
+    <PublishDependsOnTargets>$(PublishDependsOnTargets);_UpdatePublishItems</PublishDependsOnTargets>
     <_UploadPathRoot>razor</_UploadPathRoot>
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Prepare for _PublishingBlobItems target. -->
+    <!-- Prepare for _UpdatePublishItems target. -->
     <_ItemsToPublish Include="$(ArtifactsPackagesDir)**\*.tgz" Condition="'$(OS)' == 'Windows_NT'" />
     <_ItemsToPublish Include="$(ArtifactsDir)LanguageServer\**\*.zip" />
   </ItemGroup>
 
-<Target Name="_PublishingBlobItems">
+<Target Name="_UpdatePublishItems">
     <!-- This target is defined in eng/targets/Packaging.targets and included in every project. -->
     <MSBuild Projects="$(RepoRoot)src\Razor\src\Microsoft.AspNetCore.Razor.LanguageServer\Microsoft.AspNetCore.Razor.LanguageServer.csproj"
         Targets="_GetPackageVersionInfo"
@@ -25,6 +25,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <!-- Packages can be built on all platforms, but are only published on Windows to avoid collisions from the other
+           platforms. This does not affect the SB intermediate package. -->
+      <ItemsToPushToBlobFeed Remove="$(ArtifactsDir)**\*.nupkg" Condition="'$(OS)' != 'Windows_NT' and '$(ArcadeBuildFromSource)' != 'true'" />
+      
       <ItemsToPushToBlobFeed Include="@(_ItemsToPublish)">
         <IsShipping>false</IsShipping>
         <ManifestArtifactData>ShipInstaller=dotnetcli;NonShipping=true</ManifestArtifactData>

--- a/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators.Transport/Microsoft.NET.Sdk.Razor.SourceGenerators.Transport.csproj
+++ b/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators.Transport/Microsoft.NET.Sdk.Razor.SourceGenerators.Transport.csproj
@@ -7,7 +7,7 @@
     <SuppressDependenciesWhenPacking>false</SuppressDependenciesWhenPacking>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <GenerateDependencyFile>false</GenerateDependencyFile>
-    <IsPackable Condition="'$(OS)' == 'Windows_NT'">true</IsPackable>
+    <IsPackable>true</IsPackable>
     <!-- Need to build this project in source build -->
     <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
   </PropertyGroup>

--- a/src/Compiler/tools/Microsoft.AspNetCore.Mvc.Razor.Extensions.Tooling.Internal/Microsoft.AspNetCore.Mvc.Razor.Extensions.Tooling.Internal.csproj
+++ b/src/Compiler/tools/Microsoft.AspNetCore.Mvc.Razor.Extensions.Tooling.Internal/Microsoft.AspNetCore.Mvc.Razor.Extensions.Tooling.Internal.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <IsShipping>false</IsShipping>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <IsPackable Condition="'$(OS)' == 'Windows_NT'">true</IsPackable>
+    <IsPackable>true</IsPackable>
     <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
   </PropertyGroup>
 

--- a/src/Compiler/tools/Microsoft.CodeAnalysis.Razor.Tooling.Internal/Microsoft.CodeAnalysis.Razor.Tooling.Internal.csproj
+++ b/src/Compiler/tools/Microsoft.CodeAnalysis.Razor.Tooling.Internal/Microsoft.CodeAnalysis.Razor.Tooling.Internal.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <IsShipping>false</IsShipping>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <IsPackable Condition="'$(OS)' == 'Windows_NT'">true</IsPackable>
+    <IsPackable>true</IsPackable>
     <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
   </PropertyGroup>
 

--- a/src/Razor/src/rzls/rzls.csproj
+++ b/src/Razor/src/rzls/rzls.csproj
@@ -67,6 +67,6 @@
     </ItemGroup>
 
     <MSBuild Projects="@(ProjectToPublish)" Targets="Publish;_IncludeOmniSharpPlugin" BuildInParallel="false" />
-    <MSBuild Projects="@(ProjectToPublish_PlatformAgnostic)" Targets="Publish;_IncludeOmniSharpPlugin" BuildInParallel="false" Condition="'$(OS)' == 'Windows_NT'" />
+    <MSBuild Projects="@(ProjectToPublish_PlatformAgnostic)" Targets="Publish;_IncludeOmniSharpPlugin" BuildInParallel="false" />
   </Target>
 </Project>


### PR DESCRIPTION
﻿### Summary of the changes

This avoids an issue where the source build intermediate, built on Linux, didn't have the nupkgs in it because they were only packaged on Windows. Instead of restrictig packaging to only Windows, only push nupkgs on Windows, or in source-build situations. This is a little simpler, and has the added advantage that a developer can work on Linux or Mac and produce the nupkgs for testing or dev work.