### PR TITLE
Revert "Merge release/dev17.5 to release/dev17.6"

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorDocumentMappingService.cs
@@ -1034,44 +1034,4 @@ internal class DefaultRazorDocumentMappingService : RazorDocumentMappingService
 
         return tagHelperSpans;
     }
-
-    private static IReadOnlyList<ClassifiedSpanInternal> GetClassifiedSpans(RazorCodeDocument document)
-    {
-        // Since this service is called so often, we get a good performance improvement by caching these values
-        // for this code document. If the document changes, as the user types, then the document instance will be
-        // different, so we don't need to worry about invalidating the cache.
-        var classifiedSpans = (IReadOnlyList<ClassifiedSpanInternal>)document.Items[typeof(ClassifiedSpanInternal)];
-        if (classifiedSpans is null)
-        {
-            var syntaxTree = document.GetSyntaxTree();
-
-            var visitor = new ClassifiedSpanVisitor(syntaxTree.Source);
-            visitor.Visit(syntaxTree.Root);
-            classifiedSpans = visitor.ClassifiedSpans;
-
-            document.Items[typeof(ClassifiedSpanInternal)] = classifiedSpans;
-        }
-
-        return classifiedSpans;
-    }
-
-    private static IReadOnlyList<TagHelperSpanInternal> GetTagHelperSpans(RazorCodeDocument document)
-    {
-        // Since this service is called so often, we get a good performance improvement by caching these values
-        // for this code document. If the document changes, as the user types, then the document instance will be
-        // different, so we don't need to worry about invalidating the cache.
-        var tagHelperSpans = (IReadOnlyList<TagHelperSpanInternal>)document.Items[typeof(TagHelperSpanInternal)];
-        if (tagHelperSpans is null)
-        {
-            var syntaxTree = document.GetSyntaxTree();
-
-            var visitor = new TagHelperSpanVisitor(syntaxTree.Source);
-            visitor.Visit(syntaxTree.Root);
-            tagHelperSpans = visitor.TagHelperSpans;
-
-            document.Items[typeof(TagHelperSpanInternal)] = tagHelperSpans;
-        }
-
-        return tagHelperSpans;
-    }
 }


### PR DESCRIPTION
Reverts dotnet/razor#8437

Necessary changes are already in release/17.6, and this also fails the compile because there are now duplicate instances of methods.