### PR TITLE
Add more runtime checks to ComparerUtilities

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeDescriptorComparer.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeDescriptorComparer.cs
@@ -48,7 +48,7 @@ internal sealed class BoundAttributeDescriptorComparer : IEqualityComparer<Bound
             string.Equals(descriptorX.Documentation, descriptorY.Documentation, StringComparison.Ordinal) &&
             string.Equals(descriptorX.DisplayName, descriptorY.DisplayName, StringComparison.Ordinal) &&
             ComparerUtilities.Equals(descriptorX.BoundAttributeParameters, descriptorY.BoundAttributeParameters, BoundAttributeParameterDescriptorComparer.Default) &&
-            ComparerUtilities.Equals(descriptorX.Metadata, descriptorY.Metadata, StringComparer.Ordinal, StringComparer.Ordinal);
+            ComparerUtilities.Equals(descriptorX.Metadata, descriptorY.Metadata, StringComparer.Ordinal);
     }
 
     public int GetHashCode(BoundAttributeDescriptor? descriptor)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeParameterDescriptorComparer.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeParameterDescriptorComparer.cs
@@ -41,7 +41,7 @@ internal sealed class BoundAttributeParameterDescriptorComparer : IEqualityCompa
             string.Equals(descriptorX.TypeName, descriptorY.TypeName, StringComparison.Ordinal) &&
             string.Equals(descriptorX.Documentation, descriptorY.Documentation, StringComparison.Ordinal) &&
             string.Equals(descriptorX.DisplayName, descriptorY.DisplayName, StringComparison.Ordinal) &&
-            ComparerUtilities.Equals(descriptorX.Metadata, descriptorY.Metadata, StringComparer.Ordinal, StringComparer.Ordinal);
+            ComparerUtilities.Equals(descriptorX.Metadata, descriptorY.Metadata, StringComparer.Ordinal);
     }
 
     public int GetHashCode(BoundAttributeParameterDescriptor? descriptor)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/ComparerUtilities.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/ComparerUtilities.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.Extensions.Internal;
 
@@ -25,6 +26,12 @@ internal static class ComparerUtilities
             return false;
         }
 
+        // PERF: Often, the IReadOnlyLists are really just arrays. For those cases, take a faster path.
+        if (first is T[] firstArray && second is T[] secondArray)
+        {
+            return AreArrayContentsEqual(firstArray, secondArray, comparer);
+        }
+
         if (first.Count != second.Count)
         {
             return false;
@@ -41,15 +48,48 @@ internal static class ComparerUtilities
         }
 
         return true;
+
+        static bool AreArrayContentsEqual(T[] first, T[] second, IEqualityComparer<T>? comparer)
+        {
+            var length = first.Length;
+
+            if (length != second.Length)
+            {
+                return false;
+            }
+
+            comparer ??= EqualityComparer<T>.Default;
+
+            for (var i = 0; i < length; i++)
+            {
+                if (!comparer.Equals(first[i], second[i]))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
     }
 
     public static void AddToHash<T>(ref HashCodeCombiner hash, IReadOnlyList<T> list, IEqualityComparer<T>? comparer)
     {
         comparer ??= EqualityComparer<T>.Default;
 
-        for (var i = 0; i < list.Count; i++)
+        // PERF: Often, IReadOnlyLists is array. If that's the case, take a faster path.
+        if (list is T[] array)
         {
-            hash.Add(list[i], comparer);
+            foreach (var item in array)
+            {
+                hash.Add(item, comparer);
+            }
+        }
+        else
+        {
+            for (var i = 0; i < list.Count; i++)
+            {
+                hash.Add(list[i], comparer);
+            }
         }
     }
 
@@ -78,39 +118,60 @@ internal static class ComparerUtilities
         keyComparer ??= EqualityComparer<TKey>.Default;
         valueComparer ??= EqualityComparer<TValue>.Default;
 
-        // 🐇 Avoid enumerator allocations for Dictionary<TKey, TValue>
-        if (first is Dictionary<TKey, TValue> firstDictionary
-            && second is Dictionary<TKey, TValue> secondDictionary)
+        switch ((first, second))
         {
-            using var firstEnumerator = firstDictionary.GetEnumerator();
-            using var secondEnumerator = secondDictionary.GetEnumerator();
-            while (firstEnumerator.MoveNext() && secondEnumerator.MoveNext())
-            {
-                if (!keyComparer.Equals(firstEnumerator.Current.Key, secondEnumerator.Current.Key)
-                    || !valueComparer.Equals(firstEnumerator.Current.Value, secondEnumerator.Current.Value))
+            case (Dictionary<TKey, TValue> firstDictionary, Dictionary<TKey, TValue> secondDictionary):
                 {
-                    return false;
-                }
-            }
+                    // 🐇 Avoid enumerator allocations for Dictionary<TKey, TValue>
+                    using var firstEnumerator = firstDictionary.GetEnumerator();
+                    using var secondEnumerator = secondDictionary.GetEnumerator();
+                    while (firstEnumerator.MoveNext() && secondEnumerator.MoveNext())
+                    {
+                        if (!keyComparer.Equals(firstEnumerator.Current.Key, secondEnumerator.Current.Key)
+                            || !valueComparer.Equals(firstEnumerator.Current.Value, secondEnumerator.Current.Value))
+                        {
+                            return false;
+                        }
+                    }
 
-            Debug.Assert(!firstEnumerator.MoveNext() && !secondEnumerator.MoveNext(), "We already know the collections have same count.");
-            return true;
-        }
-        else
-        {
-            using var firstEnumerator = first.GetEnumerator();
-            using var secondEnumerator = second.GetEnumerator();
-            while (firstEnumerator.MoveNext() && secondEnumerator.MoveNext())
-            {
-                if (!keyComparer.Equals(firstEnumerator.Current.Key, secondEnumerator.Current.Key)
-                    || !valueComparer.Equals(firstEnumerator.Current.Value, secondEnumerator.Current.Value))
+                    Debug.Assert(!firstEnumerator.MoveNext() && !secondEnumerator.MoveNext(), "We already know the collections have same count.");
+                    return true;
+                }
+
+            case (ImmutableDictionary<TKey, TValue> firstDictionary, ImmutableDictionary<TKey, TValue> secondDictionary):
                 {
-                    return false;
-                }
-            }
+                    // 🐇 Avoid enumerator allocations for ImmutableDictionary<TKey, TValue>
+                    using var firstEnumerator = firstDictionary.GetEnumerator();
+                    using var secondEnumerator = secondDictionary.GetEnumerator();
+                    while (firstEnumerator.MoveNext() && secondEnumerator.MoveNext())
+                    {
+                        if (!keyComparer.Equals(firstEnumerator.Current.Key, secondEnumerator.Current.Key)
+                            || !valueComparer.Equals(firstEnumerator.Current.Value, secondEnumerator.Current.Value))
+                        {
+                            return false;
+                        }
+                    }
 
-            Debug.Assert(!firstEnumerator.MoveNext() && !secondEnumerator.MoveNext(), "We already know the collections have same count.");
-            return true;
+                    Debug.Assert(!firstEnumerator.MoveNext() && !secondEnumerator.MoveNext(), "We already know the collections have same count.");
+                    return true;
+                }
+
+            default:
+                {
+                    using var firstEnumerator = first.GetEnumerator();
+                    using var secondEnumerator = second.GetEnumerator();
+                    while (firstEnumerator.MoveNext() && secondEnumerator.MoveNext())
+                    {
+                        if (!keyComparer.Equals(firstEnumerator.Current.Key, secondEnumerator.Current.Key)
+                            || !valueComparer.Equals(firstEnumerator.Current.Value, secondEnumerator.Current.Value))
+                        {
+                            return false;
+                        }
+                    }
+
+                    Debug.Assert(!firstEnumerator.MoveNext() && !secondEnumerator.MoveNext(), "We already know the collections have same count.");
+                    return true;
+                }
         }
     }
 
@@ -120,22 +181,36 @@ internal static class ComparerUtilities
         keyComparer ??= EqualityComparer<TKey>.Default;
         valueComparer ??= EqualityComparer<TValue>.Default;
 
-        // 🐇 Avoid enumerator allocations for Dictionary<TKey, TValue>
-        if (dictionary is Dictionary<TKey, TValue> typedDictionary)
+        switch (dictionary)
         {
-            foreach (var kvp in typedDictionary)
-            {
-                hash.Add(kvp.Key, keyComparer);
-                hash.Add(kvp.Value, valueComparer);
-            }
-        }
-        else
-        {
-            foreach (var kvp in dictionary)
-            {
-                hash.Add(kvp.Key, keyComparer);
-                hash.Add(kvp.Value, valueComparer);
-            }
+            case Dictionary<TKey, TValue> typedDictionary:
+                // 🐇 Avoid enumerator allocations for Dictionary<TKey, TValue>
+                foreach (var (key, value) in typedDictionary)
+                {
+                    hash.Add(key, keyComparer);
+                    hash.Add(value, valueComparer);
+                }
+
+                break;
+
+            case ImmutableDictionary<TKey, TValue> typedDictionary:
+                // 🐇 Avoid enumerator allocations for ImmutableDictionary<TKey, TValue>
+                foreach (var (key, value) in typedDictionary)
+                {
+                    hash.Add(key, keyComparer);
+                    hash.Add(value, valueComparer);
+                }
+
+                break;
+
+            default:
+                foreach (var (key, value) in dictionary)
+                {
+                    hash.Add(key, keyComparer);
+                    hash.Add(value, valueComparer);
+                }
+
+                break;
         }
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptorComparer.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptorComparer.cs
@@ -94,7 +94,7 @@ internal sealed class TagHelperDescriptorComparer : IEqualityComparer<TagHelperD
             return false;
         }
 
-        if (!ComparerUtilities.Equals(descriptorX.Metadata, descriptorY.Metadata, StringComparer.Ordinal, StringComparer.Ordinal))
+        if (!ComparerUtilities.Equals(descriptorX.Metadata, descriptorY.Metadata, StringComparer.Ordinal))
         {
             return false;
         }


### PR DESCRIPTION
There was a recent regression in `TagHelperDescriptorComparer` due to several collection properties in the Default* tag helper classes being changed to be backed by immutable collections. There was already a fast path for `Dictionary<TKey, TValue>` to avoid boxing struct-based enumerators and a similar path is now needed for `ImmutableDictionary<TKey, TValue>`.

In addition, a fast path for arrays has been added to avoid calling unnecessarily through `IReadOnlyList<T>`.

The `TagHelperSerializationBenchmark` shows a decent improvement with this change:

## Old

``` ini

BenchmarkDotNet=v0.13.2.2052-nightly, OS=Windows 11 (10.0.25314.1010)
Intel Core i7-8700 CPU 3.20GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET SDK=8.0.100-preview.1.23115.2
  [Host]     : .NET 7.0.4 (7.0.423.11508), X64 RyuJIT AVX2
  Job-WFLKDR : .NET 7.0.4 (7.0.423.11508), X64 RyuJIT AVX2
  Job-FFGIFF : .NET Framework 4.8.1 (4.8.9139.0), X64 RyuJIT VectorSize=256

PowerPlanMode=00000000-0000-0000-0000-000000000000  

```
|                                    Method |        Job |            Toolchain |         Mean |      Error |     StdDev |       Median |          Min |          Max |      Gen0 |      Gen1 |     Gen2 |  Allocated |
|------------------------------------------ |----------- |--------------------- |-------------:|-----------:|-----------:|-------------:|-------------:|-------------:|----------:|----------:|---------:|-----------:|
| &#39;Razor TagHelper Roundtrip Serialization&#39; | Job-WFLKDR |             .NET 7.0 | 28,823.91 μs | 564.944 μs | 734.587 μs | 28,695.78 μs | 27,429.58 μs | 30,047.53 μs |  281.2500 |  187.5000 | 187.5000 | 16378018 B |
|           &#39;Razor TagHelper Serialization&#39; | Job-WFLKDR |             .NET 7.0 | 18,085.90 μs | 361.551 μs | 518.526 μs | 18,078.55 μs | 17,351.32 μs | 19,137.52 μs |  187.5000 |  156.2500 | 156.2500 | 11011393 B |
|         &#39;Razor TagHelper Deserialization&#39; | Job-WFLKDR |             .NET 7.0 | 10,617.31 μs | 154.739 μs | 144.743 μs | 10,592.49 μs | 10,416.35 μs | 10,862.88 μs |   62.5000 |         - |        - |  5366224 B |
|                  &#39;TagHelpers GetHashCode&#39; | Job-WFLKDR |             .NET 7.0 |     17.60 μs |   0.341 μs |   0.419 μs |     17.61 μs |     16.84 μs |     18.52 μs |         - |         - |        - |          - |
| &#39;Razor TagHelper Roundtrip Serialization&#39; | Job-FFGIFF | .NET Framework 4.7.2 | 46,568.18 μs | 631.874 μs | 591.055 μs | 46,584.98 μs | 44,938.61 μs | 47,977.28 μs | 2250.0000 | 1083.3333 | 916.6667 | 16758341 B |
|           &#39;Razor TagHelper Serialization&#39; | Job-FFGIFF | .NET Framework 4.7.2 | 24,947.08 μs | 204.765 μs | 170.988 μs | 24,886.90 μs | 24,689.90 μs | 25,326.14 μs | 1406.2500 | 1000.0000 | 968.7500 | 11026461 B |
|         &#39;Razor TagHelper Deserialization&#39; | Job-FFGIFF | .NET Framework 4.7.2 | 13,612.31 μs |  93.559 μs |  78.126 μs | 13,617.91 μs | 13,451.53 μs | 13,788.41 μs |  906.2500 |   93.7500 |        - |  5718967 B |
|                  &#39;TagHelpers GetHashCode&#39; | Job-FFGIFF | .NET Framework 4.7.2 |     18.22 μs |   0.133 μs |   0.124 μs |     18.22 μs |     17.98 μs |     18.45 μs |         - |         - |        - |          - |

## New

``` ini

BenchmarkDotNet=v0.13.2.2052-nightly, OS=Windows 11 (10.0.25314.1010)
Intel Core i7-8700 CPU 3.20GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET SDK=8.0.100-preview.1.23115.2
  [Host]     : .NET 7.0.4 (7.0.423.11508), X64 RyuJIT AVX2
  Job-RHXUOO : .NET 7.0.4 (7.0.423.11508), X64 RyuJIT AVX2
  Job-MUQIKG : .NET Framework 4.8.1 (4.8.9139.0), X64 RyuJIT VectorSize=256

PowerPlanMode=00000000-0000-0000-0000-000000000000  

```
|                                    Method |        Job |            Toolchain |         Mean |      Error |     StdDev |       Median |          Min |          Max |      Gen0 |     Gen1 |     Gen2 |  Allocated |
|------------------------------------------ |----------- |--------------------- |-------------:|-----------:|-----------:|-------------:|-------------:|-------------:|----------:|---------:|---------:|-----------:|
| &#39;Razor TagHelper Roundtrip Serialization&#39; | Job-RHXUOO |             .NET 7.0 | 27,450.33 μs | 517.406 μs | 595.846 μs | 27,460.99 μs | 26,552.55 μs | 28,531.18 μs |  218.7500 | 156.2500 | 156.2500 | 15208208 B |
|           &#39;Razor TagHelper Serialization&#39; | Job-RHXUOO |             .NET 7.0 | 17,368.91 μs | 344.089 μs | 482.364 μs | 17,470.26 μs | 16,430.67 μs | 18,174.16 μs |  125.0000 | 125.0000 | 125.0000 |  9825247 B |
|         &#39;Razor TagHelper Deserialization&#39; | Job-RHXUOO |             .NET 7.0 | 10,203.26 μs | 152.918 μs | 143.040 μs | 10,150.90 μs | 10,056.57 μs | 10,472.82 μs |   62.5000 |        - |        - |  5366224 B |
|                  &#39;TagHelpers GetHashCode&#39; | Job-RHXUOO |             .NET 7.0 |     17.25 μs |   0.224 μs |   0.210 μs |     17.28 μs |     16.79 μs |     17.55 μs |         - |        - |        - |          - |
| &#39;Razor TagHelper Roundtrip Serialization&#39; | Job-MUQIKG | .NET Framework 4.7.2 | 41,579.42 μs | 829.315 μs | 887.357 μs | 41,463.23 μs | 40,106.70 μs | 43,846.09 μs | 1916.6667 | 916.6667 | 833.3333 | 15569045 B |
|           &#39;Razor TagHelper Serialization&#39; | Job-MUQIKG | .NET Framework 4.7.2 | 24,094.01 μs | 187.119 μs | 175.031 μs | 24,122.85 μs | 23,813.28 μs | 24,343.25 μs | 1218.7500 | 968.7500 | 968.7500 |  9838186 B |
|         &#39;Razor TagHelper Deserialization&#39; | Job-MUQIKG | .NET Framework 4.7.2 | 13,114.29 μs | 102.763 μs |  91.097 μs | 13,110.83 μs | 12,995.13 μs | 13,304.44 μs |  906.2500 |  93.7500 |        - |  5718967 B |
|                  &#39;TagHelpers GetHashCode&#39; | Job-MUQIKG | .NET Framework 4.7.2 |     17.64 μs |   0.199 μs |   0.155 μs |     17.65 μs |     17.34 μs |     17.83 μs |         - |        - |        - |          - |

