### PR TITLE
Stop doing push diagnostics if we're doing pull diagnostics

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorPullDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorPullDiagnosticsEndpoint.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -10,6 +11,7 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -20,17 +22,14 @@ internal class RazorPullDiagnosticsEndpoint : IRazorPullDiagnosticsEndpoint
     private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
     private readonly ClientNotifierServiceBase _languageServer;
     private readonly RazorTranslateDiagnosticsService _translateDiagnosticsService;
-    protected readonly RazorDocumentMappingService DocumentMappingService;
 
     public RazorPullDiagnosticsEndpoint(
         LanguageServerFeatureOptions languageServerFeatureOptions,
         RazorTranslateDiagnosticsService translateDiagnosticsService,
-        RazorDocumentMappingService documentMappingService,
         ClientNotifierServiceBase languageServer)
     {
         _languageServerFeatureOptions = languageServerFeatureOptions ?? throw new ArgumentNullException(nameof(languageServerFeatureOptions));
         _translateDiagnosticsService = translateDiagnosticsService ?? throw new ArgumentNullException(nameof(translateDiagnosticsService));
-        DocumentMappingService = documentMappingService ?? throw new ArgumentNullException(nameof(documentMappingService));
         _languageServer = languageServer ?? throw new ArgumentNullException(nameof(languageServer));
     }
 
@@ -60,10 +59,65 @@ internal class RazorPullDiagnosticsEndpoint : IRazorPullDiagnosticsEndpoint
 
         var documentContext = context.GetRequiredDocumentContext();
 
+        var razorDiagnostics = await GetRazorDiagnosticsAsync(documentContext, cancellationToken).ConfigureAwait(false);
+
+        var (csharpDiagnostics, htmlDiagnostics) = await GetHtmlCSharpDiagnosticsAsync(documentContext, cancellationToken).ConfigureAwait(false);
+
+        using var _ = ListPool<VSInternalDiagnosticReport>.GetPooledObject(out var allDiagnostics);
+        allDiagnostics.SetCapacityIfLarger(
+            (razorDiagnostics?.Length ?? 0) +
+            (csharpDiagnostics?.Length ?? 0) +
+            (htmlDiagnostics?.Length ?? 0));
+
+        if (razorDiagnostics is not null)
+        {
+            // No extra work to do for Razor diagnostics
+            allDiagnostics.AddRange(razorDiagnostics);
+        }
+
+        if (csharpDiagnostics is not null)
+        {
+            foreach (var report in csharpDiagnostics)
+            {
+                if (report.Diagnostics is not null)
+                {
+                    var mappedDiagnostics = await _translateDiagnosticsService.TranslateAsync(RazorLanguageKind.CSharp, report.Diagnostics, documentContext, cancellationToken);
+                    report.Diagnostics = mappedDiagnostics;
+                }
+
+                allDiagnostics.Add(report);
+            }
+        }
+
+        if (htmlDiagnostics is not null)
+        {
+            foreach (var report in htmlDiagnostics)
+            {
+                if (report.Diagnostics is not null)
+                {
+                    var mappedDiagnostics = await _translateDiagnosticsService.TranslateAsync(RazorLanguageKind.Html, report.Diagnostics, documentContext, cancellationToken);
+                    report.Diagnostics = mappedDiagnostics;
+                }
+
+                allDiagnostics.Add(report);
+            }
+        }
+
+        return allDiagnostics.ToArray();
+    }
+
+    private static async Task<VSInternalDiagnosticReport[]?> GetRazorDiagnosticsAsync(VersionedDocumentContext documentContext, CancellationToken cancellationToken)
+    {
         var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
         var sourceText = await documentContext.GetSourceTextAsync(cancellationToken).ConfigureAwait(false);
         var csharpDocument = codeDocument.GetCSharpDocument();
         var diagnostics = csharpDocument.Diagnostics;
+
+        if (diagnostics.Count == 0)
+        {
+            return null;
+        }
+
         var convertedDiagnostics = RazorDiagnosticConverter.Convert(diagnostics, sourceText);
 
         var razorDiagnostics = new VSInternalDiagnosticReport[]
@@ -74,37 +128,22 @@ internal class RazorPullDiagnosticsEndpoint : IRazorPullDiagnosticsEndpoint
                 ResultId = Guid.NewGuid().ToString()
             }
         };
+        return razorDiagnostics;
+    }
 
+    private async Task<(VSInternalDiagnosticReport[]? CSharpDiagnostics, VSInternalDiagnosticReport[]? HtmlDiagnostics)> GetHtmlCSharpDiagnosticsAsync(VersionedDocumentContext documentContext, CancellationToken cancellationToken)
+    {
         var delegatedParams = new DelegatedDiagnosticParams(documentContext.Identifier);
-
         var delegatedResponse = await _languageServer.SendRequestAsync<DelegatedDiagnosticParams, RazorPullDiagnosticResponse?>(
             RazorLanguageServerCustomMessageTargets.RazorPullDiagnosticEndpointName,
             delegatedParams,
             cancellationToken).ConfigureAwait(false);
 
-        if (delegatedResponse is not null)
+        if (delegatedResponse is null)
         {
-            foreach (var report in delegatedResponse.CSharpDiagnostics)
-            {
-                if (report.Diagnostics is not null)
-                {
-                    var mappedDiagnostics = await _translateDiagnosticsService.TranslateAsync(RazorLanguageKind.CSharp, report.Diagnostics, documentContext, cancellationToken);
-                    report.Diagnostics = mappedDiagnostics;
-                }
-            }
-
-            foreach (var report in delegatedResponse.HtmlDiagnostics)
-            {
-                if (report.Diagnostics is not null)
-                {
-                    var mappedDiagnostics = await _translateDiagnosticsService.TranslateAsync(RazorLanguageKind.Html, report.Diagnostics, documentContext, cancellationToken);
-                    report.Diagnostics = mappedDiagnostics;
-                }
-            }
-
-            razorDiagnostics = razorDiagnostics.Concat(delegatedResponse.CSharpDiagnostics).Concat(delegatedResponse.HtmlDiagnostics).ToArray();
+            return (null, null);
         }
 
-        return razorDiagnostics;
+        return (delegatedResponse.CSharpDiagnostics, delegatedResponse.HtmlDiagnostics);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
@@ -178,7 +178,7 @@ internal static class IServiceCollectionExtensions
         services.AddSingleton<IOptionsMonitor<RazorLSPOptions>, RazorLSPOptionsMonitor>(s => s.GetRequiredService<RazorLSPOptionsMonitor>());
     }
 
-    public static void AddDocumentManagmentServices(this IServiceCollection services)
+    public static void AddDocumentManagementServices(this IServiceCollection services, LanguageServerFeatureOptions featureOptions)
     {
         services.AddSingleton<GeneratedDocumentPublisher, DefaultGeneratedDocumentPublisher>();
         services.AddSingleton<ProjectSnapshotChangeTrigger>((services) => services.GetRequiredService<GeneratedDocumentPublisher>());
@@ -206,7 +206,12 @@ internal static class IServiceCollectionExtensions
         services.AddSingleton<IFileChangeDetector, RazorFileChangeDetector>();
 
         // Document processed listeners
-        services.AddSingleton<DocumentProcessedListener, RazorDiagnosticsPublisher>();
+        if (!featureOptions.SingleServerSupport)
+        {
+            // If single server is on, then we don't want to publish diagnostics, so best to just not hook up to any
+            // events etc.
+            services.AddSingleton<DocumentProcessedListener, RazorDiagnosticsPublisher>();
+        }
         services.AddSingleton<DocumentProcessedListener, GeneratedDocumentSynchronizer>();
         services.AddSingleton<DocumentProcessedListener, CodeDocumentReferenceHolder>();
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDiagnosticConverter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDiagnosticConverter.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Text;
@@ -27,6 +28,7 @@ internal static class RazorDiagnosticConverter
         {
             Message = razorDiagnostic.GetMessage(CultureInfo.InvariantCulture),
             Code = razorDiagnostic.Id,
+            Source = "Razor",
             Severity = ConvertSeverity(razorDiagnostic.Severity),
             // This is annotated as not null, but we have tests that validate the behaviour when
             // we pass in null here
@@ -34,6 +36,19 @@ internal static class RazorDiagnosticConverter
         };
 
         return diagnostic;
+    }
+
+    internal static Diagnostic[] Convert(IReadOnlyList<RazorDiagnostic> diagnostics, SourceText sourceText)
+    {
+        var convertedDiagnostics = new Diagnostic[diagnostics.Count];
+
+        var i = 0;
+        foreach (var diagnostic in diagnostics)
+        {
+            convertedDiagnostics[i++] = Convert(diagnostic, sourceText);
+        }
+
+        return convertedDiagnostics;
     }
 
     // Internal for testing

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -124,7 +124,7 @@ internal class RazorLanguageServer : AbstractLanguageServer<RazorRequestContext>
 
         services.AddDiagnosticServices();
         services.AddSemanticTokensServices();
-        services.AddDocumentManagmentServices();
+        services.AddDocumentManagementServices(featureOptions);
         services.AddCompletionServices(featureOptions);
         services.AddFormattingServices();
         services.AddCodeActionsServices();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/CSharpDiagnosticsEndToEndTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/CSharpDiagnosticsEndToEndTest.cs
@@ -56,7 +56,7 @@ public class CSharpDiagnosticsEndToEndTest : SingleServerDelegatingEndpointTestB
         var requestContext = new RazorRequestContext(documentContext, Logger, null!);
 
         var translateDiagnosticsService = new RazorTranslateDiagnosticsService(DocumentMappingService, LoggerFactory);
-        var diagnosticsEndPoint = new RazorPullDiagnosticsEndpoint(LanguageServerFeatureOptions, translateDiagnosticsService, DocumentMappingService, LanguageServer);
+        var diagnosticsEndPoint = new RazorPullDiagnosticsEndpoint(LanguageServerFeatureOptions, translateDiagnosticsService, LanguageServer);
 
         var diagnosticsRequest = new VSInternalDocumentDiagnosticsParams
         {
@@ -64,8 +64,7 @@ public class CSharpDiagnosticsEndToEndTest : SingleServerDelegatingEndpointTestB
         };
         var diagnostics = await diagnosticsEndPoint.HandleRequestAsync(diagnosticsRequest, requestContext, DisposalToken);
 
-        var actual = diagnostics!.First().Diagnostics!;
-        Assert.NotEmpty(actual);
+        var actual = diagnostics!.SelectMany(d => d.Diagnostics!);
 
         // Because the test razor project isn't set up properly, we get some extra diagnostics that we don't care about
         // so lets just validate that we get the ones we expect. We're testing the communication and translation between


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/8161

* Turns off push diagnostics, which saves some document processing
* Returns Razor diagnostics from pull diagnostics
* Bit of cleanup