### PR TITLE
[Infra] Fix darc duplicate publishing

### DIFF
--- a/src/Razor/src/rzls/rzls.csproj
+++ b/src/Razor/src/rzls/rzls.csproj
@@ -68,6 +68,6 @@
     </ItemGroup>
 
     <MSBuild Projects="@(ProjectToPublish)" Targets="Publish;_IncludeOmniSharpPlugin" BuildInParallel="false" />
-    <MSBuild Projects="@(ProjectToPublish_PlatformAgnostic)" Targets="Publish;_IncludeOmniSharpPlugin" BuildInParallel="false" />
+    <MSBuild Projects="@(ProjectToPublish_PlatformAgnostic)" Targets="Publish;_IncludeOmniSharpPlugin" BuildInParallel="false" Condition="'$(OS)' == 'WINDOWS_NT'" />
   </Target>
 </Project>


### PR DESCRIPTION
﻿### Summary of the changes
- Only publish platform agnostic language server on Windows
- This condition previously existed but was removed in https://github.com/dotnet/razor/pull/8426. We actually still need it since the produced package (e.g. `RazorLanguageServer-PlatformAgnostic-7.0.0-preview.23167.1.zip`) doesn't follow the `*.nupkg` pattern specified in the linked PR.