### PR TITLE
Don't normalize URIs that we send to language servers

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/FilePathNormalizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/FilePathNormalizer.cs
@@ -49,12 +49,6 @@ public static class FilePathNormalizer
         return normalized;
     }
 
-    public static Uri Normalize(Uri uri)
-    {
-        var normalized = Normalize(uri.OriginalString);
-        return new Uri(normalized);
-    }
-
     public static string GetDirectory(string filePath)
     {
         if (string.IsNullOrEmpty(filePath))

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormatter.cs
@@ -112,7 +112,7 @@ internal class CSharpFormatter
         {
             Kind = RazorLanguageKind.CSharp,
             ProjectedRange = projectedRange,
-            HostDocumentFilePath = FilePathNormalizer.Normalize(context.Uri.GetAbsoluteOrUNCPath()),
+            HostDocumentFilePath = context.Uri.GetAbsoluteOrUNCPath(),
             Options = context.Options
         };
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormatter.cs
@@ -62,7 +62,7 @@ internal class CSharpFormatter
             return Array.Empty<TextEdit>();
         }
 
-        var edits = await FormatOnServerAsync(context, projectedRange, cancellationToken);
+        var edits = await GetFormattingEditsAsync(context, projectedRange, cancellationToken);
         var mappedEdits = MapEditsToHostDocument(context.CodeDocument, edits);
         return mappedEdits;
     }
@@ -97,10 +97,7 @@ internal class CSharpFormatter
         return actualEdits;
     }
 
-    private static async Task<TextEdit[]> FormatOnServerAsync(
-        FormattingContext context,
-        Range projectedRange,
-        CancellationToken cancellationToken)
+    private static async Task<TextEdit[]> GetFormattingEditsAsync(FormattingContext context, Range projectedRange, CancellationToken cancellationToken)
     {
         var csharpSourceText = context.CodeDocument.GetCSharpSourceText();
         var spanToFormat = projectedRange.AsTextSpan(csharpSourceText);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormatter.cs
@@ -14,99 +14,99 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 
 internal class HtmlFormatter
+{
+    private readonly DocumentVersionCache _documentVersionCache;
+    private readonly ClientNotifierServiceBase _server;
+
+    public HtmlFormatter(
+        ClientNotifierServiceBase languageServer,
+        DocumentVersionCache documentVersionCache)
     {
-        private readonly DocumentVersionCache _documentVersionCache;
-        private readonly ClientNotifierServiceBase _server;
-
-        public HtmlFormatter(
-            ClientNotifierServiceBase languageServer,
-            DocumentVersionCache documentVersionCache)
-        {
-            _server = languageServer;
-            _documentVersionCache = documentVersionCache;
-        }
-
-        public async Task<TextEdit[]> FormatAsync(
-            FormattingContext context,
-            CancellationToken cancellationToken)
-        {
-            if (context is null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            var documentVersion = await _documentVersionCache.TryGetDocumentVersionAsync(context.OriginalSnapshot, cancellationToken).ConfigureAwait(false);
-            if (documentVersion is null)
-            {
-                return Array.Empty<TextEdit>();
-            }
-
-            var @params = new VersionedDocumentFormattingParams()
-            {
-                TextDocument = new TextDocumentIdentifier
-                {
-                    Uri = FilePathNormalizer.Normalize(context.Uri),
-                },
-                HostDocumentVersion = documentVersion.Value,
-                Options = context.Options
-            };
-
-            var result = await _server.SendRequestAsync<DocumentFormattingParams, RazorDocumentFormattingResponse?>(
-                LanguageServerConstants.RazorDocumentFormattingEndpoint,
-                @params,
-                cancellationToken);
-
-            return result?.Edits ?? Array.Empty<TextEdit>();
-        }
-
-        public async Task<TextEdit[]> FormatOnTypeAsync(
-           FormattingContext context,
-           CancellationToken cancellationToken)
-        {
-            var documentVersion = await _documentVersionCache.TryGetDocumentVersionAsync(context.OriginalSnapshot, cancellationToken).ConfigureAwait(false);
-            if (documentVersion == null)
-            {
-                return Array.Empty<TextEdit>();
-            }
-
-            context.SourceText.GetLineAndOffset(context.HostDocumentIndex, out var line, out var col);
-            var @params = new RazorDocumentOnTypeFormattingParams()
-            {
-                Position = new Position(line, col),
-                Character = context.TriggerCharacter.ToString(),
-                TextDocument = new TextDocumentIdentifier { Uri = FilePathNormalizer.Normalize(context.Uri) },
-                Options = context.Options,
-                HostDocumentVersion = documentVersion.Value,
-            };
-
-            var result = await _server.SendRequestAsync<RazorDocumentOnTypeFormattingParams, RazorDocumentFormattingResponse?>(
-                LanguageServerConstants.RazorDocumentOnTypeFormattingEndpoint,
-                @params,
-                cancellationToken);
-
-            return result?.Edits ?? Array.Empty<TextEdit>();
-        }
-
-        /// <summary>
-        /// Sometimes the Html language server will send back an edit that contains a tilde, because the generated
-        /// document we send them has lots of tildes. In those cases, we need to do some extra work to compute the
-        /// minimal text edits
-        /// </summary>
-        // Internal for testing
-        public static TextEdit[] FixHtmlTestEdits(SourceText htmlSourceText, TextEdit[] edits)
-        {
-            // Avoid computing a minimal diff if we don't need to
-            if (!edits.Any(e => e.NewText.Contains("~")))
-                return edits;
-
-            // First we apply the edits that the Html language server wanted, to the Html document
-            var textChanges = edits.Select(e => e.AsTextChange(htmlSourceText));
-            var changedText = htmlSourceText.WithChanges(textChanges);
-
-            // Now we use our minimal text differ algorithm to get the bare minimum of edits
-            var minimalChanges = SourceTextDiffer.GetMinimalTextChanges(htmlSourceText, changedText, DiffKind.Char);
-            var minimalEdits = minimalChanges.Select(f => f.AsTextEdit(htmlSourceText)).ToArray();
-
-            return minimalEdits;
-        }
+        _server = languageServer;
+        _documentVersionCache = documentVersionCache;
     }
+
+    public async Task<TextEdit[]> FormatAsync(
+        FormattingContext context,
+        CancellationToken cancellationToken)
+    {
+        if (context is null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        var documentVersion = await _documentVersionCache.TryGetDocumentVersionAsync(context.OriginalSnapshot, cancellationToken).ConfigureAwait(false);
+        if (documentVersion is null)
+        {
+            return Array.Empty<TextEdit>();
+        }
+
+        var @params = new VersionedDocumentFormattingParams()
+        {
+            TextDocument = new TextDocumentIdentifier
+            {
+                Uri = context.Uri,
+            },
+            HostDocumentVersion = documentVersion.Value,
+            Options = context.Options
+        };
+
+        var result = await _server.SendRequestAsync<DocumentFormattingParams, RazorDocumentFormattingResponse?>(
+            LanguageServerConstants.RazorDocumentFormattingEndpoint,
+            @params,
+            cancellationToken);
+
+        return result?.Edits ?? Array.Empty<TextEdit>();
+    }
+
+    public async Task<TextEdit[]> FormatOnTypeAsync(
+       FormattingContext context,
+       CancellationToken cancellationToken)
+    {
+        var documentVersion = await _documentVersionCache.TryGetDocumentVersionAsync(context.OriginalSnapshot, cancellationToken).ConfigureAwait(false);
+        if (documentVersion == null)
+        {
+            return Array.Empty<TextEdit>();
+        }
+
+        context.SourceText.GetLineAndOffset(context.HostDocumentIndex, out var line, out var col);
+        var @params = new RazorDocumentOnTypeFormattingParams()
+        {
+            Position = new Position(line, col),
+            Character = context.TriggerCharacter.ToString(),
+            TextDocument = new TextDocumentIdentifier { Uri = context.Uri },
+            Options = context.Options,
+            HostDocumentVersion = documentVersion.Value,
+        };
+
+        var result = await _server.SendRequestAsync<RazorDocumentOnTypeFormattingParams, RazorDocumentFormattingResponse?>(
+            LanguageServerConstants.RazorDocumentOnTypeFormattingEndpoint,
+            @params,
+            cancellationToken);
+
+        return result?.Edits ?? Array.Empty<TextEdit>();
+    }
+
+    /// <summary>
+    /// Sometimes the Html language server will send back an edit that contains a tilde, because the generated
+    /// document we send them has lots of tildes. In those cases, we need to do some extra work to compute the
+    /// minimal text edits
+    /// </summary>
+    // Internal for testing
+    public static TextEdit[] FixHtmlTestEdits(SourceText htmlSourceText, TextEdit[] edits)
+    {
+        // Avoid computing a minimal diff if we don't need to
+        if (!edits.Any(e => e.NewText.Contains("~")))
+            return edits;
+
+        // First we apply the edits that the Html language server wanted, to the Html document
+        var textChanges = edits.Select(e => e.AsTextChange(htmlSourceText));
+        var changedText = htmlSourceText.WithChanges(textChanges);
+
+        // Now we use our minimal text differ algorithm to get the bare minimum of edits
+        var minimalChanges = SourceTextDiffer.GetMinimalTextChanges(htmlSourceText, changedText, DiffKind.Char);
+        var minimalEdits = minimalChanges.Select(f => f.AsTextEdit(htmlSourceText)).ToArray();
+
+        return minimalEdits;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/8465
Fixes https://github.com/dotnet/razor/issues/6182

I don't know why we were normalizing a path we got from LSP before sending an LSP request, but seems wrong to me. Also removed a bit of dead code that did the wrong thing too.