### PR TITLE
Strip generic type params from rename codeaction

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ComponentAccessibilityCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ComponentAccessibilityCodeActionProvider.cs
@@ -137,7 +137,8 @@ internal class ComponentAccessibilityCodeActionProvider : RazorCodeActionProvide
                 continue;
             }
 
-            // if fqn contains a generic typeparam, we should strip it out
+            // if fqn contains a generic typeparam, we should strip it out. Otherwise, replacing tag name will leave generic parameters in razor code, which are illegal
+            // e.g. <Component /> -> <Component<T> />
             var fullyQualifiedName = DefaultRazorComponentSearchEngine.RemoveGenericContent(tagHelperPair._short.Name).ToString();
 
             // Insert @using

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ComponentAccessibilityCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ComponentAccessibilityCodeActionProvider.cs
@@ -137,7 +137,8 @@ internal class ComponentAccessibilityCodeActionProvider : RazorCodeActionProvide
                 continue;
             }
 
-            var fullyQualifiedName = tagHelperPair._short.Name;
+            // if fqn contains a generic typeparam, we should strip it out
+            var fullyQualifiedName = DefaultRazorComponentSearchEngine.RemoveGenericContent(tagHelperPair._short.Name).ToString();
 
             // Insert @using
             if (AddUsingsCodeActionProviderHelper.TryCreateAddUsingResolutionParams(fullyQualifiedName, context.Request.TextDocument.Uri, out var @namespace, out var resolutionParams))

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorComponentSearchEngine.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorComponentSearchEngine.cs
@@ -149,7 +149,7 @@ internal class DefaultRazorComponentSearchEngine : RazorComponentSearchEngine
         return null;
     }
 
-    public static StringSegment RemoveGenericContent(StringSegment typeName)
+    internal static StringSegment RemoveGenericContent(StringSegment typeName)
     {
         var genericSeparatorStart = typeName.IndexOf('<');
         if (genericSeparatorStart > 0)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorComponentSearchEngine.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorComponentSearchEngine.cs
@@ -149,7 +149,7 @@ internal class DefaultRazorComponentSearchEngine : RazorComponentSearchEngine
         return null;
     }
 
-    private static StringSegment RemoveGenericContent(StringSegment typeName)
+    public static StringSegment RemoveGenericContent(StringSegment typeName)
     {
         var genericSeparatorStart = typeName.IndexOf('<');
         if (genericSeparatorStart > 0)


### PR DESCRIPTION
Fixes #4450

Strips type params using DefaultRazorComponentSeachEngine.RemoveGenericContent on the rename code action.