### PR TITLE
Expose the existing AutoClosingTags option in VS

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorConfigurationService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorConfigurationService.cs
@@ -85,8 +85,10 @@ internal class DefaultRazorConfigurationService : IConfigurationSyncService
     // Internal for testing
     internal RazorLSPOptions BuildOptions(JObject[] result)
     {
-        ExtractVSCodeOptions(result, out var trace, out var enableFormatting, out var autoClosingTags);
-        var settings = ExtractVSOptions(result) ?? ClientSettings.Default;
+        ExtractVSCodeOptions(result, out var trace, out var enableFormatting, out var vsCodeAutoClosingTags);
+        var settings = ExtractVSOptions(result);
+
+        var autoClosingTags = vsCodeAutoClosingTags ?? settings.AdvancedSettings.AutoClosingTags;
 
         return new RazorLSPOptions(trace, enableFormatting, autoClosingTags, settings);
     }
@@ -95,14 +97,14 @@ internal class DefaultRazorConfigurationService : IConfigurationSyncService
         JObject[] result,
         out Trace trace,
         out bool enableFormatting,
-        out bool autoClosingTags)
+        out bool? autoClosingTags)
     {
         var razor = result[0];
         var html = result[1];
 
         trace = RazorLSPOptions.Default.Trace;
         enableFormatting = RazorLSPOptions.Default.EnableFormatting;
-        autoClosingTags = RazorLSPOptions.Default.AutoClosingTags;
+        autoClosingTags = null;
 
         if (razor != null)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLSPOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLSPOptions.cs
@@ -32,6 +32,13 @@ public record RazorLSPOptions(
             _ => LogLevel.None,
         };
 
-    internal RazorLSPOptions With(ClientSettings clientSettings)
-        => new(Trace, EnableFormatting, AutoClosingTags, clientSettings);
+    /// <summary>
+    /// Initializes the LSP options with the settings from the passed in client settings, and default values for anything
+    /// not defined in client settings.
+    /// </summary>
+    internal static RazorLSPOptions From(ClientSettings clientSettings)
+        => new(Default.Trace,
+            Default.EnableFormatting,
+            clientSettings.AdvancedSettings.AutoClosingTags,
+            clientSettings);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Editor/ClientSettings.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Editor/ClientSettings.cs
@@ -25,7 +25,7 @@ public sealed record ClientSpaceSettings(bool IndentWithTabs, int IndentSize)
     public int IndentSize { get; } = IndentSize >= 0 ? IndentSize : throw new ArgumentOutOfRangeException(nameof(IndentSize));
 }
 
-public sealed record ClientAdvancedSettings(bool FormatOnType)
+public sealed record ClientAdvancedSettings(bool FormatOnType, bool AutoClosingTags)
 {
-    public static readonly ClientAdvancedSettings Default = new(FormatOnType: true);
+    public static readonly ClientAdvancedSettings Default = new(FormatOnType: true, AutoClosingTags: true);
 }

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/IClientSettingsManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/IClientSettingsManager.cs
@@ -12,6 +12,8 @@ public interface IClientSettingsManager
 
     void Update(ClientSpaceSettings updateSettings);
 
+    void Update(ClientAdvancedSettings updateSettings);
+
     ClientSettings GetClientSettings();
 }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Options/OptionsStorage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Options/OptionsStorage.cs
@@ -21,23 +21,37 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Options;
 internal class OptionsStorage : IAdvancedSettingsStorage
 {
     private readonly WritableSettingsStore _writableSettingsStore;
-    private readonly ILanguageServiceBroker2 _languageServiceBroker;
     private readonly ITelemetryReporter _telemetryReporter;
+
     private const string Collection = "Razor";
+    private const string FormatOnTypeName = "FormatOnType";
+    private const string AutoClosingTagsName = "AutoClosingTags";
+
+    public bool FormatOnType
+    {
+        get => GetBool(FormatOnTypeName, defaultValue: true);
+        set => SetBool(FormatOnTypeName, value);
+    }
+
+    public bool AutoClosingTags
+    {
+        get => GetBool(AutoClosingTagsName, defaultValue: true);
+        set => SetBool(AutoClosingTagsName, value);
+    }
 
     [ImportingConstructor]
-    public OptionsStorage(SVsServiceProvider vsServiceProvider, ILanguageServiceBroker2 languageServiceBroker, ITelemetryReporter telemetryReporter)
+    public OptionsStorage(SVsServiceProvider vsServiceProvider, ITelemetryReporter telemetryReporter)
     {
         var shellSettingsManager = new ShellSettingsManager(vsServiceProvider);
         _writableSettingsStore = shellSettingsManager.GetWritableSettingsStore(SettingsScope.UserSettings);
 
         _writableSettingsStore.CreateCollection(Collection);
-        _languageServiceBroker = languageServiceBroker;
         _telemetryReporter = telemetryReporter;
     }
 
     public event EventHandler<ClientAdvancedSettingsChangedEventArgs>? Changed;
-    public ClientAdvancedSettings GetAdvancedSettings() => new(FormatOnType);
+
+    public ClientAdvancedSettings GetAdvancedSettings() => new(FormatOnType, AutoClosingTags);
 
     public bool GetBool(string name, bool defaultValue)
     {
@@ -63,13 +77,5 @@ internal class OptionsStorage : IAdvancedSettingsStorage
     private void NotifyChange()
     {
         Changed?.Invoke(this, new ClientAdvancedSettingsChangedEventArgs(GetAdvancedSettings()));
-    }
-
-    private const string FormatOnTypeName = "FormatOnType";
-
-    public bool FormatOnType
-    {
-        get => GetBool(FormatOnTypeName, defaultValue: true);
-        set => SetBool(FormatOnTypeName, value);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
@@ -183,7 +183,7 @@ internal class RazorLanguageServerClient : ILanguageClient, ILanguageClientCusto
         var logHubLogger = _loggerProvider.CreateLogger("Razor");
         var loggers = _outputWindowLogger == null ? new ILogger[] { logHubLogger } : new ILogger[] { logHubLogger, _outputWindowLogger };
         var razorLogger = new LoggerAdapter(loggers, _telemetryReporter);
-        var lspOptions = RazorLSPOptions.Default.With(_clientSettingsManager.GetClientSettings());
+        var lspOptions = RazorLSPOptions.From(_clientSettingsManager.GetClientSettings());
         _server = RazorLanguageServerWrapper.Create(
             serverStream,
             serverStream,

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Options/AdvancedOptionPage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Options/AdvancedOptionPage.cs
@@ -34,4 +34,13 @@ internal class AdvancedOptionPage : DialogPage
         get => _optionsStorage.Value.FormatOnType;
         set => _optionsStorage.Value.FormatOnType = value;
     }
+
+    [LocCategory(nameof(VSPackage.Typing))]
+    [LocDescription(nameof(VSPackage.Setting_AutoClosingTagsDescription))]
+    [LocDisplayName(nameof(VSPackage.Setting_AutoClosingTagsDisplayName))]
+    public bool AutoClosingTags
+    {
+        get => _optionsStorage.Value.AutoClosingTags;
+        set => _optionsStorage.Value.AutoClosingTags = value;
+    }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Options/AdvancedOptionPage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Options/AdvancedOptionPage.cs
@@ -15,6 +15,9 @@ internal class AdvancedOptionPage : DialogPage
 {
     private readonly Lazy<OptionsStorage> _optionsStorage;
 
+    private bool? _formatOnType;
+    private bool? _autoClosingTags;
+
     public AdvancedOptionPage()
     {
         _optionsStorage = new Lazy<OptionsStorage>(() =>
@@ -31,8 +34,8 @@ internal class AdvancedOptionPage : DialogPage
     [LocDisplayName(nameof(VSPackage.Setting_FormattingOnTypeDisplayName))]
     public bool FormatOnType
     {
-        get => _optionsStorage.Value.FormatOnType;
-        set => _optionsStorage.Value.FormatOnType = value;
+        get => _formatOnType ?? _optionsStorage.Value.FormatOnType;
+        set => _formatOnType = value;
     }
 
     [LocCategory(nameof(VSPackage.Typing))]
@@ -40,7 +43,26 @@ internal class AdvancedOptionPage : DialogPage
     [LocDisplayName(nameof(VSPackage.Setting_AutoClosingTagsDisplayName))]
     public bool AutoClosingTags
     {
-        get => _optionsStorage.Value.AutoClosingTags;
-        set => _optionsStorage.Value.AutoClosingTags = value;
+        get => _autoClosingTags ?? _optionsStorage.Value.AutoClosingTags;
+        set => _autoClosingTags = value;
+    }
+
+    protected override void OnApply(PageApplyEventArgs e)
+    {
+        if (_formatOnType is not null)
+        {
+            _optionsStorage.Value.FormatOnType = _formatOnType.Value;
+        }
+
+        if (_autoClosingTags is not null)
+        {
+            _optionsStorage.Value.AutoClosingTags = _autoClosingTags.Value;
+        }
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        _formatOnType = null;
+        _autoClosingTags = null;
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/VSPackage.resx
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/VSPackage.resx
@@ -144,10 +144,19 @@
   <data name="RazorSyntaxVisualizer" xml:space="preserve">
     <value>Razor Syntax Visualizer</value>
   </data>
+  <data name="Setting_AutoClosingTagsDescription" xml:space="preserve">
+    <value>If true, closing tags will be automatically inserted</value>
+  </data>
+  <data name="Setting_AutoClosingTagsDisplayName" xml:space="preserve">
+    <value>Auto Insert Closing Tag</value>
+  </data>
   <data name="Setting_FormattingOnTypeDescription" xml:space="preserve">
     <value>If true, formatting will be enabled while typing</value>
   </data>
   <data name="Setting_FormattingOnTypeDisplayName" xml:space="preserve">
     <value>Format On Type</value>
+  </data>
+  <data name="Typing" xml:space="preserve">
+    <value>Typing</value>
   </data>
 </root>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.cs.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.cs.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Razor Syntax Visualizer</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_AutoClosingTagsDescription">
+        <source>If true, closing tags will be automatically inserted</source>
+        <target state="new">If true, closing tags will be automatically inserted</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_AutoClosingTagsDisplayName">
+        <source>Auto Insert Closing Tag</source>
+        <target state="new">Auto Insert Closing Tag</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_FormattingOnTypeDescription">
         <source>If true, formatting will be enabled while typing</source>
         <target state="translated">Pokud je hodnota true, při psaní se povolí formátování.</target>
@@ -40,6 +50,11 @@
       <trans-unit id="Setting_FormattingOnTypeDisplayName">
         <source>Format On Type</source>
         <target state="translated">Formátovat při psaní</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Typing">
+        <source>Typing</source>
+        <target state="new">Typing</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.de.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.de.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Razor-Syntax-Visualizer</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_AutoClosingTagsDescription">
+        <source>If true, closing tags will be automatically inserted</source>
+        <target state="new">If true, closing tags will be automatically inserted</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_AutoClosingTagsDisplayName">
+        <source>Auto Insert Closing Tag</source>
+        <target state="new">Auto Insert Closing Tag</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_FormattingOnTypeDescription">
         <source>If true, formatting will be enabled while typing</source>
         <target state="translated">Bei "true" wird die Formatierung während der Eingabe aktiviert.</target>
@@ -40,6 +50,11 @@
       <trans-unit id="Setting_FormattingOnTypeDisplayName">
         <source>Format On Type</source>
         <target state="translated">Bei Eingabe formatieren</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Typing">
+        <source>Typing</source>
+        <target state="new">Typing</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.es.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.es.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Razor Syntax Visualizer</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_AutoClosingTagsDescription">
+        <source>If true, closing tags will be automatically inserted</source>
+        <target state="new">If true, closing tags will be automatically inserted</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_AutoClosingTagsDisplayName">
+        <source>Auto Insert Closing Tag</source>
+        <target state="new">Auto Insert Closing Tag</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_FormattingOnTypeDescription">
         <source>If true, formatting will be enabled while typing</source>
         <target state="translated">Si es true, el formato se habilitará al escribir</target>
@@ -40,6 +50,11 @@
       <trans-unit id="Setting_FormattingOnTypeDisplayName">
         <source>Format On Type</source>
         <target state="translated">Dar formato al escribir</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Typing">
+        <source>Typing</source>
+        <target state="new">Typing</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.fr.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.fr.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Razor Syntax Visualizer</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_AutoClosingTagsDescription">
+        <source>If true, closing tags will be automatically inserted</source>
+        <target state="new">If true, closing tags will be automatically inserted</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_AutoClosingTagsDisplayName">
+        <source>Auto Insert Closing Tag</source>
+        <target state="new">Auto Insert Closing Tag</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_FormattingOnTypeDescription">
         <source>If true, formatting will be enabled while typing</source>
         <target state="translated">Si la valeur est true, la mise en forme est activée lors de la saisie</target>
@@ -40,6 +50,11 @@
       <trans-unit id="Setting_FormattingOnTypeDisplayName">
         <source>Format On Type</source>
         <target state="translated">Mettre en forme durant la frappe</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Typing">
+        <source>Typing</source>
+        <target state="new">Typing</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.it.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.it.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Razor Syntax Visualizer</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_AutoClosingTagsDescription">
+        <source>If true, closing tags will be automatically inserted</source>
+        <target state="new">If true, closing tags will be automatically inserted</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_AutoClosingTagsDisplayName">
+        <source>Auto Insert Closing Tag</source>
+        <target state="new">Auto Insert Closing Tag</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_FormattingOnTypeDescription">
         <source>If true, formatting will be enabled while typing</source>
         <target state="translated">Se true, la formattazione verrà abilitata durante la digitazione</target>
@@ -40,6 +50,11 @@
       <trans-unit id="Setting_FormattingOnTypeDisplayName">
         <source>Format On Type</source>
         <target state="translated">Formattare durante la digitazione</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Typing">
+        <source>Typing</source>
+        <target state="new">Typing</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.ja.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.ja.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Razor Syntax Visualizer</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_AutoClosingTagsDescription">
+        <source>If true, closing tags will be automatically inserted</source>
+        <target state="new">If true, closing tags will be automatically inserted</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_AutoClosingTagsDisplayName">
+        <source>Auto Insert Closing Tag</source>
+        <target state="new">Auto Insert Closing Tag</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_FormattingOnTypeDescription">
         <source>If true, formatting will be enabled while typing</source>
         <target state="translated">true の場合、入力中に書式設定が有効になります</target>
@@ -40,6 +50,11 @@
       <trans-unit id="Setting_FormattingOnTypeDisplayName">
         <source>Format On Type</source>
         <target state="translated">入力時に書式設定</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Typing">
+        <source>Typing</source>
+        <target state="new">Typing</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.ko.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.ko.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Razor Syntax Visualizer</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_AutoClosingTagsDescription">
+        <source>If true, closing tags will be automatically inserted</source>
+        <target state="new">If true, closing tags will be automatically inserted</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_AutoClosingTagsDisplayName">
+        <source>Auto Insert Closing Tag</source>
+        <target state="new">Auto Insert Closing Tag</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_FormattingOnTypeDescription">
         <source>If true, formatting will be enabled while typing</source>
         <target state="translated">true이면 입력하는 동안 서식을 사용할 수 있습니다.</target>
@@ -40,6 +50,11 @@
       <trans-unit id="Setting_FormattingOnTypeDisplayName">
         <source>Format On Type</source>
         <target state="translated">형식의 서식</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Typing">
+        <source>Typing</source>
+        <target state="new">Typing</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.pl.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.pl.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Syntax Visualizer Razor</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_AutoClosingTagsDescription">
+        <source>If true, closing tags will be automatically inserted</source>
+        <target state="new">If true, closing tags will be automatically inserted</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_AutoClosingTagsDisplayName">
+        <source>Auto Insert Closing Tag</source>
+        <target state="new">Auto Insert Closing Tag</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_FormattingOnTypeDescription">
         <source>If true, formatting will be enabled while typing</source>
         <target state="translated">Jeśli ma wartość „prawda”, formatowanie będzie włączone podczas pisania</target>
@@ -40,6 +50,11 @@
       <trans-unit id="Setting_FormattingOnTypeDisplayName">
         <source>Format On Type</source>
         <target state="translated">Formatuj według typu</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Typing">
+        <source>Typing</source>
+        <target state="new">Typing</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.pt-BR.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.pt-BR.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Razor Syntax Visualizer</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_AutoClosingTagsDescription">
+        <source>If true, closing tags will be automatically inserted</source>
+        <target state="new">If true, closing tags will be automatically inserted</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_AutoClosingTagsDisplayName">
+        <source>Auto Insert Closing Tag</source>
+        <target state="new">Auto Insert Closing Tag</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_FormattingOnTypeDescription">
         <source>If true, formatting will be enabled while typing</source>
         <target state="translated">Se verdadeiro, a formatação será habilitada durante a digitação</target>
@@ -40,6 +50,11 @@
       <trans-unit id="Setting_FormattingOnTypeDisplayName">
         <source>Format On Type</source>
         <target state="translated">Formatar no Tipo</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Typing">
+        <source>Typing</source>
+        <target state="new">Typing</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.ru.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.ru.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Razor Syntax Visualizer</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_AutoClosingTagsDescription">
+        <source>If true, closing tags will be automatically inserted</source>
+        <target state="new">If true, closing tags will be automatically inserted</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_AutoClosingTagsDisplayName">
+        <source>Auto Insert Closing Tag</source>
+        <target state="new">Auto Insert Closing Tag</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_FormattingOnTypeDescription">
         <source>If true, formatting will be enabled while typing</source>
         <target state="translated">Если задано значение true, при вводе текста будет включено форматирование</target>
@@ -40,6 +50,11 @@
       <trans-unit id="Setting_FormattingOnTypeDisplayName">
         <source>Format On Type</source>
         <target state="translated">Форматировать по типу</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Typing">
+        <source>Typing</source>
+        <target state="new">Typing</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.tr.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.tr.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Razor Syntax Visualizer</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_AutoClosingTagsDescription">
+        <source>If true, closing tags will be automatically inserted</source>
+        <target state="new">If true, closing tags will be automatically inserted</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_AutoClosingTagsDisplayName">
+        <source>Auto Insert Closing Tag</source>
+        <target state="new">Auto Insert Closing Tag</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_FormattingOnTypeDescription">
         <source>If true, formatting will be enabled while typing</source>
         <target state="translated">True ise, yazma sırasında biçimlendirme etkinleştirilir</target>
@@ -40,6 +50,11 @@
       <trans-unit id="Setting_FormattingOnTypeDisplayName">
         <source>Format On Type</source>
         <target state="translated">Yazarken Biçimlendir</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Typing">
+        <source>Typing</source>
+        <target state="new">Typing</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.zh-Hans.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.zh-Hans.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Razor Syntax Visualizer</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_AutoClosingTagsDescription">
+        <source>If true, closing tags will be automatically inserted</source>
+        <target state="new">If true, closing tags will be automatically inserted</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_AutoClosingTagsDisplayName">
+        <source>Auto Insert Closing Tag</source>
+        <target state="new">Auto Insert Closing Tag</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_FormattingOnTypeDescription">
         <source>If true, formatting will be enabled while typing</source>
         <target state="translated">如果为 true，则在键入时将启用格式设置</target>
@@ -40,6 +50,11 @@
       <trans-unit id="Setting_FormattingOnTypeDisplayName">
         <source>Format On Type</source>
         <target state="translated">键入时格式设置</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Typing">
+        <source>Typing</source>
+        <target state="new">Typing</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.zh-Hant.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.zh-Hant.xlf
@@ -32,6 +32,16 @@
         <target state="translated">Razor Syntax Visualizer</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_AutoClosingTagsDescription">
+        <source>If true, closing tags will be automatically inserted</source>
+        <target state="new">If true, closing tags will be automatically inserted</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_AutoClosingTagsDisplayName">
+        <source>Auto Insert Closing Tag</source>
+        <target state="new">Auto Insert Closing Tag</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_FormattingOnTypeDescription">
         <source>If true, formatting will be enabled while typing</source>
         <target state="translated">如果為 True，則會在輸入時啟用格式化</target>
@@ -40,6 +50,11 @@
       <trans-unit id="Setting_FormattingOnTypeDisplayName">
         <source>Format On Type</source>
         <target state="translated">輸入時格式化</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Typing">
+        <source>Typing</source>
+        <target state="new">Typing</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorConfigurationServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorConfigurationServiceTest.cs
@@ -145,6 +145,127 @@ public class DefaultRazorConfigurationServiceTest : LanguageServerTestBase
     }
 
     [Fact]
+    public void BuildOptions_VSCodeOptionsOnly_ReturnsExpected()
+    {
+        // Arrange - purposely choosing options opposite of default
+        var expectedOptions = new RazorLSPOptions(
+            Trace.Verbose, EnableFormatting: false, AutoClosingTags: false, InsertSpaces: true, TabSize: 4, FormatOnType: true);
+        var razorJsonString = """
+            {
+              "trace": "Verbose",
+              "format": {
+                "enable": "false"
+              }
+            }
+
+            """;
+        var htmlJsonString = """
+            {
+              "format": "true",
+              "autoClosingTags": "false"
+            }
+
+            """;
+        var vsEditorJsonString = """
+            {
+            }
+            """;
+
+        // Act
+        var result = new JObject[] { JObject.Parse(razorJsonString), JObject.Parse(htmlJsonString), JObject.Parse(vsEditorJsonString) };
+        var languageServer = GetLanguageServer(result);
+        var configurationService = new DefaultRazorConfigurationService(languageServer, LoggerFactory);
+        var options = configurationService.BuildOptions(result);
+
+        // Assert
+        Assert.Equal(expectedOptions, options);
+    }
+
+    [Fact]
+    public void BuildOptions_VSOptionsOnly_ReturnsExpected()
+    {
+        // Arrange - purposely choosing options opposite of default
+        var expectedOptions = new RazorLSPOptions(
+            Trace.Off, EnableFormatting: true, AutoClosingTags: false, InsertSpaces: false, TabSize: 8, FormatOnType: false);
+        var razorJsonString = """
+            {
+            }
+
+            """;
+        var htmlJsonString = """
+            {
+            }
+
+            """;
+        var vsEditorJsonString = """
+            {
+                "ClientSpaceSettings": {
+                    "IndentSize": 8,
+                    "IndentWithTabs": "true"
+                },
+                "AdvancedSettings": {
+                    "FormatOnType": "false",
+                    "AutoClosingTags": "false"
+                }
+            }
+            """;
+
+        // Act
+        var result = new JObject[] { JObject.Parse(razorJsonString), JObject.Parse(htmlJsonString), JObject.Parse(vsEditorJsonString) };
+        var languageServer = GetLanguageServer(result);
+        var configurationService = new DefaultRazorConfigurationService(languageServer, LoggerFactory);
+        var options = configurationService.BuildOptions(result);
+
+        // Assert
+        Assert.Equal(expectedOptions, options);
+    }
+
+    [Fact]
+    public void BuildOptions_AllOptions_VSCodeOverridesVS()
+    {
+        // Arrange - purposely choosing options opposite of default
+        var expectedOptions = new RazorLSPOptions(
+            Trace.Verbose, EnableFormatting: false, AutoClosingTags: false, InsertSpaces: false, TabSize: 8, FormatOnType: false);
+        var razorJsonString = """
+            {
+              "trace": "Verbose",
+              "format": {
+                "enable": "false"
+              }
+            }
+
+            """;
+        var htmlJsonString = """
+            {
+              "format": "true",
+              "autoClosingTags": "false"
+            }
+
+            """;
+        var vsEditorJsonString = """
+            {
+                "ClientSpaceSettings": {
+                    "IndentSize": 8,
+                    "IndentWithTabs": "true"
+                },
+                "AdvancedSettings": {
+                    "FormatOnType": "false",
+                    "AutoClosingTags": "true"
+                }
+            }
+            """;
+
+        // Act
+        var result = new JObject[] { JObject.Parse(razorJsonString), JObject.Parse(htmlJsonString), JObject.Parse(vsEditorJsonString) };
+        var languageServer = GetLanguageServer(result);
+        var configurationService = new DefaultRazorConfigurationService(languageServer, LoggerFactory);
+        var options = configurationService.BuildOptions(result);
+
+        // Assert
+        Assert.Equal(expectedOptions, options);
+    }
+
+    [Fact]
     public void BuildOptions_MalformedOptions()
     {
         // This test is purely to ensure we don't crash if the user provides malformed options.

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorConfigurationServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorConfigurationServiceTest.cs
@@ -26,7 +26,7 @@ public class DefaultRazorConfigurationServiceTest : LanguageServerTestBase
     {
         // Arrange
         var expectedOptions = new RazorLSPOptions(
-            Trace.Messages, EnableFormatting: false, AutoClosingTags: false, InsertSpaces: true, TabSize: 8, FormatOnType: false);
+            Trace.Messages, EnableFormatting: false, AutoClosingTags: false, InsertSpaces: true, TabSize: 4, FormatOnType: true);
         var razorJsonString =
             """
 
@@ -50,13 +50,6 @@ public class DefaultRazorConfigurationServiceTest : LanguageServerTestBase
 
         var vsEditorJsonString = """
             {
-                "ClientSpaceSettings": {
-                    "IndentSize": 8,
-                    "IndentWithTabs": "false"
-                },
-                "AdvancedSettings": {
-                    "FormatOnType": "false"
-                }
             }
 
             """;
@@ -98,50 +91,6 @@ public class DefaultRazorConfigurationServiceTest : LanguageServerTestBase
 
         // Assert
         Assert.Null(options);
-    }
-
-    [Fact]
-    public void BuildOptions_ReturnsExpectedOptions()
-    {
-        // Arrange - purposely choosing options opposite of default
-        var expectedOptions = new RazorLSPOptions(
-            Trace.Verbose, EnableFormatting: false, AutoClosingTags: false, InsertSpaces: false, TabSize: 8, FormatOnType: false);
-        var razorJsonString = """
-            {
-              "trace": "Verbose",
-              "format": {
-                "enable": "false"
-              }
-            }
-
-            """;
-        var htmlJsonString = """
-            {
-              "format": "true",
-              "autoClosingTags": "false"
-            }
-
-            """;
-        var vsEditorJsonString = """
-            {
-                "ClientSpaceSettings": {
-                    "IndentSize": 8,
-                    "IndentWithTabs": "true"
-                },
-                "AdvancedSettings": {
-                    "FormatOnType": "false"
-                }
-            }
-            """;
-
-        // Act
-        var result = new JObject[] { JObject.Parse(razorJsonString), JObject.Parse(htmlJsonString), JObject.Parse(vsEditorJsonString) };
-        var languageServer = GetLanguageServer(result);
-        var configurationService = new DefaultRazorConfigurationService(languageServer, LoggerFactory);
-        var options = configurationService.BuildOptions(result);
-
-        // Assert
-        Assert.Equal(expectedOptions, options);
     }
 
     [Fact]
@@ -206,51 +155,6 @@ public class DefaultRazorConfigurationServiceTest : LanguageServerTestBase
                 "AdvancedSettings": {
                     "FormatOnType": "false",
                     "AutoClosingTags": "false"
-                }
-            }
-            """;
-
-        // Act
-        var result = new JObject[] { JObject.Parse(razorJsonString), JObject.Parse(htmlJsonString), JObject.Parse(vsEditorJsonString) };
-        var languageServer = GetLanguageServer(result);
-        var configurationService = new DefaultRazorConfigurationService(languageServer, LoggerFactory);
-        var options = configurationService.BuildOptions(result);
-
-        // Assert
-        Assert.Equal(expectedOptions, options);
-    }
-
-    [Fact]
-    public void BuildOptions_AllOptions_VSCodeOverridesVS()
-    {
-        // Arrange - purposely choosing options opposite of default
-        var expectedOptions = new RazorLSPOptions(
-            Trace.Verbose, EnableFormatting: false, AutoClosingTags: false, InsertSpaces: false, TabSize: 8, FormatOnType: false);
-        var razorJsonString = """
-            {
-              "trace": "Verbose",
-              "format": {
-                "enable": "false"
-              }
-            }
-
-            """;
-        var htmlJsonString = """
-            {
-              "format": "true",
-              "autoClosingTags": "false"
-            }
-
-            """;
-        var vsEditorJsonString = """
-            {
-                "ClientSpaceSettings": {
-                    "IndentSize": 8,
-                    "IndentWithTabs": "true"
-                },
-                "AdvancedSettings": {
-                    "FormatOnType": "false",
-                    "AutoClosingTags": "true"
                 }
             }
             """;

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/ClientSettingsManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/ClientSettingsManagerTest.cs
@@ -87,7 +87,7 @@ public class ClientSettingsManagerTest : ProjectSnapshotManagerDispatcherTestBas
         var manager = new ClientSettingsManager(_editorSettingsChangeTriggers);
         var called = false;
         manager.Changed += (caller, args) => called = true;
-        var settings = new ClientAdvancedSettings(FormatOnType: false);
+        var settings = new ClientAdvancedSettings(FormatOnType: false, AutoClosingTags: true);
 
         // Act
         manager.Update(settings);

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/EditorInProcess.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/EditorInProcess.cs
@@ -4,12 +4,14 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Razor.Editor;
+using Microsoft.VisualStudio.Editor.Razor;
 using Microsoft.VisualStudio.Language.Intellisense.AsyncCompletion;
 using Microsoft.VisualStudio.OLE.Interop;
+using Microsoft.VisualStudio.Razor.IntegrationTests.Extensions;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
-using Microsoft.VisualStudio.Razor.IntegrationTests.Extensions;
 
 namespace Microsoft.VisualStudio.Extensibility.Testing;
 
@@ -88,5 +90,12 @@ internal partial class EditorInProcess
             var latencyGuardOptionKey = new EditorOptionKey<bool>("EnableTypingLatencyGuard");
             options.SetOptionValue(latencyGuardOptionKey, false);
         }
+    }
+
+    public async Task SetAdvancedSettingsAsync(ClientAdvancedSettings clientAdvancedSettings, CancellationToken cancellationToken)
+    {
+        var clientSettingsManager = await GetComponentModelServiceAsync<IClientSettingsManager>(cancellationToken);
+
+        clientSettingsManager.Update(clientAdvancedSettings);
     }
 }


### PR DESCRIPTION
Part of https://github.com/dotnet/razor/issues/6212 and fixes #8499 

We already have all of the code for the option itself, we just were only reading it from VS Code's html settings area. This adds the setting to our Advanced settings page in VS, and reads it from there.