### PR TITLE
Brings back `GetRegistration` for `RazorCompletionResolveEndpoint`

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionResolveEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionResolveEndpoint.cs
@@ -11,7 +11,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion;
 
-internal class RazorCompletionResolveEndpoint : IVSCompletionResolveEndpoint, IOnInitialized
+internal class RazorCompletionResolveEndpoint : IVSCompletionResolveEndpoint, IRegistrationExtension
 {
     private readonly AggregateCompletionItemResolver _completionItemResolver;
     private readonly CompletionListCache _completionListCache;
@@ -27,11 +27,11 @@ internal class RazorCompletionResolveEndpoint : IVSCompletionResolveEndpoint, IO
 
     public bool MutatesSolutionState => false;
 
-    public Task OnInitializedAsync(VSInternalClientCapabilities clientCapabilities, CancellationToken cancellationToken)
+    public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
     {
         _clientCapabilities = clientCapabilities.ToVSInternalClientCapabilities();
 
-        return Task.CompletedTask;
+        return null;
     }
 
     public async Task<VSInternalCompletionItem> HandleRequestAsync(VSInternalCompletionItem completionItem, RazorRequestContext requestContext, CancellationToken cancellationToken)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
@@ -70,7 +70,7 @@ internal static class IServiceCollectionExtensions
         if (featureOptions.SingleServerCompletionSupport)
         {
             services.AddRegisteringHandler<RazorCompletionEndpoint>();
-            services.AddHandler<RazorCompletionResolveEndpoint>();
+            services.AddRegisteringHandler<RazorCompletionResolveEndpoint>();
         }
         else
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IRegistrationExtension.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IRegistrationExtension.cs
@@ -7,5 +7,5 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
 internal interface IRegistrationExtension
 {
-    RegistrationExtensionResult GetRegistration(VSInternalClientCapabilities clientCapabilities);
+    RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities);
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionResolveEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionResolveEndpointTest.cs
@@ -20,6 +20,7 @@ public class RazorCompletionResolveEndpointTest : LanguageServerTestBase
 {
     private readonly RazorCompletionResolveEndpoint _endpoint;
     private readonly CompletionListCache _completionListCache;
+    private readonly VSInternalClientCapabilities _clientCapabilities;
 
     public RazorCompletionResolveEndpointTest(ITestOutputHelper testOutput)
         : base(testOutput)
@@ -29,6 +30,20 @@ public class RazorCompletionResolveEndpointTest : LanguageServerTestBase
             new AggregateCompletionItemResolver(
                 new[] { new TestCompletionItemResolver() }, LoggerFactory),
             _completionListCache);
+        _clientCapabilities = new VSInternalClientCapabilities()
+        {
+            TextDocument = new TextDocumentClientCapabilities()
+            {
+                Completion = new VSInternalCompletionSetting()
+                {
+                    CompletionItem = new CompletionItemSetting()
+                    {
+                        DocumentationFormat = new[] { MarkupKind.Markdown },
+                    }
+                }
+            }
+        };
+        _endpoint.GetRegistration(_clientCapabilities);
     }
 
     [Fact]
@@ -78,7 +93,7 @@ public class RazorCompletionResolveEndpointTest : LanguageServerTestBase
         var resolvedItem = await _endpoint.HandleRequestAsync(parameters, requestContext, DisposalToken);
 
         // Assert
-        Assert.NotNull(resolvedItem.Documentation);
+        Assert.Equal("I was resolved using markdown", resolvedItem.Documentation.Value.First);
     }
 
     [Fact]
@@ -98,7 +113,7 @@ public class RazorCompletionResolveEndpointTest : LanguageServerTestBase
         var resolvedItem = await _endpoint.HandleRequestAsync(parameters, requestContext, DisposalToken);
 
         // Assert
-        Assert.NotNull(resolvedItem.Documentation);
+        Assert.Equal("I was resolved using markdown", resolvedItem.Documentation.Value.First);
     }
 
     [Fact]
@@ -127,7 +142,7 @@ public class RazorCompletionResolveEndpointTest : LanguageServerTestBase
         var resolvedItem = await _endpoint.HandleRequestAsync(parameters, requestContext, DisposalToken);
 
         // Assert
-        Assert.NotNull(resolvedItem.Documentation);
+        Assert.Equal("I was resolved using markdown", resolvedItem.Documentation.Value.First);
         Assert.Same(completion2Context, resolvedItem.Data);
     }
 
@@ -150,7 +165,9 @@ public class RazorCompletionResolveEndpointTest : LanguageServerTestBase
             VSInternalClientCapabilities clientCapabilities,
             CancellationToken cancellationToken)
         {
-            item.Documentation = "I was resolved";
+            var completionSupportedKinds = clientCapabilities?.TextDocument?.Completion?.CompletionItem?.DocumentationFormat;
+            var documentationKind = completionSupportedKinds?.Contains(MarkupKind.Markdown) == true ? MarkupKind.Markdown : MarkupKind.PlainText;
+            item.Documentation = "I was resolved using " + documentationKind.Value;
             item.Data = originalRequestContext;
             return Task.FromResult(item);
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionResolveEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionResolveEndpointTest.cs
@@ -31,11 +31,6 @@ public class RazorCompletionResolveEndpointTest : LanguageServerTestBase
             _completionListCache);
     }
 
-    protected override Task InitializeAsync()
-    {
-        return _endpoint.OnInitializedAsync(new VSInternalClientCapabilities(), DisposalToken);
-    }
-
     [Fact]
     public async Task Handle_UncachedCompletionItem_NoChange()
     {


### PR DESCRIPTION
The code got regressed alongside some of the CLaSP code changes.
Client capabilities was not being initialized for `RazorCompletionResolveEndpoint.cs` anymore therefore the intellisense was showing up as default plain rather than being markdown showing full type name and colored

#### Before fix:

![image](https://user-images.githubusercontent.com/5897654/227314207-1be63ebb-2726-4f17-98ef-a70a4197d429.png)

#### After fix:

![image](https://user-images.githubusercontent.com/5897654/227313225-cf2cd7cf-25ff-4c03-92be-0172faac5879.png)

Fixes #8488
