### PR TITLE
Switch back to `IRegistrationExtension` from `IOnInitialized`

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LegacyRazorCompletionResolveEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LegacyRazorCompletionResolveEndpoint.cs
@@ -21,7 +21,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion;
 // The intention of this class is to temporarily exist as a snapshot in time for our pre-existing completion experience.
 // It will eventually be removed in favor of the non-Legacy variant at which point we'll also remove the feature flag
 // for this legacy version.
-internal class LegacyRazorCompletionResolveEndpoint : IVSCompletionResolveEndpoint, IOnInitialized
+internal class LegacyRazorCompletionResolveEndpoint : IVSCompletionResolveEndpoint, IRegistrationExtension
 {
     private readonly ILogger _logger;
     private readonly LSPTagHelperTooltipFactory _lspTagHelperTooltipFactory;
@@ -68,7 +68,7 @@ internal class LegacyRazorCompletionResolveEndpoint : IVSCompletionResolveEndpoi
         _completionListCache = completionListCache;
     }
 
-    public Task OnInitializedAsync(VSInternalClientCapabilities clientCapabilities, CancellationToken cancellationToken)
+    public RegistrationExtensionResult? GetRegistration(VSInternalClientCapabilities clientCapabilities)
     {
         _completionCapability = clientCapabilities.TextDocument?.Completion as VSInternalCompletionSetting;
         _clientCapabilities = clientCapabilities;
@@ -76,7 +76,7 @@ internal class LegacyRazorCompletionResolveEndpoint : IVSCompletionResolveEndpoi
         var completionSupportedKinds = clientCapabilities.TextDocument?.Completion?.CompletionItem?.DocumentationFormat;
         _documentationKind = completionSupportedKinds?.Contains(MarkupKind.Markdown) == true ? MarkupKind.Markdown : MarkupKind.PlainText;
 
-        return Task.CompletedTask;
+        return null;
     }
 
     public Task<VSInternalCompletionItem> HandleRequestAsync(VSInternalCompletionItem completionItem, RazorRequestContext requestContext, CancellationToken cancellationToken)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
@@ -75,7 +75,7 @@ internal static class IServiceCollectionExtensions
         else
         {
             services.AddRegisteringHandler<LegacyRazorCompletionEndpoint>();
-            services.AddHandler<LegacyRazorCompletionResolveEndpoint>();
+            services.AddRegisteringHandler<LegacyRazorCompletionResolveEndpoint>();
         }
 
         services.AddSingleton<CompletionListCache>();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/LegacyRazorCompletionResolveEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/LegacyRazorCompletionResolveEndpointTest.cs
@@ -66,7 +66,7 @@ public class LegacyRazorCompletionResolveEndpointTest : LanguageServerTestBase
     {
         // Arrange
         var endpoint = new LegacyRazorCompletionResolveEndpoint(_lspTagHelperTooltipFactory, _vsLspTagHelperTooltipFactory, _completionListCache, LoggerFactory);
-        await endpoint.OnInitializedAsync(_defaultClientCapability, DisposalToken);
+        endpoint.GetRegistration(_defaultClientCapability);
         var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.Directive);
         razorCompletionItem.SetDirectiveCompletionDescription(new DirectiveCompletionDescription("Test directive"));
         var completionList = CreateLSPCompletionList(new[] { razorCompletionItem });
@@ -86,7 +86,7 @@ public class LegacyRazorCompletionResolveEndpointTest : LanguageServerTestBase
     {
         // Arrange
         var endpoint = new LegacyRazorCompletionResolveEndpoint(_lspTagHelperTooltipFactory, _vsLspTagHelperTooltipFactory, _completionListCache, LoggerFactory);
-        await endpoint.OnInitializedAsync(_defaultClientCapability, DisposalToken);
+        endpoint.GetRegistration(_defaultClientCapability);
         var razorCompletionItem = new RazorCompletionItem("@...", "@", RazorCompletionItemKind.MarkupTransition);
         razorCompletionItem.SetMarkupTransitionCompletionDescription(new MarkupTransitionCompletionDescription("Test description"));
         var completionList = CreateLSPCompletionList(new[] { razorCompletionItem });
@@ -114,7 +114,7 @@ public class LegacyRazorCompletionResolveEndpointTest : LanguageServerTestBase
         lspDescriptionFactory.Setup(factory => factory.TryCreateTooltip(It.IsAny<AggregateBoundAttributeDescription>(), MarkupKind.Markdown, out markdown))
             .Returns(true);
         var endpoint = new LegacyRazorCompletionResolveEndpoint(lspDescriptionFactory.Object, _vsLspTagHelperTooltipFactory, _completionListCache, LoggerFactory);
-        await endpoint.OnInitializedAsync(_defaultClientCapability, DisposalToken);
+        endpoint.GetRegistration(_defaultClientCapability);
         var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.DirectiveAttribute);
         razorCompletionItem.SetAttributeCompletionDescription(new AggregateBoundAttributeDescription(Array.Empty<BoundAttributeDescriptionInfo>()));
         var completionList = CreateLSPCompletionList(new[] { razorCompletionItem });
@@ -142,7 +142,7 @@ public class LegacyRazorCompletionResolveEndpointTest : LanguageServerTestBase
         descriptionFactory.Setup(factory => factory.TryCreateTooltip(It.IsAny<AggregateBoundAttributeDescription>(), MarkupKind.Markdown, out markdown))
             .Returns(true);
         var endpoint = new LegacyRazorCompletionResolveEndpoint(descriptionFactory.Object, _vsLspTagHelperTooltipFactory, _completionListCache, LoggerFactory);
-        await endpoint.OnInitializedAsync(_defaultClientCapability, DisposalToken);
+        endpoint.GetRegistration(_defaultClientCapability);
         var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.DirectiveAttributeParameter);
         razorCompletionItem.SetAttributeCompletionDescription(new AggregateBoundAttributeDescription(Array.Empty<BoundAttributeDescriptionInfo>()));
         var completionList = CreateLSPCompletionList(new[] { razorCompletionItem });
@@ -170,7 +170,7 @@ public class LegacyRazorCompletionResolveEndpointTest : LanguageServerTestBase
         lspDescriptionFactory.Setup(factory => factory.TryCreateTooltip(It.IsAny<AggregateBoundElementDescription>(), MarkupKind.Markdown, out markdown))
             .Returns(true);
         var endpoint = new LegacyRazorCompletionResolveEndpoint(lspDescriptionFactory.Object, _vsLspTagHelperTooltipFactory, _completionListCache, LoggerFactory);
-        await endpoint.OnInitializedAsync(_defaultClientCapability, DisposalToken);
+        endpoint.GetRegistration(_defaultClientCapability);
         var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.TagHelperElement);
         razorCompletionItem.SetTagHelperElementDescriptionInfo(new AggregateBoundElementDescription(Array.Empty<BoundElementDescriptionInfo>()));
         var completionList = CreateLSPCompletionList(new[] { razorCompletionItem });
@@ -198,7 +198,7 @@ public class LegacyRazorCompletionResolveEndpointTest : LanguageServerTestBase
         lspDescriptionFactory.Setup(factory => factory.TryCreateTooltip(It.IsAny<AggregateBoundAttributeDescription>(), MarkupKind.Markdown, out markdown))
             .Returns(true);
         var endpoint = new LegacyRazorCompletionResolveEndpoint(lspDescriptionFactory.Object, _vsLspTagHelperTooltipFactory, _completionListCache, LoggerFactory);
-        await endpoint.OnInitializedAsync(_defaultClientCapability, DisposalToken);
+        endpoint.GetRegistration(_defaultClientCapability);
         var razorCompletionItem = new RazorCompletionItem("TestItem", "TestItem", RazorCompletionItemKind.TagHelperAttribute);
         razorCompletionItem.SetAttributeCompletionDescription(new AggregateBoundAttributeDescription(Array.Empty<BoundAttributeDescriptionInfo>()));
         var completionList = CreateLSPCompletionList(new[] { razorCompletionItem });
@@ -226,7 +226,7 @@ public class LegacyRazorCompletionResolveEndpointTest : LanguageServerTestBase
         lspDescriptionFactory.Setup(factory => factory.TryCreateTooltip(It.IsAny<AggregateBoundElementDescription>(), MarkupKind.Markdown, out markdown))
             .Returns(true);
         var endpoint = new LegacyRazorCompletionResolveEndpoint(_lspTagHelperTooltipFactory, _vsLspTagHelperTooltipFactory, _completionListCache, LoggerFactory);
-        await endpoint.OnInitializedAsync(_defaultClientCapability, DisposalToken);
+        endpoint.GetRegistration(_defaultClientCapability);
         var completionItem = new CompletionItem();
         var parameters = ConvertToBridgedItem(completionItem);
         var requestContext = CreateRazorRequestContext(documentContext: null);


### PR DESCRIPTION
- Switch back to `IRegistrationExtension` from `IOnInitialized` due to regression

Related to: #8488 and https://github.com/dotnet/razor/pull/8503
