### PR TITLE
Improve memory used by tag helper descriptors

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/AllowedChildTagDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/AllowedChildTagDescriptor.cs
@@ -30,8 +30,9 @@ public abstract class AllowedChildTagDescriptor : IEquatable<AllowedChildTagDesc
                 TagHelperDiagnostics.AddDiagnostics(this, value);
                 _containsDiagnostics = true;
             }
-            else
+            else if (_containsDiagnostics)
             {
+                TagHelperDiagnostics.RemoveDiagnostics(this);
                 _containsDiagnostics = false;
             }
         }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/AllowedChildTagDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/AllowedChildTagDescriptor.cs
@@ -11,16 +11,41 @@ namespace Microsoft.AspNetCore.Razor.Language;
 
 public abstract class AllowedChildTagDescriptor : IEquatable<AllowedChildTagDescriptor>
 {
+    private bool _containsDiagnostics;
+
     public string Name { get; protected set; }
 
     public string DisplayName { get; protected set; }
 
-    public IReadOnlyList<RazorDiagnostic> Diagnostics { get; protected set; }
+    public IReadOnlyList<RazorDiagnostic> Diagnostics
+    {
+        get => _containsDiagnostics
+            ? TagHelperDiagnostics.GetDiagnostics(this)
+            : Array.Empty<RazorDiagnostic>();
+
+        protected set
+        {
+            if (value?.Count > 0)
+            {
+                TagHelperDiagnostics.AddDiagnostics(this, value);
+                _containsDiagnostics = true;
+            }
+            else
+            {
+                _containsDiagnostics = false;
+            }
+        }
+    }
 
     public bool HasErrors
     {
         get
         {
+            if (!_containsDiagnostics)
+            {
+                return false;
+            }
+
             var errors = Diagnostics.Any(diagnostic => diagnostic.Severity == RazorDiagnosticSeverity.Error);
 
             return errors;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/AllowedChildTagDescriptorComparer.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/AllowedChildTagDescriptorComparer.cs
@@ -12,8 +12,7 @@ internal sealed class AllowedChildTagDescriptorComparer : IEqualityComparer<Allo
     /// <summary>
     /// A default instance of the <see cref="AllowedChildTagDescriptorComparer"/>.
     /// </summary>
-    public static readonly AllowedChildTagDescriptorComparer Default =
-        new AllowedChildTagDescriptorComparer();
+    public static readonly AllowedChildTagDescriptorComparer Default = new();
 
     private AllowedChildTagDescriptorComparer()
     {
@@ -24,7 +23,7 @@ internal sealed class AllowedChildTagDescriptorComparer : IEqualityComparer<Allo
         AllowedChildTagDescriptor? descriptorX,
         AllowedChildTagDescriptor? descriptorY)
     {
-        if (object.ReferenceEquals(descriptorX, descriptorY))
+        if (ReferenceEquals(descriptorX, descriptorY))
         {
             return true;
         }
@@ -38,9 +37,8 @@ internal sealed class AllowedChildTagDescriptorComparer : IEqualityComparer<Allo
             return false;
         }
 
-        return
-            string.Equals(descriptorX.Name, descriptorY.Name, StringComparison.Ordinal) &&
-            string.Equals(descriptorX.DisplayName, descriptorY.DisplayName, StringComparison.Ordinal);
+        return descriptorX.Name == descriptorY.Name &&
+               descriptorX.DisplayName == descriptorY.DisplayName;
     }
 
     /// <inheritdoc />

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeDescriptorComparer.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeDescriptorComparer.cs
@@ -12,7 +12,7 @@ internal sealed class BoundAttributeDescriptorComparer : IEqualityComparer<Bound
     /// <summary>
     /// A default instance of the <see cref="BoundAttributeDescriptorComparer"/>.
     /// </summary>
-    public static readonly BoundAttributeDescriptorComparer Default = new BoundAttributeDescriptorComparer();
+    public static readonly BoundAttributeDescriptorComparer Default = new();
 
     private BoundAttributeDescriptorComparer()
     {
@@ -34,21 +34,35 @@ internal sealed class BoundAttributeDescriptorComparer : IEqualityComparer<Bound
             return false;
         }
 
-        return
-            string.Equals(descriptorX.Kind, descriptorY.Kind, StringComparison.Ordinal) &&
-            descriptorX.IsIndexerStringProperty == descriptorY.IsIndexerStringProperty &&
-            descriptorX.IsEnum == descriptorY.IsEnum &&
-            descriptorX.HasIndexer == descriptorY.HasIndexer &&
-            descriptorX.CaseSensitive == descriptorY.CaseSensitive &&
-            descriptorX.IsEditorRequired == descriptorY.IsEditorRequired &&
-            string.Equals(descriptorX.Name, descriptorY.Name, StringComparison.Ordinal) &&
-            string.Equals(descriptorX.IndexerNamePrefix, descriptorY.IndexerNamePrefix, StringComparison.Ordinal) &&
-            string.Equals(descriptorX.TypeName, descriptorY.TypeName, StringComparison.Ordinal) &&
-            string.Equals(descriptorX.IndexerTypeName, descriptorY.IndexerTypeName, StringComparison.Ordinal) &&
-            string.Equals(descriptorX.Documentation, descriptorY.Documentation, StringComparison.Ordinal) &&
-            string.Equals(descriptorX.DisplayName, descriptorY.DisplayName, StringComparison.Ordinal) &&
-            ComparerUtilities.Equals(descriptorX.BoundAttributeParameters, descriptorY.BoundAttributeParameters, BoundAttributeParameterDescriptorComparer.Default) &&
-            ComparerUtilities.Equals(descriptorX.Metadata, descriptorY.Metadata, StringComparer.Ordinal);
+        if (descriptorX.Kind != descriptorY.Kind ||
+            descriptorX.IsIndexerStringProperty != descriptorY.IsIndexerStringProperty ||
+            descriptorX.IsEnum != descriptorY.IsEnum ||
+            descriptorX.HasIndexer != descriptorY.HasIndexer ||
+            descriptorX.CaseSensitive != descriptorY.CaseSensitive ||
+            descriptorX.IsEditorRequired != descriptorY.IsEditorRequired ||
+            descriptorX.Name != descriptorY.Name ||
+            descriptorX.IndexerNamePrefix != descriptorY.IndexerNamePrefix ||
+            descriptorX.TypeName != descriptorY.TypeName ||
+            descriptorX.IndexerTypeName != descriptorY.IndexerTypeName ||
+            descriptorX.Documentation != descriptorY.Documentation ||
+            descriptorX.DisplayName != descriptorY.DisplayName)
+        {
+            return false;
+        }
+
+        if (!ComparerUtilities.Equals(descriptorX.BoundAttributeParameters, descriptorY.BoundAttributeParameters, BoundAttributeParameterDescriptorComparer.Default))
+        {
+            return false;
+        }
+
+        if (descriptorX.Metadata is MetadataCollection metadataX &&
+            descriptorY.Metadata is MetadataCollection metadataY &&
+            !metadataX.Equals(metadataY))
+        {
+            return false;
+        }
+
+        return ComparerUtilities.Equals(descriptorX.Metadata, descriptorY.Metadata, StringComparer.Ordinal);
     }
 
     public int GetHashCode(BoundAttributeDescriptor? descriptor)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeParameterDescriptorComparer.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeParameterDescriptorComparer.cs
@@ -12,7 +12,7 @@ internal sealed class BoundAttributeParameterDescriptorComparer : IEqualityCompa
     /// <summary>
     /// A default instance of the <see cref="BoundAttributeParameterDescriptorComparer"/>.
     /// </summary>
-    public static readonly BoundAttributeParameterDescriptorComparer Default = new BoundAttributeParameterDescriptorComparer();
+    public static readonly BoundAttributeParameterDescriptorComparer Default = new();
 
     private BoundAttributeParameterDescriptorComparer()
     {
@@ -34,14 +34,24 @@ internal sealed class BoundAttributeParameterDescriptorComparer : IEqualityCompa
             return false;
         }
 
-        return
-            string.Equals(descriptorX.Kind, descriptorY.Kind, StringComparison.Ordinal) &&
-            descriptorX.IsEnum == descriptorY.IsEnum &&
-            string.Equals(descriptorX.Name, descriptorY.Name, StringComparison.Ordinal) &&
-            string.Equals(descriptorX.TypeName, descriptorY.TypeName, StringComparison.Ordinal) &&
-            string.Equals(descriptorX.Documentation, descriptorY.Documentation, StringComparison.Ordinal) &&
-            string.Equals(descriptorX.DisplayName, descriptorY.DisplayName, StringComparison.Ordinal) &&
-            ComparerUtilities.Equals(descriptorX.Metadata, descriptorY.Metadata, StringComparer.Ordinal);
+        if (descriptorX.Kind != descriptorY.Kind ||
+            descriptorX.IsEnum != descriptorY.IsEnum ||
+            descriptorX.Name != descriptorY.Name ||
+            descriptorX.TypeName != descriptorY.TypeName ||
+            descriptorX.Documentation != descriptorY.Documentation ||
+            descriptorX.DisplayName != descriptorY.DisplayName)
+        {
+            return false;
+        }
+
+        if (descriptorX.Metadata is MetadataCollection metadataX &&
+            descriptorY.Metadata is MetadataCollection metadataY &&
+            !metadataX.Equals(metadataY))
+        {
+            return false;
+        }
+
+        return ComparerUtilities.Equals(descriptorX.Metadata, descriptorY.Metadata, StringComparer.Ordinal);
     }
 
     public int GetHashCode(BoundAttributeParameterDescriptor? descriptor)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptor.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Immutable;
-
 namespace Microsoft.AspNetCore.Razor.Language;
 
 internal sealed class DefaultBoundAttributeDescriptor : BoundAttributeDescriptor
@@ -19,7 +17,7 @@ internal sealed class DefaultBoundAttributeDescriptor : BoundAttributeDescriptor
         string? displayName,
         bool caseSensitive,
         BoundAttributeParameterDescriptor[] parameterDescriptors,
-        ImmutableDictionary<string, string> metadata,
+        MetadataCollection metadata,
         RazorDiagnostic[] diagnostics)
         : base(kind)
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptorBuilder.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.Extensions.ObjectPool;
@@ -38,17 +37,14 @@ internal class DefaultBoundAttributeDescriptorBuilder : BoundAttributeDescriptor
 
     private readonly DefaultTagHelperDescriptorBuilder _parent;
     private readonly string _kind;
-    private readonly ImmutableDictionary<string, string>.Builder _metadata;
     private List<DefaultBoundAttributeParameterDescriptorBuilder>? _attributeParameterBuilders;
-
+    private Dictionary<string, string>? _metadata;
     private RazorDiagnosticCollection? _diagnostics;
 
     public DefaultBoundAttributeDescriptorBuilder(DefaultTagHelperDescriptorBuilder parent, string kind)
     {
         _parent = parent;
         _kind = kind;
-
-        _metadata = ImmutableDictionary.CreateBuilder<string, string>();
     }
 
     public override string? Name { get; set; }
@@ -67,7 +63,7 @@ internal class DefaultBoundAttributeDescriptorBuilder : BoundAttributeDescriptor
 
     public override string? DisplayName { get; set; }
 
-    public override IDictionary<string, string> Metadata => _metadata;
+    public override IDictionary<string, string> Metadata => _metadata ??= new Dictionary<string, string>();
 
     public override RazorDiagnosticCollection Diagnostics => _diagnostics ??= new RazorDiagnosticCollection();
 
@@ -110,7 +106,7 @@ internal class DefaultBoundAttributeDescriptorBuilder : BoundAttributeDescriptor
                 GetDisplayName(),
                 CaseSensitive,
                 parameters,
-                _metadata.ToImmutable(),
+                MetadataCollection.CreateOrEmpty(_metadata),
                 diagnostics.ToArray())
             {
                 IsEditorRequired = IsEditorRequired,

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeParameterDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeParameterDescriptor.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Immutable;
-
 namespace Microsoft.AspNetCore.Razor.Language;
 
 internal class DefaultBoundAttributeParameterDescriptor : BoundAttributeParameterDescriptor
@@ -15,7 +13,7 @@ internal class DefaultBoundAttributeParameterDescriptor : BoundAttributeParamete
         string? documentation,
         string? displayName,
         bool caseSensitive,
-        ImmutableDictionary<string, string> metadata,
+        MetadataCollection metadata,
         RazorDiagnostic[] diagnostics)
         : base(kind)
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeParameterDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeParameterDescriptorBuilder.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 
 namespace Microsoft.AspNetCore.Razor.Language;
@@ -12,7 +11,7 @@ internal class DefaultBoundAttributeParameterDescriptorBuilder : BoundAttributeP
 {
     private readonly DefaultBoundAttributeDescriptorBuilder _parent;
     private readonly string _kind;
-    private readonly ImmutableDictionary<string, string>.Builder _metadata;
+    private Dictionary<string, string>? _metadata;
 
     private RazorDiagnosticCollection? _diagnostics;
 
@@ -20,8 +19,6 @@ internal class DefaultBoundAttributeParameterDescriptorBuilder : BoundAttributeP
     {
         _parent = parent;
         _kind = kind;
-
-        _metadata = ImmutableDictionary.CreateBuilder<string, string>();
     }
 
     public override string? Name { get; set; }
@@ -34,7 +31,7 @@ internal class DefaultBoundAttributeParameterDescriptorBuilder : BoundAttributeP
 
     public override string? DisplayName { get; set; }
 
-    public override IDictionary<string, string> Metadata => _metadata;
+    public override IDictionary<string, string> Metadata => _metadata ??= new Dictionary<string, string>();
 
     public override RazorDiagnosticCollection Diagnostics => _diagnostics ??= new RazorDiagnosticCollection();
 
@@ -57,7 +54,7 @@ internal class DefaultBoundAttributeParameterDescriptorBuilder : BoundAttributeP
                 Documentation,
                 GetDisplayName(),
                 CaseSensitive,
-                _metadata.ToImmutable(),
+                MetadataCollection.CreateOrEmpty(_metadata),
                 diagnostics.ToArray());
 
             return descriptor;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRequiredAttributeDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRequiredAttributeDescriptor.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Immutable;
-
 namespace Microsoft.AspNetCore.Razor.Language;
 
 internal class DefaultRequiredAttributeDescriptor : RequiredAttributeDescriptor
@@ -15,7 +13,7 @@ internal class DefaultRequiredAttributeDescriptor : RequiredAttributeDescriptor
         ValueComparisonMode valueComparison,
         string displayName,
         RazorDiagnostic[] diagnostics,
-        ImmutableDictionary<string, string> metadata)
+        MetadataCollection metadata)
     {
         Name = name;
         NameComparison = nameComparison;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRequiredAttributeDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRequiredAttributeDescriptorBuilder.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 
 namespace Microsoft.AspNetCore.Razor.Language;
@@ -12,12 +11,11 @@ internal class DefaultRequiredAttributeDescriptorBuilder : RequiredAttributeDesc
 {
     private readonly DefaultTagMatchingRuleDescriptorBuilder _parent;
     private RazorDiagnosticCollection? _diagnostics;
-    private readonly ImmutableDictionary<string, string>.Builder _metadata;
+    private Dictionary<string, string>? _metadata;
 
     public DefaultRequiredAttributeDescriptorBuilder(DefaultTagMatchingRuleDescriptorBuilder parent)
     {
         _parent = parent;
-        _metadata = ImmutableDictionary.CreateBuilder<string, string>();
     }
 
     public override string? Name { get; set; }
@@ -30,7 +28,7 @@ internal class DefaultRequiredAttributeDescriptorBuilder : RequiredAttributeDesc
 
     public override RazorDiagnosticCollection Diagnostics => _diagnostics ??= new RazorDiagnosticCollection();
 
-    public override IDictionary<string, string> Metadata => _metadata;
+    public override IDictionary<string, string> Metadata => _metadata ??= new Dictionary<string, string>();
 
     internal bool CaseSensitive => _parent.CaseSensitive;
 
@@ -53,7 +51,7 @@ internal class DefaultRequiredAttributeDescriptorBuilder : RequiredAttributeDesc
                 ValueComparisonMode,
                 displayName,
                 diagnostics.ToArray(),
-                _metadata.ToImmutable());
+                MetadataCollection.CreateOrEmpty(_metadata));
 
             return descriptor;
         }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptor.cs
@@ -18,7 +18,7 @@ internal class DefaultTagHelperDescriptor : TagHelperDescriptor
         TagMatchingRuleDescriptor[] tagMatchingRules,
         BoundAttributeDescriptor[] attributeDescriptors,
         AllowedChildTagDescriptor[] allowedChildTags,
-        ImmutableDictionary<string, string> metadata,
+        MetadataCollection metadata,
         RazorDiagnostic[] diagnostics)
         : base(kind)
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.Extensions.ObjectPool;
@@ -21,13 +20,11 @@ internal class DefaultTagHelperDescriptorBuilder : TagHelperDescriptorBuilder, I
     private static readonly ObjectPool<HashSet<TagMatchingRuleDescriptor>> s_tagMatchingRuleSetPool
         = HashSetPool<TagMatchingRuleDescriptor>.Create(TagMatchingRuleDescriptorComparer.Default);
 
-    // Required values
-    private readonly ImmutableDictionary<string, string>.Builder _metadata;
-
     private List<DefaultAllowedChildTagDescriptorBuilder>? _allowedChildTags;
     private List<DefaultBoundAttributeDescriptorBuilder>? _attributeBuilders;
     private List<DefaultTagMatchingRuleDescriptorBuilder>? _tagMatchingRuleBuilders;
     private RazorDiagnosticCollection? _diagnostics;
+    private readonly Dictionary<string, string> _metadata;
 
     public DefaultTagHelperDescriptorBuilder(string kind, string name, string assemblyName)
     {
@@ -35,11 +32,12 @@ internal class DefaultTagHelperDescriptorBuilder : TagHelperDescriptorBuilder, I
         Name = name;
         AssemblyName = assemblyName;
 
-        _metadata = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.Ordinal);
-
-        // Tells code generation that these tag helpers are compatible with ITagHelper.
-        // For now that's all we support.
-        _metadata.Add(TagHelperMetadata.Runtime.Name, TagHelperConventions.DefaultKind);
+        _metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            // Tells code generation that these tag helpers are compatible with ITagHelper.
+            // For now that's all we support.
+            { TagHelperMetadata.Runtime.Name, TagHelperConventions.DefaultKind }
+        };
     }
 
     public override string Name { get; }
@@ -153,7 +151,7 @@ internal class DefaultTagHelperDescriptorBuilder : TagHelperDescriptorBuilder, I
             tagMatchingRules,
             attributes,
             allowedChildTags,
-            _metadata.ToImmutable(),
+            MetadataCollection.Create(_metadata),
             diagnostics.ToArray());
 
         return descriptor;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/MetadataCollection.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/MetadataCollection.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Internal;
 namespace Microsoft.AspNetCore.Razor.Language;
 
 /// <summary>
-///  Generally, there are only a handful of metadata data items stored on the various tag helper
+///  Generally, there are only a handful of metadata items stored on the various tag helper
 ///  objects. Often, it's just one or two items. To improve memory usage, MetadataCollection provides
 ///  multiple implementations to avoid creating a hash table.
 /// </summary>
@@ -670,6 +670,11 @@ internal abstract class MetadataCollection : IReadOnlyDictionary<string, string>
             }
 
             if (other is not FourOrMoreItems)
+            {
+                return false;
+            }
+
+            if (_count != other.Count)
             {
                 return false;
             }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/MetadataCollection.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/MetadataCollection.cs
@@ -490,7 +490,7 @@ internal abstract class MetadataCollection : IReadOnlyDictionary<string, string>
                 // Add the second item
                 if (!key1Added && (key1LessThanKey2 || key1LessThanKey3))
                 {
-                    // If we haven't added key1 and it is less that key2 or key3, it must be second.
+                    // If we haven't added key1 and it is less than key2 or key3, it must be second.
                     hash.Add(_key1, StringComparer.Ordinal);
                     hash.Add(_value1, StringComparer.Ordinal);
                     key1Added = true;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/MetadataCollection.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/MetadataCollection.cs
@@ -1,0 +1,604 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Razor.PooledObjects;
+using Microsoft.Extensions.Internal;
+
+namespace Microsoft.AspNetCore.Razor.Language;
+
+/// <summary>
+///  Generally, there are only a handful of metadata data items stored on the various tag helper
+///  objects. Often, it's just one or two items. To improve memory usage, MetadataCollection provides
+///  multiple implementations to avoid creating a hash table.
+/// </summary>
+internal abstract class MetadataCollection : IReadOnlyDictionary<string, string>, IEquatable<MetadataCollection>
+{
+    public static readonly MetadataCollection Empty = NoItems.Instance;
+
+    private int? _hashCode;
+
+    protected MetadataCollection()
+    {
+    }
+
+    public abstract string this[string key] { get; }
+
+    public abstract IEnumerable<string> Keys { get; }
+    public abstract IEnumerable<string> Values { get; }
+    public abstract int Count { get; }
+
+    public abstract bool ContainsKey(string key);
+    public abstract IEnumerator<KeyValuePair<string, string>> GetEnumerator();
+    public abstract bool TryGetValue(string key, out string value);
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public sealed override bool Equals(object obj)
+        => obj is MetadataCollection other && Equals(other);
+
+    public abstract bool Equals(MetadataCollection other);
+
+    protected abstract int ComputeHashCode();
+
+    public sealed override int GetHashCode() => _hashCode ??= ComputeHashCode();
+
+    public static MetadataCollection Create(KeyValuePair<string, string> pair)
+        => new OneToThreeItems(pair.Key, pair.Value);
+
+    public static MetadataCollection Create(params KeyValuePair<string, string>[] pairs)
+    {
+        switch (pairs.Length)
+        {
+            case 0:
+                return Empty;
+
+            case 1:
+                {
+                    var pair = pairs[0];
+
+                    return new OneToThreeItems(pair.Key, pair.Value);
+                }
+
+            case 2:
+                {
+                    var pair1 = pairs[0];
+                    var pair2 = pairs[1];
+
+                    return new OneToThreeItems(pair1.Key, pair1.Value, pair2.Key, pair2.Value);
+                }
+
+            case 3:
+                {
+                    var pair1 = pairs[0];
+                    var pair2 = pairs[1];
+                    var pair3 = pairs[2];
+
+                    return new OneToThreeItems(pair1.Key, pair1.Value, pair2.Key, pair2.Value, pair3.Key, pair3.Value);
+                }
+
+            default:
+                return new FourOrMoreItems(pairs);
+        }
+    }
+
+    public static MetadataCollection Create(IReadOnlyDictionary<string, string> map)
+    {
+        switch (map.Count)
+        {
+            case 0:
+                return Empty;
+
+            case 1:
+                {
+                    using var enumerable = map.GetEnumerator();
+
+                    if (!enumerable.MoveNext())
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    var pair = enumerable.Current;
+
+                    return new OneToThreeItems(pair.Key, pair.Value);
+                }
+
+            case 2:
+                {
+                    using var enumerable = map.GetEnumerator();
+
+                    if (!enumerable.MoveNext())
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    var pair1 = enumerable.Current;
+
+
+                    if (!enumerable.MoveNext())
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    var pair2 = enumerable.Current;
+
+                    return new OneToThreeItems(pair1.Key, pair1.Value, pair2.Key, pair2.Value);
+                }
+
+            case 3:
+                {
+                    using var enumerable = map.GetEnumerator();
+
+                    if (!enumerable.MoveNext())
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    var pair1 = enumerable.Current;
+
+                    if (!enumerable.MoveNext())
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    var pair2 = enumerable.Current;
+
+                    if (!enumerable.MoveNext())
+                    {
+                        throw new InvalidOperationException();
+                    }
+
+                    var pair3 = enumerable.Current;
+
+                    return new OneToThreeItems(pair1.Key, pair1.Value, pair2.Key, pair2.Value, pair3.Key, pair3.Value);
+                }
+
+            default:
+                return new FourOrMoreItems(map);
+        }
+
+    }
+
+    public static MetadataCollection CreateOrEmpty(IReadOnlyDictionary<string, string>? map)
+        => map is not null
+            ? MetadataCollection.Create(map)
+            : MetadataCollection.Empty;
+
+    private class NoItems : MetadataCollection
+    {
+        public static readonly NoItems Instance = new();
+
+        private static readonly IEnumerable<KeyValuePair<string, string>> s_pairs = Array.Empty<KeyValuePair<string, string>>();
+
+        private NoItems()
+        {
+        }
+
+        public override string this[string key] => throw new KeyNotFoundException();
+
+        public override IEnumerable<string> Keys => Array.Empty<string>();
+        public override IEnumerable<string> Values => Array.Empty<string>();
+        public override int Count => 0;
+
+        public override bool ContainsKey(string key) => false;
+
+        public override IEnumerator<KeyValuePair<string, string>> GetEnumerator()
+            => s_pairs.GetEnumerator();
+
+        public override bool TryGetValue(string key, out string value)
+        {
+            value = null!;
+            return false;
+        }
+
+        protected override int ComputeHashCode() => 0;
+        public override bool Equals(MetadataCollection other) => ReferenceEquals(this, other);
+    }
+
+    private class OneToThreeItems : MetadataCollection
+    {
+        private readonly string _key1;
+        private readonly string _value1;
+
+        [AllowNull]
+        private readonly string _key2;
+        [AllowNull]
+        private readonly string _value2;
+
+        [AllowNull]
+        private readonly string _key3;
+        [AllowNull]
+        private readonly string _value3;
+
+        private readonly int _count;
+
+        private string[]? _keys;
+        private string[]? _values;
+        private IEnumerable<KeyValuePair<string, string>>? _pairs;
+
+        public OneToThreeItems(string key1, string value1, string key2, string value2, string key3, string value3)
+        {
+            _key1 = key1 ?? throw new ArgumentNullException(nameof(key1));
+            _value1 = value1;
+            _key2 = key2 ?? throw new ArgumentNullException(nameof(key2));
+            _value2 = value2;
+            _key3 = key3 ?? throw new ArgumentNullException(nameof(key3));
+            _value3 = value3;
+
+            _count = 3;
+        }
+
+        public OneToThreeItems(string key1, string value1, string key2, string value2)
+        {
+            _key1 = key1 ?? throw new ArgumentNullException(nameof(key1));
+            _value1 = value1;
+            _key2 = key2 ?? throw new ArgumentNullException(nameof(key2));
+            _value2 = value2;
+
+            _count = 2;
+        }
+
+        public OneToThreeItems(string key, string value)
+        {
+            _key1 = key ?? throw new ArgumentNullException(nameof(key));
+            _value1 = value;
+
+            _count = 1;
+        }
+
+        public override string this[string key]
+        {
+            get
+            {
+                if (key == _key1)
+                {
+                    return _value1;
+                }
+
+                if (_count > 1 && key == _key2)
+                {
+                    return _value2;
+                }
+
+                if (_count > 2 && key == _key3)
+                {
+                    return _value3;
+                }
+
+                throw new KeyNotFoundException();
+            }
+        }
+
+        public override IEnumerable<string> Keys
+        {
+            get
+            {
+                return _keys ??= CreateKeys();
+
+                string[] CreateKeys()
+                {
+                    return _count switch
+                    {
+                        1 => new[] { _key1 },
+                        2 => new[] { _key1, _key2 },
+                        3 => new[] { _key1, _key2, _key3 },
+                        _ => throw new InvalidOperationException()
+                    };
+                }
+            }
+        }
+
+        public override IEnumerable<string> Values
+        {
+            get
+            {
+                return _values ??= CreateValues();
+
+                string[] CreateValues()
+                {
+                    return _count switch
+                    {
+                        1 => new[] { _value1 },
+                        2 => new[] { _value1, _value2 },
+                        3 => new[] { _value1, _value2, _value3 },
+                        _ => throw new InvalidOperationException()
+                    };
+                }
+            }
+        }
+
+        public override int Count => _count;
+
+        public override bool ContainsKey(string key)
+            => key == _key1 || (_count > 1 && key == _key2) || (_count > 2 && key == _key3);
+
+        public override IEnumerator<KeyValuePair<string, string>> GetEnumerator()
+        {
+            _pairs ??= CreatePairs();
+
+            return _pairs.GetEnumerator();
+
+            KeyValuePair<string, string>[] CreatePairs()
+            {
+                return _count switch
+                {
+                    1 => new[] { new KeyValuePair<string, string>(_key1, _value1) },
+                    2 => new[] { new KeyValuePair<string, string>(_key1, _value1), new KeyValuePair<string, string>(_key2, _value2) },
+                    3 => new[] { new KeyValuePair<string, string>(_key1, _value1), new KeyValuePair<string, string>(_key2, _value2), new KeyValuePair<string, string>(_key3, _value3) },
+                    _ => throw new InvalidOperationException()
+                };
+            }
+        }
+
+        public override bool TryGetValue(string key, out string value)
+        {
+            if (key == _key1)
+            {
+                value = _value1;
+                return true;
+            }
+
+            if (_count > 1 && key == _key2)
+            {
+                value = _value2;
+                return true;
+            }
+
+            if (_count > 2 && key == _key3)
+            {
+                value = _value3;
+                return true;
+            }
+
+            value = null!;
+            return false;
+        }
+
+        public override bool Equals(MetadataCollection other)
+        {
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            if (other is not OneToThreeItems otherCollection)
+            {
+                return false;
+            }
+
+            if (_count != otherCollection._count)
+            {
+                return false;
+            }
+
+            if (_count == 1)
+            {
+                return _key1 == otherCollection._key1 && _value1 == otherCollection._value1;
+            }
+
+            if (_count == 2)
+            {
+                if (_key1 == otherCollection._key1)
+                {
+                    return _value1 == otherCollection._value1 &&
+                           _key2 == otherCollection._key2 &&
+                           _value2 == otherCollection._value2;
+                }
+
+                return _key1 == otherCollection._key2 &&
+                       _value1 == otherCollection._value2 &&
+                       _key2 == otherCollection._key1 &&
+                       _value2 == otherCollection._value1;
+            }
+
+            if (_count == 3)
+            {
+                return otherCollection.TryGetValue(_key1, out var otherValue1) &&
+                       _value1 == otherValue1 &&
+                       otherCollection.TryGetValue(_key2, out var otherValue2) &&
+                       _value2 == otherValue2 &&
+                       otherCollection.TryGetValue(_key3, out var otherValue3) &&
+                       _value3 == otherValue3;
+            }
+
+            return false;
+        }
+
+        protected override int ComputeHashCode()
+        {
+            var hash = HashCodeCombiner.Start();
+
+            hash.Add(_key1, StringComparer.Ordinal);
+            hash.Add(_value1, StringComparer.Ordinal);
+
+            if (_count > 1)
+            {
+                hash.Add(_key2, StringComparer.Ordinal);
+                hash.Add(_value2, StringComparer.Ordinal);
+            }
+
+            if (_count > 2)
+            {
+                hash.Add(_key3, StringComparer.Ordinal);
+                hash.Add(_value3, StringComparer.Ordinal);
+            }
+
+            return hash.CombinedHash;
+        }
+    }
+
+    private class FourOrMoreItems : MetadataCollection
+    {
+        private readonly string[] _keys;
+        private readonly string[] _values;
+
+        private readonly int _count;
+
+        private IEnumerable<KeyValuePair<string, string>>? _pairs;
+
+        public FourOrMoreItems(IReadOnlyDictionary<string, string> map)
+        {
+            if (map is null)
+            {
+                throw new ArgumentNullException(nameof(map));
+            }
+
+            using var _1 = ListPool<string>.GetPooledObject(out var keys);
+            using var _2 = ListPool<string>.GetPooledObject(out var values);
+
+            var count = map.Count;
+            keys.SetCapacityIfLarger(count);
+            values.SetCapacityIfLarger(count);
+
+            foreach (var (key, value) in map)
+            {
+                // Because the keys are strings, we are guaranteed that there won't ever
+                // be a match. So, we can assume that the result of BinarySearch will
+                // always be negative and can immediately convert from the bitwise complement.
+                var index = ~keys.BinarySearch(key);
+
+                keys.Insert(index, key);
+                values.Insert(index, value);
+            }
+
+            _keys = keys.ToArrayOrEmpty();
+            _values = values.ToArrayOrEmpty();
+            _count = count;
+        }
+
+        public FourOrMoreItems(KeyValuePair<string, string>[] pairs)
+        {
+            if (pairs is null)
+            {
+                throw new ArgumentNullException(nameof(pairs));
+            }
+
+            using var _1 = ListPool<string>.GetPooledObject(out var keys);
+            using var _2 = ListPool<string>.GetPooledObject(out var values);
+
+            var count = pairs.Length;
+            keys.SetCapacityIfLarger(count);
+            values.SetCapacityIfLarger(count);
+
+            foreach (var (key, value) in pairs)
+            {
+                var index = keys.BinarySearch(key);
+
+                if (index >= 0)
+                {
+                    throw new ArgumentException("Duplicate key encountered.", nameof(pairs));
+                }
+
+                index = ~index;
+
+                keys.Insert(index, key);
+                values.Insert(index, value);
+            }
+
+            _keys = keys.ToArrayOrEmpty();
+            _values = values.ToArrayOrEmpty();
+            _count = count;
+        }
+
+        public override string this[string key]
+        {
+            get
+            {
+                var index = Array.BinarySearch(_keys, key);
+
+                return index >= 0
+                    ? _values[index]
+                    : throw new KeyNotFoundException();
+            }
+        }
+
+        public override IEnumerable<string> Keys => _keys;
+        public override IEnumerable<string> Values => _values;
+
+        public override int Count => _count;
+
+        public override bool ContainsKey(string key)
+        {
+            var index = Array.BinarySearch(_keys, key);
+
+            return index >= 0;
+        }
+
+        public override IEnumerator<KeyValuePair<string, string>> GetEnumerator()
+        {
+            _pairs ??= CreatePairs(_keys, _values);
+
+            return _pairs.GetEnumerator();
+
+            static IEnumerable<KeyValuePair<string, string>> CreatePairs(string[] keys, string[] values)
+            {
+                for (var i = 0; i < keys.Length; i++)
+                {
+                    yield return new KeyValuePair<string, string>(keys[i], values[i]);
+                }
+            }
+        }
+
+        public override bool TryGetValue(string key, out string value)
+        {
+            var index = Array.BinarySearch(_keys, key);
+
+            if (index >= 0)
+            {
+                value = _values[index];
+                return true;
+            }
+
+            value = null!;
+            return false;
+        }
+
+        public override bool Equals(MetadataCollection other)
+        {
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            if (other is not FourOrMoreItems)
+            {
+                return false;
+            }
+
+            var keys = _keys;
+            var values = _values;
+            var count = keys.Length;
+
+            for (var i = 0; i < count; i++)
+            {
+                if (!other.TryGetValue(keys[i], out var otherValue) ||
+                    values[i] != otherValue)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        protected override int ComputeHashCode()
+        {
+            var hash = HashCodeCombiner.Start();
+
+            var keys = _keys;
+            var values = _values;
+            var count = keys.Length;
+
+            for (var i = 0; i < count; i++)
+            {
+                hash.Add(keys[i], StringComparer.Ordinal);
+                hash.Add(values[i], StringComparer.Ordinal);
+            }
+
+            return hash.CombinedHash;
+        }
+    }
+}

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/MetadataCollection.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/MetadataCollection.cs
@@ -155,7 +155,7 @@ internal abstract class MetadataCollection : IReadOnlyDictionary<string, string>
         {
         }
 
-        public override string this[string key] => throw new KeyNotFoundException();
+        public override string this[string key] => throw new KeyNotFoundException(Resources.FormatThe_given_key_0_was_not_present(key));
 
         public override IEnumerable<string> Keys => Array.Empty<string>();
         public override IEnumerable<string> Values => Array.Empty<string>();
@@ -206,6 +206,24 @@ internal abstract class MetadataCollection : IReadOnlyDictionary<string, string>
             _key3 = key3 ?? throw new ArgumentNullException(nameof(key3));
             _value3 = value3;
 
+            if (key1 == key2)
+            {
+                throw new ArgumentException(
+                    Resources.FormatAn_item_with_the_same_key_has_already_been_added_Key_0(key2), nameof(key2));
+            }
+
+            if (key1 == key3)
+            {
+                throw new ArgumentException(
+                    Resources.FormatAn_item_with_the_same_key_has_already_been_added_Key_0(key3), nameof(key3));
+            }
+
+            if (key2 == key3)
+            {
+                throw new ArgumentException(
+                    Resources.FormatAn_item_with_the_same_key_has_already_been_added_Key_0(key3), nameof(key3));
+            }
+
             _count = 3;
         }
 
@@ -215,6 +233,12 @@ internal abstract class MetadataCollection : IReadOnlyDictionary<string, string>
             _value1 = value1;
             _key2 = key2 ?? throw new ArgumentNullException(nameof(key2));
             _value2 = value2;
+
+            if (key1 == key2)
+            {
+                throw new ArgumentException(
+                    Resources.FormatAn_item_with_the_same_key_has_already_been_added_Key_0(key2), nameof(key2));
+            }
 
             _count = 2;
         }
@@ -246,7 +270,8 @@ internal abstract class MetadataCollection : IReadOnlyDictionary<string, string>
                     return _value3;
                 }
 
-                throw new KeyNotFoundException();
+                throw new KeyNotFoundException(
+                    Resources.FormatThe_given_key_0_was_not_present(key));
             }
         }
 
@@ -476,9 +501,10 @@ internal abstract class MetadataCollection : IReadOnlyDictionary<string, string>
 
             foreach (var (key, value) in map)
             {
-                // Because the keys are strings, we are guaranteed that there won't ever
-                // be a match. So, we can assume that the result of BinarySearch will
-                // always be negative and can immediately convert from the bitwise complement.
+                // Because the keys are strings that are already in a dictionary, we are
+                // guaranteed that there won't ever be a match. So, we can assume that
+                // the result of BinarySearch will always be negative and can immediately
+                // convert from the bitwise complement.
                 var index = ~keys.BinarySearch(key);
 
                 keys.Insert(index, key);
@@ -510,7 +536,8 @@ internal abstract class MetadataCollection : IReadOnlyDictionary<string, string>
 
                 if (index >= 0)
                 {
-                    throw new ArgumentException("Duplicate key encountered.", nameof(pairs));
+                    throw new ArgumentException(
+                        Resources.FormatAn_item_with_the_same_key_has_already_been_added_Key_0(key), nameof(pairs));
                 }
 
                 index = ~index;
@@ -532,7 +559,7 @@ internal abstract class MetadataCollection : IReadOnlyDictionary<string, string>
 
                 return index >= 0
                     ? _values[index]
-                    : throw new KeyNotFoundException();
+                    : throw new KeyNotFoundException(Resources.FormatThe_given_key_0_was_not_present(key));
             }
         }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RequiredAttributeDescriptorComparer.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RequiredAttributeDescriptorComparer.cs
@@ -16,8 +16,7 @@ internal sealed class RequiredAttributeDescriptorComparer : IEqualityComparer<Re
     /// <summary>
     /// A default instance of the <see cref="RequiredAttributeDescriptorComparer"/>.
     /// </summary>
-    public static readonly RequiredAttributeDescriptorComparer Default =
-        new RequiredAttributeDescriptorComparer();
+    public static readonly RequiredAttributeDescriptorComparer Default = new();
 
     private RequiredAttributeDescriptorComparer()
     {
@@ -28,7 +27,7 @@ internal sealed class RequiredAttributeDescriptorComparer : IEqualityComparer<Re
         RequiredAttributeDescriptor? descriptorX,
         RequiredAttributeDescriptor? descriptorY)
     {
-        if (object.ReferenceEquals(descriptorX, descriptorY))
+        if (ReferenceEquals(descriptorX, descriptorY))
         {
             return true;
         }
@@ -42,13 +41,12 @@ internal sealed class RequiredAttributeDescriptorComparer : IEqualityComparer<Re
             return false;
         }
 
-        return
-            descriptorX.CaseSensitive == descriptorY.CaseSensitive &&
-            descriptorX.NameComparison == descriptorY.NameComparison &&
-            descriptorX.ValueComparison == descriptorY.ValueComparison &&
-            string.Equals(descriptorX.Name, descriptorY.Name, StringComparison.Ordinal) &&
-            string.Equals(descriptorX.Value, descriptorY.Value, StringComparison.Ordinal) &&
-            string.Equals(descriptorX.DisplayName, descriptorY.DisplayName, StringComparison.Ordinal);
+        return descriptorX.CaseSensitive == descriptorY.CaseSensitive &&
+               descriptorX.NameComparison == descriptorY.NameComparison &&
+               descriptorX.ValueComparison == descriptorY.ValueComparison &&
+               descriptorX.Name == descriptorY.Name &&
+               descriptorX.Value == descriptorY.Value &&
+               descriptorX.DisplayName == descriptorY.DisplayName;
     }
 
     /// <inheritdoc />

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Resources.resx
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Resources.resx
@@ -577,4 +577,10 @@
   <data name="RazorDiagnosticDescriptor_DefaultError" xml:space="preserve">
     <value>Encountered diagnostic '{0}'.</value>
   </data>
+  <data name="An_item_with_the_same_key_has_already_been_added_Key_0" xml:space="preserve">
+    <value>An item with the same key has already been added. Key: {0}</value>
+  </data>
+  <data name="The_given_key_0_was_not_present" xml:space="preserve">
+    <value>The given key '{0}' was not present.</value>
+  </data>
 </root>

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptor.cs
@@ -86,14 +86,14 @@ public abstract class TagHelperDescriptor : IEquatable<TagHelperDescriptor>
 
     internal bool? IsComponentFullyQualifiedNameMatchCache
     {
-        get => GetTriStateFlags(IsComponentFullyQualifiedNameMatchCacheSetBit, IsComponentFullyQualifiedNameMatchCacheBit);
-        set => UpdateTriStateFlags(value, IsComponentFullyQualifiedNameMatchCacheSetBit, IsComponentFullyQualifiedNameMatchCacheBit);
+        get => GetTriStateFlags(isSetFlag: IsComponentFullyQualifiedNameMatchCacheSetBit, isOnFlag: IsComponentFullyQualifiedNameMatchCacheBit);
+        set => UpdateTriStateFlags(value, isSetFlag: IsComponentFullyQualifiedNameMatchCacheSetBit, isOnFlag: IsComponentFullyQualifiedNameMatchCacheBit);
     }
 
     internal bool? IsChildContentTagHelperCache
     {
-        get => GetTriStateFlags(IsChildContentTagHelperCacheBit, IsChildContentTagHelperCacheSetBit);
-        set => UpdateTriStateFlags(value, IsChildContentTagHelperCacheBit, IsChildContentTagHelperCacheSetBit);
+        get => GetTriStateFlags(isSetFlag: IsChildContentTagHelperCacheSetBit, isOnFlag: IsChildContentTagHelperCacheBit);
+        set => UpdateTriStateFlags(value, isSetFlag: IsChildContentTagHelperCacheSetBit, isOnFlag: IsChildContentTagHelperCacheBit);
     }
 
     private bool? GetTriStateFlags(int isSetFlag, int isOnFlag)
@@ -190,6 +190,7 @@ public abstract class TagHelperDescriptor : IEquatable<TagHelperDescriptor>
             }
 
             // BUG?: Diagnostics on BoundAttributeParameterDescriptors are not collected here.
+            // https://github.com/dotnet/razor/issues/8544
 
             foreach (var rule in TagMatchingRules)
             {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptor.cs
@@ -196,12 +196,12 @@ public abstract class TagHelperDescriptor : IEquatable<TagHelperDescriptor>
                 diagnostics.AddRange(attribute.Diagnostics);
             }
 
+            // BUG?: Diagnostics on BoundAttributeParameterDescriptors are not collected here.
+
             foreach (var rule in TagMatchingRules)
             {
-                diagnostics.AddRange(rule.Diagnostics);
+                diagnostics.AddRange(rule.GetAllDiagnostics());
             }
-
-            // BUG?: Diagnostics on BoundAttributeParameterDescriptors and RequiredAttributeDescriptors are not collected here.
 
             diagnostics.AddRange(Diagnostics);
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptorComparer.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptorComparer.cs
@@ -12,7 +12,7 @@ internal sealed class TagHelperDescriptorComparer : IEqualityComparer<TagHelperD
     /// <summary>
     /// A default instance of the <see cref="TagHelperDescriptorComparer"/>.
     /// </summary>
-    public static readonly TagHelperDescriptorComparer Default = new TagHelperDescriptorComparer();
+    public static readonly TagHelperDescriptorComparer Default = new();
 
     private TagHelperDescriptorComparer()
     {
@@ -20,7 +20,7 @@ internal sealed class TagHelperDescriptorComparer : IEqualityComparer<TagHelperD
 
     public bool Equals(TagHelperDescriptor? descriptorX, TagHelperDescriptor? descriptorY)
     {
-        if (object.ReferenceEquals(descriptorX, descriptorY))
+        if (ReferenceEquals(descriptorX, descriptorY))
         {
             return true;
         }
@@ -30,76 +30,33 @@ internal sealed class TagHelperDescriptorComparer : IEqualityComparer<TagHelperD
             return false;
         }
 
-        if (!string.Equals(descriptorX.Kind, descriptorY.Kind, StringComparison.Ordinal))
+        if (descriptorX.Kind != descriptorY.Kind ||
+            descriptorX.AssemblyName != descriptorY.AssemblyName ||
+            descriptorX.Name != descriptorY.Name ||
+            descriptorX.CaseSensitive != descriptorY.CaseSensitive ||
+            descriptorX.Documentation != descriptorY.Documentation ||
+            descriptorX.DisplayName != descriptorY.DisplayName ||
+            descriptorX.TagOutputHint != descriptorY.TagOutputHint)
         {
             return false;
         }
 
-        if (!string.Equals(descriptorX.AssemblyName, descriptorY.AssemblyName, StringComparison.Ordinal))
+        if (!ComparerUtilities.Equals(descriptorX.BoundAttributes, descriptorY.BoundAttributes, BoundAttributeDescriptorComparer.Default) ||
+            !ComparerUtilities.Equals(descriptorX.TagMatchingRules, descriptorY.TagMatchingRules, TagMatchingRuleDescriptorComparer.Default) ||
+            !ComparerUtilities.Equals(descriptorX.AllowedChildTags, descriptorY.AllowedChildTags, AllowedChildTagDescriptorComparer.Default) ||
+            !ComparerUtilities.Equals(descriptorX.Diagnostics, descriptorY.Diagnostics, EqualityComparer<RazorDiagnostic>.Default))
         {
             return false;
         }
 
-        if (!string.Equals(descriptorX.Name, descriptorY.Name, StringComparison.Ordinal))
+        if (descriptorX.Metadata is MetadataCollection metadataX &&
+            descriptorY.Metadata is MetadataCollection metadataY &&
+            !metadataX.Equals(metadataY))
         {
             return false;
         }
 
-        if (!ComparerUtilities.Equals(
-            descriptorX.BoundAttributes,
-            descriptorY.BoundAttributes,
-            BoundAttributeDescriptorComparer.Default))
-        {
-            return false;
-        }
-
-        if (!ComparerUtilities.Equals(
-            descriptorX.TagMatchingRules,
-            descriptorY.TagMatchingRules,
-            TagMatchingRuleDescriptorComparer.Default))
-        {
-            return false;
-        }
-
-        if (!ComparerUtilities.Equals(
-            descriptorX.AllowedChildTags,
-            descriptorY.AllowedChildTags,
-            AllowedChildTagDescriptorComparer.Default))
-        {
-            return false;
-        }
-
-        if (descriptorX.CaseSensitive != descriptorY.CaseSensitive)
-        {
-            return false;
-        }
-
-        if (!string.Equals(descriptorX.Documentation, descriptorY.Documentation, StringComparison.Ordinal))
-        {
-            return false;
-        }
-
-        if (!string.Equals(descriptorX.DisplayName, descriptorY.DisplayName, StringComparison.Ordinal))
-        {
-            return false;
-        }
-
-        if (!string.Equals(descriptorX.TagOutputHint, descriptorY.TagOutputHint, StringComparison.Ordinal))
-        {
-            return false;
-        }
-
-        if (!ComparerUtilities.Equals(descriptorX.Diagnostics, descriptorY.Diagnostics, EqualityComparer<RazorDiagnostic>.Default))
-        {
-            return false;
-        }
-
-        if (!ComparerUtilities.Equals(descriptorX.Metadata, descriptorY.Metadata, StringComparer.Ordinal))
-        {
-            return false;
-        }
-
-        return true;
+        return ComparerUtilities.Equals(descriptorX.Metadata, descriptorY.Metadata, StringComparer.Ordinal);
     }
 
     /// <inheritdoc />

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDiagnostics.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDiagnostics.cs
@@ -1,0 +1,62 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Razor.Language;
+
+internal static class TagHelperDiagnostics
+{
+    private static readonly ConditionalWeakTable<object, IReadOnlyList<RazorDiagnostic>> s_diagnosticsTable = new();
+
+    private static void AddDiagnosticsToTable(object obj, IReadOnlyList<RazorDiagnostic> diagnostics)
+    {
+        if (diagnostics.Count > 0)
+        {
+            s_diagnosticsTable.Add(obj, diagnostics);
+        }
+    }
+
+    private static IReadOnlyList<RazorDiagnostic> GetDiagnosticsFromTable(object obj)
+        => s_diagnosticsTable.TryGetValue(obj, out var diagnostics)
+            ? diagnostics
+            : Array.Empty<RazorDiagnostic>();
+
+    public static void AddDiagnostics(AllowedChildTagDescriptor descriptor, IReadOnlyList<RazorDiagnostic> diagnostics)
+        => AddDiagnosticsToTable(descriptor, diagnostics);
+
+    public static void AddDiagnostics(BoundAttributeDescriptor descriptor, IReadOnlyList<RazorDiagnostic> diagnostics)
+        => AddDiagnosticsToTable(descriptor, diagnostics);
+
+    public static void AddDiagnostics(BoundAttributeParameterDescriptor descriptor, IReadOnlyList<RazorDiagnostic> diagnostics)
+        => AddDiagnosticsToTable(descriptor, diagnostics);
+
+    public static void AddDiagnostics(RequiredAttributeDescriptor descriptor, IReadOnlyList<RazorDiagnostic> diagnostics)
+        => AddDiagnosticsToTable(descriptor, diagnostics);
+
+    public static void AddDiagnostics(TagHelperDescriptor descriptor, IReadOnlyList<RazorDiagnostic> diagnostics)
+        => AddDiagnosticsToTable(descriptor, diagnostics);
+
+    public static void AddDiagnostics(TagMatchingRuleDescriptor descriptor, IReadOnlyList<RazorDiagnostic> diagnostics)
+        => AddDiagnosticsToTable(descriptor, diagnostics);
+
+    public static IReadOnlyList<RazorDiagnostic> GetDiagnostics(AllowedChildTagDescriptor descriptor)
+        => GetDiagnosticsFromTable(descriptor);
+
+    public static IReadOnlyList<RazorDiagnostic> GetDiagnostics(BoundAttributeDescriptor descriptor)
+        => GetDiagnosticsFromTable(descriptor);
+
+    public static IReadOnlyList<RazorDiagnostic> GetDiagnostics(BoundAttributeParameterDescriptor descriptor)
+        => GetDiagnosticsFromTable(descriptor);
+
+    public static IReadOnlyList<RazorDiagnostic> GetDiagnostics(RequiredAttributeDescriptor descriptor)
+        => GetDiagnosticsFromTable(descriptor);
+
+    public static IReadOnlyList<RazorDiagnostic> GetDiagnostics(TagHelperDescriptor descriptor)
+        => GetDiagnosticsFromTable(descriptor);
+
+    public static IReadOnlyList<RazorDiagnostic> GetDiagnostics(TagMatchingRuleDescriptor descriptor)
+        => GetDiagnosticsFromTable(descriptor);
+}

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDiagnostics.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDiagnostics.cs
@@ -24,6 +24,9 @@ internal static class TagHelperDiagnostics
             ? diagnostics
             : Array.Empty<RazorDiagnostic>();
 
+    private static void RemoveDiagnosticsFromTable(object obj)
+        => s_diagnosticsTable.Remove(obj);
+
     public static void AddDiagnostics(AllowedChildTagDescriptor descriptor, IReadOnlyList<RazorDiagnostic> diagnostics)
         => AddDiagnosticsToTable(descriptor, diagnostics);
 
@@ -59,4 +62,22 @@ internal static class TagHelperDiagnostics
 
     public static IReadOnlyList<RazorDiagnostic> GetDiagnostics(TagMatchingRuleDescriptor descriptor)
         => GetDiagnosticsFromTable(descriptor);
+
+    public static void RemoveDiagnostics(AllowedChildTagDescriptor descriptor)
+        => RemoveDiagnosticsFromTable(descriptor);
+
+    public static void RemoveDiagnostics(BoundAttributeDescriptor descriptor)
+        => RemoveDiagnosticsFromTable(descriptor);
+
+    public static void RemoveDiagnostics(BoundAttributeParameterDescriptor descriptor)
+        => RemoveDiagnosticsFromTable(descriptor);
+
+    public static void RemoveDiagnostics(RequiredAttributeDescriptor descriptor)
+        => RemoveDiagnosticsFromTable(descriptor);
+
+    public static void RemoveDiagnostics(TagHelperDescriptor descriptor)
+        => RemoveDiagnosticsFromTable(descriptor);
+
+    public static void RemoveDiagnostics(TagMatchingRuleDescriptor descriptor)
+        => RemoveDiagnosticsFromTable(descriptor);
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagMatchingRuleDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagMatchingRuleDescriptor.cs
@@ -26,8 +26,11 @@ public abstract class TagMatchingRuleDescriptor : IEquatable<TagMatchingRuleDesc
 
     public bool CaseSensitive { get; protected set; }
 
-    public IReadOnlyList<RazorDiagnostic> Diagnostics { get; protected set; }
-
+    public IReadOnlyList<RazorDiagnostic> Diagnostics
+    {
+        get => TagHelperDiagnostics.GetDiagnostics(this);
+        protected set => TagHelperDiagnostics.AddDiagnostics(this, value);
+    }
 
     public bool HasErrors
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagMatchingRuleDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagMatchingRuleDescriptor.cs
@@ -41,8 +41,9 @@ public abstract class TagMatchingRuleDescriptor : IEquatable<TagMatchingRuleDesc
                 TagHelperDiagnostics.AddDiagnostics(this, value);
                 _containsDiagnostics = true;
             }
-            else
+            else if (_containsDiagnostics)
             {
+                TagHelperDiagnostics.RemoveDiagnostics(this);
                 _containsDiagnostics = false;
             }
         }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagMatchingRuleDescriptorComparer.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagMatchingRuleDescriptorComparer.cs
@@ -12,7 +12,7 @@ internal sealed class TagMatchingRuleDescriptorComparer : IEqualityComparer<TagM
     /// <summary>
     /// A default instance of the <see cref="TagMatchingRuleDescriptorComparer"/>.
     /// </summary>
-    public static readonly TagMatchingRuleDescriptorComparer Default = new TagMatchingRuleDescriptorComparer();
+    public static readonly TagMatchingRuleDescriptorComparer Default = new();
 
     private TagMatchingRuleDescriptorComparer()
     {
@@ -20,7 +20,7 @@ internal sealed class TagMatchingRuleDescriptorComparer : IEqualityComparer<TagM
 
     public bool Equals(TagMatchingRuleDescriptor? ruleX, TagMatchingRuleDescriptor? ruleY)
     {
-        if (object.ReferenceEquals(ruleX, ruleY))
+        if (ReferenceEquals(ruleX, ruleY))
         {
             return true;
         }
@@ -35,8 +35,8 @@ internal sealed class TagMatchingRuleDescriptorComparer : IEqualityComparer<TagM
         }
 
         return
-            string.Equals(ruleX.TagName, ruleY.TagName, StringComparison.Ordinal) &&
-            string.Equals(ruleX.ParentTag, ruleY.ParentTag, StringComparison.Ordinal) &&
+            ruleX.TagName == ruleY.TagName &&
+            ruleX.ParentTag == ruleY.ParentTag &&
             ruleX.CaseSensitive == ruleY.CaseSensitive &&
             ruleX.TagStructure == ruleY.TagStructure &&
             ComparerUtilities.Equals(ruleX.Attributes, ruleY.Attributes, RequiredAttributeDescriptorComparer.Default);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/MetadataCollectionTests.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/MetadataCollectionTests.cs
@@ -79,4 +79,41 @@ public class MetadataCollectionTests
         Assert.Throws<ArgumentException>(() => MetadataCollection.Create(one, two, three, three));
         Assert.Throws<ArgumentException>(() => MetadataCollection.Create(new[] { one, one, three, three }));
     }
+
+    [Fact]
+    public void HashCodesAreSameRegardlessOfOrdering()
+    {
+        var one = new KeyValuePair<string, string>("Key1", "Value1");
+        var two = new KeyValuePair<string, string>("Key2", "Value2");
+        var three = new KeyValuePair<string, string>("Key3", "Value3");
+        var four = new KeyValuePair<string, string>("Key4", "Value4");
+
+        Assert.Equal(
+            MetadataCollection.Create(one, two).GetHashCode(),
+            MetadataCollection.Create(two, one).GetHashCode());
+
+        Assert.Equal(
+            MetadataCollection.Create(one, two, three).GetHashCode(),
+            MetadataCollection.Create(two, one, three).GetHashCode());
+
+        Assert.Equal(
+            MetadataCollection.Create(one, two, three).GetHashCode(),
+            MetadataCollection.Create(three, two, one).GetHashCode());
+
+        Assert.Equal(
+            MetadataCollection.Create(one, two, three).GetHashCode(),
+            MetadataCollection.Create(one, three, two).GetHashCode());
+
+        Assert.Equal(
+            MetadataCollection.Create(one, two, three).GetHashCode(),
+            MetadataCollection.Create(two, three, one).GetHashCode());
+
+        Assert.Equal(
+            MetadataCollection.Create(one, two, three).GetHashCode(),
+            MetadataCollection.Create(three, one, two).GetHashCode());
+
+        Assert.Equal(
+            MetadataCollection.Create(one, two, three, four).GetHashCode(),
+            MetadataCollection.Create(four, three, two, one).GetHashCode());
+    }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/MetadataCollectionTests.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/MetadataCollectionTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -45,5 +46,37 @@ public class MetadataCollectionTests
             Assert.True(collection2.TryGetValue(key, out var value2));
             Assert.Equal(value, value2);
         }
+    }
+
+    [Fact]
+    public void CreateThrowsOnDuplicateKeys()
+    {
+        var one = new KeyValuePair<string, string>("Key1", "Value1");
+        var two = new KeyValuePair<string, string>("Key2", "Value2");
+        var three = new KeyValuePair<string, string>("Key3", "Value3");
+        var four = new KeyValuePair<string, string>("Key4", "Value4");
+
+        Assert.Throws<ArgumentException>(() => MetadataCollection.Create(one, one));
+        Assert.Throws<ArgumentException>(() => MetadataCollection.Create(new[] { one, one }));
+
+        Assert.Throws<ArgumentException>(() => MetadataCollection.Create(one, one, three));
+        Assert.Throws<ArgumentException>(() => MetadataCollection.Create(new[] { one, one, three }));
+        Assert.Throws<ArgumentException>(() => MetadataCollection.Create(one, three, three));
+        Assert.Throws<ArgumentException>(() => MetadataCollection.Create(new[] { one, three, three }));
+        Assert.Throws<ArgumentException>(() => MetadataCollection.Create(one, two, one));
+        Assert.Throws<ArgumentException>(() => MetadataCollection.Create(new[] { one, two, one}));
+
+        Assert.Throws<ArgumentException>(() => MetadataCollection.Create(one, one, three, four));
+        Assert.Throws<ArgumentException>(() => MetadataCollection.Create(new[] { one, one, three, four }));
+        Assert.Throws<ArgumentException>(() => MetadataCollection.Create(one, two, one, four));
+        Assert.Throws<ArgumentException>(() => MetadataCollection.Create(new[] { one, two, one, four }));
+        Assert.Throws<ArgumentException>(() => MetadataCollection.Create(one, two, three, one));
+        Assert.Throws<ArgumentException>(() => MetadataCollection.Create(new[] { one, two, three, one }));
+        Assert.Throws<ArgumentException>(() => MetadataCollection.Create(one, two, two, four));
+        Assert.Throws<ArgumentException>(() => MetadataCollection.Create(new[] { one, two, two, four }));
+        Assert.Throws<ArgumentException>(() => MetadataCollection.Create(one, two, three, two));
+        Assert.Throws<ArgumentException>(() => MetadataCollection.Create(new[] { one, one, three, two }));
+        Assert.Throws<ArgumentException>(() => MetadataCollection.Create(one, two, three, three));
+        Assert.Throws<ArgumentException>(() => MetadataCollection.Create(new[] { one, one, three, three }));
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/MetadataCollectionTests.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/MetadataCollectionTests.cs
@@ -1,0 +1,49 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Language;
+
+public class MetadataCollectionTests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(8)]
+    [InlineData(16)]
+    [InlineData(32)]
+    [InlineData(64)]
+    public void CreateAndCompareCollections(int size)
+    {
+        var pairs = new List<KeyValuePair<string, string>>();
+
+        for (var i = 0; i < size; i++)
+        {
+            var key = i.ToString(CultureInfo.InvariantCulture);
+            var value = (int.MaxValue - i).ToString(CultureInfo.InvariantCulture);
+
+            pairs.Add(new KeyValuePair<string, string>(key, value));
+        }
+
+        var collection1 = MetadataCollection.Create(pairs.ToArray());
+        var collection2 = MetadataCollection.Create(pairs.ToArray().Reverse().ToArray());
+
+        Assert.Equal(collection1, collection2);
+
+        foreach (var (key, value) in pairs)
+        {
+            Assert.True(collection1.TryGetValue(key, out var value1));
+            Assert.Equal(value, value1);
+
+            Assert.True(collection2.TryGetValue(key, out var value2));
+            Assert.Equal(value, value2);
+        }
+    }
+}

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Remote/RemoteTagHelperDeltaProviderBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Remote/RemoteTagHelperDeltaProviderBenchmark.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Razor.Language;
@@ -109,7 +108,7 @@ public class RemoteTagHelperDeltaProviderBenchmark : TagHelperBenchmarkBase
                  origin.TagMatchingRules.ToArray(),
                  origin.BoundAttributes.ToArray(),
                  origin.AllowedChildTags.ToArray(),
-                 origin.Metadata.ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value),
+                 MetadataCollection.Create(origin.Metadata),
                  origin.Diagnostics.ToArray())
         {
         }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ListExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ListExtensions.cs
@@ -19,8 +19,14 @@ internal static class ListExtensions
         }
     }
 
-    // On .NET Framework, List<T>.ToArray() will create a new empty array for any
-    // empty List<T>. This avoids that extra allocation.
+    /// <summary>
+    ///  Copies the elements of the <see cref="List{T}"/> to a new array, or returns an
+    ///  empty array if the <see cref="List{T}"/> is null.
+    /// </summary>
+    /// <remarks>
+    ///  On .NET Framework, <see cref="List{T}.ToArray()"/> will create a new empty array for any
+    ///  empty <see cref="List{T}"/>. This method avoids that extra allocation.
+    /// </remarks>
     public static T[] ToArrayOrEmpty<T>(this List<T>? list)
         => list?.Count > 0
             ? list.ToArray()

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ListExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ListExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.Razor;
@@ -17,4 +18,11 @@ internal static class ListExtensions
             list.Capacity = newCapacity;
         }
     }
+
+    // On .NET Framework, List<T>.ToArray() will create a new empty array for any
+    // empty List<T>. This avoids that extra allocation.
+    public static T[] ToArrayOrEmpty<T>(this List<T>? list)
+        => list?.Count > 0
+            ? list.ToArray()
+            : Array.Empty<T>();
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledObjects/PooledList`1.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledObjects/PooledList`1.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.ObjectPool;
+
+namespace Microsoft.AspNetCore.Razor.PooledObjects;
+
+/// <summary>
+///  Wraps a pooled <see cref="List{T}"/> but doesn't allocate it until
+///  it's needed. Note: Dispose this to ensure that the pooled set is returned
+///  to the pool.
+/// </summary>
+internal ref struct PooledList<T>
+{
+    private readonly ObjectPool<List<T>> _pool;
+    private List<T>? _set;
+
+    public PooledList()
+        : this(ListPool<T>.Default)
+    {
+    }
+
+    public PooledList(ObjectPool<List<T>> pool)
+    {
+        _pool = pool;
+    }
+
+    public void Dispose()
+    {
+        ClearAndFree();
+    }
+
+    public int Count
+        => _set?.Count ?? 0;
+
+    public void Add(T item)
+    {
+        _set ??= _pool.Get();
+        _set.Add(item);
+    }
+
+    public void AddRange(IReadOnlyList<T> list)
+    {
+        if (list.Count == 0)
+        {
+            return;
+        }
+
+        _set ??= _pool.Get();
+        _set.AddRange(list);
+    }
+
+    public void ClearAndFree()
+    {
+        if (_set is { } set)
+        {
+            _pool.Return(set);
+            _set = null;
+        }
+    }
+
+    public readonly T[] ToArray()
+        => _set?.ToArray() ?? Array.Empty<T>();
+}

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledObjects/PooledList`1.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledObjects/PooledList`1.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Razor.PooledObjects;
 internal ref struct PooledList<T>
 {
     private readonly ObjectPool<List<T>> _pool;
-    private List<T>? _set;
+    private List<T>? _list;
 
     public PooledList()
         : this(ListPool<T>.Default)
@@ -33,12 +33,12 @@ internal ref struct PooledList<T>
     }
 
     public int Count
-        => _set?.Count ?? 0;
+        => _list?.Count ?? 0;
 
     public void Add(T item)
     {
-        _set ??= _pool.Get();
-        _set.Add(item);
+        _list ??= _pool.Get();
+        _list.Add(item);
     }
 
     public void AddRange(IReadOnlyList<T> list)
@@ -48,19 +48,25 @@ internal ref struct PooledList<T>
             return;
         }
 
-        _set ??= _pool.Get();
-        _set.AddRange(list);
+        _list ??= _pool.Get();
+        _list.AddRange(list);
+    }
+
+    public void AddRange(IEnumerable<T> list)
+    {
+        _list ??= _pool.Get();
+        _list.AddRange(list);
     }
 
     public void ClearAndFree()
     {
-        if (_set is { } set)
+        if (_list is { } set)
         {
             _pool.Return(set);
-            _set = null;
+            _list = null;
         }
     }
 
     public readonly T[] ToArray()
-        => _set?.ToArray() ?? Array.Empty<T>();
+        => _list.ToArrayOrEmpty();
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledObjects/PooledList`1.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledObjects/PooledList`1.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.ObjectPool;
 
@@ -9,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.PooledObjects;
 
 /// <summary>
 ///  Wraps a pooled <see cref="List{T}"/> but doesn't allocate it until
-///  it's needed. Note: Dispose this to ensure that the pooled set is returned
+///  it's needed. Note: Dispose this to ensure that the pooled list is returned
 ///  to the pool.
 /// </summary>
 internal ref struct PooledList<T>
@@ -60,9 +59,9 @@ internal ref struct PooledList<T>
 
     public void ClearAndFree()
     {
-        if (_list is { } set)
+        if (_list is { } list)
         {
-            _pool.Return(set);
+            _pool.Return(list);
             _list = null;
         }
     }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ThreadSafeFlagOperations.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ThreadSafeFlagOperations.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Threading;
+
+namespace Microsoft.AspNetCore.Razor;
+
+internal static class ThreadSafeFlagOperations
+{
+    public static bool Set(ref int flags, int toSet)
+    {
+        int oldState, newState;
+        do
+        {
+            oldState = flags;
+            newState = oldState | toSet;
+            if (newState == oldState)
+            {
+                return false;
+            }
+        }
+        while (Interlocked.CompareExchange(ref flags, newState, oldState) != oldState);
+
+        return true;
+    }
+
+    public static bool Clear(ref int flags, int toClear)
+    {
+        int oldState, newState;
+        do
+        {
+            oldState = flags;
+            newState = oldState & ~toClear;
+            if (newState == oldState)
+            {
+                return false;
+            }
+        }
+        while (Interlocked.CompareExchange(ref flags, newState, oldState) != oldState);
+
+        return true;
+    }
+
+    public static bool SetOrClear(ref int flags, int toChange, bool value)
+        => value
+            ? Set(ref flags, toChange)
+            : Clear(ref flags, toChange);
+}


### PR DESCRIPTION
This is the first of several changes coming for tag helper descriptors to reduce their memory footprint. In this particular change. I've made tweaks to the memory used by the tag helper descriptors themselves. Future changes will promote sharing objects between tag helper descriptors, stop using a builder pattern for construction, and shrink the serialization payloads of tag helper descriptors.

Here is a summary of the changes:

1. Each object that makes up a tag helper descriptor has a field for storing diagnostics. This is a lot of wasted space since the majority of the objects never have diagnostics and those fields end up holding empty arrays. So, I've added a `ConditionalWeakTable` to store any diagnostics, similar to how green nodes work.
2. I've collapsed loads of boolean fields into single "Flags" fields.
3. I've cleaned up the tag helper descriptor comparers.
4. A new `MetadataCollection` class has been introduced to store metadata (i.e., name/value pairs) more efficiently. Previously, every object that allowed metadata had a `Dictionary<string, string>`, which is overkill since most objects only have 0, 1, or 2 name/value pairs in their metadata. The largest are rarely more than 8.

The `TagHelperSerializationBenchmark` shows good improvements with this change:

### Old (Main)

``` ini

BenchmarkDotNet=v0.13.2.2052-nightly, OS=Windows 11 (10.0.25314.1010)
Intel Core i7-8700 CPU 3.20GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET SDK=8.0.100-preview.1.23115.2
  [Host]     : .NET 7.0.4 (7.0.423.11508), X64 RyuJIT AVX2
  Job-NWIIOW : .NET 7.0.4 (7.0.423.11508), X64 RyuJIT AVX2
  Job-AENCQN : .NET Framework 4.8.1 (4.8.9139.0), X64 RyuJIT VectorSize=256

PowerPlanMode=00000000-0000-0000-0000-000000000000  

```
|                                    Method |        Job |            Toolchain |         Mean |      Error |     StdDev |       Median |          Min |          Max |      Gen0 |     Gen1 |     Gen2 |  Allocated |
|------------------------------------------ |----------- |--------------------- |-------------:|-----------:|-----------:|-------------:|-------------:|-------------:|----------:|---------:|---------:|-----------:|
| &#39;Razor TagHelper Roundtrip Serialization&#39; | Job-NWIIOW |             .NET 7.0 | 28,031.60 μs | 530.566 μs | 743.780 μs | 27,792.65 μs | 27,133.76 μs | 29,890.14 μs |  218.7500 | 156.2500 | 156.2500 | 15208378 B |
|           &#39;Razor TagHelper Serialization&#39; | Job-NWIIOW |             .NET 7.0 | 17,229.21 μs | 336.176 μs | 492.762 μs | 17,307.98 μs | 16,422.83 μs | 18,207.24 μs |  156.2500 | 156.2500 | 156.2500 |  9825705 B |
|         &#39;Razor TagHelper Deserialization&#39; | Job-NWIIOW |             .NET 7.0 | 10,332.30 μs | 133.565 μs | 111.533 μs | 10,378.79 μs | 10,110.54 μs | 10,479.46 μs |   62.5000 |        - |        - |  5366224 B |
|                  &#39;TagHelpers GetHashCode&#39; | Job-NWIIOW |             .NET 7.0 |     17.15 μs |   0.290 μs |   0.257 μs |     17.16 μs |     16.74 μs |     17.53 μs |         - |        - |        - |          - |
| &#39;Razor TagHelper Roundtrip Serialization&#39; | Job-AENCQN | .NET Framework 4.7.2 | 41,012.16 μs | 806.312 μs | 928.550 μs | 41,073.79 μs | 39,151.62 μs | 42,963.25 μs | 2000.0000 | 923.0769 | 846.1538 | 15568690 B |
|           &#39;Razor TagHelper Serialization&#39; | Job-AENCQN | .NET Framework 4.7.2 | 24,044.73 μs | 278.377 μs | 232.457 μs | 24,047.92 μs | 23,726.12 μs | 24,408.02 μs | 1218.7500 | 968.7500 | 968.7500 |  9838762 B |
|         &#39;Razor TagHelper Deserialization&#39; | Job-AENCQN | .NET Framework 4.7.2 | 13,302.67 μs | 193.039 μs | 171.124 μs | 13,318.43 μs | 12,906.24 μs | 13,503.71 μs |  906.2500 |  93.7500 |        - |  5718967 B |
|                  &#39;TagHelpers GetHashCode&#39; | Job-AENCQN | .NET Framework 4.7.2 |     17.86 μs |   0.194 μs |   0.172 μs |     17.88 μs |     17.59 μs |     18.21 μs |         - |        - |        - |          - |

### New

``` ini

BenchmarkDotNet=v0.13.2.2052-nightly, OS=Windows 11 (10.0.25324.1000)
Intel Core i7-8700 CPU 3.20GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET SDK=8.0.100-preview.1.23115.2
  [Host]     : .NET 7.0.4 (7.0.423.11508), X64 RyuJIT AVX2
  Job-VIYVKJ : .NET 7.0.4 (7.0.423.11508), X64 RyuJIT AVX2
  Job-RIMPBK : .NET Framework 4.8.1 (4.8.9139.0), X64 RyuJIT VectorSize=256

PowerPlanMode=00000000-0000-0000-0000-000000000000  

```
|                                    Method |        Job |            Toolchain |         Mean |      Error |     StdDev |       Median |          Min |          Max |      Gen0 |      Gen1 |     Gen2 |  Allocated |
|------------------------------------------ |----------- |--------------------- |-------------:|-----------:|-----------:|-------------:|-------------:|-------------:|----------:|----------:|---------:|-----------:|
| &#39;Razor TagHelper Roundtrip Serialization&#39; | Job-VIYVKJ |             .NET 7.0 | 22,612.16 μs | 429.280 μs | 401.548 μs | 22,595.55 μs | 21,885.28 μs | 23,237.06 μs |  218.7500 |  156.2500 | 156.2500 | 14499643 B |
|           &#39;Razor TagHelper Serialization&#39; | Job-VIYVKJ |             .NET 7.0 | 12,027.30 μs | 235.511 μs | 220.297 μs | 12,031.18 μs | 11,643.88 μs | 12,447.63 μs |  140.6250 |  140.6250 | 140.6250 |  9116647 B |
|         &#39;Razor TagHelper Deserialization&#39; | Job-VIYVKJ |             .NET 7.0 |  9,769.22 μs | 110.624 μs | 103.478 μs |  9,728.16 μs |  9,609.46 μs |  9,992.05 μs |   62.5000 |         - |        - |  5366224 B |
|                  &#39;TagHelpers GetHashCode&#39; | Job-VIYVKJ |             .NET 7.0 |     16.06 μs |   0.192 μs |   0.170 μs |     16.01 μs |     15.81 μs |     16.39 μs |         - |         - |        - |          - |
| &#39;Razor TagHelper Roundtrip Serialization&#39; | Job-RIMPBK | .NET Framework 4.7.2 | 31,654.39 μs | 116.745 μs |  97.488 μs | 31,678.72 μs | 31,396.56 μs | 31,776.04 μs | 1937.5000 | 1062.5000 | 937.5000 | 14857098 B |
|           &#39;Razor TagHelper Serialization&#39; | Job-RIMPBK | .NET Framework 4.7.2 | 13,850.41 μs | 113.766 μs | 106.416 μs | 13,845.35 μs | 13,727.15 μs | 14,062.66 μs | 1109.3750 | 1000.0000 | 984.3750 |  9127239 B |
|         &#39;Razor TagHelper Deserialization&#39; | Job-RIMPBK | .NET Framework 4.7.2 | 12,470.22 μs |  87.162 μs |  72.784 μs | 12,464.00 μs | 12,370.69 μs | 12,600.38 μs |  906.2500 |   93.7500 |        - |  5718964 B |
|                  &#39;TagHelpers GetHashCode&#39; | Job-RIMPBK | .NET Framework 4.7.2 |     17.33 μs |   0.336 μs |   0.437 μs |     17.19 μs |     16.50 μs |     18.32 μs |         - |         - |        - |          - |