### PR TITLE
Workaround web tools color adornment tagger bug

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentColor/DocumentColorEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentColor/DocumentColorEndpoint.cs
@@ -36,6 +36,14 @@ internal sealed class DocumentColorEndpoint : IRazorRequestHandler<DocumentColor
 
     public async Task<ColorInformation[]> HandleRequestAsync(DocumentColorParams request, RazorRequestContext requestContext, CancellationToken cancellationToken)
     {
+        // Workaround for Web Tools bug https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1743689 where they sometimes
+        // send requests for filenames that are stale, possibly due to adornment taggers being cached incorrectly (or caching
+        // filenames incorrectly)
+        if (requestContext.DocumentContext is null)
+        {
+            return Array.Empty<ColorInformation>();
+        }
+
         var delegatedRequest = new DelegatedDocumentColorParams()
         {
             HostDocumentVersion = requestContext.GetRequiredDocumentContext().Version,


### PR DESCRIPTION
Workaround for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1743689

I can see from the dump that there is a color adornment tagger in web tools that has a stale filename making requests, so figured there is no reason for us to report faults unnecessarily.