### PR TITLE
Break up the YAML file into fine grain steps

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -104,7 +104,6 @@ stages:
           - powershell: ./restore.cmd -msbuildEngine dotnet -ci $(_InternalRuntimeDownloadArgs); ./eng/scripts/CodeCheck.ps1 -ci
             displayName: Run eng/scripts/CodeCheck.ps1
 
-
   # Three jobs for each of the three OSes we want to run on
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
@@ -200,11 +199,22 @@ stages:
             env:
               Token: $(dn-bot-dnceng-artifact-feeds-rw)
 
+        # Don't create a binary log until we can customize the name
+        # https://github.com/dotnet/arcade/pull/12988
         - script: eng\cibuild.cmd
             -configuration $(_BuildConfig)
             -msbuildEngine vs
             -prepareMachine
             -restore
+            -excludeCIBinarylog
+          name: Restore
+          displayName: Restore
+          condition: succeeded()
+
+        - script: eng\cibuild.cmd
+            -configuration $(_BuildConfig)
+            -msbuildEngine vs
+            -prepareMachine
             -build
             -pack
             -publish
@@ -233,9 +243,16 @@ stages:
             -configuration $(_BuildConfig)
             -prepareMachine
             -test
+          name: Run_Unit_Tests
+          displayName: Run Unit Tests
+          condition: succeeded()
+
+        - script: eng\CIBuild.cmd
+            -configuration $(_BuildConfig)
+            -prepareMachine
             -integrationTest
-          name: Run_Tests
-          displayName: Run Unit and Integration tests
+          name: Run_Integration_Tests
+          displayName: Run Integration Tests
           condition: succeeded()
 
         - task: PublishBuildArtifacts@1


### PR DESCRIPTION
This breaks up the YAML file such that our Restore, Build, Unit Tests and Integration Tests are now different steps. This makes it much easier for us to tell at a glance:

1. What part of our pipeline failed. 
2. How long are the different parts of our pipeline taking. 

It also means in the future we can get much better metrics via code to answer questions like 

> Which step in our build is failing the most frequently? 

Example of the new display 

<img width="234" alt="image" src="https://user-images.githubusercontent.com/146967/228600974-99b94ac1-0a15-4e78-bdc5-9ea058e5fc8c.png">
