### PR TITLE
Pool tag helper builders

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeDescriptor.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-
 using Microsoft.AspNetCore.Razor.Language.Components;
 
 namespace Microsoft.AspNetCore.Razor.Language;
@@ -75,7 +74,7 @@ public abstract class BoundAttributeDescriptor : IEquatable<BoundAttributeDescri
     internal bool IsEditorRequired
     {
         get => HasFlag(IsEditorRequiredBit);
-        set => SetOrClearFlag(IsEditorRequiredBit, value);
+        private protected set => SetOrClearFlag(IsEditorRequiredBit, value);
     }
 
     public string Name { get; protected set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultAllowedChildTagDescriptorBuilder.Policy.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultAllowedChildTagDescriptorBuilder.Policy.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.ObjectPool;
+
+namespace Microsoft.AspNetCore.Razor.Language;
+
+internal partial class DefaultAllowedChildTagDescriptorBuilder
+{
+    private sealed class Policy : IPooledObjectPolicy<DefaultAllowedChildTagDescriptorBuilder>
+    {
+        private const int MaxSize = 32;
+
+        public static Policy Instance = new();
+
+        public DefaultAllowedChildTagDescriptorBuilder Create() => new();
+
+        public bool Return(DefaultAllowedChildTagDescriptorBuilder builder)
+        {
+            builder._parent = null;
+
+            builder.Name = null;
+            builder.DisplayName = null;
+
+            if (builder._diagnostics is { } diagnostics)
+            {
+                diagnostics.Clear();
+
+                if (diagnostics.Capacity > MaxSize)
+                {
+                    diagnostics.Capacity = MaxSize;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultAllowedChildTagDescriptorBuilder.Policy.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultAllowedChildTagDescriptorBuilder.Policy.cs
@@ -7,7 +7,7 @@ internal partial class DefaultAllowedChildTagDescriptorBuilder
 {
     private sealed class Policy : TagHelperPooledObjectPolicy<DefaultAllowedChildTagDescriptorBuilder>
     {
-        public static Policy Instance = new();
+        public static readonly Policy Instance = new();
 
         public override DefaultAllowedChildTagDescriptorBuilder Create() => new();
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultAllowedChildTagDescriptorBuilder.Policy.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultAllowedChildTagDescriptorBuilder.Policy.cs
@@ -1,36 +1,24 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Extensions.ObjectPool;
-
 namespace Microsoft.AspNetCore.Razor.Language;
 
 internal partial class DefaultAllowedChildTagDescriptorBuilder
 {
-    private sealed class Policy : IPooledObjectPolicy<DefaultAllowedChildTagDescriptorBuilder>
+    private sealed class Policy : TagHelperPooledObjectPolicy<DefaultAllowedChildTagDescriptorBuilder>
     {
-        private const int MaxSize = 32;
-
         public static Policy Instance = new();
 
-        public DefaultAllowedChildTagDescriptorBuilder Create() => new();
+        public override DefaultAllowedChildTagDescriptorBuilder Create() => new();
 
-        public bool Return(DefaultAllowedChildTagDescriptorBuilder builder)
+        public override bool Return(DefaultAllowedChildTagDescriptorBuilder builder)
         {
             builder._parent = null;
 
             builder.Name = null;
             builder.DisplayName = null;
 
-            if (builder._diagnostics is { } diagnostics)
-            {
-                diagnostics.Clear();
-
-                if (diagnostics.Capacity > MaxSize)
-                {
-                    diagnostics.Capacity = MaxSize;
-                }
-            }
+            ClearDiagnostics(builder._diagnostics);
 
             return true;
         }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultAllowedChildTagDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultAllowedChildTagDescriptorBuilder.cs
@@ -12,7 +12,7 @@ internal partial class DefaultAllowedChildTagDescriptorBuilder : AllowedChildTag
 {
     private static readonly ObjectPool<DefaultAllowedChildTagDescriptorBuilder> s_pool = DefaultPool.Create(Policy.Instance);
 
-    public static DefaultAllowedChildTagDescriptorBuilder Get(DefaultTagHelperDescriptorBuilder parent)
+    public static DefaultAllowedChildTagDescriptorBuilder GetInstance(DefaultTagHelperDescriptorBuilder parent)
     {
         var builder = s_pool.Get();
 
@@ -21,7 +21,7 @@ internal partial class DefaultAllowedChildTagDescriptorBuilder : AllowedChildTag
         return builder;
     }
 
-    public static void Return(DefaultAllowedChildTagDescriptorBuilder builder)
+    public static void ReturnInstance(DefaultAllowedChildTagDescriptorBuilder builder)
         => s_pool.Return(builder);
 
     [AllowNull]

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultAllowedChildTagDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultAllowedChildTagDescriptorBuilder.cs
@@ -2,14 +2,35 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Razor.PooledObjects;
+using Microsoft.Extensions.ObjectPool;
 
 namespace Microsoft.AspNetCore.Razor.Language;
 
-internal class DefaultAllowedChildTagDescriptorBuilder : AllowedChildTagDescriptorBuilder, IBuilder<AllowedChildTagDescriptor>
+internal partial class DefaultAllowedChildTagDescriptorBuilder : AllowedChildTagDescriptorBuilder, IBuilder<AllowedChildTagDescriptor>
 {
-    private readonly DefaultTagHelperDescriptorBuilder _parent;
+    private static readonly ObjectPool<DefaultAllowedChildTagDescriptorBuilder> s_pool = DefaultPool.Create(Policy.Instance);
+
+    public static DefaultAllowedChildTagDescriptorBuilder Get(DefaultTagHelperDescriptorBuilder parent)
+    {
+        var builder = s_pool.Get();
+
+        builder._parent = parent;
+
+        return builder;
+    }
+
+    public static void Return(DefaultAllowedChildTagDescriptorBuilder builder)
+        => s_pool.Return(builder);
+
+    [AllowNull]
+    private DefaultTagHelperDescriptorBuilder _parent;
     private RazorDiagnosticCollection? _diagnostics;
+
+    private DefaultAllowedChildTagDescriptorBuilder()
+    {
+    }
 
     public DefaultAllowedChildTagDescriptorBuilder(DefaultTagHelperDescriptorBuilder parent)
     {
@@ -17,7 +38,6 @@ internal class DefaultAllowedChildTagDescriptorBuilder : AllowedChildTagDescript
     }
 
     public override string? Name { get; set; }
-
     public override string? DisplayName { get; set; }
 
     public override RazorDiagnosticCollection Diagnostics => _diagnostics ??= new RazorDiagnosticCollection();

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptor.cs
@@ -16,6 +16,7 @@ internal sealed class DefaultBoundAttributeDescriptor : BoundAttributeDescriptor
         string? documentation,
         string? displayName,
         bool caseSensitive,
+        bool isEditorRequired,
         BoundAttributeParameterDescriptor[] parameterDescriptors,
         MetadataCollection metadata,
         RazorDiagnostic[] diagnostics)
@@ -30,6 +31,7 @@ internal sealed class DefaultBoundAttributeDescriptor : BoundAttributeDescriptor
         Documentation = documentation;
         DisplayName = displayName;
         CaseSensitive = caseSensitive;
+        IsEditorRequired = isEditorRequired;
         BoundAttributeParameters = parameterDescriptors;
 
         Metadata = metadata;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptorBuilder.Policy.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptorBuilder.Policy.cs
@@ -7,7 +7,7 @@ internal partial class DefaultBoundAttributeDescriptorBuilder
 {
     private sealed class Policy : TagHelperPooledObjectPolicy<DefaultBoundAttributeDescriptorBuilder>
     {
-        public static Policy Instance = new();
+        public static readonly Policy Instance = new();
 
         public override DefaultBoundAttributeDescriptorBuilder Create() => new();
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptorBuilder.Policy.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptorBuilder.Policy.cs
@@ -1,21 +1,17 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Extensions.ObjectPool;
-
 namespace Microsoft.AspNetCore.Razor.Language;
 
 internal partial class DefaultBoundAttributeDescriptorBuilder
 {
-    private sealed class Policy : IPooledObjectPolicy<DefaultBoundAttributeDescriptorBuilder>
+    private sealed class Policy : TagHelperPooledObjectPolicy<DefaultBoundAttributeDescriptorBuilder>
     {
-        private const int MaxSize = 32;
-
         public static Policy Instance = new();
 
-        public DefaultBoundAttributeDescriptorBuilder Create() => new();
+        public override DefaultBoundAttributeDescriptorBuilder Create() => new();
 
-        public bool Return(DefaultBoundAttributeDescriptorBuilder builder)
+        public override bool Return(DefaultBoundAttributeDescriptorBuilder builder)
         {
             builder._parent = null;
             builder._kind = null;
@@ -24,6 +20,7 @@ internal partial class DefaultBoundAttributeDescriptorBuilder
             builder.TypeName = null;
             builder.IsEnum = false;
             builder.IsDictionary = false;
+            builder.IsEditorRequired = false;
             builder.IndexerAttributeNamePrefix = null;
             builder.IndexerValueTypeName = null;
             builder.Documentation = null;
@@ -36,24 +33,10 @@ internal partial class DefaultBoundAttributeDescriptorBuilder
                     DefaultBoundAttributeParameterDescriptorBuilder.Return(attributeParameterBuilder);
                 }
 
-                attributeParameterBuilders.Clear();
-
-                if (attributeParameterBuilders.Capacity > MaxSize)
-                {
-                    attributeParameterBuilders.Capacity = MaxSize;
-                }
-
+                ClearList(attributeParameterBuilders);
             }
 
-            if (builder._diagnostics is { } diagnostics)
-            {
-                diagnostics.Clear();
-
-                if (diagnostics.Capacity > MaxSize)
-                {
-                    diagnostics.Capacity = MaxSize;
-                }
-            }
+            ClearDiagnostics(builder._diagnostics);
 
             builder._metadata?.Clear();
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptorBuilder.Policy.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptorBuilder.Policy.cs
@@ -28,9 +28,10 @@ internal partial class DefaultBoundAttributeDescriptorBuilder
 
             if (builder._attributeParameterBuilders is { } attributeParameterBuilders)
             {
+                // Make sure that we return all parameter builders to their pool.
                 foreach (var attributeParameterBuilder in attributeParameterBuilders)
                 {
-                    DefaultBoundAttributeParameterDescriptorBuilder.Return(attributeParameterBuilder);
+                    DefaultBoundAttributeParameterDescriptorBuilder.ReturnInstance(attributeParameterBuilder);
                 }
 
                 ClearList(attributeParameterBuilders);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptorBuilder.Policy.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptorBuilder.Policy.cs
@@ -1,0 +1,63 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.ObjectPool;
+
+namespace Microsoft.AspNetCore.Razor.Language;
+
+internal partial class DefaultBoundAttributeDescriptorBuilder
+{
+    private sealed class Policy : IPooledObjectPolicy<DefaultBoundAttributeDescriptorBuilder>
+    {
+        private const int MaxSize = 32;
+
+        public static Policy Instance = new();
+
+        public DefaultBoundAttributeDescriptorBuilder Create() => new();
+
+        public bool Return(DefaultBoundAttributeDescriptorBuilder builder)
+        {
+            builder._parent = null;
+            builder._kind = null;
+
+            builder.Name = null;
+            builder.TypeName = null;
+            builder.IsEnum = false;
+            builder.IsDictionary = false;
+            builder.IndexerAttributeNamePrefix = null;
+            builder.IndexerValueTypeName = null;
+            builder.Documentation = null;
+            builder.DisplayName = null;
+
+            if (builder._attributeParameterBuilders is { } attributeParameterBuilders)
+            {
+                foreach (var attributeParameterBuilder in attributeParameterBuilders)
+                {
+                    DefaultBoundAttributeParameterDescriptorBuilder.Return(attributeParameterBuilder);
+                }
+
+                attributeParameterBuilders.Clear();
+
+                if (attributeParameterBuilders.Capacity > MaxSize)
+                {
+                    attributeParameterBuilders.Capacity = MaxSize;
+                }
+
+            }
+
+            if (builder._diagnostics is { } diagnostics)
+            {
+                diagnostics.Clear();
+
+                if (diagnostics.Capacity > MaxSize)
+                {
+                    diagnostics.Capacity = MaxSize;
+                }
+            }
+
+            builder._metadata?.Clear();
+
+            return true;
+        }
+    }
+}

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptorBuilder.cs
@@ -9,8 +9,23 @@ using Microsoft.Extensions.ObjectPool;
 
 namespace Microsoft.AspNetCore.Razor.Language;
 
-internal class DefaultBoundAttributeDescriptorBuilder : BoundAttributeDescriptorBuilder, IBuilder<BoundAttributeDescriptor>
+internal partial class DefaultBoundAttributeDescriptorBuilder : BoundAttributeDescriptorBuilder, IBuilder<BoundAttributeDescriptor>
 {
+    private static readonly ObjectPool<DefaultBoundAttributeDescriptorBuilder> s_pool = DefaultPool.Create(Policy.Instance);
+
+    public static DefaultBoundAttributeDescriptorBuilder Get(DefaultTagHelperDescriptorBuilder parent, string kind)
+    {
+        var builder = s_pool.Get();
+
+        builder._parent = parent;
+        builder._kind = kind;
+
+        return builder;
+    }
+
+    public static void Return(DefaultBoundAttributeDescriptorBuilder builder)
+        => s_pool.Return(builder);
+
     private static readonly ObjectPool<HashSet<BoundAttributeParameterDescriptor>> s_boundAttributeParameterSetPool
         = HashSetPool<BoundAttributeParameterDescriptor>.Create(BoundAttributeParameterDescriptorComparer.Default);
 
@@ -35,11 +50,17 @@ internal class DefaultBoundAttributeDescriptorBuilder : BoundAttributeDescriptor
         { typeof(decimal).FullName, "decimal" }
     };
 
-    private readonly DefaultTagHelperDescriptorBuilder _parent;
-    private readonly string _kind;
+    [AllowNull]
+    private DefaultTagHelperDescriptorBuilder _parent;
+    [AllowNull]
+    private string _kind;
     private List<DefaultBoundAttributeParameterDescriptorBuilder>? _attributeParameterBuilders;
     private Dictionary<string, string>? _metadata;
     private RazorDiagnosticCollection? _diagnostics;
+
+    private DefaultBoundAttributeDescriptorBuilder()
+    {
+    }
 
     public DefaultBoundAttributeDescriptorBuilder(DefaultTagHelperDescriptorBuilder parent, string kind)
     {
@@ -48,19 +69,12 @@ internal class DefaultBoundAttributeDescriptorBuilder : BoundAttributeDescriptor
     }
 
     public override string? Name { get; set; }
-
     public override string? TypeName { get; set; }
-
     public override bool IsEnum { get; set; }
-
     public override bool IsDictionary { get; set; }
-
     public override string? IndexerAttributeNamePrefix { get; set; }
-
     public override string? IndexerValueTypeName { get; set; }
-
     public override string? Documentation { get; set; }
-
     public override string? DisplayName { get; set; }
 
     public override IDictionary<string, string> Metadata => _metadata ??= new Dictionary<string, string>();
@@ -78,7 +92,7 @@ internal class DefaultBoundAttributeDescriptorBuilder : BoundAttributeDescriptor
 
         EnsureAttributeParameterBuilders();
 
-        var builder = new DefaultBoundAttributeParameterDescriptorBuilder(this, _kind);
+        var builder = DefaultBoundAttributeParameterDescriptorBuilder.Get(this, _kind);
         configure(builder);
         _attributeParameterBuilders.Add(builder);
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptorBuilder.cs
@@ -119,12 +119,10 @@ internal partial class DefaultBoundAttributeDescriptorBuilder : BoundAttributeDe
                 Documentation,
                 GetDisplayName(),
                 CaseSensitive,
+                IsEditorRequired,
                 parameters,
                 MetadataCollection.CreateOrEmpty(_metadata),
-                diagnostics.ToArray())
-            {
-                IsEditorRequired = IsEditorRequired,
-            };
+                diagnostics.ToArray());
 
             return descriptor;
         }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptorBuilder.cs
@@ -13,7 +13,7 @@ internal partial class DefaultBoundAttributeDescriptorBuilder : BoundAttributeDe
 {
     private static readonly ObjectPool<DefaultBoundAttributeDescriptorBuilder> s_pool = DefaultPool.Create(Policy.Instance);
 
-    public static DefaultBoundAttributeDescriptorBuilder Get(DefaultTagHelperDescriptorBuilder parent, string kind)
+    public static DefaultBoundAttributeDescriptorBuilder GetInstance(DefaultTagHelperDescriptorBuilder parent, string kind)
     {
         var builder = s_pool.Get();
 
@@ -23,7 +23,7 @@ internal partial class DefaultBoundAttributeDescriptorBuilder : BoundAttributeDe
         return builder;
     }
 
-    public static void Return(DefaultBoundAttributeDescriptorBuilder builder)
+    public static void ReturnInstance(DefaultBoundAttributeDescriptorBuilder builder)
         => s_pool.Return(builder);
 
     private static readonly ObjectPool<HashSet<BoundAttributeParameterDescriptor>> s_boundAttributeParameterSetPool
@@ -92,7 +92,7 @@ internal partial class DefaultBoundAttributeDescriptorBuilder : BoundAttributeDe
 
         EnsureAttributeParameterBuilders();
 
-        var builder = DefaultBoundAttributeParameterDescriptorBuilder.Get(this, _kind);
+        var builder = DefaultBoundAttributeParameterDescriptorBuilder.GetInstance(this, _kind);
         configure(builder);
         _attributeParameterBuilders.Add(builder);
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeParameterDescriptorBuilder.Policy.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeParameterDescriptorBuilder.Policy.cs
@@ -1,21 +1,17 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Extensions.ObjectPool;
-
 namespace Microsoft.AspNetCore.Razor.Language;
 
 internal partial class DefaultBoundAttributeParameterDescriptorBuilder
 {
-    private sealed class Policy : IPooledObjectPolicy<DefaultBoundAttributeParameterDescriptorBuilder>
+    private sealed class Policy : TagHelperPooledObjectPolicy<DefaultBoundAttributeParameterDescriptorBuilder>
     {
-        private const int MaxSize = 32;
-
         public static Policy Instance = new();
 
-        public DefaultBoundAttributeParameterDescriptorBuilder Create() => new();
+        public override DefaultBoundAttributeParameterDescriptorBuilder Create() => new();
 
-        public bool Return(DefaultBoundAttributeParameterDescriptorBuilder builder)
+        public override bool Return(DefaultBoundAttributeParameterDescriptorBuilder builder)
         {
             builder._parent = null;
             builder._kind = null;
@@ -26,15 +22,7 @@ internal partial class DefaultBoundAttributeParameterDescriptorBuilder
             builder.Documentation = null;
             builder.DisplayName = null;
 
-            if (builder._diagnostics is { } diagnostics)
-            {
-                diagnostics.Clear();
-
-                if (diagnostics.Capacity > MaxSize)
-                {
-                    diagnostics.Capacity = MaxSize;
-                }
-            }
+            ClearDiagnostics(builder._diagnostics);
 
             builder._metadata?.Clear();
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeParameterDescriptorBuilder.Policy.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeParameterDescriptorBuilder.Policy.cs
@@ -7,7 +7,7 @@ internal partial class DefaultBoundAttributeParameterDescriptorBuilder
 {
     private sealed class Policy : TagHelperPooledObjectPolicy<DefaultBoundAttributeParameterDescriptorBuilder>
     {
-        public static Policy Instance = new();
+        public static readonly Policy Instance = new();
 
         public override DefaultBoundAttributeParameterDescriptorBuilder Create() => new();
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeParameterDescriptorBuilder.Policy.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeParameterDescriptorBuilder.Policy.cs
@@ -1,0 +1,44 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.ObjectPool;
+
+namespace Microsoft.AspNetCore.Razor.Language;
+
+internal partial class DefaultBoundAttributeParameterDescriptorBuilder
+{
+    private sealed class Policy : IPooledObjectPolicy<DefaultBoundAttributeParameterDescriptorBuilder>
+    {
+        private const int MaxSize = 32;
+
+        public static Policy Instance = new();
+
+        public DefaultBoundAttributeParameterDescriptorBuilder Create() => new();
+
+        public bool Return(DefaultBoundAttributeParameterDescriptorBuilder builder)
+        {
+            builder._parent = null;
+            builder._kind = null;
+
+            builder.Name = null;
+            builder.TypeName = null;
+            builder.IsEnum = false;
+            builder.Documentation = null;
+            builder.DisplayName = null;
+
+            if (builder._diagnostics is { } diagnostics)
+            {
+                diagnostics.Clear();
+
+                if (diagnostics.Capacity > MaxSize)
+                {
+                    diagnostics.Capacity = MaxSize;
+                }
+            }
+
+            builder._metadata?.Clear();
+
+            return true;
+        }
+    }
+}

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeParameterDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeParameterDescriptorBuilder.cs
@@ -3,17 +3,40 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Razor.PooledObjects;
+using Microsoft.Extensions.ObjectPool;
 
 namespace Microsoft.AspNetCore.Razor.Language;
 
-internal class DefaultBoundAttributeParameterDescriptorBuilder : BoundAttributeParameterDescriptorBuilder, IBuilder<BoundAttributeParameterDescriptor>
+internal partial class DefaultBoundAttributeParameterDescriptorBuilder : BoundAttributeParameterDescriptorBuilder, IBuilder<BoundAttributeParameterDescriptor>
 {
-    private readonly DefaultBoundAttributeDescriptorBuilder _parent;
-    private readonly string _kind;
+    private static readonly ObjectPool<DefaultBoundAttributeParameterDescriptorBuilder> s_pool = DefaultPool.Create(Policy.Instance);
+
+    public static DefaultBoundAttributeParameterDescriptorBuilder Get(DefaultBoundAttributeDescriptorBuilder parent, string kind)
+    {
+        var builder = s_pool.Get();
+
+        builder._parent = parent;
+        builder._kind = kind;
+
+        return builder;
+    }
+
+    public static void Return(DefaultBoundAttributeParameterDescriptorBuilder builder)
+        => s_pool.Return(builder);
+
+    [AllowNull]
+    private DefaultBoundAttributeDescriptorBuilder _parent;
+    [AllowNull]
+    private string _kind;
     private Dictionary<string, string>? _metadata;
 
     private RazorDiagnosticCollection? _diagnostics;
+
+    private DefaultBoundAttributeParameterDescriptorBuilder()
+    {
+    }
 
     public DefaultBoundAttributeParameterDescriptorBuilder(DefaultBoundAttributeDescriptorBuilder parent, string kind)
     {
@@ -22,13 +45,9 @@ internal class DefaultBoundAttributeParameterDescriptorBuilder : BoundAttributeP
     }
 
     public override string? Name { get; set; }
-
     public override string? TypeName { get; set; }
-
     public override bool IsEnum { get; set; }
-
     public override string? Documentation { get; set; }
-
     public override string? DisplayName { get; set; }
 
     public override IDictionary<string, string> Metadata => _metadata ??= new Dictionary<string, string>();

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeParameterDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeParameterDescriptorBuilder.cs
@@ -13,7 +13,7 @@ internal partial class DefaultBoundAttributeParameterDescriptorBuilder : BoundAt
 {
     private static readonly ObjectPool<DefaultBoundAttributeParameterDescriptorBuilder> s_pool = DefaultPool.Create(Policy.Instance);
 
-    public static DefaultBoundAttributeParameterDescriptorBuilder Get(DefaultBoundAttributeDescriptorBuilder parent, string kind)
+    public static DefaultBoundAttributeParameterDescriptorBuilder GetInstance(DefaultBoundAttributeDescriptorBuilder parent, string kind)
     {
         var builder = s_pool.Get();
 
@@ -23,7 +23,7 @@ internal partial class DefaultBoundAttributeParameterDescriptorBuilder : BoundAt
         return builder;
     }
 
-    public static void Return(DefaultBoundAttributeParameterDescriptorBuilder builder)
+    public static void ReturnInstance(DefaultBoundAttributeParameterDescriptorBuilder builder)
         => s_pool.Return(builder);
 
     [AllowNull]

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRequiredAttributeDescriptorBuilder.Policy.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRequiredAttributeDescriptorBuilder.Policy.cs
@@ -7,7 +7,7 @@ internal partial class DefaultRequiredAttributeDescriptorBuilder
 {
     private sealed class Policy : TagHelperPooledObjectPolicy<DefaultRequiredAttributeDescriptorBuilder>
     {
-        public static Policy Instance = new();
+        public static readonly Policy Instance = new();
 
         public override DefaultRequiredAttributeDescriptorBuilder Create() => new();
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRequiredAttributeDescriptorBuilder.Policy.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRequiredAttributeDescriptorBuilder.Policy.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.ObjectPool;
+
+namespace Microsoft.AspNetCore.Razor.Language;
+
+internal partial class DefaultRequiredAttributeDescriptorBuilder
+{
+    private sealed class Policy : IPooledObjectPolicy<DefaultRequiredAttributeDescriptorBuilder>
+    {
+        private const int MaxSize = 32;
+
+        public static Policy Instance = new();
+
+        public DefaultRequiredAttributeDescriptorBuilder Create() => new();
+
+        public bool Return(DefaultRequiredAttributeDescriptorBuilder builder)
+        {
+            builder._parent = null;
+
+            builder.Name = null;
+            builder.NameComparisonMode = default;
+            builder.Value = null;
+            builder.ValueComparisonMode = default;
+
+            if (builder._diagnostics is { } diagnostics)
+            {
+                diagnostics.Clear();
+
+                if (diagnostics.Capacity > MaxSize)
+                {
+                    diagnostics.Capacity = MaxSize;
+                }
+            }
+
+            builder._metadata?.Clear();
+
+            return true;
+        }
+    }
+}

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRequiredAttributeDescriptorBuilder.Policy.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRequiredAttributeDescriptorBuilder.Policy.cs
@@ -1,21 +1,17 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Extensions.ObjectPool;
-
 namespace Microsoft.AspNetCore.Razor.Language;
 
 internal partial class DefaultRequiredAttributeDescriptorBuilder
 {
-    private sealed class Policy : IPooledObjectPolicy<DefaultRequiredAttributeDescriptorBuilder>
+    private sealed class Policy : TagHelperPooledObjectPolicy<DefaultRequiredAttributeDescriptorBuilder>
     {
-        private const int MaxSize = 32;
-
         public static Policy Instance = new();
 
-        public DefaultRequiredAttributeDescriptorBuilder Create() => new();
+        public override DefaultRequiredAttributeDescriptorBuilder Create() => new();
 
-        public bool Return(DefaultRequiredAttributeDescriptorBuilder builder)
+        public override bool Return(DefaultRequiredAttributeDescriptorBuilder builder)
         {
             builder._parent = null;
 
@@ -24,15 +20,7 @@ internal partial class DefaultRequiredAttributeDescriptorBuilder
             builder.Value = null;
             builder.ValueComparisonMode = default;
 
-            if (builder._diagnostics is { } diagnostics)
-            {
-                diagnostics.Clear();
-
-                if (diagnostics.Capacity > MaxSize)
-                {
-                    diagnostics.Capacity = MaxSize;
-                }
-            }
+            ClearDiagnostics(builder._diagnostics);
 
             builder._metadata?.Clear();
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRequiredAttributeDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRequiredAttributeDescriptorBuilder.cs
@@ -14,7 +14,7 @@ internal partial class DefaultRequiredAttributeDescriptorBuilder : RequiredAttri
 {
     private static readonly ObjectPool<DefaultRequiredAttributeDescriptorBuilder> s_pool = DefaultPool.Create(Policy.Instance);
 
-    public static DefaultRequiredAttributeDescriptorBuilder Get(DefaultTagMatchingRuleDescriptorBuilder parent)
+    public static DefaultRequiredAttributeDescriptorBuilder GetInstance(DefaultTagMatchingRuleDescriptorBuilder parent)
     {
         var builder = s_pool.Get();
 
@@ -23,7 +23,7 @@ internal partial class DefaultRequiredAttributeDescriptorBuilder : RequiredAttri
         return builder;
     }
 
-    public static void Return(DefaultRequiredAttributeDescriptorBuilder builder)
+    public static void ReturnInstance(DefaultRequiredAttributeDescriptorBuilder builder)
         => s_pool.Return(builder);
 
     [AllowNull]

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.Policy.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.Policy.cs
@@ -37,8 +37,25 @@ internal partial class DefaultTagHelperDescriptorBuilder
                 ClearBuilderList(allowedChildTagBuilders);
             }
 
-            ClearBuilderList(builder._attributeBuilders);
-            ClearBuilderList(builder._tagMatchingRuleBuilders);
+            if (builder._attributeBuilders is { } attributeBuilders)
+            {
+                foreach (var attributeBuilder in attributeBuilders)
+                {
+                    DefaultBoundAttributeDescriptorBuilder.Return(attributeBuilder);
+                }
+
+                ClearBuilderList(attributeBuilders);
+            }
+
+            if (builder._tagMatchingRuleBuilders is { } tagMatchingRuleBuilders)
+            {
+                foreach (var tagMatchingRuleBuilder in tagMatchingRuleBuilders)
+                {
+                    DefaultTagMatchingRuleDescriptorBuilder.Return(tagMatchingRuleBuilder);
+                }
+
+                ClearBuilderList(tagMatchingRuleBuilders);
+            }
 
             if (builder._diagnostics is { } diagnostics)
             {
@@ -54,13 +71,8 @@ internal partial class DefaultTagHelperDescriptorBuilder
 
             return true;
 
-            static void ClearBuilderList<T>(List<T>? builders)
+            static void ClearBuilderList<T>(List<T> builders)
             {
-                if (builders is null)
-                {
-                    return;
-                }
-
                 builders.Clear();
 
                 if (builders.Capacity > MaxSize)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.Policy.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.Policy.cs
@@ -1,0 +1,64 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using Microsoft.Extensions.ObjectPool;
+
+namespace Microsoft.AspNetCore.Razor.Language;
+
+internal partial class DefaultTagHelperDescriptorBuilder
+{
+    private sealed class Policy : IPooledObjectPolicy<DefaultTagHelperDescriptorBuilder>
+    {
+        private const int MaxSize = 32;
+
+        public static Policy Instance = new();
+
+        public DefaultTagHelperDescriptorBuilder Create() => new();
+
+        public bool Return(DefaultTagHelperDescriptorBuilder builder)
+        {
+            builder._kind = null;
+            builder._name = null;
+            builder._assemblyName = null;
+
+            builder.DisplayName = null;
+            builder.TagOutputHint = null;
+            builder.CaseSensitive = false;
+            builder.Documentation = null;
+
+            ClearBuilderList(builder._allowedChildTags);
+            ClearBuilderList(builder._attributeBuilders);
+            ClearBuilderList(builder._tagMatchingRuleBuilders);
+
+            if (builder._diagnostics is { } diagnostics)
+            {
+                diagnostics.Clear();
+
+                if (diagnostics.Capacity > MaxSize)
+                {
+                    diagnostics.Capacity = MaxSize;
+                }
+            }
+
+            builder._metadata.Clear();
+
+            return true;
+
+            static void ClearBuilderList<T>(List<T>? builders)
+            {
+                if (builders is null)
+                {
+                    return;
+                }
+
+                builders.Clear();
+
+                if (builders.Capacity > MaxSize)
+                {
+                    builders.Capacity = MaxSize;
+                }
+            }
+        }
+    }
+}

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.Policy.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.Policy.cs
@@ -7,7 +7,7 @@ internal partial class DefaultTagHelperDescriptorBuilder
 {
     private sealed class Policy : TagHelperPooledObjectPolicy<DefaultTagHelperDescriptorBuilder>
     {
-        public static Policy Instance = new();
+        public static readonly Policy Instance = new();
 
         public override DefaultTagHelperDescriptorBuilder Create() => new();
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.Policy.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.Policy.cs
@@ -24,9 +24,10 @@ internal partial class DefaultTagHelperDescriptorBuilder
 
             if (builder._allowedChildTags is { } allowedChildTagBuilders)
             {
+                // Make sure that we return all allowed child tag builders to their pool.
                 foreach (var allowedChildTagBuilder in allowedChildTagBuilders)
                 {
-                    DefaultAllowedChildTagDescriptorBuilder.Return(allowedChildTagBuilder);
+                    DefaultAllowedChildTagDescriptorBuilder.ReturnInstance(allowedChildTagBuilder);
                 }
 
                 ClearList(allowedChildTagBuilders);
@@ -34,9 +35,10 @@ internal partial class DefaultTagHelperDescriptorBuilder
 
             if (builder._attributeBuilders is { } attributeBuilders)
             {
+                // Make sure that we return all allowed bound attribute builders to their pool.
                 foreach (var attributeBuilder in attributeBuilders)
                 {
-                    DefaultBoundAttributeDescriptorBuilder.Return(attributeBuilder);
+                    DefaultBoundAttributeDescriptorBuilder.ReturnInstance(attributeBuilder);
                 }
 
                 ClearList(attributeBuilders);
@@ -44,9 +46,10 @@ internal partial class DefaultTagHelperDescriptorBuilder
 
             if (builder._tagMatchingRuleBuilders is { } tagMatchingRuleBuilders)
             {
+                // Make sure that we return all allowed tag matching rule builders to their pool.
                 foreach (var tagMatchingRuleBuilder in tagMatchingRuleBuilders)
                 {
-                    DefaultTagMatchingRuleDescriptorBuilder.Return(tagMatchingRuleBuilder);
+                    DefaultTagMatchingRuleDescriptorBuilder.ReturnInstance(tagMatchingRuleBuilder);
                 }
 
                 ClearList(tagMatchingRuleBuilders);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.Policy.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.Policy.cs
@@ -1,22 +1,17 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using Microsoft.Extensions.ObjectPool;
-
 namespace Microsoft.AspNetCore.Razor.Language;
 
 internal partial class DefaultTagHelperDescriptorBuilder
 {
-    private sealed class Policy : IPooledObjectPolicy<DefaultTagHelperDescriptorBuilder>
+    private sealed class Policy : TagHelperPooledObjectPolicy<DefaultTagHelperDescriptorBuilder>
     {
-        private const int MaxSize = 32;
-
         public static Policy Instance = new();
 
-        public DefaultTagHelperDescriptorBuilder Create() => new();
+        public override DefaultTagHelperDescriptorBuilder Create() => new();
 
-        public bool Return(DefaultTagHelperDescriptorBuilder builder)
+        public override bool Return(DefaultTagHelperDescriptorBuilder builder)
         {
             builder._kind = null;
             builder._name = null;
@@ -34,7 +29,7 @@ internal partial class DefaultTagHelperDescriptorBuilder
                     DefaultAllowedChildTagDescriptorBuilder.Return(allowedChildTagBuilder);
                 }
 
-                ClearBuilderList(allowedChildTagBuilders);
+                ClearList(allowedChildTagBuilders);
             }
 
             if (builder._attributeBuilders is { } attributeBuilders)
@@ -44,7 +39,7 @@ internal partial class DefaultTagHelperDescriptorBuilder
                     DefaultBoundAttributeDescriptorBuilder.Return(attributeBuilder);
                 }
 
-                ClearBuilderList(attributeBuilders);
+                ClearList(attributeBuilders);
             }
 
             if (builder._tagMatchingRuleBuilders is { } tagMatchingRuleBuilders)
@@ -54,32 +49,14 @@ internal partial class DefaultTagHelperDescriptorBuilder
                     DefaultTagMatchingRuleDescriptorBuilder.Return(tagMatchingRuleBuilder);
                 }
 
-                ClearBuilderList(tagMatchingRuleBuilders);
+                ClearList(tagMatchingRuleBuilders);
             }
 
-            if (builder._diagnostics is { } diagnostics)
-            {
-                diagnostics.Clear();
-
-                if (diagnostics.Capacity > MaxSize)
-                {
-                    diagnostics.Capacity = MaxSize;
-                }
-            }
+            ClearDiagnostics(builder._diagnostics);
 
             builder._metadata.Clear();
 
             return true;
-
-            static void ClearBuilderList<T>(List<T> builders)
-            {
-                builders.Clear();
-
-                if (builders.Capacity > MaxSize)
-                {
-                    builders.Capacity = MaxSize;
-                }
-            }
         }
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.Policy.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.Policy.cs
@@ -27,7 +27,16 @@ internal partial class DefaultTagHelperDescriptorBuilder
             builder.CaseSensitive = false;
             builder.Documentation = null;
 
-            ClearBuilderList(builder._allowedChildTags);
+            if (builder._allowedChildTags is { } allowedChildTagBuilders)
+            {
+                foreach (var allowedChildTagBuilder in allowedChildTagBuilders)
+                {
+                    DefaultAllowedChildTagDescriptorBuilder.Return(allowedChildTagBuilder);
+                }
+
+                ClearBuilderList(allowedChildTagBuilders);
+            }
+
             ClearBuilderList(builder._attributeBuilders);
             ClearBuilderList(builder._tagMatchingRuleBuilders);
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.cs
@@ -120,7 +120,7 @@ internal partial class DefaultTagHelperDescriptorBuilder : TagHelperDescriptorBu
 
         EnsureAllowedChildTags();
 
-        var builder = new DefaultAllowedChildTagDescriptorBuilder(this);
+        var builder = DefaultAllowedChildTagDescriptorBuilder.Get(this);
         configure(builder);
         _allowedChildTags.Add(builder);
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.cs
@@ -13,10 +13,10 @@ internal partial class DefaultTagHelperDescriptorBuilder : TagHelperDescriptorBu
 {
     private static readonly ObjectPool<DefaultTagHelperDescriptorBuilder> s_pool = DefaultPool.Create(Policy.Instance);
 
-    public static DefaultTagHelperDescriptorBuilder Get(string name, string assemblyName)
-        => Get(TagHelperConventions.DefaultKind, name, assemblyName);
+    public static DefaultTagHelperDescriptorBuilder GetInstance(string name, string assemblyName)
+        => GetInstance(TagHelperConventions.DefaultKind, name, assemblyName);
 
-    public static DefaultTagHelperDescriptorBuilder Get(string kind, string name, string assemblyName)
+    public static DefaultTagHelperDescriptorBuilder GetInstance(string kind, string name, string assemblyName)
     {
         var builder = s_pool.Get();
 
@@ -29,7 +29,7 @@ internal partial class DefaultTagHelperDescriptorBuilder : TagHelperDescriptorBu
         return builder;
     }
 
-    public static void Return(DefaultTagHelperDescriptorBuilder builder)
+    public static void ReturnInstance(DefaultTagHelperDescriptorBuilder builder)
         => s_pool.Return(builder);
 
     private static readonly ObjectPool<HashSet<AllowedChildTagDescriptor>> s_allowedChildTagSetPool
@@ -116,7 +116,7 @@ internal partial class DefaultTagHelperDescriptorBuilder : TagHelperDescriptorBu
 
         EnsureAllowedChildTags();
 
-        var builder = DefaultAllowedChildTagDescriptorBuilder.Get(this);
+        var builder = DefaultAllowedChildTagDescriptorBuilder.GetInstance(this);
         configure(builder);
         _allowedChildTags.Add(builder);
     }
@@ -130,7 +130,7 @@ internal partial class DefaultTagHelperDescriptorBuilder : TagHelperDescriptorBu
 
         EnsureAttributeBuilders();
 
-        var builder = DefaultBoundAttributeDescriptorBuilder.Get(this, Kind);
+        var builder = DefaultBoundAttributeDescriptorBuilder.GetInstance(this, Kind);
         configure(builder);
         _attributeBuilders.Add(builder);
     }
@@ -144,7 +144,7 @@ internal partial class DefaultTagHelperDescriptorBuilder : TagHelperDescriptorBu
 
         EnsureTagMatchingRuleBuilders();
 
-        var builder = DefaultTagMatchingRuleDescriptorBuilder.Get(this);
+        var builder = DefaultTagMatchingRuleDescriptorBuilder.GetInstance(this);
         configure(builder);
         _tagMatchingRuleBuilders.Add(builder);
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.cs
@@ -24,9 +24,7 @@ internal partial class DefaultTagHelperDescriptorBuilder : TagHelperDescriptorBu
         builder._name = name;
         builder._assemblyName = assemblyName;
 
-        // Tells code generation that these tag helpers are compatible with ITagHelper.
-        // For now that's all we support.
-        builder._metadata.Add(TagHelperMetadata.Runtime.Name, TagHelperConventions.DefaultKind);
+        builder.InitializeMetadata();
 
         return builder;
     }
@@ -65,9 +63,7 @@ internal partial class DefaultTagHelperDescriptorBuilder : TagHelperDescriptorBu
         _name = name;
         _assemblyName = assemblyName;
 
-        // Tells code generation that these tag helpers are compatible with ITagHelper.
-        // For now that's all we support.
-        _metadata.Add(TagHelperMetadata.Runtime.Name, TagHelperConventions.DefaultKind);
+        InitializeMetadata();
     }
 
     public override string Kind => _kind.AssumeNotNull();
@@ -209,5 +205,12 @@ internal partial class DefaultTagHelperDescriptorBuilder : TagHelperDescriptorBu
     private void EnsureTagMatchingRuleBuilders()
     {
         _tagMatchingRuleBuilders ??= new List<DefaultTagMatchingRuleDescriptorBuilder>();
+    }
+
+    private void InitializeMetadata()
+    {
+        // Tells code generation that these tag helpers are compatible with ITagHelper.
+        // For now that's all we support.
+        _metadata.Add(TagHelperMetadata.Runtime.Name, TagHelperConventions.DefaultKind);
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.cs
@@ -134,7 +134,7 @@ internal partial class DefaultTagHelperDescriptorBuilder : TagHelperDescriptorBu
 
         EnsureAttributeBuilders();
 
-        var builder = new DefaultBoundAttributeDescriptorBuilder(this, Kind);
+        var builder = DefaultBoundAttributeDescriptorBuilder.Get(this, Kind);
         configure(builder);
         _attributeBuilders.Add(builder);
     }
@@ -148,7 +148,7 @@ internal partial class DefaultTagHelperDescriptorBuilder : TagHelperDescriptorBu
 
         EnsureTagMatchingRuleBuilders();
 
-        var builder = new DefaultTagMatchingRuleDescriptorBuilder(this);
+        var builder = DefaultTagMatchingRuleDescriptorBuilder.Get(this);
         configure(builder);
         _tagMatchingRuleBuilders.Add(builder);
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.cs
@@ -9,8 +9,31 @@ using Microsoft.Extensions.ObjectPool;
 
 namespace Microsoft.AspNetCore.Razor.Language;
 
-internal class DefaultTagHelperDescriptorBuilder : TagHelperDescriptorBuilder, IBuilder<TagHelperDescriptor>
+internal partial class DefaultTagHelperDescriptorBuilder : TagHelperDescriptorBuilder, IBuilder<TagHelperDescriptor>
 {
+    private static readonly ObjectPool<DefaultTagHelperDescriptorBuilder> s_pool = DefaultPool.Create(Policy.Instance);
+
+    public static DefaultTagHelperDescriptorBuilder Get(string name, string assemblyName)
+        => Get(TagHelperConventions.DefaultKind, name, assemblyName);
+
+    public static DefaultTagHelperDescriptorBuilder Get(string kind, string name, string assemblyName)
+    {
+        var builder = s_pool.Get();
+
+        builder._kind = kind;
+        builder._name = name;
+        builder._assemblyName = assemblyName;
+
+        // Tells code generation that these tag helpers are compatible with ITagHelper.
+        // For now that's all we support.
+        builder._metadata.Add(TagHelperMetadata.Runtime.Name, TagHelperConventions.DefaultKind);
+
+        return builder;
+    }
+
+    public static void Return(DefaultTagHelperDescriptorBuilder builder)
+        => s_pool.Return(builder);
+
     private static readonly ObjectPool<HashSet<AllowedChildTagDescriptor>> s_allowedChildTagSetPool
         = HashSetPool<AllowedChildTagDescriptor>.Create(AllowedChildTagDescriptorComparer.Default);
 
@@ -20,42 +43,42 @@ internal class DefaultTagHelperDescriptorBuilder : TagHelperDescriptorBuilder, I
     private static readonly ObjectPool<HashSet<TagMatchingRuleDescriptor>> s_tagMatchingRuleSetPool
         = HashSetPool<TagMatchingRuleDescriptor>.Create(TagMatchingRuleDescriptorComparer.Default);
 
+    private string? _kind;
+    private string? _name;
+    private string? _assemblyName;
+
     private List<DefaultAllowedChildTagDescriptorBuilder>? _allowedChildTags;
     private List<DefaultBoundAttributeDescriptorBuilder>? _attributeBuilders;
     private List<DefaultTagMatchingRuleDescriptorBuilder>? _tagMatchingRuleBuilders;
     private RazorDiagnosticCollection? _diagnostics;
     private readonly Dictionary<string, string> _metadata;
 
-    public DefaultTagHelperDescriptorBuilder(string kind, string name, string assemblyName)
+    private DefaultTagHelperDescriptorBuilder()
     {
-        Kind = kind;
-        Name = name;
-        AssemblyName = assemblyName;
-
-        _metadata = new Dictionary<string, string>(StringComparer.Ordinal)
-        {
-            // Tells code generation that these tag helpers are compatible with ITagHelper.
-            // For now that's all we support.
-            { TagHelperMetadata.Runtime.Name, TagHelperConventions.DefaultKind }
-        };
+        _metadata = new Dictionary<string, string>(StringComparer.Ordinal);
     }
 
-    public override string Name { get; }
+    public DefaultTagHelperDescriptorBuilder(string kind, string name, string assemblyName)
+        : this()
+    {
+        _kind = kind;
+        _name = name;
+        _assemblyName = assemblyName;
 
-    public override string AssemblyName { get; }
+        // Tells code generation that these tag helpers are compatible with ITagHelper.
+        // For now that's all we support.
+        _metadata.Add(TagHelperMetadata.Runtime.Name, TagHelperConventions.DefaultKind);
+    }
 
-    public override string Kind { get; }
-
+    public override string Kind => _kind.AssumeNotNull();
+    public override string Name => _name.AssumeNotNull();
+    public override string AssemblyName => _assemblyName.AssumeNotNull();
     public override string? DisplayName { get; set; }
-
     public override string? TagOutputHint { get; set; }
-
     public override bool CaseSensitive { get; set; }
-
     public override string? Documentation { get; set; }
 
     public override IDictionary<string, string> Metadata => _metadata;
-
     public override RazorDiagnosticCollection Diagnostics => _diagnostics ??= new RazorDiagnosticCollection();
 
     public override IReadOnlyList<AllowedChildTagDescriptorBuilder> AllowedChildTags

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagMatchingRuleDescriptorBuilder.Policy.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagMatchingRuleDescriptorBuilder.Policy.cs
@@ -1,21 +1,17 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Extensions.ObjectPool;
-
 namespace Microsoft.AspNetCore.Razor.Language;
 
 internal partial class DefaultTagMatchingRuleDescriptorBuilder
 {
-    private sealed class Policy : IPooledObjectPolicy<DefaultTagMatchingRuleDescriptorBuilder>
+    private sealed class Policy : TagHelperPooledObjectPolicy<DefaultTagMatchingRuleDescriptorBuilder>
     {
-        private const int MaxSize = 32;
-
         public static Policy Instance = new();
 
-        public DefaultTagMatchingRuleDescriptorBuilder Create() => new();
+        public override DefaultTagMatchingRuleDescriptorBuilder Create() => new();
 
-        public bool Return(DefaultTagMatchingRuleDescriptorBuilder builder)
+        public override bool Return(DefaultTagMatchingRuleDescriptorBuilder builder)
         {
             builder._parent = null;
 
@@ -30,23 +26,10 @@ internal partial class DefaultTagMatchingRuleDescriptorBuilder
                     DefaultRequiredAttributeDescriptorBuilder.Return(requiredAttributeBuilder);
                 }
 
-                requiredAttributeBuilders.Clear();
-
-                if (requiredAttributeBuilders.Capacity > MaxSize)
-                {
-                    requiredAttributeBuilders.Capacity = MaxSize;
-                }
+                ClearList(requiredAttributeBuilders);
             }
 
-            if (builder._diagnostics is { } diagnostics)
-            {
-                diagnostics.Clear();
-
-                if (diagnostics.Capacity > MaxSize)
-                {
-                    diagnostics.Capacity = MaxSize;
-                }
-            }
+            ClearDiagnostics(builder._diagnostics);
 
             return true;
         }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagMatchingRuleDescriptorBuilder.Policy.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagMatchingRuleDescriptorBuilder.Policy.cs
@@ -7,7 +7,7 @@ internal partial class DefaultTagMatchingRuleDescriptorBuilder
 {
     private sealed class Policy : TagHelperPooledObjectPolicy<DefaultTagMatchingRuleDescriptorBuilder>
     {
-        public static Policy Instance = new();
+        public static readonly Policy Instance = new();
 
         public override DefaultTagMatchingRuleDescriptorBuilder Create() => new();
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagMatchingRuleDescriptorBuilder.Policy.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagMatchingRuleDescriptorBuilder.Policy.cs
@@ -21,9 +21,10 @@ internal partial class DefaultTagMatchingRuleDescriptorBuilder
 
             if (builder._requiredAttributeBuilders is { } requiredAttributeBuilders)
             {
+                // Make sure that we return all allowed required attribute builders to their pool.
                 foreach (var requiredAttributeBuilder in requiredAttributeBuilders)
                 {
-                    DefaultRequiredAttributeDescriptorBuilder.Return(requiredAttributeBuilder);
+                    DefaultRequiredAttributeDescriptorBuilder.ReturnInstance(requiredAttributeBuilder);
                 }
 
                 ClearList(requiredAttributeBuilders);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagMatchingRuleDescriptorBuilder.Policy.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagMatchingRuleDescriptorBuilder.Policy.cs
@@ -1,0 +1,54 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.ObjectPool;
+
+namespace Microsoft.AspNetCore.Razor.Language;
+
+internal partial class DefaultTagMatchingRuleDescriptorBuilder
+{
+    private sealed class Policy : IPooledObjectPolicy<DefaultTagMatchingRuleDescriptorBuilder>
+    {
+        private const int MaxSize = 32;
+
+        public static Policy Instance = new();
+
+        public DefaultTagMatchingRuleDescriptorBuilder Create() => new();
+
+        public bool Return(DefaultTagMatchingRuleDescriptorBuilder builder)
+        {
+            builder._parent = null;
+
+            builder.TagName = null;
+            builder.ParentTag = null;
+            builder.TagStructure = default;
+
+            if (builder._requiredAttributeBuilders is { } requiredAttributeBuilders)
+            {
+                foreach (var requiredAttributeBuilder in requiredAttributeBuilders)
+                {
+                    DefaultRequiredAttributeDescriptorBuilder.Return(requiredAttributeBuilder);
+                }
+
+                requiredAttributeBuilders.Clear();
+
+                if (requiredAttributeBuilders.Capacity > MaxSize)
+                {
+                    requiredAttributeBuilders.Capacity = MaxSize;
+                }
+            }
+
+            if (builder._diagnostics is { } diagnostics)
+            {
+                diagnostics.Clear();
+
+                if (diagnostics.Capacity > MaxSize)
+                {
+                    diagnostics.Capacity = MaxSize;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagMatchingRuleDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagMatchingRuleDescriptorBuilder.cs
@@ -13,7 +13,7 @@ internal partial class DefaultTagMatchingRuleDescriptorBuilder : TagMatchingRule
 {
     private static readonly ObjectPool<DefaultTagMatchingRuleDescriptorBuilder> s_pool = DefaultPool.Create(Policy.Instance);
 
-    public static DefaultTagMatchingRuleDescriptorBuilder Get(DefaultTagHelperDescriptorBuilder parent)
+    public static DefaultTagMatchingRuleDescriptorBuilder GetInstance(DefaultTagHelperDescriptorBuilder parent)
     {
         var builder = s_pool.Get();
 
@@ -22,7 +22,7 @@ internal partial class DefaultTagMatchingRuleDescriptorBuilder : TagMatchingRule
         return builder;
     }
 
-    public static void Return(DefaultTagMatchingRuleDescriptorBuilder builder)
+    public static void ReturnInstance(DefaultTagMatchingRuleDescriptorBuilder builder)
         => s_pool.Return(builder);
 
     private static readonly ObjectPool<HashSet<RequiredAttributeDescriptor>> s_requiredAttributeSetPool
@@ -69,7 +69,7 @@ internal partial class DefaultTagMatchingRuleDescriptorBuilder : TagMatchingRule
 
         EnsureRequiredAttributeBuilders();
 
-        var builder = DefaultRequiredAttributeDescriptorBuilder.Get(this);
+        var builder = DefaultRequiredAttributeDescriptorBuilder.GetInstance(this);
         configure(builder);
         _requiredAttributeBuilders.Add(builder);
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagMatchingRuleDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagMatchingRuleDescriptorBuilder.cs
@@ -9,14 +9,33 @@ using Microsoft.Extensions.ObjectPool;
 
 namespace Microsoft.AspNetCore.Razor.Language;
 
-internal class DefaultTagMatchingRuleDescriptorBuilder : TagMatchingRuleDescriptorBuilder, IBuilder<TagMatchingRuleDescriptor>
+internal partial class DefaultTagMatchingRuleDescriptorBuilder : TagMatchingRuleDescriptorBuilder, IBuilder<TagMatchingRuleDescriptor>
 {
+    private static readonly ObjectPool<DefaultTagMatchingRuleDescriptorBuilder> s_pool = DefaultPool.Create(Policy.Instance);
+
+    public static DefaultTagMatchingRuleDescriptorBuilder Get(DefaultTagHelperDescriptorBuilder parent)
+    {
+        var builder = s_pool.Get();
+
+        builder._parent = parent;
+
+        return builder;
+    }
+
+    public static void Return(DefaultTagMatchingRuleDescriptorBuilder builder)
+        => s_pool.Return(builder);
+
     private static readonly ObjectPool<HashSet<RequiredAttributeDescriptor>> s_requiredAttributeSetPool
         = HashSetPool<RequiredAttributeDescriptor>.Create(RequiredAttributeDescriptorComparer.Default);
 
-    private readonly DefaultTagHelperDescriptorBuilder _parent;
+    [AllowNull]
+    private DefaultTagHelperDescriptorBuilder _parent;
     private List<DefaultRequiredAttributeDescriptorBuilder>? _requiredAttributeBuilders;
     private RazorDiagnosticCollection? _diagnostics;
+
+    private DefaultTagMatchingRuleDescriptorBuilder()
+    {
+    }
 
     internal DefaultTagMatchingRuleDescriptorBuilder(DefaultTagHelperDescriptorBuilder parent)
     {
@@ -24,9 +43,7 @@ internal class DefaultTagMatchingRuleDescriptorBuilder : TagMatchingRuleDescript
     }
 
     public override string? TagName { get; set; }
-
     public override string? ParentTag { get; set; }
-
     public override TagStructure TagStructure { get; set; }
 
     internal bool CaseSensitive => _parent.CaseSensitive;
@@ -52,7 +69,7 @@ internal class DefaultTagMatchingRuleDescriptorBuilder : TagMatchingRuleDescript
 
         EnsureRequiredAttributeBuilders();
 
-        var builder = new DefaultRequiredAttributeDescriptorBuilder(this);
+        var builder = DefaultRequiredAttributeDescriptorBuilder.Get(this);
         configure(builder);
         _requiredAttributeBuilders.Add(builder);
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorDiagnosticCollection.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorDiagnosticCollection.cs
@@ -42,6 +42,12 @@ public sealed class RazorDiagnosticCollection : IList<RazorDiagnostic>
 
     public int Count => _inner.Count;
 
+    internal int Capacity
+    {
+        get => _inner.Capacity;
+        set => _inner.Capacity = value;
+    }
+
     public bool IsReadOnly => _inner != null;
 
     public void Add(RazorDiagnostic item)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptorBuilder.PooledBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptorBuilder.PooledBuilder.cs
@@ -1,0 +1,31 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable disable
+
+using System;
+
+namespace Microsoft.AspNetCore.Razor.Language;
+
+public abstract partial class TagHelperDescriptorBuilder
+{
+    public struct PooledBuilder : IDisposable
+    {
+        private readonly DefaultTagHelperDescriptorBuilder _builder;
+        private bool _disposed;
+
+        internal PooledBuilder(DefaultTagHelperDescriptorBuilder builder)
+        {
+            _builder = builder;
+        }
+
+        public void Dispose()
+        {
+            if (!_disposed)
+            {
+                DefaultTagHelperDescriptorBuilder.ReturnInstance(_builder);
+                _disposed = true;
+            }
+        }
+    }
+}

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptorBuilder.cs
@@ -46,7 +46,7 @@ public abstract class TagHelperDescriptorBuilder
     }
 
     /// <summary>
-    ///  Retreives a <see cref="TagHelperDescriptorBuilder"/> instance from the pool.
+    ///  Retrieves a <see cref="TagHelperDescriptorBuilder"/> instance from the pool.
     /// </summary>
     public static TagHelperDescriptorBuilder GetInstance(string kind, string name, string assemblyName)
     {
@@ -54,7 +54,7 @@ public abstract class TagHelperDescriptorBuilder
     }
 
     /// <summary>
-    ///  Retreives a <see cref="TagHelperDescriptorBuilder"/> instance from the pool.
+    ///  Retrieves a <see cref="TagHelperDescriptorBuilder"/> instance from the pool.
     /// </summary>
     public static TagHelperDescriptorBuilder GetInstance(string name, string assemblyName)
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptorBuilder.cs
@@ -45,6 +45,35 @@ public abstract class TagHelperDescriptorBuilder
         return new DefaultTagHelperDescriptorBuilder(kind, name, assemblyName);
     }
 
+    /// <summary>
+    ///  Retreives a <see cref="TagHelperDescriptorBuilder"/> instance from the pool.
+    /// </summary>
+    public static TagHelperDescriptorBuilder GetInstance(string kind, string name, string assemblyName)
+    {
+        return DefaultTagHelperDescriptorBuilder.Get(kind, name, assemblyName);
+    }
+
+    /// <summary>
+    ///  Retreives a <see cref="TagHelperDescriptorBuilder"/> instance from the pool.
+    /// </summary>
+    public static TagHelperDescriptorBuilder GetInstance(string name, string assemblyName)
+    {
+        return DefaultTagHelperDescriptorBuilder.Get(name, assemblyName);
+    }
+
+    /// <summary>
+    ///  Returns a <see cref="DefaultTagHelperDescriptorBuilder"/> instance to the pool.
+    /// </summary>
+    public static void ReturnInstance(TagHelperDescriptorBuilder builder)
+    {
+        if (builder is not DefaultTagHelperDescriptorBuilder defaultBuilder)
+        {
+            return;
+        }
+
+        DefaultTagHelperDescriptorBuilder.Return(defaultBuilder);
+    }
+
     public abstract string Name { get; }
 
     public abstract string AssemblyName { get; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptorBuilder.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.Razor.Language;
 
-public abstract class TagHelperDescriptorBuilder
+public abstract partial class TagHelperDescriptorBuilder
 {
     public static TagHelperDescriptorBuilder Create(string name, string assemblyName)
     {
@@ -46,32 +46,49 @@ public abstract class TagHelperDescriptorBuilder
     }
 
     /// <summary>
-    ///  Retrieves a <see cref="TagHelperDescriptorBuilder"/> instance from the pool.
+    ///  Retrieves a pooled <see cref="TagHelperDescriptorBuilder"/> instance.
     /// </summary>
-    public static TagHelperDescriptorBuilder GetInstance(string kind, string name, string assemblyName)
+    /// <remarks>
+    ///  The <see cref="PooledBuilder"/> returned by this method should be disposed
+    ///  to return the <see cref="TagHelperDescriptorBuilder"/> to its pool.
+    ///  The correct way to achieve this is with a using statement:
+    ///
+    /// <code>
+    ///  using var _ = TagHelperDescriptorBuilder.GetPooledInstance(..., out var builder);
+    /// </code>
+    /// 
+    ///  Once disposed, the builder can no longer be used.
+    /// </remarks>
+    public static PooledBuilder GetPooledInstance(
+        string kind, string name, string assemblyName,
+        out TagHelperDescriptorBuilder builder)
     {
-        return DefaultTagHelperDescriptorBuilder.Get(kind, name, assemblyName);
+        var defaultBuilder = DefaultTagHelperDescriptorBuilder.GetInstance(kind, name, assemblyName);
+        builder = defaultBuilder;
+        return new(defaultBuilder);
     }
 
     /// <summary>
-    ///  Retrieves a <see cref="TagHelperDescriptorBuilder"/> instance from the pool.
+    ///  Retrieves a pooled <see cref="TagHelperDescriptorBuilder"/> instance.
     /// </summary>
-    public static TagHelperDescriptorBuilder GetInstance(string name, string assemblyName)
+    /// <remarks>
+    ///  The <see cref="PooledBuilder"/> returned by this method should be disposed
+    ///  to return the <see cref="TagHelperDescriptorBuilder"/> to its pool.
+    ///  The correct way to achieve this is with a using statement:
+    ///
+    /// <code>
+    ///  using var _ = TagHelperDescriptorBuilder.GetPooledInstance(..., out var builder);
+    /// </code>
+    /// 
+    ///  Once disposed, the builder can no longer be used.
+    /// </remarks>
+    public static PooledBuilder GetPooledInstance(
+        string name, string assemblyName,
+        out TagHelperDescriptorBuilder builder)
     {
-        return DefaultTagHelperDescriptorBuilder.Get(name, assemblyName);
-    }
-
-    /// <summary>
-    ///  Returns a <see cref="DefaultTagHelperDescriptorBuilder"/> instance to the pool.
-    /// </summary>
-    public static void ReturnInstance(TagHelperDescriptorBuilder builder)
-    {
-        if (builder is not DefaultTagHelperDescriptorBuilder defaultBuilder)
-        {
-            return;
-        }
-
-        DefaultTagHelperDescriptorBuilder.Return(defaultBuilder);
+        var defaultBuilder = DefaultTagHelperDescriptorBuilder.GetInstance(name, assemblyName);
+        builder = defaultBuilder;
+        return new(defaultBuilder);
     }
 
     public abstract string Name { get; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperPooledObjectPolicy.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperPooledObjectPolicy.cs
@@ -1,0 +1,46 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using Microsoft.Extensions.ObjectPool;
+
+namespace Microsoft.AspNetCore.Razor.Language;
+
+internal abstract class TagHelperPooledObjectPolicy<T> : IPooledObjectPolicy<T>
+    where T : notnull
+{
+    private const int MaxSize = 32;
+
+    public abstract T Create();
+    public abstract bool Return(T obj);
+
+    protected static void ClearList<TList>(List<TList>? list)
+    {
+        if (list is null)
+        {
+            return;
+        }
+
+        list.Clear();
+
+        if (list.Capacity > MaxSize)
+        {
+            list.Capacity = MaxSize;
+        }
+    }
+
+    protected static void ClearDiagnostics(RazorDiagnosticCollection? collection)
+    {
+        if (collection is null)
+        {
+            return;
+        }
+
+        collection.Clear();
+
+        if (collection.Capacity > MaxSize)
+        {
+            collection.Capacity = MaxSize;
+        }
+    }
+}

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/BindTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/BindTagHelperDescriptorProvider.cs
@@ -133,111 +133,107 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
 
     private static TagHelperDescriptor CreateFallbackBindTagHelper()
     {
-        var builder = TagHelperDescriptorBuilder.GetInstance(ComponentMetadata.Bind.TagHelperKind, "Bind", ComponentsApi.AssemblyName);
-        try
+        using var _ = TagHelperDescriptorBuilder.GetPooledInstance(
+            ComponentMetadata.Bind.TagHelperKind, "Bind", ComponentsApi.AssemblyName,
+            out var builder);
+
+        builder.CaseSensitive = true;
+        builder.Documentation = ComponentResources.BindTagHelper_Fallback_Documentation;
+
+        builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.Bind.TagHelperKind);
+        builder.Metadata.Add(TagHelperMetadata.Common.ClassifyAttributesOnly, bool.TrueString);
+        builder.Metadata[TagHelperMetadata.Runtime.Name] = ComponentMetadata.Bind.RuntimeName;
+        builder.Metadata[ComponentMetadata.Bind.FallbackKey] = bool.TrueString;
+
+        // WTE has a bug in 15.7p1 where a Tag Helper without a display-name that looks like
+        // a C# property will crash trying to create the toolips.
+        builder.SetTypeName("Microsoft.AspNetCore.Components.Bind");
+        builder.SetTypeNamespace("Microsoft.AspNetCore.Components");
+        builder.SetTypeNameIdentifier("Bind");
+
+        builder.TagMatchingRule(rule =>
         {
-            builder.CaseSensitive = true;
-            builder.Documentation = ComponentResources.BindTagHelper_Fallback_Documentation;
-
-            builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.Bind.TagHelperKind);
-            builder.Metadata.Add(TagHelperMetadata.Common.ClassifyAttributesOnly, bool.TrueString);
-            builder.Metadata[TagHelperMetadata.Runtime.Name] = ComponentMetadata.Bind.RuntimeName;
-            builder.Metadata[ComponentMetadata.Bind.FallbackKey] = bool.TrueString;
-
-            // WTE has a bug in 15.7p1 where a Tag Helper without a display-name that looks like
-            // a C# property will crash trying to create the toolips.
-            builder.SetTypeName("Microsoft.AspNetCore.Components.Bind");
-            builder.SetTypeNamespace("Microsoft.AspNetCore.Components");
-            builder.SetTypeNameIdentifier("Bind");
-
-            builder.TagMatchingRule(rule =>
+            rule.TagName = "*";
+            rule.Attribute(attribute =>
             {
-                rule.TagName = "*";
-                rule.Attribute(attribute =>
-                {
-                    attribute.Name = "@bind-";
-                    attribute.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch;
-                    attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
-                });
-            });
-
-            builder.BindAttribute(attribute =>
-            {
+                attribute.Name = "@bind-";
+                attribute.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch;
                 attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
-                attribute.Documentation = ComponentResources.BindTagHelper_Fallback_Documentation;
+            });
+        });
 
-                var attributeName = "@bind-...";
-                attribute.Name = attributeName;
-                attribute.AsDictionary("@bind-", typeof(object).FullName);
+        builder.BindAttribute(attribute =>
+        {
+            attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+            attribute.Documentation = ComponentResources.BindTagHelper_Fallback_Documentation;
 
-                // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like
-                // a C# property will crash trying to create the toolips.
-                attribute.SetPropertyName("Bind");
-                attribute.TypeName = "System.Collections.Generic.Dictionary<string, object>";
+            var attributeName = "@bind-...";
+            attribute.Name = attributeName;
+            attribute.AsDictionary("@bind-", typeof(object).FullName);
 
-                attribute.BindAttributeParameter(parameter =>
-                {
-                    parameter.Name = "format";
-                    parameter.TypeName = typeof(string).FullName;
-                    parameter.Documentation = ComponentResources.BindTagHelper_Fallback_Format_Documentation;
+            // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like
+            // a C# property will crash trying to create the toolips.
+            attribute.SetPropertyName("Bind");
+            attribute.TypeName = "System.Collections.Generic.Dictionary<string, object>";
 
-                    parameter.SetPropertyName("Format");
-                });
+            attribute.BindAttributeParameter(parameter =>
+            {
+                parameter.Name = "format";
+                parameter.TypeName = typeof(string).FullName;
+                parameter.Documentation = ComponentResources.BindTagHelper_Fallback_Format_Documentation;
 
-                attribute.BindAttributeParameter(parameter =>
-                {
-                    parameter.Name = "event";
-                    parameter.TypeName = typeof(string).FullName;
-                    parameter.Documentation = string.Format(CultureInfo.CurrentCulture, ComponentResources.BindTagHelper_Fallback_Event_Documentation, attributeName);
-
-                    parameter.SetPropertyName("Event");
-                });
-
-                attribute.BindAttributeParameter(parameter =>
-                {
-                    parameter.Name = "culture";
-                    parameter.TypeName = typeof(CultureInfo).FullName;
-                    parameter.Documentation = ComponentResources.BindTagHelper_Element_Culture_Documentation;
-
-                    parameter.SetPropertyName("Culture");
-                });
-
-                attribute.BindAttributeParameter(parameter =>
-                {
-                    parameter.Name = "get";
-                    parameter.TypeName = typeof(object).FullName;
-                    parameter.Documentation = ComponentResources.BindTagHelper_Element_Get_Documentation;
-
-                    parameter.SetPropertyName("Get");
-
-                    parameter.SetBindAttributeGetSet();
-                });
-
-                attribute.BindAttributeParameter(parameter =>
-                {
-                    parameter.Name = "set";
-                    parameter.TypeName = typeof(Delegate).FullName;
-                    parameter.Documentation = ComponentResources.BindTagHelper_Element_Set_Documentation;
-
-                    parameter.SetPropertyName("Set");
-                });
-
-                attribute.BindAttributeParameter(parameter =>
-                {
-                    parameter.Name = "after";
-                    parameter.TypeName = typeof(Delegate).FullName;
-                    parameter.Documentation = ComponentResources.BindTagHelper_Element_After_Documentation;
-
-                    parameter.SetPropertyName("After");
-                });
+                parameter.SetPropertyName("Format");
             });
 
-            return builder.Build();
-        }
-        finally
-        {
-            TagHelperDescriptorBuilder.ReturnInstance(builder);
-        }
+            attribute.BindAttributeParameter(parameter =>
+            {
+                parameter.Name = "event";
+                parameter.TypeName = typeof(string).FullName;
+                parameter.Documentation = string.Format(CultureInfo.CurrentCulture, ComponentResources.BindTagHelper_Fallback_Event_Documentation, attributeName);
+
+                parameter.SetPropertyName("Event");
+            });
+
+            attribute.BindAttributeParameter(parameter =>
+            {
+                parameter.Name = "culture";
+                parameter.TypeName = typeof(CultureInfo).FullName;
+                parameter.Documentation = ComponentResources.BindTagHelper_Element_Culture_Documentation;
+
+                parameter.SetPropertyName("Culture");
+            });
+
+            attribute.BindAttributeParameter(parameter =>
+            {
+                parameter.Name = "get";
+                parameter.TypeName = typeof(object).FullName;
+                parameter.Documentation = ComponentResources.BindTagHelper_Element_Get_Documentation;
+
+                parameter.SetPropertyName("Get");
+
+                parameter.SetBindAttributeGetSet();
+            });
+
+            attribute.BindAttributeParameter(parameter =>
+            {
+                parameter.Name = "set";
+                parameter.TypeName = typeof(Delegate).FullName;
+                parameter.Documentation = ComponentResources.BindTagHelper_Element_Set_Documentation;
+
+                parameter.SetPropertyName("Set");
+            });
+
+            attribute.BindAttributeParameter(parameter =>
+            {
+                parameter.Name = "after";
+                parameter.TypeName = typeof(Delegate).FullName;
+                parameter.Documentation = ComponentResources.BindTagHelper_Element_After_Documentation;
+
+                parameter.SetPropertyName("After");
+            });
+        });
+
+        return builder.Build();
     }
 
     private List<ElementBindData> GetElementBindData(Compilation compilation)
@@ -343,188 +339,184 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
 
             var eventName = entry.Suffix == null ? "Event_" + entry.ValueAttribute : "Event_" + entry.Suffix;
 
-            var builder = TagHelperDescriptorBuilder.GetInstance(ComponentMetadata.Bind.TagHelperKind, name, ComponentsApi.AssemblyName);
-            try
+            using var _ = TagHelperDescriptorBuilder.GetPooledInstance(
+                ComponentMetadata.Bind.TagHelperKind, name, ComponentsApi.AssemblyName,
+                out var builder);
+
+            builder.CaseSensitive = true;
+            builder.Documentation = string.Format(
+                CultureInfo.CurrentCulture,
+                ComponentResources.BindTagHelper_Element_Documentation,
+                entry.ValueAttribute,
+                entry.ChangeAttribute);
+
+            builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.Bind.TagHelperKind);
+            builder.Metadata.Add(TagHelperMetadata.Common.ClassifyAttributesOnly, bool.TrueString);
+            builder.Metadata[TagHelperMetadata.Runtime.Name] = ComponentMetadata.Bind.RuntimeName;
+            builder.Metadata[ComponentMetadata.Bind.ValueAttribute] = entry.ValueAttribute;
+            builder.Metadata[ComponentMetadata.Bind.ChangeAttribute] = entry.ChangeAttribute;
+            builder.Metadata[ComponentMetadata.Bind.IsInvariantCulture] = entry.IsInvariantCulture ? bool.TrueString : bool.FalseString;
+            builder.Metadata[ComponentMetadata.Bind.Format] = entry.Format;
+
+            if (entry.TypeAttribute != null)
             {
-                builder.CaseSensitive = true;
-                builder.Documentation = string.Format(
+                // For entries that map to the <input /> element, we need to be able to know
+                // the difference between <input /> and <input type="text" .../> for which we
+                // want to use the same attributes.
+                //
+                // We provide a tag helper for <input /> that should match all input elements,
+                // but we only want it to be used when a more specific one is used.
+                //
+                // Therefore we use this metadata to know which one is more specific when two
+                // tag helpers match.
+                builder.Metadata[ComponentMetadata.Bind.TypeAttribute] = entry.TypeAttribute;
+            }
+
+            // WTE has a bug in 15.7p1 where a Tag Helper without a display-name that looks like
+            // a C# property will crash trying to create the toolips.
+            builder.SetTypeName(entry.TypeName);
+            builder.SetTypeNamespace(entry.TypeNamespace);
+            builder.SetTypeNameIdentifier(entry.TypeNameIdentifier);
+
+            builder.TagMatchingRule(rule =>
+            {
+                rule.TagName = entry.Element;
+                if (entry.TypeAttribute != null)
+                {
+                    rule.Attribute(a =>
+                    {
+                        a.Name = "type";
+                        a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                        a.Value = entry.TypeAttribute;
+                        a.ValueComparisonMode = RequiredAttributeDescriptor.ValueComparisonMode.FullMatch;
+                    });
+                }
+
+                rule.Attribute(a =>
+                {
+                    a.Name = attributeName;
+                    a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                    a.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+                });
+            });
+
+            builder.TagMatchingRule(rule =>
+            {
+                rule.TagName = entry.Element;
+                if (entry.TypeAttribute != null)
+                {
+                    rule.Attribute(a =>
+                    {
+                        a.Name = "type";
+                        a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                        a.Value = entry.TypeAttribute;
+                        a.ValueComparisonMode = RequiredAttributeDescriptor.ValueComparisonMode.FullMatch;
+                    });
+                }
+
+                rule.Attribute(a =>
+                {
+                    a.Name = $"{attributeName}:get";
+                    a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                    a.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+                });
+
+                rule.Attribute(a =>
+                {
+                    a.Name = $"{attributeName}:set";
+                    a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                    a.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+                });
+            });
+
+            builder.BindAttribute(a =>
+            {
+                a.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+                a.Documentation = string.Format(
                     CultureInfo.CurrentCulture,
                     ComponentResources.BindTagHelper_Element_Documentation,
                     entry.ValueAttribute,
                     entry.ChangeAttribute);
 
-                builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.Bind.TagHelperKind);
-                builder.Metadata.Add(TagHelperMetadata.Common.ClassifyAttributesOnly, bool.TrueString);
-                builder.Metadata[TagHelperMetadata.Runtime.Name] = ComponentMetadata.Bind.RuntimeName;
-                builder.Metadata[ComponentMetadata.Bind.ValueAttribute] = entry.ValueAttribute;
-                builder.Metadata[ComponentMetadata.Bind.ChangeAttribute] = entry.ChangeAttribute;
-                builder.Metadata[ComponentMetadata.Bind.IsInvariantCulture] = entry.IsInvariantCulture ? bool.TrueString : bool.FalseString;
-                builder.Metadata[ComponentMetadata.Bind.Format] = entry.Format;
+                a.Name = attributeName;
+                a.TypeName = typeof(object).FullName;
 
-                if (entry.TypeAttribute != null)
-                {
-                    // For entries that map to the <input /> element, we need to be able to know
-                    // the difference between <input /> and <input type="text" .../> for which we
-                    // want to use the same attributes.
-                    //
-                    // We provide a tag helper for <input /> that should match all input elements,
-                    // but we only want it to be used when a more specific one is used.
-                    //
-                    // Therefore we use this metadata to know which one is more specific when two
-                    // tag helpers match.
-                    builder.Metadata[ComponentMetadata.Bind.TypeAttribute] = entry.TypeAttribute;
-                }
-
-                // WTE has a bug in 15.7p1 where a Tag Helper without a display-name that looks like
+                // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like
                 // a C# property will crash trying to create the toolips.
-                builder.SetTypeName(entry.TypeName);
-                builder.SetTypeNamespace(entry.TypeNamespace);
-                builder.SetTypeNameIdentifier(entry.TypeNameIdentifier);
+                a.SetPropertyName(name);
 
-                builder.TagMatchingRule(rule =>
+                a.BindAttributeParameter(parameter =>
                 {
-                    rule.TagName = entry.Element;
-                    if (entry.TypeAttribute != null)
-                    {
-                        rule.Attribute(a =>
-                        {
-                            a.Name = "type";
-                            a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
-                            a.Value = entry.TypeAttribute;
-                            a.ValueComparisonMode = RequiredAttributeDescriptor.ValueComparisonMode.FullMatch;
-                        });
-                    }
+                    parameter.Name = "format";
+                    parameter.TypeName = typeof(string).FullName;
+                    parameter.Documentation = string.Format(CultureInfo.CurrentCulture, ComponentResources.BindTagHelper_Element_Format_Documentation, attributeName);
 
-                    rule.Attribute(a =>
-                    {
-                        a.Name = attributeName;
-                        a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
-                        a.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
-                    });
+                    parameter.SetPropertyName(formatName);
                 });
 
-                builder.TagMatchingRule(rule =>
+                a.BindAttributeParameter(parameter =>
                 {
-                    rule.TagName = entry.Element;
-                    if (entry.TypeAttribute != null)
-                    {
-                        rule.Attribute(a =>
-                        {
-                            a.Name = "type";
-                            a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
-                            a.Value = entry.TypeAttribute;
-                            a.ValueComparisonMode = RequiredAttributeDescriptor.ValueComparisonMode.FullMatch;
-                        });
-                    }
+                    parameter.Name = "event";
+                    parameter.TypeName = typeof(string).FullName;
+                    parameter.Documentation = string.Format(CultureInfo.CurrentCulture, ComponentResources.BindTagHelper_Element_Event_Documentation, attributeName);
 
-                    rule.Attribute(a =>
-                    {
-                        a.Name = $"{attributeName}:get";
-                        a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
-                        a.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
-                    });
-
-                    rule.Attribute(a =>
-                    {
-                        a.Name = $"{attributeName}:set";
-                        a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
-                        a.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
-                    });
+                    parameter.SetPropertyName(eventName);
                 });
 
-                builder.BindAttribute(a =>
+                a.BindAttributeParameter(parameter =>
                 {
-                    a.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
-                    a.Documentation = string.Format(
-                        CultureInfo.CurrentCulture,
-                        ComponentResources.BindTagHelper_Element_Documentation,
-                        entry.ValueAttribute,
-                        entry.ChangeAttribute);
+                    parameter.Name = "culture";
+                    parameter.TypeName = typeof(CultureInfo).FullName;
+                    parameter.Documentation = ComponentResources.BindTagHelper_Element_Culture_Documentation;
 
-                    a.Name = attributeName;
-                    a.TypeName = typeof(object).FullName;
-
-                    // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like
-                    // a C# property will crash trying to create the toolips.
-                    a.SetPropertyName(name);
-
-                    a.BindAttributeParameter(parameter =>
-                    {
-                        parameter.Name = "format";
-                        parameter.TypeName = typeof(string).FullName;
-                        parameter.Documentation = string.Format(CultureInfo.CurrentCulture, ComponentResources.BindTagHelper_Element_Format_Documentation, attributeName);
-
-                        parameter.SetPropertyName(formatName);
-                    });
-
-                    a.BindAttributeParameter(parameter =>
-                    {
-                        parameter.Name = "event";
-                        parameter.TypeName = typeof(string).FullName;
-                        parameter.Documentation = string.Format(CultureInfo.CurrentCulture, ComponentResources.BindTagHelper_Element_Event_Documentation, attributeName);
-
-                        parameter.SetPropertyName(eventName);
-                    });
-
-                    a.BindAttributeParameter(parameter =>
-                    {
-                        parameter.Name = "culture";
-                        parameter.TypeName = typeof(CultureInfo).FullName;
-                        parameter.Documentation = ComponentResources.BindTagHelper_Element_Culture_Documentation;
-
-                        parameter.SetPropertyName("Culture");
-                    });
-
-                    a.BindAttributeParameter(parameter =>
-                    {
-                        parameter.Name = "get";
-                        parameter.TypeName = typeof(object).FullName;
-                        parameter.Documentation = ComponentResources.BindTagHelper_Element_Get_Documentation;
-
-                        parameter.SetPropertyName("Get");
-                        parameter.SetBindAttributeGetSet();
-                    });
-
-                    a.BindAttributeParameter(parameter =>
-                    {
-                        parameter.Name = "set";
-                        parameter.TypeName = typeof(Delegate).FullName;
-                        parameter.Documentation = ComponentResources.BindTagHelper_Element_Set_Documentation;
-
-                        parameter.SetPropertyName("Set");
-                    });
-
-                    a.BindAttributeParameter(parameter =>
-                    {
-                        parameter.Name = "after";
-                        parameter.TypeName = typeof(Delegate).FullName;
-                        parameter.Documentation = ComponentResources.BindTagHelper_Element_After_Documentation;
-
-                        parameter.SetPropertyName("After");
-                    });
+                    parameter.SetPropertyName("Culture");
                 });
 
-                // This is no longer supported. This is just here so we can add a diagnostic later on when this matches.
-                builder.BindAttribute(attribute =>
+                a.BindAttributeParameter(parameter =>
                 {
-                    attribute.Name = formatAttributeName;
-                    attribute.TypeName = "System.String";
-                    attribute.Documentation = string.Format(CultureInfo.CurrentCulture, ComponentResources.BindTagHelper_Element_Format_Documentation, attributeName);
+                    parameter.Name = "get";
+                    parameter.TypeName = typeof(object).FullName;
+                    parameter.Documentation = ComponentResources.BindTagHelper_Element_Get_Documentation;
 
-                    // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like
-                    // a C# property will crash trying to create the toolips.
-                    attribute.SetPropertyName(formatName);
+                    parameter.SetPropertyName("Get");
+                    parameter.SetBindAttributeGetSet();
                 });
 
-                results.Add(builder.Build());
-            }
-            finally
+                a.BindAttributeParameter(parameter =>
+                {
+                    parameter.Name = "set";
+                    parameter.TypeName = typeof(Delegate).FullName;
+                    parameter.Documentation = ComponentResources.BindTagHelper_Element_Set_Documentation;
+
+                    parameter.SetPropertyName("Set");
+                });
+
+                a.BindAttributeParameter(parameter =>
+                {
+                    parameter.Name = "after";
+                    parameter.TypeName = typeof(Delegate).FullName;
+                    parameter.Documentation = ComponentResources.BindTagHelper_Element_After_Documentation;
+
+                    parameter.SetPropertyName("After");
+                });
+            });
+
+            // This is no longer supported. This is just here so we can add a diagnostic later on when this matches.
+            builder.BindAttribute(attribute =>
             {
-                TagHelperDescriptorBuilder.ReturnInstance(builder);
-            }
-        }
-        return results;
+                attribute.Name = formatAttributeName;
+                attribute.TypeName = "System.String";
+                attribute.Documentation = string.Format(CultureInfo.CurrentCulture, ComponentResources.BindTagHelper_Element_Format_Documentation, attributeName);
 
+                // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like
+                // a C# property will crash trying to create the toolips.
+                attribute.SetPropertyName(formatName);
+            });
+
+            results.Add(builder.Build());
+        }
+
+        return results;
     }
 
     private static List<TagHelperDescriptor> CreateComponentBindTagHelpers(ICollection<TagHelperDescriptor> tagHelpers)
@@ -588,120 +580,116 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                     continue;
                 }
 
-                var builder = TagHelperDescriptorBuilder.GetInstance(ComponentMetadata.Bind.TagHelperKind, tagHelper.Name, tagHelper.AssemblyName);
-                try
+                using var _ = TagHelperDescriptorBuilder.GetPooledInstance(
+                    ComponentMetadata.Bind.TagHelperKind, tagHelper.Name, tagHelper.AssemblyName,
+                    out var builder);
+
+                builder.DisplayName = tagHelper.DisplayName;
+                builder.CaseSensitive = true;
+                builder.Documentation = string.Format(
+                    CultureInfo.CurrentCulture,
+                    ComponentResources.BindTagHelper_Component_Documentation,
+                    valueAttribute.Name,
+                    changeAttribute.Name);
+
+                builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.Bind.TagHelperKind);
+                builder.Metadata[TagHelperMetadata.Runtime.Name] = ComponentMetadata.Bind.RuntimeName;
+                builder.Metadata[ComponentMetadata.Bind.ValueAttribute] = valueAttribute.Name;
+                builder.Metadata[ComponentMetadata.Bind.ChangeAttribute] = changeAttribute.Name;
+
+                if (expressionAttribute != null)
                 {
-                    builder.DisplayName = tagHelper.DisplayName;
-                    builder.CaseSensitive = true;
-                    builder.Documentation = string.Format(
+                    builder.Metadata[ComponentMetadata.Bind.ExpressionAttribute] = expressionAttribute.Name;
+                }
+
+                // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like
+                // a C# property will crash trying to create the toolips.
+                builder.SetTypeName(tagHelper.GetTypeName());
+                builder.SetTypeNamespace(tagHelper.GetTypeNamespace());
+                builder.SetTypeNameIdentifier(tagHelper.GetTypeNameIdentifier());
+
+                // Match the component and attribute name
+                builder.TagMatchingRule(rule =>
+                {
+                    rule.TagName = tagHelper.TagMatchingRules.Single().TagName;
+                    rule.Attribute(attribute =>
+                    {
+                        attribute.Name = "@bind-" + valueAttribute.Name;
+                        attribute.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                        attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+                    });
+                });
+
+                builder.TagMatchingRule(rule =>
+                {
+                    rule.TagName = tagHelper.TagMatchingRules.Single().TagName;
+                    rule.Attribute(attribute =>
+                    {
+                        attribute.Name = "@bind-" + valueAttribute.Name + ":get";
+                        attribute.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                        attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+                    });
+                    rule.Attribute(attribute =>
+                    {
+                        attribute.Name = "@bind-" + valueAttribute.Name + ":set";
+                        attribute.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                        attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+                    });
+                });
+
+                builder.BindAttribute(attribute =>
+                {
+                    attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+                    attribute.Documentation = string.Format(
                         CultureInfo.CurrentCulture,
                         ComponentResources.BindTagHelper_Component_Documentation,
                         valueAttribute.Name,
                         changeAttribute.Name);
 
-                    builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.Bind.TagHelperKind);
-                    builder.Metadata[TagHelperMetadata.Runtime.Name] = ComponentMetadata.Bind.RuntimeName;
-                    builder.Metadata[ComponentMetadata.Bind.ValueAttribute] = valueAttribute.Name;
-                    builder.Metadata[ComponentMetadata.Bind.ChangeAttribute] = changeAttribute.Name;
-
-                    if (expressionAttribute != null)
-                    {
-                        builder.Metadata[ComponentMetadata.Bind.ExpressionAttribute] = expressionAttribute.Name;
-                    }
+                    attribute.Name = "@bind-" + valueAttribute.Name;
+                    attribute.TypeName = changeAttribute.TypeName;
+                    attribute.IsEnum = valueAttribute.IsEnum;
 
                     // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like
                     // a C# property will crash trying to create the toolips.
-                    builder.SetTypeName(tagHelper.GetTypeName());
-                    builder.SetTypeNamespace(tagHelper.GetTypeNamespace());
-                    builder.SetTypeNameIdentifier(tagHelper.GetTypeNameIdentifier());
+                    attribute.SetPropertyName(valueAttribute.GetPropertyName());
 
-                    // Match the component and attribute name
-                    builder.TagMatchingRule(rule =>
+                    attribute.BindAttributeParameter(parameter =>
                     {
-                        rule.TagName = tagHelper.TagMatchingRules.Single().TagName;
-                        rule.Attribute(attribute =>
-                        {
-                            attribute.Name = "@bind-" + valueAttribute.Name;
-                            attribute.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
-                            attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
-                        });
+                        parameter.Name = "get";
+                        parameter.TypeName = typeof(object).FullName;
+                        parameter.Documentation = ComponentResources.BindTagHelper_Element_Get_Documentation;
+
+                        parameter.SetPropertyName("Get");
+                        parameter.SetBindAttributeGetSet();
                     });
 
-                    builder.TagMatchingRule(rule =>
+                    attribute.BindAttributeParameter(parameter =>
                     {
-                        rule.TagName = tagHelper.TagMatchingRules.Single().TagName;
-                        rule.Attribute(attribute =>
-                        {
-                            attribute.Name = "@bind-" + valueAttribute.Name + ":get";
-                            attribute.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
-                            attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
-                        });
-                        rule.Attribute(attribute =>
-                        {
-                            attribute.Name = "@bind-" + valueAttribute.Name + ":set";
-                            attribute.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
-                            attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
-                        });
+                        parameter.Name = "set";
+                        parameter.TypeName = typeof(Delegate).FullName;
+                        parameter.Documentation = ComponentResources.BindTagHelper_Element_Set_Documentation;
+
+                        parameter.SetPropertyName("Set");
                     });
 
-                    builder.BindAttribute(attribute =>
+                    attribute.BindAttributeParameter(parameter =>
                     {
-                        attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
-                        attribute.Documentation = string.Format(
-                            CultureInfo.CurrentCulture,
-                            ComponentResources.BindTagHelper_Component_Documentation,
-                            valueAttribute.Name,
-                            changeAttribute.Name);
+                        parameter.Name = "after";
+                        parameter.TypeName = typeof(Delegate).FullName;
+                        parameter.Documentation = ComponentResources.BindTagHelper_Element_After_Documentation;
 
-                        attribute.Name = "@bind-" + valueAttribute.Name;
-                        attribute.TypeName = changeAttribute.TypeName;
-                        attribute.IsEnum = valueAttribute.IsEnum;
-
-                        // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like
-                        // a C# property will crash trying to create the toolips.
-                        attribute.SetPropertyName(valueAttribute.GetPropertyName());
-
-                        attribute.BindAttributeParameter(parameter =>
-                        {
-                            parameter.Name = "get";
-                            parameter.TypeName = typeof(object).FullName;
-                            parameter.Documentation = ComponentResources.BindTagHelper_Element_Get_Documentation;
-
-                            parameter.SetPropertyName("Get");
-                            parameter.SetBindAttributeGetSet();
-                        });
-
-                        attribute.BindAttributeParameter(parameter =>
-                        {
-                            parameter.Name = "set";
-                            parameter.TypeName = typeof(Delegate).FullName;
-                            parameter.Documentation = ComponentResources.BindTagHelper_Element_Set_Documentation;
-
-                            parameter.SetPropertyName("Set");
-                        });
-
-                        attribute.BindAttributeParameter(parameter =>
-                        {
-                            parameter.Name = "after";
-                            parameter.TypeName = typeof(Delegate).FullName;
-                            parameter.Documentation = ComponentResources.BindTagHelper_Element_After_Documentation;
-
-                            parameter.SetPropertyName("After");
-                        });
+                        parameter.SetPropertyName("After");
                     });
+                });
 
 
-                    if (tagHelper.IsComponentFullyQualifiedNameMatch())
-                    {
-                        builder.Metadata[ComponentMetadata.Component.NameMatchKey] = ComponentMetadata.Component.FullyQualifiedNameMatch;
-                    }
-
-                    results.Add(builder.Build());
-                }
-                finally
+                if (tagHelper.IsComponentFullyQualifiedNameMatch())
                 {
-                    TagHelperDescriptorBuilder.ReturnInstance(builder);
+                    builder.Metadata[ComponentMetadata.Component.NameMatchKey] = ComponentMetadata.Component.FullyQualifiedNameMatch;
                 }
+
+                results.Add(builder.Build());
             }
         }
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/BindTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/BindTagHelperDescriptorProvider.cs
@@ -131,106 +131,113 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
         }
     }
 
-    private TagHelperDescriptor CreateFallbackBindTagHelper()
+    private static TagHelperDescriptor CreateFallbackBindTagHelper()
     {
-        var builder = TagHelperDescriptorBuilder.Create(ComponentMetadata.Bind.TagHelperKind, "Bind", ComponentsApi.AssemblyName);
-        builder.CaseSensitive = true;
-        builder.Documentation = ComponentResources.BindTagHelper_Fallback_Documentation;
-
-        builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.Bind.TagHelperKind);
-        builder.Metadata.Add(TagHelperMetadata.Common.ClassifyAttributesOnly, bool.TrueString);
-        builder.Metadata[TagHelperMetadata.Runtime.Name] = ComponentMetadata.Bind.RuntimeName;
-        builder.Metadata[ComponentMetadata.Bind.FallbackKey] = bool.TrueString;
-
-        // WTE has a bug in 15.7p1 where a Tag Helper without a display-name that looks like
-        // a C# property will crash trying to create the toolips.
-        builder.SetTypeName("Microsoft.AspNetCore.Components.Bind");
-        builder.SetTypeNamespace("Microsoft.AspNetCore.Components");
-        builder.SetTypeNameIdentifier("Bind");
-
-        builder.TagMatchingRule(rule =>
+        var builder = TagHelperDescriptorBuilder.GetInstance(ComponentMetadata.Bind.TagHelperKind, "Bind", ComponentsApi.AssemblyName);
+        try
         {
-            rule.TagName = "*";
-            rule.Attribute(attribute =>
+            builder.CaseSensitive = true;
+            builder.Documentation = ComponentResources.BindTagHelper_Fallback_Documentation;
+
+            builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.Bind.TagHelperKind);
+            builder.Metadata.Add(TagHelperMetadata.Common.ClassifyAttributesOnly, bool.TrueString);
+            builder.Metadata[TagHelperMetadata.Runtime.Name] = ComponentMetadata.Bind.RuntimeName;
+            builder.Metadata[ComponentMetadata.Bind.FallbackKey] = bool.TrueString;
+
+            // WTE has a bug in 15.7p1 where a Tag Helper without a display-name that looks like
+            // a C# property will crash trying to create the toolips.
+            builder.SetTypeName("Microsoft.AspNetCore.Components.Bind");
+            builder.SetTypeNamespace("Microsoft.AspNetCore.Components");
+            builder.SetTypeNameIdentifier("Bind");
+
+            builder.TagMatchingRule(rule =>
             {
-                attribute.Name = "@bind-";
-                attribute.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch;
-                attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+                rule.TagName = "*";
+                rule.Attribute(attribute =>
+                {
+                    attribute.Name = "@bind-";
+                    attribute.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch;
+                    attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+                });
             });
-        });
 
-        builder.BindAttribute(attribute =>
-        {
-            attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
-            attribute.Documentation = ComponentResources.BindTagHelper_Fallback_Documentation;
+            builder.BindAttribute(attribute =>
+            {
+                attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+                attribute.Documentation = ComponentResources.BindTagHelper_Fallback_Documentation;
 
-            var attributeName = "@bind-...";
-            attribute.Name = attributeName;
-            attribute.AsDictionary("@bind-", typeof(object).FullName);
+                var attributeName = "@bind-...";
+                attribute.Name = attributeName;
+                attribute.AsDictionary("@bind-", typeof(object).FullName);
 
                 // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like
                 // a C# property will crash trying to create the toolips.
                 attribute.SetPropertyName("Bind");
-            attribute.TypeName = "System.Collections.Generic.Dictionary<string, object>";
+                attribute.TypeName = "System.Collections.Generic.Dictionary<string, object>";
 
-            attribute.BindAttributeParameter(parameter =>
-            {
-                parameter.Name = "format";
-                parameter.TypeName = typeof(string).FullName;
-                parameter.Documentation = ComponentResources.BindTagHelper_Fallback_Format_Documentation;
+                attribute.BindAttributeParameter(parameter =>
+                {
+                    parameter.Name = "format";
+                    parameter.TypeName = typeof(string).FullName;
+                    parameter.Documentation = ComponentResources.BindTagHelper_Fallback_Format_Documentation;
 
-                parameter.SetPropertyName("Format");
+                    parameter.SetPropertyName("Format");
+                });
+
+                attribute.BindAttributeParameter(parameter =>
+                {
+                    parameter.Name = "event";
+                    parameter.TypeName = typeof(string).FullName;
+                    parameter.Documentation = string.Format(CultureInfo.CurrentCulture, ComponentResources.BindTagHelper_Fallback_Event_Documentation, attributeName);
+
+                    parameter.SetPropertyName("Event");
+                });
+
+                attribute.BindAttributeParameter(parameter =>
+                {
+                    parameter.Name = "culture";
+                    parameter.TypeName = typeof(CultureInfo).FullName;
+                    parameter.Documentation = ComponentResources.BindTagHelper_Element_Culture_Documentation;
+
+                    parameter.SetPropertyName("Culture");
+                });
+
+                attribute.BindAttributeParameter(parameter =>
+                {
+                    parameter.Name = "get";
+                    parameter.TypeName = typeof(object).FullName;
+                    parameter.Documentation = ComponentResources.BindTagHelper_Element_Get_Documentation;
+
+                    parameter.SetPropertyName("Get");
+
+                    parameter.SetBindAttributeGetSet();
+                });
+
+                attribute.BindAttributeParameter(parameter =>
+                {
+                    parameter.Name = "set";
+                    parameter.TypeName = typeof(Delegate).FullName;
+                    parameter.Documentation = ComponentResources.BindTagHelper_Element_Set_Documentation;
+
+                    parameter.SetPropertyName("Set");
+                });
+
+                attribute.BindAttributeParameter(parameter =>
+                {
+                    parameter.Name = "after";
+                    parameter.TypeName = typeof(Delegate).FullName;
+                    parameter.Documentation = ComponentResources.BindTagHelper_Element_After_Documentation;
+
+                    parameter.SetPropertyName("After");
+                });
             });
 
-            attribute.BindAttributeParameter(parameter =>
-            {
-                parameter.Name = "event";
-                parameter.TypeName = typeof(string).FullName;
-                parameter.Documentation = string.Format(CultureInfo.CurrentCulture, ComponentResources.BindTagHelper_Fallback_Event_Documentation, attributeName);
-
-                parameter.SetPropertyName("Event");
-            });
-
-            attribute.BindAttributeParameter(parameter =>
-            {
-                parameter.Name = "culture";
-                parameter.TypeName = typeof(CultureInfo).FullName;
-                parameter.Documentation = ComponentResources.BindTagHelper_Element_Culture_Documentation;
-
-                parameter.SetPropertyName("Culture");
-            });
-
-            attribute.BindAttributeParameter(parameter =>
-            {
-                parameter.Name = "get";
-                parameter.TypeName = typeof(object).FullName;
-                parameter.Documentation = ComponentResources.BindTagHelper_Element_Get_Documentation;
-
-                parameter.SetPropertyName("Get");
-
-                parameter.SetBindAttributeGetSet();
-            });
-
-            attribute.BindAttributeParameter(parameter =>
-            {
-                parameter.Name = "set";
-                parameter.TypeName = typeof(Delegate).FullName;
-                parameter.Documentation = ComponentResources.BindTagHelper_Element_Set_Documentation;
-
-                parameter.SetPropertyName("Set");
-            });
-
-            attribute.BindAttributeParameter(parameter =>
-            {
-                parameter.Name = "after";
-                parameter.TypeName = typeof(Delegate).FullName;
-                parameter.Documentation = ComponentResources.BindTagHelper_Element_After_Documentation;
-
-                parameter.SetPropertyName("After");
-            });
-        });
-
-        return builder.Build();
+            return builder.Build();
+        }
+        finally
+        {
+            TagHelperDescriptorBuilder.ReturnInstance(builder);
+        }
     }
 
     private List<ElementBindData> GetElementBindData(Compilation compilation)
@@ -322,14 +329,12 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
         return results;
     }
 
-    private List<TagHelperDescriptor> CreateElementBindTagHelpers(List<ElementBindData> data)
+    private static List<TagHelperDescriptor> CreateElementBindTagHelpers(List<ElementBindData> data)
     {
         var results = new List<TagHelperDescriptor>();
 
-        for (var i = 0; i < data.Count; i++)
+        foreach (var entry in data)
         {
-            var entry = data[i];
-
             var name = entry.Suffix == null ? "Bind" : "Bind_" + entry.Suffix;
             var attributeName = entry.Suffix == null ? "@bind" : "@bind-" + entry.Suffix;
 
@@ -338,184 +343,191 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
 
             var eventName = entry.Suffix == null ? "Event_" + entry.ValueAttribute : "Event_" + entry.Suffix;
 
-            var builder = TagHelperDescriptorBuilder.Create(ComponentMetadata.Bind.TagHelperKind, name, ComponentsApi.AssemblyName);
-            builder.CaseSensitive = true;
-            builder.Documentation = string.Format(
-                CultureInfo.CurrentCulture,
-                ComponentResources.BindTagHelper_Element_Documentation,
-                entry.ValueAttribute,
-                entry.ChangeAttribute);
-
-            builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.Bind.TagHelperKind);
-            builder.Metadata.Add(TagHelperMetadata.Common.ClassifyAttributesOnly, bool.TrueString);
-            builder.Metadata[TagHelperMetadata.Runtime.Name] = ComponentMetadata.Bind.RuntimeName;
-            builder.Metadata[ComponentMetadata.Bind.ValueAttribute] = entry.ValueAttribute;
-            builder.Metadata[ComponentMetadata.Bind.ChangeAttribute] = entry.ChangeAttribute;
-            builder.Metadata[ComponentMetadata.Bind.IsInvariantCulture] = entry.IsInvariantCulture ? bool.TrueString : bool.FalseString;
-            builder.Metadata[ComponentMetadata.Bind.Format] = entry.Format;
-
-            if (entry.TypeAttribute != null)
+            var builder = TagHelperDescriptorBuilder.GetInstance(ComponentMetadata.Bind.TagHelperKind, name, ComponentsApi.AssemblyName);
+            try
             {
-                // For entries that map to the <input /> element, we need to be able to know
-                // the difference between <input /> and <input type="text" .../> for which we
-                // want to use the same attributes.
-                //
-                // We provide a tag helper for <input /> that should match all input elements,
-                // but we only want it to be used when a more specific one is used.
-                //
-                // Therefore we use this metadata to know which one is more specific when two
-                // tag helpers match.
-                builder.Metadata[ComponentMetadata.Bind.TypeAttribute] = entry.TypeAttribute;
-            }
-
-            // WTE has a bug in 15.7p1 where a Tag Helper without a display-name that looks like
-            // a C# property will crash trying to create the toolips.
-            builder.SetTypeName(entry.TypeName);
-            builder.SetTypeNamespace(entry.TypeNamespace);
-            builder.SetTypeNameIdentifier(entry.TypeNameIdentifier);
-
-            builder.TagMatchingRule(rule =>
-            {
-                rule.TagName = entry.Element;
-                if (entry.TypeAttribute != null)
-                {
-                    rule.Attribute(a =>
-                    {
-                        a.Name = "type";
-                        a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
-                        a.Value = entry.TypeAttribute;
-                        a.ValueComparisonMode = RequiredAttributeDescriptor.ValueComparisonMode.FullMatch;
-                    });
-                }
-
-                rule.Attribute(a =>
-                {
-                    a.Name = attributeName;
-                    a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
-                    a.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
-                });
-            });
-
-            builder.TagMatchingRule(rule =>
-            {
-                rule.TagName = entry.Element;
-                if (entry.TypeAttribute != null)
-                {
-                    rule.Attribute(a =>
-                    {
-                        a.Name = "type";
-                        a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
-                        a.Value = entry.TypeAttribute;
-                        a.ValueComparisonMode = RequiredAttributeDescriptor.ValueComparisonMode.FullMatch;
-                    });
-                }
-
-                rule.Attribute(a =>
-                {
-                    a.Name = $"{attributeName}:get";
-                    a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
-                    a.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
-                });
-
-                rule.Attribute(a =>
-                {
-                    a.Name = $"{attributeName}:set";
-                    a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
-                    a.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
-                });
-            });
-
-            builder.BindAttribute(a =>
-            {
-                a.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
-                a.Documentation = string.Format(
+                builder.CaseSensitive = true;
+                builder.Documentation = string.Format(
                     CultureInfo.CurrentCulture,
                     ComponentResources.BindTagHelper_Element_Documentation,
                     entry.ValueAttribute,
                     entry.ChangeAttribute);
 
-                a.Name = attributeName;
-                a.TypeName = typeof(object).FullName;
+                builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.Bind.TagHelperKind);
+                builder.Metadata.Add(TagHelperMetadata.Common.ClassifyAttributesOnly, bool.TrueString);
+                builder.Metadata[TagHelperMetadata.Runtime.Name] = ComponentMetadata.Bind.RuntimeName;
+                builder.Metadata[ComponentMetadata.Bind.ValueAttribute] = entry.ValueAttribute;
+                builder.Metadata[ComponentMetadata.Bind.ChangeAttribute] = entry.ChangeAttribute;
+                builder.Metadata[ComponentMetadata.Bind.IsInvariantCulture] = entry.IsInvariantCulture ? bool.TrueString : bool.FalseString;
+                builder.Metadata[ComponentMetadata.Bind.Format] = entry.Format;
+
+                if (entry.TypeAttribute != null)
+                {
+                    // For entries that map to the <input /> element, we need to be able to know
+                    // the difference between <input /> and <input type="text" .../> for which we
+                    // want to use the same attributes.
+                    //
+                    // We provide a tag helper for <input /> that should match all input elements,
+                    // but we only want it to be used when a more specific one is used.
+                    //
+                    // Therefore we use this metadata to know which one is more specific when two
+                    // tag helpers match.
+                    builder.Metadata[ComponentMetadata.Bind.TypeAttribute] = entry.TypeAttribute;
+                }
+
+                // WTE has a bug in 15.7p1 where a Tag Helper without a display-name that looks like
+                // a C# property will crash trying to create the toolips.
+                builder.SetTypeName(entry.TypeName);
+                builder.SetTypeNamespace(entry.TypeNamespace);
+                builder.SetTypeNameIdentifier(entry.TypeNameIdentifier);
+
+                builder.TagMatchingRule(rule =>
+                {
+                    rule.TagName = entry.Element;
+                    if (entry.TypeAttribute != null)
+                    {
+                        rule.Attribute(a =>
+                        {
+                            a.Name = "type";
+                            a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                            a.Value = entry.TypeAttribute;
+                            a.ValueComparisonMode = RequiredAttributeDescriptor.ValueComparisonMode.FullMatch;
+                        });
+                    }
+
+                    rule.Attribute(a =>
+                    {
+                        a.Name = attributeName;
+                        a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                        a.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+                    });
+                });
+
+                builder.TagMatchingRule(rule =>
+                {
+                    rule.TagName = entry.Element;
+                    if (entry.TypeAttribute != null)
+                    {
+                        rule.Attribute(a =>
+                        {
+                            a.Name = "type";
+                            a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                            a.Value = entry.TypeAttribute;
+                            a.ValueComparisonMode = RequiredAttributeDescriptor.ValueComparisonMode.FullMatch;
+                        });
+                    }
+
+                    rule.Attribute(a =>
+                    {
+                        a.Name = $"{attributeName}:get";
+                        a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                        a.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+                    });
+
+                    rule.Attribute(a =>
+                    {
+                        a.Name = $"{attributeName}:set";
+                        a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                        a.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+                    });
+                });
+
+                builder.BindAttribute(a =>
+                {
+                    a.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+                    a.Documentation = string.Format(
+                        CultureInfo.CurrentCulture,
+                        ComponentResources.BindTagHelper_Element_Documentation,
+                        entry.ValueAttribute,
+                        entry.ChangeAttribute);
+
+                    a.Name = attributeName;
+                    a.TypeName = typeof(object).FullName;
 
                     // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like
                     // a C# property will crash trying to create the toolips.
                     a.SetPropertyName(name);
 
-                a.BindAttributeParameter(parameter =>
-                {
-                    parameter.Name = "format";
-                    parameter.TypeName = typeof(string).FullName;
-                    parameter.Documentation = string.Format(CultureInfo.CurrentCulture, ComponentResources.BindTagHelper_Element_Format_Documentation, attributeName);
+                    a.BindAttributeParameter(parameter =>
+                    {
+                        parameter.Name = "format";
+                        parameter.TypeName = typeof(string).FullName;
+                        parameter.Documentation = string.Format(CultureInfo.CurrentCulture, ComponentResources.BindTagHelper_Element_Format_Documentation, attributeName);
 
-                    parameter.SetPropertyName(formatName);
+                        parameter.SetPropertyName(formatName);
+                    });
+
+                    a.BindAttributeParameter(parameter =>
+                    {
+                        parameter.Name = "event";
+                        parameter.TypeName = typeof(string).FullName;
+                        parameter.Documentation = string.Format(CultureInfo.CurrentCulture, ComponentResources.BindTagHelper_Element_Event_Documentation, attributeName);
+
+                        parameter.SetPropertyName(eventName);
+                    });
+
+                    a.BindAttributeParameter(parameter =>
+                    {
+                        parameter.Name = "culture";
+                        parameter.TypeName = typeof(CultureInfo).FullName;
+                        parameter.Documentation = ComponentResources.BindTagHelper_Element_Culture_Documentation;
+
+                        parameter.SetPropertyName("Culture");
+                    });
+
+                    a.BindAttributeParameter(parameter =>
+                    {
+                        parameter.Name = "get";
+                        parameter.TypeName = typeof(object).FullName;
+                        parameter.Documentation = ComponentResources.BindTagHelper_Element_Get_Documentation;
+
+                        parameter.SetPropertyName("Get");
+                        parameter.SetBindAttributeGetSet();
+                    });
+
+                    a.BindAttributeParameter(parameter =>
+                    {
+                        parameter.Name = "set";
+                        parameter.TypeName = typeof(Delegate).FullName;
+                        parameter.Documentation = ComponentResources.BindTagHelper_Element_Set_Documentation;
+
+                        parameter.SetPropertyName("Set");
+                    });
+
+                    a.BindAttributeParameter(parameter =>
+                    {
+                        parameter.Name = "after";
+                        parameter.TypeName = typeof(Delegate).FullName;
+                        parameter.Documentation = ComponentResources.BindTagHelper_Element_After_Documentation;
+
+                        parameter.SetPropertyName("After");
+                    });
                 });
 
-                a.BindAttributeParameter(parameter =>
+                // This is no longer supported. This is just here so we can add a diagnostic later on when this matches.
+                builder.BindAttribute(attribute =>
                 {
-                    parameter.Name = "event";
-                    parameter.TypeName = typeof(string).FullName;
-                    parameter.Documentation = string.Format(CultureInfo.CurrentCulture, ComponentResources.BindTagHelper_Element_Event_Documentation, attributeName);
-
-                    parameter.SetPropertyName(eventName);
-                });
-
-                a.BindAttributeParameter(parameter =>
-                {
-                    parameter.Name = "culture";
-                    parameter.TypeName = typeof(CultureInfo).FullName;
-                    parameter.Documentation = ComponentResources.BindTagHelper_Element_Culture_Documentation;
-
-                    parameter.SetPropertyName("Culture");
-                });
-
-                a.BindAttributeParameter(parameter =>
-                {
-                    parameter.Name = "get";
-                    parameter.TypeName = typeof(object).FullName;
-                    parameter.Documentation = ComponentResources.BindTagHelper_Element_Get_Documentation;
-
-                    parameter.SetPropertyName("Get");
-                    parameter.SetBindAttributeGetSet();
-                });
-
-                a.BindAttributeParameter(parameter =>
-                {
-                    parameter.Name = "set";
-                    parameter.TypeName = typeof(Delegate).FullName;
-                    parameter.Documentation = ComponentResources.BindTagHelper_Element_Set_Documentation;
-
-                    parameter.SetPropertyName("Set");
-                });
-
-                a.BindAttributeParameter(parameter =>
-                {
-                    parameter.Name = "after";
-                    parameter.TypeName = typeof(Delegate).FullName;
-                    parameter.Documentation = ComponentResources.BindTagHelper_Element_After_Documentation;
-
-                    parameter.SetPropertyName("After");
-                });
-            });
-
-            // This is no longer supported. This is just here so we can add a diagnostic later on when this matches.
-            builder.BindAttribute(attribute =>
-            {
-                attribute.Name = formatAttributeName;
-                attribute.TypeName = "System.String";
-                attribute.Documentation = string.Format(CultureInfo.CurrentCulture, ComponentResources.BindTagHelper_Element_Format_Documentation, attributeName);
+                    attribute.Name = formatAttributeName;
+                    attribute.TypeName = "System.String";
+                    attribute.Documentation = string.Format(CultureInfo.CurrentCulture, ComponentResources.BindTagHelper_Element_Format_Documentation, attributeName);
 
                     // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like
                     // a C# property will crash trying to create the toolips.
                     attribute.SetPropertyName(formatName);
-            });
+                });
 
-            results.Add(builder.Build());
+                results.Add(builder.Build());
+            }
+            finally
+            {
+                TagHelperDescriptorBuilder.ReturnInstance(builder);
+            }
         }
-
         return results;
+
     }
 
-    private List<TagHelperDescriptor> CreateComponentBindTagHelpers(ICollection<TagHelperDescriptor> tagHelpers)
+    private static List<TagHelperDescriptor> CreateComponentBindTagHelpers(ICollection<TagHelperDescriptor> tagHelpers)
     {
         var results = new List<TagHelperDescriptor>();
 
@@ -576,113 +588,120 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                     continue;
                 }
 
-                var builder = TagHelperDescriptorBuilder.Create(ComponentMetadata.Bind.TagHelperKind, tagHelper.Name, tagHelper.AssemblyName);
-                builder.DisplayName = tagHelper.DisplayName;
-                builder.CaseSensitive = true;
-                builder.Documentation = string.Format(
-                    CultureInfo.CurrentCulture,
-                    ComponentResources.BindTagHelper_Component_Documentation,
-                    valueAttribute.Name,
-                    changeAttribute.Name);
-
-                builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.Bind.TagHelperKind);
-                builder.Metadata[TagHelperMetadata.Runtime.Name] = ComponentMetadata.Bind.RuntimeName;
-                builder.Metadata[ComponentMetadata.Bind.ValueAttribute] = valueAttribute.Name;
-                builder.Metadata[ComponentMetadata.Bind.ChangeAttribute] = changeAttribute.Name;
-
-                if (expressionAttribute != null)
+                var builder = TagHelperDescriptorBuilder.GetInstance(ComponentMetadata.Bind.TagHelperKind, tagHelper.Name, tagHelper.AssemblyName);
+                try
                 {
-                    builder.Metadata[ComponentMetadata.Bind.ExpressionAttribute] = expressionAttribute.Name;
-                }
-
-                // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like
-                // a C# property will crash trying to create the toolips.
-                builder.SetTypeName(tagHelper.GetTypeName());
-                builder.SetTypeNamespace(tagHelper.GetTypeNamespace());
-                builder.SetTypeNameIdentifier(tagHelper.GetTypeNameIdentifier());
-
-                // Match the component and attribute name
-                builder.TagMatchingRule(rule =>
-                {
-                    rule.TagName = tagHelper.TagMatchingRules.Single().TagName;
-                    rule.Attribute(attribute =>
-                    {
-                        attribute.Name = "@bind-" + valueAttribute.Name;
-                        attribute.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
-                        attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
-                    });
-                });
-
-                builder.TagMatchingRule(rule =>
-                {
-                    rule.TagName = tagHelper.TagMatchingRules.Single().TagName;
-                    rule.Attribute(attribute =>
-                    {
-                        attribute.Name = "@bind-" + valueAttribute.Name + ":get";
-                        attribute.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
-                        attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
-                    });
-                    rule.Attribute(attribute =>
-                    {
-                        attribute.Name = "@bind-" + valueAttribute.Name + ":set";
-                        attribute.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
-                        attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
-                    });
-                });
-
-                builder.BindAttribute(attribute =>
-                {
-                    attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
-                    attribute.Documentation = string.Format(
+                    builder.DisplayName = tagHelper.DisplayName;
+                    builder.CaseSensitive = true;
+                    builder.Documentation = string.Format(
                         CultureInfo.CurrentCulture,
                         ComponentResources.BindTagHelper_Component_Documentation,
                         valueAttribute.Name,
                         changeAttribute.Name);
 
-                    attribute.Name = "@bind-" + valueAttribute.Name;
-                    attribute.TypeName = changeAttribute.TypeName;
-                    attribute.IsEnum = valueAttribute.IsEnum;
+                    builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.Bind.TagHelperKind);
+                    builder.Metadata[TagHelperMetadata.Runtime.Name] = ComponentMetadata.Bind.RuntimeName;
+                    builder.Metadata[ComponentMetadata.Bind.ValueAttribute] = valueAttribute.Name;
+                    builder.Metadata[ComponentMetadata.Bind.ChangeAttribute] = changeAttribute.Name;
+
+                    if (expressionAttribute != null)
+                    {
+                        builder.Metadata[ComponentMetadata.Bind.ExpressionAttribute] = expressionAttribute.Name;
+                    }
 
                     // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like
                     // a C# property will crash trying to create the toolips.
-                    attribute.SetPropertyName(valueAttribute.GetPropertyName());
+                    builder.SetTypeName(tagHelper.GetTypeName());
+                    builder.SetTypeNamespace(tagHelper.GetTypeNamespace());
+                    builder.SetTypeNameIdentifier(tagHelper.GetTypeNameIdentifier());
 
-                    attribute.BindAttributeParameter(parameter =>
+                    // Match the component and attribute name
+                    builder.TagMatchingRule(rule =>
                     {
-                        parameter.Name = "get";
-                        parameter.TypeName = typeof(object).FullName;
-                        parameter.Documentation = ComponentResources.BindTagHelper_Element_Get_Documentation;
-
-                        parameter.SetPropertyName("Get");
-                        parameter.SetBindAttributeGetSet();
+                        rule.TagName = tagHelper.TagMatchingRules.Single().TagName;
+                        rule.Attribute(attribute =>
+                        {
+                            attribute.Name = "@bind-" + valueAttribute.Name;
+                            attribute.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                            attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+                        });
                     });
 
-                    attribute.BindAttributeParameter(parameter =>
+                    builder.TagMatchingRule(rule =>
                     {
-                        parameter.Name = "set";
-                        parameter.TypeName = typeof(Delegate).FullName;
-                        parameter.Documentation = ComponentResources.BindTagHelper_Element_Set_Documentation;
-
-                        parameter.SetPropertyName("Set");
+                        rule.TagName = tagHelper.TagMatchingRules.Single().TagName;
+                        rule.Attribute(attribute =>
+                        {
+                            attribute.Name = "@bind-" + valueAttribute.Name + ":get";
+                            attribute.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                            attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+                        });
+                        rule.Attribute(attribute =>
+                        {
+                            attribute.Name = "@bind-" + valueAttribute.Name + ":set";
+                            attribute.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                            attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+                        });
                     });
 
-                    attribute.BindAttributeParameter(parameter =>
+                    builder.BindAttribute(attribute =>
                     {
-                        parameter.Name = "after";
-                        parameter.TypeName = typeof(Delegate).FullName;
-                        parameter.Documentation = ComponentResources.BindTagHelper_Element_After_Documentation;
+                        attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+                        attribute.Documentation = string.Format(
+                            CultureInfo.CurrentCulture,
+                            ComponentResources.BindTagHelper_Component_Documentation,
+                            valueAttribute.Name,
+                            changeAttribute.Name);
 
-                        parameter.SetPropertyName("After");
+                        attribute.Name = "@bind-" + valueAttribute.Name;
+                        attribute.TypeName = changeAttribute.TypeName;
+                        attribute.IsEnum = valueAttribute.IsEnum;
+
+                        // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like
+                        // a C# property will crash trying to create the toolips.
+                        attribute.SetPropertyName(valueAttribute.GetPropertyName());
+
+                        attribute.BindAttributeParameter(parameter =>
+                        {
+                            parameter.Name = "get";
+                            parameter.TypeName = typeof(object).FullName;
+                            parameter.Documentation = ComponentResources.BindTagHelper_Element_Get_Documentation;
+
+                            parameter.SetPropertyName("Get");
+                            parameter.SetBindAttributeGetSet();
+                        });
+
+                        attribute.BindAttributeParameter(parameter =>
+                        {
+                            parameter.Name = "set";
+                            parameter.TypeName = typeof(Delegate).FullName;
+                            parameter.Documentation = ComponentResources.BindTagHelper_Element_Set_Documentation;
+
+                            parameter.SetPropertyName("Set");
+                        });
+
+                        attribute.BindAttributeParameter(parameter =>
+                        {
+                            parameter.Name = "after";
+                            parameter.TypeName = typeof(Delegate).FullName;
+                            parameter.Documentation = ComponentResources.BindTagHelper_Element_After_Documentation;
+
+                            parameter.SetPropertyName("After");
+                        });
                     });
-                });
 
 
-                if (tagHelper.IsComponentFullyQualifiedNameMatch())
-                {
-                    builder.Metadata[ComponentMetadata.Component.NameMatchKey] = ComponentMetadata.Component.FullyQualifiedNameMatch;
+                    if (tagHelper.IsComponentFullyQualifiedNameMatch())
+                    {
+                        builder.Metadata[ComponentMetadata.Component.NameMatchKey] = ComponentMetadata.Component.FullyQualifiedNameMatch;
+                    }
+
+                    results.Add(builder.Build());
                 }
-
-                results.Add(builder.Build());
+                finally
+                {
+                    TagHelperDescriptorBuilder.ReturnInstance(builder);
+                }
             }
         }
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/DefaultTagHelperDescriptorFactory.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/DefaultTagHelperDescriptorFactory.cs
@@ -42,27 +42,23 @@ internal class DefaultTagHelperDescriptorFactory
         var typeName = GetFullName(type);
         var assemblyName = type.ContainingAssembly.Identity.Name;
 
-        var descriptorBuilder = TagHelperDescriptorBuilder.GetInstance(typeName, assemblyName);
-        try
-        {
-            descriptorBuilder.SetTypeName(typeName);
-            descriptorBuilder.SetTypeNamespace(type.ContainingNamespace.ToDisplayString(SymbolExtensions.FullNameTypeDisplayFormat));
-            descriptorBuilder.SetTypeNameIdentifier(type.Name);
+        using var _ = TagHelperDescriptorBuilder.GetPooledInstance(
+            typeName, assemblyName,
+            out var descriptorBuilder);
 
-            AddBoundAttributes(type, descriptorBuilder);
-            AddTagMatchingRules(type, descriptorBuilder);
-            AddAllowedChildren(type, descriptorBuilder);
-            AddDocumentation(type, descriptorBuilder);
-            AddTagOutputHint(type, descriptorBuilder);
+        descriptorBuilder.SetTypeName(typeName);
+        descriptorBuilder.SetTypeNamespace(type.ContainingNamespace.ToDisplayString(SymbolExtensions.FullNameTypeDisplayFormat));
+        descriptorBuilder.SetTypeNameIdentifier(type.Name);
 
-            var descriptor = descriptorBuilder.Build();
+        AddBoundAttributes(type, descriptorBuilder);
+        AddTagMatchingRules(type, descriptorBuilder);
+        AddAllowedChildren(type, descriptorBuilder);
+        AddDocumentation(type, descriptorBuilder);
+        AddTagOutputHint(type, descriptorBuilder);
 
-            return descriptor;
-        }
-        finally
-        {
-            TagHelperDescriptorBuilder.ReturnInstance(descriptorBuilder);
-        }
+        var descriptor = descriptorBuilder.Build();
+
+        return descriptor;
     }
 
     private static void AddTagMatchingRules(INamedTypeSymbol type, TagHelperDescriptorBuilder descriptorBuilder)

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/DefaultTagHelperDescriptorFactory.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/DefaultTagHelperDescriptorFactory.cs
@@ -386,7 +386,7 @@ internal class DefaultTagHelperDescriptorFactory
                     property.GetMethod.DeclaredAccessibility == Accessibility.Public &&
                     property.GetAttributes().FirstOrDefault(a => a.AttributeClass.HasFullName(TagHelperTypes.HtmlAttributeNotBoundAttribute)) == null &&
                     (property.GetAttributes().Any(a => a.AttributeClass.HasFullName(TagHelperTypes.HtmlAttributeNameAttribute)) ||
-                    (property.SetMethod != null && property.SetMethod.DeclaredAccessibility == Accessibility.Public) ||
+                    property.SetMethod != null && property.SetMethod.DeclaredAccessibility == Accessibility.Public ||
                     IsPotentialDictionaryProperty(property)) &&
                     !accessibleProperties.ContainsKey(property.Name))
                 {

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/EventHandlerTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/EventHandlerTagHelperDescriptorProvider.cs
@@ -115,125 +115,121 @@ internal class EventHandlerTagHelperDescriptorProvider : ITagHelperDescriptorPro
             var attributeName = "@" + entry.Attribute;
             var eventArgType = entry.EventArgsType.ToDisplayString();
 
-            var builder = TagHelperDescriptorBuilder.GetInstance(ComponentMetadata.EventHandler.TagHelperKind, entry.Attribute, ComponentsApi.AssemblyName);
-            try
+            using var _ = TagHelperDescriptorBuilder.GetPooledInstance(
+                ComponentMetadata.EventHandler.TagHelperKind, entry.Attribute, ComponentsApi.AssemblyName,
+                out var builder);
+
+            builder.CaseSensitive = true;
+            builder.Documentation = string.Format(
+                CultureInfo.CurrentCulture,
+                ComponentResources.EventHandlerTagHelper_Documentation,
+                attributeName,
+                eventArgType);
+
+            builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.EventHandler.TagHelperKind);
+            builder.Metadata.Add(ComponentMetadata.EventHandler.EventArgsType, eventArgType);
+            builder.Metadata.Add(TagHelperMetadata.Common.ClassifyAttributesOnly, bool.TrueString);
+            builder.Metadata[TagHelperMetadata.Runtime.Name] = ComponentMetadata.EventHandler.RuntimeName;
+
+            // WTE has a bug in 15.7p1 where a Tag Helper without a display-name that looks like
+            // a C# property will crash trying to create the tooltips.
+            builder.SetTypeName(entry.TypeName);
+            builder.SetTypeNamespace(entry.TypeNamespace);
+            builder.SetTypeNameIdentifier(entry.TypeNameIdentifier);
+
+            builder.TagMatchingRule(rule =>
             {
-                builder.CaseSensitive = true;
-                builder.Documentation = string.Format(
-                    CultureInfo.CurrentCulture,
-                    ComponentResources.EventHandlerTagHelper_Documentation,
-                    attributeName,
-                    eventArgType);
+                rule.TagName = "*";
 
-                builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.EventHandler.TagHelperKind);
-                builder.Metadata.Add(ComponentMetadata.EventHandler.EventArgsType, eventArgType);
-                builder.Metadata.Add(TagHelperMetadata.Common.ClassifyAttributesOnly, bool.TrueString);
-                builder.Metadata[TagHelperMetadata.Runtime.Name] = ComponentMetadata.EventHandler.RuntimeName;
+                rule.Attribute(a =>
+                {
+                    a.Name = attributeName;
+                    a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                    a.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+                });
+            });
 
-                // WTE has a bug in 15.7p1 where a Tag Helper without a display-name that looks like
-                // a C# property will crash trying to create the tooltips.
-                builder.SetTypeName(entry.TypeName);
-                builder.SetTypeNamespace(entry.TypeNamespace);
-                builder.SetTypeNameIdentifier(entry.TypeNameIdentifier);
-
+            if (entry.EnablePreventDefault)
+            {
                 builder.TagMatchingRule(rule =>
                 {
                     rule.TagName = "*";
 
                     rule.Attribute(a =>
                     {
-                        a.Name = attributeName;
+                        a.Name = attributeName + ":preventDefault";
                         a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
                         a.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
                     });
                 });
+            }
+
+            if (entry.EnableStopPropagation)
+            {
+                builder.TagMatchingRule(rule =>
+                {
+                    rule.TagName = "*";
+
+                    rule.Attribute(a =>
+                    {
+                        a.Name = attributeName + ":stopPropagation";
+                        a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
+                        a.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+                    });
+                });
+            }
+
+            builder.BindAttribute(a =>
+            {
+                a.Documentation = string.Format(
+                    CultureInfo.CurrentCulture,
+                    ComponentResources.EventHandlerTagHelper_Documentation,
+                    attributeName,
+                    eventArgType);
+
+                a.Name = attributeName;
+
+                // We want event handler directive attributes to default to C# context.
+                a.TypeName = $"Microsoft.AspNetCore.Components.EventCallback<{eventArgType}>";
+
+                // But make this weakly typed (don't type check) - delegates have their own type-checking
+                // logic that we don't want to interfere with.
+                a.Metadata.Add(ComponentMetadata.Component.WeaklyTypedKey, bool.TrueString);
+
+                a.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+
+                // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like
+                // a C# property will crash trying to create the tooltips.
+                a.SetPropertyName(entry.Attribute);
 
                 if (entry.EnablePreventDefault)
                 {
-                    builder.TagMatchingRule(rule =>
+                    a.BindAttributeParameter(parameter =>
                     {
-                        rule.TagName = "*";
+                        parameter.Name = "preventDefault";
+                        parameter.TypeName = typeof(bool).FullName;
+                        parameter.Documentation = string.Format(
+                            CultureInfo.CurrentCulture, ComponentResources.EventHandlerTagHelper_PreventDefault_Documentation, attributeName);
 
-                        rule.Attribute(a =>
-                        {
-                            a.Name = attributeName + ":preventDefault";
-                            a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
-                            a.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
-                        });
+                        parameter.SetPropertyName("PreventDefault");
                     });
                 }
 
                 if (entry.EnableStopPropagation)
                 {
-                    builder.TagMatchingRule(rule =>
+                    a.BindAttributeParameter(parameter =>
                     {
-                        rule.TagName = "*";
+                        parameter.Name = "stopPropagation";
+                        parameter.TypeName = typeof(bool).FullName;
+                        parameter.Documentation = string.Format(
+                            CultureInfo.CurrentCulture, ComponentResources.EventHandlerTagHelper_StopPropagation_Documentation, attributeName);
 
-                        rule.Attribute(a =>
-                        {
-                            a.Name = attributeName + ":stopPropagation";
-                            a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
-                            a.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
-                        });
+                        parameter.SetPropertyName("StopPropagation");
                     });
                 }
+            });
 
-                builder.BindAttribute(a =>
-                {
-                    a.Documentation = string.Format(
-                        CultureInfo.CurrentCulture,
-                        ComponentResources.EventHandlerTagHelper_Documentation,
-                        attributeName,
-                        eventArgType);
-
-                    a.Name = attributeName;
-
-                    // We want event handler directive attributes to default to C# context.
-                    a.TypeName = $"Microsoft.AspNetCore.Components.EventCallback<{eventArgType}>";
-
-                    // But make this weakly typed (don't type check) - delegates have their own type-checking
-                    // logic that we don't want to interfere with.
-                    a.Metadata.Add(ComponentMetadata.Component.WeaklyTypedKey, bool.TrueString);
-
-                    a.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
-
-                    // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like
-                    // a C# property will crash trying to create the tooltips.
-                    a.SetPropertyName(entry.Attribute);
-
-                    if (entry.EnablePreventDefault)
-                    {
-                        a.BindAttributeParameter(parameter =>
-                        {
-                            parameter.Name = "preventDefault";
-                            parameter.TypeName = typeof(bool).FullName;
-                            parameter.Documentation = string.Format(
-                                CultureInfo.CurrentCulture, ComponentResources.EventHandlerTagHelper_PreventDefault_Documentation, attributeName);
-
-                            parameter.SetPropertyName("PreventDefault");
-                        });
-                    }
-
-                    if (entry.EnableStopPropagation)
-                    {
-                        a.BindAttributeParameter(parameter =>
-                        {
-                            parameter.Name = "stopPropagation";
-                            parameter.TypeName = typeof(bool).FullName;
-                            parameter.Documentation = string.Format(
-                                CultureInfo.CurrentCulture, ComponentResources.EventHandlerTagHelper_StopPropagation_Documentation, attributeName);
-
-                            parameter.SetPropertyName("StopPropagation");
-                        });
-                    }
-                });
-
-                results.Add(builder.Build());
-            }
-            finally
-            {
-                TagHelperDescriptorBuilder.ReturnInstance(builder);
-            }
+            results.Add(builder.Build());
         }
 
         return results;

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/KeyTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/KeyTagHelperDescriptorProvider.cs
@@ -48,47 +48,43 @@ internal class KeyTagHelperDescriptorProvider : ITagHelperDescriptorProvider
 
     private static TagHelperDescriptor CreateKeyTagHelper()
     {
-        var builder = TagHelperDescriptorBuilder.GetInstance(ComponentMetadata.Key.TagHelperKind, "Key", ComponentsApi.AssemblyName);
-        try
+        using var _ = TagHelperDescriptorBuilder.GetPooledInstance(
+            ComponentMetadata.Key.TagHelperKind, "Key", ComponentsApi.AssemblyName,
+            out var builder);
+
+        builder.CaseSensitive = true;
+        builder.Documentation = ComponentResources.KeyTagHelper_Documentation;
+
+        builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.Key.TagHelperKind);
+        builder.Metadata.Add(TagHelperMetadata.Common.ClassifyAttributesOnly, bool.TrueString);
+        builder.Metadata[TagHelperMetadata.Runtime.Name] = ComponentMetadata.Key.RuntimeName;
+
+        // WTE has a bug in 15.7p1 where a Tag Helper without a display-name that looks like
+        // a C# property will crash trying to create the tooltips.
+        builder.SetTypeName("Microsoft.AspNetCore.Components.Key");
+
+        builder.TagMatchingRule(rule =>
         {
-            builder.CaseSensitive = true;
-            builder.Documentation = ComponentResources.KeyTagHelper_Documentation;
-
-            builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.Key.TagHelperKind);
-            builder.Metadata.Add(TagHelperMetadata.Common.ClassifyAttributesOnly, bool.TrueString);
-            builder.Metadata[TagHelperMetadata.Runtime.Name] = ComponentMetadata.Key.RuntimeName;
-
-            // WTE has a bug in 15.7p1 where a Tag Helper without a display-name that looks like
-            // a C# property will crash trying to create the tooltips.
-            builder.SetTypeName("Microsoft.AspNetCore.Components.Key");
-
-            builder.TagMatchingRule(rule =>
+            rule.TagName = "*";
+            rule.Attribute(attribute =>
             {
-                rule.TagName = "*";
-                rule.Attribute(attribute =>
-                {
-                    attribute.Name = "@key";
-                    attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
-                });
-            });
-
-            builder.BindAttribute(attribute =>
-            {
-                attribute.Documentation = ComponentResources.KeyTagHelper_Documentation;
                 attribute.Name = "@key";
-
-                // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like
-                // a C# property will crash trying to create the tooltips.
-                attribute.SetPropertyName("Key");
-                attribute.TypeName = typeof(object).FullName;
                 attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
             });
+        });
 
-            return builder.Build();
-        }
-        finally
+        builder.BindAttribute(attribute =>
         {
-            TagHelperDescriptorBuilder.ReturnInstance(builder);
-        }
+            attribute.Documentation = ComponentResources.KeyTagHelper_Documentation;
+            attribute.Name = "@key";
+
+            // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like
+            // a C# property will crash trying to create the tooltips.
+            attribute.SetPropertyName("Key");
+            attribute.TypeName = typeof(object).FullName;
+            attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+        });
+
+        return builder.Build();
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/KeyTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/KeyTagHelperDescriptorProvider.cs
@@ -46,42 +46,49 @@ internal class KeyTagHelperDescriptorProvider : ITagHelperDescriptorProvider
         context.Results.Add(CreateKeyTagHelper());
     }
 
-    private TagHelperDescriptor CreateKeyTagHelper()
+    private static TagHelperDescriptor CreateKeyTagHelper()
     {
-        var builder = TagHelperDescriptorBuilder.Create(ComponentMetadata.Key.TagHelperKind, "Key", ComponentsApi.AssemblyName);
-        builder.CaseSensitive = true;
-        builder.Documentation = ComponentResources.KeyTagHelper_Documentation;
-
-        builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.Key.TagHelperKind);
-        builder.Metadata.Add(TagHelperMetadata.Common.ClassifyAttributesOnly, bool.TrueString);
-        builder.Metadata[TagHelperMetadata.Runtime.Name] = ComponentMetadata.Key.RuntimeName;
-
-        // WTE has a bug in 15.7p1 where a Tag Helper without a display-name that looks like
-        // a C# property will crash trying to create the tooltips.
-        builder.SetTypeName("Microsoft.AspNetCore.Components.Key");
-
-        builder.TagMatchingRule(rule =>
+        var builder = TagHelperDescriptorBuilder.GetInstance(ComponentMetadata.Key.TagHelperKind, "Key", ComponentsApi.AssemblyName);
+        try
         {
-            rule.TagName = "*";
-            rule.Attribute(attribute =>
+            builder.CaseSensitive = true;
+            builder.Documentation = ComponentResources.KeyTagHelper_Documentation;
+
+            builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.Key.TagHelperKind);
+            builder.Metadata.Add(TagHelperMetadata.Common.ClassifyAttributesOnly, bool.TrueString);
+            builder.Metadata[TagHelperMetadata.Runtime.Name] = ComponentMetadata.Key.RuntimeName;
+
+            // WTE has a bug in 15.7p1 where a Tag Helper without a display-name that looks like
+            // a C# property will crash trying to create the tooltips.
+            builder.SetTypeName("Microsoft.AspNetCore.Components.Key");
+
+            builder.TagMatchingRule(rule =>
             {
-                attribute.Name = "@key";
-                attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+                rule.TagName = "*";
+                rule.Attribute(attribute =>
+                {
+                    attribute.Name = "@key";
+                    attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+                });
             });
-        });
 
-        builder.BindAttribute(attribute =>
-        {
-            attribute.Documentation = ComponentResources.KeyTagHelper_Documentation;
-            attribute.Name = "@key";
+            builder.BindAttribute(attribute =>
+            {
+                attribute.Documentation = ComponentResources.KeyTagHelper_Documentation;
+                attribute.Name = "@key";
 
                 // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like
                 // a C# property will crash trying to create the tooltips.
                 attribute.SetPropertyName("Key");
-            attribute.TypeName = typeof(object).FullName;
-            attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
-        });
+                attribute.TypeName = typeof(object).FullName;
+                attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+            });
 
-        return builder.Build();
+            return builder.Build();
+        }
+        finally
+        {
+            TagHelperDescriptorBuilder.ReturnInstance(builder);
+        }
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/RefTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/RefTagHelperDescriptorProvider.cs
@@ -48,47 +48,43 @@ internal class RefTagHelperDescriptorProvider : ITagHelperDescriptorProvider
 
     private static TagHelperDescriptor CreateRefTagHelper()
     {
-        var builder = TagHelperDescriptorBuilder.GetInstance(ComponentMetadata.Ref.TagHelperKind, "Ref", ComponentsApi.AssemblyName);
-        try
+        using var _ = TagHelperDescriptorBuilder.GetPooledInstance(
+            ComponentMetadata.Ref.TagHelperKind, "Ref", ComponentsApi.AssemblyName,
+            out var builder);
+
+        builder.CaseSensitive = true;
+        builder.Documentation = ComponentResources.RefTagHelper_Documentation;
+
+        builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.Ref.TagHelperKind);
+        builder.Metadata.Add(TagHelperMetadata.Common.ClassifyAttributesOnly, bool.TrueString);
+        builder.Metadata[TagHelperMetadata.Runtime.Name] = ComponentMetadata.Ref.RuntimeName;
+
+        // WTE has a bug in 15.7p1 where a Tag Helper without a display-name that looks like
+        // a C# property will crash trying to create the tooltips.
+        builder.SetTypeName("Microsoft.AspNetCore.Components.Ref");
+
+        builder.TagMatchingRule(rule =>
         {
-            builder.CaseSensitive = true;
-            builder.Documentation = ComponentResources.RefTagHelper_Documentation;
-
-            builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.Ref.TagHelperKind);
-            builder.Metadata.Add(TagHelperMetadata.Common.ClassifyAttributesOnly, bool.TrueString);
-            builder.Metadata[TagHelperMetadata.Runtime.Name] = ComponentMetadata.Ref.RuntimeName;
-
-            // WTE has a bug in 15.7p1 where a Tag Helper without a display-name that looks like
-            // a C# property will crash trying to create the tooltips.
-            builder.SetTypeName("Microsoft.AspNetCore.Components.Ref");
-
-            builder.TagMatchingRule(rule =>
+            rule.TagName = "*";
+            rule.Attribute(attribute =>
             {
-                rule.TagName = "*";
-                rule.Attribute(attribute =>
-                {
-                    attribute.Name = "@ref";
-                    attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
-                });
-            });
-
-            builder.BindAttribute(attribute =>
-            {
-                attribute.Documentation = ComponentResources.RefTagHelper_Documentation;
                 attribute.Name = "@ref";
-
-                // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like
-                // a C# property will crash trying to create the tooltips.
-                attribute.SetPropertyName("Ref");
-                attribute.TypeName = typeof(object).FullName;
                 attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
             });
+        });
 
-            return builder.Build();
-        }
-        finally
+        builder.BindAttribute(attribute =>
         {
-            TagHelperDescriptorBuilder.ReturnInstance(builder);
-        }
+            attribute.Documentation = ComponentResources.RefTagHelper_Documentation;
+            attribute.Name = "@ref";
+
+            // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like
+            // a C# property will crash trying to create the tooltips.
+            attribute.SetPropertyName("Ref");
+            attribute.TypeName = typeof(object).FullName;
+            attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+        });
+
+        return builder.Build();
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/RefTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/RefTagHelperDescriptorProvider.cs
@@ -46,42 +46,49 @@ internal class RefTagHelperDescriptorProvider : ITagHelperDescriptorProvider
         context.Results.Add(CreateRefTagHelper());
     }
 
-    private TagHelperDescriptor CreateRefTagHelper()
+    private static TagHelperDescriptor CreateRefTagHelper()
     {
-        var builder = TagHelperDescriptorBuilder.Create(ComponentMetadata.Ref.TagHelperKind, "Ref", ComponentsApi.AssemblyName);
-        builder.CaseSensitive = true;
-        builder.Documentation = ComponentResources.RefTagHelper_Documentation;
-
-        builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.Ref.TagHelperKind);
-        builder.Metadata.Add(TagHelperMetadata.Common.ClassifyAttributesOnly, bool.TrueString);
-        builder.Metadata[TagHelperMetadata.Runtime.Name] = ComponentMetadata.Ref.RuntimeName;
-
-        // WTE has a bug in 15.7p1 where a Tag Helper without a display-name that looks like
-        // a C# property will crash trying to create the tooltips.
-        builder.SetTypeName("Microsoft.AspNetCore.Components.Ref");
-
-        builder.TagMatchingRule(rule =>
+        var builder = TagHelperDescriptorBuilder.GetInstance(ComponentMetadata.Ref.TagHelperKind, "Ref", ComponentsApi.AssemblyName);
+        try
         {
-            rule.TagName = "*";
-            rule.Attribute(attribute =>
+            builder.CaseSensitive = true;
+            builder.Documentation = ComponentResources.RefTagHelper_Documentation;
+
+            builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.Ref.TagHelperKind);
+            builder.Metadata.Add(TagHelperMetadata.Common.ClassifyAttributesOnly, bool.TrueString);
+            builder.Metadata[TagHelperMetadata.Runtime.Name] = ComponentMetadata.Ref.RuntimeName;
+
+            // WTE has a bug in 15.7p1 where a Tag Helper without a display-name that looks like
+            // a C# property will crash trying to create the tooltips.
+            builder.SetTypeName("Microsoft.AspNetCore.Components.Ref");
+
+            builder.TagMatchingRule(rule =>
             {
-                attribute.Name = "@ref";
-                attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+                rule.TagName = "*";
+                rule.Attribute(attribute =>
+                {
+                    attribute.Name = "@ref";
+                    attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+                });
             });
-        });
 
-        builder.BindAttribute(attribute =>
-        {
-            attribute.Documentation = ComponentResources.RefTagHelper_Documentation;
-            attribute.Name = "@ref";
+            builder.BindAttribute(attribute =>
+            {
+                attribute.Documentation = ComponentResources.RefTagHelper_Documentation;
+                attribute.Name = "@ref";
 
                 // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like
                 // a C# property will crash trying to create the tooltips.
                 attribute.SetPropertyName("Ref");
-            attribute.TypeName = typeof(object).FullName;
-            attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
-        });
+                attribute.TypeName = typeof(object).FullName;
+                attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+            });
 
-        return builder.Build();
+            return builder.Build();
+        }
+        finally
+        {
+            TagHelperDescriptorBuilder.ReturnInstance(builder);
+        }
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/SplatTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/SplatTagHelperDescriptorProvider.cs
@@ -46,42 +46,49 @@ internal class SplatTagHelperDescriptorProvider : ITagHelperDescriptorProvider
         context.Results.Add(CreateSplatTagHelper());
     }
 
-    private TagHelperDescriptor CreateSplatTagHelper()
+    private static TagHelperDescriptor CreateSplatTagHelper()
     {
-        var builder = TagHelperDescriptorBuilder.Create(ComponentMetadata.Splat.TagHelperKind, "Attributes", ComponentsApi.AssemblyName);
-        builder.CaseSensitive = true;
-        builder.Documentation = ComponentResources.SplatTagHelper_Documentation;
-
-        builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.Splat.TagHelperKind);
-        builder.Metadata.Add(TagHelperMetadata.Common.ClassifyAttributesOnly, bool.TrueString);
-        builder.Metadata[TagHelperMetadata.Runtime.Name] = ComponentMetadata.Splat.RuntimeName;
-
-        // WTE has a bug in 15.7p1 where a Tag Helper without a display-name that looks like
-        // a C# property will crash trying to create the tooltips.
-        builder.SetTypeName("Microsoft.AspNetCore.Components.Attributes");
-
-        builder.TagMatchingRule(rule =>
+        var builder = TagHelperDescriptorBuilder.GetInstance(ComponentMetadata.Splat.TagHelperKind, "Attributes", ComponentsApi.AssemblyName);
+        try
         {
-            rule.TagName = "*";
-            rule.Attribute(attribute =>
+            builder.CaseSensitive = true;
+            builder.Documentation = ComponentResources.SplatTagHelper_Documentation;
+
+            builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.Splat.TagHelperKind);
+            builder.Metadata.Add(TagHelperMetadata.Common.ClassifyAttributesOnly, bool.TrueString);
+            builder.Metadata[TagHelperMetadata.Runtime.Name] = ComponentMetadata.Splat.RuntimeName;
+
+            // WTE has a bug in 15.7p1 where a Tag Helper without a display-name that looks like
+            // a C# property will crash trying to create the tooltips.
+            builder.SetTypeName("Microsoft.AspNetCore.Components.Attributes");
+
+            builder.TagMatchingRule(rule =>
             {
-                attribute.Name = "@attributes";
-                attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+                rule.TagName = "*";
+                rule.Attribute(attribute =>
+                {
+                    attribute.Name = "@attributes";
+                    attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+                });
             });
-        });
 
-        builder.BindAttribute(attribute =>
-        {
-            attribute.Documentation = ComponentResources.SplatTagHelper_Documentation;
-            attribute.Name = "@attributes";
+            builder.BindAttribute(attribute =>
+            {
+                attribute.Documentation = ComponentResources.SplatTagHelper_Documentation;
+                attribute.Name = "@attributes";
 
                 // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like
                 // a C# property will crash trying to create the tooltips.
                 attribute.SetPropertyName("Attributes");
-            attribute.TypeName = typeof(object).FullName;
-            attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
-        });
+                attribute.TypeName = typeof(object).FullName;
+                attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
+            });
 
-        return builder.Build();
+            return builder.Build();
+        }
+        finally
+        {
+            TagHelperDescriptorBuilder.ReturnInstance(builder);
+        }
     }
 }

--- a/src/Compiler/shared/TagHelperDescriptorJsonConverter.cs
+++ b/src/Compiler/shared/TagHelperDescriptorJsonConverter.cs
@@ -30,52 +30,59 @@ internal class TagHelperDescriptorJsonConverter : JsonConverter
         var descriptorKind = reader.ReadNextStringProperty(nameof(TagHelperDescriptor.Kind));
         var typeName = reader.ReadNextStringProperty(nameof(TagHelperDescriptor.Name));
         var assemblyName = reader.ReadNextStringProperty(nameof(TagHelperDescriptor.AssemblyName));
-        var builder = TagHelperDescriptorBuilder.Create(descriptorKind, typeName, assemblyName);
+        var builder = TagHelperDescriptorBuilder.GetInstance(descriptorKind, typeName, assemblyName);
 
-        reader.ReadProperties(propertyName =>
+        try
         {
-            switch (propertyName)
+            reader.ReadProperties(propertyName =>
             {
-                case nameof(TagHelperDescriptor.Documentation):
-                    if (reader.Read())
-                    {
-                        var documentation = (string)reader.Value;
-                        builder.Documentation = documentation;
-                    }
-                    break;
-                case nameof(TagHelperDescriptor.TagOutputHint):
-                    if (reader.Read())
-                    {
-                        var tagOutputHint = (string)reader.Value;
-                        builder.TagOutputHint = tagOutputHint;
-                    }
-                    break;
-                case nameof(TagHelperDescriptor.CaseSensitive):
-                    if (reader.Read())
-                    {
-                        var caseSensitive = (bool)reader.Value;
-                        builder.CaseSensitive = caseSensitive;
-                    }
-                    break;
-                case nameof(TagHelperDescriptor.TagMatchingRules):
-                    ReadTagMatchingRules(reader, builder);
-                    break;
-                case nameof(TagHelperDescriptor.BoundAttributes):
-                    ReadBoundAttributes(reader, builder);
-                    break;
-                case nameof(TagHelperDescriptor.AllowedChildTags):
-                    ReadAllowedChildTags(reader, builder);
-                    break;
-                case nameof(TagHelperDescriptor.Diagnostics):
-                    ReadDiagnostics(reader, builder.Diagnostics);
-                    break;
-                case nameof(TagHelperDescriptor.Metadata):
-                    ReadMetadata(reader, builder.Metadata);
-                    break;
-            }
-        });
+                switch (propertyName)
+                {
+                    case nameof(TagHelperDescriptor.Documentation):
+                        if (reader.Read())
+                        {
+                            var documentation = (string)reader.Value;
+                            builder.Documentation = documentation;
+                        }
+                        break;
+                    case nameof(TagHelperDescriptor.TagOutputHint):
+                        if (reader.Read())
+                        {
+                            var tagOutputHint = (string)reader.Value;
+                            builder.TagOutputHint = tagOutputHint;
+                        }
+                        break;
+                    case nameof(TagHelperDescriptor.CaseSensitive):
+                        if (reader.Read())
+                        {
+                            var caseSensitive = (bool)reader.Value;
+                            builder.CaseSensitive = caseSensitive;
+                        }
+                        break;
+                    case nameof(TagHelperDescriptor.TagMatchingRules):
+                        ReadTagMatchingRules(reader, builder);
+                        break;
+                    case nameof(TagHelperDescriptor.BoundAttributes):
+                        ReadBoundAttributes(reader, builder);
+                        break;
+                    case nameof(TagHelperDescriptor.AllowedChildTags):
+                        ReadAllowedChildTags(reader, builder);
+                        break;
+                    case nameof(TagHelperDescriptor.Diagnostics):
+                        ReadDiagnostics(reader, builder.Diagnostics);
+                        break;
+                    case nameof(TagHelperDescriptor.Metadata):
+                        ReadMetadata(reader, builder.Metadata);
+                        break;
+                }
+            });
 
-        return builder.Build();
+            return builder.Build();
+        }
+        finally
+        {
+            TagHelperDescriptorBuilder.ReturnInstance(builder);
+        }
     }
 
     public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/Compiler/shared/TagHelperDescriptorJsonConverter.cs
+++ b/src/Compiler/shared/TagHelperDescriptorJsonConverter.cs
@@ -30,59 +30,52 @@ internal class TagHelperDescriptorJsonConverter : JsonConverter
         var descriptorKind = reader.ReadNextStringProperty(nameof(TagHelperDescriptor.Kind));
         var typeName = reader.ReadNextStringProperty(nameof(TagHelperDescriptor.Name));
         var assemblyName = reader.ReadNextStringProperty(nameof(TagHelperDescriptor.AssemblyName));
-        var builder = TagHelperDescriptorBuilder.GetInstance(descriptorKind, typeName, assemblyName);
+        using var _ = TagHelperDescriptorBuilder.GetPooledInstance(descriptorKind, typeName, assemblyName, out var builder);
 
-        try
+        reader.ReadProperties(propertyName =>
         {
-            reader.ReadProperties(propertyName =>
+            switch (propertyName)
             {
-                switch (propertyName)
-                {
-                    case nameof(TagHelperDescriptor.Documentation):
-                        if (reader.Read())
-                        {
-                            var documentation = (string)reader.Value;
-                            builder.Documentation = documentation;
-                        }
-                        break;
-                    case nameof(TagHelperDescriptor.TagOutputHint):
-                        if (reader.Read())
-                        {
-                            var tagOutputHint = (string)reader.Value;
-                            builder.TagOutputHint = tagOutputHint;
-                        }
-                        break;
-                    case nameof(TagHelperDescriptor.CaseSensitive):
-                        if (reader.Read())
-                        {
-                            var caseSensitive = (bool)reader.Value;
-                            builder.CaseSensitive = caseSensitive;
-                        }
-                        break;
-                    case nameof(TagHelperDescriptor.TagMatchingRules):
-                        ReadTagMatchingRules(reader, builder);
-                        break;
-                    case nameof(TagHelperDescriptor.BoundAttributes):
-                        ReadBoundAttributes(reader, builder);
-                        break;
-                    case nameof(TagHelperDescriptor.AllowedChildTags):
-                        ReadAllowedChildTags(reader, builder);
-                        break;
-                    case nameof(TagHelperDescriptor.Diagnostics):
-                        ReadDiagnostics(reader, builder.Diagnostics);
-                        break;
-                    case nameof(TagHelperDescriptor.Metadata):
-                        ReadMetadata(reader, builder.Metadata);
-                        break;
-                }
-            });
+                case nameof(TagHelperDescriptor.Documentation):
+                    if (reader.Read())
+                    {
+                        var documentation = (string)reader.Value;
+                        builder.Documentation = documentation;
+                    }
+                    break;
+                case nameof(TagHelperDescriptor.TagOutputHint):
+                    if (reader.Read())
+                    {
+                        var tagOutputHint = (string)reader.Value;
+                        builder.TagOutputHint = tagOutputHint;
+                    }
+                    break;
+                case nameof(TagHelperDescriptor.CaseSensitive):
+                    if (reader.Read())
+                    {
+                        var caseSensitive = (bool)reader.Value;
+                        builder.CaseSensitive = caseSensitive;
+                    }
+                    break;
+                case nameof(TagHelperDescriptor.TagMatchingRules):
+                    ReadTagMatchingRules(reader, builder);
+                    break;
+                case nameof(TagHelperDescriptor.BoundAttributes):
+                    ReadBoundAttributes(reader, builder);
+                    break;
+                case nameof(TagHelperDescriptor.AllowedChildTags):
+                    ReadAllowedChildTags(reader, builder);
+                    break;
+                case nameof(TagHelperDescriptor.Diagnostics):
+                    ReadDiagnostics(reader, builder.Diagnostics);
+                    break;
+                case nameof(TagHelperDescriptor.Metadata):
+                    ReadMetadata(reader, builder.Metadata);
+                    break;
+            }
+        });
 
-            return builder.Build();
-        }
-        finally
-        {
-            TagHelperDescriptorBuilder.ReturnInstance(builder);
-        }
+        return builder.Build();
     }
 
     public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Serialization/TagHelperDescriptorJsonConverter.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Serialization/TagHelperDescriptorJsonConverter.cs
@@ -63,57 +63,64 @@ internal class TagHelperDescriptorJsonConverter : JsonConverter
             return default;
         }
 
-        var builder = TagHelperDescriptorBuilder.Create(Cached(descriptorKind), Cached(typeName), Cached(assemblyName));
-
-        reader.ReadProperties(static (propertyName, arg) =>
+        var builder = TagHelperDescriptorBuilder.GetInstance(Cached(descriptorKind), Cached(typeName), Cached(assemblyName));
+        try
         {
-            var (reader, builder) = (arg.reader, arg.builder);
-            switch (propertyName)
+            reader.ReadProperties(static (propertyName, arg) =>
             {
-                case nameof(TagHelperDescriptor.Documentation):
-                    if (reader.Read())
-                    {
-                        var documentation = (string)reader.Value;
-                        builder.Documentation = Cached(documentation);
-                    }
+                var (reader, builder) = (arg.reader, arg.builder);
+                switch (propertyName)
+                {
+                    case nameof(TagHelperDescriptor.Documentation):
+                        if (reader.Read())
+                        {
+                            var documentation = (string)reader.Value;
+                            builder.Documentation = Cached(documentation);
+                        }
 
-                    break;
-                case nameof(TagHelperDescriptor.TagOutputHint):
-                    if (reader.Read())
-                    {
-                        var tagOutputHint = (string)reader.Value;
-                        // TODO: Needed?
-                        builder.TagOutputHint = Cached(tagOutputHint);
-                    }
+                        break;
+                    case nameof(TagHelperDescriptor.TagOutputHint):
+                        if (reader.Read())
+                        {
+                            var tagOutputHint = (string)reader.Value;
+                            // TODO: Needed?
+                            builder.TagOutputHint = Cached(tagOutputHint);
+                        }
 
-                    break;
-                case nameof(TagHelperDescriptor.CaseSensitive):
-                    if (reader.Read())
-                    {
-                        var caseSensitive = (bool)reader.Value;
-                        builder.CaseSensitive = caseSensitive;
-                    }
+                        break;
+                    case nameof(TagHelperDescriptor.CaseSensitive):
+                        if (reader.Read())
+                        {
+                            var caseSensitive = (bool)reader.Value;
+                            builder.CaseSensitive = caseSensitive;
+                        }
 
-                    break;
-                case nameof(TagHelperDescriptor.TagMatchingRules):
-                    ReadTagMatchingRules(reader, builder);
-                    break;
-                case nameof(TagHelperDescriptor.BoundAttributes):
-                    ReadBoundAttributes(reader, builder);
-                    break;
-                case nameof(TagHelperDescriptor.AllowedChildTags):
-                    ReadAllowedChildTags(reader, builder);
-                    break;
-                case nameof(TagHelperDescriptor.Diagnostics):
-                    ReadDiagnostics(reader, builder.Diagnostics);
-                    break;
-                case nameof(TagHelperDescriptor.Metadata):
-                    ReadMetadata(reader, builder.Metadata);
-                    break;
-            }
-        }, (reader, builder));
+                        break;
+                    case nameof(TagHelperDescriptor.TagMatchingRules):
+                        ReadTagMatchingRules(reader, builder);
+                        break;
+                    case nameof(TagHelperDescriptor.BoundAttributes):
+                        ReadBoundAttributes(reader, builder);
+                        break;
+                    case nameof(TagHelperDescriptor.AllowedChildTags):
+                        ReadAllowedChildTags(reader, builder);
+                        break;
+                    case nameof(TagHelperDescriptor.Diagnostics):
+                        ReadDiagnostics(reader, builder.Diagnostics);
+                        break;
+                    case nameof(TagHelperDescriptor.Metadata):
+                        ReadMetadata(reader, builder.Metadata);
+                        break;
+                }
+            }, (reader, builder));
 
-        descriptor = builder.Build();
+            descriptor = builder.Build();
+        }
+        finally
+        {
+            TagHelperDescriptorBuilder.ReturnInstance(builder);
+        }
+
         if (!DisableCachingForTesting && hashWasRead)
         {
             TagHelperDescriptorCache.Set(hash, descriptor);


### PR DESCRIPTION
This PR introduces object pools for each sort of builder that is used to produce `TagHelperDescriptors`. The primary change related to this is returning the fields of each to a default state of each builder before they are returned to the pool. The rest of the change is primarily updating all of the places in the compiler and tooling that used to call `TagHelperDescriptorBuilder.Create(...)` to now call `TagHelperDescriptorBuilder.GetInstance(...)` and `TagHelperDescriptorBuilder.ReleaseInstance(...)`. Over time, this should improve allocations at design-time by ensuring that we don't _always_ create new builders for every descriptor.