### PR TITLE
Clean up the YML for our Unix based builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -352,6 +352,7 @@ stages:
         - script: eng/cibuild.sh
             --test
             --nobl
+            --restore
             $(_BuildArgs)
             $(_InternalRuntimeDownloadArgs)
           name: Test
@@ -435,6 +436,7 @@ stages:
         - script: eng/cibuild.sh
             --test
             --nobl
+            --restore
             $(_BuildArgs)
             $(_InternalRuntimeDownloadArgs)
           name: Test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -305,6 +305,14 @@ stages:
             matrix:
               release:
                 _BuildConfig: Release
+        variables:
+        - _BuildArgs: ''
+
+        # Variables for internal Official builds
+        - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+          - _BuildArgs: /p:DotNetPublishUsingPipelines=true
+              /p:OfficialBuildId=$(Build.BuildNumber)
+
         steps:
         - task: NodeTool@0
           displayName: Install Node 10.x
@@ -318,34 +326,21 @@ stages:
               arguments: $(Build.SourcesDirectory)/NuGet.config $Token
             env:
               Token: $(dn-bot-dnceng-artifact-feeds-rw)
-        - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          - script: eng/cibuild.sh
-              --restore
-              --build
-              --test
-              --pack
-              --publish
-              --configuration $(_BuildConfig)
-              --prepareMachine
-              /p:DotNetPublishUsingPipelines=true
-              /p:OfficialBuildId=$(Build.BuildNumber)
-              $(_InternalRuntimeDownloadArgs)
-            name: Build
-            displayName: Build
-            condition: succeeded()
-        - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          - script: eng/cibuild.sh
-              --restore
-              --build
-              --test
-              --pack
-              --publish
-              --configuration $(_BuildConfig)
-              --prepareMachine
-              $(_InternalRuntimeDownloadArgs)
-            name: Build
-            displayName: Build
-            condition: succeeded()
+
+        - script: eng/cibuild.sh
+            --restore
+            --build
+            --test
+            --pack
+            --publish
+            --configuration $(_BuildConfig)
+            --prepareMachine
+            $(_BuildArgs)
+            $(_InternalRuntimeDownloadArgs)
+          name: Build
+          displayName: Build
+          condition: succeeded()
+
         - publish: artifacts/TestResults/$(_BuildConfig)
           artifact: $(Agent.Os)_$(Agent.JobName) Attempt $(System.JobAttempt) TestResults
           displayName: Publish Test Results
@@ -362,10 +357,6 @@ stages:
             name: $(DncEngInternalBuildPool)
             demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
 
-        variables:
-        - LC_ALL: 'en_US.UTF-8'
-        - LANG: 'en_US.UTF-8'
-        - LANGUAGE: 'en_US.UTF-8'
         strategy:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             matrix:
@@ -377,6 +368,18 @@ stages:
             matrix:
               release:
                 _BuildConfig: Release
+
+        variables:
+        - LC_ALL: 'en_US.UTF-8'
+        - LANG: 'en_US.UTF-8'
+        - LANGUAGE: 'en_US.UTF-8'
+        - _BuildArgs: ''
+
+        # Variables for internal Official builds
+        - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
+          - _BuildArgs: /p:DotNetPublishUsingPipelines=true
+              /p:OfficialBuildId=$(Build.BuildNumber)
+
         steps:
         - task: NodeTool@0
           displayName: Install Node 10.x
@@ -390,34 +393,21 @@ stages:
               arguments: $(Build.SourcesDirectory)/NuGet.config $Token
             env:
               Token: $(dn-bot-dnceng-artifact-feeds-rw)
-        - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          - script: eng/cibuild.sh
-              --restore
-              --build
-              --pack
-              --test
-              --publish
-              --configuration $(_BuildConfig)
-              --prepareMachine
-              /p:DotNetPublishUsingPipelines=true
-              /p:OfficialBuildId=$(Build.BuildNumber)
-              $(_InternalRuntimeDownloadArgs)
-            name: Build
-            displayName: Build
-            condition: succeeded()
-        - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          - script: eng/cibuild.sh
-              --restore
-              --build
-              --pack
-              --test
-              --publish
-              --configuration $(_BuildConfig)
-              --prepareMachine
-              $(_InternalRuntimeDownloadArgs)
-            name: Build
-            displayName: Build
-            condition: succeeded()
+
+        - script: eng/cibuild.sh
+            --restore
+            --build
+            --pack
+            --test
+            --publish
+            --configuration $(_BuildConfig)
+            --prepareMachine
+            $(_BuildArgs)
+            $(_InternalRuntimeDownloadArgs)
+          name: Build
+          displayName: Build
+          condition: succeeded()
+
         - publish: artifacts/TestResults/$(_BuildConfig)/
           artifact: $(Agent.Os)_$(Agent.JobName) Attempt $(System.JobAttempt) TestResults
           displayName: Publish Test Results

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -329,8 +329,15 @@ stages:
 
         - script: eng/cibuild.sh
             --restore
+            --excludeCIBinaryLog
+            $(_BuildArgs)
+            $(_InternalRuntimeDownloadArgs)
+          name: Restore
+          displayName: Restore
+          condition: succeeded()
+
+        - script: eng/cibuild.sh
             --build
-            --test
             --pack
             --publish
             --configuration $(_BuildConfig)
@@ -339,6 +346,15 @@ stages:
             $(_InternalRuntimeDownloadArgs)
           name: Build
           displayName: Build
+          condition: succeeded()
+
+        - script: eng/cibuild.sh
+            --test
+            --excludeCIBinaryLog
+            $(_BuildArgs)
+            $(_InternalRuntimeDownloadArgs)
+          name: Test
+          displayName: Test
           condition: succeeded()
 
         - publish: artifacts/TestResults/$(_BuildConfig)
@@ -396,9 +412,16 @@ stages:
 
         - script: eng/cibuild.sh
             --restore
+            --excludeCIBinaryLog
+            $(_BuildArgs)
+            $(_InternalRuntimeDownloadArgs)
+          name: Restore
+          displayName: Restore
+          condition: succeeded()
+
+        - script: eng/cibuild.sh
             --build
             --pack
-            --test
             --publish
             --configuration $(_BuildConfig)
             --prepareMachine
@@ -406,6 +429,15 @@ stages:
             $(_InternalRuntimeDownloadArgs)
           name: Build
           displayName: Build
+          condition: succeeded()
+
+        - script: eng/cibuild.sh
+            --test
+            --excludeCIBinaryLog
+            $(_BuildArgs)
+            $(_InternalRuntimeDownloadArgs)
+          name: Test
+          displayName: Test
           condition: succeeded()
 
         - publish: artifacts/TestResults/$(_BuildConfig)/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -206,7 +206,7 @@ stages:
             -msbuildEngine vs
             -prepareMachine
             -restore
-            -excludeCIBinarylog
+            -nobl
           name: Restore
           displayName: Restore
           condition: succeeded()
@@ -233,6 +233,7 @@ stages:
             -configuration $(_BuildConfig)
             -prepareMachine
             -test
+            -nobl
           name: Run_Unit_Tests
           displayName: Run Unit Tests
           condition: succeeded()
@@ -329,7 +330,7 @@ stages:
 
         - script: eng/cibuild.sh
             --restore
-            --excludeCIBinaryLog
+            --nobl
             $(_BuildArgs)
             $(_InternalRuntimeDownloadArgs)
           name: Restore
@@ -350,7 +351,7 @@ stages:
 
         - script: eng/cibuild.sh
             --test
-            --excludeCIBinaryLog
+            --nobl
             $(_BuildArgs)
             $(_InternalRuntimeDownloadArgs)
           name: Test
@@ -412,7 +413,7 @@ stages:
 
         - script: eng/cibuild.sh
             --restore
-            --excludeCIBinaryLog
+            --nobl
             $(_BuildArgs)
             $(_InternalRuntimeDownloadArgs)
           name: Restore
@@ -433,7 +434,7 @@ stages:
 
         - script: eng/cibuild.sh
             --test
-            --excludeCIBinaryLog
+            --nobl
             $(_BuildArgs)
             $(_InternalRuntimeDownloadArgs)
           name: Test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -329,6 +329,7 @@ stages:
               Token: $(dn-bot-dnceng-artifact-feeds-rw)
 
         - script: eng/cibuild.sh
+            --restore
             --build
             --pack
             --publish
@@ -395,6 +396,7 @@ stages:
               Token: $(dn-bot-dnceng-artifact-feeds-rw)
 
         - script: eng/cibuild.sh
+            --restore
             --build
             --pack
             --publish

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -329,34 +329,16 @@ stages:
               Token: $(dn-bot-dnceng-artifact-feeds-rw)
 
         - script: eng/cibuild.sh
-            --restore
-            --nobl
-            $(_BuildArgs)
-            $(_InternalRuntimeDownloadArgs)
-          name: Restore
-          displayName: Restore
-          condition: succeeded()
-
-        - script: eng/cibuild.sh
             --build
             --pack
             --publish
             --configuration $(_BuildConfig)
             --prepareMachine
+            --test
             $(_BuildArgs)
             $(_InternalRuntimeDownloadArgs)
           name: Build
-          displayName: Build
-          condition: succeeded()
-
-        - script: eng/cibuild.sh
-            --test
-            --nobl
-            --restore
-            $(_BuildArgs)
-            $(_InternalRuntimeDownloadArgs)
-          name: Test
-          displayName: Test
+          displayName: Restore, Build and Test
           condition: succeeded()
 
         - publish: artifacts/TestResults/$(_BuildConfig)
@@ -413,34 +395,16 @@ stages:
               Token: $(dn-bot-dnceng-artifact-feeds-rw)
 
         - script: eng/cibuild.sh
-            --restore
-            --nobl
-            $(_BuildArgs)
-            $(_InternalRuntimeDownloadArgs)
-          name: Restore
-          displayName: Restore
-          condition: succeeded()
-
-        - script: eng/cibuild.sh
             --build
             --pack
             --publish
             --configuration $(_BuildConfig)
             --prepareMachine
+            --test
             $(_BuildArgs)
             $(_InternalRuntimeDownloadArgs)
           name: Build
-          displayName: Build
-          condition: succeeded()
-
-        - script: eng/cibuild.sh
-            --test
-            --nobl
-            --restore
-            $(_BuildArgs)
-            $(_InternalRuntimeDownloadArgs)
-          name: Test
-          displayName: Test
+          displayName: Restore, Build and Test
           condition: succeeded()
 
         - publish: artifacts/TestResults/$(_BuildConfig)/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -319,9 +319,10 @@ stages:
             env:
               Token: $(dn-bot-dnceng-artifact-feeds-rw)
         - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          - script: eng/common/cibuild.sh
+          - script: eng/cibuild.sh
               --restore
               --build
+              --test
               --pack
               --publish
               --configuration $(_BuildConfig)
@@ -333,7 +334,12 @@ stages:
             displayName: Build
             condition: succeeded()
         - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          - script: eng/common/cibuild.sh
+          - script: eng/cibuild.sh
+              --restore
+              --build
+              --test
+              --pack
+              --publish
               --configuration $(_BuildConfig)
               --prepareMachine
               $(_InternalRuntimeDownloadArgs)
@@ -385,10 +391,11 @@ stages:
             env:
               Token: $(dn-bot-dnceng-artifact-feeds-rw)
         - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-          - script: eng/common/cibuild.sh
+          - script: eng/cibuild.sh
               --restore
               --build
               --pack
+              --test
               --publish
               --configuration $(_BuildConfig)
               --prepareMachine
@@ -399,7 +406,12 @@ stages:
             displayName: Build
             condition: succeeded()
         - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-          - script: eng/common/cibuild.sh
+          - script: eng/cibuild.sh
+              --restore
+              --build
+              --pack
+              --test
+              --publish
               --configuration $(_BuildConfig)
               --prepareMachine
               $(_InternalRuntimeDownloadArgs)

--- a/eng/cibuild.sh
+++ b/eng/cibuild.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+source="${BASH_SOURCE[0]}"
+
+# resolve $SOURCE until the file is no longer a symlink
+while [[ -h $source ]]; do
+  scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+  source="$(readlink "$source")"
+
+  # if $source was a relative symlink, we need to resolve it relative to the path where
+  # the symlink file was located
+  [[ $source != /* ]] && source="$scriptroot/$source"
+done
+scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+
+. "$scriptroot/common/build.sh" --ci $@


### PR DESCRIPTION
This PR is best read commit by commit. 

Summary of changes: 

1. Normalize `CIBuild.cmd` and `cibuild.sh` to have same semantics.
2. Remove the `{{ if ... }}` in our Unix builds and use a variable instead as we do in Windows
3. ~~Break up into Restore, Build and Test steps~~