### PR TITLE
Use powershell global tool

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "powershell": {
+      "version": "7.3.3",
+      "commands": [
+        "pwsh"
+      ]
+    }
+  }
+}

--- a/NuGet.config
+++ b/NuGet.config
@@ -119,6 +119,7 @@
       <package pattern="omnisharp.roslyn.csharp" />
       <package pattern="omnisharp.shared" />
       <package pattern="perfolizer" />
+      <package pattern="powershell" />
       <package pattern="roslyn.diagnostics.analyzers" />
       <package pattern="runtime.*" />
       <package pattern="streamjsonrpc" />

--- a/eng/AfterSigning.targets
+++ b/eng/AfterSigning.targets
@@ -23,8 +23,8 @@
       <RidsPublishDir>$(ArtifactsDir)LanguageServer\$(Configuration)\</RidsPublishDir>
       <ZipOutputDir>$(RidsPublishDir)</ZipOutputDir>
       <_PackageVersion>@(_ResolvedPackageVersionInfo->'%(PackageVersion)')</_PackageVersion>
-      <_DotNetPath>$(MSBuildThisFileDirectory)..\.dotnet\dotnet</_DotNetPath>
-      <_DotNetPath Condition="!Exists($(_DotNetPath))">dotnet</_DotNetPath>
+      <_DotNetPath>$(DOTNET_HOST_PATH)</_DotNetPath>
+      <_DotNetPath Condition="'$(_DotNetPath)' == ''">dotnet</_DotNetPath>
     </PropertyGroup>
 
     <ItemGroup>

--- a/eng/AfterSigning.targets
+++ b/eng/AfterSigning.targets
@@ -1,4 +1,5 @@
 ﻿<Project>
+
   <Target Name="_EnsureVSIXWasGenerated" AfterTargets="GenerateVisualStudioInsertionManifests" Condition="'$(OS)'=='WINDOWS_NT' AND '$(ArcadeBuildFromSource)' != 'true'">
     <PropertyGroup>
       <VSSetupDir>$(ArtifactsDir)VSSetup\</VSSetupDir>
@@ -22,6 +23,8 @@
       <RidsPublishDir>$(ArtifactsDir)LanguageServer\$(Configuration)\</RidsPublishDir>
       <ZipOutputDir>$(RidsPublishDir)</ZipOutputDir>
       <_PackageVersion>@(_ResolvedPackageVersionInfo->'%(PackageVersion)')</_PackageVersion>
+      <_DotNetPath>$(MSBuildThisFileDirectory)..\.dotnet\dotnet</_DotNetPath>
+      <_DotNetPath Condition="!Exists($(_DotNetPath))">dotnet</_DotNetPath>
     </PropertyGroup>
 
     <ItemGroup>
@@ -36,19 +39,7 @@
     <Delete Files="%(LanguageServiceBinary.ZipFile)" />
 
     <!-- Build a .zip file from each platform's directory and write it to 'artifacts' -->
-
-    <!-- Mac -->
-    <Exec Command="pwsh -NonInteractive -command &quot;&amp;{ Write-Host &quot;Writing %(LanguageServiceBinary.ZipFile)...&quot; ; Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::CreateFromDirectory('%(LanguageServiceBinary.SourceDir)', '%(LanguageServiceBinary.ZipFile)') }&quot;"
-          Condition="$([MSBuild]::IsOSPlatform('OSX'))" />
-
-    <!-- Windows -->
-    <Exec Command="powershell.exe -NonInteractive -command &quot;&amp;{ Write-Host &quot;Writing %(LanguageServiceBinary.ZipFile)...&quot; ; Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::CreateFromDirectory('%(LanguageServiceBinary.SourceDir)', '%(LanguageServiceBinary.ZipFile)') }&quot;"
-          Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
-
-    <!-- Linux -->
-    <Exec Command="curl https://packages.microsoft.com/config/rhel/8/prod.repo | sudo tee /etc/yum.repos.d/microsoft.repo" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
-    <Exec Command="sudo yum install -y powershell 2>/dev/null" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
-    <Exec Command="pwsh -NonInteractive -command &quot;&amp;{ Write-Host &quot;Writing %(LanguageServiceBinary.ZipFile)...&quot; ; Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::CreateFromDirectory('%(LanguageServiceBinary.SourceDir)', '%(LanguageServiceBinary.ZipFile)') }&quot;"
-          Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <Exec Command="$(_DotNetPath) pwsh -NonInteractive -command &quot;&amp;{ Write-Host &quot;Writing %(LanguageServiceBinary.ZipFile)...&quot; ; Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::CreateFromDirectory('%(LanguageServiceBinary.SourceDir)', '%(LanguageServiceBinary.ZipFile)') }&quot;"
+          WorkingDirectory="$(MSBuildThisFileDirectory)..\" />
   </Target>
 </Project>


### PR DESCRIPTION
The code for producing the zip of our servers was different per platform:

- Windows: use PowerShell
- Mac: use pwsh 
- Linux: sudo to install then use pwsh

This change unifies everything on `dotnet pwsh` and restores it as a global tool. That makes our zip consistent across platforms and removes the need for a `sudo` call in a build file. 