### PR TITLE
Remove TRX warning on Unix builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -303,7 +303,7 @@ stages:
       testResultsFormat: xunit
       helixRepo: dotnet/razor
       helixType: build.product/
-    -jobs:
+      jobs:
       - job: macOS
         pool:
           vmImage: macOS-12

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,6 +70,7 @@ stages:
       enablePublishBuildArtifacts: false
       enablePublishTestResults: false
       enablePublishUsingPipelines: false
+      enableSourcebuild: true
       jobs:
       # Code check
       - ${{ if or(eq(variables['System.TeamProject'], 'public'), in(variables['Build.Reason'], 'PullRequest')) }}:
@@ -104,13 +105,14 @@ stages:
           - powershell: ./restore.cmd -msbuildEngine dotnet -ci $(_InternalRuntimeDownloadArgs); ./eng/scripts/CodeCheck.ps1 -ci
             displayName: Run eng/scripts/CodeCheck.ps1
 
-  # Three jobs for each of the three OSes we want to run on
+  # Windows based jobs. This needs to be separate from Unix based jobs because it generates
+  # TRX files. That can only be toggled at the top level template level, not at the individual
+  # job.
   - template: /eng/common/templates/jobs/jobs.yml
     parameters:
       enablePublishBuildArtifacts: false
       enablePublishTestResults: true
       enableTelemetry: true
-      enableSourcebuild: true
       helixRepo: dotnet/razor
       helixType: build.product/
       # enableMicrobuild can't be read from a user-defined variable (Azure DevOps limitation)
@@ -292,23 +294,29 @@ stages:
             continueOnError: true
             condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
 
+  # Unix jobs done as a group since they share the same test results format.
+  - template: /eng/common/templates/jobs/jobs.yml
+    parameters:
+      enablePublishBuildArtifacts: false
+      enablePublishTestResults: true
+      enableTelemetry: true
+      testResultsFormat: xunit
+      helixRepo: dotnet/razor
+      helixType: build.product/
+    -jobs:
       - job: macOS
         pool:
           vmImage: macOS-12
         strategy:
-          ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            matrix:
-              debug:
-                _BuildConfig: Debug
-              release:
-                _BuildConfig: Release
-          ${{ if ne(variables['System.TeamProject'], 'public') }}:
             matrix:
               release:
                 _BuildConfig: Release
+              ${{ if eq(variables['System.TeamProject'], 'public') }}:
+                  debug:
+                    _BuildConfig: Debug
+
         variables:
         - _BuildArgs: ''
-
         # Variables for internal Official builds
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
           - _BuildArgs: /p:DotNetPublishUsingPipelines=true
@@ -319,6 +327,7 @@ stages:
           displayName: Install Node 10.x
           inputs:
             versionSpec: 10.x
+
         - ${{ if ne(variables['System.TeamProject'], 'public') }}:
           - task: Bash@3
             displayName: Setup Private Feeds Credentials
@@ -359,16 +368,12 @@ stages:
             demands: ImageOverride -equals Build.Ubuntu.1804.Amd64
 
         strategy:
-          ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            matrix:
-              debug:
-                _BuildConfig: Debug
-              release:
-                _BuildConfig: Release
-          ${{ if ne(variables['System.TeamProject'], 'public') }}:
-            matrix:
-              release:
-                _BuildConfig: Release
+          matrix:
+            release:
+              _BuildConfig: Release
+            ${{ if eq(variables['System.TeamProject'], 'public') }}:
+                debug:
+                  _BuildConfig: Debug
 
         variables:
         - LC_ALL: 'en_US.UTF-8'


### PR DESCRIPTION
The last remaining warning in our build, that we control, was about missing TRX files 

<img width="319" alt="image" src="https://user-images.githubusercontent.com/146967/229244068-74cd934f-2b90-4fde-9da9-aa280a604987.png">

This happens because when `enablePublishTestResults: true` is passed to the `jobs.yml` template it will default to looking for TRX results in every job that it creates. The problem is that only integration tests produce TRX files though. Unit tests only produce XML files. The end result is that our Unix jobs were not producing TRX files yet `jobs.xml` produced code to look for them. 

The way the `jobs.yml` template works means every job created will get the parameters passed into the template. There is no way to say "disable TRX in this job". 

To fix this I just had to put our Windows and Unix jobs into different `jobs.yml` template expansions. The one for Unix disables TRX lookup by specifying it's xunit output. At the same time I moved the source build check up to the codeql instantiation of `jobs.xml`. That meant our later uses were purely about build and test for the various OS. 
