### PR TITLE
Add feature flag to show all C# code actions

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultLanguageServerFeatureOptions.cs
@@ -27,4 +27,6 @@ internal class DefaultLanguageServerFeatureOptions : LanguageServerFeatureOption
     // https://github.com/dotnet/razor/issues/8131
     public override bool ReturnCodeActionAndRenamePathsWithPrefixedSlash
         => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+    public override bool ShowAllCSharpCodeActions => false;
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/DefaultCSharpCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/DefaultCSharpCodeActionProvider.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
 
@@ -84,10 +85,31 @@ internal class DefaultCSharpCodeActionProvider : CSharpCodeActionProvider
 
         foreach (var codeAction in codeActions)
         {
-            if (_languageServerFeatureOptions.ShowAllCSharpCodeActions ||
-                (codeAction.Name is not null && allowList.Contains(codeAction.Name)))
+            var isOnAllowList = codeAction.Name is not null && allowList.Contains(codeAction.Name);
+
+            if (_languageServerFeatureOptions.ShowAllCSharpCodeActions && codeAction.Data is not null)
             {
-                results.Add(codeAction.WrapResolvableCodeAction(context));
+                // If this code action isn't on the allow list, it might have been handled by another provider, which means
+                // it will already have been wrapped, so we have to check not to double-wrap it. Unfortunately there isn't a
+                // good way to do this, but to try and deserialize some Json. Since this only needs to happen if the feature
+                // flag is on, any perf hit here isn't going to affect real users.
+                try
+                {
+                    if (((JToken)codeAction.Data).ToObject<RazorCodeActionResolutionParams>() is not null)
+                    {
+                        // This code action has already been wrapped by something else, so skip it here, or it could
+                        // be marked as experimental when its not, and more importantly would be duplicated in the list.
+                        continue;
+                    }
+                }
+                catch
+                {
+                }
+            }
+
+            if (_languageServerFeatureOptions.ShowAllCSharpCodeActions || isOnAllowList)
+            {
+                results.Add(codeAction.WrapResolvableCodeAction(context, isOnAllowList: isOnAllowList));
             }
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/DefaultCSharpCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/DefaultCSharpCodeActionProvider.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
 
@@ -41,6 +42,13 @@ internal class DefaultCSharpCodeActionProvider : CSharpCodeActionProvider
     {
         // RazorPredefinedCodeFixProviderNames.RemoveUnusedVariable,
     };
+
+    private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
+
+    public DefaultCSharpCodeActionProvider(LanguageServerFeatureOptions languageServerFeatureOptions)
+    {
+        _languageServerFeatureOptions = languageServerFeatureOptions;
+    }
 
     public override Task<IReadOnlyList<RazorVSInternalCodeAction>?> ProvideAsync(
         RazorCodeActionContext context,
@@ -76,7 +84,8 @@ internal class DefaultCSharpCodeActionProvider : CSharpCodeActionProvider
 
         foreach (var codeAction in codeActions)
         {
-            if (codeAction.Name is not null && allowList.Contains(codeAction.Name))
+            if (_languageServerFeatureOptions.ShowAllCSharpCodeActions ||
+                (codeAction.Name is not null && allowList.Contains(codeAction.Name)))
             {
                 results.Add(codeAction.WrapResolvableCodeAction(context));
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/CodeActionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/CodeActionExtensions.cs
@@ -47,7 +47,8 @@ internal static class CodeActionExtensions
         this RazorVSInternalCodeAction razorCodeAction,
         RazorCodeActionContext context,
         string action = LanguageServerConstants.CodeActions.Default,
-        string language = LanguageServerConstants.CodeActions.Languages.CSharp)
+        string language = LanguageServerConstants.CodeActions.Languages.CSharp,
+        bool isOnAllowList = true)
     {
         if (razorCodeAction is null)
         {
@@ -73,11 +74,16 @@ internal static class CodeActionExtensions
         };
         razorCodeAction.Data = JToken.FromObject(resolutionParams);
 
+        if (!isOnAllowList)
+        {
+            razorCodeAction.Title = "(Exp) " + razorCodeAction.Title;
+        }
+
         if (razorCodeAction.Children != null)
         {
             for (var i = 0; i < razorCodeAction.Children.Length; i++)
             {
-                razorCodeAction.Children[i] = razorCodeAction.Children[i].WrapResolvableCodeAction(context, action, language);
+                razorCodeAction.Children[i] = razorCodeAction.Children[i].WrapResolvableCodeAction(context, action, language, isOnAllowList);
             }
         }
 
@@ -88,7 +94,8 @@ internal static class CodeActionExtensions
         this VSInternalCodeAction razorCodeAction,
         RazorCodeActionContext context,
         string action,
-        string language)
+        string language,
+        bool isOnAllowList)
     {
         var resolveParams = new CodeActionResolveParams()
         {
@@ -104,11 +111,16 @@ internal static class CodeActionExtensions
         };
         razorCodeAction.Data = JToken.FromObject(resolutionParams);
 
+        if (!isOnAllowList)
+        {
+            razorCodeAction.Title = "(Exp) " + razorCodeAction.Title;
+        }
+
         if (razorCodeAction.Children != null)
         {
             for (var i = 0; i < razorCodeAction.Children.Length; i++)
             {
-                razorCodeAction.Children[i] = razorCodeAction.Children[i].WrapResolvableCodeAction(context, action, language);
+                razorCodeAction.Children[i] = razorCodeAction.Children[i].WrapResolvableCodeAction(context, action, language, isOnAllowList);
             }
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ConfigurableLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ConfigurableLanguageServerFeatureOptions.cs
@@ -20,6 +20,7 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
     private readonly bool? _singleServerSupport;
     private readonly bool? _supportsDelegatedCodeActions;
     private readonly bool? _returnCodeActionAndRenamePathsWithPrefixedSlash;
+    private readonly bool? _showAllCSharpCodeActions;
 
     public override bool SupportsFileManipulation => _supportsFileManipulation ?? _defaults.SupportsFileManipulation;
     public override string ProjectConfigurationFileName => _projectConfigurationFileName ?? _defaults.ProjectConfigurationFileName;
@@ -29,6 +30,7 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
     public override bool SingleServerSupport => _singleServerSupport ?? _defaults.SingleServerSupport;
     public override bool SupportsDelegatedCodeActions => _supportsDelegatedCodeActions ?? _defaults.SupportsDelegatedCodeActions;
     public override bool ReturnCodeActionAndRenamePathsWithPrefixedSlash => _returnCodeActionAndRenamePathsWithPrefixedSlash ?? _defaults.ReturnCodeActionAndRenamePathsWithPrefixedSlash;
+    public override bool ShowAllCSharpCodeActions => _showAllCSharpCodeActions ?? _defaults.ShowAllCSharpCodeActions;
 
     public ConfigurableLanguageServerFeatureOptions(string[] args)
     {
@@ -47,6 +49,7 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
             TryProcessBoolOption(nameof(SingleServerSupport), ref _singleServerSupport, option, args, i);
             TryProcessBoolOption(nameof(SupportsDelegatedCodeActions), ref _supportsDelegatedCodeActions, option, args, i);
             TryProcessBoolOption(nameof(ReturnCodeActionAndRenamePathsWithPrefixedSlash), ref _returnCodeActionAndRenamePathsWithPrefixedSlash, option, args, i);
+            TryProcessBoolOption(nameof(ShowAllCSharpCodeActions), ref _showAllCSharpCodeActions, option, args, i);
         }
     }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
@@ -21,6 +21,8 @@ internal abstract class LanguageServerFeatureOptions
 
     public abstract bool SupportsDelegatedCodeActions { get; }
 
+    public abstract bool ShowAllCSharpCodeActions { get; }
+
     // Code action and rename paths in Windows VS Code need to be prefixed with '/':
     // https://github.com/dotnet/razor/issues/8131
     public abstract bool ReturnCodeActionAndRenamePathsWithPrefixedSlash { get; }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
@@ -14,10 +14,12 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
 {
     private const string SingleServerCompletionFeatureFlag = "Razor.LSP.SingleServerCompletion";
     private const string SingleServerFeatureFlag = "Razor.LSP.SingleServer";
+    private const string ShowAllCSharpCodeActionsFeatureFlag = "Razor.LSP.ShowAllCSharpCodeActions";
 
     private readonly LSPEditorFeatureDetector _lspEditorFeatureDetector;
     private readonly Lazy<bool> _singleServerCompletionSupport;
     private readonly Lazy<bool> _singleServerSupport;
+    private readonly Lazy<bool> _showAllCSharpCodeActions;
 
     [ImportingConstructor]
     public VisualStudioWindowsLanguageServerFeatureOptions(LSPEditorFeatureDetector lspEditorFeatureDetector)
@@ -42,6 +44,13 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
             var singleServerEnabled = featureFlags.IsFeatureEnabled(SingleServerFeatureFlag, defaultValue: false);
             return singleServerEnabled;
         });
+
+        _showAllCSharpCodeActions = new Lazy<bool>(() =>
+        {
+            var featureFlags = (IVsFeatureFlags)AsyncPackage.GetGlobalService(typeof(SVsFeatureFlags));
+            var showAllCSharpCodeActions = featureFlags.IsFeatureEnabled(ShowAllCSharpCodeActionsFeatureFlag, defaultValue: false);
+            return showAllCSharpCodeActions;
+        });
     }
 
     // We don't currently support file creation operations on VS Codespaces or VS Liveshare
@@ -63,4 +72,6 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
     public override bool ReturnCodeActionAndRenamePathsWithPrefixedSlash => false;
 
     private bool IsCodespacesOrLiveshare => _lspEditorFeatureDetector.IsRemoteClient() || _lspEditorFeatureDetector.IsLiveShareHost();
+
+    public override bool ShowAllCSharpCodeActions => _showAllCSharpCodeActions.Value;
 }

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacLanguageServerFeatureOptions.cs
@@ -39,6 +39,8 @@ internal class VisualStudioMacLanguageServerFeatureOptions : LanguageServerFeatu
 
     public override bool SupportsDelegatedCodeActions => true;
 
+    public override bool ShowAllCSharpCodeActions => false;
+
     public override bool ReturnCodeActionAndRenamePathsWithPrefixedSlash => false;
 
     private bool IsCodespacesOrLiveshare => _lspEditorFeatureDetector.IsRemoteClient() || _lspEditorFeatureDetector.IsLiveShareHost();

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
@@ -54,3 +54,9 @@
 "Value"=dword:00000001
 "Title"="Enable enhanced Razor LSP server (requires restart)"
 "PreviewPaneChannels"="IntPreview,int.main"
+
+[$RootKey$\FeatureFlags\Razor\LSP\ShowAllCSharpCodeActions]
+"Description"="Show all C# code actions in Razor files. Note: This is experimental, some actions may not apply correctly, or at all!"
+"Value"=dword:00000000
+"Title"="Show all C# code actions in Razor files (requires restart)"
+"PreviewPaneChannels"="IntPreview,int.main"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/CSharpCodeActionEndToEndTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/CSharpCodeActionEndToEndTest.cs
@@ -76,7 +76,7 @@ public class CSharpCodeActionEndToEndTest : SingleServerDelegatingEndpointTestBa
         var razorCodeActionProviders = Array.Empty<RazorCodeActionProvider>();
         var csharpCodeActionProviders = new CSharpCodeActionProvider[]
         {
-            new DefaultCSharpCodeActionProvider()
+            new DefaultCSharpCodeActionProvider(TestLanguageServerFeatureOptions.Instance)
         };
         var htmlCodeActionProviders = Array.Empty<HtmlCodeActionProvider>();
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/DefaultCSharpCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/DefaultCSharpCodeActionProviderTest.cs
@@ -58,7 +58,7 @@ public class DefaultCSharpCodeActionProviderTest : LanguageServerTestBase
         var context = CreateRazorCodeActionContext(request, location, documentPath, contents, new SourceSpan(8, 4));
         context.CodeDocument.SetFileKind(FileKinds.Legacy);
 
-        var provider = new DefaultCSharpCodeActionProvider();
+        var provider = new DefaultCSharpCodeActionProvider(TestLanguageServerFeatureOptions.Instance);
 
         // Act
         var providedCodeActions = await provider.ProvideAsync(context, _supportedCodeActions, default);
@@ -90,7 +90,7 @@ public class DefaultCSharpCodeActionProviderTest : LanguageServerTestBase
         var context = CreateRazorCodeActionContext(request, location, documentPath, contents, new SourceSpan(8, 4), supportsCodeActionResolve: false);
         context.CodeDocument.SetFileKind(FileKinds.Legacy);
 
-        var provider = new DefaultCSharpCodeActionProvider();
+        var provider = new DefaultCSharpCodeActionProvider(TestLanguageServerFeatureOptions.Instance);
 
         // Act
         var providedCodeActions = await provider.ProvideAsync(context, _supportedCodeActions, default);
@@ -119,7 +119,7 @@ public class DefaultCSharpCodeActionProviderTest : LanguageServerTestBase
         var context = CreateRazorCodeActionContext(request, location, documentPath, contents, new SourceSpan(13, 4));
         context.CodeDocument.SetFileKind(FileKinds.Legacy);
 
-        var provider = new DefaultCSharpCodeActionProvider();
+        var provider = new DefaultCSharpCodeActionProvider(TestLanguageServerFeatureOptions.Instance);
 
         // Act
         var providedCodeActions = await provider.ProvideAsync(context, _supportedCodeActions, default);
@@ -153,7 +153,7 @@ $$Path;
         var context = CreateRazorCodeActionContext(request, location, documentPath, contents, new SourceSpan(13, 4));
         context.CodeDocument.SetFileKind(FileKinds.Legacy);
 
-        var provider = new DefaultCSharpCodeActionProvider();
+        var provider = new DefaultCSharpCodeActionProvider(TestLanguageServerFeatureOptions.Instance);
 
         // Act
         var providedCodeActions = await provider.ProvideAsync(context, _supportedCodeActions, default);
@@ -188,7 +188,7 @@ $$Path;
         var context = CreateRazorCodeActionContext(request, location, documentPath, contents, new SourceSpan(13, 4));
         context.CodeDocument.SetFileKind(FileKinds.Legacy);
 
-        var provider = new DefaultCSharpCodeActionProvider();
+        var provider = new DefaultCSharpCodeActionProvider(TestLanguageServerFeatureOptions.Instance);
 
         // Act
         var providedCodeActions = await provider.ProvideAsync(context, _supportedCodeActions, default);
@@ -220,7 +220,7 @@ $$Path;
         var context = CreateRazorCodeActionContext(request, location, documentPath, contents, new SourceSpan(8, 4));
         context.CodeDocument.SetFileKind(FileKinds.Legacy);
 
-        var provider = new DefaultCSharpCodeActionProvider();
+        var provider = new DefaultCSharpCodeActionProvider(TestLanguageServerFeatureOptions.Instance);
 
         var codeActions = new RazorVSInternalCodeAction[]
         {
@@ -237,6 +237,45 @@ $$Path;
         // Assert
         Assert.NotNull(providedCodeActions);
         Assert.Empty(providedCodeActions);
+    }
+
+    [Fact]
+    public async Task ProvideAsync_InvalidCodeActions_ShowAllFeatureFlagOn_ReturnsCodeActions()
+    {
+        // Arrange
+        var documentPath = "c:/Test.razor";
+        var contents = "@code { $$Path; }";
+        TestFileMarkupParser.GetPosition(contents, out contents, out var cursorPosition);
+
+        var request = new VSCodeActionParams()
+        {
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
+            Range = new Range(),
+            Context = new VSInternalCodeActionContext()
+        };
+
+        var location = new SourceLocation(cursorPosition, -1, -1);
+        var context = CreateRazorCodeActionContext(request, location, documentPath, contents, new SourceSpan(8, 4));
+        context.CodeDocument.SetFileKind(FileKinds.Legacy);
+
+        var options = new ConfigurableLanguageServerFeatureOptions(new[] { $"--{nameof(ConfigurableLanguageServerFeatureOptions.ShowAllCSharpCodeActions)}" });
+        var provider = new DefaultCSharpCodeActionProvider(options);
+
+        var codeActions = new RazorVSInternalCodeAction[]
+        {
+           new RazorVSInternalCodeAction()
+           {
+               Title = "Do something not really supported in razor",
+               Name = "Non-existant name"
+           }
+        };
+
+        // Act
+        var providedCodeActions = await provider.ProvideAsync(context, codeActions, default);
+
+        // Assert
+        Assert.NotNull(providedCodeActions);
+        Assert.NotEmpty(providedCodeActions);
     }
 
     [Fact]
@@ -266,7 +305,7 @@ $$Path;
         var context = CreateRazorCodeActionContext(request, location, documentPath, contents, new SourceSpan(8, 4));
         context.CodeDocument.SetFileKind(FileKinds.Legacy);
 
-        var provider = new DefaultCSharpCodeActionProvider();
+        var provider = new DefaultCSharpCodeActionProvider(TestLanguageServerFeatureOptions.Instance);
 
         // Act
         var providedCodeActions = await provider.ProvideAsync(context, _supportedCodeActions, default);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common/TestLanguageServerFeatureOptions.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common/TestLanguageServerFeatureOptions.cs
@@ -28,4 +28,6 @@ internal class TestLanguageServerFeatureOptions : LanguageServerFeatureOptions
     public override bool SupportsDelegatedCodeActions => false;
 
     public override bool ReturnCodeActionAndRenamePathsWithPrefixedSlash => false;
+
+    public override bool ShowAllCSharpCodeActions => false;
 }


### PR DESCRIPTION
Something for our dogfooding.

This adds a flag to Preview Features in VS that allows any code action to be displayed, and at least attempted to be applied. Its a good way to find things we can add to our allow list for little to no cost. eg, just from a quick play it looks like "Convert to interpolated string" might be a good candidate. Looks like this:

<img width="516" alt="image" src="https://user-images.githubusercontent.com/754264/229267021-12164a8b-4788-4476-a0e8-9d5e3b21ee12.png">

You can tell if the code action will work, by the preview. eg, this will work:
<img width="483" alt="image" src="https://user-images.githubusercontent.com/754264/229266944-a81788d7-5606-4bb2-8951-adf5f5ccc138.png">

And this one won't (its trying to offer to change the whole RenderBody method to an expression I think???)
<img width="276" alt="image" src="https://user-images.githubusercontent.com/754264/229266998-1dd6d414-c453-4c57-a52b-d2e15e9dbc84.png">

Sometimes it can apply, but the results are pretty funny:
<img width="639" alt="image" src="https://user-images.githubusercontent.com/754264/229267071-bd6a722d-5981-405a-ae21-b8e4c4903a8c.png">

Thats why its a feature flag, and internal only, and off by default. Sorry community 😝 Don't worry, I have a pretty good idea how to make these work, just need some time :)