### PR TITLE
Package compiler dependencies in the package

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.csproj
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.csproj
@@ -3,6 +3,9 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+
+    <!-- Ensure we run our custom target, below, to copy compiler project references -->
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,7 +14,30 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\Compiler\Microsoft.CodeAnalysis.Razor\src\Microsoft.CodeAnalysis.Razor.csproj" />
-    <ProjectReference Include="..\Microsoft.AspNetCore.Razor.ProjectEngineHost\Microsoft.AspNetCore.Razor.ProjectEngineHost.csproj" />
+    <!-- Since we're including these DLLs in the package, we mark them as private assets so they're not also dependencies -->
+    <ProjectReference Include="..\..\..\Compiler\Microsoft.CodeAnalysis.Razor\src\Microsoft.CodeAnalysis.Razor.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\Microsoft.AspNetCore.Razor.ProjectEngineHost\Microsoft.AspNetCore.Razor.ProjectEngineHost.csproj" PrivateAssets="all" />
   </ItemGroup>
+
+  <!--
+    Include the build output of project references in the package created. We need to do this because the compiler packages
+    are published via a separate process to tooling, so anything that references this package will try to transitively pull
+    in the compiler packages, but will be unable to find packages with the same version.
+
+    This means we end up with the package for this project including the following additional DLLs:
+      * Microsoft.AspNetCore.Mvc.Razor.Extensions.dll
+      * Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X.dll
+      * Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X.dll
+      * Microsoft.AspNetCore.Razor.Language.dll
+      * Microsoft.AspNetCore.Razor.ProjectEngineHost.dll
+      * Microsoft.AspNetCore.Razor.Utilities.Shared.dll
+      * Microsoft.CodeAnalysis.Razor.dll
+
+    (and Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.dll obviously)
+  -->
+  <Target DependsOnTargets="ResolveReferences" Name="CopyProjectReferencesToPackage">
+    <ItemGroup>
+      <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
Follow up to the previous PR.

Depending solely on nupkgs doesn't work when tooling projects reference the compliler, because it is published differently. This works around the issue by baking in the compiler DLLs. Since everything is built in this repo, it seems to me like a safe option, because even if there is a breaking compiler change, it can't be done without this project being built too.

FYI @jjonescz. I don't think this will break when the compiler moves to a single DLL, but thought I'd better keep you in the loop :)