### PR TITLE
Prefix completion workaround

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/LSPDocumentSynchronizer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/LSPDocumentSynchronizer.cs
@@ -20,8 +20,7 @@ internal abstract class LSPDocumentSynchronizer : LSPDocumentChangeListener
         int requiredHostDocumentVersion,
         Uri hostDocumentUri,
         bool rejectOnNewerParallelRequest,
-        CancellationToken cancellationToken,
-        bool isResolveCodeActionEndpoint = false)
+        CancellationToken cancellationToken)
         where TVirtualDocumentSnapshot : VirtualDocumentSnapshot;
 
     [Obsolete]

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/LSPDocumentSynchronizer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/LSPDocumentSynchronizer.cs
@@ -20,7 +20,8 @@ internal abstract class LSPDocumentSynchronizer : LSPDocumentChangeListener
         int requiredHostDocumentVersion,
         Uri hostDocumentUri,
         bool rejectOnNewerParallelRequest,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        bool isResolveCodeActionEndpoint = false)
         where TVirtualDocumentSnapshot : VirtualDocumentSnapshot;
 
     [Obsolete]

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -1015,7 +1015,9 @@ internal class DefaultRazorLanguageServerCustomMessageTarget : RazorLanguageServ
             (synchronized, virtualDocumentSnapshot) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<CSharpVirtualDocumentSnapshot>(
                 request.HostDocument.Version,
                 request.HostDocument.Uri,
-                cancellationToken);
+                rejectOnNewerParallelRequest: true,
+                cancellationToken,
+                isResolveCodeActionEndpoint: true);
             languageServerName = RazorLSPConstants.RazorCSharpLanguageServerName;
         }
         else


### PR DESCRIPTION
Temporary workaround for https://github.com/dotnet/razor/issues/8209 for prefix completions.

@DustinCampbell @davidwengier I've been unable to make any additional progress on this document synchronization issue for completion. It still appears that we only end up receiving file version updates after timeout is reached on synchronization, LSP logs seem to show nothing unusual. I'd love either of your insight.

In the meantime, falsely claiming that we are synchronized if we've seen a version > required is a temporary workaround that fixes prefix completions but not postfix completions, and is gated only on the resolve endpoint.