### PR TITLE
Reference MS.Ext.ObjectPool package in ExternalAccess.RoslynWorkspace

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.csproj
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(MicrosoftCodeAnalysisWorkspacesCommonPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="$(MicrosoftExtensionsPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This package must be referenced because Roslyn doesn't include it.