### PR TITLE
Remove package refs with PrivateAssets="true"

### DIFF
--- a/src/Razor/src/rzls/rzls.csproj
+++ b/src/Razor/src/rzls/rzls.csproj
@@ -47,8 +47,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="$(MicrosoftExtensionsPackageVersion)" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsPackageVersion)" PrivateAssets="All" />
     <PackageReference Include="System.Private.Uri" Version="$(SystemPrivateUriPackageVersion)" ExcludeAssets="true" PrivateAssets="true" />
   </ItemGroup>
 


### PR DESCRIPTION
In rzls, the package references, Microsoft.Extensions.Logging and Microsoft.Extensions.Configuration, were defined with PrivateAssets="true". (According to git blame, this was done as part of an attempt to fix spurious build issues.) However, it seems that this also means that the libs in these packages are not included in published output, which is critical for rzls.exe to run.
