### PR TITLE
Add small colorization microbenchmark

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticColorizationBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticColorizationBenchmark.cs
@@ -1,0 +1,156 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Microsoft.AspNetCore.Razor.LanguageServer;
+using Microsoft.AspNetCore.Razor.LanguageServer.DocumentColor;
+using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.Microbenchmarks.LanguageServer;
+
+public class RazorSemanticColorizationBenchmark : RazorLanguageServerBenchmarkBase
+{
+    public enum FileTypes
+    {
+        Small,
+        Large
+    }
+
+    private string? _filePath;
+    private Uri? DocumentUri { get; set; }
+    private DocumentColorEndpoint? DocumentColorEndpoint { get; set; }
+    private IDocumentSnapshot? DocumentSnapshot { get; set; }
+    private RazorRequestContext RazorRequestContext { get; set; }
+
+    [ParamsAllValues] public FileTypes FileType { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        var languageServer = RazorLanguageServer.GetInnerLanguageServerForTesting();
+
+        DocumentColorEndpoint = new DocumentColorEndpoint(new ClientNotifierService());
+        var projectRoot = Path.Combine(RepoRoot, "src", "Razor", "test", "testapps", "ComponentApp");
+        var projectFilePath = Path.Combine(projectRoot, "ComponentApp.csproj");
+        _filePath = Path.Combine(projectRoot, "Components", "Pages", "Generated.razor");
+
+        var content = GetFileContents(FileType);
+        File.WriteAllText(_filePath, content);
+
+        var targetPath = "/Components/Pages/Generated.razor";
+
+        DocumentUri = new Uri(_filePath);
+        DocumentSnapshot = GetDocumentSnapshot(projectFilePath, _filePath, targetPath);
+        var documentContext = new VersionedDocumentContext(DocumentUri, DocumentSnapshot, 1);
+
+        RazorRequestContext = new RazorRequestContext(documentContext, Logger, languageServer.GetLspServices());
+    }
+
+
+    private protected override LanguageServerFeatureOptions BuildFeatureOptions()
+    {
+        return new ColorizationLanguageServerFeatureOptions();
+    }
+
+    private string GetFileContents(FileTypes fileType)
+    {
+        var sb = new StringBuilder();
+
+        sb.Append("""
+            @using System;
+            """);
+
+        for (var i = 0; i < (fileType == FileTypes.Small ? 1 : 100); i++)
+        {
+            sb.Append($$"""
+            @{
+                var y{{i}} = 456;
+            }
+
+            <div>
+                <p>Hello there Mr {{i}}</p>
+                <div>
+                    <span>hi!</span>
+                </div>
+            </div>
+            """);
+        }
+
+        return sb.ToString();
+    }
+
+    [Benchmark(Description = "SemanticColorizationNoLsp")]
+    public async Task SemanticColorizationNoLspAsync()
+    {
+        var request = new DocumentColorParams { TextDocument = new TextDocumentIdentifier { Uri = DocumentUri! } };
+
+        await DocumentColorEndpoint!.HandleRequestAsync(request, RazorRequestContext, CancellationToken.None);
+    }
+
+    [GlobalCleanup]
+    public async Task CleanupAsync()
+    {
+        File.Delete(_filePath!);
+
+        var innerServer = RazorLanguageServer.GetInnerLanguageServerForTesting();
+
+        await innerServer.ShutdownAsync();
+        await innerServer.ExitAsync();
+    }
+
+    private class ColorizationLanguageServerFeatureOptions : LanguageServerFeatureOptions
+    {
+        public override bool SupportsFileManipulation => true;
+
+        public override string ProjectConfigurationFileName => "project.razor.json";
+
+        public override string CSharpVirtualDocumentSuffix => ".ide.g.cs";
+
+        public override string HtmlVirtualDocumentSuffix => "__virtual.html";
+
+        public override bool SingleServerCompletionSupport => true;
+
+        public override bool SingleServerSupport => true;
+
+        public override bool SupportsDelegatedCodeActions => true;
+
+        public override bool ReturnCodeActionAndRenamePathsWithPrefixedSlash => true;
+
+        public override bool ShowAllCSharpCodeActions => true;
+    }
+
+    private class ClientNotifierService : ClientNotifierServiceBase
+    {
+        public override Task OnInitializedAsync(VSInternalClientCapabilities clientCapabilities,
+            CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        public override Task SendNotificationAsync<TParams>(string method, TParams @params,
+            CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task SendNotificationAsync(string method, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Task<TResponse> SendRequestAsync<TParams, TResponse>(string method, TParams @params,
+            CancellationToken cancellationToken)
+        {
+            object response = new[] { new ColorInformation() };
+            return Task.FromResult<TResponse>((TResponse)response);
+        }
+    }
+}


### PR DESCRIPTION
## Summary of the changes
* Adds colorization (without real LSP call) microbenchmark.
Resolves #8540

```
// * Summary *

BenchmarkDotNet=v0.13.2.2052-nightly, OS=Windows 11 (10.0.22621.1631)
Intel Core i9-10900K CPU 3.70GHz, 1 CPU, 20 logical and 10 physical cores
  [Host]     : .NET Framework 4.8.1 (4.8.9139.0), X64 RyuJIT VectorSize=256
  Job-EJEXYW : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
  Job-DSHCRS : .NET Framework 4.8.1 (4.8.9139.0), X64 RyuJIT VectorSize=256

PowerPlanMode=00000000-0000-0000-0000-000000000000

|                    Method |        Job |            Toolchain | FileType |      Mean |    Error |   StdDev |    Median |       Min |       Max |   Gen0 | Allocated |
|-------------------------- |----------- |--------------------- |--------- |----------:|---------:|---------:|----------:|----------:|----------:|-------:|----------:|
| SemanticColorizationNoLsp | Job-EJEXYW |             .NET 7.0 |    Small |  72.41 ns | 1.412 ns | 2.547 ns |  71.79 ns |  66.33 ns |  77.40 ns | 0.0275 |     288 B |
| SemanticColorizationNoLsp | Job-DSHCRS | .NET Framework 4.7.2 |    Small | 160.77 ns | 3.208 ns | 3.432 ns | 159.34 ns | 156.32 ns | 168.82 ns | 0.0484 |     305 B |
| SemanticColorizationNoLsp | Job-EJEXYW |             .NET 7.0 |    Large |  71.23 ns | 1.435 ns | 1.409 ns |  71.29 ns |  68.17 ns |  73.98 ns | 0.0275 |     288 B |
| SemanticColorizationNoLsp | Job-DSHCRS | .NET Framework 4.7.2 |    Large | 160.87 ns | 3.070 ns | 6.930 ns | 157.45 ns | 153.39 ns | 180.06 ns | 0.0484 |     305 B |
```

The document color endpoint literally contains little more than one LSP request object allocation, then an underlying LSP call. If there are to be any optimizations, they would be part of ClientNotifierServiceBase impls SendRequestAsync methods.