### PR TITLE
Only capture project id, and get the latest project from the workspace

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace/PublicAPI.Unshipped.txt
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace/PublicAPI.Unshipped.txt
@@ -3,4 +3,4 @@ Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.RazorWorkspaceListener
 Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.RazorWorkspaceListener.Dispose() -> void
 Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.RazorWorkspaceListener.EnsureInitialized(Microsoft.CodeAnalysis.Workspace! workspace, string! projectRazorJsonFileName) -> void
 Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.RazorWorkspaceListener.RazorWorkspaceListener() -> void
-virtual Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.RazorWorkspaceListener.SerializeProjectAsync(Microsoft.CodeAnalysis.Project! project, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task!
+virtual Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.RazorWorkspaceListener.SerializeProjectAsync(Microsoft.CodeAnalysis.ProjectId! projectId, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task!

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.Test/RazorWorkspaceListenerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.Test/RazorWorkspaceListenerTest.cs
@@ -126,14 +126,14 @@ public class RazorWorkspaceListenerTest
 
         public Dictionary<ProjectId, int> SerializeCalls => _serializeCalls;
 
-        protected override Task SerializeProjectAsync(Project project, CancellationToken ct)
+        protected override Task SerializeProjectAsync(ProjectId projectId, CancellationToken ct)
         {
-            if (!_serializeCalls.ContainsKey(project.Id))
+            if (!_serializeCalls.ContainsKey(projectId))
             {
-                _serializeCalls.Add(project.Id, 0);
+                _serializeCalls.Add(projectId, 0);
             }
 
-            _serializeCalls[project.Id]++;
+            _serializeCalls[projectId]++;
 
             return Task.CompletedTask;
         }


### PR DESCRIPTION
This means we're not holding only project references, and avoids a race condition where document changes after the debounce won't be seen.