### PR TITLE
Don't create task schedulers until we know we'll need one

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.csproj
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(MicrosoftCodeAnalysisWorkspacesCommonPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="$(MicrosoftExtensionsPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace/PublicAPI.Unshipped.txt
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace/PublicAPI.Unshipped.txt
@@ -2,5 +2,6 @@
 Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.RazorWorkspaceListener
 Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.RazorWorkspaceListener.Dispose() -> void
 Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.RazorWorkspaceListener.EnsureInitialized(Microsoft.CodeAnalysis.Workspace! workspace, string! projectRazorJsonFileName) -> void
-Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.RazorWorkspaceListener.RazorWorkspaceListener() -> void
+Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.RazorWorkspaceListener.NotifyDynamicFile(Microsoft.CodeAnalysis.ProjectId! projectId) -> void
+Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.RazorWorkspaceListener.RazorWorkspaceListener(Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory) -> void
 virtual Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.RazorWorkspaceListener.SerializeProjectAsync(Microsoft.CodeAnalysis.ProjectId! projectId, System.Threading.CancellationToken ct) -> System.Threading.Tasks.Task!

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace/RazorWorkspaceListener.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace/RazorWorkspaceListener.cs
@@ -1,22 +1,25 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace;
 
 public class RazorWorkspaceListener : IDisposable
 {
-    private static readonly TimeSpan s_debounceTime = TimeSpan.FromMilliseconds(100);
+    private static readonly TimeSpan s_debounceTime = TimeSpan.FromMilliseconds(500);
+
+    private readonly ILogger _logger;
 
     private string? _projectRazorJsonFileName;
     private Workspace? _workspace;
-    private readonly Dictionary<ProjectId, TaskDelayScheduler> _workQueues;
-    private readonly object _gate = new();
+    private ImmutableDictionary<ProjectId, TaskDelayScheduler> _workQueues = ImmutableDictionary<ProjectId, TaskDelayScheduler>.Empty;
 
-    public RazorWorkspaceListener()
+    public RazorWorkspaceListener(ILoggerFactory loggerFactory)
     {
-        _workQueues = new Dictionary<ProjectId, TaskDelayScheduler>();
+        _logger = loggerFactory.CreateLogger(nameof(RazorWorkspaceListener));
     }
 
     public void EnsureInitialized(Workspace workspace, string projectRazorJsonFileName)
@@ -30,6 +33,18 @@ public class RazorWorkspaceListener : IDisposable
         _projectRazorJsonFileName = projectRazorJsonFileName;
         _workspace = workspace;
         _workspace.WorkspaceChanged += Workspace_WorkspaceChanged;
+    }
+
+    public void NotifyDynamicFile(ProjectId projectId)
+    {
+        // We expect this to be called multiple times per project so a no-op update operation seems like a better choice
+        // than constructing a new TaskDelayScheduler each time, and using the TryAdd method, which doesn't support a
+        // valueFactory argument.
+        var scheduler = ImmutableInterlocked.AddOrUpdate(ref _workQueues, projectId, static _ => new TaskDelayScheduler(s_debounceTime, CancellationToken.None), static (_, val) => val);
+
+        // Schedule a task, in case adding a dynamic file is the last thing that happens
+        _logger.LogTrace("{projectId} scheduling task due to dynamic file", projectId);
+        scheduler.ScheduleAsyncTask(ct => SerializeProjectAsync(projectId, ct), CancellationToken.None);
     }
 
     private void Workspace_WorkspaceChanged(object? sender, WorkspaceChangeEventArgs e)
@@ -109,16 +124,10 @@ public class RazorWorkspaceListener : IDisposable
             return;
         }
 
-        TaskDelayScheduler? scheduler;
-        lock (_gate)
+        if (ImmutableInterlocked.TryRemove(ref _workQueues, project.Id, out var scheduler))
         {
-            if (_workQueues.TryGetValue(project.Id, out scheduler))
-            {
-                _workQueues.Remove(project.Id);
-            }
+            scheduler.Dispose();
         }
-
-        scheduler?.Dispose();
     }
 
     private void EnqueueUpdate(Project? project)
@@ -132,18 +141,13 @@ public class RazorWorkspaceListener : IDisposable
             return;
         }
 
-        TaskDelayScheduler? scheduler;
-        lock (_gate)
-        {
-            if (!_workQueues.TryGetValue(project.Id, out scheduler))
-            {
-                scheduler = new TaskDelayScheduler(s_debounceTime, CancellationToken.None);
-                _workQueues.Add(project.Id, scheduler);
-            }
-        }
-
         var projectId = project.Id;
-        scheduler.ScheduleAsyncTask(ct => SerializeProjectAsync(projectId, ct), CancellationToken.None);
+        if (_workQueues.TryGetValue(projectId, out var scheduler))
+        {
+            _logger.LogTrace("{projectId} scheduling task due to workspace event", projectId);
+
+            scheduler.ScheduleAsyncTask(ct => SerializeProjectAsync(projectId, ct), CancellationToken.None);
+        }
     }
 
     // Protected for testing
@@ -160,17 +164,17 @@ public class RazorWorkspaceListener : IDisposable
             return Task.CompletedTask;
         }
 
+        _logger.LogTrace("{projectId} writing json file", projectId);
         return RazorProjectJsonSerializer.SerializeAsync(project, _projectRazorJsonFileName, ct);
     }
 
     public void Dispose()
     {
-        lock (_gate)
+        var queues = _workQueues;
+        _workQueues.Clear();
+        foreach (var (_, value) in queues)
         {
-            foreach (var (_, value) in _workQueues)
-            {
-                value.Dispose();
-            }
+            value.Dispose();
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace/RazorWorkspaceListener.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace/RazorWorkspaceListener.cs
@@ -170,8 +170,12 @@ public class RazorWorkspaceListener : IDisposable
 
     public void Dispose()
     {
-        var queues = _workQueues;
-        _workQueues.Clear();
+        if (_workspace is not null)
+        {
+            _workspace.WorkspaceChanged -= Workspace_WorkspaceChanged;
+        }
+
+        var queues = Interlocked.Exchange(ref _workQueues, ImmutableDictionary<ProjectId, TaskDelayScheduler>.Empty);
         foreach (var (_, value) in queues)
         {
             value.Dispose();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.Test/RazorWorkspaceListenerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.Test/RazorWorkspaceListenerTest.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.Test;
@@ -18,11 +19,31 @@ public class RazorWorkspaceListenerTest
         listener.EnsureInitialized(workspace, "temp.json");
 
         var project = workspace.AddProject("TestProject", LanguageNames.CSharp);
+        listener.NotifyDynamicFile(project.Id);
 
-        // Wait for debounce
-        await Task.Delay(500);
+        await listener.WaitForDebounceAsync();
 
         Assert.Equal(1, listener.SerializeCalls[project.Id]);
+    }
+
+    [Fact]
+    public async Task TwoProjectsAdded_OneWithDynamicFiles_SchedulesOneTask()
+    {
+        using var workspace = new AdhocWorkspace(CodeAnalysis.Host.Mef.MefHostServices.DefaultHost);
+
+        using var listener = new TestRazorWorkspaceListener();
+        listener.EnsureInitialized(workspace, "temp.json");
+
+        var project1 = workspace.AddProject("TestProject1", LanguageNames.CSharp);
+
+        var project2 = workspace.AddProject("TestProject2", LanguageNames.CSharp);
+        listener.NotifyDynamicFile(project2.Id);
+
+        await listener.WaitForDebounceAsync();
+
+        // These are different projects, so should cause two calls
+        Assert.False(listener.SerializeCalls.ContainsKey(project1.Id));
+        Assert.Equal(1, listener.SerializeCalls[project2.Id]);
     }
 
     [Fact]
@@ -34,10 +55,14 @@ public class RazorWorkspaceListenerTest
         listener.EnsureInitialized(workspace, "temp.json");
 
         var project1 = workspace.AddProject("TestProject1", LanguageNames.CSharp);
-        var project2 = workspace.AddProject("TestProject2", LanguageNames.CSharp);
+        listener.NotifyDynamicFile(project1.Id);
 
-        // Wait for debounce
-        await Task.Delay(500);
+        await listener.WaitForDebounceAsync();
+
+        var project2 = workspace.AddProject("TestProject2", LanguageNames.CSharp);
+        listener.NotifyDynamicFile(project2.Id);
+
+        await listener.WaitForDebounceAsync();
 
         // These are different projects, so should cause two calls
         Assert.Equal(1, listener.SerializeCalls[project1.Id]);
@@ -53,17 +78,20 @@ public class RazorWorkspaceListenerTest
         listener.EnsureInitialized(workspace, "temp.json");
 
         var project = workspace.AddProject("TestProject", LanguageNames.CSharp);
+        listener.NotifyDynamicFile(project.Id);
+
         var newSolution = project.Solution.RemoveProject(project.Id);
         Assert.True(workspace.TryApplyChanges(newSolution));
 
-        // Wait for debounce
+        // We can't wait for debounce here, because it won't happen, but if we don't wait for _something_ we won't know
+        // if the test fails, so a delay is annoyingly necessary.
         await Task.Delay(500);
 
         Assert.Empty(listener.SerializeCalls);
     }
 
     [Fact]
-    public async Task TwoProjectChanges_SchedulesOneTasks()
+    public async Task TwoProjectChanges_SchedulesOneTask()
     {
         using var workspace = new AdhocWorkspace(CodeAnalysis.Host.Mef.MefHostServices.DefaultHost);
 
@@ -71,13 +99,33 @@ public class RazorWorkspaceListenerTest
         listener.EnsureInitialized(workspace, "temp.json");
 
         var project = workspace.AddProject("TestProject", LanguageNames.CSharp);
+        listener.NotifyDynamicFile(project.Id);
+
         var newSolution = project.Solution.WithProjectDefaultNamespace(project.Id, "NewDefaultNamespace");
         Assert.True(workspace.TryApplyChanges(newSolution));
 
-        // Wait for debounce
-        await Task.Delay(500);
+        await listener.WaitForDebounceAsync();
 
         Assert.Equal(1, listener.SerializeCalls[project.Id]);
+    }
+
+    [Fact]
+    public async Task DocumentAdded_NoDynamicFiles_NoTasks()
+    {
+        using var workspace = new AdhocWorkspace(CodeAnalysis.Host.Mef.MefHostServices.DefaultHost);
+
+        using var listener = new TestRazorWorkspaceListener();
+        listener.EnsureInitialized(workspace, "temp.json");
+
+        var project = workspace.AddProject("TestProject", LanguageNames.CSharp);
+
+        workspace.AddDocument(project.Id, "Document", SourceText.From("Hi there"));
+
+        // We can't wait for debounce here, because it won't happen, but if we don't wait for _something_ we won't know
+        // if the test fails, so a delay is annoyingly necessary.
+        await Task.Delay(500);
+
+        Assert.Empty(listener.SerializeCalls);
     }
 
     [Fact]
@@ -89,11 +137,11 @@ public class RazorWorkspaceListenerTest
         listener.EnsureInitialized(workspace, "temp.json");
 
         var project = workspace.AddProject("TestProject", LanguageNames.CSharp);
+        listener.NotifyDynamicFile(project.Id);
 
         workspace.AddDocument(project.Id, "Document", SourceText.From("Hi there"));
 
-        // Wait for debounce
-        await Task.Delay(500);
+        await listener.WaitForDebounceAsync();
 
         Assert.Equal(1, listener.SerializeCalls[project.Id]);
     }
@@ -107,14 +155,13 @@ public class RazorWorkspaceListenerTest
         listener.EnsureInitialized(workspace, "temp.json");
 
         var project = workspace.AddProject("TestProject", LanguageNames.CSharp);
+        listener.NotifyDynamicFile(project.Id);
 
-        // Wait for debounce
-        await Task.Delay(500);
+        await listener.WaitForDebounceAsync();
 
         workspace.AddDocument(project.Id, "Document", SourceText.From("Hi there"));
 
-        // Wait for debounce
-        await Task.Delay(500);
+        await listener.WaitForDebounceAsync();
 
         Assert.Equal(2, listener.SerializeCalls[project.Id]);
     }
@@ -122,14 +169,29 @@ public class RazorWorkspaceListenerTest
     private class TestRazorWorkspaceListener : RazorWorkspaceListener
     {
         private ConcurrentDictionary<ProjectId, int> _serializeCalls = new();
+        private TaskCompletionSource _completionSource = new();
 
         public ConcurrentDictionary<ProjectId, int> SerializeCalls => _serializeCalls;
+
+        public TestRazorWorkspaceListener()
+            : base(NullLoggerFactory.Instance)
+        {
+        }
 
         protected override Task SerializeProjectAsync(ProjectId projectId, CancellationToken ct)
         {
             _serializeCalls.AddOrUpdate(projectId, 1, (id, curr) => curr + 1);
 
+            _completionSource.TrySetResult();
+            _completionSource = new();
+
             return Task.CompletedTask;
+        }
+
+        internal async Task WaitForDebounceAsync()
+        {
+            await _completionSource.Task;
+            _completionSource = new();
         }
     }
 }


### PR DESCRIPTION
When I originally wrote this, I was smart enough to not generate the json file if there are no razor documents in a project, but it turns out for a reasonable sized project there are a _lot_ of workspace events flying around. This PR tweaks things so that we can just ignore any event for a project, until we get confirmation that it actually has a razor document in it.