### PR TITLE
Restore behaviour for attributes when single server support is off

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AbstractRazorDelegatingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AbstractRazorDelegatingEndpoint.cs
@@ -36,6 +36,8 @@ internal abstract class AbstractRazorDelegatingEndpoint<TRequest, TResponse> : I
         Logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
+    protected bool SingleServerSupport => _languageServerFeatureOptions.SingleServerSupport;
+
     protected virtual bool OnlySingleServer { get; } = true;
 
     /// <summary>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/DefinitionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/DefinitionEndpoint.cs
@@ -11,7 +11,11 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -64,7 +68,8 @@ internal sealed class DefinitionEndpoint : AbstractRazorDelegatingEndpoint<TextD
             return default;
         }
 
-        var originTagDescriptor = await GetOriginTagHelperBindingAsync(documentContext, projection.AbsoluteIndex, requestContext.Logger, cancellationToken).ConfigureAwait(false);
+        // If single server support is on, then we ignore attributes, as they are better handled by delegating to Roslyn
+        var (originTagDescriptor, attributeDescriptor) = await GetOriginTagHelperBindingAsync(documentContext, projection.AbsoluteIndex, SingleServerSupport, requestContext.Logger, cancellationToken).ConfigureAwait(false);
         if (originTagDescriptor is null)
         {
             requestContext.Logger.LogInformation("Origin TagHelper descriptor is null.");
@@ -82,6 +87,8 @@ internal sealed class DefinitionEndpoint : AbstractRazorDelegatingEndpoint<TextD
 
         requestContext.Logger.LogInformation("Definition found at file path: {filePath}", originComponentDocumentFilePath);
 
+        var range = await GetNavigateRangeAsync(originComponentDocumentSnapshot, attributeDescriptor, requestContext.Logger, cancellationToken);
+
         var originComponentUri = new UriBuilder
         {
             Path = originComponentDocumentFilePath,
@@ -94,8 +101,7 @@ internal sealed class DefinitionEndpoint : AbstractRazorDelegatingEndpoint<TextD
             new VSInternalLocation
             {
                 Uri = originComponentUri,
-                // When navigating from a start or end tag, we just take the user to the top of the file.
-                Range = new Range { Start = new Position(0, 0), End = new Position(0, 0) }
+                Range = range,
             },
         };
     }
@@ -141,9 +147,10 @@ internal sealed class DefinitionEndpoint : AbstractRazorDelegatingEndpoint<TextD
         return response;
     }
 
-    internal static async Task<TagHelperDescriptor?> GetOriginTagHelperBindingAsync(
+    internal static async Task<(TagHelperDescriptor?, BoundAttributeDescriptor?)> GetOriginTagHelperBindingAsync(
         DocumentContext documentContext,
         int absoluteIndex,
+        bool ignoreAttributes,
         ILogger logger,
         CancellationToken cancellationToken)
     {
@@ -151,7 +158,7 @@ internal sealed class DefinitionEndpoint : AbstractRazorDelegatingEndpoint<TextD
         if (owner is null)
         {
             logger.LogInformation("Could not locate owner.");
-            return null;
+            return (null, null);
         }
 
         var node = owner.Ancestors().FirstOrDefault(n =>
@@ -160,36 +167,59 @@ internal sealed class DefinitionEndpoint : AbstractRazorDelegatingEndpoint<TextD
         if (node is null)
         {
             logger.LogInformation("Could not locate ancestor of type MarkupTagHelperStartTag or MarkupTagHelperEndTag.");
-            return null;
+            return (null, null);
         }
 
         var name = GetStartOrEndTagName(node);
         if (name is null)
         {
             logger.LogInformation("Could not retrieve name of start or end tag.");
-            return null;
+            return (null, null);
+        }
+
+        string? propertyName = null;
+
+        if (!ignoreAttributes)
+        {
+            // If we're on an attribute then just validate against the attribute name
+            if (owner.Parent is MarkupTagHelperAttributeSyntax attribute)
+            {
+                // Normal attribute, ie <Component attribute=value />
+                name = attribute.Name;
+                propertyName = attribute.TagHelperAttributeInfo.Name;
+            }
+            else if (owner.Parent is MarkupMinimizedTagHelperAttributeSyntax minimizedAttribute)
+            {
+                // Minimized attribute, ie <Component attribute />
+                name = minimizedAttribute.Name;
+                propertyName = minimizedAttribute.TagHelperAttributeInfo.Name;
+            }
         }
 
         if (!name.Span.IntersectsWith(absoluteIndex))
         {
-            logger.LogInformation("Tag name's span does not intersect with location's absolute index ({absoluteIndex}).", absoluteIndex);
-            return null;
+            logger.LogInformation("Tag name or attributes' span does not intersect with location's absolute index ({absoluteIndex}).", absoluteIndex);
+            return (null, null);
         }
 
         if (node.Parent is not MarkupTagHelperElementSyntax tagHelperElement)
         {
             logger.LogInformation("Parent of start or end tag is not a MarkupTagHelperElement.");
-            return null;
+            return (null, null);
         }
 
         var originTagDescriptor = tagHelperElement.TagHelperInfo.BindingResult.Descriptors.FirstOrDefault(d => !d.IsAttributeDescriptor());
         if (originTagDescriptor is null)
         {
             logger.LogInformation("Origin TagHelper descriptor is null.");
-            return null;
+            return (null, null);
         }
 
-        return originTagDescriptor;
+        var attributeDescriptor = (propertyName is not null)
+            ? originTagDescriptor.BoundAttributes.FirstOrDefault(a => a.Name?.Equals(propertyName, StringComparison.Ordinal) == true)
+            : null;
+
+        return (originTagDescriptor, attributeDescriptor);
     }
 
     private static SyntaxNode? GetStartOrEndTagName(SyntaxNode node)
@@ -200,5 +230,78 @@ internal sealed class DefinitionEndpoint : AbstractRazorDelegatingEndpoint<TextD
             MarkupTagHelperEndTagSyntax tagHelperEndTag => tagHelperEndTag.Name,
             _ => null
         };
+    }
+
+    private async Task<Range> GetNavigateRangeAsync(IDocumentSnapshot documentSnapshot, BoundAttributeDescriptor? attributeDescriptor, ILogger logger, CancellationToken cancellationToken)
+    {
+        if (attributeDescriptor is not null)
+        {
+            logger.LogInformation("Attempting to get definition from an attribute directly.");
+
+            var originCodeDocument = await documentSnapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
+            var range = await TryGetPropertyRangeAsync(originCodeDocument, attributeDescriptor.GetPropertyName(), _documentMappingService, logger, cancellationToken).ConfigureAwait(false);
+
+            if (range is not null)
+            {
+                return range;
+            }
+        }
+
+        // When navigating from a start or end tag, we just take the user to the top of the file.
+        // If we were trying to navigate to a property, and we couldn't find it, we can at least take
+        // them to the file for the component. If the property was defined in a partial class they can
+        // at least then press F7 to go there.
+        return new Range { Start = new Position(0, 0), End = new Position(0, 0) };
+    }
+
+    internal static async Task<Range?> TryGetPropertyRangeAsync(RazorCodeDocument codeDocument, string propertyName, RazorDocumentMappingService documentMappingService, ILogger logger, CancellationToken cancellationToken)
+    {
+        // Parse the C# file and find the property that matches the name.
+        // We don't worry about parameter attributes here for two main reasons:
+        //   1. We don't have symbolic information, so the best we could do would be checking for any
+        //      attribute named Parameter, regardless of which namespace. It also means we would have
+        //      to do more checks for all of the various ways that the attribute could be specified
+        //      (eg fully qualified, aliased, etc.)
+        //   2. Since C# doesn't allow multiple properties with the same name, and we're doing a case
+        //      sensitive search, we know the property we find is the one the user is trying to encode in a
+        //      tag helper attribute. If they don't have the [Parameter] attribute then the Razor compiler
+        //      will error, but allowing them to Go To Def on that property regardless, actually helps
+        //      them fix the error.
+        var csharpText = codeDocument.GetCSharpSourceText();
+        var syntaxTree = CSharpSyntaxTree.ParseText(csharpText, cancellationToken: cancellationToken);
+        var root = await syntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
+
+        // Since we know how the compiler generates the C# source we can be a little specific here, and avoid
+        // long tree walks. If the compiler ever changes how they generate their code, the tests for this will break
+        // so we'll know about it.
+        if (root is CompilationUnitSyntax compilationUnit &&
+            compilationUnit.Members[0] is NamespaceDeclarationSyntax namespaceDeclaration &&
+            namespaceDeclaration.Members[0] is ClassDeclarationSyntax classDeclaration)
+        {
+            var property = classDeclaration
+                .Members
+                .OfType<PropertyDeclarationSyntax>()
+                .Where(p => p.Identifier.ValueText.Equals(propertyName, StringComparison.Ordinal))
+                .FirstOrDefault();
+
+            if (property is null)
+            {
+                // The property probably exists in a partial class
+                logger.LogInformation("Could not find property in the generated source. Comes from partial?");
+                return null;
+            }
+
+            var range = property.Identifier.Span.AsRange(csharpText);
+            if (documentMappingService.TryMapFromProjectedDocumentRange(codeDocument.GetCSharpDocument(), range, out var originalRange))
+            {
+                return originalRange;
+            }
+
+            logger.LogInformation("Property found but couldn't map its location.");
+        }
+
+        logger.LogInformation("Generated C# was not in expected shape (CompilationUnit -> Namespace -> Class)");
+
+        return null;
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/HoverEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/HoverEndpoint.cs
@@ -70,9 +70,11 @@ internal sealed class HoverEndpoint : AbstractRazorDelegatingEndpoint<TextDocume
             return null;
         }
 
-        // Sometimes what looks like a html attribute can actually map to C#, in which case its better to let Roslyn try to handle this.
         var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
-        if (_documentMappingService.TryMapToProjectedDocumentPosition(codeDocument.GetCSharpDocument(), projection.AbsoluteIndex, out _, out _))
+
+        // Sometimes what looks like a html attribute can actually map to C#, in which case its better to let Roslyn try to handle this.
+        // We can only do this if we're in single server mode though, otherwise we won't be delegating to Roslyn at all
+        if (SingleServerSupport && _documentMappingService.TryMapToProjectedDocumentPosition(codeDocument.GetCSharpDocument(), projection.AbsoluteIndex, out _, out _))
         {
             return null;
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/DefinitionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/DefinitionEndpointTest.cs
@@ -7,7 +7,11 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Completion;
+using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
+using Microsoft.AspNetCore.Razor.LanguageServer.Test.Common;
+using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
 using Moq;
@@ -191,15 +195,183 @@ public class DefinitionEndpointTest : TagHelperServiceTestBase
         await VerifyOriginTagHelperBindingAsync(content);
     }
 
+    [Fact]
+    public async Task GetOriginTagHelperBindingAsync_IgnoreAttribute_PropertyAttribute()
+    {
+        var content = """
+                @addTagHelper *, TestAssembly
+                <Component1 boo$$l-val="true"></Component1>
+                @code {
+                    public void Increment()
+                    {
+                    }
+                }
+                """;
+
+        await VerifyOriginTagHelperBindingAsync(content, ignoreAttributes: true, tagHelperDescriptorName: null, attributeDescriptorPropertyName: null);
+    }
+
+    [Fact]
+    public async Task GetOriginTagHelperBindingAsync_TagHelper_PropertyAttribute()
+    {
+        var content = """
+                @addTagHelper *, TestAssembly
+                <Component1 boo$$l-val="true"></Component1>
+                @code {
+                    public void Increment()
+                    {
+                    }
+                }
+                """;
+
+        await VerifyOriginTagHelperBindingAsync(content, "Component1TagHelper", "BoolVal");
+    }
+
+    [Fact]
+    public async Task GetOriginTagHelperBindingAsync_TagHelper_MinimizedPropertyAttribute()
+    {
+        var content = """
+                @addTagHelper *, TestAssembly
+                <Component1 boo$$l-val></Component1>
+                @code {
+                    public void Increment()
+                    {
+                    }
+                }
+                """;
+
+        await VerifyOriginTagHelperBindingAsync(content, "Component1TagHelper", "BoolVal");
+    }
+
+    [Fact]
+    public async Task GetOriginTagHelperBindingAsync_TagHelper_MinimizedPropertyAttributeEdge1()
+    {
+        var content = """
+                @addTagHelper *, TestAssembly
+                <Component1 $$bool-val></Component1>
+                @code {
+                    public void Increment()
+                    {
+                    }
+                }
+                """;
+
+        await VerifyOriginTagHelperBindingAsync(content, "Component1TagHelper", "BoolVal");
+    }
+
+    [Fact]
+    public async Task GetOriginTagHelperBindingAsync_TagHelper_MinimizedPropertyAttributeEdge2()
+    {
+        var content = """
+                @addTagHelper *, TestAssembly
+                <Component1 bool-val$$></Component1>
+                @code {
+                    public void Increment()
+                    {
+                    }
+                }
+                """;
+
+        await VerifyOriginTagHelperBindingAsync(content, "Component1TagHelper", "BoolVal");
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/razor-tooling/issues/6775")]
+    public async Task GetOriginTagHelperBindingAsync_TagHelper_PropertyAttributeEdge()
+    {
+        var content = """
+                @addTagHelper *, TestAssembly
+                <Component1 bool-val$$="true"></Component1>
+                @code {
+                    public void Increment()
+                    {
+                    }
+                }
+                """;
+
+        await VerifyOriginTagHelperBindingAsync(content, "Component1TagHelper", "BoolVal");
+    }
+
+    [Fact]
+    public async Task GetNavigatePositionAsync_TagHelperProperty_CorrectRange1()
+    {
+        var content = """
+                <div>@Title</div>
+
+                @code
+                {
+                    [Parameter]
+                    public string NotTitle { get; set; }
+
+                    [Parameter]
+                    public string [|Title|] { get; set; }
+                }
+                """;
+
+        await VerifyNavigatePositionAsync(content, "Title");
+    }
+
+    [Fact]
+    public async Task GetNavigatePositionAsync_TagHelperProperty_CorrectRange2()
+    {
+        var content = """
+                <div>@Title</div>
+
+                @code
+                {
+                    [Microsoft.AspNetCore.Components.Parameter]
+                    public string [|Title|] { get; set; }
+                }
+                """;
+
+        await VerifyNavigatePositionAsync(content, "Title");
+    }
+
+    [Fact]
+    public async Task GetNavigatePositionAsync_TagHelperProperty_CorrectRange3()
+    {
+        var content = """
+                <div>@Title</div>
+
+                @code
+                {
+                    [Components.ParameterAttribute]
+                    public string [|Title|] { get; set; }
+                }
+                """;
+
+        await VerifyNavigatePositionAsync(content, "Title");
+    }
+
+    [Fact]
+    public async Task GetNavigatePositionAsync_TagHelperProperty_IgnoreInnerProperty()
+    {
+        var content = """
+                <div>@Title</div>
+
+                @code
+                {
+                    private class NotTheDroidsYoureLookingFor
+                    {
+                        public string Title { get; set; }
+                    }
+
+                    public string [|Title|] { get; set; }
+                }
+                """;
+
+        await VerifyNavigatePositionAsync(content, "Title");
+    }
+
     #region Helpers
-    private async Task VerifyOriginTagHelperBindingAsync(string content, string tagHelperDescriptorName = null, bool isRazorFile = true)
+    private async Task VerifyOriginTagHelperBindingAsync(string content, string tagHelperDescriptorName = null, string attributeDescriptorPropertyName = null, bool isRazorFile = true, bool ignoreAttributes = false)
     {
         TestFileMarkupParser.GetPosition(content, out content, out var position);
 
         SetupDocument(out _, out var documentSnapshot, content, isRazorFile);
         var documentContext = CreateDocumentContext(new Uri(@"C:\file.razor"), documentSnapshot);
 
-        var descriptor = await DefinitionEndpoint.GetOriginTagHelperBindingAsync(documentContext, position, LoggerFactory.CreateLogger("RazorDefinitionEndpoint"), DisposalToken);
+        var (descriptor, attributeDescriptor) = await DefinitionEndpoint.GetOriginTagHelperBindingAsync(
+            documentContext, position, ignoreAttributes, LoggerFactory.CreateLogger("RazorDefinitionEndpoint"), DisposalToken);
 
         if (tagHelperDescriptorName is null)
         {
@@ -210,6 +382,30 @@ public class DefinitionEndpointTest : TagHelperServiceTestBase
             Assert.NotNull(descriptor);
             Assert.Equal(tagHelperDescriptorName, descriptor!.Name);
         }
+
+        if (attributeDescriptorPropertyName is null)
+        {
+            Assert.Null(attributeDescriptor);
+        }
+        else
+        {
+            Assert.NotNull(attributeDescriptor);
+            Assert.Equal(attributeDescriptorPropertyName, attributeDescriptor.GetPropertyName());
+        }
+    }
+
+    private async Task VerifyNavigatePositionAsync(string content, string propertyName)
+    {
+        TestFileMarkupParser.GetSpan(content, out content, out var selection);
+
+        SetupDocument(out var codeDocument, out _, content);
+        var expectedRange = selection.AsRange(codeDocument.GetSourceText());
+
+        var mappingService = new DefaultRazorDocumentMappingService(TestLanguageServerFeatureOptions.Instance, new TestDocumentContextFactory(), LoggerFactory);
+
+        var range = await DefinitionEndpoint.TryGetPropertyRangeAsync(codeDocument, propertyName, mappingService, Logger, DisposalToken);
+        Assert.NotNull(range);
+        Assert.Equal(expectedRange, range);
     }
 
     private void SetupDocument(out RazorCodeDocument codeDocument, out IDocumentSnapshot documentSnapshot, string content, bool isRazorFile = true)


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/8624

I broke Go To Def and Hover by making it smarter, but the smartness only works if we are delegating to other servers from ours, which is not always true. This restores the previous behaviour in those cases (ie, when single server is off)