### PR TITLE
Don't create a task scheduler if the project doesn't exist

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace/RazorWorkspaceListener.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace/RazorWorkspaceListener.cs
@@ -37,6 +37,14 @@ public class RazorWorkspaceListener : IDisposable
 
     public void NotifyDynamicFile(ProjectId projectId)
     {
+        // Since there is no "un-notify" API to indicate that callers no longer care about a project, it's entirely
+        // possible that by the time we get notified, a project might have been removed from the workspace. Whilst
+        // that wouldn't cause any issues we may as well avoid creating a task scheduler.
+        if (_workspace is null || !_workspace.CurrentSolution.ContainsProject(projectId))
+        {
+            return;
+        }
+
         // We expect this to be called multiple times per project so a no-op update operation seems like a better choice
         // than constructing a new TaskDelayScheduler each time, and using the TryAdd method, which doesn't support a
         // valueFactory argument.


### PR DESCRIPTION
Found this on my machine. Seems like a good change. I guess I missed committing it last time 🤷‍♂️

Unlikely to be hit in real life anywhere, so I don't think its too important :)