### PR TITLE
Include the missing deps as analyzer references

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/source.extension.vsixmanifest
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/source.extension.vsixmanifest
@@ -82,5 +82,7 @@
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Microsoft.CodeAnalysis.Razor.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Microsoft.AspNetCore.Mvc.Razor.Extensions.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Microsoft.AspNetCore.Razor.Language.dll" />
+    <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Microsoft.Extensions.ObjectPool.dll" />
+    <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Microsoft.AspNetCore.Razor.Utilities.Shared.dll" />
   </Assets>
 </PackageManifest>


### PR DESCRIPTION
Roslyn has special logic to replace the razor SDK generator with the one from the VSIX. However we get the list of assemblies to replace from the VSIX, and we weren't listing the dependencies as analyzers. 

In the main process these assemblies are present by virtue of the tooling being loaded. In the OOP scenario, we only load the ones listed from the main process, and so they never get loaded. 