### PR TITLE
Small improvements to MetadataCollection

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptorBuilder.cs
@@ -55,7 +55,7 @@ internal partial class DefaultBoundAttributeDescriptorBuilder : BoundAttributeDe
     [AllowNull]
     private string _kind;
     private List<DefaultBoundAttributeParameterDescriptorBuilder>? _attributeParameterBuilders;
-    private Dictionary<string, string>? _metadata;
+    private Dictionary<string, string?>? _metadata;
     private RazorDiagnosticCollection? _diagnostics;
 
     private DefaultBoundAttributeDescriptorBuilder()
@@ -77,7 +77,7 @@ internal partial class DefaultBoundAttributeDescriptorBuilder : BoundAttributeDe
     public override string? Documentation { get; set; }
     public override string? DisplayName { get; set; }
 
-    public override IDictionary<string, string> Metadata => _metadata ??= new Dictionary<string, string>();
+    public override IDictionary<string, string?> Metadata => _metadata ??= new Dictionary<string, string?>();
 
     public override RazorDiagnosticCollection Diagnostics => _diagnostics ??= new RazorDiagnosticCollection();
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeParameterDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeParameterDescriptorBuilder.cs
@@ -30,7 +30,7 @@ internal partial class DefaultBoundAttributeParameterDescriptorBuilder : BoundAt
     private DefaultBoundAttributeDescriptorBuilder _parent;
     [AllowNull]
     private string _kind;
-    private Dictionary<string, string>? _metadata;
+    private Dictionary<string, string?>? _metadata;
 
     private RazorDiagnosticCollection? _diagnostics;
 
@@ -50,7 +50,7 @@ internal partial class DefaultBoundAttributeParameterDescriptorBuilder : BoundAt
     public override string? Documentation { get; set; }
     public override string? DisplayName { get; set; }
 
-    public override IDictionary<string, string> Metadata => _metadata ??= new Dictionary<string, string>();
+    public override IDictionary<string, string?> Metadata => _metadata ??= new Dictionary<string, string?>();
 
     public override RazorDiagnosticCollection Diagnostics => _diagnostics ??= new RazorDiagnosticCollection();
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRequiredAttributeDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRequiredAttributeDescriptorBuilder.cs
@@ -29,7 +29,7 @@ internal partial class DefaultRequiredAttributeDescriptorBuilder : RequiredAttri
     [AllowNull]
     private DefaultTagMatchingRuleDescriptorBuilder _parent;
     private RazorDiagnosticCollection? _diagnostics;
-    private Dictionary<string, string>? _metadata;
+    private Dictionary<string, string?>? _metadata;
 
     private DefaultRequiredAttributeDescriptorBuilder()
     {
@@ -47,7 +47,7 @@ internal partial class DefaultRequiredAttributeDescriptorBuilder : RequiredAttri
 
     public override RazorDiagnosticCollection Diagnostics => _diagnostics ??= new RazorDiagnosticCollection();
 
-    public override IDictionary<string, string> Metadata => _metadata ??= new Dictionary<string, string>();
+    public override IDictionary<string, string?> Metadata => _metadata ??= new Dictionary<string, string?>();
 
     internal bool CaseSensitive => _parent.CaseSensitive;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.cs
@@ -49,11 +49,11 @@ internal partial class DefaultTagHelperDescriptorBuilder : TagHelperDescriptorBu
     private List<DefaultBoundAttributeDescriptorBuilder>? _attributeBuilders;
     private List<DefaultTagMatchingRuleDescriptorBuilder>? _tagMatchingRuleBuilders;
     private RazorDiagnosticCollection? _diagnostics;
-    private readonly Dictionary<string, string> _metadata;
+    private readonly Dictionary<string, string?> _metadata;
 
     private DefaultTagHelperDescriptorBuilder()
     {
-        _metadata = new Dictionary<string, string>(StringComparer.Ordinal);
+        _metadata = new Dictionary<string, string?>(StringComparer.Ordinal);
     }
 
     public DefaultTagHelperDescriptorBuilder(string kind, string name, string assemblyName)
@@ -74,7 +74,7 @@ internal partial class DefaultTagHelperDescriptorBuilder : TagHelperDescriptorBu
     public override bool CaseSensitive { get; set; }
     public override string? Documentation { get; set; }
 
-    public override IDictionary<string, string> Metadata => _metadata;
+    public override IDictionary<string, string?> Metadata => _metadata;
     public override RazorDiagnosticCollection Diagnostics => _diagnostics ??= new RazorDiagnosticCollection();
 
     public override IReadOnlyList<AllowedChildTagDescriptorBuilder> AllowedChildTags

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/MetadataCollection.Enumerator.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/MetadataCollection.Enumerator.cs
@@ -1,0 +1,51 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.Language;
+
+internal abstract partial class MetadataCollection
+{
+    public struct Enumerator : IEnumerator<KeyValuePair<string, string?>>
+    {
+        private readonly MetadataCollection _collection;
+        private int _index;
+        private KeyValuePair<string, string?> _current;
+
+        internal Enumerator(MetadataCollection collection)
+        {
+            _collection = collection;
+            _index = 0;
+            _current = default;
+        }
+
+        public readonly KeyValuePair<string, string?> Current => _current;
+
+        readonly object IEnumerator.Current => Current;
+
+        public bool MoveNext()
+        {
+            var collection = _collection;
+            if (_index < collection.Count)
+            {
+                _current = _collection.GetEntry(_index);
+                _index++;
+                return true;
+            }
+
+            return false;
+        }
+
+        public void Reset()
+        {
+            _index = 0;
+            _current = default;
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/MetadataCollectionTests.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/MetadataCollectionTests.cs
@@ -23,14 +23,14 @@ public class MetadataCollectionTests
     [InlineData(64)]
     public void CreateAndCompareCollections(int size)
     {
-        var pairs = new List<KeyValuePair<string, string>>();
+        var pairs = new List<KeyValuePair<string, string?>>();
 
         for (var i = 0; i < size; i++)
         {
             var key = i.ToString(CultureInfo.InvariantCulture);
             var value = (int.MaxValue - i).ToString(CultureInfo.InvariantCulture);
 
-            pairs.Add(new KeyValuePair<string, string>(key, value));
+            pairs.Add(new(key, value));
         }
 
         var collection1 = MetadataCollection.Create(pairs.ToArray());
@@ -48,13 +48,70 @@ public class MetadataCollectionTests
         }
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(8)]
+    [InlineData(16)]
+    [InlineData(32)]
+    [InlineData(64)]
+    public void EnumeratorReturnsAllItemsInCollection(int size)
+    {
+        var pairs = new List<KeyValuePair<string, string?>>();
+        var map = new Dictionary<string, bool>();
+
+        for (var i = 0; i < size; i++)
+        {
+            var key = i.ToString(CultureInfo.InvariantCulture);
+            var value = (int.MaxValue - i).ToString(CultureInfo.InvariantCulture);
+
+            pairs.Add(new(key, value));
+            map.Add(key, false);
+        }
+
+        Assert.True(map.All(kvp => kvp.Value == false));
+
+        var collection = MetadataCollection.Create(pairs);
+
+        foreach (var (key, _) in collection)
+        {
+            map[key] = true;
+        }
+
+        Assert.True(map.All(kvp => kvp.Value == true));
+
+        var enumerator = collection.GetEnumerator();
+
+        while (enumerator.MoveNext())
+        {
+            var (key, _) = enumerator.Current;
+            map[key] = false;
+        }
+
+        Assert.True(map.All(kvp => kvp.Value == false));
+
+        // Verify that reset works.
+        enumerator.Reset();
+
+        while (enumerator.MoveNext())
+        {
+            var (key, _) = enumerator.Current;
+            map[key] = true;
+        }
+
+        Assert.True(map.All(kvp => kvp.Value == true));
+    }
+
     [Fact]
     public void CreateThrowsOnDuplicateKeys()
     {
-        var one = new KeyValuePair<string, string>("Key1", "Value1");
-        var two = new KeyValuePair<string, string>("Key2", "Value2");
-        var three = new KeyValuePair<string, string>("Key3", "Value3");
-        var four = new KeyValuePair<string, string>("Key4", "Value4");
+        var one = new KeyValuePair<string, string?>("Key1", "Value1");
+        var two = new KeyValuePair<string, string?>("Key2", "Value2");
+        var three = new KeyValuePair<string, string?>("Key3", "Value3");
+        var four = new KeyValuePair<string, string?>("Key4", "Value4");
 
         Assert.Throws<ArgumentException>(() => MetadataCollection.Create(one, one));
         Assert.Throws<ArgumentException>(() => MetadataCollection.Create(new[] { one, one }));
@@ -64,7 +121,7 @@ public class MetadataCollectionTests
         Assert.Throws<ArgumentException>(() => MetadataCollection.Create(one, three, three));
         Assert.Throws<ArgumentException>(() => MetadataCollection.Create(new[] { one, three, three }));
         Assert.Throws<ArgumentException>(() => MetadataCollection.Create(one, two, one));
-        Assert.Throws<ArgumentException>(() => MetadataCollection.Create(new[] { one, two, one}));
+        Assert.Throws<ArgumentException>(() => MetadataCollection.Create(new[] { one, two, one }));
 
         Assert.Throws<ArgumentException>(() => MetadataCollection.Create(one, one, three, four));
         Assert.Throws<ArgumentException>(() => MetadataCollection.Create(new[] { one, one, three, four }));
@@ -83,10 +140,10 @@ public class MetadataCollectionTests
     [Fact]
     public void HashCodesAreSameRegardlessOfOrdering()
     {
-        var one = new KeyValuePair<string, string>("Key1", "Value1");
-        var two = new KeyValuePair<string, string>("Key2", "Value2");
-        var three = new KeyValuePair<string, string>("Key3", "Value3");
-        var four = new KeyValuePair<string, string>("Key4", "Value4");
+        var one = new KeyValuePair<string, string?>("Key1", "Value1");
+        var two = new KeyValuePair<string, string?>("Key2", "Value2");
+        var three = new KeyValuePair<string, string?>("Key3", "Value3");
+        var four = new KeyValuePair<string, string?>("Key4", "Value4");
 
         Assert.Equal(
             MetadataCollection.Create(one, two).GetHashCode(),


### PR DESCRIPTION
This change corrects the nullability annotations for `MetadataCollection`, since it there are cases where tag helper metadata can have null values. In addition, I've added a struct-based enumerator, which will be used in future work to avoid allocations when iterating metadata.