### PR TITLE
Allow for clients that always want to generate code all the time

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorDiagnosticsBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorDiagnosticsBenchmark.cs
@@ -192,6 +192,8 @@ public class RazorDiagnosticsBenchmark : RazorLanguageServerBenchmarkBase
 
         public override bool SupportsDelegatedDiagnostics => false;
 
+        public override bool UpdateBuffersForClosedDocuments => false;
+
         // Code action and rename paths in Windows VS Code need to be prefixed with '/':
         // https://github.com/dotnet/razor/issues/8131
         public override bool ReturnCodeActionAndRenamePathsWithPrefixedSlash

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/DefaultLanguageServerFeatureOptions.cs
@@ -25,6 +25,8 @@ internal class DefaultLanguageServerFeatureOptions : LanguageServerFeatureOption
 
     public override bool SupportsDelegatedDiagnostics => false;
 
+    public override bool UpdateBuffersForClosedDocuments => false;
+
     // Code action and rename paths in Windows VS Code need to be prefixed with '/':
     // https://github.com/dotnet/razor/issues/8131
     public override bool ReturnCodeActionAndRenamePathsWithPrefixedSlash

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ConfigurableLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ConfigurableLanguageServerFeatureOptions.cs
@@ -22,6 +22,7 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
     private readonly bool? _supportsDelegatedDiagnostics;
     private readonly bool? _returnCodeActionAndRenamePathsWithPrefixedSlash;
     private readonly bool? _showAllCSharpCodeActions;
+    private readonly bool? _updateBuffersForClosedDocuments;
 
     public override bool SupportsFileManipulation => _supportsFileManipulation ?? _defaults.SupportsFileManipulation;
     public override string ProjectConfigurationFileName => _projectConfigurationFileName ?? _defaults.ProjectConfigurationFileName;
@@ -33,6 +34,7 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
     public override bool SupportsDelegatedDiagnostics => _supportsDelegatedDiagnostics ?? _defaults.SupportsDelegatedDiagnostics;
     public override bool ReturnCodeActionAndRenamePathsWithPrefixedSlash => _returnCodeActionAndRenamePathsWithPrefixedSlash ?? _defaults.ReturnCodeActionAndRenamePathsWithPrefixedSlash;
     public override bool ShowAllCSharpCodeActions => _showAllCSharpCodeActions ?? _defaults.ShowAllCSharpCodeActions;
+    public override bool UpdateBuffersForClosedDocuments => _updateBuffersForClosedDocuments ?? _defaults.UpdateBuffersForClosedDocuments;
 
     public ConfigurableLanguageServerFeatureOptions(string[] args)
     {
@@ -53,6 +55,7 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
             TryProcessBoolOption(nameof(SupportsDelegatedDiagnostics), ref _supportsDelegatedDiagnostics, option, args, i);
             TryProcessBoolOption(nameof(ReturnCodeActionAndRenamePathsWithPrefixedSlash), ref _returnCodeActionAndRenamePathsWithPrefixedSlash, option, args, i);
             TryProcessBoolOption(nameof(ShowAllCSharpCodeActions), ref _showAllCSharpCodeActions, option, args, i);
+            TryProcessBoolOption(nameof(UpdateBuffersForClosedDocuments), ref _updateBuffersForClosedDocuments, option, args, i);
         }
     }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
@@ -25,6 +25,8 @@ internal abstract class LanguageServerFeatureOptions
 
     public abstract bool ShowAllCSharpCodeActions { get; }
 
+    public abstract bool UpdateBuffersForClosedDocuments { get; }
+
     // Code action and rename paths in Windows VS Code need to be prefixed with '/':
     // https://github.com/dotnet/razor/issues/8131
     public abstract bool ReturnCodeActionAndRenamePathsWithPrefixedSlash { get; }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
@@ -73,6 +73,8 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
 
     public override bool ReturnCodeActionAndRenamePathsWithPrefixedSlash => false;
 
+    public override bool UpdateBuffersForClosedDocuments => false;
+
     private bool IsCodespacesOrLiveshare => _lspEditorFeatureDetector.IsRemoteClient() || _lspEditorFeatureDetector.IsLiveShareHost();
 
     public override bool ShowAllCSharpCodeActions => _showAllCSharpCodeActions.Value;

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacLanguageServerFeatureOptions.cs
@@ -45,6 +45,8 @@ internal class VisualStudioMacLanguageServerFeatureOptions : LanguageServerFeatu
 
     public override bool ReturnCodeActionAndRenamePathsWithPrefixedSlash => false;
 
+    public override bool UpdateBuffersForClosedDocuments => false;
+
     private bool IsCodespacesOrLiveshare => _lspEditorFeatureDetector.IsRemoteClient() || _lspEditorFeatureDetector.IsLiveShareHost();
 
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultGeneratedDocumentPublisherTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultGeneratedDocumentPublisherTest.cs
@@ -34,7 +34,7 @@ public class DefaultGeneratedDocumentPublisherTest : LanguageServerTestBase
     public void PublishCSharp_FirstTime_PublishesEntireSourceText()
     {
         // Arrange
-        var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, LoggerFactory);
+        var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         var content = "// C# content";
         var sourceText = SourceText.From(content);
 
@@ -53,7 +53,7 @@ public class DefaultGeneratedDocumentPublisherTest : LanguageServerTestBase
     public void PublishHtml_FirstTime_PublishesEntireSourceText()
     {
         // Arrange
-        var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, LoggerFactory);
+        var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         var content = "HTML content";
         var sourceText = SourceText.From(content);
 
@@ -72,7 +72,7 @@ public class DefaultGeneratedDocumentPublisherTest : LanguageServerTestBase
     public void PublishCSharp_SecondTime_PublishesSourceTextDifferences()
     {
         // Arrange
-        var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, LoggerFactory);
+        var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         var initialSourceText = SourceText.From("// Initial content\n");
         generatedDocumentPublisher.PublishCSharp("/path/to/file.razor", initialSourceText, 123);
         var change = new TextChange(
@@ -96,7 +96,7 @@ public class DefaultGeneratedDocumentPublisherTest : LanguageServerTestBase
     public void PublishHtml_SecondTime_PublishesSourceTextDifferences()
     {
         // Arrange
-        var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, LoggerFactory);
+        var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         var initialSourceText = SourceText.From("HTML content\n");
         generatedDocumentPublisher.PublishHtml("/path/to/file.razor", initialSourceText, 123);
         var change = new TextChange(
@@ -120,7 +120,7 @@ public class DefaultGeneratedDocumentPublisherTest : LanguageServerTestBase
     public void PublishCSharp_SecondTime_IdenticalContent_NoTextChanges()
     {
         // Arrange
-        var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, LoggerFactory);
+        var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         var sourceTextContent = "// The content";
         var initialSourceText = SourceText.From(sourceTextContent);
         generatedDocumentPublisher.PublishCSharp("/path/to/file.razor", initialSourceText, 123);
@@ -141,7 +141,7 @@ public class DefaultGeneratedDocumentPublisherTest : LanguageServerTestBase
     public void PublishHtml_SecondTime_IdenticalContent_NoTextChanges()
     {
         // Arrange
-        var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, LoggerFactory);
+        var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         var sourceTextContent = "HTMl content";
         var initialSourceText = SourceText.From(sourceTextContent);
         generatedDocumentPublisher.PublishHtml("/path/to/file.razor", initialSourceText, 123);
@@ -162,7 +162,7 @@ public class DefaultGeneratedDocumentPublisherTest : LanguageServerTestBase
     public void PublishCSharp_DifferentFileSameContent_PublishesEverything()
     {
         // Arrange
-        var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, LoggerFactory);
+        var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         var sourceTextContent = "// The content";
         var initialSourceText = SourceText.From(sourceTextContent);
         generatedDocumentPublisher.PublishCSharp("/path/to/file1.razor", initialSourceText, 123);
@@ -184,7 +184,7 @@ public class DefaultGeneratedDocumentPublisherTest : LanguageServerTestBase
     public void PublishHtml_DifferentFileSameContent_PublishesEverything()
     {
         // Arrange
-        var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, LoggerFactory);
+        var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         var sourceTextContent = "HTML content";
         var initialSourceText = SourceText.From(sourceTextContent);
         generatedDocumentPublisher.PublishHtml("/path/to/file1.razor", initialSourceText, 123);
@@ -206,7 +206,7 @@ public class DefaultGeneratedDocumentPublisherTest : LanguageServerTestBase
     public void ProjectSnapshotManager_DocumentChanged_OpenDocument_PublishesEmptyTextChanges_CSharp()
     {
         // Arrange
-        var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, LoggerFactory);
+        var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         generatedDocumentPublisher.Initialize(_projectManager);
         var sourceTextContent = "// The content";
         var initialSourceText = SourceText.From(sourceTextContent);
@@ -228,7 +228,7 @@ public class DefaultGeneratedDocumentPublisherTest : LanguageServerTestBase
     public void ProjectSnapshotManager_DocumentChanged_OpenDocument_VersionEquivalent_Noops_CSharp()
     {
         // Arrange
-        var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, LoggerFactory);
+        var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         generatedDocumentPublisher.Initialize(_projectManager);
         var sourceTextContent = "// The content";
         var initialSourceText = SourceText.From(sourceTextContent);
@@ -248,7 +248,7 @@ public class DefaultGeneratedDocumentPublisherTest : LanguageServerTestBase
     public void ProjectSnapshotManager_DocumentChanged_OpenDocument_PublishesEmptyTextChanges_Html()
     {
         // Arrange
-        var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, LoggerFactory);
+        var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         generatedDocumentPublisher.Initialize(_projectManager);
         var sourceTextContent = "<!-- The content -->";
         var initialSourceText = SourceText.From(sourceTextContent);
@@ -270,7 +270,7 @@ public class DefaultGeneratedDocumentPublisherTest : LanguageServerTestBase
     public void ProjectSnapshotManager_DocumentChanged_OpenDocument_VersionEquivalent_Noops_Html()
     {
         // Arrange
-        var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, LoggerFactory);
+        var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         generatedDocumentPublisher.Initialize(_projectManager);
         var sourceTextContent = "<!-- The content -->";
         var initialSourceText = SourceText.From(sourceTextContent);
@@ -290,7 +290,7 @@ public class DefaultGeneratedDocumentPublisherTest : LanguageServerTestBase
     public void ProjectSnapshotManager_DocumentChanged_ClosedDocument_RepublishesTextChanges()
     {
         // Arrange
-        var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, LoggerFactory);
+        var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         generatedDocumentPublisher.Initialize(_projectManager);
         var sourceTextContent = "// The content";
         var initialSourceText = SourceText.From(sourceTextContent);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/OpenDocumentGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/OpenDocumentGeneratorTest.cs
@@ -173,7 +173,7 @@ public class OpenDocumentGeneratorTest : LanguageServerTestBase
             ProjectSnapshotManagerDispatcher dispatcher,
             IErrorReporter errorReporter,
             params DocumentProcessedListener[] listeners)
-            : base(listeners, dispatcher, errorReporter)
+            : base(listeners, dispatcher, TestLanguageServerFeatureOptions.Instance, errorReporter)
         {
         }
     }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common/TestLanguageServerFeatureOptions.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common/TestLanguageServerFeatureOptions.cs
@@ -32,4 +32,6 @@ internal class TestLanguageServerFeatureOptions : LanguageServerFeatureOptions
     public override bool ReturnCodeActionAndRenamePathsWithPrefixedSlash => false;
 
     public override bool ShowAllCSharpCodeActions => false;
+
+    public override bool UpdateBuffersForClosedDocuments => false;
 }


### PR DESCRIPTION
Right now we monitor for .razor files being open and closed, and we stop generating and pushing code for closed documents. Sometimes this is problematic because we end up sending didChange notifications based on our understanding of things (document is going from empty to not), but the receiving end, if it holds documents open, will see document content being duplicated.