### PR TITLE
Use CorrelationId to track Sub-LSP call duration for Diagnostics

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/DocumentPullDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/DocumentPullDiagnosticsEndpoint.cs
@@ -57,13 +57,13 @@ internal class DocumentPullDiagnosticsEndpoint : IRazorRequestHandler<VSInternal
 
     public async Task<IEnumerable<VSInternalDiagnosticReport>?> HandleRequestAsync(VSInternalDocumentDiagnosticsParams request, RazorRequestContext context, CancellationToken cancellationToken)
     {
+        if (!_languageServerFeatureOptions.SingleServerSupport)
+        {
+            return default;
+        }
+
         using (Track("diagnostics"))
         {
-            if (!_languageServerFeatureOptions.SingleServerSupport)
-            {
-                return default;
-            }
-
             var documentContext = context.GetRequiredDocumentContext();
 
             var razorDiagnostics = await GetRazorDiagnosticsAsync(documentContext, cancellationToken).ConfigureAwait(false);
@@ -114,7 +114,7 @@ internal class DocumentPullDiagnosticsEndpoint : IRazorRequestHandler<VSInternal
         }
     }
 
-    private IDisposable? Track(string name, Guid guid)
+    private IDisposable? Track(string name)
     {
         return _telemetryReporter.BeginBlock(name, Severity.Normal, ImmutableDictionary.CreateRange(new KeyValuePair<string, object?>[]
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/DocumentPullDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/DocumentPullDiagnosticsEndpoint.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
@@ -10,6 +11,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.AspNetCore.Razor.PooledObjects;
+using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -22,15 +24,18 @@ internal class DocumentPullDiagnosticsEndpoint : IRazorRequestHandler<VSInternal
     private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
     private readonly ClientNotifierServiceBase _languageServer;
     private readonly RazorTranslateDiagnosticsService _translateDiagnosticsService;
+    private readonly ITelemetryReporter _telemetryReporter;
 
     public DocumentPullDiagnosticsEndpoint(
         LanguageServerFeatureOptions languageServerFeatureOptions,
         RazorTranslateDiagnosticsService translateDiagnosticsService,
-        ClientNotifierServiceBase languageServer)
+        ClientNotifierServiceBase languageServer,
+        ITelemetryReporter telemetryReporter)
     {
         _languageServerFeatureOptions = languageServerFeatureOptions ?? throw new ArgumentNullException(nameof(languageServerFeatureOptions));
         _translateDiagnosticsService = translateDiagnosticsService ?? throw new ArgumentNullException(nameof(translateDiagnosticsService));
         _languageServer = languageServer ?? throw new ArgumentNullException(nameof(languageServer));
+        _telemetryReporter = telemetryReporter ?? throw new ArgumentNullException(nameof(telemetryReporter));
     }
 
     public bool MutatesSolutionState => false;
@@ -52,58 +57,71 @@ internal class DocumentPullDiagnosticsEndpoint : IRazorRequestHandler<VSInternal
 
     public async Task<IEnumerable<VSInternalDiagnosticReport>?> HandleRequestAsync(VSInternalDocumentDiagnosticsParams request, RazorRequestContext context, CancellationToken cancellationToken)
     {
-        if (!_languageServerFeatureOptions.SingleServerSupport)
+        using (Track("diagnostics"))
         {
-            return default;
-        }
-
-        var documentContext = context.GetRequiredDocumentContext();
-
-        var razorDiagnostics = await GetRazorDiagnosticsAsync(documentContext, cancellationToken).ConfigureAwait(false);
-
-        var (csharpDiagnostics, htmlDiagnostics) = await GetHtmlCSharpDiagnosticsAsync(documentContext, cancellationToken).ConfigureAwait(false);
-
-        using var _ = ListPool<VSInternalDiagnosticReport>.GetPooledObject(out var allDiagnostics);
-        allDiagnostics.SetCapacityIfLarger(
-            (razorDiagnostics?.Length ?? 0) +
-            (csharpDiagnostics?.Length ?? 0) +
-            (htmlDiagnostics?.Length ?? 0));
-
-        if (razorDiagnostics is not null)
-        {
-            // No extra work to do for Razor diagnostics
-            allDiagnostics.AddRange(razorDiagnostics);
-        }
-
-        if (csharpDiagnostics is not null)
-        {
-            foreach (var report in csharpDiagnostics)
+            if (!_languageServerFeatureOptions.SingleServerSupport)
             {
-                if (report.Diagnostics is not null)
-                {
-                    var mappedDiagnostics = await _translateDiagnosticsService.TranslateAsync(RazorLanguageKind.CSharp, report.Diagnostics, documentContext, cancellationToken);
-                    report.Diagnostics = mappedDiagnostics;
-                }
-
-                allDiagnostics.Add(report);
+                return default;
             }
-        }
 
-        if (htmlDiagnostics is not null)
-        {
-            foreach (var report in htmlDiagnostics)
+            var documentContext = context.GetRequiredDocumentContext();
+
+            var razorDiagnostics = await GetRazorDiagnosticsAsync(documentContext, cancellationToken).ConfigureAwait(false);
+
+            var (csharpDiagnostics, htmlDiagnostics) = await GetHtmlCSharpDiagnosticsAsync(documentContext, cancellationToken).ConfigureAwait(false);
+
+            using var _ = ListPool<VSInternalDiagnosticReport>.GetPooledObject(out var allDiagnostics);
+            allDiagnostics.SetCapacityIfLarger(
+                (razorDiagnostics?.Length ?? 0) +
+                (csharpDiagnostics?.Length ?? 0) +
+                (htmlDiagnostics?.Length ?? 0));
+
+            if (razorDiagnostics is not null)
             {
-                if (report.Diagnostics is not null)
-                {
-                    var mappedDiagnostics = await _translateDiagnosticsService.TranslateAsync(RazorLanguageKind.Html, report.Diagnostics, documentContext, cancellationToken);
-                    report.Diagnostics = mappedDiagnostics;
-                }
-
-                allDiagnostics.Add(report);
+                // No extra work to do for Razor diagnostics
+                allDiagnostics.AddRange(razorDiagnostics);
             }
-        }
 
-        return allDiagnostics.ToArray();
+            if (csharpDiagnostics is not null)
+            {
+                foreach (var report in csharpDiagnostics)
+                {
+                    if (report.Diagnostics is not null)
+                    {
+                        var mappedDiagnostics = await _translateDiagnosticsService.TranslateAsync(RazorLanguageKind.CSharp, report.Diagnostics, documentContext, cancellationToken);
+                        report.Diagnostics = mappedDiagnostics;
+                    }
+
+                    allDiagnostics.Add(report);
+                }
+            }
+
+            if (htmlDiagnostics is not null)
+            {
+                foreach (var report in htmlDiagnostics)
+                {
+                    if (report.Diagnostics is not null)
+                    {
+                        var mappedDiagnostics = await _translateDiagnosticsService.TranslateAsync(RazorLanguageKind.Html, report.Diagnostics, documentContext, cancellationToken);
+                        report.Diagnostics = mappedDiagnostics;
+                    }
+
+                    allDiagnostics.Add(report);
+                }
+            }
+
+            return allDiagnostics.ToArray();
+        }
+    }
+
+    private IDisposable? Track(string name, Guid guid)
+    {
+        return _telemetryReporter.BeginBlock(name, Severity.Normal, ImmutableDictionary.CreateRange(new KeyValuePair<string, object?>[]
+        {
+            new("eventscope.method", "textdocument/_vs_diagnostic"),
+            new("eventscope.languageservername", "Razor Language Server"),
+            new("eventscope.activityid", System.Diagnostics.Trace.CorrelationManager.ActivityId),
+        }));
     }
 
     private static async Task<VSInternalDiagnosticReport[]?> GetRazorDiagnosticsAsync(VersionedDocumentContext documentContext, CancellationToken cancellationToken)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/TelemetryReportingLSPRequestInvoker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/TelemetryReportingLSPRequestInvoker.cs
@@ -12,6 +12,7 @@ using Microsoft.VisualStudio.Text;
 using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Newtonsoft.Json.Linq;
+using System.Diagnostics;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor;
 
@@ -84,6 +85,7 @@ internal class TelemetryReportingLSPRequestInvoker : LSPRequestInvoker
         {
             new("eventscope.method", method),
             new("eventscope.languageservername", languageServerName),
+            new("eventscope.activityid", Trace.CorrelationManager.ActivityId),
         }));
     }
 }


### PR DESCRIPTION
Includes a context ID with the sub LSP call to help correlate the calls that are for the same main LSP request (e.g. for diagnostics we may send sub LSP call for both html and c# LSP server and this way we can associate them together using this id).

/cc @ryzngard 
