### PR TITLE
Make our logs a bit nicer

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LoggerAdapter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LoggerAdapter.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.AspNetCore.Razor.Telemetry;
@@ -17,11 +18,13 @@ public class LoggerAdapter : IRazorLogger
 {
     private readonly IEnumerable<ILogger> _loggers;
     private readonly ITelemetryReporter? _telemetryReporter;
+    private readonly TraceSource? _traceSource;
 
-    public LoggerAdapter(IEnumerable<ILogger> loggers, ITelemetryReporter? telemetryReporter)
+    public LoggerAdapter(IEnumerable<ILogger> loggers, ITelemetryReporter? telemetryReporter, TraceSource? traceSource = null)
     {
         _loggers = loggers;
         _telemetryReporter = telemetryReporter;
+        _traceSource = traceSource;
     }
 
     public IDisposable BeginScope<TState>(TState state)
@@ -52,9 +55,26 @@ public class LoggerAdapter : IRazorLogger
         }
     }
 
+    public void LogStartContext(string message, params object[] @params)
+    {
+        if (_traceSource != null)
+        {
+            // This should provide for a better activity name when looking at traces, rather than the
+            // random number we normally get.
+            _traceSource.TraceEvent(TraceEventType.Start, id: 0, message);
+        }
+
+        LogInformation("Start: {message}", message);
+    }
+
     public void LogEndContext(string message, params object[] @params)
     {
-        LogInformation("Exiting: {}", message);
+        LogInformation("Stop: {message}", message);
+
+        if (_traceSource != null)
+        {
+            _traceSource.TraceEvent(TraceEventType.Stop, id: 0, message);
+        }
     }
 
     public void LogError(string message, params object[] @params)
@@ -116,11 +136,6 @@ public class LoggerAdapter : IRazorLogger
                 logger.LogDebug(message, @params);
             }
         }
-    }
-
-    public void LogStartContext(string message, params object[] @params)
-    {
-        LogInformation("Entering: {}", message);
     }
 
     public void LogWarning(string message, params object[] @params)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServerWrapper.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServerWrapper.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common.Extensions;
@@ -41,9 +42,16 @@ internal sealed class RazorLanguageServerWrapper : IDisposable
         ProjectSnapshotManagerDispatcher? projectSnapshotManagerDispatcher = null,
         Action<IServiceCollection>? configure = null,
         LanguageServerFeatureOptions? featureOptions = null,
-        RazorLSPOptions? razorLSPOptions = null)
+        RazorLSPOptions? razorLSPOptions = null,
+        TraceSource? traceSource = null)
     {
         var jsonRpc = CreateJsonRpc(input, output);
+
+        // This ensures each request is a separate activity in loghub
+        jsonRpc.ActivityTracingStrategy = new CorrelationManagerTracingStrategy
+        {
+            TraceSource = traceSource
+        };
 
         var server = new RazorLanguageServer(
             jsonRpc,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorRequestContextFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorRequestContextFactory.cs
@@ -49,7 +49,6 @@ internal class RazorRequestContextFactory : IRequestContextFactory<RazorRequestC
         }
 
         var loggerAdapter = _lspServices.GetRequiredService<LoggerAdapter>();
-        loggerAdapter.LogDebug("Entering method {methodName}.", queueItem.MethodName);
 
         var requestContext = new RazorRequestContext(documentContext, loggerAdapter, _lspServices);
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
@@ -179,10 +179,10 @@ internal class RazorLanguageServerClient : ILanguageClient, ILanguageClientCusto
 
         // Initialize Logging Infrastructure
         _loggerProvider = (LogHubLoggerProvider)await _logHubLoggerProviderFactory.GetOrCreateAsync(LogFileIdentifier, token).ConfigureAwait(false);
-
+        var traceSource = _loggerProvider.GetTraceSource();
         var logHubLogger = _loggerProvider.CreateLogger("Razor");
         var loggers = _outputWindowLogger == null ? new ILogger[] { logHubLogger } : new ILogger[] { logHubLogger, _outputWindowLogger };
-        var razorLogger = new LoggerAdapter(loggers, _telemetryReporter);
+        var razorLogger = new LoggerAdapter(loggers, _telemetryReporter, traceSource);
         var lspOptions = RazorLSPOptions.From(_clientSettingsManager.GetClientSettings());
         _server = RazorLanguageServerWrapper.Create(
             serverStream,
@@ -192,7 +192,8 @@ internal class RazorLanguageServerClient : ILanguageClient, ILanguageClientCusto
             _projectSnapshotManagerDispatcher,
             ConfigureLanguageServer,
             _languageServerFeatureOptions,
-            lspOptions);
+            lspOptions,
+            traceSource);
 
         // This must not happen on an RPC endpoint due to UIThread concerns, so ActivateAsync was chosen.
         await EnsureContainedLanguageServersInitializedAsync();


### PR DESCRIPTION
Fixes #8704

Makes our loghub logs look like this:
<img width="659" alt="image" src="https://github.com/dotnet/razor/assets/754264/a93ec58c-4ea8-4c66-b171-0445c74b161e">

Each activity is essentially an LSP request, with log messages scoped within them. The "Activity" column on the left should have the LSP message as its value, but that doesn't seem to happen for local dev, so best I can do is hope this works when we get a feedback item. It also doesn't happen for Roslyn when doing local dev, but does in feedback items, so I'm hopeful 😬