### PR TITLE
Avoid computing tag helper documentation strings in compiler

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeDescriptor.cs
@@ -28,7 +28,7 @@ public abstract class BoundAttributeDescriptor : IEquatable<BoundAttributeDescri
     private const int CaseSensitiveBit = 1 << 10;
 
     private int _flags;
-    private object _documentationObject;
+    private DocumentationObject _documentationObject;
 
     private bool HasFlag(int flag) => (_flags & flag) != 0;
     private void SetFlag(int toSet) => ThreadSafeFlagOperations.Set(ref _flags, toSet);
@@ -94,21 +94,11 @@ public abstract class BoundAttributeDescriptor : IEquatable<BoundAttributeDescri
 
     public string Documentation
     {
-        get
-        {
-            return _documentationObject switch
-            {
-                string s => s,
-                DocumentationDescriptor d => d.GetText(),
-                null => null,
-                _ => throw new NotSupportedException()
-            };
-        }
-
-        protected set => _documentationObject = value;
+        get => _documentationObject.GetText();
+        protected set => _documentationObject = new(value);
     }
 
-    internal object DocumentationObject
+    internal DocumentationObject DocumentationObject
     {
         get => _documentationObject;
         set => _documentationObject = value;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeDescriptor.cs
@@ -28,6 +28,7 @@ public abstract class BoundAttributeDescriptor : IEquatable<BoundAttributeDescri
     private const int CaseSensitiveBit = 1 << 10;
 
     private int _flags;
+    private object _documentationObject;
 
     private bool HasFlag(int flag) => (_flags & flag) != 0;
     private void SetFlag(int toSet) => ThreadSafeFlagOperations.Set(ref _flags, toSet);
@@ -91,7 +92,27 @@ public abstract class BoundAttributeDescriptor : IEquatable<BoundAttributeDescri
         protected set => SetOrClearFlag(HasIndexerBit, value);
     }
 
-    public string Documentation { get; protected set; }
+    public string Documentation
+    {
+        get
+        {
+            return _documentationObject switch
+            {
+                string s => s,
+                DocumentationDescriptor d => d.GetText(),
+                null => null,
+                _ => throw new NotSupportedException()
+            };
+        }
+
+        protected set => _documentationObject = value;
+    }
+
+    internal object DocumentationObject
+    {
+        get => _documentationObject;
+        set => _documentationObject = value;
+    }
 
     public string DisplayName { get; protected set; }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeDescriptorBuilder.cs
@@ -37,4 +37,14 @@ public abstract class BoundAttributeDescriptorBuilder
     public virtual void BindAttributeParameter(Action<BoundAttributeParameterDescriptorBuilder> configure)
     {
     }
+
+    internal virtual void SetDocumentation(string text)
+    {
+        throw new NotImplementedException();
+    }
+
+    internal virtual void SetDocumentation(DocumentationDescriptor documentation)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeDescriptorComparer.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeDescriptorComparer.cs
@@ -44,8 +44,12 @@ internal sealed class BoundAttributeDescriptorComparer : IEqualityComparer<Bound
             descriptorX.IndexerNamePrefix != descriptorY.IndexerNamePrefix ||
             descriptorX.TypeName != descriptorY.TypeName ||
             descriptorX.IndexerTypeName != descriptorY.IndexerTypeName ||
-            descriptorX.Documentation != descriptorY.Documentation ||
             descriptorX.DisplayName != descriptorY.DisplayName)
+        {
+            return false;
+        }
+
+        if (!ComparerUtilities.AreDocumentationObjectsEqual(descriptorX.DocumentationObject, descriptorY.DocumentationObject))
         {
             return false;
         }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeDescriptorComparer.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeDescriptorComparer.cs
@@ -44,12 +44,8 @@ internal sealed class BoundAttributeDescriptorComparer : IEqualityComparer<Bound
             descriptorX.IndexerNamePrefix != descriptorY.IndexerNamePrefix ||
             descriptorX.TypeName != descriptorY.TypeName ||
             descriptorX.IndexerTypeName != descriptorY.IndexerTypeName ||
+            descriptorX.DocumentationObject != descriptorY.DocumentationObject ||
             descriptorX.DisplayName != descriptorY.DisplayName)
-        {
-            return false;
-        }
-
-        if (!ComparerUtilities.AreDocumentationObjectsEqual(descriptorX.DocumentationObject, descriptorY.DocumentationObject))
         {
             return false;
         }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeParameterDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeParameterDescriptor.cs
@@ -18,7 +18,7 @@ public abstract class BoundAttributeParameterDescriptor : IEquatable<BoundAttrib
     private const int CaseSensitiveBit = 1 << 4;
 
     private int _flags;
-    private object _documentationObject;
+    private DocumentationObject _documentationObject;
 
     private bool HasFlag(int flag) => (_flags & flag) != 0;
     private void SetFlag(int toSet) => ThreadSafeFlagOperations.Set(ref _flags, toSet);
@@ -56,21 +56,11 @@ public abstract class BoundAttributeParameterDescriptor : IEquatable<BoundAttrib
 
     public string Documentation
     {
-        get
-        {
-            return _documentationObject switch
-            {
-                string s => s,
-                DocumentationDescriptor d => d.GetText(),
-                null => null,
-                _ => throw new NotSupportedException()
-            };
-        }
-
-        protected set => _documentationObject = value;
+        get => _documentationObject.GetText();
+        protected set => _documentationObject = new(value);
     }
 
-    internal object DocumentationObject
+    internal DocumentationObject DocumentationObject
     {
         get => _documentationObject;
         set => _documentationObject = value;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeParameterDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeParameterDescriptor.cs
@@ -18,6 +18,7 @@ public abstract class BoundAttributeParameterDescriptor : IEquatable<BoundAttrib
     private const int CaseSensitiveBit = 1 << 4;
 
     private int _flags;
+    private object _documentationObject;
 
     private bool HasFlag(int flag) => (_flags & flag) != 0;
     private void SetFlag(int toSet) => ThreadSafeFlagOperations.Set(ref _flags, toSet);
@@ -53,7 +54,27 @@ public abstract class BoundAttributeParameterDescriptor : IEquatable<BoundAttrib
 
     public string TypeName { get; protected set; }
 
-    public string Documentation { get; protected set; }
+    public string Documentation
+    {
+        get
+        {
+            return _documentationObject switch
+            {
+                string s => s,
+                DocumentationDescriptor d => d.GetText(),
+                null => null,
+                _ => throw new NotSupportedException()
+            };
+        }
+
+        protected set => _documentationObject = value;
+    }
+
+    internal object DocumentationObject
+    {
+        get => _documentationObject;
+        set => _documentationObject = value;
+    }
 
     public string DisplayName { get; protected set; }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeParameterDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeParameterDescriptorBuilder.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.Razor.Language;
@@ -22,4 +23,14 @@ public abstract class BoundAttributeParameterDescriptorBuilder
     public abstract IDictionary<string, string> Metadata { get; }
 
     public abstract RazorDiagnosticCollection Diagnostics { get; }
+
+    internal virtual void SetDocumentation(string text)
+    {
+        throw new NotImplementedException();
+    }
+
+    internal virtual void SetDocumentation(DocumentationDescriptor documentation)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeParameterDescriptorComparer.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeParameterDescriptorComparer.cs
@@ -38,12 +38,8 @@ internal sealed class BoundAttributeParameterDescriptorComparer : IEqualityCompa
             descriptorX.IsEnum != descriptorY.IsEnum ||
             descriptorX.Name != descriptorY.Name ||
             descriptorX.TypeName != descriptorY.TypeName ||
+            descriptorX.DocumentationObject != descriptorY.DocumentationObject ||
             descriptorX.DisplayName != descriptorY.DisplayName)
-        {
-            return false;
-        }
-
-        if (!ComparerUtilities.AreDocumentationObjectsEqual(descriptorX.DocumentationObject, descriptorY.DocumentationObject))
         {
             return false;
         }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeParameterDescriptorComparer.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeParameterDescriptorComparer.cs
@@ -38,8 +38,12 @@ internal sealed class BoundAttributeParameterDescriptorComparer : IEqualityCompa
             descriptorX.IsEnum != descriptorY.IsEnum ||
             descriptorX.Name != descriptorY.Name ||
             descriptorX.TypeName != descriptorY.TypeName ||
-            descriptorX.Documentation != descriptorY.Documentation ||
             descriptorX.DisplayName != descriptorY.DisplayName)
+        {
+            return false;
+        }
+
+        if (!ComparerUtilities.AreDocumentationObjectsEqual(descriptorX.DocumentationObject, descriptorY.DocumentationObject))
         {
             return false;
         }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/ComparerUtilities.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/ComparerUtilities.cs
@@ -9,6 +9,17 @@ namespace Microsoft.AspNetCore.Razor.Language;
 
 internal static class ComparerUtilities
 {
+    public static bool AreDocumentationObjectsEqual(object? x, object? y)
+    {
+        return (x, y) switch
+        {
+            (string s1, string s2) => s1 == s2,
+            (DocumentationDescriptor d1, DocumentationDescriptor d2) => d1.Equals(d2),
+            (null, null) => true,
+            _ => false
+        };
+    }
+
     public static bool Equals<T>(IReadOnlyList<T>? first, IReadOnlyList<T>? second, IEqualityComparer<T>? comparer)
     {
         if (first == second)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/ComparerUtilities.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/ComparerUtilities.cs
@@ -9,17 +9,6 @@ namespace Microsoft.AspNetCore.Razor.Language;
 
 internal static class ComparerUtilities
 {
-    public static bool AreDocumentationObjectsEqual(object? x, object? y)
-    {
-        return (x, y) switch
-        {
-            (string s1, string s2) => s1 == s2,
-            (DocumentationDescriptor d1, DocumentationDescriptor d2) => d1.Equals(d2),
-            (null, null) => true,
-            _ => false
-        };
-    }
-
     public static bool Equals<T>(IReadOnlyList<T>? first, IReadOnlyList<T>? second, IEqualityComparer<T>? comparer)
     {
         if (first == second)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptor.cs
@@ -13,7 +13,7 @@ internal sealed class DefaultBoundAttributeDescriptor : BoundAttributeDescriptor
         bool hasIndexer,
         string? indexerNamePrefix,
         string? indexerTypeName,
-        object? documentationObject,
+        DocumentationObject documentationObject,
         string? displayName,
         bool caseSensitive,
         bool isEditorRequired,

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptor.cs
@@ -13,7 +13,7 @@ internal sealed class DefaultBoundAttributeDescriptor : BoundAttributeDescriptor
         bool hasIndexer,
         string? indexerNamePrefix,
         string? indexerTypeName,
-        string? documentation,
+        object? documentationObject,
         string? displayName,
         bool caseSensitive,
         bool isEditorRequired,
@@ -28,7 +28,7 @@ internal sealed class DefaultBoundAttributeDescriptor : BoundAttributeDescriptor
         HasIndexer = hasIndexer;
         IndexerNamePrefix = indexerNamePrefix;
         IndexerTypeName = indexerTypeName;
-        Documentation = documentation;
+        DocumentationObject = documentationObject;
         DisplayName = displayName;
         CaseSensitive = caseSensitive;
         IsEditorRequired = isEditorRequired;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptorBuilder.Policy.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptorBuilder.Policy.cs
@@ -15,7 +15,7 @@ internal partial class DefaultBoundAttributeDescriptorBuilder
         {
             builder._parent = null;
             builder._kind = null;
-            builder._documentationObject = null;
+            builder._documentationObject = default;
 
             builder.Name = null;
             builder.TypeName = null;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptorBuilder.Policy.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptorBuilder.Policy.cs
@@ -15,6 +15,7 @@ internal partial class DefaultBoundAttributeDescriptorBuilder
         {
             builder._parent = null;
             builder._kind = null;
+            builder._documentationObject = null;
 
             builder.Name = null;
             builder.TypeName = null;
@@ -23,7 +24,6 @@ internal partial class DefaultBoundAttributeDescriptorBuilder
             builder.IsEditorRequired = false;
             builder.IndexerAttributeNamePrefix = null;
             builder.IndexerValueTypeName = null;
-            builder.Documentation = null;
             builder.DisplayName = null;
 
             if (builder._attributeParameterBuilders is { } attributeParameterBuilders)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptorBuilder.cs
@@ -55,7 +55,7 @@ internal partial class DefaultBoundAttributeDescriptorBuilder : BoundAttributeDe
     [AllowNull]
     private string _kind;
     private List<DefaultBoundAttributeParameterDescriptorBuilder>? _attributeParameterBuilders;
-    private object? _documentationObject;
+    private DocumentationObject _documentationObject;
     private Dictionary<string, string?>? _metadata;
     private RazorDiagnosticCollection? _diagnostics;
 
@@ -78,18 +78,8 @@ internal partial class DefaultBoundAttributeDescriptorBuilder : BoundAttributeDe
 
     public override string? Documentation
     {
-        get
-        {
-            return _documentationObject switch
-            {
-                string s => s,
-                DocumentationDescriptor d => d.GetText(),
-                null => null,
-                _ => throw new NotSupportedException()
-            };
-        }
-
-        set => _documentationObject = value;
+        get => _documentationObject.GetText();
+        set => _documentationObject = new(value);
     }
 
     public override string? DisplayName { get; set; }
@@ -116,12 +106,12 @@ internal partial class DefaultBoundAttributeDescriptorBuilder : BoundAttributeDe
 
     internal override void SetDocumentation(string text)
     {
-        _documentationObject = text;
+        _documentationObject = new(text);
     }
 
     internal override void SetDocumentation(DocumentationDescriptor documentation)
     {
-        _documentationObject = documentation;
+        _documentationObject = new(documentation);
     }
 
     public BoundAttributeDescriptor Build()

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeParameterDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeParameterDescriptor.cs
@@ -10,7 +10,7 @@ internal class DefaultBoundAttributeParameterDescriptor : BoundAttributeParamete
         string? name,
         string? typeName,
         bool isEnum,
-        string? documentation,
+        object? documentationObject,
         string? displayName,
         bool caseSensitive,
         MetadataCollection metadata,
@@ -20,7 +20,7 @@ internal class DefaultBoundAttributeParameterDescriptor : BoundAttributeParamete
         Name = name;
         TypeName = typeName;
         IsEnum = isEnum;
-        Documentation = documentation;
+        DocumentationObject = documentationObject;
         DisplayName = displayName;
         CaseSensitive = caseSensitive;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeParameterDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeParameterDescriptor.cs
@@ -10,7 +10,7 @@ internal class DefaultBoundAttributeParameterDescriptor : BoundAttributeParamete
         string? name,
         string? typeName,
         bool isEnum,
-        object? documentationObject,
+        DocumentationObject documentationObject,
         string? displayName,
         bool caseSensitive,
         MetadataCollection metadata,

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeParameterDescriptorBuilder.Policy.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeParameterDescriptorBuilder.Policy.cs
@@ -15,11 +15,11 @@ internal partial class DefaultBoundAttributeParameterDescriptorBuilder
         {
             builder._parent = null;
             builder._kind = null;
+            builder._documentationObject = null;
 
             builder.Name = null;
             builder.TypeName = null;
             builder.IsEnum = false;
-            builder.Documentation = null;
             builder.DisplayName = null;
 
             ClearDiagnostics(builder._diagnostics);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeParameterDescriptorBuilder.Policy.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeParameterDescriptorBuilder.Policy.cs
@@ -15,7 +15,7 @@ internal partial class DefaultBoundAttributeParameterDescriptorBuilder
         {
             builder._parent = null;
             builder._kind = null;
-            builder._documentationObject = null;
+            builder._documentationObject = default;
 
             builder.Name = null;
             builder.TypeName = null;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeParameterDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeParameterDescriptorBuilder.cs
@@ -30,7 +30,7 @@ internal partial class DefaultBoundAttributeParameterDescriptorBuilder : BoundAt
     private DefaultBoundAttributeDescriptorBuilder _parent;
     [AllowNull]
     private string _kind;
-    private object? _documentationObject;
+    private DocumentationObject _documentationObject;
     private Dictionary<string, string?>? _metadata;
 
     private RazorDiagnosticCollection? _diagnostics;
@@ -51,18 +51,8 @@ internal partial class DefaultBoundAttributeParameterDescriptorBuilder : BoundAt
 
     public override string? Documentation
     {
-        get
-        {
-            return _documentationObject switch
-            {
-                string s => s,
-                DocumentationDescriptor d => d.GetText(),
-                null => null,
-                _ => throw new NotSupportedException()
-            };
-        }
-
-        set => _documentationObject = value;
+        get => _documentationObject.GetText();
+        set => _documentationObject = new(value);
     }
 
     public override string? DisplayName { get; set; }
@@ -75,12 +65,12 @@ internal partial class DefaultBoundAttributeParameterDescriptorBuilder : BoundAt
 
     internal override void SetDocumentation(string text)
     {
-        _documentationObject = text;
+        _documentationObject = new(text);
     }
 
     internal override void SetDocumentation(DocumentationDescriptor documentation)
     {
-        _documentationObject = documentation;
+        _documentationObject = new(documentation);
     }
 
     public BoundAttributeParameterDescriptor Build()

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeParameterDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeParameterDescriptorBuilder.cs
@@ -30,6 +30,7 @@ internal partial class DefaultBoundAttributeParameterDescriptorBuilder : BoundAt
     private DefaultBoundAttributeDescriptorBuilder _parent;
     [AllowNull]
     private string _kind;
+    private object? _documentationObject;
     private Dictionary<string, string?>? _metadata;
 
     private RazorDiagnosticCollection? _diagnostics;
@@ -47,7 +48,23 @@ internal partial class DefaultBoundAttributeParameterDescriptorBuilder : BoundAt
     public override string? Name { get; set; }
     public override string? TypeName { get; set; }
     public override bool IsEnum { get; set; }
-    public override string? Documentation { get; set; }
+
+    public override string? Documentation
+    {
+        get
+        {
+            return _documentationObject switch
+            {
+                string s => s,
+                DocumentationDescriptor d => d.GetText(),
+                null => null,
+                _ => throw new NotSupportedException()
+            };
+        }
+
+        set => _documentationObject = value;
+    }
+
     public override string? DisplayName { get; set; }
 
     public override IDictionary<string, string?> Metadata => _metadata ??= new Dictionary<string, string?>();
@@ -55,6 +72,16 @@ internal partial class DefaultBoundAttributeParameterDescriptorBuilder : BoundAt
     public override RazorDiagnosticCollection Diagnostics => _diagnostics ??= new RazorDiagnosticCollection();
 
     internal bool CaseSensitive => _parent.CaseSensitive;
+
+    internal override void SetDocumentation(string text)
+    {
+        _documentationObject = text;
+    }
+
+    internal override void SetDocumentation(DocumentationDescriptor documentation)
+    {
+        _documentationObject = documentation;
+    }
 
     public BoundAttributeParameterDescriptor Build()
     {
@@ -70,7 +97,7 @@ internal partial class DefaultBoundAttributeParameterDescriptorBuilder : BoundAt
                 Name,
                 TypeName,
                 IsEnum,
-                Documentation,
+                _documentationObject,
                 GetDisplayName(),
                 CaseSensitive,
                 MetadataCollection.CreateOrEmpty(_metadata),

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptor.cs
@@ -10,7 +10,7 @@ internal class DefaultTagHelperDescriptor : TagHelperDescriptor
         string name,
         string assemblyName,
         string displayName,
-        object? documentationObject,
+        DocumentationObject documentationObject,
         string? tagOutputHint,
         bool caseSensitive,
         TagMatchingRuleDescriptor[] tagMatchingRules,

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptor.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Immutable;
-
 namespace Microsoft.AspNetCore.Razor.Language;
 
 internal class DefaultTagHelperDescriptor : TagHelperDescriptor
@@ -12,7 +10,7 @@ internal class DefaultTagHelperDescriptor : TagHelperDescriptor
         string name,
         string assemblyName,
         string displayName,
-        string? documentation,
+        object? documentationObject,
         string? tagOutputHint,
         bool caseSensitive,
         TagMatchingRuleDescriptor[] tagMatchingRules,
@@ -25,7 +23,7 @@ internal class DefaultTagHelperDescriptor : TagHelperDescriptor
         Name = name;
         AssemblyName = assemblyName;
         DisplayName = displayName;
-        Documentation = documentation;
+        DocumentationObject = documentationObject;
         TagOutputHint = tagOutputHint;
         CaseSensitive = caseSensitive;
         TagMatchingRules = tagMatchingRules;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.Policy.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.Policy.cs
@@ -16,7 +16,7 @@ internal partial class DefaultTagHelperDescriptorBuilder
             builder._kind = null;
             builder._name = null;
             builder._assemblyName = null;
-            builder._documentationObject = null;
+            builder._documentationObject = default;
 
             builder.DisplayName = null;
             builder.TagOutputHint = null;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.Policy.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.Policy.cs
@@ -16,11 +16,11 @@ internal partial class DefaultTagHelperDescriptorBuilder
             builder._kind = null;
             builder._name = null;
             builder._assemblyName = null;
+            builder._documentationObject = null;
 
             builder.DisplayName = null;
             builder.TagOutputHint = null;
             builder.CaseSensitive = false;
-            builder.Documentation = null;
 
             if (builder._allowedChildTags is { } allowedChildTagBuilders)
             {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultTagHelperDescriptorBuilder.cs
@@ -45,7 +45,7 @@ internal partial class DefaultTagHelperDescriptorBuilder : TagHelperDescriptorBu
     private string? _name;
     private string? _assemblyName;
 
-    private object? _documentationObject;
+    private DocumentationObject _documentationObject;
 
     private List<DefaultAllowedChildTagDescriptorBuilder>? _allowedChildTags;
     private List<DefaultBoundAttributeDescriptorBuilder>? _attributeBuilders;
@@ -77,18 +77,8 @@ internal partial class DefaultTagHelperDescriptorBuilder : TagHelperDescriptorBu
 
     public override string? Documentation
     {
-        get
-        {
-            return _documentationObject switch
-            {
-                string s => s,
-                DocumentationDescriptor d => d.GetText(),
-                null => null,
-                _ => throw new NotSupportedException()
-            };
-        }
-
-        set => _documentationObject = value;
+        get => _documentationObject.GetText();
+        set => _documentationObject = new(value);
     }
 
     public override IDictionary<string, string?> Metadata => _metadata;
@@ -168,12 +158,12 @@ internal partial class DefaultTagHelperDescriptorBuilder : TagHelperDescriptorBu
 
     internal override void SetDocumentation(string text)
     {
-        _documentationObject = text;
+        _documentationObject = new(text);
     }
 
     internal override void SetDocumentation(DocumentationDescriptor documentation)
     {
-        _documentationObject = documentation;
+        _documentationObject = new(documentation);
     }
 
     public override TagHelperDescriptor Build()
@@ -205,7 +195,7 @@ internal partial class DefaultTagHelperDescriptorBuilder : TagHelperDescriptorBu
 
     public override void Reset()
     {
-        _documentationObject = null;
+        _documentationObject = default;
         TagOutputHint = null;
         _allowedChildTags?.Clear();
         _attributeBuilders?.Clear();

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DocumentationDescriptor.FormattedDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DocumentationDescriptor.FormattedDescriptor.cs
@@ -1,0 +1,93 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Globalization;
+using Microsoft.Extensions.Internal;
+
+namespace Microsoft.AspNetCore.Razor.Language;
+
+internal abstract partial class DocumentationDescriptor
+{
+    private sealed class FormattedDescriptor : DocumentationDescriptor
+    {
+        public override object?[] Args { get; }
+
+        private string? _formattedString;
+
+        public FormattedDescriptor(DocumentationId id, object?[] args)
+            : base(id)
+        {
+#if DEBUG
+            foreach (var arg in args)
+            {
+                Debug.Assert(
+                    arg is string || arg is int || arg is bool || arg is null,
+                    "Only string, int, bool, or null arguments are allowed.");
+            }
+#endif
+
+            Args = args;
+        }
+
+        public override string GetText()
+            => _formattedString ??= string.Format(CultureInfo.CurrentCulture, GetDocumentationText(), Args);
+
+        public override bool Equals(DocumentationDescriptor other)
+        {
+            if (other is not FormattedDescriptor { Id: var id, Args: var args })
+            {
+                return false;
+            }
+
+            if (Id != id)
+            {
+                return false;
+            }
+
+            var length = Args.Length;
+
+            if (length != args.Length)
+            {
+                return false;
+            }
+
+            for (var i = 0; i < length; i++)
+            {
+                var thisArg = Args[i];
+                var otherArg = args[i];
+
+                var areEqual = (thisArg, otherArg) switch
+                {
+                    (string s1, string s2) => s1 == s2,
+                    (int i1, int i2) => i1 == i2,
+                    (bool b1, bool b2) => b1 == b2,
+                    (object o1, object o2) => Equals(o1, o2),
+                    (null, null) => true,
+                    _ => false
+                };
+
+                if (!areEqual)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        protected override int ComputeHashCode()
+        {
+            var result = HashCodeCombiner.Start();
+
+            result.Add((int)Id);
+
+            foreach (var arg in Args)
+            {
+                result.Add(arg);
+            }
+
+            return result.CombinedHash;
+        }
+    }
+}

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DocumentationDescriptor.FormattedDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DocumentationDescriptor.FormattedDescriptor.cs
@@ -22,7 +22,7 @@ internal abstract partial class DocumentationDescriptor
             foreach (var arg in args)
             {
                 Debug.Assert(
-                    arg is string || arg is int || arg is bool || arg is null,
+                    arg is string or int or bool or null,
                     "Only string, int, bool, or null arguments are allowed.");
             }
 #endif
@@ -62,7 +62,6 @@ internal abstract partial class DocumentationDescriptor
                     (string s1, string s2) => s1 == s2,
                     (int i1, int i2) => i1 == i2,
                     (bool b1, bool b2) => b1 == b2,
-                    (object o1, object o2) => Equals(o1, o2),
                     (null, null) => true,
                     _ => false
                 };

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DocumentationDescriptor.FormattedDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DocumentationDescriptor.FormattedDescriptor.cs
@@ -79,7 +79,7 @@ internal abstract partial class DocumentationDescriptor
         {
             var result = HashCodeCombiner.Start();
 
-            result.Add((int)Id);
+            result.Add(Id);
 
             foreach (var arg in Args)
             {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DocumentationDescriptor.SimpleDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DocumentationDescriptor.SimpleDescriptor.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.Extensions.Internal;
+
+namespace Microsoft.AspNetCore.Razor.Language;
+
+internal abstract partial class DocumentationDescriptor
+{
+    private sealed class SimpleDescriptor : DocumentationDescriptor
+    {
+        public override object?[] Args => Array.Empty<object>();
+
+        public SimpleDescriptor(DocumentationId id)
+            : base(id)
+        {
+        }
+
+        public override string GetText()
+            => GetDocumentationText();
+
+        public override bool Equals(DocumentationDescriptor other)
+            => other is SimpleDescriptor { Id: var id } && Id == id;
+
+        protected override int ComputeHashCode()
+        {
+            var result = HashCodeCombiner.Start();
+
+            result.Add((int)Id);
+
+            return result.CombinedHash;
+        }
+    }
+}

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DocumentationDescriptor.SimpleDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DocumentationDescriptor.SimpleDescriptor.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language;
 
@@ -24,12 +23,6 @@ internal abstract partial class DocumentationDescriptor
             => other is SimpleDescriptor { Id: var id } && Id == id;
 
         protected override int ComputeHashCode()
-        {
-            var result = HashCodeCombiner.Start();
-
-            result.Add((int)Id);
-
-            return result.CombinedHash;
-        }
+            => Id.GetHashCode();
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DocumentationDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DocumentationDescriptor.cs
@@ -1,0 +1,118 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.AspNetCore.Razor.Language;
+
+internal abstract partial class DocumentationDescriptor : IEquatable<DocumentationDescriptor>
+{
+    public static readonly DocumentationDescriptor BindTagHelper_Fallback = new SimpleDescriptor(DocumentationId.BindTagHelper_Fallback);
+    public static readonly DocumentationDescriptor BindTagHelper_Fallback_Event = new SimpleDescriptor(DocumentationId.BindTagHelper_Fallback_Event);
+    public static readonly DocumentationDescriptor BindTagHelper_Fallback_Format = new SimpleDescriptor(DocumentationId.BindTagHelper_Fallback_Format);
+    public static readonly DocumentationDescriptor BindTagHelper_Element = new SimpleDescriptor(DocumentationId.BindTagHelper_Element);
+    public static readonly DocumentationDescriptor BindTagHelper_Element_After = new SimpleDescriptor(DocumentationId.BindTagHelper_Element_After);
+    public static readonly DocumentationDescriptor BindTagHelper_Element_Culture = new SimpleDescriptor(DocumentationId.BindTagHelper_Element_Culture);
+    public static readonly DocumentationDescriptor BindTagHelper_Element_Event = new SimpleDescriptor(DocumentationId.BindTagHelper_Element_Event);
+    public static readonly DocumentationDescriptor BindTagHelper_Element_Format = new SimpleDescriptor(DocumentationId.BindTagHelper_Element_Format);
+    public static readonly DocumentationDescriptor BindTagHelper_Element_Get = new SimpleDescriptor(DocumentationId.BindTagHelper_Element_Get);
+    public static readonly DocumentationDescriptor BindTagHelper_Element_Set = new SimpleDescriptor(DocumentationId.BindTagHelper_Element_Set);
+    public static readonly DocumentationDescriptor BindTagHelper_Component = new SimpleDescriptor(DocumentationId.BindTagHelper_Component);
+    public static readonly DocumentationDescriptor ChildContentParameterName = new SimpleDescriptor(DocumentationId.ChildContentParameterName);
+    public static readonly DocumentationDescriptor ChildContentParameterName_TopLevel = new SimpleDescriptor(DocumentationId.ChildContentParameterName_TopLevel);
+    public static readonly DocumentationDescriptor ComponentTypeParameter = new SimpleDescriptor(DocumentationId.ComponentTypeParameter);
+    public static readonly DocumentationDescriptor EventHandlerTagHelper = new SimpleDescriptor(DocumentationId.EventHandlerTagHelper);
+    public static readonly DocumentationDescriptor EventHandlerTagHelper_PreventDefault = new SimpleDescriptor(DocumentationId.EventHandlerTagHelper_PreventDefault);
+    public static readonly DocumentationDescriptor EventHandlerTagHelper_StopPropagation = new SimpleDescriptor(DocumentationId.EventHandlerTagHelper_StopPropagation);
+    public static readonly DocumentationDescriptor KeyTagHelper = new SimpleDescriptor(DocumentationId.KeyTagHelper);
+    public static readonly DocumentationDescriptor RefTagHelper = new SimpleDescriptor(DocumentationId.RefTagHelper);
+    public static readonly DocumentationDescriptor SplatTagHelper = new SimpleDescriptor(DocumentationId.SplatTagHelper);
+
+    public static DocumentationDescriptor Format(DocumentationId id, params object?[] args)
+        => new FormattedDescriptor(id, args);
+
+    public static DocumentationDescriptor From(DocumentationId id, params object?[]? args)
+    {
+        if (args is null or { Length: 0 })
+        {
+            return id switch
+            {
+                DocumentationId.BindTagHelper_Fallback => BindTagHelper_Fallback,
+                DocumentationId.BindTagHelper_Fallback_Event => BindTagHelper_Fallback_Event,
+                DocumentationId.BindTagHelper_Fallback_Format => BindTagHelper_Fallback_Format,
+                DocumentationId.BindTagHelper_Element => BindTagHelper_Element,
+                DocumentationId.BindTagHelper_Element_After => BindTagHelper_Element_After,
+                DocumentationId.BindTagHelper_Element_Culture => BindTagHelper_Element_Culture,
+                DocumentationId.BindTagHelper_Element_Event => BindTagHelper_Element_Event,
+                DocumentationId.BindTagHelper_Element_Format => BindTagHelper_Element_Format,
+                DocumentationId.BindTagHelper_Element_Get => BindTagHelper_Element_Get,
+                DocumentationId.BindTagHelper_Element_Set => BindTagHelper_Element_Set,
+                DocumentationId.BindTagHelper_Component => BindTagHelper_Component,
+                DocumentationId.ChildContentParameterName => ChildContentParameterName,
+                DocumentationId.ChildContentParameterName_TopLevel => ChildContentParameterName_TopLevel,
+                DocumentationId.ComponentTypeParameter => ComponentTypeParameter,
+                DocumentationId.EventHandlerTagHelper => EventHandlerTagHelper,
+                DocumentationId.EventHandlerTagHelper_PreventDefault => EventHandlerTagHelper_PreventDefault,
+                DocumentationId.EventHandlerTagHelper_StopPropagation => EventHandlerTagHelper_StopPropagation,
+                DocumentationId.KeyTagHelper => KeyTagHelper,
+                DocumentationId.RefTagHelper => RefTagHelper,
+                DocumentationId.SplatTagHelper => SplatTagHelper,
+
+                _ => throw new NotSupportedException(Resources.FormatUnknown_documentation_id_0(id))
+            };
+        }
+
+        return Format(id, args);
+    }
+
+    public DocumentationId Id { get; }
+    public abstract object?[] Args { get; }
+
+    private int? _hashCode;
+
+    private protected DocumentationDescriptor(DocumentationId id)
+    {
+        Id = id;
+    }
+
+    public sealed override bool Equals(object obj)
+        => obj is DocumentationDescriptor other && Equals(other);
+
+    public abstract bool Equals(DocumentationDescriptor other);
+
+    public sealed override int GetHashCode()
+        => _hashCode ??= ComputeHashCode();
+
+    protected abstract int ComputeHashCode();
+
+    public abstract string GetText();
+
+    private string GetDocumentationText()
+    {
+        return Id switch
+        {
+            DocumentationId.BindTagHelper_Fallback => ComponentResources.BindTagHelper_Fallback_Documentation,
+            DocumentationId.BindTagHelper_Fallback_Event => ComponentResources.BindTagHelper_Fallback_Event_Documentation,
+            DocumentationId.BindTagHelper_Fallback_Format => ComponentResources.BindTagHelper_Fallback_Format_Documentation,
+            DocumentationId.BindTagHelper_Element => ComponentResources.BindTagHelper_Element_Documentation,
+            DocumentationId.BindTagHelper_Element_After => ComponentResources.BindTagHelper_Element_After_Documentation,
+            DocumentationId.BindTagHelper_Element_Culture => ComponentResources.BindTagHelper_Element_Culture_Documentation,
+            DocumentationId.BindTagHelper_Element_Event => ComponentResources.BindTagHelper_Element_Event_Documentation,
+            DocumentationId.BindTagHelper_Element_Format => ComponentResources.BindTagHelper_Element_Format_Documentation,
+            DocumentationId.BindTagHelper_Element_Get => ComponentResources.BindTagHelper_Element_Get_Documentation,
+            DocumentationId.BindTagHelper_Element_Set => ComponentResources.BindTagHelper_Element_Set_Documentation,
+            DocumentationId.BindTagHelper_Component => ComponentResources.BindTagHelper_Component_Documentation,
+            DocumentationId.ChildContentParameterName => ComponentResources.ChildContentParameterName_Documentation,
+            DocumentationId.ChildContentParameterName_TopLevel => ComponentResources.ChildContentParameterName_TopLevelDocumentation,
+            DocumentationId.ComponentTypeParameter => ComponentResources.ComponentTypeParameter_Documentation,
+            DocumentationId.EventHandlerTagHelper => ComponentResources.EventHandlerTagHelper_Documentation,
+            DocumentationId.EventHandlerTagHelper_PreventDefault => ComponentResources.EventHandlerTagHelper_PreventDefault_Documentation,
+            DocumentationId.EventHandlerTagHelper_StopPropagation => ComponentResources.EventHandlerTagHelper_StopPropagation_Documentation,
+            DocumentationId.KeyTagHelper => ComponentResources.KeyTagHelper_Documentation,
+            DocumentationId.RefTagHelper => ComponentResources.RefTagHelper_Documentation,
+            DocumentationId.SplatTagHelper => ComponentResources.SplatTagHelper_Documentation,
+
+            var id => throw new NotSupportedException(Resources.FormatUnknown_documentation_id_0(id))
+        };
+    }
+}

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DocumentationDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DocumentationDescriptor.cs
@@ -30,6 +30,12 @@ internal abstract partial class DocumentationDescriptor : IEquatable<Documentati
 
     public static DocumentationDescriptor From(DocumentationId id, params object?[]? args)
     {
+        if (id < 0 || id > DocumentationId.Last)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(id), id, Resources.FormatUnknown_documentation_id_0(id));
+        }
+
         if (args is null or { Length: 0 })
         {
             return id switch

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DocumentationDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DocumentationDescriptor.cs
@@ -28,9 +28,6 @@ internal abstract partial class DocumentationDescriptor : IEquatable<Documentati
     public static readonly DocumentationDescriptor RefTagHelper = new SimpleDescriptor(DocumentationId.RefTagHelper);
     public static readonly DocumentationDescriptor SplatTagHelper = new SimpleDescriptor(DocumentationId.SplatTagHelper);
 
-    public static DocumentationDescriptor Format(DocumentationId id, params object?[] args)
-        => new FormattedDescriptor(id, args);
-
     public static DocumentationDescriptor From(DocumentationId id, params object?[]? args)
     {
         if (args is null or { Length: 0 })
@@ -58,11 +55,17 @@ internal abstract partial class DocumentationDescriptor : IEquatable<Documentati
                 DocumentationId.RefTagHelper => RefTagHelper,
                 DocumentationId.SplatTagHelper => SplatTagHelper,
 
+                // If this exception is thrown, there are two potential problems:
+                //
+                // 1. Arguments are being passed for a DocumentationId that doesn't require formatting.
+                // 2. A new DocumentationId was added that needs an entry added in the switch expression above
+                //    to return a DocumentationDescriptor.
+
                 _ => throw new NotSupportedException(Resources.FormatUnknown_documentation_id_0(id))
             };
         }
 
-        return Format(id, args);
+        return new FormattedDescriptor(id, args);
     }
 
     public DocumentationId Id { get; }
@@ -111,6 +114,9 @@ internal abstract partial class DocumentationDescriptor : IEquatable<Documentati
             DocumentationId.KeyTagHelper => ComponentResources.KeyTagHelper_Documentation,
             DocumentationId.RefTagHelper => ComponentResources.RefTagHelper_Documentation,
             DocumentationId.SplatTagHelper => ComponentResources.SplatTagHelper_Documentation,
+
+            // If this exception is thrown, a new DocumentationId was added that needs an entry added in
+            // the switch expression above to return a resource string.
 
             var id => throw new NotSupportedException(Resources.FormatUnknown_documentation_id_0(id))
         };

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DocumentationId.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DocumentationId.cs
@@ -5,6 +5,9 @@ namespace Microsoft.AspNetCore.Razor.Language;
 
 internal enum DocumentationId
 {
+    // New values must always be placed at the end of the enum
+    // and Last must be updated to point to the final value.
+    // Do NOT insert items or change the order below.
     BindTagHelper_Fallback,
     BindTagHelper_Fallback_Event,
     BindTagHelper_Fallback_Format,
@@ -25,4 +28,6 @@ internal enum DocumentationId
     KeyTagHelper,
     RefTagHelper,
     SplatTagHelper,
+
+    Last = SplatTagHelper
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DocumentationId.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DocumentationId.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.AspNetCore.Razor.Language;
+
+internal enum DocumentationId
+{
+    BindTagHelper_Fallback,
+    BindTagHelper_Fallback_Event,
+    BindTagHelper_Fallback_Format,
+    BindTagHelper_Element,
+    BindTagHelper_Element_After,
+    BindTagHelper_Element_Culture,
+    BindTagHelper_Element_Event,
+    BindTagHelper_Element_Format,
+    BindTagHelper_Element_Get,
+    BindTagHelper_Element_Set,
+    BindTagHelper_Component,
+    ChildContentParameterName,
+    ChildContentParameterName_TopLevel,
+    ComponentTypeParameter,
+    EventHandlerTagHelper,
+    EventHandlerTagHelper_PreventDefault,
+    EventHandlerTagHelper_StopPropagation,
+    KeyTagHelper,
+    RefTagHelper,
+    SplatTagHelper,
+}

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DocumentationObject.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DocumentationObject.cs
@@ -1,0 +1,60 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.AspNetCore.Razor.Language;
+
+/// <summary>
+///  Helper struct that wraps a <see cref="DocumentationDescriptor"/>, <see cref="string"/>, or <see langword="null"/>.
+/// </summary>
+internal readonly record struct DocumentationObject
+{
+    public readonly object? Object;
+
+    public DocumentationObject(object? obj)
+    {
+        if (obj is not (DocumentationDescriptor or string or null))
+        {
+            throw new ArgumentException(
+                Resources.FormatA_documentation_object_can_only_be_a_0_instance_string_or_null(nameof(DocumentationDescriptor)),
+                paramName: nameof(obj));
+        }
+
+        Object = obj;
+    }
+
+    public readonly string? GetText()
+        => Object switch
+        {
+            DocumentationDescriptor d => d.GetText(),
+            string s => s,
+            null => null,
+            _ => Assumed.Unreachable<string>()
+        };
+
+    public override int GetHashCode()
+        => Object switch
+        {
+            DocumentationDescriptor d => d.GetHashCode(),
+            string s => s.GetHashCode(),
+            null => 0,
+            _ => Assumed.Unreachable<int>()
+        };
+
+    public bool Equals(DocumentationObject other)
+        => (Object, other.Object) switch
+        {
+            (DocumentationDescriptor d1, DocumentationDescriptor d2) => d1.Equals(d2),
+            (string s1, string s2) => s1 == s2,
+            (null, null) => true,
+            (DocumentationDescriptor or string or null, DocumentationDescriptor or string or null) => false,
+            _ => Assumed.Unreachable<bool>()
+        };
+
+    public static implicit operator DocumentationObject(string text)
+        => new(text);
+
+    public static implicit operator DocumentationObject(DocumentationDescriptor descriptor)
+        => new(descriptor);
+}

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Resources.resx
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Resources.resx
@@ -583,4 +583,7 @@
   <data name="The_given_key_0_was_not_present" xml:space="preserve">
     <value>The given key '{0}' was not present.</value>
   </data>
+  <data name="Unknown_documentation_id_0" xml:space="preserve">
+    <value>Unknown documentation id: '{0}'.</value>
+  </data>
 </root>

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Resources.resx
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Resources.resx
@@ -586,4 +586,7 @@
   <data name="Unknown_documentation_id_0" xml:space="preserve">
     <value>Unknown documentation id: '{0}'.</value>
   </data>
+  <data name="A_documentation_object_can_only_be_a_0_instance_string_or_null" xml:space="preserve">
+    <value>A documentation object can only be a '{0}' instance, string, or null.</value>
+  </data>
 </root>

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptor.cs
@@ -23,7 +23,7 @@ public abstract class TagHelperDescriptor : IEquatable<TagHelperDescriptor>
 
     private int _flags;
     private int? _hashCode;
-    private object _documentationObject;
+    private DocumentationObject _documentationObject;
 
     private IEnumerable<RazorDiagnostic> _allDiagnostics;
     private BoundAttributeDescriptor[] _editorRequiredAttributes;
@@ -52,21 +52,11 @@ public abstract class TagHelperDescriptor : IEquatable<TagHelperDescriptor>
 
     public string Documentation
     {
-        get
-        {
-            return _documentationObject switch
-            {
-                string s => s,
-                DocumentationDescriptor d => d.GetText(),
-                null => null,
-                _ => throw new NotSupportedException()
-            };
-        }
-
-        protected set => _documentationObject = value;
+        get => _documentationObject.GetText();
+        protected set => _documentationObject = new(value);
     }
 
-    internal object DocumentationObject
+    internal DocumentationObject DocumentationObject
     {
         get => _documentationObject;
         set => _documentationObject = value;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptor.cs
@@ -23,6 +23,7 @@ public abstract class TagHelperDescriptor : IEquatable<TagHelperDescriptor>
 
     private int _flags;
     private int? _hashCode;
+    private object _documentationObject;
 
     private IEnumerable<RazorDiagnostic> _allDiagnostics;
     private BoundAttributeDescriptor[] _editorRequiredAttributes;
@@ -49,7 +50,27 @@ public abstract class TagHelperDescriptor : IEquatable<TagHelperDescriptor>
 
     public IReadOnlyList<AllowedChildTagDescriptor> AllowedChildTags { get; protected set; }
 
-    public string Documentation { get; protected set; }
+    public string Documentation
+    {
+        get
+        {
+            return _documentationObject switch
+            {
+                string s => s,
+                DocumentationDescriptor d => d.GetText(),
+                null => null,
+                _ => throw new NotSupportedException()
+            };
+        }
+
+        protected set => _documentationObject = value;
+    }
+
+    internal object DocumentationObject
+    {
+        get => _documentationObject;
+        set => _documentationObject = value;
+    }
 
     public string DisplayName { get; protected set; }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptorBuilder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptorBuilder.cs
@@ -124,4 +124,14 @@ public abstract partial class TagHelperDescriptorBuilder
     public abstract TagHelperDescriptor Build();
 
     public abstract void Reset();
+
+    internal virtual void SetDocumentation(string text)
+    {
+        throw new NotImplementedException();
+    }
+
+    internal virtual void SetDocumentation(DocumentationDescriptor documentation)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptorComparer.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptorComparer.cs
@@ -34,9 +34,13 @@ internal sealed class TagHelperDescriptorComparer : IEqualityComparer<TagHelperD
             descriptorX.AssemblyName != descriptorY.AssemblyName ||
             descriptorX.Name != descriptorY.Name ||
             descriptorX.CaseSensitive != descriptorY.CaseSensitive ||
-            descriptorX.Documentation != descriptorY.Documentation ||
             descriptorX.DisplayName != descriptorY.DisplayName ||
             descriptorX.TagOutputHint != descriptorY.TagOutputHint)
+        {
+            return false;
+        }
+
+        if (!ComparerUtilities.AreDocumentationObjectsEqual(descriptorX.DocumentationObject, descriptorY.DocumentationObject))
         {
             return false;
         }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptorComparer.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDescriptorComparer.cs
@@ -35,12 +35,8 @@ internal sealed class TagHelperDescriptorComparer : IEqualityComparer<TagHelperD
             descriptorX.Name != descriptorY.Name ||
             descriptorX.CaseSensitive != descriptorY.CaseSensitive ||
             descriptorX.DisplayName != descriptorY.DisplayName ||
+            descriptorX.DocumentationObject != descriptorY.DocumentationObject ||
             descriptorX.TagOutputHint != descriptorY.TagOutputHint)
-        {
-            return false;
-        }
-
-        if (!ComparerUtilities.AreDocumentationObjectsEqual(descriptorX.DocumentationObject, descriptorY.DocumentationObject))
         {
             return false;
         }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/BindTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/BindTagHelperDescriptorProvider.cs
@@ -198,7 +198,7 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                     parameter.Name = "event";
                     parameter.TypeName = typeof(string).FullName;
                     parameter.SetDocumentation(
-                        DocumentationDescriptor.Format(
+                        DocumentationDescriptor.From(
                             DocumentationId.BindTagHelper_Fallback_Event, attributeName));
 
                     parameter.SetPropertyName("Event");
@@ -384,7 +384,7 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
 
             builder.CaseSensitive = true;
             builder.SetDocumentation(
-                DocumentationDescriptor.Format(
+                DocumentationDescriptor.From(
                     DocumentationId.BindTagHelper_Element,
                     entry.ValueAttribute,
                     entry.ChangeAttribute));
@@ -472,7 +472,7 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
             {
                 a.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
                 a.SetDocumentation(
-                    DocumentationDescriptor.Format(
+                    DocumentationDescriptor.From(
                         DocumentationId.BindTagHelper_Element,
                         entry.ValueAttribute,
                         entry.ChangeAttribute));
@@ -489,7 +489,7 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                     parameter.Name = "format";
                     parameter.TypeName = typeof(string).FullName;
                     parameter.SetDocumentation(
-                        DocumentationDescriptor.Format(
+                        DocumentationDescriptor.From(
                             DocumentationId.BindTagHelper_Element_Format,
                             attributeName));
 
@@ -501,7 +501,7 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                     parameter.Name = "event";
                     parameter.TypeName = typeof(string).FullName;
                     parameter.SetDocumentation(
-                        DocumentationDescriptor.Format(
+                        DocumentationDescriptor.From(
                             DocumentationId.BindTagHelper_Element_Event,
                             attributeName));
 
@@ -552,7 +552,7 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                 attribute.Name = formatAttributeName;
                 attribute.TypeName = "System.String";
                 attribute.SetDocumentation(
-                    DocumentationDescriptor.Format(
+                    DocumentationDescriptor.From(
                         DocumentationId.BindTagHelper_Element_Format,
                         attributeName));
 
@@ -635,7 +635,7 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                 builder.DisplayName = tagHelper.DisplayName;
                 builder.CaseSensitive = true;
                 builder.SetDocumentation(
-                    DocumentationDescriptor.Format(
+                    DocumentationDescriptor.From(
                         DocumentationId.BindTagHelper_Component,
                         valueAttribute.Name,
                         changeAttribute.Name));
@@ -689,7 +689,7 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                 {
                     attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
                     attribute.SetDocumentation(
-                        DocumentationDescriptor.Format(
+                        DocumentationDescriptor.From(
                             DocumentationId.BindTagHelper_Component,
                             valueAttribute.Name,
                             changeAttribute.Name));

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/BindTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/BindTagHelperDescriptorProvider.cs
@@ -146,7 +146,7 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                 out var builder);
 
             builder.CaseSensitive = true;
-            builder.Documentation = ComponentResources.BindTagHelper_Fallback_Documentation;
+            builder.SetDocumentation(DocumentationDescriptor.BindTagHelper_Fallback);
 
             builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.Bind.TagHelperKind);
             builder.Metadata.Add(TagHelperMetadata.Common.ClassifyAttributesOnly, bool.TrueString);
@@ -173,7 +173,7 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
             builder.BindAttribute(attribute =>
             {
                 attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
-                attribute.Documentation = ComponentResources.BindTagHelper_Fallback_Documentation;
+                attribute.SetDocumentation(DocumentationDescriptor.BindTagHelper_Fallback);
 
                 var attributeName = "@bind-...";
                 attribute.Name = attributeName;
@@ -188,7 +188,7 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                 {
                     parameter.Name = "format";
                     parameter.TypeName = typeof(string).FullName;
-                    parameter.Documentation = ComponentResources.BindTagHelper_Fallback_Format_Documentation;
+                    parameter.SetDocumentation(DocumentationDescriptor.BindTagHelper_Fallback_Format);
 
                     parameter.SetPropertyName("Format");
                 });
@@ -197,7 +197,9 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                 {
                     parameter.Name = "event";
                     parameter.TypeName = typeof(string).FullName;
-                    parameter.Documentation = string.Format(CultureInfo.CurrentCulture, ComponentResources.BindTagHelper_Fallback_Event_Documentation, attributeName);
+                    parameter.SetDocumentation(
+                        DocumentationDescriptor.Format(
+                            DocumentationId.BindTagHelper_Fallback_Event, attributeName));
 
                     parameter.SetPropertyName("Event");
                 });
@@ -206,7 +208,7 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                 {
                     parameter.Name = "culture";
                     parameter.TypeName = typeof(CultureInfo).FullName;
-                    parameter.Documentation = ComponentResources.BindTagHelper_Element_Culture_Documentation;
+                    parameter.SetDocumentation(DocumentationDescriptor.BindTagHelper_Element_Culture);
 
                     parameter.SetPropertyName("Culture");
                 });
@@ -215,7 +217,7 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                 {
                     parameter.Name = "get";
                     parameter.TypeName = typeof(object).FullName;
-                    parameter.Documentation = ComponentResources.BindTagHelper_Element_Get_Documentation;
+                    parameter.SetDocumentation(DocumentationDescriptor.BindTagHelper_Element_Get);
 
                     parameter.SetPropertyName("Get");
 
@@ -226,7 +228,7 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                 {
                     parameter.Name = "set";
                     parameter.TypeName = typeof(Delegate).FullName;
-                    parameter.Documentation = ComponentResources.BindTagHelper_Element_Set_Documentation;
+                    parameter.SetDocumentation(DocumentationDescriptor.BindTagHelper_Element_Set);
 
                     parameter.SetPropertyName("Set");
                 });
@@ -235,7 +237,7 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                 {
                     parameter.Name = "after";
                     parameter.TypeName = typeof(Delegate).FullName;
-                    parameter.Documentation = ComponentResources.BindTagHelper_Element_After_Documentation;
+                    parameter.SetDocumentation(DocumentationDescriptor.BindTagHelper_Element_After);
 
                     parameter.SetPropertyName("After");
                 });
@@ -381,11 +383,11 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                 out var builder);
 
             builder.CaseSensitive = true;
-            builder.Documentation = string.Format(
-                CultureInfo.CurrentCulture,
-                ComponentResources.BindTagHelper_Element_Documentation,
-                entry.ValueAttribute,
-                entry.ChangeAttribute);
+            builder.SetDocumentation(
+                DocumentationDescriptor.Format(
+                    DocumentationId.BindTagHelper_Element,
+                    entry.ValueAttribute,
+                    entry.ChangeAttribute));
 
             builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.Bind.TagHelperKind);
             builder.Metadata.Add(TagHelperMetadata.Common.ClassifyAttributesOnly, bool.TrueString);
@@ -469,11 +471,11 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
             builder.BindAttribute(a =>
             {
                 a.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
-                a.Documentation = string.Format(
-                    CultureInfo.CurrentCulture,
-                    ComponentResources.BindTagHelper_Element_Documentation,
-                    entry.ValueAttribute,
-                    entry.ChangeAttribute);
+                a.SetDocumentation(
+                    DocumentationDescriptor.Format(
+                        DocumentationId.BindTagHelper_Element,
+                        entry.ValueAttribute,
+                        entry.ChangeAttribute));
 
                 a.Name = attributeName;
                 a.TypeName = typeof(object).FullName;
@@ -486,7 +488,10 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                 {
                     parameter.Name = "format";
                     parameter.TypeName = typeof(string).FullName;
-                    parameter.Documentation = string.Format(CultureInfo.CurrentCulture, ComponentResources.BindTagHelper_Element_Format_Documentation, attributeName);
+                    parameter.SetDocumentation(
+                        DocumentationDescriptor.Format(
+                            DocumentationId.BindTagHelper_Element_Format,
+                            attributeName));
 
                     parameter.SetPropertyName(formatName);
                 });
@@ -495,7 +500,10 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                 {
                     parameter.Name = "event";
                     parameter.TypeName = typeof(string).FullName;
-                    parameter.Documentation = string.Format(CultureInfo.CurrentCulture, ComponentResources.BindTagHelper_Element_Event_Documentation, attributeName);
+                    parameter.SetDocumentation(
+                        DocumentationDescriptor.Format(
+                            DocumentationId.BindTagHelper_Element_Event,
+                            attributeName));
 
                     parameter.SetPropertyName(eventName);
                 });
@@ -504,7 +512,7 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                 {
                     parameter.Name = "culture";
                     parameter.TypeName = typeof(CultureInfo).FullName;
-                    parameter.Documentation = ComponentResources.BindTagHelper_Element_Culture_Documentation;
+                    parameter.SetDocumentation(DocumentationDescriptor.BindTagHelper_Element_Culture);
 
                     parameter.SetPropertyName("Culture");
                 });
@@ -513,7 +521,7 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                 {
                     parameter.Name = "get";
                     parameter.TypeName = typeof(object).FullName;
-                    parameter.Documentation = ComponentResources.BindTagHelper_Element_Get_Documentation;
+                    parameter.SetDocumentation(DocumentationDescriptor.BindTagHelper_Element_Get);
 
                     parameter.SetPropertyName("Get");
                     parameter.SetBindAttributeGetSet();
@@ -523,7 +531,7 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                 {
                     parameter.Name = "set";
                     parameter.TypeName = typeof(Delegate).FullName;
-                    parameter.Documentation = ComponentResources.BindTagHelper_Element_Set_Documentation;
+                    parameter.SetDocumentation(DocumentationDescriptor.BindTagHelper_Element_Set);
 
                     parameter.SetPropertyName("Set");
                 });
@@ -532,7 +540,7 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                 {
                     parameter.Name = "after";
                     parameter.TypeName = typeof(Delegate).FullName;
-                    parameter.Documentation = ComponentResources.BindTagHelper_Element_After_Documentation;
+                    parameter.SetDocumentation(DocumentationDescriptor.BindTagHelper_Element_After);
 
                     parameter.SetPropertyName("After");
                 });
@@ -543,7 +551,10 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
             {
                 attribute.Name = formatAttributeName;
                 attribute.TypeName = "System.String";
-                attribute.Documentation = string.Format(CultureInfo.CurrentCulture, ComponentResources.BindTagHelper_Element_Format_Documentation, attributeName);
+                attribute.SetDocumentation(
+                    DocumentationDescriptor.Format(
+                        DocumentationId.BindTagHelper_Element_Format,
+                        attributeName));
 
                 // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like
                 // a C# property will crash trying to create the toolips.
@@ -623,11 +634,11 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
 
                 builder.DisplayName = tagHelper.DisplayName;
                 builder.CaseSensitive = true;
-                builder.Documentation = string.Format(
-                    CultureInfo.CurrentCulture,
-                    ComponentResources.BindTagHelper_Component_Documentation,
-                    valueAttribute.Name,
-                    changeAttribute.Name);
+                builder.SetDocumentation(
+                    DocumentationDescriptor.Format(
+                        DocumentationId.BindTagHelper_Component,
+                        valueAttribute.Name,
+                        changeAttribute.Name));
 
                 builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.Bind.TagHelperKind);
                 builder.Metadata[TagHelperMetadata.Runtime.Name] = ComponentMetadata.Bind.RuntimeName;
@@ -677,11 +688,11 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                 builder.BindAttribute(attribute =>
                 {
                     attribute.Metadata[ComponentMetadata.Common.DirectiveAttribute] = bool.TrueString;
-                    attribute.Documentation = string.Format(
-                        CultureInfo.CurrentCulture,
-                        ComponentResources.BindTagHelper_Component_Documentation,
-                        valueAttribute.Name,
-                        changeAttribute.Name);
+                    attribute.SetDocumentation(
+                        DocumentationDescriptor.Format(
+                            DocumentationId.BindTagHelper_Component,
+                            valueAttribute.Name,
+                            changeAttribute.Name));
 
                     attribute.Name = "@bind-" + valueAttribute.Name;
                     attribute.TypeName = changeAttribute.TypeName;
@@ -695,7 +706,7 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                     {
                         parameter.Name = "get";
                         parameter.TypeName = typeof(object).FullName;
-                        parameter.Documentation = ComponentResources.BindTagHelper_Element_Get_Documentation;
+                        parameter.SetDocumentation(DocumentationDescriptor.BindTagHelper_Element_Get);
 
                         parameter.SetPropertyName("Get");
                         parameter.SetBindAttributeGetSet();
@@ -705,7 +716,7 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                     {
                         parameter.Name = "set";
                         parameter.TypeName = typeof(Delegate).FullName;
-                        parameter.Documentation = ComponentResources.BindTagHelper_Element_Set_Documentation;
+                        parameter.SetDocumentation(DocumentationDescriptor.BindTagHelper_Element_Set);
 
                         parameter.SetPropertyName("Set");
                     });
@@ -714,7 +725,7 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                     {
                         parameter.Name = "after";
                         parameter.TypeName = typeof(Delegate).FullName;
-                        parameter.Documentation = ComponentResources.BindTagHelper_Element_After_Documentation;
+                        parameter.SetDocumentation(DocumentationDescriptor.BindTagHelper_Element_After);
 
                         parameter.SetPropertyName("After");
                     });

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentTagHelperDescriptorProvider.cs
@@ -441,7 +441,7 @@ internal class ComponentTagHelperDescriptorProvider : RazorEngineFeatureBase, IT
             }
 
             pb.SetDocumentation(
-                DocumentationDescriptor.Format(
+                DocumentationDescriptor.From(
                     DocumentationId.ComponentTypeParameter,
                     typeParameter.Name,
                     builder.Name));
@@ -544,7 +544,7 @@ internal class ComponentTagHelperDescriptorProvider : RazorEngineFeatureBase, IT
 
             var documentation = childContentName == null
                 ? DocumentationDescriptor.ChildContentParameterName_TopLevel
-                : DocumentationDescriptor.Format(DocumentationId.ChildContentParameterName, childContentName);
+                : DocumentationDescriptor.From(DocumentationId.ChildContentParameterName, childContentName);
 
             b.SetDocumentation(documentation);
         });

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentTagHelperDescriptorProvider.cs
@@ -165,7 +165,7 @@ internal class ComponentTagHelperDescriptorProvider : RazorEngineFeatureBase, IT
         var xml = type.GetDocumentationCommentXml();
         if (!string.IsNullOrEmpty(xml))
         {
-            builder.Documentation = xml;
+            builder.SetDocumentation(xml);
         }
 
         foreach (var (property, kind) in properties)
@@ -233,7 +233,7 @@ internal class ComponentTagHelperDescriptorProvider : RazorEngineFeatureBase, IT
             var xml = property.GetDocumentationCommentXml();
             if (!string.IsNullOrEmpty(xml))
             {
-                pb.Documentation = xml;
+                pb.SetDocumentation(xml);
             }
         });
 
@@ -440,7 +440,11 @@ internal class ComponentTagHelperDescriptorProvider : RazorEngineFeatureBase, IT
                 pb.Metadata[ComponentMetadata.Component.TypeParameterConstraintsKey] = whereClauseText;
             }
 
-            pb.Documentation = string.Format(CultureInfo.InvariantCulture, ComponentResources.ComponentTypeParameter_Documentation, typeParameter.Name, builder.Name);
+            pb.SetDocumentation(
+                DocumentationDescriptor.Format(
+                    DocumentationId.ComponentTypeParameter,
+                    typeParameter.Name,
+                    builder.Name));
         });
 
         static bool TryGetWhereClauseText(ITypeParameterSymbol typeParameter, PooledList<string> constraints, [NotNullWhen(true)] out string constraintsText)
@@ -502,7 +506,7 @@ internal class ComponentTagHelperDescriptorProvider : RazorEngineFeatureBase, IT
         var xml = attribute.Documentation;
         if (!string.IsNullOrEmpty(xml))
         {
-            builder.Documentation = xml;
+            builder.SetDocumentation(xml);
         }
 
         // Child content matches the property name, but only as a direct child of the component.
@@ -538,9 +542,11 @@ internal class ComponentTagHelperDescriptorProvider : RazorEngineFeatureBase, IT
             b.Metadata.Add(ComponentMetadata.Component.ChildContentParameterNameKey, bool.TrueString);
             b.Metadata.Add(TagHelperMetadata.Common.PropertyName, b.Name);
 
-            b.Documentation = childContentName == null
-                ? ComponentResources.ChildContentParameterName_TopLevelDocumentation
-                : string.Format(CultureInfo.InvariantCulture, ComponentResources.ChildContentParameterName_Documentation, childContentName);
+            var documentation = childContentName == null
+                ? DocumentationDescriptor.ChildContentParameterName_TopLevel
+                : DocumentationDescriptor.Format(DocumentationId.ChildContentParameterName, childContentName);
+
+            b.SetDocumentation(documentation);
         });
     }
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/DefaultTagHelperDescriptorFactory.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/DefaultTagHelperDescriptorFactory.cs
@@ -162,7 +162,7 @@ internal class DefaultTagHelperDescriptorFactory
 
         if (!string.IsNullOrEmpty(xml))
         {
-            builder.Documentation = xml;
+            builder.SetDocumentation(xml);
         }
     }
 
@@ -221,7 +221,7 @@ internal class DefaultTagHelperDescriptorFactory
 
                 if (!string.IsNullOrEmpty(xml))
                 {
-                    builder.Documentation = xml;
+                    builder.SetDocumentation(xml);
                 }
             }
         }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/EventHandlerTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/EventHandlerTagHelperDescriptorProvider.cs
@@ -145,7 +145,7 @@ internal class EventHandlerTagHelperDescriptorProvider : ITagHelperDescriptorPro
 
             builder.CaseSensitive = true;
             builder.SetDocumentation(
-                DocumentationDescriptor.Format(
+                DocumentationDescriptor.From(
                     DocumentationId.EventHandlerTagHelper,
                     attributeName,
                     eventArgType));
@@ -206,7 +206,7 @@ internal class EventHandlerTagHelperDescriptorProvider : ITagHelperDescriptorPro
             builder.BindAttribute(a =>
             {
                 a.SetDocumentation(
-                    DocumentationDescriptor.Format(
+                    DocumentationDescriptor.From(
                         DocumentationId.EventHandlerTagHelper,
                         attributeName,
                         eventArgType));
@@ -233,7 +233,7 @@ internal class EventHandlerTagHelperDescriptorProvider : ITagHelperDescriptorPro
                         parameter.Name = "preventDefault";
                         parameter.TypeName = typeof(bool).FullName;
                         parameter.SetDocumentation(
-                            DocumentationDescriptor.Format(
+                            DocumentationDescriptor.From(
                                 DocumentationId.EventHandlerTagHelper_PreventDefault,
                                 attributeName));
 
@@ -248,7 +248,7 @@ internal class EventHandlerTagHelperDescriptorProvider : ITagHelperDescriptorPro
                         parameter.Name = "stopPropagation";
                         parameter.TypeName = typeof(bool).FullName;
                         parameter.SetDocumentation(
-                            DocumentationDescriptor.Format(
+                            DocumentationDescriptor.From(
                                 DocumentationId.EventHandlerTagHelper_StopPropagation,
                                 attributeName));
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/EventHandlerTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/EventHandlerTagHelperDescriptorProvider.cs
@@ -144,11 +144,11 @@ internal class EventHandlerTagHelperDescriptorProvider : ITagHelperDescriptorPro
                 out var builder);
 
             builder.CaseSensitive = true;
-            builder.Documentation = string.Format(
-                CultureInfo.CurrentCulture,
-                ComponentResources.EventHandlerTagHelper_Documentation,
-                attributeName,
-                eventArgType);
+            builder.SetDocumentation(
+                DocumentationDescriptor.Format(
+                    DocumentationId.EventHandlerTagHelper,
+                    attributeName,
+                    eventArgType));
 
             builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.EventHandler.TagHelperKind);
             builder.Metadata.Add(ComponentMetadata.EventHandler.EventArgsType, eventArgType);
@@ -205,11 +205,11 @@ internal class EventHandlerTagHelperDescriptorProvider : ITagHelperDescriptorPro
 
             builder.BindAttribute(a =>
             {
-                a.Documentation = string.Format(
-                    CultureInfo.CurrentCulture,
-                    ComponentResources.EventHandlerTagHelper_Documentation,
-                    attributeName,
-                    eventArgType);
+                a.SetDocumentation(
+                    DocumentationDescriptor.Format(
+                        DocumentationId.EventHandlerTagHelper,
+                        attributeName,
+                        eventArgType));
 
                 a.Name = attributeName;
 
@@ -232,8 +232,10 @@ internal class EventHandlerTagHelperDescriptorProvider : ITagHelperDescriptorPro
                     {
                         parameter.Name = "preventDefault";
                         parameter.TypeName = typeof(bool).FullName;
-                        parameter.Documentation = string.Format(
-                            CultureInfo.CurrentCulture, ComponentResources.EventHandlerTagHelper_PreventDefault_Documentation, attributeName);
+                        parameter.SetDocumentation(
+                            DocumentationDescriptor.Format(
+                                DocumentationId.EventHandlerTagHelper_PreventDefault,
+                                attributeName));
 
                         parameter.SetPropertyName("PreventDefault");
                     });
@@ -245,8 +247,10 @@ internal class EventHandlerTagHelperDescriptorProvider : ITagHelperDescriptorPro
                     {
                         parameter.Name = "stopPropagation";
                         parameter.TypeName = typeof(bool).FullName;
-                        parameter.Documentation = string.Format(
-                            CultureInfo.CurrentCulture, ComponentResources.EventHandlerTagHelper_StopPropagation_Documentation, attributeName);
+                        parameter.SetDocumentation(
+                            DocumentationDescriptor.Format(
+                                DocumentationId.EventHandlerTagHelper_StopPropagation,
+                                attributeName));
 
                         parameter.SetPropertyName("StopPropagation");
                     });

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/KeyTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/KeyTagHelperDescriptorProvider.cs
@@ -59,7 +59,7 @@ internal class KeyTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                 out var builder);
 
             builder.CaseSensitive = true;
-            builder.Documentation = ComponentResources.KeyTagHelper_Documentation;
+            builder.SetDocumentation(DocumentationDescriptor.KeyTagHelper);
 
             builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.Key.TagHelperKind);
             builder.Metadata.Add(TagHelperMetadata.Common.ClassifyAttributesOnly, bool.TrueString);
@@ -81,7 +81,7 @@ internal class KeyTagHelperDescriptorProvider : ITagHelperDescriptorProvider
 
             builder.BindAttribute(attribute =>
             {
-                attribute.Documentation = ComponentResources.KeyTagHelper_Documentation;
+                attribute.SetDocumentation(DocumentationDescriptor.KeyTagHelper);
                 attribute.Name = "@key";
 
                 // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/RefTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/RefTagHelperDescriptorProvider.cs
@@ -59,7 +59,7 @@ internal class RefTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                 out var builder);
 
             builder.CaseSensitive = true;
-            builder.Documentation = ComponentResources.RefTagHelper_Documentation;
+            builder.SetDocumentation(DocumentationDescriptor.RefTagHelper);
 
             builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.Ref.TagHelperKind);
             builder.Metadata.Add(TagHelperMetadata.Common.ClassifyAttributesOnly, bool.TrueString);
@@ -81,7 +81,7 @@ internal class RefTagHelperDescriptorProvider : ITagHelperDescriptorProvider
 
             builder.BindAttribute(attribute =>
             {
-                attribute.Documentation = ComponentResources.RefTagHelper_Documentation;
+                attribute.SetDocumentation(DocumentationDescriptor.RefTagHelper);
                 attribute.Name = "@ref";
 
                 // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/SplatTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/SplatTagHelperDescriptorProvider.cs
@@ -59,7 +59,7 @@ internal class SplatTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                 out var builder);
 
             builder.CaseSensitive = true;
-            builder.Documentation = ComponentResources.SplatTagHelper_Documentation;
+            builder.SetDocumentation(DocumentationDescriptor.SplatTagHelper);
 
             builder.Metadata.Add(ComponentMetadata.SpecialKindKey, ComponentMetadata.Splat.TagHelperKind);
             builder.Metadata.Add(TagHelperMetadata.Common.ClassifyAttributesOnly, bool.TrueString);
@@ -81,7 +81,7 @@ internal class SplatTagHelperDescriptorProvider : ITagHelperDescriptorProvider
 
             builder.BindAttribute(attribute =>
             {
-                attribute.Documentation = ComponentResources.SplatTagHelper_Documentation;
+                attribute.SetDocumentation(DocumentationDescriptor.SplatTagHelper);
                 attribute.Name = "@attributes";
 
                 // WTE has a bug 15.7p1 where a Tag Helper without a display-name that looks like

--- a/src/Compiler/shared/TagHelperDescriptorJsonConverter.cs
+++ b/src/Compiler/shared/TagHelperDescriptorJsonConverter.cs
@@ -40,7 +40,7 @@ internal class TagHelperDescriptorJsonConverter : JsonConverter
                     if (reader.Read())
                     {
                         var documentation = (string)reader.Value;
-                        builder.Documentation = documentation;
+                        builder.SetDocumentation(documentation);
                     }
                     break;
                 case nameof(TagHelperDescriptor.TagOutputHint):
@@ -410,7 +410,7 @@ internal class TagHelperDescriptorJsonConverter : JsonConverter
                         if (reader.Read())
                         {
                             var documentation = (string)reader.Value;
-                            attribute.Documentation = documentation;
+                            attribute.SetDocumentation(documentation);
                         }
                         break;
                     case nameof(BoundAttributeDescriptor.IndexerNamePrefix):
@@ -524,7 +524,7 @@ internal class TagHelperDescriptorJsonConverter : JsonConverter
                         if (reader.Read())
                         {
                             var documentation = (string)reader.Value;
-                            parameter.Documentation = documentation;
+                            parameter.SetDocumentation(documentation);
                         }
                         break;
                     case nameof(BoundAttributeParameterDescriptor.Metadata):

--- a/src/Compiler/test/Microsoft.AspNetCore.Razor.Test.Common/Language/TestTagHelperDescriptorBuilderExtensions.cs
+++ b/src/Compiler/test/Microsoft.AspNetCore.Razor.Test.Common/Language/TestTagHelperDescriptorBuilderExtensions.cs
@@ -76,7 +76,7 @@ public static class TestTagHelperDescriptorBuilderExtensions
             throw new ArgumentNullException(nameof(builder));
         }
 
-        builder.Documentation = documentation;
+        builder.SetDocumentation(documentation);
 
         return builder;
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Resources/SR.resx
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Resources/SR.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Could_not_read_value_JSON_token_was_0" xml:space="preserve">
+    <value>Could not read value - JSON token was '{0}'.</value>
+  </data>
   <data name="Encountered_end_of_stream_before_end_of_object" xml:space="preserve">
     <value>Encountered end of stream before end of object.</value>
   </data>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Resources/xlf/SR.cs.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Resources/xlf/SR.cs.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../SR.resx">
     <body>
+      <trans-unit id="Could_not_read_value_JSON_token_was_0">
+        <source>Could not read value - JSON token was '{0}'.</source>
+        <target state="new">Could not read value - JSON token was '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Encountered_end_of_stream_before_end_of_object">
         <source>Encountered end of stream before end of object.</source>
         <target state="translated">Došlo k ukončení datového proudu před dokončením objektu.</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Resources/xlf/SR.de.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Resources/xlf/SR.de.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../SR.resx">
     <body>
+      <trans-unit id="Could_not_read_value_JSON_token_was_0">
+        <source>Could not read value - JSON token was '{0}'.</source>
+        <target state="new">Could not read value - JSON token was '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Encountered_end_of_stream_before_end_of_object">
         <source>Encountered end of stream before end of object.</source>
         <target state="new">Encountered end of stream before end of object.</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Resources/xlf/SR.es.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Resources/xlf/SR.es.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../SR.resx">
     <body>
+      <trans-unit id="Could_not_read_value_JSON_token_was_0">
+        <source>Could not read value - JSON token was '{0}'.</source>
+        <target state="new">Could not read value - JSON token was '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Encountered_end_of_stream_before_end_of_object">
         <source>Encountered end of stream before end of object.</source>
         <target state="translated">Se encontró el final de la secuencia antes del final del objeto.</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Resources/xlf/SR.fr.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Resources/xlf/SR.fr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../SR.resx">
     <body>
+      <trans-unit id="Could_not_read_value_JSON_token_was_0">
+        <source>Could not read value - JSON token was '{0}'.</source>
+        <target state="new">Could not read value - JSON token was '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Encountered_end_of_stream_before_end_of_object">
         <source>Encountered end of stream before end of object.</source>
         <target state="translated">Fin de flux rencontrée avant la fin de l’objet.</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Resources/xlf/SR.it.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Resources/xlf/SR.it.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../SR.resx">
     <body>
+      <trans-unit id="Could_not_read_value_JSON_token_was_0">
+        <source>Could not read value - JSON token was '{0}'.</source>
+        <target state="new">Could not read value - JSON token was '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Encountered_end_of_stream_before_end_of_object">
         <source>Encountered end of stream before end of object.</source>
         <target state="translated">È stata rilevata fine del flusso prima della fine dell'oggetto.</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Resources/xlf/SR.ja.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Resources/xlf/SR.ja.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../SR.resx">
     <body>
+      <trans-unit id="Could_not_read_value_JSON_token_was_0">
+        <source>Could not read value - JSON token was '{0}'.</source>
+        <target state="new">Could not read value - JSON token was '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Encountered_end_of_stream_before_end_of_object">
         <source>Encountered end of stream before end of object.</source>
         <target state="translated">オブジェクトの終わりの前にストリームの終わりが見つかりました。</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Resources/xlf/SR.ko.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Resources/xlf/SR.ko.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../SR.resx">
     <body>
+      <trans-unit id="Could_not_read_value_JSON_token_was_0">
+        <source>Could not read value - JSON token was '{0}'.</source>
+        <target state="new">Could not read value - JSON token was '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Encountered_end_of_stream_before_end_of_object">
         <source>Encountered end of stream before end of object.</source>
         <target state="translated">개체의 끝 전에 스트림의 끝이 발견되었습니다.</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Resources/xlf/SR.pl.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Resources/xlf/SR.pl.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../SR.resx">
     <body>
+      <trans-unit id="Could_not_read_value_JSON_token_was_0">
+        <source>Could not read value - JSON token was '{0}'.</source>
+        <target state="new">Could not read value - JSON token was '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Encountered_end_of_stream_before_end_of_object">
         <source>Encountered end of stream before end of object.</source>
         <target state="translated">Napotkano koniec strumienia przed końcem obiektu.</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Resources/xlf/SR.pt-BR.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Resources/xlf/SR.pt-BR.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../SR.resx">
     <body>
+      <trans-unit id="Could_not_read_value_JSON_token_was_0">
+        <source>Could not read value - JSON token was '{0}'.</source>
+        <target state="new">Could not read value - JSON token was '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Encountered_end_of_stream_before_end_of_object">
         <source>Encountered end of stream before end of object.</source>
         <target state="translated">Fim de fluxo encontrado antes do fim do objeto.</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Resources/xlf/SR.ru.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Resources/xlf/SR.ru.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../SR.resx">
     <body>
+      <trans-unit id="Could_not_read_value_JSON_token_was_0">
+        <source>Could not read value - JSON token was '{0}'.</source>
+        <target state="new">Could not read value - JSON token was '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Encountered_end_of_stream_before_end_of_object">
         <source>Encountered end of stream before end of object.</source>
         <target state="translated">Обнаружен конец потока перед концом объекта.</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Resources/xlf/SR.tr.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Resources/xlf/SR.tr.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../SR.resx">
     <body>
+      <trans-unit id="Could_not_read_value_JSON_token_was_0">
+        <source>Could not read value - JSON token was '{0}'.</source>
+        <target state="new">Could not read value - JSON token was '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Encountered_end_of_stream_before_end_of_object">
         <source>Encountered end of stream before end of object.</source>
         <target state="translated">Nesne sonundan önce akış sonuyla karşılaşıldı.</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Resources/xlf/SR.zh-Hans.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../SR.resx">
     <body>
+      <trans-unit id="Could_not_read_value_JSON_token_was_0">
+        <source>Could not read value - JSON token was '{0}'.</source>
+        <target state="new">Could not read value - JSON token was '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Encountered_end_of_stream_before_end_of_object">
         <source>Encountered end of stream before end of object.</source>
         <target state="translated">在对象结尾之前遇到流结尾。</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Resources/xlf/SR.zh-Hant.xlf
@@ -2,6 +2,11 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../SR.resx">
     <body>
+      <trans-unit id="Could_not_read_value_JSON_token_was_0">
+        <source>Could not read value - JSON token was '{0}'.</source>
+        <target state="new">Could not read value - JSON token was '{0}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Encountered_end_of_stream_before_end_of_object">
         <source>Encountered end of stream before end of object.</source>
         <target state="translated">在物件結尾之前發現資料流結尾。</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/JsonDataReader.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/JsonDataReader.cs
@@ -230,6 +230,25 @@ internal partial class JsonDataReader
         return ReadNonNullString();
     }
 
+    public object? ReadValue()
+    {
+        return _reader.TokenType switch
+        {
+            JsonToken.String => ReadString(),
+            JsonToken.Integer => ReadInt32(),
+            JsonToken.Boolean => ReadBoolean(),
+
+            var token => ThrowNotSupported(token)
+        };
+
+        [DoesNotReturn]
+        static object? ThrowNotSupported(JsonToken token)
+        {
+            throw new NotSupportedException(
+                SR.FormatCould_not_read_value_JSON_token_was_0(token));
+        }
+    }
+
     public Uri? ReadUri(string propertyName)
     {
         ReadPropertyName(propertyName);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/JsonDataWriter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/JsonDataWriter.cs
@@ -41,6 +41,11 @@ internal partial class JsonDataWriter
     {
     }
 
+    public void Write(bool value)
+    {
+        _writer.WriteValue(value);
+    }
+
     public void Write(string propertyName, bool value)
     {
         _writer.WritePropertyName(propertyName);
@@ -63,6 +68,11 @@ internal partial class JsonDataWriter
         }
     }
 
+    public void Write(int value)
+    {
+        _writer.WriteValue(value);
+    }
+
     public void Write(string propertyName, int value)
     {
         _writer.WritePropertyName(propertyName);
@@ -75,6 +85,11 @@ internal partial class JsonDataWriter
         {
             Write(propertyName, value);
         }
+    }
+
+    public void Write(string? value)
+    {
+        _writer.WriteValue(value);
     }
 
     public void Write(string propertyName, string? value)
@@ -96,6 +111,31 @@ internal partial class JsonDataWriter
         if (value is not null)
         {
             Write(propertyName, value);
+        }
+    }
+
+    public void WriteValue(object? value)
+    {
+        switch (value)
+        {
+            case string s:
+                Write(s);
+                break;
+
+            case int i:
+                Write(i);
+                break;
+
+            case bool b:
+                Write(b);
+                break;
+
+            case null:
+                Write((string?)null);
+                break;
+
+            default:
+                throw new NotSupportedException();
         }
     }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/ObjectReaders.BoundAttributeParameterReader.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/ObjectReaders.BoundAttributeParameterReader.cs
@@ -34,7 +34,18 @@ internal static partial class ObjectReaders
             => arg.Builder.IsEnum = reader.ReadBoolean();
 
         private static void ReadDocumentation(JsonDataReader reader, ref BoundAttributeParameterReader arg)
-            => arg.Builder.Documentation = Cached(reader.ReadString());
+        {
+            var documentationObject = ReadDocumentationObject(reader);
+
+            if (documentationObject is string text)
+            {
+                arg.Builder.SetDocumentation(Cached(text));
+            }
+            else
+            {
+                arg.Builder.SetDocumentation(documentationObject as DocumentationDescriptor);
+            }
+        }
 
         private static void ReadMetadata(JsonDataReader reader, ref BoundAttributeParameterReader arg)
             => reader.ProcessObject(arg.Builder.Metadata, ProcessMetadata);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/ObjectReaders.BoundAttributeReader.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/ObjectReaders.BoundAttributeReader.cs
@@ -35,7 +35,18 @@ internal static partial class ObjectReaders
             => arg.Builder.TypeName = Cached(reader.ReadString());
 
         private static void ReadDocumentation(JsonDataReader reader, ref BoundAttributeReader arg)
-                => arg.Builder.Documentation = Cached(reader.ReadString());
+        {
+            var documentationObject = ReadDocumentationObject(reader);
+
+            if (documentationObject is string text)
+            {
+                arg.Builder.SetDocumentation(Cached(text));
+            }
+            else
+            {
+                arg.Builder.SetDocumentation(documentationObject as DocumentationDescriptor);
+            }
+        }
 
         private static void ReadIndexerNamePrefix(JsonDataReader reader, ref BoundAttributeReader arg)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/ObjectReaders.TagHelperReader.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/ObjectReaders.TagHelperReader.cs
@@ -20,7 +20,18 @@ internal static partial class ObjectReaders
             (nameof(TagHelperDescriptor.Metadata), ReadMetadata));
 
         private static void ReadDocumentation(JsonDataReader reader, ref TagHelperReader arg)
-            => arg.Builder.Documentation = Cached(reader.ReadString());
+        {
+            var documentationObject = ReadDocumentationObject(reader);
+
+            if (documentationObject is string text)
+            {
+                arg.Builder.SetDocumentation(Cached(text));
+            }
+            else
+            {
+                arg.Builder.SetDocumentation(documentationObject as DocumentationDescriptor);
+            }
+        }
 
         private static void ReadTagOutputHint(JsonDataReader reader, ref TagHelperReader arg)
             => arg.Builder.TagOutputHint = Cached(reader.ReadString());

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/ObjectReaders.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/ObjectReaders.cs
@@ -122,6 +122,27 @@ internal static partial class ObjectReaders
         return descriptor;
     }
 
+    private static object? ReadDocumentationObject(JsonDataReader reader)
+    {
+        if (reader.IsObjectStart)
+        {
+            return reader.ReadNonNullObject(static reader =>
+            {
+                var id = (DocumentationId)reader.ReadInt32(nameof(DocumentationDescriptor.Id));
+                // Check to see if the Args property was actually written before trying to read it;
+                // otherwise, assume the args are null.
+                var args = reader.TryReadPropertyName(nameof(DocumentationDescriptor.Args))
+                    ? reader.ReadArray(static r => r.ReadValue())
+                    : null;
+                return DocumentationDescriptor.From(id, args);
+            });
+        }
+        else
+        {
+            return reader.ReadString();
+        }
+    }
+
     private static void ProcessDiagnostic(JsonDataReader reader, RazorDiagnosticCollection collection)
     {
         DiagnosticData data = default;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/ObjectWriters.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/ObjectWriters.cs
@@ -92,9 +92,9 @@ internal static class ObjectWriters
         writer.WriteArrayIfNotNullOrEmpty(nameof(value.Diagnostics), value.Diagnostics, Write);
         writer.WriteObject(nameof(value.Metadata), value.Metadata, WriteMetadata);
 
-        static void WriteDocumentationObject(JsonDataWriter writer, string propertyName, object? documentationObject)
+        static void WriteDocumentationObject(JsonDataWriter writer, string propertyName, DocumentationObject documentationObject)
         {
-            switch (documentationObject)
+            switch (documentationObject.Object)
             {
                 case DocumentationDescriptor descriptor:
                     writer.WriteObject(propertyName, descriptor, static (writer, value) =>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/ObjectWriters.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/ObjectWriters.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -113,7 +114,11 @@ internal static class ObjectWriters
                     break;
 
                 case null:
-                    // Don't write anything if there isn't any documentation.
+                    // Don't write a property if there isn't any documentation.
+                    break;
+
+                default:
+                    Debug.Fail($"Documentation objects should only be of type {nameof(DocumentationDescriptor)}, string, or null.");
                     break;
             }
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/ObjectWriters.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/ObjectWriters.cs
@@ -83,7 +83,7 @@ internal static class ObjectWriters
         writer.Write(nameof(value.Kind), value.Kind);
         writer.Write(nameof(value.Name), value.Name);
         writer.Write(nameof(value.AssemblyName), value.AssemblyName);
-        writer.WriteIfNotNull(nameof(value.Documentation), value.Documentation);
+        WriteDocumentationObject(writer, nameof(value.Documentation), value.DocumentationObject);
         writer.WriteIfNotNull(nameof(value.TagOutputHint), value.TagOutputHint);
         writer.Write(nameof(value.CaseSensitive), value.CaseSensitive);
         writer.WriteArray(nameof(value.TagMatchingRules), value.TagMatchingRules, WriteTagMatchingRule);
@@ -91,6 +91,32 @@ internal static class ObjectWriters
         writer.WriteArrayIfNotNullOrEmpty(nameof(value.AllowedChildTags), value.AllowedChildTags, WriteAllowedChildTag);
         writer.WriteArrayIfNotNullOrEmpty(nameof(value.Diagnostics), value.Diagnostics, Write);
         writer.WriteObject(nameof(value.Metadata), value.Metadata, WriteMetadata);
+
+        static void WriteDocumentationObject(JsonDataWriter writer, string propertyName, object? documentationObject)
+        {
+            switch (documentationObject)
+            {
+                case DocumentationDescriptor descriptor:
+                    writer.WriteObject(propertyName, descriptor, static (writer, value) =>
+                    {
+                        writer.Write(nameof(value.Id), (int)value.Id);
+                        if (value.Args is { Length: > 0 })
+                        {
+                            writer.WriteArray(nameof(value.Args), value.Args, static (w, v) => w.WriteValue(v));
+                        }
+                    });
+
+                    break;
+
+                case string text:
+                    writer.Write(propertyName, text);
+                    break;
+
+                case null:
+                    // Don't write anything if there isn't any documentation.
+                    break;
+            }
+        }
 
         static void WriteTagMatchingRule(JsonDataWriter writer, TagMatchingRuleDescriptor value)
         {
@@ -132,7 +158,7 @@ internal static class ObjectWriters
                 writer.WriteIfNotTrue(nameof(value.IsEditorRequired), value.IsEditorRequired);
                 writer.WriteIfNotNull(nameof(value.IndexerNamePrefix), value.IndexerNamePrefix);
                 writer.WriteIfNotNull(nameof(value.IndexerTypeName), value.IndexerTypeName);
-                writer.WriteIfNotNull(nameof(value.Documentation), value.Documentation);
+                WriteDocumentationObject(writer, nameof(value.Documentation), value.DocumentationObject);
                 writer.WriteArrayIfNotNullOrEmpty(nameof(value.Diagnostics), value.Diagnostics, Write);
                 writer.WriteObject(nameof(value.Metadata), value.Metadata, WriteMetadata);
                 writer.WriteArrayIfNotNullOrEmpty(nameof(value.BoundAttributeParameters), value.BoundAttributeParameters, WriteBoundAttributeParameter);
@@ -146,7 +172,7 @@ internal static class ObjectWriters
                 writer.Write(nameof(value.Name), value.Name);
                 writer.Write(nameof(value.TypeName), value.TypeName);
                 writer.WriteIfNotTrue(nameof(value.IsEnum), value.IsEnum);
-                writer.WriteIfNotNull(nameof(value.Documentation), value.Documentation);
+                WriteDocumentationObject(writer, nameof(value.Documentation), value.DocumentationObject);
                 writer.WriteArrayIfNotNullOrEmpty(nameof(value.Diagnostics), value.Diagnostics, Write);
                 writer.WriteObject(nameof(value.Metadata), value.Metadata, WriteMetadata);
             });

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Assumed.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Assumed.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.AspNetCore.Razor;
+
+internal static class Assumed
+{
+    private static readonly Exception s_unreachable
+        = new InvalidOperationException(SR.This_program_location_is_throught_to_be_unreachable);
+
+    /// <summary>
+    ///  Can be called at points that are assumed to be unreachable at runtime.
+    /// </summary>
+    /// <exception cref="InvalidOperationException"/>
+    [DoesNotReturn]
+    public static void Unreachable()
+        => throw s_unreachable;
+
+    /// <summary>
+    ///  Can be called at points that are assumed to be unreachable at runtime.
+    /// </summary>
+    /// <exception cref="InvalidOperationException"/>
+    [DoesNotReturn]
+    public static T Unreachable<T>()
+        => throw s_unreachable;
+}

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Assumed.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Assumed.cs
@@ -3,27 +3,27 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.AspNetCore.Razor;
 
 internal static class Assumed
 {
-    private static readonly Exception s_unreachable
-        = new InvalidOperationException(SR.This_program_location_is_throught_to_be_unreachable);
+    /// <summary>
+    ///  Can be called at points that are assumed to be unreachable at runtime.
+    /// </summary>
+    /// <exception cref="InvalidOperationException"/>
+    [DoesNotReturn]
+    public static void Unreachable([CallerFilePath] string? path = null, [CallerLineNumber] int line = 0)
+        => throw new InvalidOperationException(
+            SR.FormatThis_program_location_is_throught_to_be_unreachable_File_0_Line_1(path, line));
 
     /// <summary>
     ///  Can be called at points that are assumed to be unreachable at runtime.
     /// </summary>
     /// <exception cref="InvalidOperationException"/>
     [DoesNotReturn]
-    public static void Unreachable()
-        => throw s_unreachable;
-
-    /// <summary>
-    ///  Can be called at points that are assumed to be unreachable at runtime.
-    /// </summary>
-    /// <exception cref="InvalidOperationException"/>
-    [DoesNotReturn]
-    public static T Unreachable<T>()
-        => throw s_unreachable;
+    public static T Unreachable<T>([CallerFilePath] string? path = null, [CallerLineNumber] int line = 0)
+        => throw new InvalidOperationException(
+            SR.FormatThis_program_location_is_throught_to_be_unreachable_File_0_Line_1(path, line));
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/SR.resx
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/SR.resx
@@ -120,7 +120,7 @@
   <data name="Non_negative_number_required" xml:space="preserve">
     <value>Non-negative number required.</value>
   </data>
-  <data name="This_program_location_is_throught_to_be_unreachable" xml:space="preserve">
-    <value>This program location is thought to be unreachable.</value>
+  <data name="This_program_location_is_throught_to_be_unreachable_File_0_Line_1" xml:space="preserve">
+    <value>This program location is thought to be unreachable. File='{0}', Line={1}</value>
   </data>
 </root>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/SR.resx
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/SR.resx
@@ -120,4 +120,7 @@
   <data name="Non_negative_number_required" xml:space="preserve">
     <value>Non-negative number required.</value>
   </data>
+  <data name="This_program_location_is_throught_to_be_unreachable" xml:space="preserve">
+    <value>This program location is thought to be unreachable.</value>
+  </data>
 </root>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.cs.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.cs.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Vyžaduje se nezáporné číslo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="This_program_location_is_throught_to_be_unreachable">
+        <source>This program location is thought to be unreachable.</source>
+        <target state="new">This program location is thought to be unreachable.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.cs.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.cs.xlf
@@ -7,9 +7,9 @@
         <target state="translated">Vyžaduje se nezáporné číslo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="This_program_location_is_throught_to_be_unreachable">
-        <source>This program location is thought to be unreachable.</source>
-        <target state="new">This program location is thought to be unreachable.</target>
+      <trans-unit id="This_program_location_is_throught_to_be_unreachable_File_0_Line_1">
+        <source>This program location is thought to be unreachable. File='{0}', Line={1}</source>
+        <target state="new">This program location is thought to be unreachable. File='{0}', Line={1}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.de.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.de.xlf
@@ -7,9 +7,9 @@
         <target state="translated">Nicht negative Zahl erforderlich.</target>
         <note />
       </trans-unit>
-      <trans-unit id="This_program_location_is_throught_to_be_unreachable">
-        <source>This program location is thought to be unreachable.</source>
-        <target state="new">This program location is thought to be unreachable.</target>
+      <trans-unit id="This_program_location_is_throught_to_be_unreachable_File_0_Line_1">
+        <source>This program location is thought to be unreachable. File='{0}', Line={1}</source>
+        <target state="new">This program location is thought to be unreachable. File='{0}', Line={1}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.de.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.de.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Nicht negative Zahl erforderlich.</target>
         <note />
       </trans-unit>
+      <trans-unit id="This_program_location_is_throught_to_be_unreachable">
+        <source>This program location is thought to be unreachable.</source>
+        <target state="new">This program location is thought to be unreachable.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.es.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.es.xlf
@@ -7,9 +7,9 @@
         <target state="translated">Se requiere un número no negativo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="This_program_location_is_throught_to_be_unreachable">
-        <source>This program location is thought to be unreachable.</source>
-        <target state="new">This program location is thought to be unreachable.</target>
+      <trans-unit id="This_program_location_is_throught_to_be_unreachable_File_0_Line_1">
+        <source>This program location is thought to be unreachable. File='{0}', Line={1}</source>
+        <target state="new">This program location is thought to be unreachable. File='{0}', Line={1}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.es.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.es.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Se requiere un número no negativo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="This_program_location_is_throught_to_be_unreachable">
+        <source>This program location is thought to be unreachable.</source>
+        <target state="new">This program location is thought to be unreachable.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.fr.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.fr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Nombre non négatif obligatoire.</target>
         <note />
       </trans-unit>
+      <trans-unit id="This_program_location_is_throught_to_be_unreachable">
+        <source>This program location is thought to be unreachable.</source>
+        <target state="new">This program location is thought to be unreachable.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.fr.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.fr.xlf
@@ -7,9 +7,9 @@
         <target state="translated">Nombre non négatif obligatoire.</target>
         <note />
       </trans-unit>
-      <trans-unit id="This_program_location_is_throught_to_be_unreachable">
-        <source>This program location is thought to be unreachable.</source>
-        <target state="new">This program location is thought to be unreachable.</target>
+      <trans-unit id="This_program_location_is_throught_to_be_unreachable_File_0_Line_1">
+        <source>This program location is thought to be unreachable. File='{0}', Line={1}</source>
+        <target state="new">This program location is thought to be unreachable. File='{0}', Line={1}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.it.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.it.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Numero non negativo obbligatorio.</target>
         <note />
       </trans-unit>
+      <trans-unit id="This_program_location_is_throught_to_be_unreachable">
+        <source>This program location is thought to be unreachable.</source>
+        <target state="new">This program location is thought to be unreachable.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.it.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.it.xlf
@@ -7,9 +7,9 @@
         <target state="translated">Numero non negativo obbligatorio.</target>
         <note />
       </trans-unit>
-      <trans-unit id="This_program_location_is_throught_to_be_unreachable">
-        <source>This program location is thought to be unreachable.</source>
-        <target state="new">This program location is thought to be unreachable.</target>
+      <trans-unit id="This_program_location_is_throught_to_be_unreachable_File_0_Line_1">
+        <source>This program location is thought to be unreachable. File='{0}', Line={1}</source>
+        <target state="new">This program location is thought to be unreachable. File='{0}', Line={1}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.ja.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.ja.xlf
@@ -7,9 +7,9 @@
         <target state="translated">負でない数値が必要です。</target>
         <note />
       </trans-unit>
-      <trans-unit id="This_program_location_is_throught_to_be_unreachable">
-        <source>This program location is thought to be unreachable.</source>
-        <target state="new">This program location is thought to be unreachable.</target>
+      <trans-unit id="This_program_location_is_throught_to_be_unreachable_File_0_Line_1">
+        <source>This program location is thought to be unreachable. File='{0}', Line={1}</source>
+        <target state="new">This program location is thought to be unreachable. File='{0}', Line={1}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.ja.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.ja.xlf
@@ -7,6 +7,11 @@
         <target state="translated">負でない数値が必要です。</target>
         <note />
       </trans-unit>
+      <trans-unit id="This_program_location_is_throught_to_be_unreachable">
+        <source>This program location is thought to be unreachable.</source>
+        <target state="new">This program location is thought to be unreachable.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.ko.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.ko.xlf
@@ -7,6 +7,11 @@
         <target state="translated">음수가 아닌 수가 필요합니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="This_program_location_is_throught_to_be_unreachable">
+        <source>This program location is thought to be unreachable.</source>
+        <target state="new">This program location is thought to be unreachable.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.ko.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.ko.xlf
@@ -7,9 +7,9 @@
         <target state="translated">음수가 아닌 수가 필요합니다.</target>
         <note />
       </trans-unit>
-      <trans-unit id="This_program_location_is_throught_to_be_unreachable">
-        <source>This program location is thought to be unreachable.</source>
-        <target state="new">This program location is thought to be unreachable.</target>
+      <trans-unit id="This_program_location_is_throught_to_be_unreachable_File_0_Line_1">
+        <source>This program location is thought to be unreachable. File='{0}', Line={1}</source>
+        <target state="new">This program location is thought to be unreachable. File='{0}', Line={1}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.pl.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.pl.xlf
@@ -7,9 +7,9 @@
         <target state="translated">Wymagana jest liczba nieujemna.</target>
         <note />
       </trans-unit>
-      <trans-unit id="This_program_location_is_throught_to_be_unreachable">
-        <source>This program location is thought to be unreachable.</source>
-        <target state="new">This program location is thought to be unreachable.</target>
+      <trans-unit id="This_program_location_is_throught_to_be_unreachable_File_0_Line_1">
+        <source>This program location is thought to be unreachable. File='{0}', Line={1}</source>
+        <target state="new">This program location is thought to be unreachable. File='{0}', Line={1}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.pl.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.pl.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Wymagana jest liczba nieujemna.</target>
         <note />
       </trans-unit>
+      <trans-unit id="This_program_location_is_throught_to_be_unreachable">
+        <source>This program location is thought to be unreachable.</source>
+        <target state="new">This program location is thought to be unreachable.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.pt-BR.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.pt-BR.xlf
@@ -7,9 +7,9 @@
         <target state="translated">É necessário um número não negativo.</target>
         <note />
       </trans-unit>
-      <trans-unit id="This_program_location_is_throught_to_be_unreachable">
-        <source>This program location is thought to be unreachable.</source>
-        <target state="new">This program location is thought to be unreachable.</target>
+      <trans-unit id="This_program_location_is_throught_to_be_unreachable_File_0_Line_1">
+        <source>This program location is thought to be unreachable. File='{0}', Line={1}</source>
+        <target state="new">This program location is thought to be unreachable. File='{0}', Line={1}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.pt-BR.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="translated">É necessário um número não negativo.</target>
         <note />
       </trans-unit>
+      <trans-unit id="This_program_location_is_throught_to_be_unreachable">
+        <source>This program location is thought to be unreachable.</source>
+        <target state="new">This program location is thought to be unreachable.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.ru.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.ru.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Требуется неотрицательное число.</target>
         <note />
       </trans-unit>
+      <trans-unit id="This_program_location_is_throught_to_be_unreachable">
+        <source>This program location is thought to be unreachable.</source>
+        <target state="new">This program location is thought to be unreachable.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.ru.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.ru.xlf
@@ -7,9 +7,9 @@
         <target state="translated">Требуется неотрицательное число.</target>
         <note />
       </trans-unit>
-      <trans-unit id="This_program_location_is_throught_to_be_unreachable">
-        <source>This program location is thought to be unreachable.</source>
-        <target state="new">This program location is thought to be unreachable.</target>
+      <trans-unit id="This_program_location_is_throught_to_be_unreachable_File_0_Line_1">
+        <source>This program location is thought to be unreachable. File='{0}', Line={1}</source>
+        <target state="new">This program location is thought to be unreachable. File='{0}', Line={1}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.tr.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.tr.xlf
@@ -7,9 +7,9 @@
         <target state="translated">Negatif olmayan sayı gerekiyor.</target>
         <note />
       </trans-unit>
-      <trans-unit id="This_program_location_is_throught_to_be_unreachable">
-        <source>This program location is thought to be unreachable.</source>
-        <target state="new">This program location is thought to be unreachable.</target>
+      <trans-unit id="This_program_location_is_throught_to_be_unreachable_File_0_Line_1">
+        <source>This program location is thought to be unreachable. File='{0}', Line={1}</source>
+        <target state="new">This program location is thought to be unreachable. File='{0}', Line={1}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.tr.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.tr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Negatif olmayan sayı gerekiyor.</target>
         <note />
       </trans-unit>
+      <trans-unit id="This_program_location_is_throught_to_be_unreachable">
+        <source>This program location is thought to be unreachable.</source>
+        <target state="new">This program location is thought to be unreachable.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.zh-Hans.xlf
@@ -7,9 +7,9 @@
         <target state="translated">需要提供非负数。</target>
         <note />
       </trans-unit>
-      <trans-unit id="This_program_location_is_throught_to_be_unreachable">
-        <source>This program location is thought to be unreachable.</source>
-        <target state="new">This program location is thought to be unreachable.</target>
+      <trans-unit id="This_program_location_is_throught_to_be_unreachable_File_0_Line_1">
+        <source>This program location is thought to be unreachable. File='{0}', Line={1}</source>
+        <target state="new">This program location is thought to be unreachable. File='{0}', Line={1}</target>
         <note />
       </trans-unit>
     </body>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="translated">需要提供非负数。</target>
         <note />
       </trans-unit>
+      <trans-unit id="This_program_location_is_throught_to_be_unreachable">
+        <source>This program location is thought to be unreachable.</source>
+        <target state="new">This program location is thought to be unreachable.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="translated">需要非負數。</target>
         <note />
       </trans-unit>
+      <trans-unit id="This_program_location_is_throught_to_be_unreachable">
+        <source>This program location is thought to be unreachable.</source>
+        <target state="new">This program location is thought to be unreachable.</target>
+        <note />
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.zh-Hant.xlf
@@ -7,9 +7,9 @@
         <target state="translated">需要非負數。</target>
         <note />
       </trans-unit>
-      <trans-unit id="This_program_location_is_throught_to_be_unreachable">
-        <source>This program location is thought to be unreachable.</source>
-        <target state="new">This program location is thought to be unreachable.</target>
+      <trans-unit id="This_program_location_is_throught_to_be_unreachable_File_0_Line_1">
+        <source>This program location is thought to be unreachable. File='{0}', Line={1}</source>
+        <target state="new">This program location is thought to be unreachable. File='{0}', Line={1}</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
Fixes #8538

The Razor compiler spends time formatting documentation strings for various tag helper objects, even though it never uses them. Each string is written directly to JSON when tag helpers are serialized. This affects throughput performance when tag helpers are passed from Microsoft.AspNet.Razor.Remote (running in Roslyn OOP) to VS, or when they are written to or read from the project.razor.json file.

This change provides a mechanism for tag helpers to reference a `DocumentationDescriptor` rather than a string. This descriptor holds onto an ID that refers to the expected string resource and an `object[]` of arguments if formatting is required. I've ensured that this is a non-breaking change. The `Documentation` property still exists and can be set on tag helper builders. However, I've gone ahead and updated the compiler to _never_ set that property and to use documentation descriptors instead. The net result is that excess work can be avoided in the compiler and in serialization.
