### PR TITLE
Add Microsoft.Net.Compilers.Razor.Toolset

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -51,7 +51,7 @@
       the same type that is included in Microsoft.CodeAnalysis.ExternalAccess.Razor, which allows InternalsVisibleTo access
       to Razor tooling.
     -->
-    <Compile Include="$(MSBuildThisFileDirectory)\src\Shared\LanguageSupport\IsExternalInit.cs" Link="LanguageSupport\IsExternalInit.cs" />
+    <Compile Condition="'$(SkipLanguageSupport)' != 'true'" Include="$(MSBuildThisFileDirectory)\src\Shared\LanguageSupport\IsExternalInit.cs" Link="LanguageSupport\IsExternalInit.cs" />
   </ItemGroup>
 
   <PropertyGroup Label="Package and Assembly Metadata">

--- a/Razor.Slim.slnf
+++ b/Razor.Slim.slnf
@@ -6,6 +6,7 @@
       "src\\Compiler\\Microsoft.AspNetCore.Mvc.Razor.Extensions\\src\\Microsoft.AspNetCore.Mvc.Razor.Extensions.csproj",
       "src\\Compiler\\Microsoft.AspNetCore.Razor.Language\\src\\Microsoft.AspNetCore.Razor.Language.csproj",
       "src\\Compiler\\Microsoft.CodeAnalysis.Razor\\src\\Microsoft.CodeAnalysis.Razor.csproj",
+      "src\\Compiler\\Microsoft.Net.Compilers.Razor.Toolset\\Microsoft.Net.Compilers.Razor.Toolset.csproj",
       "src\\Compiler\\Microsoft.NET.Sdk.Razor.SourceGenerators.Transport\\Microsoft.NET.Sdk.Razor.SourceGenerators.Transport.csproj",
       "src\\Compiler\\tools\\Microsoft.AspNetCore.Mvc.Razor.Extensions.Tooling.Internal\\Microsoft.AspNetCore.Mvc.Razor.Extensions.Tooling.Internal.csproj",
       "src\\Compiler\\tools\\Microsoft.CodeAnalysis.Razor.Tooling.Internal\\Microsoft.CodeAnalysis.Razor.Tooling.Internal.csproj",

--- a/Razor.sln
+++ b/Razor.sln
@@ -178,6 +178,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Razor.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.Test", "src\Razor\test\Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.Test\Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace.Test.csproj", "{70C6EAF1-202B-481B-ADD4-D30DF1396BDE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Net.Compilers.Razor.Toolset", "src\Compiler\Microsoft.Net.Compilers.Razor.Toolset\Microsoft.Net.Compilers.Razor.Toolset.csproj", "{6117D32B-DDAE-4654-8260-783B27153E0B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -746,6 +748,14 @@ Global
 		{70C6EAF1-202B-481B-ADD4-D30DF1396BDE}.Release|Any CPU.Build.0 = Release|Any CPU
 		{70C6EAF1-202B-481B-ADD4-D30DF1396BDE}.ReleaseNoVSIX|Any CPU.ActiveCfg = Release|Any CPU
 		{70C6EAF1-202B-481B-ADD4-D30DF1396BDE}.ReleaseNoVSIX|Any CPU.Build.0 = Release|Any CPU
+		{6117D32B-DDAE-4654-8260-783B27153E0B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6117D32B-DDAE-4654-8260-783B27153E0B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6117D32B-DDAE-4654-8260-783B27153E0B}.DebugNoVSIX|Any CPU.ActiveCfg = Debug|Any CPU
+		{6117D32B-DDAE-4654-8260-783B27153E0B}.DebugNoVSIX|Any CPU.Build.0 = Debug|Any CPU
+		{6117D32B-DDAE-4654-8260-783B27153E0B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6117D32B-DDAE-4654-8260-783B27153E0B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6117D32B-DDAE-4654-8260-783B27153E0B}.ReleaseNoVSIX|Any CPU.ActiveCfg = Debug|Any CPU
+		{6117D32B-DDAE-4654-8260-783B27153E0B}.ReleaseNoVSIX|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -828,6 +838,7 @@ Global
 		{2223B8FD-D98A-47BE-94A9-6A3A6B8557B8} = {3C0D6505-79B3-49D0-B4C3-176F0F1836ED}
 		{2FB4801C-A083-4F08-A4FB-C4910985DE31} = {3C0D6505-79B3-49D0-B4C3-176F0F1836ED}
 		{70C6EAF1-202B-481B-ADD4-D30DF1396BDE} = {92463391-81BE-462B-AC3C-78C6C760741F}
+		{6117D32B-DDAE-4654-8260-783B27153E0B} = {AA4EE974-E765-4B97-AF35-F734BF9830F6}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0035341D-175A-4D05-95E6-F1C2785A1E26}

--- a/src/Compiler/Microsoft.Net.Compilers.Razor.Toolset/Microsoft.Net.Compilers.Razor.Toolset.csproj
+++ b/src/Compiler/Microsoft.Net.Compilers.Razor.Toolset/Microsoft.Net.Compilers.Razor.Toolset.csproj
@@ -1,0 +1,42 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <!-- There's no source, no need to include language support here. -->
+    <SkipLanguageSupport>true</SkipLanguageSupport>
+
+    <IsPackable>true</IsPackable>
+    <IsShipping>true</IsShipping>
+    <NuspecPackageId>Microsoft.Net.Compilers.Razor.Toolset</NuspecPackageId>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <DevelopmentDependency>true</DevelopmentDependency>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+    <PackageDescription>
+      .NET Compilers Razor Toolset Package.
+      Referencing this package will cause the project to be built using the Razor compilers and source generator contained in the package, as opposed to the version installed with the SDK.
+
+      This package is primarily intended as a method for rapidly shipping hotfixes to customers. Using it as a long term solution for providing newer compilers on older MSBuild installations is explicitly not supported. That can and will break on a regular basis.
+
+      The supported mechanism for providing new compilers in a build enviroment is updating to the newer .NET SDK or Visual Studio Build Tools SKU.
+    </PackageDescription>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.NET.Sdk.Razor.SourceGenerators\Microsoft.NET.Sdk.Razor.SourceGenerators.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\tools\Microsoft.CodeAnalysis.Razor.Tooling.Internal\Microsoft.CodeAnalysis.Razor.Tooling.Internal.csproj" PrivateAssets="all"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="build\**\*.*" PackagePath="build\" />
+  </ItemGroup>
+
+  <Target Name="PackLayout" BeforeTargets="$(GenerateNuspecDependsOn)">
+    <ItemGroup>
+      <Content Include="$(ArtifactsBinDir)Microsoft.NET.Sdk.Razor.SourceGenerators\$(Configuration)\$(TargetFramework)\*.dll" PackagePath="\source-generators" />
+      <Content Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.Razor.Tooling.Internal\$(Configuration)\$(TargetFramework)\Microsoft.Extensions.ObjectPool.dll" PackagePath="\source-generators" />
+      <Content Include="$(ArtifactsBinDir)Microsoft.CodeAnalysis.Razor.Tooling.Internal\$(Configuration)\$(TargetFramework)\System.Collections.Immutable.dll" PackagePath="\source-generators" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Compiler/Microsoft.Net.Compilers.Razor.Toolset/Microsoft.Net.Compilers.Razor.Toolset.csproj
+++ b/src/Compiler/Microsoft.Net.Compilers.Razor.Toolset/Microsoft.Net.Compilers.Razor.Toolset.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup>
     <Content Include="build\**\*.*" PackagePath="build\" />
-    <Content Include="build\**\*.*" PackagePath="buildMultiTarget\" PackageCopyToOutput="true" PackageFlatten="true" />
+    <Content Include="buildMultiTargeting\**\*.*" PackagePath="buildMultiTargeting\" />
   </ItemGroup>
 
   <Target Name="PackLayout" BeforeTargets="$(GenerateNuspecDependsOn)">

--- a/src/Compiler/Microsoft.Net.Compilers.Razor.Toolset/Microsoft.Net.Compilers.Razor.Toolset.csproj
+++ b/src/Compiler/Microsoft.Net.Compilers.Razor.Toolset/Microsoft.Net.Compilers.Razor.Toolset.csproj
@@ -29,6 +29,7 @@
 
   <ItemGroup>
     <Content Include="build\**\*.*" PackagePath="build\" />
+    <Content Include="build\**\*.*" PackagePath="buildMultiTarget\" PackageCopyToOutput="true" PackageFlatten="true" />
   </ItemGroup>
 
   <Target Name="PackLayout" BeforeTargets="$(GenerateNuspecDependsOn)">

--- a/src/Compiler/Microsoft.Net.Compilers.Razor.Toolset/build/Microsoft.Net.Compilers.Razor.Toolset.targets
+++ b/src/Compiler/Microsoft.Net.Compilers.Razor.Toolset/build/Microsoft.Net.Compilers.Razor.Toolset.targets
@@ -1,0 +1,20 @@
+<Project>
+  <!-- Run after https://github.com/dotnet/sdk/blob/main/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.SourceGenerators.targets#L15 -->
+  <Target Name="_PrepareRazorSourceGeneratorsToolset"
+    BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun"
+    DependsOnTargets="_PrepareRazorSourceGenerators">
+
+    <ItemGroup>
+      <Analyzer Remove="@(_RazorAnalyzer)" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_RazorSdkSourceGeneratorDirectoryRootOverride>$(MSBuildThisFileDirectory)..\source-generators\</_RazorSdkSourceGeneratorDirectoryRootOverride>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_RazorAnalyzerOverride Include="$(_RazorSdkSourceGeneratorDirectoryRootOverride)*.dll" />
+      <Analyzer Include="@(_RazorAnalyzerOverride)" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/Compiler/Microsoft.Net.Compilers.Razor.Toolset/buildMultiTargeting/Microsoft.Net.Compilers.Razor.Toolset.targets
+++ b/src/Compiler/Microsoft.Net.Compilers.Razor.Toolset/buildMultiTargeting/Microsoft.Net.Compilers.Razor.Toolset.targets
@@ -1,0 +1,4 @@
+<!-- Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. -->
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\build\$(MSBuildThisFile)" />
+</Project>


### PR DESCRIPTION
Similar to the Microsoft.Net.Compilers.Toolset package that we use in roslyn, this nuget package will override the generators used by a project, replacing them with the specific versions from this package. The purpose of this package is to allow shipping hotfixes to customers directly in a simple manner, without having to ask them to manually do a bunch of msbuild magic or replacing existing dlls. It may be helpful to reference the targets that add the razor generators to the compilation in the first place when reviewing: https://github.com/dotnet/sdk/blob/main/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.SourceGenerators.targets#L15.
