### PR TITLE
Fix end of document formatting

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpOnTypeFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpOnTypeFormattingPass.cs
@@ -168,7 +168,7 @@ internal class CSharpOnTypeFormattingPass : CSharpFormattingPassBase
         //
         // We'll happy format lines 1 and 2, and ignore the closing brace altogether. So, by looking one line further
         // we won't have that problem.
-        if (rangeAfterFormatting.End.Line + lineDelta < cleanedText.Lines.Count)
+        if (rangeAfterFormatting.End.Line + lineDelta < cleanedText.Lines.Count - 1)
         {
             lineDelta++;
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CSharpStatementBlockOnTypeFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CSharpStatementBlockOnTypeFormattingTest.cs
@@ -122,4 +122,19 @@ public class CSharpStatementBlockOnTypeFormattingTest : FormattingTestBase
                     """,
             triggerCharacter: ';');
     }
+
+    [Fact]
+    public async Task Semicolon_AddsLineAtEndOfDocument()
+    {
+        await RunOnTypeFormattingTestAsync(
+            input: """
+                    @{ var x = new HtmlString("sdf");$$ }
+                    """,
+            expected: """
+                    @{
+                        var x = new HtmlString("sdf"); 
+                    }
+                    """,
+            triggerCharacter: ';');
+    }
 }


### PR DESCRIPTION
﻿### Summary of the changes

- Some code actions in VS Code would fail if the edit involved adding a line at the end of the file. This was due to a bug with source text boundaries.
- Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1821816