### PR TITLE
Move file to the misc workspace when it is deleted, if it is open

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LspLogger.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LspLogger.cs
@@ -58,6 +58,10 @@ internal class LspLogger : IRazorLogger
             _ => throw new NotImplementedException(),
         };
         var message = formatter(state, exception);
+        if (message == "[null]" && exception is not null)
+        {
+            message = exception.ToString();
+        }
 
         var @params = new LogMessageParams
         {


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1823464

We have file watchers, because we care about projects and things, and LSP has `didOpen` and `didClose` because LSP cares about documents. Sometimes these two things don't agree :)

We were removing all of our knowledge of a document when the file is deleted, which makes sense at first glance, but there is no rule in LSP that says a file that is open has to exist in the physical realm. This change makes us move an open file to our Misc Files workspace, instead of forgetting about it, if its open. 

Matches Roslyn behaviour here: https://github.com/dotnet/roslyn/blob/1119057b76330c6ec80b2a8c04c7fb4973d48773/src/Features/LanguageServer/Protocol/Workspaces/LspWorkspaceManager.cs#L251-L257