### PR TITLE
During source build, target net8.0 only

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,11 +1,5 @@
 ﻿<UsageData>
   <IgnorePatterns>
     <UsagePattern IdentityGlob="Microsoft.SourceBuild.Intermediate.*/*" />
-
-    <!-- Ignoring the following prebuilts. net7.0 targeting is still needed
-         due to https://github.com/dotnet/razor/issues/8293#issuecomment-1454042002
-         net7.0 targeting removal is tracked in https://github.com/dotnet/razor/issues/8531 -->
-    <UsagePattern IdentityGlob="Microsoft.AspNetCore.App.Ref/7.0.2" />
-    <UsagePattern IdentityGlob="Microsoft.NETCore.App.Ref/7.0.2" />
   </IgnorePatterns>
 </UsageData>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -27,6 +27,7 @@
     <DefaultNetFxTargetFramework>net472</DefaultNetFxTargetFramework>
     <DefaultNetCoreTargetFramework>net8.0</DefaultNetCoreTargetFramework>
     <DefaultNetCoreTargetFrameworks>$(DefaultNetCoreTargetFramework);net7.0</DefaultNetCoreTargetFrameworks>
+    <DefaultNetCoreTargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">$(DefaultNetCoreTargetFramework)</DefaultNetCoreTargetFrameworks>
     <DefaultNetCoreWindowsTargetFrameworks>net8.0-windows;net7.0-windows</DefaultNetCoreWindowsTargetFrameworks>
   </PropertyGroup>
   <!--


### PR DESCRIPTION
Related to https://github.com/dotnet/razor/issues/8293

For .NET source-build, repos must target NetCurrent (.NET 8.0) and/or NetStandard.  This initial changes for https://github.com/dotnet/razor/issues/8293 added .NET 8.0 on top of the existing tfms.  This PR conditions source-build to only target net8.0 in order to eliminate prebuilts.
