### PR TITLE
add review comment to sb files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,7 @@
 /eng/common/                                   @dotnet/razor-tooling @dotnet/razor-compiler
 /eng/Versions.props                            @dotnet/razor-tooling @dotnet/razor-compiler
 /eng/Version.Details.xml                       @dotnet/razor-tooling @dotnet/razor-compiler
+/eng/SourceBuild*                              @dotnet/source-build-internal
 /src/Razor                                     @dotnet/razor-tooling
 /src/Compiler                                  @dotnet/razor-compiler
 /src/Shared                                    @dotnet/razor-tooling @dotnet/razor-compiler

--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -1,4 +1,6 @@
-﻿<Project>
+﻿<!-- Whenever altering this or other Source Build files, please include @dotnet/source-build-internal as a reviewer. -->
+
+<Project>
   <PropertyGroup>
     <GitHubRepositoryName>razor</GitHubRepositoryName>
     <SourceBuildManagedOnly>true</SourceBuildManagedOnly>

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,4 +1,7 @@
-﻿<UsageData>
+﻿<!-- Whenever altering this or other Source Build files, please include @dotnet/source-build-internal as a reviewer. -->
+<!-- See aka.ms/dotnet/prebuilts for guidance on what pre-builts are and how to eliminate them. -->
+
+<UsageData>
   <IgnorePatterns>
     <UsagePattern IdentityGlob="Microsoft.SourceBuild.Intermediate.*/*" />
 


### PR DESCRIPTION
Contributes to https://github.com/dotnet/source-build/issues/3435

Adds comments to source-build files asking for the inclusion of the source-build team in PRs that alter `SourceBuild*` files. Non-reviewed changes could potentially cause issues down the line, be it in the downstream repos or the product build (as has happened in the past, see https://github.com/dotnet/source-build/issues/3435#issuecomment-1570650046)