### PR TITLE
Prevent large number of dictionary resizes

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/TagHelperParseTreeRewriter.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/TagHelperParseTreeRewriter.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy;
 
 internal static class TagHelperParseTreeRewriter
 {
-    public static RazorSyntaxTree Rewrite(RazorSyntaxTree syntaxTree, string tagHelperPrefix, IEnumerable<TagHelperDescriptor> descriptors, out ISet<TagHelperDescriptor> usedDescriptors)
+    public static RazorSyntaxTree Rewrite(RazorSyntaxTree syntaxTree, string tagHelperPrefix, IReadOnlyList<TagHelperDescriptor> descriptors, out ISet<TagHelperDescriptor> usedDescriptors)
     {
         var errorSink = new ErrorSink();
 
@@ -68,7 +68,7 @@ internal static class TagHelperParseTreeRewriter
         public Rewriter(
             RazorSourceDocument source,
             string tagHelperPrefix,
-            IEnumerable<TagHelperDescriptor> descriptors,
+            IReadOnlyList<TagHelperDescriptor> descriptors,
             RazorParserFeatureFlags featureFlags,
             ErrorSink errorSink)
         {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperBinder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperBinder.cs
@@ -24,8 +24,12 @@ internal sealed class TagHelperBinder
     /// <param name="descriptors">The descriptors that the <see cref="TagHelperBinder"/> will pull from.</param>
     public TagHelperBinder(string tagHelperPrefix, IEnumerable<TagHelperDescriptor> descriptors)
     {
+        // To prevent creating a dictionary that gets resized many times, we attempt to guess at a
+        // suitable capacity.
+        var descriptorCount = (descriptors is ICollection<TagHelperDescriptor> bounded) ? bounded.Count : descriptors.Count();
+
         _tagHelperPrefix = tagHelperPrefix;
-        _registrations = new Dictionary<string, HashSet<TagHelperDescriptor>>(StringComparer.OrdinalIgnoreCase);
+        _registrations = new Dictionary<string, HashSet<TagHelperDescriptor>>(descriptorCount, StringComparer.OrdinalIgnoreCase);
 
         // Populate our registrations
         foreach (var descriptor in descriptors)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperBinder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperBinder.cs
@@ -22,14 +22,11 @@ internal sealed class TagHelperBinder
     /// </summary>
     /// <param name="tagHelperPrefix">The tag helper prefix being used by the document.</param>
     /// <param name="descriptors">The descriptors that the <see cref="TagHelperBinder"/> will pull from.</param>
-    public TagHelperBinder(string tagHelperPrefix, IEnumerable<TagHelperDescriptor> descriptors)
+    public TagHelperBinder(string tagHelperPrefix, IReadOnlyList<TagHelperDescriptor> descriptors)
     {
-        // To prevent creating a dictionary that gets resized many times, we attempt to guess at a
-        // suitable capacity.
-        var descriptorCount = (descriptors is ICollection<TagHelperDescriptor> bounded) ? bounded.Count : descriptors.Count();
-
         _tagHelperPrefix = tagHelperPrefix;
-        _registrations = new Dictionary<string, HashSet<TagHelperDescriptor>>(descriptorCount, StringComparer.OrdinalIgnoreCase);
+        // To reduce the frequency of dictionary resizes we use the incoming number of descriptors as a heuristic
+        _registrations = new Dictionary<string, HashSet<TagHelperDescriptor>>(descriptors.Count, StringComparer.OrdinalIgnoreCase);
 
         // Populate our registrations
         foreach (var descriptor in descriptors)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/TagHelperParseTreeRewriterTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/TagHelperParseTreeRewriterTest.cs
@@ -56,7 +56,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
         var parseTreeRewriter = new TagHelperParseTreeRewriter.Rewriter(
             parseResult.Source,
             null,
-            Enumerable.Empty<TagHelperDescriptor>(),
+            Array.Empty<TagHelperDescriptor>(),
             parseResult.Options.FeatureFlags,
             errorSink);
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/TagHelperRewritingTestBase.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/TagHelperRewritingTestBase.cs
@@ -17,7 +17,7 @@ public class TagHelperRewritingTestBase : ParserTestBase
         EvaluateData(descriptors, documentContent);
     }
 
-    internal IEnumerable<TagHelperDescriptor> BuildDescriptors(params string[] tagNames)
+    internal IReadOnlyList<TagHelperDescriptor> BuildDescriptors(params string[] tagNames)
     {
         var descriptors = new List<TagHelperDescriptor>();
 
@@ -29,11 +29,11 @@ public class TagHelperRewritingTestBase : ParserTestBase
             descriptors.Add(descriptor);
         }
 
-        return descriptors;
+        return descriptors.AsReadOnly();
     }
 
     internal void EvaluateData(
-        IEnumerable<TagHelperDescriptor> descriptors,
+        IReadOnlyList<TagHelperDescriptor> descriptors,
         string documentContent,
         string tagHelperPrefix = null,
         RazorParserFeatureFlags featureFlags = null)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TagHelperBinderTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TagHelperBinderTest.cs
@@ -167,8 +167,8 @@ public class TagHelperBinderTest
             return new TheoryData<
                 string, // tagName
                 string, // parentTagName
-                IEnumerable<TagHelperDescriptor>, // availableDescriptors
-                IEnumerable<TagHelperDescriptor>> // expectedDescriptors
+                IReadOnlyList<TagHelperDescriptor>, // availableDescriptors
+                IReadOnlyList<TagHelperDescriptor>> // expectedDescriptors
                 {
                     {
                         "strong",
@@ -207,7 +207,7 @@ public class TagHelperBinderTest
         object expectedDescriptors)
     {
         // Arrange
-        var tagHelperBinder = new TagHelperBinder(null, (IEnumerable<TagHelperDescriptor>)availableDescriptors);
+        var tagHelperBinder = new TagHelperBinder(null, (IReadOnlyList<TagHelperDescriptor>)availableDescriptors);
 
         // Act
         var bindingResult = tagHelperBinder.GetBinding(


### PR DESCRIPTION
### Summary of the changes
GCPauseWatson reports high GC pressure caused by frequent dictionary resizes in this code:
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1824275

We attempt to reduce these by giving the dictionary a reasonable size to start with.
-

Fixes:
- Preallocate a dictionary large enough for all the likely additions we'll make.
