### PR TITLE
Refactor SB TFM logic to account for multiple branch dependents

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -41,7 +41,48 @@
 
     <!-- By default, nothing builds from source build. Individual projects can opt in instead -->
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
+
+    <DefaultNetFxTargetFramework>net472</DefaultNetFxTargetFramework>
   </PropertyGroup>
+
+  <!--
+    There are effectively three modes that are needed for our source build TFMs and this is where
+    we calculate them
+  -->
+  <Choose>
+    <!--
+      1. CI source build leg: this needs to build the current and previous source build TFM. Both are
+        necessary as the output of this leg is used in other CI source build legs. Those could be
+        targeting NetCurrent or NetPrevious hence we must produce both.
+    -->
+    <When Condition="'$(DotNetBuildFromSource)' == 'true' AND '$(DotNetBuildFromSourceFlavor)' != 'Product'">
+      <PropertyGroup>
+        <DefaultNetCoreTargetFramework>$(NetCurrent)</DefaultNetCoreTargetFramework>
+        <DefaultNetCoreTargetFrameworks>$(DefaultNetCoreTargetFramework);$(NetPrevious)</DefaultNetCoreTargetFrameworks>
+      </PropertyGroup>
+    </When>
+
+    <!--
+      2. Source build the product: this is the all up build of the product which needs only NetCurrent
+    -->
+    <When Condition="'$(DotNetBuildFromSource)' == 'true' AND '$(DotNetBuildFromSourceFlavor)' == 'Product'">
+      <PropertyGroup>
+        <DefaultNetCoreTargetFramework>$(NetCurrent)</DefaultNetCoreTargetFramework>
+        <DefaultNetCoreTargetFrameworks>$(DefaultNetCoreTargetFramework)</DefaultNetCoreTargetFrameworks>
+      </PropertyGroup>
+    </When>
+
+    <!--
+      3. Everything else including normal CI, developer machines and official builds.
+    -->
+    <Otherwise>
+      <PropertyGroup>
+        <DefaultNetCoreTargetFramework>net8.0</DefaultNetCoreTargetFramework>
+        <DefaultNetCoreTargetFrameworks>$(DefaultNetCoreTargetFramework);net7.0</DefaultNetCoreTargetFrameworks>
+        <DefaultNetCoreWindowsTargetFrameworks>net8.0-windows;net7.0-windows</DefaultNetCoreWindowsTargetFrameworks>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
 
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)eng\BannedSymbols.txt" />

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,5 +1,12 @@
 ﻿<UsageData>
   <IgnorePatterns>
     <UsagePattern IdentityGlob="Microsoft.SourceBuild.Intermediate.*/*" />
+
+    <!-- 
+      Ignoring the following prebuilts. NetPrevious targeting is needed in repo legs
+      because the intermediate is used by multiple versions of dependent repos.
+    -->
+    <UsagePattern IdentityGlob="Microsoft.AspNetCore.App.Ref/7.0.*" />
+    <UsagePattern IdentityGlob="Microsoft.NETCore.App.Ref/7.0.*" />
   </IgnorePatterns>
 </UsageData>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -24,11 +24,6 @@
     -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">false</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>
-    <DefaultNetFxTargetFramework>net472</DefaultNetFxTargetFramework>
-    <DefaultNetCoreTargetFramework>net8.0</DefaultNetCoreTargetFramework>
-    <DefaultNetCoreTargetFrameworks>$(DefaultNetCoreTargetFramework);net7.0</DefaultNetCoreTargetFrameworks>
-    <DefaultNetCoreTargetFrameworks Condition="'$(DotNetBuildFromSource)' == 'true'">$(DefaultNetCoreTargetFramework)</DefaultNetCoreTargetFrameworks>
-    <DefaultNetCoreWindowsTargetFrameworks>net8.0-windows;net7.0-windows</DefaultNetCoreWindowsTargetFrameworks>
   </PropertyGroup>
   <!--
     Versioning for tooling releases.


### PR DESCRIPTION
Because Razor flows into multiple SDK major version branches, the TFM logic for source-build needs to be updated so that only the "current" TFM for the SDK is targeted in order to prevent prebuilts.

This is in response to https://github.com/dotnet/razor/pull/8779/files#r1213897264.