### PR TITLE
Don't show assert dialog UI during test runs

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/TestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/TestBase.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer;
@@ -92,7 +91,7 @@ public abstract partial class TestBase : IAsyncLifetime
         // Give this thread a name, so it's easier to find in the VS Threads window.
         Thread.CurrentThread.Name ??= "Main Thread";
 
-        ThrowingTraceListener.ReplaceDefaultListener();
+        ThrowingTraceListener.AddToListeners();
     }
 
     Task IAsyncLifetime.InitializeAsync() => InitializeAsync();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/TestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/TestBase.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer;
@@ -90,6 +91,8 @@ public abstract partial class TestBase : IAsyncLifetime
 
         // Give this thread a name, so it's easier to find in the VS Threads window.
         Thread.CurrentThread.Name ??= "Main Thread";
+
+        ThrowingTraceListener.ReplaceDefaultListener();
     }
 
     Task IAsyncLifetime.InitializeAsync() => InitializeAsync();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/ThrowingTraceListener.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/ThrowingTraceListener.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.AspNetCore.Razor.Test.Common;
+
+public sealed class ThrowingTraceListener : TraceListener
+{
+    public static void ReplaceDefaultListener()
+    {
+        // Remove the default trace listener so that Debug.Assert and Debug.Fail don't diplay
+        // assert dialog during test runs.
+
+        var sawThrowingTraceListener = false;
+        var listeners = Trace.Listeners;
+        for (var i = listeners.Count - 1; i >= 0; i--)
+        {
+            switch (listeners[i])
+            {
+                case DefaultTraceListener:
+                    listeners.RemoveAt(i);
+                    break;
+                case ThrowingTraceListener:
+                    sawThrowingTraceListener = true;
+                    break;
+            }
+        }
+
+        if (!sawThrowingTraceListener)
+        {
+            // Add an instance of the ThrowingTraceListener so that Debug.Assert and Debug.Fail
+            // throw exceptions during test runs.
+            listeners.Add(new ThrowingTraceListener());
+        }
+    }
+
+    public override void Fail(string? message, string? detailMessage)
+    {
+        throw new InvalidOperationException(
+            (string.IsNullOrEmpty(message) ? "Assertion failed" : message) +
+            (string.IsNullOrEmpty(detailMessage) ? "" : Environment.NewLine + detailMessage));
+    }
+
+    public override void Write(object? o)
+    {
+    }
+
+    public override void Write(object? o, string? category)
+    {
+    }
+
+    public override void Write(string? message)
+    {
+    }
+
+    public override void Write(string? message, string? category)
+    {
+    }
+
+    public override void WriteLine(object? o)
+    {
+    }
+
+    public override void WriteLine(object? o, string? category)
+    {
+    }
+
+    public override void WriteLine(string? message)
+    {
+    }
+
+    public override void WriteLine(string? message, string? category)
+    {
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractIntegrationTest.cs
@@ -39,7 +39,7 @@ public abstract class AbstractIntegrationTest : AbstractIdeIntegrationTest
 
     public override async Task InitializeAsync()
     {
-        ThrowingTraceListener.ReplaceDefaultListener();
+        ThrowingTraceListener.AddToListeners();
 
         await base.InitializeAsync();
     }

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractIntegrationTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading;
+using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.VisualStudio.Extensibility.Testing;
 using Xunit;
 using Xunit.Sdk;
@@ -38,6 +39,8 @@ public abstract class AbstractIntegrationTest : AbstractIdeIntegrationTest
 
     public override async Task InitializeAsync()
     {
+        ThrowingTraceListener.ReplaceDefaultListener();
+
         await base.InitializeAsync();
     }
 }


### PR DESCRIPTION
This change sets `DefaultTraceListener.AssertUiEnabled` to false during test runs to avoid displaying assert dialogs, which can hang CI machines. To ensure that we continue seeing assertions fail during debug tests (just without UI) a new `ThrowingTraceListener` has been added.