### PR TITLE
Add System.Collections.Immutable package dependency

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -105,12 +105,16 @@
       <Sha>9e7fbcab4e5275f63c0cd37553ba426de9194309</Sha>
       <SourceBuild RepoName="xliff-tasks" ManagedOnly="true" />
     </Dependency>
-    <!-- Necessary for source-build. This allows the package to be retrieved from previously-source-built artifacts
-         and flow in as dependencies of the packages produced by razor. Without this entry an SBRP version of the
-         dependency would be bundled together with the produced package, causing issues for the consumer. -->
+    <!-- Necessary for source-build. This allows Microsoft.Extensions.ObjectPool and System.Collections.Immutable packages
+         to be retrieved from live source-build and their content consumed by packages produced by razor.
+         Without these entries, due to PVP flow work, SBRP packages would be consumed causing runtime issue. -->
     <Dependency Name="Microsoft.Extensions.ObjectPool" Version="6.0.0">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>ae1a6cbe225b99c0bf38b7e31bf60cb653b73a52</Sha>
+    </Dependency>
+    <Dependency Name="System.Collections.Immutable" Version="6.0.0">
+      <Uri>https://github.com/dotnet/runtime</Uri>
+      <Sha>4822e3c3aa77eb82b2fb33c9321f923cf11ddde6</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -72,9 +72,12 @@
     <MicrosoftVisualStudioLanguageServicesPackageVersion>4.7.0-2.23301.2</MicrosoftVisualStudioLanguageServicesPackageVersion>
     <MicrosoftSourceLinkGitHubPackageVersion>8.0.0-beta.23252.2</MicrosoftSourceLinkGitHubPackageVersion>
     <MicrosoftDotNetXliffTasksPackageVersion>1.0.0-beta.23266.1</MicrosoftDotNetXliffTasksPackageVersion>
-    <!-- Exception - this version is not updated by automation, but is in Version.Details due to source-build.
-        See its entry in Version.Details for more information. -->
+    <!--
+      Exception - Microsoft.Extensions.ObjectPool and System.Collections.Immutable packages are not updated by automation,
+      but are present in Version.Details.xml for source-build PVP flow. See the comment in Version.Details.xml for more information.
+    -->
     <MicrosoftExtensionsObjectPoolPackageVersion>6.0.0</MicrosoftExtensionsObjectPoolPackageVersion>
+    <SystemCollectionsImmutablePackageVersion>6.0.0</SystemCollectionsImmutablePackageVersion>
   </PropertyGroup>
   <!--
 
@@ -95,7 +98,6 @@
     <VisualStudioLanguageServerProtocolVersion>17.6.22</VisualStudioLanguageServerProtocolVersion>
     <!-- dotnet/runtime packages -->
     <MicrosoftExtensionsPackageVersion>6.0.0</MicrosoftExtensionsPackageVersion>
-    <SystemCollectionsImmutablePackageVersion>6.0.0</SystemCollectionsImmutablePackageVersion>
     <SystemCompositionPackageVersion>7.0.0</SystemCompositionPackageVersion>
     <SystemDiagnosticsDiagnosticSourcePackageVersion>6.0.0</SystemDiagnosticsDiagnosticSourcePackageVersion>
     <SystemResourcesExtensionsPackageVersion>6.0.0</SystemResourcesExtensionsPackageVersion>


### PR DESCRIPTION
Contributes to: https://github.com/dotnet/source-build/issues/3224

This dependency is needed for source-build PVP flow, which was enabled for `razor` with https://github.com/dotnet/installer/pull/16495

Fix for ttps://github.com/dotnet/source-build/issues/3224 will enable `razor` to consume live `runtime` and `aspnetcore` packages, during product source-build.