### PR TITLE
Fix perf of multiline semantic tokens, and LF handling of same

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensBenchmark.cs
@@ -45,6 +45,9 @@ public class RazorSemanticTokensBenchmark : RazorLanguageServerBenchmarkBase
 
     private string TargetPath { get; set; }
 
+    [ParamsAllValues]
+    public bool WithMultiLineComment { get; set; }
+
     [GlobalSetup(Target = nameof(RazorSemanticTokensRangeAsync))]
     public async Task InitializeRazorSemanticAsync()
     {
@@ -53,8 +56,10 @@ public class RazorSemanticTokensBenchmark : RazorLanguageServerBenchmarkBase
         var projectRoot = Path.Combine(RepoRoot, "src", "Razor", "test", "testapps", "ComponentApp");
         ProjectFilePath = Path.Combine(projectRoot, "ComponentApp.csproj");
         PagesDirectory = Path.Combine(projectRoot, "Components", "Pages");
-        var filePath = Path.Combine(PagesDirectory, $"SemanticTokens.razor");
-        TargetPath = "/Components/Pages/SemanticTokens.razor";
+
+        var fileName = WithMultiLineComment ? "SemanticTokens_LargeMultiLineComment" : "SemanticTokens";
+        var filePath = Path.Combine(PagesDirectory, $"{fileName}.razor");
+        TargetPath = $"/Components/Pages/{fileName}.razor";
 
         var documentUri = new Uri(filePath);
         var documentSnapshot = GetDocumentSnapshot(ProjectFilePath, filePath, TargetPath);
@@ -92,11 +97,6 @@ public class RazorSemanticTokensBenchmark : RazorLanguageServerBenchmarkBase
         await UpdateDocumentAsync(documentVersion, DocumentSnapshot, cancellationToken).ConfigureAwait(false);
         await RazorSemanticTokenService.GetSemanticTokensAsync(
             textDocumentIdentifier, Range, DocumentContext, SemanticTokensLegend, cancellationToken).ConfigureAwait(false);
-    }
-
-    private static LspServices GetLspServices()
-    {
-        throw new NotImplementedException();
     }
 
     private async Task UpdateDocumentAsync(int newVersion, IDocumentSnapshot documentSnapshot, CancellationToken cancellationToken)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/TagHelperSemanticRangeVisitor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/TagHelperSemanticRangeVisitor.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
-using Microsoft.AspNetCore.Razor.LanguageServer.Semantic.Models;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -485,13 +484,35 @@ internal sealed class TagHelperSemanticRangeVisitor : SyntaxWalker
             var childNodes = node.ChildNodes();
             if (childNodes.Count == 0)
             {
-                var content = node.GetContent();
-                var lines = content.Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
                 var charPosition = range.Start.Character;
-                for (var i = 0; i < lines.Length; i++)
+                var lineStartAbsoluteIndex = node.SpanStart - charPosition;
+                for (var i = range.Start.Line; i <= range.End.Line; i++)
                 {
-                    var startPosition = new Position(range.Start.Line + i, charPosition);
-                    var endPosition = new Position(range.Start.Line + i, charPosition + lines[i].Length);
+                    var startPosition = new Position(i, charPosition);
+
+                    // NOTE: GetLineLength includes newlines but we don't report tokens for newlines so
+                    // need to account for them.
+                    var lineLength = source.Lines.GetLineLength(i);
+
+                    // For the last line, we end where the syntax tree tells us to. For all other lines, we end at the
+                    // last non-newline character
+                    var endChar = i == range.End.Line
+                       ? range.End.Character
+                       : GetLastNonWhitespaceCharacterOffset(source, lineStartAbsoluteIndex, lineLength);
+
+                    // Make sure we move our line start index pointer on, before potentially skipping out on the loop
+                    lineStartAbsoluteIndex += lineLength;
+                    charPosition = 0;
+
+                    // Blank line. The less than check is important because we could have seen two newline characters, but
+                    // be in a situation where we have an LF file with multiple blank lines, so endChar would be -1. Still
+                    // a blank line though :)
+                    if (endChar <= 0)
+                    {
+                        continue;
+                    }
+
+                    var endPosition = new Position(i, endChar);
                     var lineRange = new Range
                     {
                         Start = startPosition,
@@ -499,7 +520,6 @@ internal sealed class TagHelperSemanticRangeVisitor : SyntaxWalker
                     };
                     var semantic = new SemanticRange(semanticKind, lineRange, modifier: 0);
                     AddRange(semantic);
-                    charPosition = 0;
                 }
             }
             else
@@ -532,6 +552,22 @@ internal sealed class TagHelperSemanticRangeVisitor : SyntaxWalker
             {
                 _semanticRanges.Add(semanticRange);
             }
+        }
+
+        static int GetLastNonWhitespaceCharacterOffset(RazorSourceDocument source, int lineStartAbsoluteIndex, int lineLength)
+        {
+            // lineStartAbsoluteIndex + lineLength is the first character of the next line, so move back one to get to the end of the line
+            lineLength--;
+
+            var lineEndAbsoluteIndex = lineStartAbsoluteIndex + lineLength;
+            if (lineEndAbsoluteIndex == 0)
+            {
+                return lineLength;
+            }
+
+            return source[lineEndAbsoluteIndex - 1] is '\n' or '\r'
+                ? lineLength - 1
+                : lineLength;
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/RazorSemanticTokenInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/RazorSemanticTokenInfoServiceTest.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
+using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.Mef;
 using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -611,6 +612,35 @@ public class RazorSemanticTokenInfoServiceTest : SemanticTokenTestBase
                 skd
                 slf*@
                 """;
+
+        var razorRange = GetRange(documentText);
+        var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
+        await AssertSemanticTokensAsync(documentText, isRazorFile: false, razorRange, csharpTokens: csharpTokens);
+    }
+
+    [Fact]
+    public async Task GetSemanticTokens_Razor_MultiLineCommentWithBlankLines()
+    {
+        var documentText =
+            """
+                @* kdl
+
+                skd
+                    
+                        sdfasdfasdf
+                slf*@
+                """;
+
+        var razorRange = GetRange(documentText);
+        var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);
+        await AssertSemanticTokensAsync(documentText, isRazorFile: false, razorRange, csharpTokens: csharpTokens);
+    }
+
+    [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/8176")]
+    public async Task GetSemanticTokens_Razor_MultiLineCommentWithBlankLines_LF()
+    {
+        var documentText = "@* kdl\n\nskd\n    \n        sdfasdfasdf\nslf*@";
 
         var razorRange = GetRange(documentText);
         var csharpTokens = await GetCSharpSemanticTokensResponseAsync(documentText, razorRange, isRazorFile: false);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/TestFiles/RazorSemanticTokenInfoServiceTest/GetSemanticTokens_Razor_MultiLineCommentWithBlankLines.semantic.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/TestFiles/RazorSemanticTokenInfoServiceTest/GetSemanticTokens_Razor_MultiLineCommentWithBlankLines.semantic.txt
@@ -1,0 +1,10 @@
+//line,characterPos,length,tokenType,modifier
+0 0 1 razorCommentTransition 0
+0 1 1 razorCommentStar 0
+0 1 4 razorComment 0
+2 0 3 razorComment 0
+1 0 4 razorComment 0
+1 0 19 razorComment 0
+1 0 3 razorComment 0
+0 3 1 razorCommentStar 0
+0 1 1 razorCommentTransition 0

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/TestFiles/RazorSemanticTokenInfoServiceTest/GetSemanticTokens_Razor_MultiLineCommentWithBlankLines_LF.semantic.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/TestFiles/RazorSemanticTokenInfoServiceTest/GetSemanticTokens_Razor_MultiLineCommentWithBlankLines_LF.semantic.txt
@@ -1,0 +1,10 @@
+//line,characterPos,length,tokenType,modifier
+0 0 1 razorCommentTransition 0
+0 1 1 razorCommentStar 0
+0 1 4 razorComment 0
+2 0 3 razorComment 0
+1 0 4 razorComment 0
+1 0 19 razorComment 0
+1 0 3 razorComment 0
+0 3 1 razorCommentStar 0
+0 1 1 razorCommentTransition 0

--- a/src/Razor/test/testapps/ComponentApp/Components/Pages/SemanticTokens_LargeMultiLineComment.razor
+++ b/src/Razor/test/testapps/ComponentApp/Components/Pages/SemanticTokens_LargeMultiLineComment.razor
@@ -1,0 +1,51 @@
+﻿@page "/semantic"
+
+<p>Words!</p>
+
+<p>@* this is 
+a multi
+line comment *@</p>
+
+<NavMenu 
+    Collapse="true"
+ />
+
+<NavMenu />
+
+@*<div class="top-row pl-4 navbar navbar-dark">
+    <a class="navbar-brand" href="">ComponentApp</a>
+    <button class="navbar-toggler" @onclick="@ToggleNavMenu">
+        <span class="navbar-toggler-icon"></span>
+    </button>
+</div>
+
+<div class="@NavMenuCssClass" @onclick="@ToggleNavMenu">
+    <ul class="nav flex-column">
+        <li class="nav-item px-3">
+            <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
+                <span class="oi oi-home" aria-hidden="true"></span> Home
+            </NavLink>
+        </li>
+        <li class="nav-item px-3">
+            <NavLink class="nav-link" href="counter">
+                <span class="oi oi-plus" aria-hidden="true"></span> Counter
+            </NavLink>
+        </li>
+        <li class="nav-item px-3">
+            <NavLink class="nav-link" href="fetchdata">
+                <span class="oi oi-list-rich" aria-hidden="true"></span> Fetch data
+            </NavLink>
+        </li>
+    </ul>
+</div>
+
+@functions {
+    bool collapseNavMenu = true;
+
+    string NavMenuCssClass => collapseNavMenu ? "collapse" : null;
+
+    void ToggleNavMenu()
+    {
+        collapseNavMenu = !collapseNavMenu;
+    }
+}*@


### PR DESCRIPTION
Fixes #6756
Fixes #8176

The compiler team fixed the perf of `GetContent()` in https://github.com/dotnet/razor/pull/8032 but we were still being pretty naive in our usage here, and the use of `Environment.NewLine` was just wrong.

Results show no harm without a large comment, but a big saving in allocations when there is a large comment.

Old:

|                        Method | WithMultiLineComment |     Mean |    Error |   StdDev |   Median |      Min |       Max |   Gen0 |   Gen1 | Allocated |
|------------------------------ |--------------------- |---------:|---------:|---------:|---------:|---------:|----------:|-------:|-------:|----------:|
| RazorSemanticTokensRangeAsync |                False | 53.43 us | 1.057 us | 2.428 us | 53.54 us | 48.58 us |  60.56 us | 0.6104 |      - |   3.75 KB |
| RazorSemanticTokensRangeAsync |                 True | 97.77 us | 1.787 us | 1.912 us | 98.18 us | 93.45 us | 100.36 us | 6.1035 | 0.2441 |  34.87 KB |

New:

|                        Method | WithMultiLineComment |     Mean |    Error |   StdDev |   Median |      Min |       Max |   Gen0 |   Gen1 | Allocated |
|------------------------------ |--------------------- |---------:|---------:|---------:|---------:|---------:|----------:|-------:|-------:|----------:|
| RazorSemanticTokensRangeAsync |                False | 53.50 us | 1.023 us | 1.218 us | 53.63 us | 50.81 us |  55.36 us | 0.6104 | 0.0610 |   3.75 KB |
| RazorSemanticTokensRangeAsync |                 True | 83.66 us | 1.581 us | 1.401 us | 83.25 us | 82.27 us |  86.72 us | 2.6855 | 0.1221 |  15.29 KB |
