### PR TITLE
Allow the Introduce local code action to run in code blocks

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/DefaultCSharpCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/DefaultCSharpCodeActionProvider.cs
@@ -33,6 +33,7 @@ internal sealed class DefaultCSharpCodeActionProvider : ICSharpCodeActionProvide
         RazorPredefinedCodeRefactoringProviderNames.GenerateDefaultConstructors,
         RazorPredefinedCodeRefactoringProviderNames.GenerateConstructorFromMembers,
         RazorPredefinedCodeRefactoringProviderNames.UseExpressionBody,
+        RazorPredefinedCodeRefactoringProviderNames.IntroduceVariable,
         RazorPredefinedCodeFixProviderNames.ImplementAbstractClass,
         RazorPredefinedCodeFixProviderNames.ImplementInterface,
         RazorPredefinedCodeFixProviderNames.RemoveUnusedVariable,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/CodeActionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/CodeActionExtensions.cs
@@ -76,7 +76,7 @@ internal static class CodeActionExtensions
 
         if (!isOnAllowList)
         {
-            razorCodeAction.Title = "(Exp) " + razorCodeAction.Title;
+            razorCodeAction.Title = $"(Exp) {razorCodeAction.Title} ({razorCodeAction.Name})";
         }
 
         if (razorCodeAction.Children != null)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/CSharpCodeActionEndToEndTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/CSharpCodeActionEndToEndTest.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
@@ -59,10 +60,104 @@ public class CSharpCodeActionEndToEndTest : SingleServerDelegatingEndpointTestBa
 
             """;
 
-        await ValidateCodeActionAsync(input, "Generate Default Constructors Code Action Provider", expected);
+        await ValidateCodeActionAsync(input, expected, RazorPredefinedCodeRefactoringProviderNames.GenerateDefaultConstructors);
     }
 
-    private async Task ValidateCodeActionAsync(string input, string codeAction, string expected)
+    [Fact]
+    public async Task Handle_IntroduceLocal()
+    {
+        var input = """
+            @using System.Linq
+
+            <div></div>
+
+            @functions
+            {
+                void M(string[] args)
+                {
+                    if ([|args.First()|].Length > 0)
+                    {
+                    }
+                    if (args.First().Length > 0)
+                    {
+                    }
+                }
+            }
+
+            """;
+
+        var expected = """
+            @using System.Linq
+
+            <div></div>
+            
+            @functions
+            {
+                void M(string[] args)
+                {
+                    string v = args.First();
+                    if (v.Length > 0)
+                    {
+                    }
+                    if (args.First().Length > 0)
+                    {
+                    }
+                }
+            }
+
+            """;
+
+        await ValidateCodeActionAsync(input, expected, RazorPredefinedCodeRefactoringProviderNames.IntroduceVariable);
+    }
+
+    [Fact]
+    public async Task Handle_IntroduceLocal_All()
+    {
+        var input = """
+            @using System.Linq
+
+            <div></div>
+
+            @functions
+            {
+                void M(string[] args)
+                {
+                    if ([|args.First()|].Length > 0)
+                    {
+                    }
+                    if (args.First().Length > 0)
+                    {
+                    }
+                }
+            }
+
+            """;
+
+        var expected = """
+            @using System.Linq
+
+            <div></div>
+            
+            @functions
+            {
+                void M(string[] args)
+                {
+                    string v = args.First();
+                    if (v.Length > 0)
+                    {
+                    }
+                    if (v.Length > 0)
+                    {
+                    }
+                }
+            }
+
+            """;
+
+        await ValidateCodeActionAsync(input, expected, RazorPredefinedCodeRefactoringProviderNames.IntroduceVariable, childActionIndex: 1);
+    }
+
+    private async Task ValidateCodeActionAsync(string input, string expected, string codeAction, int childActionIndex = 0)
     {
         TestFileMarkupParser.GetSpan(input, out input, out var textSpan);
 
@@ -108,7 +203,12 @@ public class CSharpCodeActionEndToEndTest : SingleServerDelegatingEndpointTestBa
         Assert.NotNull(result);
         Assert.NotEmpty(result);
 
-        var codeActionToRun = (RazorVSInternalCodeAction)result.Single(e => ((RazorVSInternalCodeAction)e.Value!).Name == codeAction);
+        var codeActionToRun = (VSInternalCodeAction)result.Single(e => ((RazorVSInternalCodeAction)e.Value!).Name == codeAction);
+
+        if (codeActionToRun.Children?.Length > 0)
+        {
+            codeActionToRun = codeActionToRun.Children[childActionIndex];
+        }
 
         var formattingService = await TestRazorFormattingService.CreateWithFullSupportAsync();
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/8578

TL;DR: I added 4 tests per line of code, and I expect everyone of you to do the same from now on! 😛

This isn't _perfect_ because cursor position after the code action can be questionable, and there is no way for us to trigger a rename of the introduced local after the code action executes, but neither of those things are possible to make any better with the current LSP spec and client implementations, so here we are. I basically just played around with this in VS with all of the possibilities I could think of, and couldn't break it, so I figure its better than not having the code action available.

Looks like this:
![RazorIntroduceLocal](https://github.com/dotnet/razor/assets/754264/08ff375f-a014-471c-83a6-3d578f35d15f)
