### PR TITLE
Fixes interoperability issue for System.Private.Uri

### DIFF
--- a/src/Razor/src/rzls/rzls.csproj
+++ b/src/Razor/src/rzls/rzls.csproj
@@ -48,6 +48,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.DiaSymReader" Version="$(MicrosoftDiaSymReaderVersion)" />
+    <PackageReference Include="System.Private.Uri" Version="$(SystemPrivateUriPackageVersion)" />
   </ItemGroup>
 
   <Target Name="PublishAllRids">


### PR DESCRIPTION
﻿### Summary of the changes

This is a follow up PR to https://github.com/dotnet/razor/pull/8806
The rslz project picks up the older version of System.Private.Uri. Using this fix to adds direct reference to System.Private.Uri.
This makes sure the restore steps would no longer pick up the older version (4.3.0) of System.Private.Uri.
