### PR TITLE
Don't call the obsolete type

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Models/RazorSemanticTokensLegend.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Models/RazorSemanticTokensLegend.cs
@@ -63,15 +63,11 @@ internal class RazorSemanticTokensLegend
     private readonly SemanticTokensLegend _legend;
     private readonly Dictionary<string, int> _razorTokenTypeMap;
 
-#pragma warning disable IDE0060 // Remove unused parameter
     public RazorSemanticTokensLegend(ClientCapabilities clientCapabilities)
-#pragma warning restore IDE0060 // Remove unused parameter
     {
         using var _ = ArrayBuilderPool<string>.GetPooledObject(out var builder);
 
-#pragma warning disable CS0618 // Type or member is obsolete
-        builder.AddRange(RazorSemanticTokensAccessor.RoslynTokenTypes);
-#pragma warning restore CS0618 // Type or member is obsolete
+        builder.AddRange(RazorSemanticTokensAccessor.GetTokenTypes(clientCapabilities));
 
         _razorTokenTypeMap = new Dictionary<string, int>();
         foreach (var razorTokenType in GetRazorSemanticTokenTypes())


### PR DESCRIPTION
Un-reverts the revert of a revert of a something that was done in #8835

Just putting this up so I don't forget or lose it, but can't be merged yet. Need to wait for integration test machines to be updated.

Toyed with the idea of fixing Rolyn too, to not expose VS.LSP.Protocol types, but thats an annoying amount of work so not convinced its worth it yet.