### PR TITLE
Change DisposableAction to ref struct

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/DisposableAction.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/DisposableAction.cs
@@ -1,25 +1,18 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy;
 
-internal class DisposableAction : IDisposable
+internal ref struct DisposableAction
 {
     private readonly Action _action;
     private bool _invoked;
 
     public DisposableAction(Action action)
     {
-        if (action == null)
-        {
-            throw new ArgumentNullException(nameof(action));
-        }
-
-        _action = action;
+        _action = action ?? throw new ArgumentNullException(nameof(action));
     }
 
     public void Dispose()

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/TokenizerBackedParser.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/TokenizerBackedParser.cs
@@ -626,17 +626,17 @@ internal abstract class TokenizerBackedParser<TTokenizer> : ParserBase
         return (TNode)node.SetAnnotations(new[] { annotation });
     }
 
-    protected IDisposable PushSpanContextConfig()
+    protected DisposableAction PushSpanContextConfig()
     {
         return PushSpanContextConfig(newConfig: (SpanContextConfigActionWithPreviousConfig)null);
     }
 
-    protected IDisposable PushSpanContextConfig(SpanContextConfigAction newConfig)
+    protected DisposableAction PushSpanContextConfig(SpanContextConfigAction newConfig)
     {
         return PushSpanContextConfig(newConfig == null ? null : (SpanEditHandlerBuilder span, ref ISpanChunkGenerator chunkGenerator, SpanContextConfigAction _) => newConfig(span, ref chunkGenerator));
     }
 
-    protected IDisposable PushSpanContextConfig(SpanContextConfigActionWithPreviousConfig  newConfig)
+    protected DisposableAction PushSpanContextConfig(SpanContextConfigActionWithPreviousConfig  newConfig)
     {
         var old = SpanContextConfig;
         ConfigureSpanContext(newConfig);

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/BackgroundParser.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/BackgroundParser.cs
@@ -58,7 +58,7 @@ internal class BackgroundParser : IDisposable
         _main.Dispose();
     }
 
-    public IDisposable SynchronizeMainThreadState()
+    public DisposableAction SynchronizeMainThreadState()
     {
         return _main.Lock();
     }
@@ -147,7 +147,7 @@ internal class BackgroundParser : IDisposable
             _cancelSource.Cancel();
         }
 
-        public IDisposable Lock()
+        public DisposableAction Lock()
         {
             Monitor.Enter(_stateLock);
             return new DisposableAction(() => Monitor.Exit(_stateLock));

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParser.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParser.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.CodeAnalysis.Razor;
@@ -326,7 +327,7 @@ internal class DefaultVisualStudioRazorParser : VisualStudioRazorParser, IDispos
         var change = new SourceChange(changeInformation.firstChange.OldPosition, changeInformation.oldText.Length, changeInformation.newText);
         var result = PartialParseResultInternal.Rejected;
         RazorSyntaxTree? partialParseSyntaxTree = null;
-        using (_parser!.SynchronizeMainThreadState())
+        using (_parser.AssumeNotNull().SynchronizeMainThreadState())
         {
             // Check if we can partial-parse
             if (_partialParser is not null && _parser.IsIdle)


### PR DESCRIPTION
This is a small change that removes some unnecessary heap allocations.