### PR TITLE
Handle `global::` in `@addTagHelper`

### DIFF
--- a/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/TestFiles/RazorSourceGeneratorTagHelperTests/GlobalPrefixedDirective/Views_Home_Index.html
+++ b/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/TestFiles/RazorSourceGeneratorTagHelperTests/GlobalPrefixedDirective/Views_Home_Index.html
@@ -1,0 +1,6 @@
+﻿<email>no directive</email>
+<a>full name</a>
+<a>namespace prefix</a>
+<a>global prefix</a>
+<email>add global, remove simple</email>
+<email>add simple, remove global</email>

--- a/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/TestFiles/RazorSourceGeneratorTagHelperTests/UrlResolutionTagHelper/Views_Home_Index.html
+++ b/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/TestFiles/RazorSourceGeneratorTagHelperTests/UrlResolutionTagHelper/Views_Home_Index.html
@@ -1,0 +1,2 @@
+
+<img src="/images/red.png" alt="Red block" title="&lt;the title>" id="1">


### PR DESCRIPTION
Fixes errors reported in https://github.com/dotnet/aspnetcore/pull/49034#issuecomment-1608571858.
Fixes https://github.com/dotnet/razor/issues/8884 (a regression introduced by https://github.com/dotnet/razor/pull/8857).