### PR TITLE
Adds Telemetry for CodeAction

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCodeActionsBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCodeActionsBenchmark.cs
@@ -53,7 +53,7 @@ public class RazorCodeActionsBenchmark : RazorLanguageServerBenchmarkBase
             htmlCodeActionProviders: languageServer.GetRequiredService<IEnumerable<IHtmlCodeActionProvider>>(),
             languageServer: languageServer.GetRequiredService<ClientNotifierServiceBase>(),
             languageServerFeatureOptions: languageServer.GetRequiredService<LanguageServerFeatureOptions>(),
-            telemetryReporter: default);
+            telemetryReporter: null);
 
         var projectRoot = Path.Combine(RepoRoot, "src", "Razor", "test", "testapps", "ComponentApp");
         var projectFilePath = Path.Combine(projectRoot, "ComponentApp.csproj");

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCodeActionsBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCodeActionsBenchmark.cs
@@ -53,7 +53,7 @@ public class RazorCodeActionsBenchmark : RazorLanguageServerBenchmarkBase
             htmlCodeActionProviders: languageServer.GetRequiredService<IEnumerable<IHtmlCodeActionProvider>>(),
             languageServer: languageServer.GetRequiredService<ClientNotifierServiceBase>(),
             languageServerFeatureOptions: languageServer.GetRequiredService<LanguageServerFeatureOptions>(),
-            default);
+            telemetryReporter: default);
 
         var projectRoot = Path.Combine(RepoRoot, "src", "Razor", "test", "testapps", "ComponentApp");
         var projectFilePath = Path.Combine(projectRoot, "ComponentApp.csproj");

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCodeActionsBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCodeActionsBenchmark.cs
@@ -52,7 +52,8 @@ public class RazorCodeActionsBenchmark : RazorLanguageServerBenchmarkBase
             csharpCodeActionProviders: languageServer.GetRequiredService<IEnumerable<ICSharpCodeActionProvider>>(),
             htmlCodeActionProviders: languageServer.GetRequiredService<IEnumerable<IHtmlCodeActionProvider>>(),
             languageServer: languageServer.GetRequiredService<ClientNotifierServiceBase>(),
-            languageServerFeatureOptions: languageServer.GetRequiredService<LanguageServerFeatureOptions>());
+            languageServerFeatureOptions: languageServer.GetRequiredService<LanguageServerFeatureOptions>(),
+            default);
 
         var projectRoot = Path.Combine(RepoRoot, "src", "Razor", "test", "testapps", "ComponentApp");
         var projectFilePath = Path.Combine(projectRoot, "ComponentApp.csproj");

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensRangeEndpointBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensRangeEndpointBenchmark.cs
@@ -57,7 +57,6 @@ public class RazorSemanticTokensRangeEndpointBenchmark : RazorLanguageServerBenc
 
     private static List<SemanticRange> PregeneratedRandomSemanticRanges { get; set; }
 
-
     [GlobalSetup]
     public async Task InitializeRazorSemanticAsync()
     {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.OmniSharp/Project/OmniSharpTelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.OmniSharp/Project/OmniSharpTelemetryReporter.cs
@@ -30,7 +30,7 @@ internal class OmniSharpTelemetryReporter : ITelemetryReporter
         return NullScope.Instance;
     }
 
-    public IDisposable TrackLspRequest(string name, string lspMethodName, string lspServerName, Guid correlationId)
+    public IDisposable TrackLspRequest(string lspMethodName, string lspServerName, Guid correlationId)
     {
         return NullScope.Instance;
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
@@ -94,7 +94,7 @@ internal sealed class CodeActionEndpoint : IRazorRequestHandler<VSCodeActionPara
         // HTML code actions aren't currently supported in VS Code:
         // https://github.com/dotnet/razor/issues/8062
         var delegatedCodeActions = _languageServerFeatureOptions.SupportsDelegatedCodeActions
-            ? await GetDelegatedCodeActionsAsync(documentContext, razorCodeActionContext, requestContext.Logger, correlationId, cancellationToken).ConfigureAwait(false)
+            ? await GetDelegatedCodeActionsAsync(documentContext, razorCodeActionContext, correlationId, requestContext.Logger, cancellationToken).ConfigureAwait(false)
             : ImmutableArray.Create<RazorVSInternalCodeAction>();
 
         cancellationToken.ThrowIfCancellationRequested();
@@ -193,7 +193,7 @@ internal sealed class CodeActionEndpoint : IRazorRequestHandler<VSCodeActionPara
         return context;
     }
 
-    private async Task<ImmutableArray<RazorVSInternalCodeAction>> GetDelegatedCodeActionsAsync(VersionedDocumentContext documentContext, RazorCodeActionContext context, IRazorLogger logger, Guid correlationId, CancellationToken cancellationToken)
+    private async Task<ImmutableArray<RazorVSInternalCodeAction>> GetDelegatedCodeActionsAsync(VersionedDocumentContext documentContext, RazorCodeActionContext context, Guid correlationId, IRazorLogger logger, CancellationToken cancellationToken)
     {
         var languageKind = _documentMappingService.GetLanguageKind(context.CodeDocument, context.Location.AbsoluteIndex, rightAssociative: false);
 
@@ -203,7 +203,7 @@ internal sealed class CodeActionEndpoint : IRazorRequestHandler<VSCodeActionPara
             return ImmutableArray<RazorVSInternalCodeAction>.Empty;
         }
 
-        var codeActions = await GetCodeActionsFromLanguageServerAsync(languageKind, documentContext, context, logger, correlationId, cancellationToken).ConfigureAwait(false);
+        var codeActions = await GetCodeActionsFromLanguageServerAsync(languageKind, documentContext, context, correlationId, logger, cancellationToken).ConfigureAwait(false);
         if (codeActions is not [_, ..])
         {
             return ImmutableArray<RazorVSInternalCodeAction>.Empty;
@@ -275,7 +275,7 @@ internal sealed class CodeActionEndpoint : IRazorRequestHandler<VSCodeActionPara
     }
 
     // Internal for testing
-    internal async Task<RazorVSInternalCodeAction[]> GetCodeActionsFromLanguageServerAsync(RazorLanguageKind languageKind, VersionedDocumentContext documentContext, RazorCodeActionContext context, IRazorLogger logger, Guid correlationId, CancellationToken cancellationToken)
+    internal async Task<RazorVSInternalCodeAction[]> GetCodeActionsFromLanguageServerAsync(RazorLanguageKind languageKind, VersionedDocumentContext documentContext, RazorCodeActionContext context, Guid correlationId, IRazorLogger logger, CancellationToken cancellationToken)
     {
         if (languageKind == RazorLanguageKind.CSharp)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
@@ -36,7 +36,7 @@ internal sealed class CodeActionEndpoint : IRazorRequestHandler<VSCodeActionPara
     private readonly IEnumerable<IHtmlCodeActionProvider> _htmlCodeActionProviders;
     private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
     private readonly ClientNotifierServiceBase _languageServer;
-    private ITelemetryReporter? _telemetryReporter;
+    private readonly ITelemetryReporter? _telemetryReporter;
 
     internal bool _supportsCodeActionResolve = false;
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/DelegatedCodeActionParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/DelegatedCodeActionParams.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Runtime.Serialization;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
@@ -18,4 +19,7 @@ internal class DelegatedCodeActionParams
 
     [DataMember(Name = "languageKind")]
     public RazorLanguageKind LanguageKind { get; set; }
+
+    [DataMember(Name = "correlationId")]
+    public Guid CorrelationId { get; set; }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/DocumentPullDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/DocumentPullDiagnosticsEndpoint.cs
@@ -62,7 +62,7 @@ internal class DocumentPullDiagnosticsEndpoint : IRazorRequestHandler<VSInternal
         }
 
         var correlationId = Guid.NewGuid();
-        using var __ = _telemetryReporter?.TrackLspRequest("diagnostics", VSInternalMethods.DocumentPullDiagnosticName, LanguageServerConstants.RazorLanguageServerName, correlationId);
+        using var __ = _telemetryReporter?.TrackLspRequest(VSInternalMethods.DocumentPullDiagnosticName, LanguageServerConstants.RazorLanguageServerName, correlationId);
         var documentContext = context.GetRequiredDocumentContext();
 
         var razorDiagnostics = await GetRazorDiagnosticsAsync(documentContext, cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/ITelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/ITelemetryReporter.cs
@@ -10,7 +10,7 @@ public interface ITelemetryReporter
 {
     IDisposable BeginBlock(string name, Severity severity);
     IDisposable BeginBlock(string name, Severity severity, ImmutableDictionary<string, object?> values);
-    IDisposable TrackLspRequest(string name, string lspMethodName, string lspServerName, Guid correlationId);
+    IDisposable TrackLspRequest(string lspMethodName, string lspServerName, Guid correlationId);
     void ReportEvent(string name, Severity severity);
     void ReportEvent(string name, Severity severity, ImmutableDictionary<string, object?> values);
     void ReportFault(Exception exception, string? message, params object?[] @params);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/NoOpTelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/NoOpTelemetryReporter.cs
@@ -36,7 +36,7 @@ public class NoOpTelemetryReporter : ITelemetryReporter
         return NullScope.Instance;
     }
 
-    public IDisposable TrackLspRequest(string name, string lspMethodName, string lspServerName, Guid correlationId)
+    public IDisposable TrackLspRequest(string lspMethodName, string lspServerName, Guid correlationId)
     {
         return NullScope.Instance;
     }

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/TelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/TelemetryReporter.cs
@@ -221,14 +221,14 @@ internal class TelemetryReporter : ITelemetryReporter
         return new TelemetryScope(this, name, severity, values.ToImmutableDictionary((tuple) => tuple.Key, (tuple) => (object?)tuple.Value));
     }
 
-    public IDisposable TrackLspRequest(string name, string lspMethodName, string languageServerName, Guid correlationId)
+    public IDisposable TrackLspRequest(string lspMethodName, string languageServerName, Guid correlationId)
     {
         if (correlationId == Guid.Empty)
         {
             return NullTelemetryScope.Instance;
         }
 
-        return BeginBlock(name, Severity.Normal, ImmutableDictionary.CreateRange(new KeyValuePair<string, object?>[]
+        return BeginBlock("TrackLspRequest", Severity.Normal, ImmutableDictionary.CreateRange(new KeyValuePair<string, object?>[]
         {
             new("eventscope.method", lspMethodName),
             new("eventscope.languageservername", languageServerName),

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -265,12 +265,14 @@ internal class DefaultRazorLanguageServerCustomMessageTarget : RazorLanguageServ
 
         bool synchronized;
         VirtualDocumentSnapshot virtualDocumentSnapshot;
+        string languageServerName;
         if (codeActionParams.LanguageKind == RazorLanguageKind.Html)
         {
             (synchronized, virtualDocumentSnapshot) = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<HtmlVirtualDocumentSnapshot>(
                 codeActionParams.HostDocumentVersion,
                 codeActionParams.CodeActionParams.TextDocument.Uri,
                 cancellationToken);
+            languageServerName = RazorLSPConstants.RazorCSharpLanguageServerName;
         }
         else if (codeActionParams.LanguageKind == RazorLanguageKind.CSharp)
         {
@@ -278,6 +280,7 @@ internal class DefaultRazorLanguageServerCustomMessageTarget : RazorLanguageServ
                 codeActionParams.HostDocumentVersion,
                 codeActionParams.CodeActionParams.TextDocument.Uri,
                 cancellationToken);
+            languageServerName = RazorLSPConstants.HtmlLanguageServerName;
         }
         else
         {
@@ -294,7 +297,6 @@ internal class DefaultRazorLanguageServerCustomMessageTarget : RazorLanguageServ
         codeActionParams.CodeActionParams.TextDocument.Uri = virtualDocumentSnapshot.Uri;
 
         var textBuffer = virtualDocumentSnapshot.Snapshot.TextBuffer;
-        var languageServerName = codeActionParams.LanguageKind == RazorLanguageKind.CSharp ? RazorLSPConstants.RazorCSharpLanguageServerName : RazorLSPConstants.HtmlLanguageServerName;
         using var _ = _telemetryReporter.TrackLspRequest(Methods.TextDocumentCodeActionName, languageServerName, codeActionParams.CorrelationId);
         var requests = _requestInvoker.ReinvokeRequestOnMultipleServersAsync<VSCodeActionParams, IReadOnlyList<VSInternalCodeAction>>(
             textBuffer,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -294,6 +294,8 @@ internal class DefaultRazorLanguageServerCustomMessageTarget : RazorLanguageServ
         codeActionParams.CodeActionParams.TextDocument.Uri = virtualDocumentSnapshot.Uri;
 
         var textBuffer = virtualDocumentSnapshot.Snapshot.TextBuffer;
+        var languageServerName = codeActionParams.LanguageKind == RazorLanguageKind.CSharp ? RazorLSPConstants.RazorCSharpLanguageServerName : RazorLSPConstants.HtmlLanguageServerName;
+        using var _ = _telemetryReporter.TrackLspRequest(Methods.TextDocumentCodeActionName, languageServerName, codeActionParams.CorrelationId);
         var requests = _requestInvoker.ReinvokeRequestOnMultipleServersAsync<VSCodeActionParams, IReadOnlyList<VSInternalCodeAction>>(
             textBuffer,
             Methods.TextDocumentCodeActionName,
@@ -1165,7 +1167,7 @@ internal class DefaultRazorLanguageServerCustomMessageTarget : RazorLanguageServ
             },
         };
 
-        using var _ = _telemetryReporter.TrackLspRequest(nameof(_requestInvoker.ReinvokeRequestOnServerAsync), VSInternalMethods.DocumentPullDiagnosticName, delegatedLanguageServerName, correlationId);
+        using var _ = _telemetryReporter.TrackLspRequest(VSInternalMethods.DocumentPullDiagnosticName, delegatedLanguageServerName, correlationId);
         var response = await _requestInvoker.ReinvokeRequestOnServerAsync<VSInternalDocumentDiagnosticsParams, VSInternalDiagnosticReport[]?>(
             virtualDocument.Snapshot.TextBuffer,
             VSInternalMethods.DocumentPullDiagnosticName,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/CSharpCodeActionEndToEndTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/CSharpCodeActionEndToEndTest.cs
@@ -347,7 +347,7 @@ public class CSharpCodeActionEndToEndTest : SingleServerDelegatingEndpointTestBa
         };
         var htmlCodeActionProviders = Array.Empty<IHtmlCodeActionProvider>();
 
-        var endpoint = new CodeActionEndpoint(DocumentMappingService, razorCodeActionProviders, csharpCodeActionProviders, htmlCodeActionProviders, LanguageServer, LanguageServerFeatureOptions);
+        var endpoint = new CodeActionEndpoint(DocumentMappingService, razorCodeActionProviders, csharpCodeActionProviders, htmlCodeActionProviders, LanguageServer, LanguageServerFeatureOptions, default);
 
         // Call GetRegistration, so the endpoint knows we support resolve
         endpoint.GetRegistration(new VSInternalClientCapabilities

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
@@ -644,7 +644,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
         Assert.NotNull(context);
 
         // Act
-        var results = await codeActionEndpoint.GetCodeActionsFromLanguageServerAsync(RazorLanguageKind.CSharp, documentContext, context, Logger, default, Guid.Empty);
+        var results = await codeActionEndpoint.GetCodeActionsFromLanguageServerAsync(RazorLanguageKind.CSharp, documentContext, context, Logger, Guid.Empty, default);
 
         // Assert
         Assert.Empty(results);
@@ -690,7 +690,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
         Assert.NotNull(context);
 
         // Act
-        var results = await codeActionEndpoint.GetCodeActionsFromLanguageServerAsync(RazorLanguageKind.CSharp, documentContext, context, Logger, default, Guid.Empty);
+        var results = await codeActionEndpoint.GetCodeActionsFromLanguageServerAsync(RazorLanguageKind.CSharp, documentContext, context, Logger, Guid.Empty, default);
 
         // Assert
         var result = Assert.Single(results);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
@@ -59,7 +59,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
             _languageServerFeatureOptions,
-            default)
+            telemetryReporter: default)
         {
             _supportsCodeActionResolve = false
         };
@@ -94,7 +94,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
             _languageServerFeatureOptions,
-            default)
+            telemetryReporter: default)
         {
             _supportsCodeActionResolve = false
         };
@@ -127,7 +127,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
             _languageServerFeatureOptions,
-            default)
+            telemetryReporter: default)
         {
             _supportsCodeActionResolve = false
         };
@@ -162,7 +162,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
             _languageServerFeatureOptions,
-            default)
+            telemetryReporter: default)
         {
             _supportsCodeActionResolve = false
         };
@@ -201,7 +201,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             languageServer,
             _languageServerFeatureOptions,
-            default)
+            telemetryReporter: default)
         {
             _supportsCodeActionResolve = false
         };
@@ -238,7 +238,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
             _languageServerFeatureOptions,
-            default)
+            telemetryReporter: default)
         {
             _supportsCodeActionResolve = false
         };
@@ -282,7 +282,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             languageServer,
             _languageServerFeatureOptions,
-            default)
+            telemetryReporter: default)
         {
             _supportsCodeActionResolve = false
         };
@@ -326,7 +326,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             languageServer,
             _languageServerFeatureOptions,
-            default)
+            telemetryReporter: default)
         {
             _supportsCodeActionResolve = false
         };
@@ -363,7 +363,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
             _languageServerFeatureOptions,
-            default)
+            telemetryReporter: default)
         {
             _supportsCodeActionResolve = false
         };
@@ -407,7 +407,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             languageServer,
             _languageServerFeatureOptions,
-            default)
+            telemetryReporter: default)
         {
             _supportsCodeActionResolve = false
         };
@@ -446,7 +446,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
             _languageServerFeatureOptions,
-            default)
+            telemetryReporter: default)
         {
             _supportsCodeActionResolve = true
         };
@@ -495,7 +495,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
             _languageServerFeatureOptions,
-            default)
+            telemetryReporter: default)
         {
             _supportsCodeActionResolve = false
         };
@@ -542,7 +542,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
             _languageServerFeatureOptions,
-            default)
+            telemetryReporter: default)
         {
             _supportsCodeActionResolve = false
         };
@@ -583,7 +583,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
             _languageServerFeatureOptions,
-            default)
+            telemetryReporter: default)
         {
             _supportsCodeActionResolve = false
         };
@@ -627,7 +627,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
             _languageServerFeatureOptions,
-            default)
+            telemetryReporter: default)
         {
             _supportsCodeActionResolve = false
         };
@@ -644,7 +644,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
         Assert.NotNull(context);
 
         // Act
-        var results = await codeActionEndpoint.GetCodeActionsFromLanguageServerAsync(RazorLanguageKind.CSharp, documentContext, context, Logger, Guid.Empty, default);
+        var results = await codeActionEndpoint.GetCodeActionsFromLanguageServerAsync(RazorLanguageKind.CSharp, documentContext, context, Guid.Empty, Logger, cancellationToken: default);
 
         // Assert
         Assert.Empty(results);
@@ -670,7 +670,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             languageServer,
             _languageServerFeatureOptions,
-            default)
+            telemetryReporter: default)
         {
             _supportsCodeActionResolve = false
         };
@@ -690,7 +690,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
         Assert.NotNull(context);
 
         // Act
-        var results = await codeActionEndpoint.GetCodeActionsFromLanguageServerAsync(RazorLanguageKind.CSharp, documentContext, context, Logger, Guid.Empty, default);
+        var results = await codeActionEndpoint.GetCodeActionsFromLanguageServerAsync(RazorLanguageKind.CSharp, documentContext, context, Guid.Empty, Logger, cancellationToken: default);
 
         // Assert
         var result = Assert.Single(results);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
@@ -59,7 +59,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
             _languageServerFeatureOptions,
-            telemetryReporter: default)
+            telemetryReporter: null)
         {
             _supportsCodeActionResolve = false
         };
@@ -94,7 +94,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
             _languageServerFeatureOptions,
-            telemetryReporter: default)
+            telemetryReporter: null)
         {
             _supportsCodeActionResolve = false
         };
@@ -127,7 +127,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
             _languageServerFeatureOptions,
-            telemetryReporter: default)
+            telemetryReporter: null)
         {
             _supportsCodeActionResolve = false
         };
@@ -162,7 +162,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
             _languageServerFeatureOptions,
-            telemetryReporter: default)
+            telemetryReporter: null)
         {
             _supportsCodeActionResolve = false
         };
@@ -201,7 +201,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             languageServer,
             _languageServerFeatureOptions,
-            telemetryReporter: default)
+            telemetryReporter: null)
         {
             _supportsCodeActionResolve = false
         };
@@ -238,7 +238,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
             _languageServerFeatureOptions,
-            telemetryReporter: default)
+            telemetryReporter: null)
         {
             _supportsCodeActionResolve = false
         };
@@ -282,7 +282,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             languageServer,
             _languageServerFeatureOptions,
-            telemetryReporter: default)
+            telemetryReporter: null)
         {
             _supportsCodeActionResolve = false
         };
@@ -326,7 +326,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             languageServer,
             _languageServerFeatureOptions,
-            telemetryReporter: default)
+            telemetryReporter: null)
         {
             _supportsCodeActionResolve = false
         };
@@ -363,7 +363,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
             _languageServerFeatureOptions,
-            telemetryReporter: default)
+            telemetryReporter: null)
         {
             _supportsCodeActionResolve = false
         };
@@ -407,7 +407,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             languageServer,
             _languageServerFeatureOptions,
-            telemetryReporter: default)
+            telemetryReporter: null)
         {
             _supportsCodeActionResolve = false
         };
@@ -446,7 +446,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
             _languageServerFeatureOptions,
-            telemetryReporter: default)
+            telemetryReporter: null)
         {
             _supportsCodeActionResolve = true
         };
@@ -495,7 +495,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
             _languageServerFeatureOptions,
-            telemetryReporter: default)
+            telemetryReporter: null)
         {
             _supportsCodeActionResolve = false
         };
@@ -542,7 +542,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
             _languageServerFeatureOptions,
-            telemetryReporter: default)
+            telemetryReporter: null)
         {
             _supportsCodeActionResolve = false
         };
@@ -583,7 +583,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
             _languageServerFeatureOptions,
-            telemetryReporter: default)
+            telemetryReporter: null)
         {
             _supportsCodeActionResolve = false
         };
@@ -627,7 +627,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
             _languageServerFeatureOptions,
-            telemetryReporter: default)
+            telemetryReporter: null)
         {
             _supportsCodeActionResolve = false
         };
@@ -670,7 +670,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<IHtmlCodeActionProvider>(),
             languageServer,
             _languageServerFeatureOptions,
-            telemetryReporter: default)
+            telemetryReporter: null)
         {
             _supportsCodeActionResolve = false
         };

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
@@ -629,7 +629,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
         Assert.NotNull(context);
 
         // Act
-        var results = await codeActionEndpoint.GetCodeActionsFromLanguageServerAsync(RazorLanguageKind.CSharp, documentContext, context, Logger, default);
+        var results = await codeActionEndpoint.GetCodeActionsFromLanguageServerAsync(RazorLanguageKind.CSharp, documentContext, context, Logger, default, Guid.Empty);
 
         // Assert
         Assert.Empty(results);
@@ -674,7 +674,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
         Assert.NotNull(context);
 
         // Act
-        var results = await codeActionEndpoint.GetCodeActionsFromLanguageServerAsync(RazorLanguageKind.CSharp, documentContext, context, Logger, default);
+        var results = await codeActionEndpoint.GetCodeActionsFromLanguageServerAsync(RazorLanguageKind.CSharp, documentContext, context, Logger, default, Guid.Empty);
 
         // Assert
         var result = Assert.Single(results);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
@@ -58,7 +58,8 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<ICSharpCodeActionProvider>(),
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
-            _languageServerFeatureOptions)
+            _languageServerFeatureOptions,
+            default)
         {
             _supportsCodeActionResolve = false
         };
@@ -92,7 +93,8 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<ICSharpCodeActionProvider>(),
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
-            _languageServerFeatureOptions)
+            _languageServerFeatureOptions,
+            default)
         {
             _supportsCodeActionResolve = false
         };
@@ -124,7 +126,8 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<ICSharpCodeActionProvider>(),
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
-            _languageServerFeatureOptions)
+            _languageServerFeatureOptions,
+            default)
         {
             _supportsCodeActionResolve = false
         };
@@ -158,7 +161,8 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<ICSharpCodeActionProvider>(),
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
-            _languageServerFeatureOptions)
+            _languageServerFeatureOptions,
+            default)
         {
             _supportsCodeActionResolve = false
         };
@@ -196,7 +200,8 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             },
             Array.Empty<IHtmlCodeActionProvider>(),
             languageServer,
-            _languageServerFeatureOptions)
+            _languageServerFeatureOptions,
+            default)
         {
             _supportsCodeActionResolve = false
         };
@@ -232,7 +237,8 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<ICSharpCodeActionProvider>(),
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
-            _languageServerFeatureOptions)
+            _languageServerFeatureOptions,
+            default)
         {
             _supportsCodeActionResolve = false
         };
@@ -275,7 +281,8 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             },
             Array.Empty<IHtmlCodeActionProvider>(),
             languageServer,
-            _languageServerFeatureOptions)
+            _languageServerFeatureOptions,
+            default)
         {
             _supportsCodeActionResolve = false
         };
@@ -318,7 +325,8 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             },
             Array.Empty<IHtmlCodeActionProvider>(),
             languageServer,
-            _languageServerFeatureOptions)
+            _languageServerFeatureOptions,
+            default)
         {
             _supportsCodeActionResolve = false
         };
@@ -354,7 +362,8 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<ICSharpCodeActionProvider>(),
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
-            _languageServerFeatureOptions)
+            _languageServerFeatureOptions,
+            default)
         {
             _supportsCodeActionResolve = false
         };
@@ -397,7 +406,8 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             },
             Array.Empty<IHtmlCodeActionProvider>(),
             languageServer,
-            _languageServerFeatureOptions)
+            _languageServerFeatureOptions,
+            default)
         {
             _supportsCodeActionResolve = false
         };
@@ -435,7 +445,8 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<ICSharpCodeActionProvider>(),
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
-            _languageServerFeatureOptions)
+            _languageServerFeatureOptions,
+            default)
         {
             _supportsCodeActionResolve = true
         };
@@ -483,7 +494,8 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<ICSharpCodeActionProvider>(),
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
-            _languageServerFeatureOptions)
+            _languageServerFeatureOptions,
+            default)
         {
             _supportsCodeActionResolve = false
         };
@@ -529,7 +541,8 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<ICSharpCodeActionProvider>(),
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
-            _languageServerFeatureOptions)
+            _languageServerFeatureOptions,
+            default)
         {
             _supportsCodeActionResolve = false
         };
@@ -569,7 +582,8 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Array.Empty<ICSharpCodeActionProvider>(),
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
-            _languageServerFeatureOptions)
+            _languageServerFeatureOptions,
+            default)
         {
             _supportsCodeActionResolve = false
         };
@@ -612,7 +626,8 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             },
             Array.Empty<IHtmlCodeActionProvider>(),
             _languageServer,
-            _languageServerFeatureOptions)
+            _languageServerFeatureOptions,
+            default)
         {
             _supportsCodeActionResolve = false
         };
@@ -654,7 +669,8 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             },
             Array.Empty<IHtmlCodeActionProvider>(),
             languageServer,
-            _languageServerFeatureOptions)
+            _languageServerFeatureOptions,
+            default)
         {
             _supportsCodeActionResolve = false
         };

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultRazorLanguageServerCustomMessageTargetTest.cs
@@ -169,6 +169,7 @@ public class DefaultRazorLanguageServerCustomMessageTargetTest : TestBase
         var documentSynchronizer = GetDocumentSynchronizer(GetCSharpSnapshot());
         var outputWindowLogger = Mock.Of<IOutputWindowLogger>(MockBehavior.Strict);
         var telemetryReporter = new Mock<ITelemetryReporter>(MockBehavior.Strict);
+        telemetryReporter.Setup(r => r.TrackLspRequest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>())).Returns(NullScope.Instance);
 
         var target = new DefaultRazorLanguageServerCustomMessageTarget(
                 documentManager.Object, JoinableTaskContext, requestInvoker.Object,


### PR DESCRIPTION
Includes correlationId, a Guid we generate for the sub LSP call to correlate between the calls from Razor Code Action LSP request and C# or Html LSP.

Here's a PR adding a similar telemetry added earlier for Diagnostics in Preview 2: https://github.com/dotnet/razor/pull/8789