### PR TITLE
Remove XUnitVerifier and use the roslyn utilities that the compiler references

### DIFF
--- a/SpellingExclusions.dic
+++ b/SpellingExclusions.dic
@@ -1,1 +1,2 @@
 csharp
+Blazor

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -93,8 +93,6 @@
   <PropertyGroup Label="Manual">
     <!-- Several packages from the editor are used for testing HTML support, and share the following version. -->
     <Tooling_HtmlEditorPackageVersion>17.5.101-preview-0002</Tooling_HtmlEditorPackageVersion>
-    <!-- Several packages share the MS.CA.Testing version -->
-    <Tooling_MicrosoftCodeAnalysisTestingVersion>1.1.2-beta1.23323.1</Tooling_MicrosoftCodeAnalysisTestingVersion>
     <MicrosoftVisualStudioShellPackagesVersion>17.7.35047-preview.1</MicrosoftVisualStudioShellPackagesVersion>
     <MicrosoftVisualStudioPackagesVersion>17.7.38-preview</MicrosoftVisualStudioPackagesVersion>
     <VisualStudioLanguageServerProtocolVersion>17.7.8-preview-g8c33dc3a76</VisualStudioLanguageServerProtocolVersion>
@@ -113,7 +111,7 @@
     <MicrosoftNETSdkRazorPackageVersion>6.0.0-alpha.1.21072.5</MicrosoftNETSdkRazorPackageVersion>
     <!-- Packages from dotnet/roslyn -->
     <MicrosoftNetCompilersToolsetVersion>$(MicrosoftNetCompilersToolsetPackageVersion)</MicrosoftNetCompilersToolsetVersion>
-    <MicrosoftCodeAnalysisAnalyzerTestingPackageVersion>$(Tooling_MicrosoftCodeAnalysisTestingVersion)</MicrosoftCodeAnalysisAnalyzerTestingPackageVersion>
+    <MicrosoftCodeAnalysisAnalyzerTestingPackageVersion>1.1.2-beta1.23323.1</MicrosoftCodeAnalysisAnalyzerTestingPackageVersion>
     <MicrosoftVisualStudioEditorPackageVersion>$(MicrosoftVisualStudioPackagesVersion)</MicrosoftVisualStudioEditorPackageVersion>
     <MicrosoftVisualStudioExtensibilityTestingXunitVersion>0.1.169-beta</MicrosoftVisualStudioExtensibilityTestingXunitVersion>
     <MicrosoftVisualStudioExtensibilityTestingSourceGeneratorVersion>$(MicrosoftVisualStudioExtensibilityTestingXunitVersion)</MicrosoftVisualStudioExtensibilityTestingSourceGeneratorVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -114,7 +114,6 @@
     <!-- Packages from dotnet/roslyn -->
     <MicrosoftNetCompilersToolsetVersion>$(MicrosoftNetCompilersToolsetPackageVersion)</MicrosoftNetCompilersToolsetVersion>
     <MicrosoftCodeAnalysisAnalyzerTestingPackageVersion>$(Tooling_MicrosoftCodeAnalysisTestingVersion)</MicrosoftCodeAnalysisAnalyzerTestingPackageVersion>
-    <MicrosoftCodeAnalysisTestingVerifiersXunitPackageVersion>$(Tooling_MicrosoftCodeAnalysisTestingVersion)</MicrosoftCodeAnalysisTestingVerifiersXunitPackageVersion>
     <MicrosoftVisualStudioEditorPackageVersion>$(MicrosoftVisualStudioPackagesVersion)</MicrosoftVisualStudioEditorPackageVersion>
     <MicrosoftVisualStudioExtensibilityTestingXunitVersion>0.1.169-beta</MicrosoftVisualStudioExtensibilityTestingXunitVersion>
     <MicrosoftVisualStudioExtensibilityTestingSourceGeneratorVersion>$(MicrosoftVisualStudioExtensibilityTestingXunitVersion)</MicrosoftVisualStudioExtensibilityTestingSourceGeneratorVersion>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/CSharpTestLspServer.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/CSharpTestLspServer.cs
@@ -81,7 +81,9 @@ public sealed class CSharpTestLspServer : IAsyncDisposable
 
             var languageServerFactory = exportProvider.GetExportedValue<IRazorLanguageServerFactoryWrapper>();
             var hostServices = workspace.Services.HostServices;
+#pragma warning disable CS0618 // Type or member is obsolete
             var languageServer = languageServerFactory.CreateLanguageServer(serverRpc, capabilitiesProvider, hostServices);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             serverRpc.StartListening();
             return languageServer;
@@ -188,16 +190,18 @@ public sealed class CSharpTestLspServer : IAsyncDisposable
 
     #endregion
 
-    private class RazorCapabilitiesProvider : IRazorTestCapabilitiesProvider
+#pragma warning disable CS0618 // Type or member is obsolete
+    private class RazorCapabilitiesProvider : IRazorCapabilitiesProvider
+#pragma warning restore CS0618 // Type or member is obsolete
     {
-        private readonly string _serverCapabilities;
+        private readonly ServerCapabilities _serverCapabilities;
 
         public RazorCapabilitiesProvider(ServerCapabilities serverCapabilities)
         {
-            _serverCapabilities = JsonConvert.SerializeObject(serverCapabilities);
+            _serverCapabilities = serverCapabilities;
         }
 
-        public string GetServerCapabilitiesJson(string clientCapabilitiesJson)
+        public ServerCapabilities GetCapabilities(ClientCapabilities clientCapabilitiesJson)
             => _serverCapabilities;
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/CSharpTestLspServer.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/CSharpTestLspServer.cs
@@ -21,8 +21,8 @@ public sealed class CSharpTestLspServer : IAsyncDisposable
     private readonly AdhocWorkspace _testWorkspace;
     private readonly IRazorLanguageServerTarget _languageServer;
 
-    private readonly StreamJsonRpc.JsonRpc _clientRpc;
-    private readonly StreamJsonRpc.JsonRpc _serverRpc;
+    private readonly JsonRpc _clientRpc;
+    private readonly JsonRpc _serverRpc;
 
     private readonly JsonMessageFormatter _clientMessageFormatter;
     private readonly JsonMessageFormatter _serverMessageFormatter;
@@ -35,7 +35,7 @@ public sealed class CSharpTestLspServer : IAsyncDisposable
     private CSharpTestLspServer(
         AdhocWorkspace testWorkspace,
         ExportProvider exportProvider,
-        ServerCapabilities serverCapabilities,
+        VSInternalServerCapabilities serverCapabilities,
         CancellationToken cancellationToken)
     {
         _testWorkspace = testWorkspace;
@@ -45,7 +45,7 @@ public sealed class CSharpTestLspServer : IAsyncDisposable
 
         _serverMessageFormatter = CreateJsonMessageFormatter();
         _serverMessageHandler = new HeaderDelimitedMessageHandler(serverStream, serverStream, _serverMessageFormatter);
-        _serverRpc = new StreamJsonRpc.JsonRpc(_serverMessageHandler)
+        _serverRpc = new JsonRpc(_serverMessageHandler)
         {
             ExceptionStrategy = ExceptionProcessing.ISerializable,
         };
@@ -54,7 +54,7 @@ public sealed class CSharpTestLspServer : IAsyncDisposable
 
         _clientMessageFormatter = CreateJsonMessageFormatter();
         _clientMessageHandler = new HeaderDelimitedMessageHandler(clientStream, clientStream, _clientMessageFormatter);
-        _clientRpc = new StreamJsonRpc.JsonRpc(_clientMessageHandler)
+        _clientRpc = new JsonRpc(_clientMessageHandler)
         {
             ExceptionStrategy = ExceptionProcessing.ISerializable,
         };
@@ -69,10 +69,10 @@ public sealed class CSharpTestLspServer : IAsyncDisposable
         }
 
         static IRazorLanguageServerTarget CreateLanguageServer(
-            StreamJsonRpc.JsonRpc serverRpc,
+            JsonRpc serverRpc,
             Workspace workspace,
             ExportProvider exportProvider,
-            ServerCapabilities serverCapabilities)
+            VSInternalServerCapabilities serverCapabilities)
         {
             var capabilitiesProvider = new RazorCapabilitiesProvider(serverCapabilities);
 
@@ -81,9 +81,7 @@ public sealed class CSharpTestLspServer : IAsyncDisposable
 
             var languageServerFactory = exportProvider.GetExportedValue<IRazorLanguageServerFactoryWrapper>();
             var hostServices = workspace.Services.HostServices;
-#pragma warning disable CS0618 // Type or member is obsolete
             var languageServer = languageServerFactory.CreateLanguageServer(serverRpc, capabilitiesProvider, hostServices);
-#pragma warning restore CS0618 // Type or member is obsolete
 
             serverRpc.StartListening();
             return languageServer;
@@ -94,7 +92,7 @@ public sealed class CSharpTestLspServer : IAsyncDisposable
         AdhocWorkspace testWorkspace,
         ExportProvider exportProvider,
         ClientCapabilities clientCapabilities,
-        ServerCapabilities serverCapabilities,
+        VSInternalServerCapabilities serverCapabilities,
         CancellationToken cancellationToken)
     {
         var server = new CSharpTestLspServer(testWorkspace, exportProvider, serverCapabilities, cancellationToken);
@@ -190,18 +188,16 @@ public sealed class CSharpTestLspServer : IAsyncDisposable
 
     #endregion
 
-#pragma warning disable CS0618 // Type or member is obsolete
-    private class RazorCapabilitiesProvider : IRazorCapabilitiesProvider
-#pragma warning restore CS0618 // Type or member is obsolete
+    private class RazorCapabilitiesProvider : IRazorTestCapabilitiesProvider
     {
-        private readonly ServerCapabilities _serverCapabilities;
+        private readonly string _serverCapabilities;
 
-        public RazorCapabilitiesProvider(ServerCapabilities serverCapabilities)
+        public RazorCapabilitiesProvider(VSInternalServerCapabilities serverCapabilities)
         {
-            _serverCapabilities = serverCapabilities;
+            _serverCapabilities = JsonConvert.SerializeObject(serverCapabilities);
         }
 
-        public ServerCapabilities GetCapabilities(ClientCapabilities clientCapabilitiesJson)
+        public string GetServerCapabilitiesJson(string clientCapabilitiesJson)
             => _serverCapabilities;
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/CSharpTestLspServerHelpers.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/CSharpTestLspServerHelpers.cs
@@ -30,14 +30,14 @@ internal class CSharpTestLspServerHelpers
     public static Task<CSharpTestLspServer> CreateCSharpLspServerAsync(
         SourceText csharpSourceText,
         Uri csharpDocumentUri,
-        ServerCapabilities serverCapabilities,
+        VSInternalServerCapabilities serverCapabilities,
         CancellationToken cancellationToken) =>
         CreateCSharpLspServerAsync(csharpSourceText, csharpDocumentUri, serverCapabilities, new EmptyMappingService(), cancellationToken);
 
     public static Task<CSharpTestLspServer> CreateCSharpLspServerAsync(
         SourceText csharpSourceText,
         Uri csharpDocumentUri,
-        ServerCapabilities serverCapabilities,
+        VSInternalServerCapabilities serverCapabilities,
         IRazorSpanMappingService razorSpanMappingService,
         CancellationToken cancellationToken)
     {
@@ -49,7 +49,7 @@ internal class CSharpTestLspServerHelpers
         return CreateCSharpLspServerAsync(files, serverCapabilities, razorSpanMappingService, cancellationToken);
     }
 
-    public static async Task<CSharpTestLspServer> CreateCSharpLspServerAsync(IEnumerable<(Uri Uri, SourceText SourceText)> files, ServerCapabilities serverCapabilities, IRazorSpanMappingService razorSpanMappingService, CancellationToken cancellationToken)
+    public static async Task<CSharpTestLspServer> CreateCSharpLspServerAsync(IEnumerable<(Uri Uri, SourceText SourceText)> files, VSInternalServerCapabilities serverCapabilities, IRazorSpanMappingService razorSpanMappingService, CancellationToken cancellationToken)
     {
         var cSharpFiles = files.Select(f => new CSharpFile(f.Uri, f.SourceText));
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/CSharpTestLspServerHelpers.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/CSharpTestLspServerHelpers.cs
@@ -138,7 +138,7 @@ internal class CSharpTestLspServerHelpers
         var analyzerLoader = RazorTestAnalyzerLoader.CreateAnalyzerAssemblyLoader();
 
         var analyzerPaths = new DirectoryInfo(AppContext.BaseDirectory).GetFiles("*.dll")
-            .Where(f => f.Name.StartsWith("Microsoft.CodeAnalysis.", StringComparison.Ordinal) && !f.Name.Contains("LanguageServer"))
+            .Where(f => f.Name.StartsWith("Microsoft.CodeAnalysis.", StringComparison.Ordinal) && !f.Name.Contains("LanguageServer") && !f.Name.Contains("Test.Utilities"))
             .Select(f => f.FullName)
             .ToImmutableArray();
         var references = new List<AnalyzerFileReference>();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/LanguageServerTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/LanguageServerTestBase.cs
@@ -143,7 +143,7 @@ public abstract class LanguageServerTestBase : TestBase
 
     private static IReadOnlyList<TagHelperDescriptor> GetDefaultRuntimeComponents()
     {
-        var bytes = TestResources.GetResourceBytes(TestResources.BlazorServerAppTagHelpersJson);
+        var bytes = RazorTestResources.GetResourceBytes(RazorTestResources.BlazorServerAppTagHelpersJson);
 
         using var stream = new MemoryStream(bytes);
         using var reader = new StreamReader(stream);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/CSharpCodeActionEndToEndTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/CSharpCodeActionEndToEndTest.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
@@ -13,9 +12,9 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Roslyn.Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -407,6 +406,6 @@ public class CSharpCodeActionEndToEndTest : SingleServerDelegatingEndpointTestBa
         }
 
         var actual = sourceText.WithChanges(edits).ToString();
-        new XUnitVerifier().EqualOrDiff(expected, actual);
+        AssertEx.EqualOrDiff(expected, actual);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionItemResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionItemResolverTest.cs
@@ -234,7 +234,7 @@ public class DelegatedCompletionItemResolverTest : LanguageServerTestBase
     {
         var csharpSourceText = codeDocument.GetCSharpSourceText();
         var csharpDocumentUri = new Uri("C:/path/to/file.razor__virtual.g.cs");
-        var serverCapabilities = new ServerCapabilities()
+        var serverCapabilities = new VSInternalServerCapabilities()
         {
             CompletionProvider = new CompletionOptions
             {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionListProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionListProviderTest.cs
@@ -268,7 +268,7 @@ public class DelegatedCompletionListProviderTest : LanguageServerTestBase
         var codeDocument = CreateCodeDocument(output);
         var csharpSourceText = codeDocument.GetCSharpSourceText();
         var csharpDocumentUri = new Uri("C:/path/to/file.razor__virtual.g.cs");
-        var serverCapabilities =  new ServerCapabilities()
+        var serverCapabilities =  new VSInternalServerCapabilities()
         {
             CompletionProvider = new CompletionOptions
             {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentHighlighting/DocumentHighlightEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentHighlighting/DocumentHighlightEndpointTest.cs
@@ -110,7 +110,7 @@ public class DocumentHighlightEndpointTest : LanguageServerTestBase
         var codeDocument = CreateCodeDocument(output);
         var csharpSourceText = codeDocument.GetCSharpSourceText();
         var csharpDocumentUri = new Uri("C:/path/to/file.razor__virtual.g.cs");
-        var serverCapabilities = new ServerCapabilities()
+        var serverCapabilities = new VSInternalServerCapabilities()
         {
             DocumentHighlightProvider = true
         };

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
@@ -21,10 +20,10 @@ using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Moq;
+using Roslyn.Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -99,7 +98,7 @@ public class FormattingTestBase : RazorIntegrationTestBase
         var edited = ApplyEdits(source, edits);
         var actual = edited.ToString();
 
-        new XUnitVerifier().EqualOrDiff(expected, actual);
+        AssertEx.EqualOrDiff(expected, actual);
 
         if (input.Equals(expected))
         {
@@ -146,7 +145,7 @@ public class FormattingTestBase : RazorIntegrationTestBase
         var edited = ApplyEdits(razorSourceText, edits);
         var actual = edited.ToString();
 
-        new XUnitVerifier().EqualOrDiff(expected, actual);
+        AssertEx.EqualOrDiff(expected, actual);
 
         if (input.Equals(expected))
         {
@@ -212,7 +211,7 @@ public class FormattingTestBase : RazorIntegrationTestBase
         var edited = ApplyEdits(razorSourceText, edits);
         var actual = edited.ToString();
 
-        new XUnitVerifier().EqualOrDiff(expected, actual);
+        AssertEx.EqualOrDiff(expected, actual);
     }
 
     protected static TextEdit Edit(int startLine, int startChar, int endLine, int endChar, string newText)
@@ -336,7 +335,7 @@ public class FormattingTestBase : RazorIntegrationTestBase
 
     private static ImmutableArray<TagHelperDescriptor> GetDefaultRuntimeComponents()
     {
-        var bytes = TestResources.GetResourceBytes(TestResources.BlazorServerAppTagHelpersJson);
+        var bytes = RazorTestResources.GetResourceBytes(RazorTestResources.BlazorServerAppTagHelpersJson);
 
         using var stream = new MemoryStream(bytes);
         using var reader = new StreamReader(stream);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingTest.cs
@@ -608,8 +608,8 @@ public class RazorFormattingTest : FormattingTestBase
     public async Task LargeFile()
     {
         await RunFormattingTestAsync(
-            input: TestResources.GetResourceText("FormattingTest.razor"),
-            expected: TestResources.GetResourceText("FormattingTest_Expected.razor"),
+            input: RazorTestResources.GetResourceText("FormattingTest.razor"),
+            expected: RazorTestResources.GetResourceText("FormattingTest_Expected.razor"),
             allowDiagnostics: true);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverInfoServiceTest.cs
@@ -715,7 +715,7 @@ public class HoverInfoServiceTest : TagHelperServiceTestBase
         var codeDocument = CreateCodeDocument(output, DefaultTagHelpers);
         var csharpSourceText = codeDocument.GetCSharpSourceText();
         var csharpDocumentUri = new Uri("C:/path/to/file.razor__virtual.g.cs");
-        var serverCapabilities = new ServerCapabilities()
+        var serverCapabilities = new VSInternalServerCapabilities()
         {
             HoverProvider = true
         };

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokenTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokenTestBase.cs
@@ -28,7 +28,7 @@ public abstract class SemanticTokenTestBase : TagHelperServiceTestBase
     private static readonly AsyncLocal<string?> s_fileName = new();
     private static readonly string s_projectPath = TestProject.GetProjectDirectory(typeof(TagHelperServiceTestBase));
 
-    protected static readonly ServerCapabilities SemanticTokensServerCapabilities = new()
+    protected static readonly VSInternalServerCapabilities SemanticTokensServerCapabilities = new()
     {
         SemanticTokensOptions = new()
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SpellCheck/DocumentSpellCheckEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SpellCheck/DocumentSpellCheckEndpointTest.cs
@@ -10,9 +10,9 @@ using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Roslyn.Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -187,6 +187,6 @@ public class DocumentSpellCheckEndpointTest : SingleServerDelegatingEndpointTest
             actual = actual.Insert(range.End, "|]").Insert(range.Start, "[|");
         }
 
-        new XUnitVerifier().EqualOrDiff(originalInput, actual);
+        AssertEx.EqualOrDiff(originalInput, actual);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Microsoft.AspNetCore.Razor.Test.Common.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/Microsoft.AspNetCore.Razor.Test.Common.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzer.Testing" Version="$(MicrosoftCodeAnalysisAnalyzerTestingPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpPackageVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Testing.Verifiers.XUnit" Version="$(MicrosoftCodeAnalysisTestingVerifiersXunitPackageVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Test.Utilities" Version="$(MicrosoftCodeAnalysisTestUtilitiesPackageVersion)"/>
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(MicrosoftCodeAnalysisWorkspacesCommonPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="$(MicrosoftVisualStudioThreadingPackageVersion)" />

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/RazorTestResources.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common/RazorTestResources.cs
@@ -8,7 +8,7 @@ using System.Reflection;
 
 namespace Microsoft.AspNetCore.Razor.Test.Common;
 
-internal static class TestResources
+internal static class RazorTestResources
 {
     public const string BlazorServerAppTagHelpersJson = "BlazorServerApp.TagHelpers.json";
 
@@ -17,8 +17,8 @@ internal static class TestResources
 
     private static string GetResourceName(string name, string? folder)
         => folder is not null
-            ? $"{typeof(TestResources).Namespace}.Resources.{folder}.{name}"
-            : $"{typeof(TestResources).Namespace}.Resources.{name}";
+            ? $"{typeof(RazorTestResources).Namespace}.Resources.{folder}.{name}"
+            : $"{typeof(RazorTestResources).Namespace}.Resources.{name}";
 
     private static Stream GetResourceStream(string name, string? folder = null)
     {

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Serialization/TagHelperDescriptorSerializationTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Serialization/TagHelperDescriptorSerializationTest.cs
@@ -25,7 +25,7 @@ public class TagHelperDescriptorSerializationTest : TestBase
     public void TagHelperDescriptor_DefaultBlazorServerProject_RoundTrips()
     {
         // Arrange
-        var bytes = TestResources.GetResourceBytes(TestResources.BlazorServerAppTagHelpersJson);
+        var bytes = RazorTestResources.GetResourceBytes(RazorTestResources.BlazorServerAppTagHelpersJson);
 
         // Act
 

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/TagHelperDescriptorCacheTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/TagHelperDescriptorCacheTest.cs
@@ -93,7 +93,7 @@ public class TagHelperDescriptorCacheTest : TestBase
 
     private static ImmutableArray<TagHelperDescriptor> ReadTagHelpers()
     {
-        var bytes = TestResources.GetResourceBytes(TestResources.BlazorServerAppTagHelpersJson);
+        var bytes = RazorTestResources.GetResourceBytes(RazorTestResources.BlazorServerAppTagHelpersJson);
 
         using var stream = new MemoryStream(bytes);
         using var reader = new StreamReader(stream);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.Test/Serialization/TagHelperResolutionResultSerializationTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.Test/Serialization/TagHelperResolutionResultSerializationTest.cs
@@ -29,7 +29,7 @@ public class TagHelperResolutionResultSerializationTest : TestBase
     public void TagHelperResolutionResult_DefaultBlazorServerProject_RoundTrips()
     {
         // Arrange
-        var bytes = TestResources.GetResourceBytes(TestResources.BlazorServerAppTagHelpersJson);
+        var bytes = RazorTestResources.GetResourceBytes(RazorTestResources.BlazorServerAppTagHelpersJson);
 
         ImmutableArray<TagHelperDescriptor> tagHelpers;
         using (var stream = new MemoryStream(bytes))

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionHandlerTest.cs
@@ -45,7 +45,7 @@ public class CompletionHandlerTest : HandlerTestBase
     private readonly CSharpVirtualDocumentSnapshot _csharpVirtualDocumentSnapshot;
     private readonly HtmlVirtualDocumentSnapshot _htmlVirtualDocumentSnapshot;
     private readonly Uri _uri;
-    private readonly ServerCapabilities _completionServerCapabilities;
+    private readonly VSInternalServerCapabilities _completionServerCapabilities;
 
     public CompletionHandlerTest(ITestOutputHelper testOutput)
         : base(testOutput)

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionResolveHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/CompletionResolveHandlerTest.cs
@@ -41,7 +41,7 @@ public class CompletionResolveHandlerTest : HandlerTestBase
     private readonly CompletionRequestContextCache _completionRequestContextCache;
     private readonly Uri _hostDocumentUri;
     private readonly TestTextBuffer _textBuffer;
-    private readonly ServerCapabilities _completionResolveServerCapabilities;
+    private readonly VSInternalServerCapabilities _completionResolveServerCapabilities;
 
     public CompletionResolveHandlerTest(ITestOutputHelper testOutput)
         : base(testOutput)

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DocumentHighlightHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/DocumentHighlightHandlerTest.cs
@@ -29,7 +29,7 @@ public class DocumentHighlightHandlerTest : HandlerTestBase
     private readonly Uri _uri;
     private readonly LSPDocumentSnapshot _documentSnapshot;
     private readonly TestDocumentManager _documentManager;
-    private readonly ServerCapabilities _documentHighlightServerCapabilities;
+    private readonly VSInternalServerCapabilities _documentHighlightServerCapabilities;
 
     public DocumentHighlightHandlerTest(ITestOutputHelper testOutput)
         : base(testOutput)

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/HoverHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/HoverHandlerTest.cs
@@ -32,7 +32,7 @@ public class HoverHandlerTest : HandlerTestBase
 {
     private readonly Uri _uri;
     private readonly TestDocumentManager _documentManager;
-    private readonly ServerCapabilities _hoverServerCapabilities;
+    private readonly VSInternalServerCapabilities _hoverServerCapabilities;
 
     public HoverHandlerTest(ITestOutputHelper testOutput)
         : base(testOutput)

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/RenameHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/RenameHandlerTest.cs
@@ -30,7 +30,7 @@ public class RenameHandlerTest : HandlerTestBase
 {
     private readonly Uri _uri;
     private readonly TestDocumentManager _documentManager;
-    private readonly ServerCapabilities _renameServerCapabilities;
+    private readonly VSInternalServerCapabilities _renameServerCapabilities;
 
     public RenameHandlerTest(ITestOutputHelper testOutput)
         : base(testOutput)

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/SignatureHelpHandlerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlCSharp/SignatureHelpHandlerTest.cs
@@ -30,7 +30,7 @@ public class SignatureHelpHandlerTest : HandlerTestBase
 {
     private readonly Uri _uri;
     private readonly TestDocumentManager _defaultDocumentManager;
-    private readonly ServerCapabilities _signatureHelpServerCapabilities;
+    private readonly VSInternalServerCapabilities _signatureHelpServerCapabilities;
 
     public SignatureHelpHandlerTest(ITestOutputHelper testOutput)
         : base(testOutput)


### PR DESCRIPTION
I was intending this to be a little cleanup PR after the Roslyn bump, so use the Roslyn `AssertEx.EqualOrDiff` method, which is an easier to discover signature than `new XUnitVerifier().EqualOrDiff` (which also introduces a whole package reference, and creates a new object, just to call an extension method that is part of a different package we were already referencing 🤷‍♂️). It ended up being a little more. Sorry!

* Removed XUnitVerifier
* Added reference to MS.CA.Test.Utilities
* This broke tooling tests that used our test LSP, because that DLL contains analyzers that have an infinite loop
* Excluded that DLL from our analyzers to fix that issue
* Added "Blazor" to our dictionary because it annoyed me
* Renamed `TestResources` to `RazorTestResources` because the name clashed with a namespace in MS.CA.Test.Utilities
* Made our test LSP servers take a `VSInternalServerCapabilities` because thats what I made Roslyn deserialize anyway.