### PR TITLE
Fixes Microsoft.NETCore.App.Runtime Component Governance issues

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -173,7 +173,7 @@
     <BenchmarkDotNetVersion>0.13.2.1938</BenchmarkDotNetVersion>
     <DiffPlexVersion>1.5.0</DiffPlexVersion>
     <FluentAssertionsVersion>6.7.0</FluentAssertionsVersion>
-    <MicrosoftAspNetCoreAppVersion>7.0.5</MicrosoftAspNetCoreAppVersion>
+    <MicrosoftAspNetCoreAppVersion>7.0.7</MicrosoftAspNetCoreAppVersion>
     <MicrosoftBuildLocatorVersion>1.4.1</MicrosoftBuildLocatorVersion>
     <MicrosoftBuildVersion>17.3.0-preview-22364-05</MicrosoftBuildVersion>
     <MicrosoftBuildFrameworkVersion>$(MicrosoftBuildVersion)</MicrosoftBuildFrameworkVersion>


### PR DESCRIPTION
﻿### Summary of the changes

When building a .NET core app we implicitly pull down references for the runtime. e.g. `Microsoft.NetCore.App.Runtime.linux-arm` when building for Linux. At the moment our builds are pulling down 7.0.5 but CG is asking to be 7.0.7.
So this PR updates MicrosoftAspNetCoreAppVersion to 7.0.7.

Here is a recent [Component Governance - Compliance (visualstudio.com)](https://devdiv.visualstudio.com/DevDiv/_componentGovernance/205182?_a=alerts&typeId=13385733&alerts-view-option=active) report: [Pipelines - Run 20230624.1 (visualstudio.com)](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=7971461&view=results) taken from merged PR [#8863](https://github.com/dotnet/razor/pull/8863).

The report shows the `Microsoft.NETCore.App.Runtime.win-arm64` items are still showing up after the arcade update already merged in PR [#8762)](https://github.com/dotnet/razor/pull/8762)).


