### PR TITLE
Make the latest configuration actually be somewhat recent

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/FallbackRazorConfiguration.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/FallbackRazorConfiguration.cs
@@ -40,7 +40,11 @@ internal class FallbackRazorConfiguration : RazorConfiguration
          "MVC-3.0",
          new[] { new FallbackRazorExtension("MVC-3.0"), });
 
-    public static readonly RazorConfiguration Latest = MVC_3_0;
+    public static readonly RazorConfiguration Latest = new FallbackRazorConfiguration(
+         RazorLanguageVersion.Latest,
+         // Razor latest uses MVC 3.0 Razor configuration.
+         "MVC-3.0",
+         new[] { new FallbackRazorExtension("MVC-3.0"), });
 
     public static RazorConfiguration SelectConfiguration(Version version)
     {


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/8572

I don't know _why_ the fallback configuration is being used, so logged https://github.com/dotnet/razor/issues/8905 to investigate that further. This mitigates the problem though.