### PR TITLE
Subscribe to all target frameworks in the project file

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -122,11 +122,11 @@
     <MicrosoftVisualStudioLanguageServerProtocolExtensionsPackageVersion>$(VisualStudioLanguageServerProtocolVersion)</MicrosoftVisualStudioLanguageServerProtocolExtensionsPackageVersion>
     <MicrosoftVisualStudioLanguageServerProtocolInternalPackageVersion>$(VisualStudioLanguageServerProtocolVersion)</MicrosoftVisualStudioLanguageServerProtocolInternalPackageVersion>
     <MicrosoftVisualStudioLiveSharePackageVersion>0.3.1074</MicrosoftVisualStudioLiveSharePackageVersion>
-    <MicrosoftVisualStudioProjectSystemSDKPackageVersion>16.10.81-pre</MicrosoftVisualStudioProjectSystemSDKPackageVersion>
+    <MicrosoftVisualStudioProjectSystemSDKPackageVersion>17.7.294-pre</MicrosoftVisualStudioProjectSystemSDKPackageVersion>
     <MicrosoftVisualStudioShell150PackageVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioShell150PackageVersion>
     <MicrosoftVisualStudioInteropPackageVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioInteropPackageVersion>
     <MicrosoftInternalVisualStudioInteropPackageVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftInternalVisualStudioInteropPackageVersion>
-    <MicrosoftVisualStudioRpcContractsPackageVersion>17.7.1-preview</MicrosoftVisualStudioRpcContractsPackageVersion>
+    <MicrosoftVisualStudioRpcContractsPackageVersion>17.7.5-preview</MicrosoftVisualStudioRpcContractsPackageVersion>
     <MicrosoftVisualStudioTelemetryVersion>17.7.8</MicrosoftVisualStudioTelemetryVersion>
     <MicrosoftVisualStudioTextDataPackageVersion>$(MicrosoftVisualStudioPackagesVersion)</MicrosoftVisualStudioTextDataPackageVersion>
     <MicrosoftVisualStudioTextImplementationPackageVersion>$(MicrosoftVisualStudioPackagesVersion)</MicrosoftVisualStudioTextImplementationPackageVersion>

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 internal class DefaultWindowsRazorProjectHost : WindowsRazorProjectHostBase
 {
     private const string RootNamespaceProperty = "RootNamespace";
-    private static readonly string[] s_ruleNames = new string[]
+    private static readonly ImmutableHashSet<string> s_ruleNames = ImmutableHashSet.CreateRange(new string[]
         {
             Rules.RazorGeneral.SchemaName,
             Rules.RazorConfiguration.SchemaName,
@@ -34,7 +34,7 @@ internal class DefaultWindowsRazorProjectHost : WindowsRazorProjectHostBase
             Rules.RazorComponentWithTargetPath.SchemaName,
             Rules.RazorGenerateWithTargetPath.SchemaName,
             ConfigurationGeneralSchemaName,
-        };
+        });
     private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
 
     [ImportingConstructor]
@@ -62,7 +62,7 @@ internal class DefaultWindowsRazorProjectHost : WindowsRazorProjectHostBase
     {
     }
 
-    protected override string[] GetRuleNames() => s_ruleNames;
+    protected override ImmutableHashSet<string> GetRuleNames() => s_ruleNames;
 
     protected override async Task HandleProjectChangeAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update)
     {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
@@ -108,7 +108,7 @@ internal class DefaultWindowsRazorProjectHost : WindowsRazorProjectHostBase
         else
         {
             // Ok we can't find a configuration. Let's assume this project isn't using Razor then.
-            await UpdateAsync(UninitializeProjectUnsafe, CancellationToken.None).ConfigureAwait(false);
+            await UpdateAsync(() => UninitializeProjectUnsafe(CommonServices.UnconfiguredProject.FullPath), CancellationToken.None).ConfigureAwait(false);
         }
     }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
@@ -26,6 +26,15 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 internal class DefaultWindowsRazorProjectHost : WindowsRazorProjectHostBase
 {
     private const string RootNamespaceProperty = "RootNamespace";
+    private static readonly string[] s_ruleNames = new string[]
+        {
+            Rules.RazorGeneral.SchemaName,
+            Rules.RazorConfiguration.SchemaName,
+            Rules.RazorExtension.SchemaName,
+            Rules.RazorComponentWithTargetPath.SchemaName,
+            Rules.RazorGenerateWithTargetPath.SchemaName,
+            ConfigurationGeneralSchemaName,
+        };
     private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
 
     [ImportingConstructor]
@@ -53,18 +62,7 @@ internal class DefaultWindowsRazorProjectHost : WindowsRazorProjectHostBase
     {
     }
 
-    protected override string[] GetRuleNames()
-    {
-        return new string[]
-        {
-            Rules.RazorGeneral.SchemaName,
-            Rules.RazorConfiguration.SchemaName,
-            Rules.RazorExtension.SchemaName,
-            Rules.RazorComponentWithTargetPath.SchemaName,
-            Rules.RazorGenerateWithTargetPath.SchemaName,
-            ConfigurationGeneralSchemaName,
-        };
-    }
+    protected override string[] GetRuleNames() => s_ruleNames;
 
     protected override async Task HandleProjectChangeAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update)
     {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
@@ -86,7 +86,7 @@ internal class FallbackWindowsRazorProjectHost : WindowsRazorProjectHostBase
         if (mvcReferenceFullPath is null)
         {
             // Ok we can't find an MVC version. Let's assume this project isn't using Razor then.
-            await UpdateAsync(UninitializeProjectUnsafe, CancellationToken.None).ConfigureAwait(false);
+            await UpdateAsync(() => UninitializeProjectUnsafe(CommonServices.UnconfiguredProject.FullPath), CancellationToken.None).ConfigureAwait(false);
             return;
         }
 
@@ -94,7 +94,7 @@ internal class FallbackWindowsRazorProjectHost : WindowsRazorProjectHostBase
         if (version is null)
         {
             // Ok we can't find an MVC version. Let's assume this project isn't using Razor then.
-            await UpdateAsync(UninitializeProjectUnsafe, CancellationToken.None).ConfigureAwait(false);
+            await UpdateAsync(() => UninitializeProjectUnsafe(CommonServices.UnconfiguredProject.FullPath), CancellationToken.None).ConfigureAwait(false);
             return;
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
@@ -23,9 +23,6 @@ using ResolvedCompilationReference = Microsoft.CodeAnalysis.Razor.ProjectSystem.
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
-// Somewhat similar to https://github.com/dotnet/project-system/blob/bf4f33ec1843551eb775f73cff515a939aa2f629/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
-// but a lot simpler
-//
 // This class is responsible for initializing the Razor ProjectSnapshotManager for cases where
 // MSBuild does not provides configuration support (SDK < 2.1).
 [AppliesTo("(DotNetCoreRazor | DotNetCoreWeb) & !DotNetCoreRazorConfiguration")]
@@ -70,79 +67,70 @@ internal class FallbackWindowsRazorProjectHost : WindowsRazorProjectHostBase
         };
     }
 
-    // Internal for testing
-    internal override async Task OnProjectChangedAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update)
+    protected override async Task HandleProjectChangeAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update)
     {
-        if (IsDisposing || IsDisposed)
+        string? mvcReferenceFullPath = null;
+        if (update.Value.CurrentState.ContainsKey(ResolvedCompilationReference.SchemaName))
         {
+            var references = update.Value.CurrentState[ResolvedCompilationReference.SchemaName].Items;
+            foreach (var reference in references)
+            {
+                if (reference.Key.EndsWith(MvcAssemblyFileName, StringComparison.OrdinalIgnoreCase))
+                {
+                    mvcReferenceFullPath = reference.Key;
+                    break;
+                }
+            }
+        }
+
+        if (mvcReferenceFullPath is null)
+        {
+            // Ok we can't find an MVC version. Let's assume this project isn't using Razor then.
+            await UpdateAsync(UninitializeProjectUnsafe, CancellationToken.None).ConfigureAwait(false);
             return;
         }
 
-        await CommonServices.TasksService.LoadedProjectAsync(async () => await ExecuteWithLockAsync(async () =>
+        var version = GetAssemblyVersion(mvcReferenceFullPath);
+        if (version is null)
         {
-            string? mvcReferenceFullPath = null;
-            if (update.Value.CurrentState.ContainsKey(ResolvedCompilationReference.SchemaName))
+            // Ok we can't find an MVC version. Let's assume this project isn't using Razor then.
+            await UpdateAsync(UninitializeProjectUnsafe, CancellationToken.None).ConfigureAwait(false);
+            return;
+        }
+
+        // We need to deal with the case where the project was uninitialized, but now
+        // is valid for Razor. In that case we might have previously seen all of the documents
+        // but ignored them because the project wasn't active.
+        //
+        // So what we do to deal with this, is that we 'remove' all changed and removed items
+        // and then we 'add' all current items. This allows minimal churn to the PSM, but still
+        // makes us up-to-date.
+        var documents = GetCurrentDocuments(update.Value);
+        var changedDocuments = GetChangedAndRemovedDocuments(update.Value);
+
+        await UpdateAsync(() =>
+        {
+            var configuration = FallbackRazorConfiguration.SelectConfiguration(version);
+            var hostProject = new HostProject(CommonServices.UnconfiguredProject.FullPath, configuration, rootNamespace: null);
+
+            if (TryGetIntermediateOutputPath(update.Value.CurrentState, out var intermediatePath))
             {
-                var references = update.Value.CurrentState[ResolvedCompilationReference.SchemaName].Items;
-                foreach (var reference in references)
-                {
-                    if (reference.Key.EndsWith(MvcAssemblyFileName, StringComparison.OrdinalIgnoreCase))
-                    {
-                        mvcReferenceFullPath = reference.Key;
-                        break;
-                    }
-                }
+                var projectConfigurationFile = Path.Combine(intermediatePath, _languageServerFeatureOptions.ProjectConfigurationFileName);
+                ProjectConfigurationFilePathStore.Set(hostProject.FilePath, projectConfigurationFile);
             }
 
-            if (mvcReferenceFullPath is null)
+            UpdateProjectUnsafe(hostProject);
+
+            for (var i = 0; i < changedDocuments.Length; i++)
             {
-                // Ok we can't find an MVC version. Let's assume this project isn't using Razor then.
-                await UpdateAsync(UninitializeProjectUnsafe, CancellationToken.None).ConfigureAwait(false);
-                return;
+                RemoveDocumentUnsafe(hostProject, changedDocuments[i]);
             }
 
-            var version = GetAssemblyVersion(mvcReferenceFullPath);
-            if (version is null)
+            for (var i = 0; i < documents.Length; i++)
             {
-                // Ok we can't find an MVC version. Let's assume this project isn't using Razor then.
-                await UpdateAsync(UninitializeProjectUnsafe, CancellationToken.None).ConfigureAwait(false);
-                return;
+                AddDocumentUnsafe(hostProject, documents[i]);
             }
-
-            // We need to deal with the case where the project was uninitialized, but now
-            // is valid for Razor. In that case we might have previously seen all of the documents
-            // but ignored them because the project wasn't active.
-            //
-            // So what we do to deal with this, is that we 'remove' all changed and removed items
-            // and then we 'add' all current items. This allows minimal churn to the PSM, but still
-            // makes us up-to-date.
-            var documents = GetCurrentDocuments(update.Value);
-            var changedDocuments = GetChangedAndRemovedDocuments(update.Value);
-
-            await UpdateAsync(() =>
-            {
-                var configuration = FallbackRazorConfiguration.SelectConfiguration(version);
-                var hostProject = new HostProject(CommonServices.UnconfiguredProject.FullPath, configuration, rootNamespace: null);
-
-                if (TryGetIntermediateOutputPath(update.Value.CurrentState, out var intermediatePath))
-                {
-                    var projectConfigurationFile = Path.Combine(intermediatePath, _languageServerFeatureOptions.ProjectConfigurationFileName);
-                    ProjectConfigurationFilePathStore.Set(hostProject.FilePath, projectConfigurationFile);
-                }
-
-                UpdateProjectUnsafe(hostProject);
-
-                for (var i = 0; i < changedDocuments.Length; i++)
-                {
-                    RemoveDocumentUnsafe(changedDocuments[i]);
-                }
-
-                for (var i = 0; i < documents.Length; i++)
-                {
-                    AddDocumentUnsafe(documents[i]);
-                }
-            }, CancellationToken.None).ConfigureAwait(false);
-        }).ConfigureAwait(false), registerFaultHandler: true);
+        }, CancellationToken.None).ConfigureAwait(false);
     }
 
     // virtual for overriding in tests

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
@@ -30,6 +30,12 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 internal class FallbackWindowsRazorProjectHost : WindowsRazorProjectHostBase
 {
     private const string MvcAssemblyFileName = "Microsoft.AspNetCore.Mvc.Razor.dll";
+    private static readonly string[] s_ruleNames = new string[]
+        {
+            ResolvedCompilationReference.SchemaName,
+            ContentItem.SchemaName,
+            NoneItem.SchemaName,
+        };
     private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
 
     [ImportingConstructor]
@@ -57,15 +63,7 @@ internal class FallbackWindowsRazorProjectHost : WindowsRazorProjectHostBase
     {
     }
 
-    protected override string[] GetRuleNames()
-    {
-        return new string[]
-        {
-            ResolvedCompilationReference.SchemaName,
-            ContentItem.SchemaName,
-            NoneItem.SchemaName,
-        };
-    }
+    protected override string[] GetRuleNames() => s_ruleNames;
 
     protected override async Task HandleProjectChangeAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update)
     {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
@@ -35,7 +35,7 @@ internal class FallbackWindowsRazorProjectHost : WindowsRazorProjectHostBase
             ResolvedCompilationReference.SchemaName,
             ContentItem.SchemaName,
             NoneItem.SchemaName,
-        };
+        });
     private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
 
     [ImportingConstructor]

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 internal class FallbackWindowsRazorProjectHost : WindowsRazorProjectHostBase
 {
     private const string MvcAssemblyFileName = "Microsoft.AspNetCore.Mvc.Razor.dll";
-    private static readonly string[] s_ruleNames = new string[]
+    private static readonly ImmutableHashSet<string> s_ruleNames = ImmutableHashSet.CreateRange(new string[]
         {
             ResolvedCompilationReference.SchemaName,
             ContentItem.SchemaName,
@@ -63,7 +63,7 @@ internal class FallbackWindowsRazorProjectHost : WindowsRazorProjectHostBase
     {
     }
 
-    protected override string[] GetRuleNames() => s_ruleNames;
+    protected override ImmutableHashSet<string> GetRuleNames() => s_ruleNames;
 
     protected override async Task HandleProjectChangeAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update)
     {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/IUnconfiguredProjectCommonServices.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/IUnconfiguredProjectCommonServices.cs
@@ -12,11 +12,13 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 // for us to build reusable mocks instead.
 internal interface IUnconfiguredProjectCommonServices
 {
-    IActiveConfiguredProjectSubscriptionService ActiveConfiguredProjectSubscription { get; }
-
     IProjectAsynchronousTasksService TasksService { get; }
 
     IProjectThreadingService ThreadingService { get; }
 
     UnconfiguredProject UnconfiguredProject { get; }
+
+    IProjectFaultHandlerService FaultHandlerService { get; }
+
+    IActiveConfigurationGroupSubscriptionService ActiveConfigurationGroupSubscriptionService { get; }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/IUnconfiguredProjectCommonServices.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/IUnconfiguredProjectCommonServices.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using Microsoft.VisualStudio.ProjectSystem;
-using Microsoft.VisualStudio.ProjectSystem.References;
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
@@ -13,14 +12,6 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 // for us to build reusable mocks instead.
 internal interface IUnconfiguredProjectCommonServices
 {
-    ConfiguredProject ActiveConfiguredProject { get; }
-
-    IAssemblyReferencesService ActiveConfiguredProjectAssemblyReferences { get; }
-
-    IPackageReferencesService ActiveConfiguredProjectPackageReferences { get; }
-
-    Rules.RazorProjectProperties ActiveConfiguredProjectRazorProperties { get; }
-
     IActiveConfiguredProjectSubscriptionService ActiveConfiguredProjectSubscription { get; }
 
     IProjectAsynchronousTasksService TasksService { get; }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/UnconfiguredProjectCommonServices.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/UnconfiguredProjectCommonServices.cs
@@ -4,28 +4,18 @@
 using System;
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.ProjectSystem;
-using Microsoft.VisualStudio.ProjectSystem.References;
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 [Export(typeof(IUnconfiguredProjectCommonServices))]
 internal class UnconfiguredProjectCommonServices : IUnconfiguredProjectCommonServices
 {
-    private readonly ActiveConfiguredProject<ConfiguredProject> _activeConfiguredProject;
-    private readonly ActiveConfiguredProject<IAssemblyReferencesService> _activeConfiguredProjectAssemblyReferences;
-    private readonly ActiveConfiguredProject<IPackageReferencesService> _activeConfiguredProjectPackageReferences;
-    private readonly ActiveConfiguredProject<Rules.RazorProjectProperties> _activeConfiguredProjectProperties;
-
     [ImportingConstructor]
     public UnconfiguredProjectCommonServices(
         [Import(ExportContractNames.Scopes.UnconfiguredProject)] IProjectAsynchronousTasksService tasksService,
         IProjectThreadingService threadingService,
         UnconfiguredProject unconfiguredProject,
-        IActiveConfiguredProjectSubscriptionService activeConfiguredProjectSubscription,
-        ActiveConfiguredProject<ConfiguredProject> activeConfiguredProject,
-        ActiveConfiguredProject<IAssemblyReferencesService> activeConfiguredProjectAssemblyReferences,
-        ActiveConfiguredProject<IPackageReferencesService> activeConfiguredProjectPackageReferences,
-        ActiveConfiguredProject<Rules.RazorProjectProperties> activeConfiguredProjectRazorProperties)
+        IActiveConfiguredProjectSubscriptionService activeConfiguredProjectSubscription)
     {
         if (tasksService is null)
         {
@@ -47,43 +37,11 @@ internal class UnconfiguredProjectCommonServices : IUnconfiguredProjectCommonSer
             throw new ArgumentNullException(nameof(activeConfiguredProjectSubscription));
         }
 
-        if (activeConfiguredProject is null)
-        {
-            throw new ArgumentNullException(nameof(activeConfiguredProject));
-        }
-
-        if (activeConfiguredProjectAssemblyReferences is null)
-        {
-            throw new ArgumentNullException(nameof(activeConfiguredProjectAssemblyReferences));
-        }
-
-        if (activeConfiguredProjectPackageReferences is null)
-        {
-            throw new ArgumentNullException(nameof(activeConfiguredProjectPackageReferences));
-        }
-
-        if (activeConfiguredProjectRazorProperties is null)
-        {
-            throw new ArgumentNullException(nameof(activeConfiguredProjectRazorProperties));
-        }
-
         TasksService = tasksService;
         ThreadingService = threadingService;
         UnconfiguredProject = unconfiguredProject;
         ActiveConfiguredProjectSubscription = activeConfiguredProjectSubscription;
-        _activeConfiguredProject = activeConfiguredProject;
-        _activeConfiguredProjectAssemblyReferences = activeConfiguredProjectAssemblyReferences;
-        _activeConfiguredProjectPackageReferences = activeConfiguredProjectPackageReferences;
-        _activeConfiguredProjectProperties = activeConfiguredProjectRazorProperties;
     }
-
-    public ConfiguredProject ActiveConfiguredProject => _activeConfiguredProject.Value;
-
-    public IAssemblyReferencesService ActiveConfiguredProjectAssemblyReferences => _activeConfiguredProjectAssemblyReferences.Value;
-
-    public IPackageReferencesService ActiveConfiguredProjectPackageReferences => _activeConfiguredProjectPackageReferences.Value;
-
-    public Rules.RazorProjectProperties ActiveConfiguredProjectRazorProperties => _activeConfiguredProjectProperties.Value;
 
     public IActiveConfiguredProjectSubscriptionService ActiveConfiguredProjectSubscription { get; }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/UnconfiguredProjectCommonServices.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/UnconfiguredProjectCommonServices.cs
@@ -15,7 +15,8 @@ internal class UnconfiguredProjectCommonServices : IUnconfiguredProjectCommonSer
         [Import(ExportContractNames.Scopes.UnconfiguredProject)] IProjectAsynchronousTasksService tasksService,
         IProjectThreadingService threadingService,
         UnconfiguredProject unconfiguredProject,
-        IActiveConfiguredProjectSubscriptionService activeConfiguredProjectSubscription)
+        IProjectFaultHandlerService faultHandlerService,
+        IActiveConfigurationGroupSubscriptionService activeConfigurationGroupSubscriptionService)
     {
         if (tasksService is null)
         {
@@ -32,22 +33,25 @@ internal class UnconfiguredProjectCommonServices : IUnconfiguredProjectCommonSer
             throw new ArgumentNullException(nameof(unconfiguredProject));
         }
 
-        if (activeConfiguredProjectSubscription is null)
+        if (activeConfigurationGroupSubscriptionService is null)
         {
-            throw new ArgumentNullException(nameof(activeConfiguredProjectSubscription));
+            throw new ArgumentNullException(nameof(activeConfigurationGroupSubscriptionService));
         }
 
         TasksService = tasksService;
         ThreadingService = threadingService;
         UnconfiguredProject = unconfiguredProject;
-        ActiveConfiguredProjectSubscription = activeConfiguredProjectSubscription;
+        FaultHandlerService = faultHandlerService;
+        ActiveConfigurationGroupSubscriptionService = activeConfigurationGroupSubscriptionService;
     }
-
-    public IActiveConfiguredProjectSubscriptionService ActiveConfiguredProjectSubscription { get; }
 
     public IProjectAsynchronousTasksService TasksService { get; }
 
     public IProjectThreadingService ThreadingService { get; }
 
     public UnconfiguredProject UnconfiguredProject { get; }
+
+    public IProjectFaultHandlerService FaultHandlerService { get; }
+
+    public IActiveConfigurationGroupSubscriptionService ActiveConfigurationGroupSubscriptionService { get; }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
@@ -137,7 +137,7 @@ internal abstract class WindowsRazorProjectHostBase : OnceInitializedOnceDispose
         // Somewhat similar to https://github.com/dotnet/project-system/blob/bf4f33ec1843551eb775f73cff515a939aa2f629/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
         // but a lot simpler.
         _disposables.Add(CommonServices.ActiveConfigurationGroupSubscriptionService.SourceBlock.LinkTo(
-            DataflowBlockSlim.CreateActionBlock<IProjectVersionedValue<ConfigurationSubscriptionSources>>(SlicesChanged, nameFormat: "Slice {0}"),
+            DataflowBlockSlim.CreateActionBlock<IProjectVersionedValue<ConfigurationSubscriptionSources>>(SlicesChanged, nameFormat: "Slice {1}"),
             new DataflowLinkOptions() { PropagateCompletion = true }));
 
         // Join, in the JTF sense, the ActiveConfigurationGroupSubscriptionService, to help avoid hangs in our OnProjectChangedAsync method
@@ -164,7 +164,7 @@ internal abstract class WindowsRazorProjectHostBase : OnceInitializedOnceDispose
                 // affect about the same project.razor.json file, but our event handling code ensures we don't handle them more than
                 // necessary.
                 var subscription = source.JointRuleSource.SourceBlock.LinkTo(
-                    DataflowBlockSlim.CreateActionBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(OnProjectChangedAsync, "OnProjectChanged {0}"),
+                    DataflowBlockSlim.CreateActionBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(OnProjectChangedAsync, nameFormat: "OnProjectChanged {1}"),
                     initialDataAsNew: true,
                     suppressVersionOnlyUpdates: true,
                     ruleNames: GetRuleNames(),

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
@@ -19,10 +19,6 @@ using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
-/// <summary>
-/// Somewhat similar to https://github.com/dotnet/project-system/blob/bf4f33ec1843551eb775f73cff515a939aa2f629/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
-/// but a lot simpler. Needs to SetPublisherPath for DefaultRazorProjectChangePublisher
-/// </summary>
 internal abstract class WindowsRazorProjectHostBase : OnceInitializedOnceDisposedAsync, IProjectDynamicLoadComponent
 {
     private readonly Workspace _workspace;
@@ -137,6 +133,9 @@ internal abstract class WindowsRazorProjectHostBase : OnceInitializedOnceDispose
         // but they could be strictly anything, and could change at any time. If they do, we'll get new events, so the easiest
         // thing to do is just treat the key as an opaque object. CPS implements IEquatable on it, expressly for this purpose.
         // We should not have any logic that depends on the contents of the key.
+        //
+        // Somewhat similar to https://github.com/dotnet/project-system/blob/bf4f33ec1843551eb775f73cff515a939aa2f629/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Tree/Dependencies/Subscriptions/DependenciesSnapshotProvider.cs
+        // but a lot simpler.
         _disposables.Add(CommonServices.ActiveConfigurationGroupSubscriptionService.SourceBlock.LinkTo(
             DataflowBlockSlim.CreateActionBlock<IProjectVersionedValue<ConfigurationSubscriptionSources>>(SlicesChanged, nameFormat: "Slice {0}"),
             new DataflowLinkOptions() { PropagateCompletion = true }));

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
@@ -21,6 +21,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 internal abstract class WindowsRazorProjectHostBase : OnceInitializedOnceDisposedAsync, IProjectDynamicLoadComponent
 {
+    private static readonly DataflowLinkOptions s_dataflowLinkOptions = new DataflowLinkOptions() { PropagateCompletion = true };
+
     private readonly Workspace _workspace;
     private readonly ProjectSnapshotManagerDispatcher _projectSnapshotManagerDispatcher;
     private readonly AsyncSemaphore _lock;
@@ -92,7 +94,7 @@ internal abstract class WindowsRazorProjectHostBase : OnceInitializedOnceDispose
         _projectManager = projectManager;
     }
 
-    protected abstract string[] GetRuleNames();
+    protected abstract ImmutableHashSet<string> GetRuleNames();
 
     protected abstract Task HandleProjectChangeAsync(IProjectVersionedValue<IProjectSubscriptionUpdate> update);
 
@@ -168,7 +170,7 @@ internal abstract class WindowsRazorProjectHostBase : OnceInitializedOnceDispose
                     initialDataAsNew: true,
                     suppressVersionOnlyUpdates: true,
                     ruleNames: GetRuleNames(),
-                    linkOptions: new DataflowLinkOptions() { PropagateCompletion = true });
+                    linkOptions: s_dataflowLinkOptions);
 
                 _projectSubscriptions.Add(slice, subscription);
             }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
@@ -660,75 +660,75 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
         Assert.Empty(_projectManager.Projects);
     }
 
-    // [UIFact]
-    // public async Task OnProjectChanged_ReadsProperties_InitializesProject()
-    // {
-    //     // Arrange
-    //     RazorGeneralProperties.Property(Rules.RazorGeneral.RazorLangVersionProperty, "2.1");
-    //     RazorGeneralProperties.Property(Rules.RazorGeneral.RazorDefaultConfigurationProperty, "MVC-2.1");
+    [UIFact]
+    public async Task OnProjectChanged_ReadsProperties_InitializesProject()
+    {
+        // Arrange
+        _razorGeneralProperties.Property(Rules.RazorGeneral.RazorLangVersionProperty, "2.1");
+        _razorGeneralProperties.Property(Rules.RazorGeneral.RazorDefaultConfigurationProperty, "MVC-2.1");
 
-    //     ConfigurationItems.Item("MVC-2.1");
-    //     ConfigurationItems.Property("MVC-2.1", Rules.RazorConfiguration.ExtensionsProperty, "MVC-2.1;Another-Thing");
+        _configurationItems.Item("MVC-2.1");
+        _configurationItems.Property("MVC-2.1", Rules.RazorConfiguration.ExtensionsProperty, "MVC-2.1;Another-Thing");
 
-    //     ExtensionItems.Item("MVC-2.1");
-    //     ExtensionItems.Item("Another-Thing");
+        _extensionItems.Item("MVC-2.1");
+        _extensionItems.Item("Another-Thing");
 
-    //     RazorComponentWithTargetPathItems.Item(Path.GetFileName(TestProjectData.SomeProjectComponentFile1.FilePath));
-    //     RazorComponentWithTargetPathItems.Property(Path.GetFileName(TestProjectData.SomeProjectComponentFile1.FilePath), Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectComponentFile1.TargetPath);
+        _razorComponentWithTargetPathItems.Item(Path.GetFileName(TestProjectData.SomeProjectComponentFile1.FilePath));
+        _razorComponentWithTargetPathItems.Property(Path.GetFileName(TestProjectData.SomeProjectComponentFile1.FilePath), Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectComponentFile1.TargetPath);
 
-    //     RazorGenerateWithTargetPathItems.Item(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath));
-    //     RazorGenerateWithTargetPathItems.Property(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath), Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectFile1.TargetPath);
+        _razorGenerateWithTargetPathItems.Item(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath));
+        _razorGenerateWithTargetPathItems.Property(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath), Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectFile1.TargetPath);
 
-    //     var changes = new TestProjectChangeDescription[]
-    //     {
-    //         RazorGeneralProperties.ToChange(),
-    //         ConfigurationItems.ToChange(),
-    //         ExtensionItems.ToChange(),
-    //         RazorComponentWithTargetPathItems.ToChange(),
-    //         RazorGenerateWithTargetPathItems.ToChange(),
-    //     };
+        var changes = new TestProjectChangeDescription[]
+        {
+             _razorGeneralProperties.ToChange(),
+             _configurationItems.ToChange(),
+             _extensionItems.ToChange(),
+             _razorComponentWithTargetPathItems.ToChange(),
+             _razorGenerateWithTargetPathItems.ToChange(),
+        };
 
-    //     var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
+        var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
 
-    //     var host = new DefaultRazorProjectHost(services, Workspace, ProjectConfigurationFilePathStore, ProjectManager);
+        var host = new DefaultWindowsRazorProjectHost(services, Workspace, Dispatcher, _projectConfigurationFilePathStore, _projectManager);
 
-    //     await Task.Run(async () => await host.LoadAsync());
-    //     Assert.Empty(ProjectManager.Projects);
+        await Task.Run(async () => await host.LoadAsync());
+        Assert.Empty(_projectManager.Projects);
 
-    //     // Act
-    //     await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
+        // Act
+        await Task.Run(async () => await host.OnProjectChangedAsync(services.CreateUpdate(changes)));
 
-    //     // Assert
-    //     var snapshot = Assert.Single(ProjectManager.Projects);
-    //     Assert.Equal(TestProjectData.SomeProject.FilePath, snapshot.FilePath);
+        // Assert
+        var snapshot = Assert.Single(_projectManager.Projects);
+        Assert.Equal(TestProjectData.SomeProject.FilePath, snapshot.FilePath);
 
-    //     Assert.Equal(RazorLanguageVersion.Version_2_1, snapshot.Configuration.LanguageVersion);
-    //     Assert.Equal("MVC-2.1", snapshot.Configuration.ConfigurationName);
-    //     Assert.Collection(
-    //         snapshot.Configuration.Extensions.OrderBy(e => e.ExtensionName),
-    //         e => Assert.Equal("Another-Thing", e.ExtensionName),
-    //         e => Assert.Equal("MVC-2.1", e.ExtensionName));
+        Assert.Equal(RazorLanguageVersion.Version_2_1, snapshot.Configuration.LanguageVersion);
+        Assert.Equal("MVC-2.1", snapshot.Configuration.ConfigurationName);
+        Assert.Collection(
+            snapshot.Configuration.Extensions.OrderBy(e => e.ExtensionName),
+            e => Assert.Equal("Another-Thing", e.ExtensionName),
+            e => Assert.Equal("MVC-2.1", e.ExtensionName));
 
-    //     Assert.Collection(
-    //         snapshot.DocumentFilePaths.OrderBy(d => d),
-    //         d =>
-    //         {
-    //             var document = snapshot.GetDocument(d);
-    //             Assert.Equal(TestProjectData.SomeProjectFile1.FilePath, document.FilePath);
-    //             Assert.Equal(TestProjectData.SomeProjectFile1.TargetPath, document.TargetPath);
-    //             Assert.Equal(FileKinds.Legacy, document.FileKind);
-    //         },
-    //         d =>
-    //         {
-    //             var document = snapshot.GetDocument(d);
-    //             Assert.Equal(TestProjectData.SomeProjectComponentFile1.FilePath, document.FilePath);
-    //             Assert.Equal(TestProjectData.SomeProjectComponentFile1.TargetPath, document.TargetPath);
-    //             Assert.Equal(FileKinds.Component, document.FileKind);
-    //         });
+        Assert.Collection(
+            snapshot.DocumentFilePaths.OrderBy(d => d),
+            d =>
+            {
+                var document = snapshot.GetDocument(d);
+                Assert.Equal(TestProjectData.SomeProjectFile1.FilePath, document.FilePath);
+                Assert.Equal(TestProjectData.SomeProjectFile1.TargetPath, document.TargetPath);
+                Assert.Equal(FileKinds.Legacy, document.FileKind);
+            },
+            d =>
+            {
+                var document = snapshot.GetDocument(d);
+                Assert.Equal(TestProjectData.SomeProjectComponentFile1.FilePath, document.FilePath);
+                Assert.Equal(TestProjectData.SomeProjectComponentFile1.TargetPath, document.TargetPath);
+                Assert.Equal(FileKinds.Component, document.FileKind);
+            });
 
-    //     await Task.Run(async () => await host.DisposeAsync());
-    //     Assert.Empty(ProjectManager.Projects);
-    // }
+        await Task.Run(async () => await host.DisposeAsync());
+        Assert.Empty(_projectManager.Projects);
+    }
 
     [UIFact]
     public async Task OnProjectChanged_NoVersionFound_DoesNotIniatializeProject()

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
@@ -1154,6 +1154,23 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
         Assert.Equal(TestProjectData.SomeProject.FilePath, snapshot.FilePath);
         Assert.Same("MVC-2.1", snapshot.Configuration.ConfigurationName);
 
+        Assert.Collection(
+           snapshot.DocumentFilePaths.OrderBy(d => d),
+           d =>
+           {
+               var document = snapshot.GetDocument(d);
+               Assert.Equal(TestProjectData.SomeProjectFile1.FilePath, document.FilePath);
+               Assert.Equal(TestProjectData.SomeProjectFile1.TargetPath, document.TargetPath);
+               Assert.Equal(FileKinds.Legacy, document.FileKind);
+           },
+           d =>
+           {
+               var document = snapshot.GetDocument(d);
+               Assert.Equal(TestProjectData.SomeProjectComponentFile1.FilePath, document.FilePath);
+               Assert.Equal(TestProjectData.SomeProjectComponentFile1.TargetPath, document.TargetPath);
+               Assert.Equal(FileKinds.Component, document.FileKind);
+           });
+
         // Act - 2
         services.UnconfiguredProject.FullPath = TestProjectData.AnotherProject.FilePath;
         await Task.Run(async () => await host.OnProjectRenamingAsync(TestProjectData.SomeProject.FilePath, TestProjectData.AnotherProject.FilePath));
@@ -1162,6 +1179,23 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
         snapshot = Assert.Single(_projectManager.Projects);
         Assert.Equal(TestProjectData.AnotherProject.FilePath, snapshot.FilePath);
         Assert.Same("MVC-2.1", snapshot.Configuration.ConfigurationName);
+
+        Assert.Collection(
+           snapshot.DocumentFilePaths.OrderBy(d => d),
+           d =>
+           {
+               var document = snapshot.GetDocument(d);
+               Assert.Equal(TestProjectData.SomeProjectFile1.FilePath, document.FilePath);
+               Assert.Equal(TestProjectData.SomeProjectFile1.TargetPath, document.TargetPath);
+               Assert.Equal(FileKinds.Legacy, document.FileKind);
+           },
+           d =>
+           {
+               var document = snapshot.GetDocument(d);
+               Assert.Equal(TestProjectData.SomeProjectComponentFile1.FilePath, document.FilePath);
+               Assert.Equal(TestProjectData.SomeProjectComponentFile1.TargetPath, document.TargetPath);
+               Assert.Equal(FileKinds.Component, document.FileKind);
+           });
 
         await Task.Run(async () => await host.DisposeAsync());
         Assert.Empty(_projectManager.Projects);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
@@ -1156,7 +1156,7 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
 
         // Act - 2
         services.UnconfiguredProject.FullPath = TestProjectData.AnotherProject.FilePath;
-        await Task.Run(async () => await host.OnProjectRenamingAsync());
+        await Task.Run(async () => await host.OnProjectRenamingAsync(TestProjectData.SomeProject.FilePath, TestProjectData.AnotherProject.FilePath));
 
         // Assert - 1
         snapshot = Assert.Single(_projectManager.Projects);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/FallbackWindowsRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/FallbackWindowsRazorProjectHostTest.cs
@@ -622,7 +622,7 @@ public class FallbackWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatc
 
         // Act - 2
         services.UnconfiguredProject.FullPath = "Test2.csproj";
-        await Task.Run(async () => await host.OnProjectRenamingAsync());
+        await Task.Run(async () => await host.OnProjectRenamingAsync("Test.csproj", "Test2.csproj"));
 
         // Assert - 1
         snapshot = Assert.Single(_projectManager.Projects);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/TestProjectSystemServices.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/TestProjectSystemServices.cs
@@ -38,8 +38,6 @@ internal class TestProjectSystemServices : IUnconfiguredProjectCommonServices
         ActiveConfiguredProject = new TestConfiguredProject(UnconfiguredProject, data);
         UnconfiguredProject.LoadedConfiguredProjects.Add(ActiveConfiguredProject);
 
-        ActiveConfiguredProjectAssemblyReferences = new TestAssemblyReferencesService();
-        ActiveConfiguredProjectRazorProperties = new Rules.RazorProjectProperties(ActiveConfiguredProject, UnconfiguredProject);
         ActiveConfiguredProjectSubscription = new TestActiveConfiguredProjectSubscriptionService();
 
         TasksService = new TestProjectAsynchronousTasksService(ProjectService, UnconfiguredProject, ActiveConfiguredProject);
@@ -53,23 +51,11 @@ internal class TestProjectSystemServices : IUnconfiguredProjectCommonServices
 
     public TestConfiguredProject ActiveConfiguredProject { get; }
 
-    public TestAssemblyReferencesService ActiveConfiguredProjectAssemblyReferences { get; }
-
-    public Rules.RazorProjectProperties ActiveConfiguredProjectRazorProperties { get; }
-
     public TestActiveConfiguredProjectSubscriptionService ActiveConfiguredProjectSubscription { get; }
 
     public TestProjectAsynchronousTasksService TasksService { get; }
 
     public TestThreadingService ThreadingService { get; }
-
-    ConfiguredProject IUnconfiguredProjectCommonServices.ActiveConfiguredProject => ActiveConfiguredProject;
-
-    IAssemblyReferencesService IUnconfiguredProjectCommonServices.ActiveConfiguredProjectAssemblyReferences => ActiveConfiguredProjectAssemblyReferences;
-
-    IPackageReferencesService IUnconfiguredProjectCommonServices.ActiveConfiguredProjectPackageReferences => throw new NotImplementedException();
-
-    Rules.RazorProjectProperties IUnconfiguredProjectCommonServices.ActiveConfiguredProjectRazorProperties => ActiveConfiguredProjectRazorProperties;
 
     IActiveConfiguredProjectSubscriptionService IUnconfiguredProjectCommonServices.ActiveConfiguredProjectSubscription => ActiveConfiguredProjectSubscription;
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/TestProjectSystemServices.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/TestProjectSystemServices.cs
@@ -38,9 +38,11 @@ internal class TestProjectSystemServices : IUnconfiguredProjectCommonServices
         ActiveConfiguredProject = new TestConfiguredProject(UnconfiguredProject, data);
         UnconfiguredProject.LoadedConfiguredProjects.Add(ActiveConfiguredProject);
 
-        ActiveConfiguredProjectSubscription = new TestActiveConfiguredProjectSubscriptionService();
+        ActiveConfigurationGroupSubscriptionService = new TestActiveConfigurationGroupSubscriptionService();
 
         TasksService = new TestProjectAsynchronousTasksService(ProjectService, UnconfiguredProject, ActiveConfiguredProject);
+
+        FaultHandlerService = new TestProjectFaultHandlerService();
     }
 
     public ProjectServices Services { get; }
@@ -51,19 +53,23 @@ internal class TestProjectSystemServices : IUnconfiguredProjectCommonServices
 
     public TestConfiguredProject ActiveConfiguredProject { get; }
 
-    public TestActiveConfiguredProjectSubscriptionService ActiveConfiguredProjectSubscription { get; }
+    public TestActiveConfigurationGroupSubscriptionService ActiveConfigurationGroupSubscriptionService { get; }
 
     public TestProjectAsynchronousTasksService TasksService { get; }
 
     public TestThreadingService ThreadingService { get; }
 
-    IActiveConfiguredProjectSubscriptionService IUnconfiguredProjectCommonServices.ActiveConfiguredProjectSubscription => ActiveConfiguredProjectSubscription;
+    public TestProjectFaultHandlerService FaultHandlerService { get; }
+
+    IActiveConfigurationGroupSubscriptionService IUnconfiguredProjectCommonServices.ActiveConfigurationGroupSubscriptionService => ActiveConfigurationGroupSubscriptionService;
 
     IProjectAsynchronousTasksService IUnconfiguredProjectCommonServices.TasksService => TasksService;
 
     IProjectThreadingService IUnconfiguredProjectCommonServices.ThreadingService => ThreadingService;
 
     UnconfiguredProject IUnconfiguredProjectCommonServices.UnconfiguredProject => UnconfiguredProject;
+
+    IProjectFaultHandlerService IUnconfiguredProjectCommonServices.FaultHandlerService => FaultHandlerService;
 
     public IProjectVersionedValue<IProjectSubscriptionUpdate> CreateUpdate(params TestProjectChangeDescription[] descriptions)
     {
@@ -420,51 +426,37 @@ internal class TestProjectSystemServices : IUnconfiguredProjectCommonServices
         }
     }
 
-    public class TestActiveConfiguredProjectSubscriptionService : IActiveConfiguredProjectSubscriptionService
+    public class TestActiveConfigurationGroupSubscriptionService : IActiveConfigurationGroupSubscriptionService
     {
-        public TestActiveConfiguredProjectSubscriptionService()
+        public TestActiveConfigurationGroupSubscriptionService()
         {
-            JointRuleBlock = new BufferBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>();
-            JointRuleSource = new TestProjectValueDataSource<IProjectSubscriptionUpdate>(JointRuleBlock);
+            SourceBlock = new BufferBlock<IProjectVersionedValue<ConfigurationSubscriptionSources>>();
         }
 
-        public BufferBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>> JointRuleBlock { get; }
+        public BufferBlock<IProjectVersionedValue<ConfigurationSubscriptionSources>> SourceBlock { get; }
 
-        public TestProjectValueDataSource<IProjectSubscriptionUpdate> JointRuleSource { get; }
+        ConfigurationSubscriptionSources IActiveConfigurationGroupSubscriptionService.Current { get; }
 
-        IReceivableSourceBlock<IProjectVersionedValue<VisualStudio.ProjectSystem.IProjectSnapshot>> IProjectSubscriptionService.ProjectBlock => throw new NotImplementedException();
+        IReceivableSourceBlock<IProjectVersionedValue<ConfigurationSubscriptionSources>> IProjectValueDataSource<ConfigurationSubscriptionSources>.SourceBlock => SourceBlock;
 
-        IProjectValueDataSource<VisualStudio.ProjectSystem.IProjectSnapshot> IProjectSubscriptionService.ProjectSource => throw new NotImplementedException();
+        ISourceBlock<IProjectVersionedValue<object>> IProjectValueDataSource.SourceBlock => SourceBlock;
 
-        IProjectValueDataSource<IProjectImportTreeSnapshot> IProjectSubscriptionService.ImportTreeSource => throw new NotImplementedException();
+        NamedIdentity IProjectValueDataSource.DataSourceKey { get; }
 
-        IProjectValueDataSource<IProjectSharedFoldersSnapshot> IProjectSubscriptionService.SharedFoldersSource => throw new NotImplementedException();
+        IComparable IProjectValueDataSource.DataSourceVersion { get; }
 
-        IProjectValueDataSource<IImmutableDictionary<string, IOutputGroup>> IProjectSubscriptionService.OutputGroupsSource => throw new NotImplementedException();
+        IDisposable IJoinableProjectValueDataSource.Join() => null;
+    }
 
-        IReceivableSourceBlock<IProjectVersionedValue<IProjectCatalogSnapshot>> IProjectSubscriptionService.ProjectCatalogBlock => throw new NotImplementedException();
+    public class TestProjectFaultHandlerService : IProjectFaultHandlerService
+    {
+        Task IProjectFaultHandlerService.HandleFaultAsync(Exception ex, ErrorReportSettings watsonReportSettings, ProjectFaultSeverity severity, UnconfiguredProject project) => throw new NotImplementedException();
 
-        IProjectValueDataSource<IProjectCatalogSnapshot> IProjectSubscriptionService.ProjectCatalogSource => throw new NotImplementedException();
+        void IProjectFaultHandlerService.RegisterFaultHandler(Task task, ErrorReportSettings watsonReportSettings, ProjectFaultSeverity severity, UnconfiguredProject project) => throw new NotImplementedException();
 
-        IReceivableSourceBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>> IProjectSubscriptionService.ProjectRuleBlock => throw new NotImplementedException();
+        void IProjectFaultHandlerService.RegisterFaultHandler<TResult>(Task<TResult> task, ErrorReportSettings watsonReportSettings, ProjectFaultSeverity severity, UnconfiguredProject project) => throw new NotImplementedException();
 
-        IProjectValueDataSource<IProjectSubscriptionUpdate> IProjectSubscriptionService.ProjectRuleSource => throw new NotImplementedException();
-
-        IReceivableSourceBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>> IProjectSubscriptionService.ProjectBuildRuleBlock => throw new NotImplementedException();
-
-        IProjectValueDataSource<IProjectSubscriptionUpdate> IProjectSubscriptionService.ProjectBuildRuleSource => throw new NotImplementedException();
-
-        ISourceBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>> IProjectSubscriptionService.JointRuleBlock => JointRuleBlock;
-
-        IProjectValueDataSource<IProjectSubscriptionUpdate> IProjectSubscriptionService.JointRuleSource => JointRuleSource;
-
-        IReceivableSourceBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>> IProjectSubscriptionService.SourceItemsRuleBlock => throw new NotImplementedException();
-
-        IProjectValueDataSource<IProjectSubscriptionUpdate> IProjectSubscriptionService.SourceItemsRuleSource => throw new NotImplementedException();
-
-        IReceivableSourceBlock<IProjectVersionedValue<IImmutableSet<string>>> IProjectSubscriptionService.SourceItemRuleNamesBlock => throw new NotImplementedException();
-
-        IProjectValueDataSource<IImmutableSet<string>> IProjectSubscriptionService.SourceItemRuleNamesSource => throw new NotImplementedException();
+        Task IProjectFaultHandlerService.ReportUserFaultAsync(Exception ex, ProjectFaultSeverity severity, UnconfiguredProject project) => throw new NotImplementedException();
     }
 
     public class TestProjectValueDataSource<T> : IProjectValueDataSource<T>

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/EditorInProcess_Commands.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/EditorInProcess_Commands.cs
@@ -17,6 +17,13 @@ namespace Microsoft.VisualStudio.Extensibility.Testing;
 
 internal partial class EditorInProcess
 {
+    public async Task InvokeDeleteLineAsync(CancellationToken cancellationToken)
+    {
+        var commandGuid = typeof(VSStd2KCmdID).GUID;
+        var commandId = VSStd2KCmdID.DELETELINE;
+        await ExecuteCommandAsync(commandGuid, (uint)commandId, cancellationToken);
+    }
+
     public async Task InvokeFormatDocumentAsync(CancellationToken cancellationToken)
     {
         var commandGuid = typeof(VSStd2KCmdID).GUID;

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/EditorInProcess_Text.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/EditorInProcess_Text.cs
@@ -21,6 +21,18 @@ internal partial class EditorInProcess
         dte.ActiveDocument.Undo();
     }
 
+    public async Task InsertTextAsync(string text, CancellationToken cancellationToken)
+    {
+        await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+        var view = await GetActiveTextViewAsync(cancellationToken);
+        var textSnapshot = view.TextSnapshot;
+
+        var position = await GetCaretPositionAsync(cancellationToken);
+
+        _ = view.TextBuffer.Insert(position, text);
+    }
+
     public async Task SetTextAsync(string text, CancellationToken cancellationToken)
     {
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
@@ -94,15 +106,21 @@ internal partial class EditorInProcess
     public async Task WaitForCurrentLineTextAsync(string text, CancellationToken cancellationToken)
     {
         await Helper.RetryAsync(async ct =>
-            {
-                var view = await GetActiveTextViewAsync(cancellationToken);
-                var caret = view.Caret.Position.BufferPosition;
-                var line = view.TextBuffer.CurrentSnapshot.GetLineFromPosition(caret).GetText();
+        {
+            var line = await GetCurrentLineTextAsync(cancellationToken);
 
-                return line.Trim() == text.Trim();
-            },
+            return line.Trim() == text.Trim();
+        },
             TimeSpan.FromMilliseconds(50),
             cancellationToken);
+    }
+
+    public async Task<string> GetCurrentLineTextAsync(CancellationToken cancellationToken)
+    {
+        var view = await GetActiveTextViewAsync(cancellationToken);
+        var caret = view.Caret.Position.BufferPosition;
+        var line = view.TextBuffer.CurrentSnapshot.GetLineFromPosition(caret).GetText();
+        return line;
     }
 
     public async Task WaitForCurrentLineTextStartsWithAsync(string text, CancellationToken cancellationToken)

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/SolutionExplorerInProcess.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/SolutionExplorerInProcess.cs
@@ -296,7 +296,7 @@ internal partial class SolutionExplorerInProcess
         return Path.Combine(projectPath, relativeFilePath);
     }
 
-    private async Task<string> GetDirectoryNameAsync(CancellationToken cancellationToken)
+    public async Task<string> GetDirectoryNameAsync(CancellationToken cancellationToken)
     {
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/ProjectTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/ProjectTests.cs
@@ -1,7 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
+using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Razor.IntegrationTests.InProcess;
 using Xunit;
 
 namespace Microsoft.VisualStudio.Razor.IntegrationTests;
@@ -13,5 +17,51 @@ public class ProjectTests : AbstractRazorEditorTest
     {
         await TestServices.SolutionExplorer.OpenFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.CounterRazorFile, ControlledHangMitigatingCancellationToken);
         await TestServices.SolutionExplorer.CloseSolutionAsync(ControlledHangMitigatingCancellationToken);
+    }
+
+    [IdeFact]
+    public async Task ChangeTargetFramework()
+    {
+        var solutionPath = await TestServices.SolutionExplorer.GetDirectoryNameAsync(ControlledHangMitigatingCancellationToken);
+
+        Assert.Equal(1, GetProjectRazorJsonFileCount());
+
+        await TestServices.SolutionExplorer.OpenFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.ProjectFile, ControlledHangMitigatingCancellationToken);
+
+        await TestServices.Editor.PlaceCaretAsync("<TargetFramework", charsOffset: -1, ControlledHangMitigatingCancellationToken);
+
+        var currentLine = await TestServices.Editor.GetCurrentLineTextAsync(ControlledHangMitigatingCancellationToken);
+        var tfElement = currentLine.Contains("net6.0")
+            ? "<TargetFramework>net7.0</TargetFramework>"
+            : "<TargetFramework>net6.0</TargetFramework>";
+
+        await TestServices.Editor.InvokeDeleteLineAsync(ControlledHangMitigatingCancellationToken);
+
+        await TestServices.Editor.InsertTextAsync(tfElement + Environment.NewLine, ControlledHangMitigatingCancellationToken);
+
+        await TestServices.Editor.CloseCodeFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.ProjectFile, saveFile: true, ControlledHangMitigatingCancellationToken);
+
+        await TestServices.Workspace.WaitForProjectSystemAsync(ControlledHangMitigatingCancellationToken);
+        await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.LanguageServer, ControlledHangMitigatingCancellationToken);
+        await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.Workspace, ControlledHangMitigatingCancellationToken);
+
+        // We open the Index.razor file, and wait for 3 RazorComponentElement's to be classified, as that
+        // way we know the LSP server is up, running, and has processed both local and library-sourced Components
+        await TestServices.SolutionExplorer.OpenFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.IndexRazorFile, ControlledHangMitigatingCancellationToken);
+
+        // Razor extension doesn't launch until a razor file is opened, so wait for it to equalize
+        await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.LanguageServer, ControlledHangMitigatingCancellationToken);
+        await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.Workspace, ControlledHangMitigatingCancellationToken);
+        await TestServices.Workspace.WaitForProjectSystemAsync(ControlledHangMitigatingCancellationToken);
+
+        await TestServices.Editor.PlaceCaretAsync("</PageTitle>", charsOffset: 1, ControlledHangMitigatingCancellationToken);
+        await TestServices.Editor.WaitForComponentClassificationAsync(ControlledHangMitigatingCancellationToken, count: 3);
+
+        // This is a little odd, but there is no "real" way to check this via VS, and one of the most important things this test can do
+        // is ensure that each target framework gets its own project.razor.json file, and doesn't share one from a cache or anything.
+        Assert.Equal(2, GetProjectRazorJsonFileCount());
+
+        int GetProjectRazorJsonFileCount()
+            => Directory.EnumerateFiles(solutionPath, "project.razor.*.json", SearchOption.AllDirectories).Count();
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/RazorProjectConstants.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/RazorProjectConstants.cs
@@ -22,6 +22,7 @@ public static class RazorProjectConstants
     internal static readonly string SurveyPromptFile = Path.Combine(s_sharedDir, "SurveyPrompt.razor");
     internal static readonly string ErrorCshtmlFile = Path.Combine(s_pagesDir, "Error.cshtml");
     internal static readonly string ImportsRazorFile = "_Imports.razor";
+    internal static readonly string ProjectFile = $"{BlazorProjectName}.csproj";
 
     internal static readonly string IndexPageContent = @"@page ""/""
 


### PR DESCRIPTION
This is the first part of https://github.com/dotnet/razor/issues/8879
I'm hoping to do the changes in managable (to review) chunks, but with the holidays in the US and potential conflicts from other PRs, that might not be possible.

What this does is change our CPS code from only getting updates about a single TFM in a mutli-target project, to getting updates for all of them. There is nothing that takes advantage of this _yet_, but without this the rest wouldn't be possible. There is also some extra stuff here to remove state from the `WindowsRazorProjectHostBase` class because it contianed a bunch of state about the last project we got updates for, and its documents, and obviously that doesn't work in a mutli-target world. No state will make it easier to make more change in future anyway.

Reviewing commit-at-a-time is by far the easiest way to understand what is actually going on here, except of course for the bits that talk to CPS, because that is objectively impossible for anyone to understand 😁