### PR TITLE
Remove unsupported feature

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Completion/RazorCompletionItemProvider.ts
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.VSCode/src/Completion/RazorCompletionItemProvider.ts
@@ -48,7 +48,7 @@ export class RazorCompletionItemProvider
                 if (doc) {
                     // Without this, the documentation doesn't get rendered in the editor.
                     const newDoc = new vscode.MarkdownString(doc.value);
-                    newDoc.isTrusted = doc.isTrusted;
+                    newDoc.isTrusted = false;
                     completionItem.documentation = newDoc;
                 }
 


### PR DESCRIPTION
we don't support commands in our markdown documentation for completion, so just remove it entirely

Tested in a cshtml and .razor file:

* CSharp completion
* HTML completion (links to MDN still work)
* Razor completion
