### PR TITLE
Add reference to Microsoft.CodeAnalysis.CSharp

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentDesignTimeNodeWriter.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentDesignTimeNodeWriter.cs
@@ -10,7 +10,9 @@ using System.Linq;
 using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
 using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
-using Microsoft.AspNetCore.Razor.Language.Legacy;
+
+using CSharpSyntaxFacts = Microsoft.CodeAnalysis.CSharp.SyntaxFacts;
+using CSharpSyntaxKind = Microsoft.CodeAnalysis.CSharp.SyntaxKind;
 
 namespace Microsoft.AspNetCore.Razor.Language.Components;
 
@@ -762,9 +764,8 @@ internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
         {
             context.CodeWriter.WritePadding(0, attributeSourceSpan, context);
             // Escape the property name in case it's a C# keyword
-            // When https://github.com/dotnet/razor/issues/8445 is implemented,
-            // replace with a check against SyntaxFacts.IsKeywordKind || SyntaxFacts.IsConditionalKeywordKind
-            if (CSharpLanguageCharacteristics.GetKeywordKind(node.PropertyName) != null)
+            if (CSharpSyntaxFacts.GetKeywordKind(node.PropertyName) != CSharpSyntaxKind.None ||
+                CSharpSyntaxFacts.GetContextualKeywordKind(node.PropertyName) != CSharpSyntaxKind.None)
             {
                 context.CodeWriter.Write("@");
             }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/CSharpLanguageCharacteristics.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/CSharpLanguageCharacteristics.cs
@@ -271,19 +271,6 @@ internal class CSharpLanguageCharacteristics : LanguageCharacteristics<CSharpTok
         }
     }
 
-    public static CSharpKeyword? GetKeywordKind(string keyword)
-    {
-        foreach (var kvp in _keywordNames)
-        {
-            if (string.Equals(kvp.Value, keyword, StringComparison.Ordinal))
-            {
-                return kvp.Key;
-            }
-        }
-
-        return null;
-    }
-
     public static string GetKeyword(CSharpKeyword keyword)
     {
         if (!_keywordNames.TryGetValue(keyword, out var value))

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/CSharpTokenizer.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/CSharpTokenizer.cs
@@ -6,8 +6,10 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using Microsoft.AspNetCore.Razor.Language.Syntax.InternalSyntax;
+using Microsoft.CodeAnalysis.CSharp;
+
+using SyntaxFactory = Microsoft.AspNetCore.Razor.Language.Syntax.InternalSyntax.SyntaxFactory;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy;
 
@@ -354,7 +356,7 @@ internal class CSharpTokenizer : Tokenizer
 
     private StateResult Data()
     {
-        if (ParserHelpers.IsNewLine(CurrentCharacter))
+        if (SyntaxFacts.IsNewLine(CurrentCharacter))
         {
             // CSharp Spec §2.3.1
             var checkTwoCharNewline = CurrentCharacter == '\r';
@@ -365,13 +367,13 @@ internal class CSharpTokenizer : Tokenizer
             }
             return Stay(EndToken(SyntaxKind.NewLine));
         }
-        else if (ParserHelpers.IsWhitespace(CurrentCharacter))
+        else if (SyntaxFacts.IsWhitespace(CurrentCharacter))
         {
             // CSharp Spec §2.3.3
-            TakeUntil(c => !ParserHelpers.IsWhitespace(c));
+            TakeUntil(c => !SyntaxFacts.IsWhitespace(c));
             return Stay(EndToken(SyntaxKind.Whitespace));
         }
-        else if (IsIdentifierStart(CurrentCharacter))
+        else if (SyntaxFacts.IsIdentifierStartCharacter(CurrentCharacter))
         {
             return Identifier();
         }
@@ -561,8 +563,8 @@ internal class CSharpTokenizer : Tokenizer
 
     private StateResult QuotedStringLiteral() => QuotedLiteral('\"', IsEndQuotedStringLiteral, SyntaxKind.StringLiteral);
 
-    private readonly Func<char, bool> IsEndQuotedCharacterLiteral = (c) => c == '\\' || c == '\'' || ParserHelpers.IsNewLine(c);
-    private readonly Func<char, bool> IsEndQuotedStringLiteral = (c) => c == '\\' || c == '\"' || ParserHelpers.IsNewLine(c);
+    private readonly Func<char, bool> IsEndQuotedCharacterLiteral = (c) => c == '\\' || c == '\'' || SyntaxFacts.IsNewLine(c);
+    private readonly Func<char, bool> IsEndQuotedStringLiteral = (c) => c == '\\' || c == '\"' || SyntaxFacts.IsNewLine(c);
 
     private StateResult QuotedLiteral(char quote, Func<char, bool> isEndQuotedLiteral, SyntaxKind literalType)
     {
@@ -578,7 +580,7 @@ internal class CSharpTokenizer : Tokenizer
             }
             return Stay();
         }
-        else if (EndOfFile || ParserHelpers.IsNewLine(CurrentCharacter))
+        else if (EndOfFile || SyntaxFacts.IsNewLine(CurrentCharacter))
         {
             CurrentErrors.Add(
                 RazorDiagnosticFactory.CreateParsing_UnterminatedStringLiteral(
@@ -618,7 +620,7 @@ internal class CSharpTokenizer : Tokenizer
     // CSharp Spec §2.3.2
     private StateResult SingleLineComment()
     {
-        TakeUntil(c => ParserHelpers.IsNewLine(c));
+        TakeUntil(c => SyntaxFacts.IsNewLine(c));
         return Stay(EndToken(SyntaxKind.CSharpComment));
     }
 
@@ -712,9 +714,9 @@ internal class CSharpTokenizer : Tokenizer
     // CSharp Spec §2.4.2
     private StateResult Identifier()
     {
-        Debug.Assert(IsIdentifierStart(CurrentCharacter));
+        Debug.Assert(SyntaxFacts.IsIdentifierStartCharacter(CurrentCharacter));
         TakeCurrent();
-        TakeUntil(c => !IsIdentifierPart(c));
+        TakeUntil(c => !SyntaxFacts.IsIdentifierPartCharacter(c));
         SyntaxToken token = null;
         if (HaveContent)
         {
@@ -745,20 +747,6 @@ internal class CSharpTokenizer : Tokenizer
         return Transition((int)state, result);
     }
 
-    private static bool IsIdentifierStart(char character)
-    {
-        return char.IsLetter(character) ||
-               character == '_' ||
-               CharUnicodeInfo.GetUnicodeCategory(character) == UnicodeCategory.LetterNumber;
-    }
-
-    private static bool IsIdentifierPart(char character)
-    {
-        return char.IsDigit(character) ||
-               IsIdentifierStart(character) ||
-               IsIdentifierPartByUnicodeCategory(character);
-    }
-
     private static bool IsRealLiteralSuffix(char character)
     {
         return character == 'F' ||
@@ -767,16 +755,6 @@ internal class CSharpTokenizer : Tokenizer
                character == 'd' ||
                character == 'M' ||
                character == 'm';
-    }
-
-    private static bool IsIdentifierPartByUnicodeCategory(char character)
-    {
-        var category = CharUnicodeInfo.GetUnicodeCategory(character);
-
-        return category == UnicodeCategory.NonSpacingMark || // Mn
-               category == UnicodeCategory.SpacingCombiningMark || // Mc
-               category == UnicodeCategory.ConnectorPunctuation || // Pc
-               category == UnicodeCategory.Format; // Cf
     }
 
     private static bool IsHexDigit(char value)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/HtmlTokenizer.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/HtmlTokenizer.cs
@@ -3,9 +3,11 @@
 
 #nullable disable
 
-using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.AspNetCore.Razor.Language.Syntax.InternalSyntax;
+using Microsoft.CodeAnalysis.CSharp;
+
+using SyntaxFactory = Microsoft.AspNetCore.Razor.Language.Syntax.InternalSyntax.SyntaxFactory;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy;
 
@@ -125,11 +127,11 @@ internal class HtmlTokenizer : Tokenizer
     // http://dev.w3.org/html5/spec/Overview.html#data-state
     private StateResult Data()
     {
-        if (ParserHelpers.IsWhitespace(CurrentCharacter))
+        if (SyntaxFacts.IsWhitespace(CurrentCharacter))
         {
             return Stay(Whitespace());
         }
-        else if (ParserHelpers.IsNewLine(CurrentCharacter))
+        else if (SyntaxFacts.IsNewLine(CurrentCharacter))
         {
             return Stay(Newline());
         }
@@ -172,7 +174,7 @@ internal class HtmlTokenizer : Tokenizer
     {
         var prev = '\0';
         while (!EndOfFile &&
-            !(ParserHelpers.IsWhitespace(CurrentCharacter) || ParserHelpers.IsNewLine(CurrentCharacter)) &&
+            !(SyntaxFacts.IsWhitespace(CurrentCharacter) || SyntaxFacts.IsNewLine(CurrentCharacter)) &&
             !AtToken())
         {
             prev = CurrentCharacter;
@@ -182,8 +184,8 @@ internal class HtmlTokenizer : Tokenizer
         if (CurrentCharacter == '@')
         {
             var next = Peek();
-            if ((ParserHelpers.IsLetter(prev) || ParserHelpers.IsDecimalDigit(prev)) &&
-                (ParserHelpers.IsLetter(next) || ParserHelpers.IsDecimalDigit(next)))
+            if ((char.IsLetter(prev) || char.IsDigit(prev)) &&
+                (char.IsLetter(next) || char.IsDigit(next)))
             {
                 TakeCurrent(); // Take the "@"
                 return Stay(); // Stay in the Text state
@@ -233,7 +235,7 @@ internal class HtmlTokenizer : Tokenizer
 
     private SyntaxToken Whitespace()
     {
-        while (ParserHelpers.IsWhitespace(CurrentCharacter))
+        while (SyntaxFacts.IsWhitespace(CurrentCharacter))
         {
             TakeCurrent();
         }
@@ -242,7 +244,7 @@ internal class HtmlTokenizer : Tokenizer
 
     private SyntaxToken Newline()
     {
-        Debug.Assert(ParserHelpers.IsNewLine(CurrentCharacter));
+        Debug.Assert(SyntaxFacts.IsNewLine(CurrentCharacter));
         // CSharp Spec §2.3.1
         var checkTwoCharNewline = CurrentCharacter == '\r';
         TakeCurrent();

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/ImplicitExpressionEditHandler.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/ImplicitExpressionEditHandler.cs
@@ -11,6 +11,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy;
@@ -482,7 +483,7 @@ internal class ImplicitExpressionEditHandler : SpanEditHandler
         {
             return TryAcceptChange(target, change, PartialParseResultInternal.Accepted | PartialParseResultInternal.Provisional);
         }
-        else if (ParserHelpers.IsIdentifierPart(previousChar))
+        else if (SyntaxFacts.IsIdentifierPartCharacter(previousChar))
         {
             return TryAcceptChange(target, change);
         }
@@ -505,7 +506,7 @@ internal class ImplicitExpressionEditHandler : SpanEditHandler
         {
             return HandleInsertionAfterDot(target, change);
         }
-        else if (ParserHelpers.IsIdentifierPart(previousChar) || previousChar == ')' || previousChar == ']')
+        else if (SyntaxFacts.IsIdentifierPartCharacter(previousChar) || previousChar == ')' || previousChar == ']')
         {
             return HandleInsertionAfterIdPart(target, change);
         }
@@ -561,7 +562,7 @@ internal class ImplicitExpressionEditHandler : SpanEditHandler
     private PartialParseResultInternal HandleInsertionAfterDot(SyntaxNode target, SourceChange change)
     {
         // If the insertion is a full identifier or another dot, accept it
-        if (ParserHelpers.IsIdentifier(change.NewText) || change.NewText == ".")
+        if (SyntaxFacts.IsValidIdentifier(change.NewText) || change.NewText == ".")
         {
             return TryAcceptChange(target, change);
         }
@@ -607,14 +608,14 @@ internal class ImplicitExpressionEditHandler : SpanEditHandler
     {
         return (content.Length == 1 && content[0] == '.') ||
                (content[content.Length - 1] == '.' &&
-                content.Take(content.Length - 1).All(ParserHelpers.IsIdentifierPart));
+                content.Take(content.Length - 1).All(SyntaxFacts.IsIdentifierPartCharacter));
     }
 
     private bool StartsWithKeyword(string newContent)
     {
         using (var reader = new StringReader(newContent))
         {
-            return Keywords.Contains(reader.ReadWhile(ParserHelpers.IsIdentifierPart));
+            return Keywords.Contains(reader.ReadWhile(SyntaxFacts.IsIdentifierPartCharacter));
         }
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/SourceLocationTracker.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/SourceLocationTracker.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy;
 
@@ -34,7 +35,7 @@ internal static class SourceLocationTracker
         absoluteIndex++;
 
         if ((Environment.NewLine.Length == 1 && characterRead == Environment.NewLine[0]) ||
-            (ParserHelpers.IsNewLine(characterRead) && (characterRead != '\r' || nextCharacter != '\n')))
+            (SyntaxFacts.IsNewLine(characterRead) && (characterRead != '\r' || nextCharacter != '\n')))
         {
             lineIndex++;
             characterIndex = 0;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/Tokenizer.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/Tokenizer.cs
@@ -32,7 +32,7 @@ internal abstract class Tokenizer : ITokenizer
 
     protected int? CurrentState { get; set; }
 
-    protected SyntaxToken CurrenSyntaxToken { get; private set; }
+    protected SyntaxToken CurrentSyntaxToken { get; private set; }
 
     public ITextDocument Source { get; private set; }
 
@@ -106,16 +106,16 @@ internal abstract class Tokenizer : ITokenizer
                 var next = Dispatch();
 
                 CurrentState = next.State;
-                CurrenSyntaxToken = next.Result;
+                CurrentSyntaxToken = next.Result;
             }
-            while (CurrentState != null && CurrenSyntaxToken == null);
+            while (CurrentState != null && CurrentSyntaxToken == null);
 
             if (CurrentState == null)
             {
                 return default(SyntaxToken); // Terminated
             }
 
-            return CurrenSyntaxToken;
+            return CurrentSyntaxToken;
         }
 
         return default(SyntaxToken);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Microsoft.AspNetCore.Razor.Language.csproj
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Microsoft.AspNetCore.Razor.Language.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="$(SharedSourceRoot)\Microsoft.AspNetCore.Razor.Utilities.Shared\Microsoft.AspNetCore.Razor.Utilities.Shared.csproj" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/SyntaxNodeExtensions.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/SyntaxNodeExtensions.cs
@@ -6,7 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using Microsoft.AspNetCore.Razor.Language.Legacy;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.AspNetCore.Razor.Language.Syntax;
 
@@ -78,7 +78,7 @@ internal static class SyntaxNodeExtensions
             {
                 // E.g. Marker symbol at the end of the document
                 var lastPosition = source.Length - 1;
-                var endsWithLineBreak = ParserHelpers.IsNewLine(source[lastPosition]);
+                var endsWithLineBreak = SyntaxFacts.IsNewLine(source[lastPosition]);
                 var lastLocation = source.Lines.GetLocation(lastPosition);
                 return new SourceLocation(
                     source.FilePath, // GetLocation prefers RelativePath but we want FilePath.

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test.Common/StringTextSnapshot.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test.Common/StringTextSnapshot.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.VisualStudio.Text;
@@ -41,7 +42,7 @@ public class StringTextSnapshot : ITextSnapshot2
                 delimiterLength = 1;
                 for (var i = start; i < Content.Length; i++)
                 {
-                    if (ParserHelpers.IsNewLine(content[i]))
+                    if (SyntaxFacts.IsNewLine(content[i]))
                     {
                         delimiterIndex = i;
                         break;
@@ -221,7 +222,7 @@ public class StringTextSnapshot : ITextSnapshot2
             {
                 _content = _content[..^2];
             }
-            else if(_content.Length > 0 && ParserHelpers.IsNewLine(_content[_content.Length - 1]))
+            else if(_content.Length > 0 && SyntaxFacts.IsNewLine(_content[_content.Length - 1]))
             {
                 _content = _content[..^1];
             }


### PR DESCRIPTION
The language level currently doesn't have a reference to MS.CA.CSharp, which makes many things quite difficult, and resulted in a number of copy/pastes of utility functions from roslyn over to razor. This is the start of addressing that, adding a reference to MS.CA.CSharp and eliminating some of the simpler helpers that were copy/pasted. Contributes to https://github.com/dotnet/razor/issues/8445.
