### PR TITLE
[Infra] Publish 17.8 P1 VS PRs 

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -7,7 +7,7 @@
       ],
       "vsBranch": "main",
       "vsMajorVersion": 17,
-      "insertionCreateDraftPR": true,
+      "insertionCreateDraftPR": false,
       "insertionTitlePrefix": "[17.8P1]"
     },
     "release/dev17.5": {


### PR DESCRIPTION
Takes 17.8 P1 PRs out of draft mode. This enables more checks to run by default.