### PR TITLE
[Infra] Set 'Next' milestone on merged PRs to main

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1557,6 +1557,46 @@
           }
         ]
       }
+    },
+    {
+      "taskType": "trigger",
+      "capabilityId": "IssueResponder",
+      "subCapability": "PullRequestResponder",
+      "version": "1.0",
+      "config": {
+        "conditions": {
+          "operator": "and",
+          "operands": [
+            {
+              "name": "isAction",
+              "parameters": {
+                "action": "merged"
+              }
+            },
+            {
+              "name": "prTargetsBranch",
+              "parameters": {
+                "branchName": "main"
+              }
+            }
+          ]
+        },
+        "eventType": "pull_request",
+        "eventNames": [
+          "pull_request",
+          "issues",
+          "project_card"
+        ],
+        "taskName": "[PRs] Milestone tracking",
+        "actions": [
+          {
+            "name": "addMilestone",
+            "parameters": {
+              "milestoneName": "Next"
+            }
+          }
+        ]
+      }
     }
   ],
   "userGroups": []


### PR DESCRIPTION
﻿### Summary of the changes

- Sets 'Next' milestone on merged PRs to main, which Tigers at the end of each sprint can then switch to the correct milestone. This is aligned with how Roslyn does things today.