### PR TITLE
Single line explicit expressions don't affect indentation so aren't "significant"

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPassBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPassBase.cs
@@ -68,10 +68,9 @@ internal abstract class CSharpFormattingPassBase : FormattingPassBase
             // single line explicit expressions shouldn't. If there are any at the start of a line, the next
             // loop will find them. Sadly the ShouldFormat method is used in too many places, for too many
             // different purposes, to put this check there.
-            if (owner is not null &&
-                owner.AncestorsAndSelf().Any(n => n is CSharpExplicitExpressionSyntax &&
-                    n.Span.AsRange(text) is { } range &&
-                    range.Start.Line == range.End.Line))
+            if (owner is { Parent.Parent.Parent: CSharpExplicitExpressionSyntax explicitExpression } &&
+                explicitExpression.Span.AsRange(text) is { } exprRange &&
+                exprRange.Start.Line == exprRange.End.Line)
             {
                 continue;
             }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
@@ -463,6 +463,76 @@ public class HtmlFormattingTest : FormattingTestBase
     }
 
     [Fact]
+    public async Task FormatsComponentTag_WithExplicitExpression()
+    {
+        var tagHelpers = GetComponents();
+        await RunFormattingTestAsync(
+            input: """
+                        <GridTable>
+                            <GridRow >
+                        <GridCell>@(cell)</GridCell>
+                        </GridRow>
+                    </GridTable>
+                    """,
+            expected: """
+                    <GridTable>
+                        <GridRow>
+                            <GridCell>@(cell)</GridCell>
+                        </GridRow>
+                    </GridTable>
+                    """,
+            tagHelpers: tagHelpers);
+    }
+
+    [Fact]
+    public async Task FormatsComponentTag_WithExplicitExpression_FormatsInside()
+    {
+        var tagHelpers = GetComponents();
+        await RunFormattingTestAsync(
+            input: """
+                        <GridTable>
+                            <GridRow >
+                        <GridCell>@(""  +    "")</GridCell>
+                        </GridRow>
+                    </GridTable>
+                    """,
+            expected: """
+                    <GridTable>
+                        <GridRow>
+                            <GridCell>@("" + "")</GridCell>
+                        </GridRow>
+                    </GridTable>
+                    """,
+            tagHelpers: tagHelpers);
+    }
+
+    [Fact]
+    public async Task FormatsComponentTag_WithExplicitExpression_MovesStart()
+    {
+        var tagHelpers = GetComponents();
+        await RunFormattingTestAsync(
+            input: """
+                        <GridTable>
+                            <GridRow >
+                        <GridCell>
+                        @(""  +    "")
+                        </GridCell>
+                        </GridRow>
+                    </GridTable>
+                    """,
+            expected: """
+                    <GridTable>
+                        <GridRow>
+                            <GridCell>
+                                @("" + "")
+                            </GridCell>
+                        </GridRow>
+                    </GridTable>
+                    """,
+            tagHelpers: tagHelpers);
+    }
+
+    [Fact]
     public async Task FormatsShortBlock()
     {
         await RunFormattingTestAsync(


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/8915

Another layer to the house of cards :(