### PR TITLE
Collect more info for integration test failures

### DIFF
--- a/azure-pipelines-integration-dartlab.yml
+++ b/azure-pipelines-integration-dartlab.yml
@@ -31,6 +31,8 @@ variables:
   value: 1
 - name: RAZOR_RUN_ALL_TESTS
   value: 'true'
+- name: LogLevel
+  value: 'Verbose'
 
 stages:
 - template: \stages\visual-studio\agent.yml@DartLabTemplates

--- a/eng/scripts/CreateVSHive.ps1
+++ b/eng/scripts/CreateVSHive.ps1
@@ -18,7 +18,7 @@ Set-StrictMode -Version 1
 $success=$false
 for($i=0; $i -le 3; $i++)
 {
-  & $devenvExePath /rootsuffix $rootSuffix /updateConfiguration /log
+  & $devenvExePath /rootsuffix $rootSuffix /updateConfiguration
   if(Test-Path -Path $env:LocalAppData\Microsoft\VisualStudio\17.0*RoslynDev)
   {
     Write-Host "The hive 'RoslynDev' exists"

--- a/eng/scripts/CreateVSHive.ps1
+++ b/eng/scripts/CreateVSHive.ps1
@@ -18,7 +18,7 @@ Set-StrictMode -Version 1
 $success=$false
 for($i=0; $i -le 3; $i++)
 {
-  & $devenvExePath /rootsuffix $rootSuffix /updateConfiguration
+  & $devenvExePath /rootsuffix $rootSuffix /updateConfiguration /log
   if(Test-Path -Path $env:LocalAppData\Microsoft\VisualStudio\17.0*RoslynDev)
   {
     Write-Host "The hive 'RoslynDev' exists"


### PR DESCRIPTION
﻿### Summary of the changes

- I was attempting to investigate the flakiness of Razor integration tests, however this has been difficult because the current LogHub logs seem to be lacking. They don't contain the contents of the request params, instead only indicating that a request was made. This change should hopefully allow us to collect more data to investigate. (Thanks DavidB for the tip on how to collect more info!)
