### PR TITLE
Rename bugfix - When component is in the same file

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
@@ -133,7 +133,6 @@ internal sealed class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenamePar
         var documentChanges = new List<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>>();
         var fileRename = GetFileRenameForComponent(originComponentDocumentSnapshot, newPath);
         documentChanges.Add(fileRename);
-        var fileRenameUriLookup = new Dictionary<Uri, Uri>() { { fileRename.OldUri, fileRename.NewUri } };
         AddEditsForCodeDocument(documentChanges, originTagHelpers, request.NewName, request.TextDocument.Uri, codeDocument);
 
         var documentSnapshots = await GetAllDocumentSnapshotsAsync(documentContext, cancellationToken).ConfigureAwait(false);
@@ -146,9 +145,9 @@ internal sealed class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenamePar
         foreach (var documentChange in documentChanges)
         {
             if (documentChange.TryGetFirst(out var textDocumentEdit) &&
-                fileRenameUriLookup.TryGetValue(textDocumentEdit.TextDocument.Uri, out var renamedUri))
+                textDocumentEdit.TextDocument.Uri == fileRename.OldUri)
             {
-                textDocumentEdit.TextDocument.Uri = renamedUri;
+                textDocumentEdit.TextDocument.Uri = fileRename.NewUri;
             }
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
@@ -132,7 +132,7 @@ internal sealed class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenamePar
         var documentChanges = new List<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>>();
         var fileRename = AddFileRenameForComponent(originComponentDocumentSnapshot, newPath);
         documentChanges.Add(fileRename);
-        var fileRenameUriLookup = new Dictionary<string, Uri>() { { fileRename.OldUri.OriginalString, fileRename.NewUri } };
+        var fileRenameUriLookup = new Dictionary<Uri, Uri>() { { fileRename.OldUri, fileRename.NewUri } };
         AddEditsForCodeDocument(documentChanges, originTagHelpers, request.NewName, request.TextDocument.Uri, codeDocument, fileRenameUriLookup);
 
         var documentSnapshots = await GetAllDocumentSnapshotsAsync(documentContext, cancellationToken).ConfigureAwait(false);
@@ -233,7 +233,7 @@ internal sealed class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenamePar
         IReadOnlyList<TagHelperDescriptor> originTagHelpers,
         string newName,
         IDocumentSnapshot? documentSnapshot,
-        Dictionary<string, Uri> fileRenameUriLookup)
+        Dictionary<Uri, Uri> fileRenameUriLookup)
     {
         if (documentSnapshot is null)
         {
@@ -272,7 +272,7 @@ internal sealed class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenamePar
         string newName,
         Uri uri,
         RazorCodeDocument codeDocument,
-        Dictionary<string, Uri> fileRenameUriLookup)
+        Dictionary<Uri, Uri> fileRenameUriLookup)
     {
         var documentIdentifier = new OptionalVersionedTextDocumentIdentifier { Uri = uri };
         var tagHelperElements = codeDocument.GetSyntaxTree().Root
@@ -301,7 +301,7 @@ internal sealed class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenamePar
             {
                 if (node is MarkupTagHelperElementSyntax tagHelperElement && BindingContainsTagHelper(originTagHelper, tagHelperElement.TagHelperInfo.BindingResult))
                 {
-                    if (fileRenameUriLookup.TryGetValue(uri.OriginalString, out var newUri))
+                    if (fileRenameUriLookup.TryGetValue(uri, out var newUri))
                     {
                         documentIdentifier.Uri = newUri;
                     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
@@ -130,8 +130,8 @@ internal sealed class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenamePar
         }
 
         var documentChanges = new List<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>>();
-        AddFileRenameForComponent(documentChanges, originComponentDocumentSnapshot, newPath);
         AddEditsForCodeDocument(documentChanges, originTagHelpers, request.NewName, request.TextDocument.Uri, codeDocument);
+        AddFileRenameForComponent(documentChanges, originComponentDocumentSnapshot, newPath);
 
         var documentSnapshots = await GetAllDocumentSnapshotsAsync(documentContext, cancellationToken).ConfigureAwait(false);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
@@ -147,9 +147,8 @@ internal sealed class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenamePar
         {
             if (documentChange.TryGetFirst(out var textDocumentEdit) &&
                 fileRenameUriLookup.TryGetValue(textDocumentEdit.TextDocument.Uri, out var renamedUri))
-                {
-                    textDocumentEdit.TextDocument.Uri = renamedUri;
-                }
+            {
+                textDocumentEdit.TextDocument.Uri = renamedUri;
             }
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Security.Policy;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
@@ -95,13 +95,13 @@ public class RenameEndpointTest : LanguageServerTestBase
         Assert.NotNull(result);
         var documentChanges = result.DocumentChanges.Value;
         Assert.Equal(2, documentChanges.Count());
-        var renameChange = documentChanges.ElementAt(0);
+        var editChange = documentChanges.ElementAt(0);
+        Assert.True(editChange.TryGetFirst(out var textDocumentEdit));
+        Assert.Equal("file:///c:/First/Component1.razor", textDocumentEdit.TextDocument.Uri.ToString());
+        var renameChange = documentChanges.ElementAt(1);
         Assert.True(renameChange.TryGetThird(out var renameFile));
         Assert.Equal(new Uri("file:///c:/First/Component2.razor"), renameFile.OldUri);
         Assert.Equal(new Uri("file:///c:/First/Component5.razor"), renameFile.NewUri);
-        var editChange = documentChanges.ElementAt(1);
-        Assert.True(editChange.TryGetFirst(out var textDocumentEdit));
-        Assert.Equal("file:///c:/First/Component1.razor", textDocumentEdit.TextDocument.Uri.ToString());
         Assert.Collection(
             textDocumentEdit.Edits,
             edit =>
@@ -266,11 +266,7 @@ public class RenameEndpointTest : LanguageServerTestBase
         Assert.NotNull(result);
         var documentChanges = result.DocumentChanges.Value;
         Assert.Equal(3, documentChanges.Count());
-        var renameChange = documentChanges.ElementAt(0);
-        Assert.True(renameChange.TryGetThird(out var renameFile));
-        Assert.Equal(new Uri("file:///c:/First/Component1337.razor"), renameFile.OldUri);
-        Assert.Equal(new Uri("file:///c:/First/Component5.razor"), renameFile.NewUri);
-        var editChange1 = documentChanges.ElementAt(1);
+        var editChange1 = documentChanges.ElementAt(0);
         Assert.True(editChange1.TryGetFirst(out var textDocumentEdit));
         Assert.Equal("file:///c:/First/Index.razor", textDocumentEdit.TextDocument.Uri.ToString());
         Assert.Collection(
@@ -292,7 +288,7 @@ public class RenameEndpointTest : LanguageServerTestBase
                 Assert.Equal(30, edit.Range.End.Character);
             });
 
-        var editChange2 = result.DocumentChanges.Value.ElementAt(2);
+        var editChange2 = result.DocumentChanges.Value.ElementAt(1);
         Assert.True(editChange2.TryGetFirst(out var textDocumentEdit2));
         Assert.Equal("file:///c:/First/Index.razor", textDocumentEdit2.TextDocument.Uri.ToString());
         Assert.Collection(
@@ -313,6 +309,10 @@ public class RenameEndpointTest : LanguageServerTestBase
                 Assert.Equal(3, edit.Range.End.Line);
                 Assert.Equal(40, edit.Range.End.Character);
             });
+        var renameChange = documentChanges.ElementAt(2);
+        Assert.True(renameChange.TryGetThird(out var renameFile));
+        Assert.Equal(new Uri("file:///c:/First/Component1337.razor"), renameFile.OldUri);
+        Assert.Equal(new Uri("file:///c:/First/Component5.razor"), renameFile.NewUri);
     }
 
     [Fact]
@@ -338,13 +338,13 @@ public class RenameEndpointTest : LanguageServerTestBase
         // Assert
         Assert.NotNull(result);
         Assert.Equal(4, result.DocumentChanges.Value.Count());
-        var renameChange = result.DocumentChanges.Value.ElementAt(0);
+        var editChange1 = result.DocumentChanges.Value.ElementAt(0);
+        Assert.True(editChange1.TryGetFirst(out var textDocumentEdit));
+        Assert.Equal("file:///c:/Second/Component3.razor", textDocumentEdit.TextDocument.Uri.ToString());
+        var renameChange = result.DocumentChanges.Value.ElementAt(1);
         Assert.True(renameChange.TryGetThird(out var renameFile));
         Assert.Equal(new Uri("file:///c:/Second/Component3.razor"), renameFile.OldUri);
         Assert.Equal(new Uri("file:///c:/Second/Component5.razor"), renameFile.NewUri);
-        var editChange1 = result.DocumentChanges.Value.ElementAt(1);
-        Assert.True(editChange1.TryGetFirst(out var textDocumentEdit));
-        Assert.Equal("file:///c:/Second/Component3.razor", textDocumentEdit.TextDocument.Uri.ToString());
         Assert.Collection(
             textDocumentEdit.Edits,
             edit =>
@@ -392,13 +392,13 @@ public class RenameEndpointTest : LanguageServerTestBase
         // Assert
         Assert.NotNull(result);
         Assert.Equal(2, result.DocumentChanges.Value.Count());
-        var renameChange = result.DocumentChanges.Value.ElementAt(0);
+        var editChange = result.DocumentChanges.Value.ElementAt(0);
+        Assert.True(editChange.TryGetFirst(out var textDocumentEdit));
+        Assert.Equal("file:///c:/Dir1/Directory1.razor", textDocumentEdit.TextDocument.Uri.ToString());
+        var renameChange = result.DocumentChanges.Value.ElementAt(1);
         Assert.True(renameChange.TryGetThird(out var renameFile));
         Assert.Equal(new Uri("file:///c:/Dir2/Directory2.razor"), renameFile.OldUri);
         Assert.Equal(new Uri("file:///c:/Dir2/TestComponent.razor"), renameFile.NewUri);
-        var editChange = result.DocumentChanges.Value.ElementAt(1);
-        Assert.True(editChange.TryGetFirst(out var textDocumentEdit));
-        Assert.Equal("file:///c:/Dir1/Directory1.razor", textDocumentEdit.TextDocument.Uri.ToString());
         Assert.Collection(
             textDocumentEdit.Edits,
             edit =>


### PR DESCRIPTION
Text edit on the file being renamed gets lost.

To fix this we first apply text edits and then
apply file rename as the last thing to do.

To do:
- [x] set up the new testcase for the bugfix

Contributes to: #8541