### PR TITLE
Add a couple of basic project operation tests

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractRazorEditorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractRazorEditorTest.cs
@@ -28,8 +28,9 @@ public abstract class AbstractRazorEditorTest : AbstractEditorTest
 
         VisualStudioLogging.AddCustomLoggers();
 
-        await TestServices.SolutionExplorer.CreateSolutionAsync("BlazorSolution", ControlledHangMitigatingCancellationToken);
-        await TestServices.SolutionExplorer.AddProjectAsync("BlazorProject", WellKnownProjectTemplates.BlazorProject, groupId: WellKnownProjectTemplates.GroupIdentifiers.Server, templateId: null, LanguageName, ControlledHangMitigatingCancellationToken);
+        await TestServices.SolutionExplorer.CreateSolutionAsync(RazorProjectConstants.BlazorSolutionName, ControlledHangMitigatingCancellationToken);
+        await TestServices.SolutionExplorer.AddProjectAsync(RazorProjectConstants.BlazorProjectName, WellKnownProjectTemplates.BlazorProject, groupId: WellKnownProjectTemplates.GroupIdentifiers.Server, templateId: null, LanguageName, ControlledHangMitigatingCancellationToken);
+
         await TestServices.SolutionExplorer.RestoreNuGetPackagesAsync(ControlledHangMitigatingCancellationToken);
         await TestServices.Workspace.WaitForProjectSystemAsync(ControlledHangMitigatingCancellationToken);
 

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/SolutionExplorerInProcess.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/SolutionExplorerInProcess.cs
@@ -88,6 +88,15 @@ internal partial class SolutionExplorerInProcess
             cancellationToken);
     }
 
+    public async Task OpenSolutionAsync(string solutionFileName, CancellationToken cancellationToken)
+    {
+        await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
+
+        var dte = await GetRequiredGlobalServiceAsync<SDTE, EnvDTE.DTE>(cancellationToken);
+
+        dte.Solution.Open(solutionFileName);
+    }
+
     public async Task OpenFileAsync(string projectName, string relativeFilePath, CancellationToken cancellationToken)
     {
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
@@ -276,7 +285,7 @@ internal partial class SolutionExplorerInProcess
         };
     }
 
-    private async Task<string> GetAbsolutePathForProjectRelativeFilePathAsync(string projectName, string relativeFilePath, CancellationToken cancellationToken)
+    public async Task<string> GetAbsolutePathForProjectRelativeFilePathAsync(string projectName, string relativeFilePath, CancellationToken cancellationToken)
     {
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/ProjectTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/ProjectTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.Razor.IntegrationTests.InProcess;
 using Xunit;
@@ -63,5 +64,94 @@ public class ProjectTests : AbstractRazorEditorTest
 
         int GetProjectRazorJsonFileCount()
             => Directory.EnumerateFiles(solutionPath, "project.razor.*.json", SearchOption.AllDirectories).Count();
+    }
+
+    [IdeFact]
+    public async Task MultiTargetProject()
+    {
+        var solutionPath = await TestServices.SolutionExplorer.GetDirectoryNameAsync(ControlledHangMitigatingCancellationToken);
+
+        Assert.Equal(1, GetProjectRazorJsonFileCount());
+
+        var projectFileName = await TestServices.SolutionExplorer.GetAbsolutePathForProjectRelativeFilePathAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.ProjectFile, ControlledHangMitigatingCancellationToken);
+
+        // CPS doesn't support changing from single targeting to multi-targeting while a project is open
+        await TestServices.SolutionExplorer.CloseSolutionAsync(ControlledHangMitigatingCancellationToken);
+
+        var sb = new StringBuilder();
+        foreach (var line in File.ReadAllLines(projectFileName))
+        {
+            if (line.Contains("<TargetFramework>"))
+            {
+                sb.AppendLine("<TargetFrameworks>net6.0;net7.0</TargetFrameworks>");
+            }
+            else
+            {
+                sb.AppendLine(line);
+            }
+        }
+
+        File.WriteAllText(projectFileName, sb.ToString());
+
+        var projectFolder = Path.GetDirectoryName(projectFileName);
+        // Clear out the obj folder, so we don't break the test when the default project is updated in the project template, resulting in 3 .json files
+        Directory.Delete(Path.Combine(projectFolder, "obj"), recursive: true);
+        var solutionFileName = Path.Combine(solutionPath, RazorProjectConstants.BlazorSolutionName + ".sln");
+        await TestServices.SolutionExplorer.OpenSolutionAsync(solutionFileName, ControlledHangMitigatingCancellationToken);
+
+        await TestServices.Workspace.WaitForProjectSystemAsync(ControlledHangMitigatingCancellationToken);
+        await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.LanguageServer, ControlledHangMitigatingCancellationToken);
+        await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.Workspace, ControlledHangMitigatingCancellationToken);
+
+        // We open the Index.razor file, and wait for 3 RazorComponentElement's to be classified, as that
+        // way we know the LSP server is up, running, and has processed both local and library-sourced Components
+        await TestServices.SolutionExplorer.OpenFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.IndexRazorFile, ControlledHangMitigatingCancellationToken);
+
+        // Razor extension doesn't launch until a razor file is opened, so wait for it to equalize
+        await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.LanguageServer, ControlledHangMitigatingCancellationToken);
+        await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.Workspace, ControlledHangMitigatingCancellationToken);
+        await TestServices.Workspace.WaitForProjectSystemAsync(ControlledHangMitigatingCancellationToken);
+
+        await TestServices.Editor.PlaceCaretAsync("</PageTitle>", charsOffset: 1, ControlledHangMitigatingCancellationToken);
+        await TestServices.Editor.WaitForComponentClassificationAsync(ControlledHangMitigatingCancellationToken, count: 3);
+
+        // This is a little odd, but there is no "real" way to check this via VS, and one of the most important things this test can do
+        // is ensure that each target framework gets its own project.razor.json file, and doesn't share one from a cache or anything.
+        Assert.Equal(2, GetProjectRazorJsonFileCount());
+
+        int GetProjectRazorJsonFileCount()
+            => Directory.EnumerateFiles(solutionPath, "project.razor.*.json", SearchOption.AllDirectories).Count();
+    }
+
+    [IdeFact]
+    public async Task OpenExistingProject()
+    {
+        var solutionPath = await TestServices.SolutionExplorer.GetDirectoryNameAsync(ControlledHangMitigatingCancellationToken);
+        var expectedProjectFileName = await TestServices.SolutionExplorer.GetAbsolutePathForProjectRelativeFilePathAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.ProjectFile, ControlledHangMitigatingCancellationToken);
+
+        await TestServices.SolutionExplorer.CloseSolutionAsync(ControlledHangMitigatingCancellationToken);
+
+        var solutionFileName = Path.Combine(solutionPath, RazorProjectConstants.BlazorSolutionName + ".sln");
+        await TestServices.SolutionExplorer.OpenSolutionAsync(solutionFileName, ControlledHangMitigatingCancellationToken);
+
+        await TestServices.Workspace.WaitForProjectSystemAsync(ControlledHangMitigatingCancellationToken);
+        await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.LanguageServer, ControlledHangMitigatingCancellationToken);
+        await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.Workspace, ControlledHangMitigatingCancellationToken);
+
+        // We open the Index.razor file, and wait for 3 RazorComponentElement's to be classified, as that
+        // way we know the LSP server is up, running, and has processed both local and library-sourced Components
+        await TestServices.SolutionExplorer.OpenFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.IndexRazorFile, ControlledHangMitigatingCancellationToken);
+
+        // Razor extension doesn't launch until a razor file is opened, so wait for it to equalize
+        await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.LanguageServer, ControlledHangMitigatingCancellationToken);
+        await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.Workspace, ControlledHangMitigatingCancellationToken);
+        await TestServices.Workspace.WaitForProjectSystemAsync(ControlledHangMitigatingCancellationToken);
+
+        await TestServices.Editor.PlaceCaretAsync("</PageTitle>", charsOffset: 1, ControlledHangMitigatingCancellationToken);
+        await TestServices.Editor.WaitForComponentClassificationAsync(ControlledHangMitigatingCancellationToken, count: 3);
+
+        // Make sure the test framework didn't do something weird and create new project
+        var actualProjectFileName = await TestServices.SolutionExplorer.GetAbsolutePathForProjectRelativeFilePathAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.ProjectFile, ControlledHangMitigatingCancellationToken);
+        Assert.Equal(expectedProjectFileName, actualProjectFileName);
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/RazorProjectConstants.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/RazorProjectConstants.cs
@@ -7,6 +7,7 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests;
 
 public static class RazorProjectConstants
 {
+    internal const string BlazorSolutionName = "BlazorSolution";
     internal const string BlazorProjectName = "BlazorProject";
 
     private static readonly string s_pagesDir = Path.Combine("Pages");


### PR DESCRIPTION
After writing a message in teams that we didn't have tests for opening existing projects, I realised that there wasn't a reason we couldn't. That also made me realise we could use the same trick (closing and opening a solution) to work around CPS limitations for switching to multi-targeting while a project is open.