### PR TITLE
Generate EventHandler CodeAction: Add Async Version and Fully Qualified Type Params

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/GenerateMethodCodeActionParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/GenerateMethodCodeActionParams.cs
@@ -9,4 +9,5 @@ internal class GenerateMethodCodeActionParams
 {
     public required Uri Uri { get; set; }
     public required string MethodName { get; set; }
+    public required string EventName { get; set;}
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/GenerateMethodCodeActionParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/GenerateMethodCodeActionParams.cs
@@ -10,4 +10,5 @@ internal class GenerateMethodCodeActionParams
     public required Uri Uri { get; set; }
     public required string MethodName { get; set; }
     public required string EventName { get; set;}
+    public required bool IsAsync { get; set; }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/CodeBlockService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/CodeBlockService.cs
@@ -20,12 +20,12 @@ internal static class CodeBlockService
     /// <param name="code">
     ///  The <see cref="RazorCodeDocument"/> of the file where the generated method will be placed.
     /// </param>
-    /// <param name="templateWithMethodName">
+    /// <param name="templateWithMethodSignature">
     ///  The skeleton of the generated method where a <see cref="FormattingUtilities.Indent"/> should be placed
     ///  anywhere that needs to have some indenting, <see cref="FormattingUtilities.InitialIndent"/> anywhere that
-    ///  needs some initial indenting, and a '$$MethodName$$' for where the method name should be placed.
+    ///  needs some initial indenting.
     ///  It should look something like:
-    ///   <see cref="FormattingUtilities.InitialIndent"/><see cref="FormattingUtilities.Indent"/>public void $$MethodName$$()
+    ///   <see cref="FormattingUtilities.InitialIndent"/><see cref="FormattingUtilities.Indent"/>public void MethodName()
     ///   <see cref="FormattingUtilities.InitialIndent"/><see cref="FormattingUtilities.Indent"/>{
     ///   <see cref="FormattingUtilities.InitialIndent"/><see cref="FormattingUtilities.Indent"/><see cref="FormattingUtilities.Indent"/>throw new NotImplementedException();
     ///   <see cref="FormattingUtilities.InitialIndent"/><see cref="FormattingUtilities.Indent"/>}
@@ -36,7 +36,7 @@ internal static class CodeBlockService
     /// <returns>
     ///  A <see cref="TextEdit"/> that will place the formatted generated method within a @code block in the file.
     /// </returns>
-    public static TextEdit CreateFormattedTextEdit(RazorCodeDocument code, string templateWithMethodName, RazorLSPOptions options)
+    public static TextEdit CreateFormattedTextEdit(RazorCodeDocument code, string templateWithMethodSignature, RazorLSPOptions options)
     {
         var csharpCodeBlock = code.GetSyntaxTree().Root.DescendantNodes()
             .Select(RazorSyntaxFacts.TryGetCSharpCodeFromCodeBlock)
@@ -46,7 +46,7 @@ internal static class CodeBlockService
             || !csharpCodeBlock.Children.TryGetCloseBraceNode(out var closeBrace))
         {
             // No well-formed @code block exists. Generate the method within an @code block at the end of the file.
-            var indentedMethod = FormattingUtilities.AddIndentationToMethod(templateWithMethodName, options, startingIndent: 0);
+            var indentedMethod = FormattingUtilities.AddIndentationToMethod(templateWithMethodSignature, options, startingIndent: 0);
             var textWithCodeBlock = "@code {" + Environment.NewLine + indentedMethod + Environment.NewLine + "}";
             var lastCharacterLocation = code.Source.Lines.GetLocation(code.Source.Length - 1);
             var insertCharacterIndex = 0;
@@ -82,7 +82,7 @@ internal static class CodeBlockService
             closeBraceLocation.LineIndex,
             insertLineLocation,
             options,
-            templateWithMethodName);
+            templateWithMethodSignature);
 
         var insertCharacter = openBraceLocation.LineIndex == closeBraceLocation.LineIndex
             ? closeBraceLocation.CharacterIndex

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/GenerateMethodCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/GenerateMethodCodeActionProvider.cs
@@ -79,6 +79,14 @@ internal class GenerateMethodCodeActionProvider : IRazorCodeActionProvider
         }
 
         var eventName = markupTagHelperDirectiveAttribute.TagHelperAttributeInfo.Name[1..];
+        if (markupTagHelperDirectiveAttribute.TagHelperAttributeInfo.ParameterName is { } parameterName
+            && eventName.Contains(parameterName))
+        {
+            // An event parameter is being set instead of the event handler e.g.
+            // <button @onclick:preventDefault=SomeValue/>, this is not a generate event handler scenario.
+            return false;
+        }
+
         var methodName = markupTagHelperDirectiveAttribute.Value.GetContent();
         if (!SyntaxFacts.IsValidIdentifier(methodName))
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/GenerateMethodCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/GenerateMethodCodeActionProvider.cs
@@ -79,8 +79,7 @@ internal class GenerateMethodCodeActionProvider : IRazorCodeActionProvider
         }
 
         var eventName = markupTagHelperDirectiveAttribute.TagHelperAttributeInfo.Name[1..];
-        if (markupTagHelperDirectiveAttribute.TagHelperAttributeInfo.ParameterName is { } parameterName
-            && eventName.Contains(parameterName))
+        if (markupTagHelperDirectiveAttribute.TagHelperAttributeInfo.ParameterName is not null)
         {
             // An event parameter is being set instead of the event handler e.g.
             // <button @onclick:preventDefault=SomeValue/>, this is not a generate event handler scenario.

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/GenerateMethodCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/GenerateMethodCodeActionResolver.cs
@@ -125,9 +125,9 @@ internal class GenerateMethodCodeActionResolver : IRazorCodeActionResolver
         return new WorkspaceEdit() { DocumentChanges = new[] { codeBehindTextDocEdit } };
     }
 
-    private WorkspaceEdit GenerateMethodInCodeBlock(RazorCodeDocument code, GenerateMethodCodeActionParams actionParams, string templateWithMethodName)
+    private WorkspaceEdit GenerateMethodInCodeBlock(RazorCodeDocument code, GenerateMethodCodeActionParams actionParams, string templateWithMethodSignature)
     {
-        var edit = CodeBlockService.CreateFormattedTextEdit(code, templateWithMethodName, _razorLSPOptionsMonitor.CurrentValue);
+        var edit = CodeBlockService.CreateFormattedTextEdit(code, templateWithMethodSignature, _razorLSPOptionsMonitor.CurrentValue);
         var razorTextDocEdit = new TextDocumentEdit()
         {
             TextDocument = new OptionalVersionedTextDocumentIdentifier() { Uri = actionParams.Uri },

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/RazorCodeActionFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/RazorCodeActionFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Newtonsoft.Json.Linq;
 
@@ -67,9 +68,23 @@ internal static class RazorCodeActionFactory
         return codeAction;
     }
 
-    public static RazorVSInternalCodeAction CreateGenerateMethod(RazorCodeActionResolutionParams resolutionParams)
+    public static RazorVSInternalCodeAction CreateGenerateMethod(Uri uri, string methodName, string eventName)
     {
-        var title = SR.FormatGenerate_Event_Handler_Title(((GenerateMethodCodeActionParams)resolutionParams.Data).MethodName);
+        var @params = new GenerateMethodCodeActionParams
+        {
+            Uri = uri,
+            MethodName = methodName,
+            EventName = eventName,
+            IsAsync = false
+        };
+        var resolutionParams = new RazorCodeActionResolutionParams()
+        {
+            Action = LanguageServerConstants.CodeActions.GenerateEventHandler,
+            Language = LanguageServerConstants.CodeActions.Languages.Razor,
+            Data = @params,
+        };
+
+        var title = SR.FormatGenerate_Event_Handler_Title(methodName);
         var data = JToken.FromObject(resolutionParams);
         var codeAction = new RazorVSInternalCodeAction()
         {
@@ -80,9 +95,23 @@ internal static class RazorCodeActionFactory
         return codeAction;
     }
 
-    public static RazorVSInternalCodeAction CreateAsyncGenerateMethod(RazorCodeActionResolutionParams resolutionParams)
+    public static RazorVSInternalCodeAction CreateAsyncGenerateMethod(Uri uri, string methodName, string eventName)
     {
-        var title = SR.FormatGenerate_Async_Event_Handler_Title(((GenerateMethodCodeActionParams)resolutionParams.Data).MethodName);
+        var @params = new GenerateMethodCodeActionParams
+        {
+            Uri = uri,
+            MethodName = methodName,
+            EventName = eventName,
+            IsAsync = true
+        };
+        var resolutionParams = new RazorCodeActionResolutionParams()
+        {
+            Action = LanguageServerConstants.CodeActions.GenerateEventHandler,
+            Language = LanguageServerConstants.CodeActions.Languages.Razor,
+            Data = @params,
+        };
+
+        var title = SR.FormatGenerate_Async_Event_Handler_Title(methodName);
         var data = JToken.FromObject(resolutionParams);
         var codeAction = new RazorVSInternalCodeAction()
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/RazorCodeActionFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/RazorCodeActionFactory.cs
@@ -15,6 +15,7 @@ internal static class RazorCodeActionFactory
     private readonly static Guid s_createComponentFromTagTelemetryId = new("a28e0baa-a4d5-4953-a817-1db586035841");
     private readonly static Guid s_createExtractToCodeBehindTelemetryId = new("f63167f7-fdc6-450f-8b7b-b240892f4a27");
     private readonly static Guid s_generateMethodTelemetryId = new("c14fa003-c752-45fc-bb29-3a123ae5ecef");
+    private readonly static Guid s_generateAsyncMethodTelemetryId = new("9058ca47-98e2-4f11-bf7c-a16a444dd939");
 
     public static RazorVSInternalCodeAction CreateAddComponentUsing(string @namespace, RazorCodeActionResolutionParams resolutionParams)
     {
@@ -75,6 +76,19 @@ internal static class RazorCodeActionFactory
             Title = title,
             Data = data,
             TelemetryId = s_generateMethodTelemetryId
+        };
+        return codeAction;
+    }
+
+    public static RazorVSInternalCodeAction CreateAsyncGenerateMethod(RazorCodeActionResolutionParams resolutionParams)
+    {
+        var title = SR.FormatGenerate_Async_Event_Handler_Title(((GenerateMethodCodeActionParams)resolutionParams.Data).MethodName);
+        var data = JToken.FromObject(resolutionParams);
+        var codeAction = new RazorVSInternalCodeAction()
+        {
+            Title = title,
+            Data = data,
+            TelemetryId = s_generateAsyncMethodTelemetryId
         };
         return codeAction;
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/SR.resx
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/SR.resx
@@ -129,6 +129,9 @@
   <data name="ExtractTo_CodeBehind_Title" xml:space="preserve">
     <value>Extract block to code behind</value>
   </data>
+  <data name="Generate_Async_Event_Handler_Title" xml:space="preserve">
+    <value>Generate Async Event Handler '{0}'</value>
+  </data>
   <data name="Generate_Event_Handler_Title" xml:space="preserve">
     <value>Generate Event Handler '{0}'</value>
   </data>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.cs.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.cs.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Extrahovat blok do kódu na pozadí</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generate_Async_Event_Handler_Title">
+        <source>Generate Async Event Handler '{0}'</source>
+        <target state="new">Generate Async Event Handler '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_Event_Handler_Title">
         <source>Generate Event Handler '{0}'</source>
         <target state="new">Generate Event Handler '{0}'</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.de.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.de.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Block auf CodeBehind extrahieren</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generate_Async_Event_Handler_Title">
+        <source>Generate Async Event Handler '{0}'</source>
+        <target state="new">Generate Async Event Handler '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_Event_Handler_Title">
         <source>Generate Event Handler '{0}'</source>
         <target state="new">Generate Event Handler '{0}'</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.es.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.es.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Extraer el bloque al código subyacente</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generate_Async_Event_Handler_Title">
+        <source>Generate Async Event Handler '{0}'</source>
+        <target state="new">Generate Async Event Handler '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_Event_Handler_Title">
         <source>Generate Event Handler '{0}'</source>
         <target state="translated">Generar controlador de eventos ''{0}''</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.fr.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.fr.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Extraire le bloc vers le code-behind</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generate_Async_Event_Handler_Title">
+        <source>Generate Async Event Handler '{0}'</source>
+        <target state="new">Generate Async Event Handler '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_Event_Handler_Title">
         <source>Generate Event Handler '{0}'</source>
         <target state="translated">Générer le gestionnaire d’événements '{0}'</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.it.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.it.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Estrai il blocco in code-behind</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generate_Async_Event_Handler_Title">
+        <source>Generate Async Event Handler '{0}'</source>
+        <target state="new">Generate Async Event Handler '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_Event_Handler_Title">
         <source>Generate Event Handler '{0}'</source>
         <target state="translated">Genera gestore dell'evento '{0}'</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.ja.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.ja.xlf
@@ -22,6 +22,11 @@
         <target state="translated">ブロック抽出から分離コード</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generate_Async_Event_Handler_Title">
+        <source>Generate Async Event Handler '{0}'</source>
+        <target state="new">Generate Async Event Handler '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_Event_Handler_Title">
         <source>Generate Event Handler '{0}'</source>
         <target state="translated">イベント ハンドラー '{0}' の生成</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.ko.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.ko.xlf
@@ -22,6 +22,11 @@
         <target state="translated">코드 숨김에 블록 추출</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generate_Async_Event_Handler_Title">
+        <source>Generate Async Event Handler '{0}'</source>
+        <target state="new">Generate Async Event Handler '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_Event_Handler_Title">
         <source>Generate Event Handler '{0}'</source>
         <target state="new">Generate Event Handler '{0}'</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.pl.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.pl.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Wyodrębnij blok do kodu znajdującego się poza</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generate_Async_Event_Handler_Title">
+        <source>Generate Async Event Handler '{0}'</source>
+        <target state="new">Generate Async Event Handler '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_Event_Handler_Title">
         <source>Generate Event Handler '{0}'</source>
         <target state="new">Generate Event Handler '{0}'</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.pt-BR.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.pt-BR.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Extrair o bloco para codificar atrás</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generate_Async_Event_Handler_Title">
+        <source>Generate Async Event Handler '{0}'</source>
+        <target state="new">Generate Async Event Handler '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_Event_Handler_Title">
         <source>Generate Event Handler '{0}'</source>
         <target state="translated">Gerar manipulador de eventos '{0}'</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.ru.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.ru.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Извлечь блок в код программной части</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generate_Async_Event_Handler_Title">
+        <source>Generate Async Event Handler '{0}'</source>
+        <target state="new">Generate Async Event Handler '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_Event_Handler_Title">
         <source>Generate Event Handler '{0}'</source>
         <target state="translated">Создать обработчик событий "{0}"</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.tr.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.tr.xlf
@@ -22,6 +22,11 @@
         <target state="translated">Bloğu arkadaki koda ayıkla</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generate_Async_Event_Handler_Title">
+        <source>Generate Async Event Handler '{0}'</source>
+        <target state="new">Generate Async Event Handler '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_Event_Handler_Title">
         <source>Generate Event Handler '{0}'</source>
         <target state="new">Generate Event Handler '{0}'</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.zh-Hans.xlf
@@ -22,6 +22,11 @@
         <target state="translated">将块提取到代码隐藏中</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generate_Async_Event_Handler_Title">
+        <source>Generate Async Event Handler '{0}'</source>
+        <target state="new">Generate Async Event Handler '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_Event_Handler_Title">
         <source>Generate Event Handler '{0}'</source>
         <target state="new">Generate Event Handler '{0}'</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.zh-Hant.xlf
@@ -22,6 +22,11 @@
         <target state="translated">擷取區塊以在後方編碼</target>
         <note />
       </trans-unit>
+      <trans-unit id="Generate_Async_Event_Handler_Title">
+        <source>Generate Async Event Handler '{0}'</source>
+        <target state="new">Generate Async Event Handler '{0}'</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Generate_Event_Handler_Title">
         <source>Generate Event Handler '{0}'</source>
         <target state="translated">產生事件處理常式 '{0}'</target>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestDocumentContextFactory.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestDocumentContextFactory.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Common;
 internal class TestDocumentContextFactory : DocumentContextFactory
 {
     private protected readonly string? FilePath;
-    private protected readonly RazorCodeDocument? _codeDocument;
+    private protected readonly RazorCodeDocument? CodeDocument;
     private readonly int? _version;
 
     public TestDocumentContextFactory()
@@ -21,27 +21,27 @@ internal class TestDocumentContextFactory : DocumentContextFactory
     public TestDocumentContextFactory(string filePath, RazorCodeDocument codeDocument, int? version = null)
     {
         FilePath = filePath;
-        _codeDocument = codeDocument;
+        CodeDocument = codeDocument;
         _version = version;
     }
 
     public override Task<DocumentContext?> TryCreateAsync(Uri documentUri, CancellationToken cancellationToken)
     {
-        if (FilePath is null || _codeDocument is null)
+        if (FilePath is null || CodeDocument is null)
         {
             return Task.FromResult<DocumentContext?>(null);
         }
 
-        return Task.FromResult<DocumentContext?>(TestDocumentContext.From(FilePath, _codeDocument));
+        return Task.FromResult<DocumentContext?>(TestDocumentContext.From(FilePath, CodeDocument));
     }
 
     public override Task<VersionedDocumentContext?> TryCreateForOpenDocumentAsync(Uri documentUri, CancellationToken cancellationToken)
     {
-        if (FilePath is null || _codeDocument is null || _version is null)
+        if (FilePath is null || CodeDocument is null || _version is null)
         {
             return Task.FromResult<VersionedDocumentContext?>(null);
         }
 
-        return Task.FromResult<VersionedDocumentContext?>(TestDocumentContext.From(FilePath, _codeDocument, _version.Value));
+        return Task.FromResult<VersionedDocumentContext?>(TestDocumentContext.From(FilePath, CodeDocument, _version.Value));
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestDocumentContextFactory.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestDocumentContextFactory.cs
@@ -10,8 +10,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Common;
 
 internal class TestDocumentContextFactory : DocumentContextFactory
 {
-    private readonly string? _filePath;
-    private readonly RazorCodeDocument? _codeDocument;
+    private protected readonly string? FilePath;
+    private protected readonly RazorCodeDocument? _codeDocument;
     private readonly int? _version;
 
     public TestDocumentContextFactory()
@@ -20,28 +20,28 @@ internal class TestDocumentContextFactory : DocumentContextFactory
 
     public TestDocumentContextFactory(string filePath, RazorCodeDocument codeDocument, int? version = null)
     {
-        _filePath = filePath;
+        FilePath = filePath;
         _codeDocument = codeDocument;
         _version = version;
     }
 
     public override Task<DocumentContext?> TryCreateAsync(Uri documentUri, CancellationToken cancellationToken)
     {
-        if (_filePath is null || _codeDocument is null)
+        if (FilePath is null || _codeDocument is null)
         {
             return Task.FromResult<DocumentContext?>(null);
         }
 
-        return Task.FromResult<DocumentContext?>(TestDocumentContext.From(_filePath, _codeDocument));
+        return Task.FromResult<DocumentContext?>(TestDocumentContext.From(FilePath, _codeDocument));
     }
 
     public override Task<VersionedDocumentContext?> TryCreateForOpenDocumentAsync(Uri documentUri, CancellationToken cancellationToken)
     {
-        if (_filePath is null || _codeDocument is null || _version is null)
+        if (FilePath is null || _codeDocument is null || _version is null)
         {
             return Task.FromResult<VersionedDocumentContext?>(null);
         }
 
-        return Task.FromResult<VersionedDocumentContext?>(TestDocumentContext.From(_filePath, _codeDocument, _version.Value));
+        return Task.FromResult<VersionedDocumentContext?>(TestDocumentContext.From(FilePath, _codeDocument, _version.Value));
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestDocumentSnapshot.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestDocumentSnapshot.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Utilities;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -25,8 +26,8 @@ internal class TestDocumentSnapshot : DocumentSnapshot
     public static TestDocumentSnapshot Create(string filePath, string text)
         => Create(filePath, text, VersionStamp.Default);
 
-    public static TestDocumentSnapshot Create(string filePath, string text, VersionStamp version)
-        => Create(filePath, text, version, TestProjectSnapshot.Create(filePath + ".csproj"));
+    public static TestDocumentSnapshot Create(string filePath, string text, VersionStamp version, ProjectWorkspaceState? projectWorkspaceState = null)
+        => Create(filePath, text, version, TestProjectSnapshot.Create(filePath + ".csproj", projectWorkspaceState));
 
     public static TestDocumentSnapshot Create(string filePath, string text, VersionStamp version, TestProjectSnapshot projectSnapshot)
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndToEndTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndToEndTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -13,14 +14,17 @@ using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Razor;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
+using Microsoft.AspNetCore.Razor.LanguageServer.Test.Common;
+using Microsoft.AspNetCore.Razor.ProjectSystem;
+using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Utilities;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
-using Moq;
 using Roslyn.Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
@@ -29,6 +33,17 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
 
 public class CodeActionEndToEndTest : SingleServerDelegatingEndpointTestBase
 {
+    private static GenerateMethodCodeActionResolver[] CreateRazorCodeActionResolversFn(
+        string filePath,
+        RazorCodeDocument codeDocument,
+        RazorLSPOptionsMonitor? optionsMonitor = null)
+            => new[]
+            {
+                new GenerateMethodCodeActionResolver(
+                    new GenerateMethodResolverDocumentContextFactory(filePath, codeDocument),
+                    optionsMonitor ?? TestRazorLSPOptionsMonitor.Create())
+            };
+
     public CodeActionEndToEndTest(ITestOutputHelper testOutput)
         : base(testOutput)
     {
@@ -353,7 +368,7 @@ public class CodeActionEndToEndTest : SingleServerDelegatingEndpointTestBase
         var expected = """
             <button @onclick="DoesNotExist"></button>
             @code {
-                private void DoesNotExist()
+                private void DoesNotExist(Microsoft.AspNetCore.Components.Web.MouseEventArgs e)
                 {
                     throw new System.NotImplementedException();
                 }
@@ -364,7 +379,7 @@ public class CodeActionEndToEndTest : SingleServerDelegatingEndpointTestBase
         await ValidateCodeActionAsync(input,
             expected, "Generate Event Handler 'DoesNotExist'",
             razorCodeActionProviders: new[] { new GenerateMethodCodeActionProvider() },
-            createRazorCodeActionResolversFn: () => new[] { new GenerateMethodCodeActionResolver(DocumentContextFactory, TestRazorLSPOptionsMonitor.Create()) },
+            createRazorCodeActionResolversFn: CreateRazorCodeActionResolversFn,
             diagnostics: diagnostics);
     }
 
@@ -382,7 +397,7 @@ public class CodeActionEndToEndTest : SingleServerDelegatingEndpointTestBase
         var expected = """
             <button @onclick="DoesNotExist"></button>
             @code {
-                private void DoesNotExist()
+                private void DoesNotExist(Microsoft.AspNetCore.Components.Web.MouseEventArgs e)
                 {
                     throw new System.NotImplementedException();
                 }
@@ -394,7 +409,7 @@ public class CodeActionEndToEndTest : SingleServerDelegatingEndpointTestBase
             expected,
             "Generate Event Handler 'DoesNotExist'",
             razorCodeActionProviders: new[] { new GenerateMethodCodeActionProvider() },
-            createRazorCodeActionResolversFn: () => new[] { new GenerateMethodCodeActionResolver(DocumentContextFactory, TestRazorLSPOptionsMonitor.Create()) },
+            createRazorCodeActionResolversFn: CreateRazorCodeActionResolversFn,
             diagnostics: diagnostics);
     }
 
@@ -419,7 +434,7 @@ public class CodeActionEndToEndTest : SingleServerDelegatingEndpointTestBase
                 {
                 }
 
-                private void DoesNotExist()
+                private void DoesNotExist(Microsoft.AspNetCore.Components.Web.MouseEventArgs e)
                 {
                     throw new System.NotImplementedException();
                 }
@@ -431,7 +446,7 @@ public class CodeActionEndToEndTest : SingleServerDelegatingEndpointTestBase
             expected,
             "Generate Event Handler 'DoesNotExist'",
             razorCodeActionProviders: new[] { new GenerateMethodCodeActionProvider() },
-            createRazorCodeActionResolversFn: () => new[] { new GenerateMethodCodeActionResolver(DocumentContextFactory, TestRazorLSPOptionsMonitor.Create()) },
+            createRazorCodeActionResolversFn: CreateRazorCodeActionResolversFn,
             diagnostics: diagnostics);
     }
 
@@ -486,7 +501,7 @@ public class CodeActionEndToEndTest : SingleServerDelegatingEndpointTestBase
         var expected = $$"""
             <button @onclick="DoesNotExist"></button>
             {{inputIndentString}}@code {
-            {{initialIndentString}}{{indent}}private void DoesNotExist()
+            {{initialIndentString}}{{indent}}private void DoesNotExist(Microsoft.AspNetCore.Components.Web.MouseEventArgs e)
             {{initialIndentString}}{{indent}}{
             {{initialIndentString}}{{indent}}{{indent}}throw new System.NotImplementedException();
             {{initialIndentString}}{{indent}}}
@@ -501,7 +516,8 @@ public class CodeActionEndToEndTest : SingleServerDelegatingEndpointTestBase
             expected,
             "Generate Event Handler 'DoesNotExist'",
             razorCodeActionProviders: new[] { new GenerateMethodCodeActionProvider() },
-            createRazorCodeActionResolversFn: () => new[] { new GenerateMethodCodeActionResolver(DocumentContextFactory, optionsMonitor) },
+            createRazorCodeActionResolversFn: CreateRazorCodeActionResolversFn,
+            optionsMonitor: optionsMonitor,
             diagnostics: diagnostics);
     }
 
@@ -534,7 +550,7 @@ public class CodeActionEndToEndTest : SingleServerDelegatingEndpointTestBase
             {
                 public partial class test
                 {{{spacingOrMethod}}
-                    private void DoesNotExist()
+                    private void DoesNotExist(Microsoft.AspNetCore.Components.Web.MouseEventArgs e)
                     {
                         throw new System.NotImplementedException();
                     }
@@ -556,7 +572,7 @@ public class CodeActionEndToEndTest : SingleServerDelegatingEndpointTestBase
         var expectedRazorContent = """
             <button @onclick="DoesNotExist"></button>
             @code {
-                private void DoesNotExist()
+                private void DoesNotExist(Microsoft.AspNetCore.Components.Web.MouseEventArgs e)
                 {
                     throw new System.NotImplementedException();
                 }
@@ -589,7 +605,7 @@ public class CodeActionEndToEndTest : SingleServerDelegatingEndpointTestBase
             namespace {{@namespace}};
             public partial class test
             {
-                private void DoesNotExist()
+                private void DoesNotExist(Microsoft.AspNetCore.Components.Web.MouseEventArgs e)
                 {
                     throw new System.NotImplementedException();
                 }
@@ -628,7 +644,7 @@ public class CodeActionEndToEndTest : SingleServerDelegatingEndpointTestBase
             File.WriteAllText(codeBehindFilePath, initialCodeBehindContent);
 
             var result = await GetCodeActionsAsync(uri, textSpan, razorSourceText, requestContext, razorCodeActionProviders: new[] { new GenerateMethodCodeActionProvider() }, diagnostics);
-            var changes = await GetEditsAsync(result, requestContext, "Generate Event Handler 'DoesNotExist'", createRazorCodeActionResolversFn: () => new[] { new GenerateMethodCodeActionResolver(DocumentContextFactory, TestRazorLSPOptionsMonitor.Create()) });
+            var changes = await GetEditsAsync(result, requestContext, "Generate Event Handler 'DoesNotExist'", CreateRazorCodeActionResolversFn(razorFilePath, codeDocument));
 
             var razorEdits = new List<TextChange>();
             var codeBehindEdits = new List<TextChange>();
@@ -663,7 +679,8 @@ public class CodeActionEndToEndTest : SingleServerDelegatingEndpointTestBase
         string codeAction,
         int childActionIndex = 0,
         IRazorCodeActionProvider[]? razorCodeActionProviders = null,
-        Func<IRazorCodeActionResolver[]>? createRazorCodeActionResolversFn = null,
+        Func<string, RazorCodeDocument, RazorLSPOptionsMonitor?, IRazorCodeActionResolver[]>? createRazorCodeActionResolversFn = null,
+        RazorLSPOptionsMonitor? optionsMonitor = null,
         Diagnostic[]? diagnostics = null)
     {
         TestFileMarkupParser.GetSpan(input, out input, out var textSpan);
@@ -678,7 +695,11 @@ public class CodeActionEndToEndTest : SingleServerDelegatingEndpointTestBase
 
         var result = await GetCodeActionsAsync(uri, textSpan, sourceText, requestContext, razorCodeActionProviders, diagnostics);
         Assert.NotEmpty(result);
-        var changes = await GetEditsAsync(result, requestContext, codeAction, childActionIndex, createRazorCodeActionResolversFn);
+
+        var razorCodeActionResolvers = createRazorCodeActionResolversFn is null
+            ? Array.Empty<IRazorCodeActionResolver>()
+            : createRazorCodeActionResolversFn(razorFilePath, codeDocument, optionsMonitor);
+        var changes = await GetEditsAsync(result, requestContext, codeAction, razorCodeActionResolvers, childActionIndex);
 
         var edits = new List<TextChange>();
         foreach (var change in changes)
@@ -734,8 +755,8 @@ public class CodeActionEndToEndTest : SingleServerDelegatingEndpointTestBase
         SumType<Command, CodeAction>[] result,
         RazorRequestContext requestContext,
         string codeAction,
-        int childActionIndex = 0,
-        Func<IRazorCodeActionResolver[]>? createRazorCodeActionResolversFn = null)
+        IRazorCodeActionResolver[] razorCodeActionResolvers,
+        int childActionIndex = 0)
     {
         var codeActionToRun = (VSInternalCodeAction)result.Single(e => ((RazorVSInternalCodeAction)e.Value!).Name == codeAction || ((RazorVSInternalCodeAction)e.Value!).Title == codeAction);
 
@@ -752,7 +773,7 @@ public class CodeActionEndToEndTest : SingleServerDelegatingEndpointTestBase
         };
         var htmlCodeActionResolvers = Array.Empty<HtmlCodeActionResolver>();
 
-        var resolveEndpoint = new CodeActionResolveEndpoint(createRazorCodeActionResolversFn is null ? Array.Empty<IRazorCodeActionResolver>() : createRazorCodeActionResolversFn(), csharpCodeActionResolvers, htmlCodeActionResolvers, LoggerFactory);
+        var resolveEndpoint = new CodeActionResolveEndpoint(razorCodeActionResolvers, csharpCodeActionResolvers, htmlCodeActionResolvers, LoggerFactory);
 
         var resolveResult = await resolveEndpoint.HandleRequestAsync(codeActionToRun, requestContext, DisposalToken);
 
@@ -762,5 +783,46 @@ public class CodeActionEndToEndTest : SingleServerDelegatingEndpointTestBase
         Assert.True(workspaceEdit.TryGetDocumentChanges(out var changes));
 
         return changes;
+    }
+
+    private class GenerateMethodResolverDocumentContextFactory : TestDocumentContextFactory
+    {
+        private readonly List<TagHelperDescriptor> _tagHelperDescriptors;
+
+        public GenerateMethodResolverDocumentContextFactory
+            (string filePath,
+            RazorCodeDocument codeDocument,
+            TagHelperDescriptor[]? tagHelpers = null,
+            int? version = null)
+            : base(filePath, codeDocument, version)
+        {
+
+            _tagHelperDescriptors = new() { CreateOnClickTagHelperDescriptor() };
+            if (tagHelpers is not null)
+            {
+                _tagHelperDescriptors.AddRange(tagHelpers);
+            }
+        }
+
+        public override Task<VersionedDocumentContext?> TryCreateForOpenDocumentAsync(Uri documentUri, CancellationToken cancellationToken)
+        {
+            if (FilePath is null || _codeDocument is null)
+            {
+                return Task.FromResult<VersionedDocumentContext?>(null);
+            }
+
+            var projectWorkspaceState = new ProjectWorkspaceState(_tagHelperDescriptors.ToImmutableArray(), LanguageVersion.Default);
+            var testDocumentSnapshot = TestDocumentSnapshot.Create(FilePath, _codeDocument.GetSourceText().ToString(), CodeAnalysis.VersionStamp.Default, projectWorkspaceState);
+            testDocumentSnapshot.With(_codeDocument);
+
+            return Task.FromResult<VersionedDocumentContext?>(CreateDocumentContext(new Uri(FilePath), testDocumentSnapshot));
+        }
+
+        private static TagHelperDescriptor CreateOnClickTagHelperDescriptor()
+        {
+            var builder = TagHelperDescriptorBuilder.Create("onclick", "Microsoft.AspNetCore.Components");
+            builder.SetMetadata(new KeyValuePair<string, string>("Components.EventHandler.EventArgs", "Microsoft.AspNetCore.Components.Web.MouseEventArgs"));
+            return builder.Build();
+        }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndToEndTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndToEndTest.cs
@@ -850,14 +850,14 @@ public class CodeActionEndToEndTest : SingleServerDelegatingEndpointTestBase
 
         public override Task<VersionedDocumentContext?> TryCreateForOpenDocumentAsync(Uri documentUri, CancellationToken cancellationToken)
         {
-            if (FilePath is null || _codeDocument is null)
+            if (FilePath is null || CodeDocument is null)
             {
                 return Task.FromResult<VersionedDocumentContext?>(null);
             }
 
             var projectWorkspaceState = new ProjectWorkspaceState(_tagHelperDescriptors.ToImmutableArray(), LanguageVersion.Default);
-            var testDocumentSnapshot = TestDocumentSnapshot.Create(FilePath, _codeDocument.GetSourceText().ToString(), CodeAnalysis.VersionStamp.Default, projectWorkspaceState);
-            testDocumentSnapshot.With(_codeDocument);
+            var testDocumentSnapshot = TestDocumentSnapshot.Create(FilePath, CodeDocument.GetSourceText().ToString(), CodeAnalysis.VersionStamp.Default, projectWorkspaceState);
+            testDocumentSnapshot.With(CodeDocument);
 
             return Task.FromResult<VersionedDocumentContext?>(CreateDocumentContext(new Uri(FilePath), testDocumentSnapshot));
         }


### PR DESCRIPTION
﻿### Summary of the changes
Related: #4381 

- 1st commit:
    - Uses information from project.razor.json to add fully qualified type parameters to the generate event handler code action. Note that this also takes care of user defined events and event args.
    - Update tests to reflect the new parameters. 
- 2nd commit:
    - Provide a lightbulb to generate the async version of the generate event handler since blazor supports async event callbacks.
    - Add some more test scenarios that test generating the async version.

VS:

![eventhandlerv2](https://github.com/dotnet/razor/assets/30007367/23cdd884-3e87-4cac-9fce-03d340df71d4)

VSCode:
![eventhandlerv2vscode](https://github.com/dotnet/razor/assets/30007367/17b954e4-0f43-427a-9c1c-d265ba81c8fb)
