### PR TITLE
Don't mark Utilities.Shared package ref as PrivateAssets="All"

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.csproj
@@ -17,8 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- This is marked with PrivateAssets="All" to avoid exposing this internal dependency to Web Tools. -->
-    <ProjectReference Include="$(SharedSourceRoot)\Microsoft.AspNetCore.Razor.Utilities.Shared\Microsoft.AspNetCore.Razor.Utilities.Shared.csproj" PrivateAssets="All" />
+    <ProjectReference Include="$(SharedSourceRoot)\Microsoft.AspNetCore.Razor.Utilities.Shared\Microsoft.AspNetCore.Razor.Utilities.Shared.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Previously, I had made a change to the ContainedLanguage project to marrk the Utilities.Shared package ref as PrivateAssets="All". However, this is problematics for Web Tools unit tests, which will fail if Utilities.Shared isn't present when exercising ContainedLanguage. To address this, I'm removing PrivateAssets="All" and allowing the project reference to flow through as a dependency of ContainedLanguage. It's not ideal, but this is better than adding a direct dependency on Utilities.Shared to Web Tools' unit tests.