### PR TITLE
Add API analyzers to Utilities.Shared

### DIFF
--- a/src/Shared/Directory.Build.props
+++ b/src/Shared/Directory.Build.props
@@ -12,7 +12,7 @@
     <PublishWindowsPdb Condition="'$(DotNetSymbolServerTokenMsdl)'!='' and '$(DotNetSymbolServerTokenSymWeb)'!=''">true</PublishWindowsPdb>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion)" NoWarn="NU1608" />
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="$(Tooling_MicrosoftCodeAnalysisBannedApiAnalyzersPackageVersion)" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="$(Tooling_RoslynDiagnosticsAnalyzersPackageVersion)" />

--- a/src/Shared/Directory.Build.props
+++ b/src/Shared/Directory.Build.props
@@ -12,4 +12,10 @@
     <PublishWindowsPdb Condition="'$(DotNetSymbolServerTokenMsdl)'!='' and '$(DotNetSymbolServerTokenSymWeb)'!=''">true</PublishWindowsPdb>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="$(Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion)" NoWarn="NU1608" />
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="$(Tooling_MicrosoftCodeAnalysisBannedApiAnalyzersPackageVersion)" />
+    <PackageReference Include="Roslyn.Diagnostics.Analyzers" Version="$(Tooling_RoslynDiagnosticsAnalyzersPackageVersion)" />
+  </ItemGroup>
+
 </Project>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/.editorconfig
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/.editorconfig
@@ -1,0 +1,2 @@
+[**]
+dotnet_diagnostic.RS0016.severity = error

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/HashAlgorithmOperations.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/HashAlgorithmOperations.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Security.Cryptography;
 
 namespace System;

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.csproj
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.csproj
@@ -24,4 +24,9 @@
     <Using Include="$(ProjectName).Resources" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AdditionalFiles Include="PublicAPI\PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI\PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+
 </Project>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PublicAPI/PublicAPI.Shipped.txt
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PublicAPI/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+﻿#nullable enable

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PublicAPI/PublicAPI.Unshipped.txt
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PublicAPI/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+﻿#nullable enable

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/readme.md
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/readme.md
@@ -1,0 +1,5 @@
+Microsoft.AspNetCore.Razor.Utilities.Shared is used across the compiiler and tooling layers and is not exposed outside of Razor.
+To ensure that nothing from the assembly is shared externally, please follow these rules:
+
+1. Only add internal APIs to this project.
+2. Do not add InternalsVisibleTo for an assembly that is external to Razor compiler or tooling.


### PR DESCRIPTION
Our Utilities.Shared library is intended to only contain internal APIs for use across both Razor compiler and tooling. This change brings in the public API analyzers to ensure that we don't unintentionally add public APIs to Utilities.Shared.
