### PR TITLE
Updates darc dependencies from the .NET Core Tooling Dev channel

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -10,86 +10,86 @@
       <Sha>2b54fbefe764f25c622a0c6b7376bcf561d156cf</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.7.0-3.23326.2">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.7.0-3.23366.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>419ee237406466eebd6bdfbf932a31e26971ec4c</Sha>
+      <Sha>dad7898acd6372d4380612b9f225db0c2cbfa1e9</Sha>
       <SourceBuild RepoName="roslyn" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.CommonLanguageServerProtocol.Framework" Version="4.7.0-3.23326.2">
+    <Dependency Name="Microsoft.CommonLanguageServerProtocol.Framework" Version="4.7.0-3.23366.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>419ee237406466eebd6bdfbf932a31e26971ec4c</Sha>
+      <Sha>dad7898acd6372d4380612b9f225db0c2cbfa1e9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.ExternalAccess.Razor" Version="4.7.0-3.23326.2">
+    <Dependency Name="Microsoft.CodeAnalysis.ExternalAccess.Razor" Version="4.7.0-3.23366.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>419ee237406466eebd6bdfbf932a31e26971ec4c</Sha>
+      <Sha>dad7898acd6372d4380612b9f225db0c2cbfa1e9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.ExternalAccess.RazorCompiler" Version="4.7.0-3.23326.2">
+    <Dependency Name="Microsoft.CodeAnalysis.ExternalAccess.RazorCompiler" Version="4.7.0-3.23366.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>419ee237406466eebd6bdfbf932a31e26971ec4c</Sha>
+      <Sha>dad7898acd6372d4380612b9f225db0c2cbfa1e9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.CSharp" Version="4.7.0-3.23326.2">
+    <Dependency Name="Microsoft.CodeAnalysis.ExternalAccess.OmniSharp.CSharp" Version="4.7.0-3.23366.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>419ee237406466eebd6bdfbf932a31e26971ec4c</Sha>
+      <Sha>dad7898acd6372d4380612b9f225db0c2cbfa1e9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Common" Version="4.7.0-3.23326.2">
+    <Dependency Name="Microsoft.CodeAnalysis.Common" Version="4.7.0-3.23366.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>419ee237406466eebd6bdfbf932a31e26971ec4c</Sha>
+      <Sha>dad7898acd6372d4380612b9f225db0c2cbfa1e9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.7.0-3.23326.2">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.7.0-3.23366.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>419ee237406466eebd6bdfbf932a31e26971ec4c</Sha>
+      <Sha>dad7898acd6372d4380612b9f225db0c2cbfa1e9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.EditorFeatures" Version="4.7.0-3.23326.2">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.EditorFeatures" Version="4.7.0-3.23366.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>419ee237406466eebd6bdfbf932a31e26971ec4c</Sha>
+      <Sha>dad7898acd6372d4380612b9f225db0c2cbfa1e9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="4.7.0-3.23326.2">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="4.7.0-3.23366.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>419ee237406466eebd6bdfbf932a31e26971ec4c</Sha>
+      <Sha>dad7898acd6372d4380612b9f225db0c2cbfa1e9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0-3.23326.2">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0-3.23366.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>419ee237406466eebd6bdfbf932a31e26971ec4c</Sha>
+      <Sha>dad7898acd6372d4380612b9f225db0c2cbfa1e9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures" Version="4.7.0-3.23326.2">
+    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures" Version="4.7.0-3.23366.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>419ee237406466eebd6bdfbf932a31e26971ec4c</Sha>
+      <Sha>dad7898acd6372d4380612b9f225db0c2cbfa1e9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Common" Version="4.7.0-3.23326.2">
+    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Common" Version="4.7.0-3.23366.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>419ee237406466eebd6bdfbf932a31e26971ec4c</Sha>
+      <Sha>dad7898acd6372d4380612b9f225db0c2cbfa1e9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Text" Version="4.7.0-3.23326.2">
+    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Text" Version="4.7.0-3.23366.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>419ee237406466eebd6bdfbf932a31e26971ec4c</Sha>
+      <Sha>dad7898acd6372d4380612b9f225db0c2cbfa1e9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Wpf" Version="4.7.0-3.23326.2">
+    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Wpf" Version="4.7.0-3.23366.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>419ee237406466eebd6bdfbf932a31e26971ec4c</Sha>
+      <Sha>dad7898acd6372d4380612b9f225db0c2cbfa1e9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Remote.ServiceHub" Version="4.7.0-3.23326.2">
+    <Dependency Name="Microsoft.CodeAnalysis.Remote.ServiceHub" Version="4.7.0-3.23366.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>419ee237406466eebd6bdfbf932a31e26971ec4c</Sha>
+      <Sha>dad7898acd6372d4380612b9f225db0c2cbfa1e9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.7.0-3.23326.2">
+    <Dependency Name="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.7.0-3.23366.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>419ee237406466eebd6bdfbf932a31e26971ec4c</Sha>
+      <Sha>dad7898acd6372d4380612b9f225db0c2cbfa1e9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.7.0-3.23326.2">
+    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.7.0-3.23366.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>419ee237406466eebd6bdfbf932a31e26971ec4c</Sha>
+      <Sha>dad7898acd6372d4380612b9f225db0c2cbfa1e9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.7.0-3.23326.2">
+    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.7.0-3.23366.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>419ee237406466eebd6bdfbf932a31e26971ec4c</Sha>
+      <Sha>dad7898acd6372d4380612b9f225db0c2cbfa1e9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.VisualStudio.LanguageServices" Version="4.7.0-3.23326.2">
+    <Dependency Name="Microsoft.VisualStudio.LanguageServices" Version="4.7.0-3.23366.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>419ee237406466eebd6bdfbf932a31e26971ec4c</Sha>
+      <Sha>dad7898acd6372d4380612b9f225db0c2cbfa1e9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Test.Utilities" Version="4.7.0-3.23326.2">
+    <Dependency Name="Microsoft.CodeAnalysis.Test.Utilities" Version="4.7.0-3.23366.1">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>419ee237406466eebd6bdfbf932a31e26971ec4c</Sha>
+      <Sha>dad7898acd6372d4380612b9f225db0c2cbfa1e9</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -52,26 +52,26 @@
     <MicrosoftNETCoreBrowserDebugHostTransportPackageVersion>6.0.2-servicing.22064.6</MicrosoftNETCoreBrowserDebugHostTransportPackageVersion>
     <MicrosoftNETCorePlatformsPackageVersion>6.0.1</MicrosoftNETCorePlatformsPackageVersion>
     <MicrosoftSourceBuildIntermediatesourcebuildreferencepackagesPackageVersion>8.0.0-alpha.1.23362.3</MicrosoftSourceBuildIntermediatesourcebuildreferencepackagesPackageVersion>
-    <MicrosoftNetCompilersToolsetPackageVersion>4.7.0-3.23326.2</MicrosoftNetCompilersToolsetPackageVersion>
-    <MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>4.7.0-3.23326.2</MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>
-    <MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>4.7.0-3.23326.2</MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>
-    <MicrosoftCodeAnalysisExternalAccessRazorCompilerPackageVersion>4.7.0-3.23326.2</MicrosoftCodeAnalysisExternalAccessRazorCompilerPackageVersion>
-    <MicrosoftCodeAnalysisExternalAccessOmniSharpCSharpPackageVersion>4.7.0-3.23326.2</MicrosoftCodeAnalysisExternalAccessOmniSharpCSharpPackageVersion>
-    <MicrosoftCodeAnalysisCommonPackageVersion>4.7.0-3.23326.2</MicrosoftCodeAnalysisCommonPackageVersion>
-    <MicrosoftCodeAnalysisCSharpPackageVersion>4.7.0-3.23326.2</MicrosoftCodeAnalysisCSharpPackageVersion>
-    <MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion>4.7.0-3.23326.2</MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.7.0-3.23326.2</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>4.7.0-3.23326.2</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
-    <MicrosoftCodeAnalysisEditorFeaturesPackageVersion>4.7.0-3.23326.2</MicrosoftCodeAnalysisEditorFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisEditorFeaturesCommonPackageVersion>4.7.0-3.23326.2</MicrosoftCodeAnalysisEditorFeaturesCommonPackageVersion>
-    <MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>4.7.0-3.23326.2</MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>
-    <MicrosoftCodeAnalysisEditorFeaturesWpfPackageVersion>4.7.0-3.23326.2</MicrosoftCodeAnalysisEditorFeaturesWpfPackageVersion>
-    <MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>4.7.0-3.23326.2</MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>
-    <MicrosoftCodeAnalysisTestUtilitiesPackageVersion>4.7.0-3.23326.2</MicrosoftCodeAnalysisTestUtilitiesPackageVersion>
-    <MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>4.7.0-3.23326.2</MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>
-    <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>4.7.0-3.23326.2</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
-    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.7.0-3.23326.2</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
-    <MicrosoftVisualStudioLanguageServicesPackageVersion>4.7.0-3.23326.2</MicrosoftVisualStudioLanguageServicesPackageVersion>
+    <MicrosoftNetCompilersToolsetPackageVersion>4.7.0-3.23366.1</MicrosoftNetCompilersToolsetPackageVersion>
+    <MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>4.7.0-3.23366.1</MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>
+    <MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>4.7.0-3.23366.1</MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>
+    <MicrosoftCodeAnalysisExternalAccessRazorCompilerPackageVersion>4.7.0-3.23366.1</MicrosoftCodeAnalysisExternalAccessRazorCompilerPackageVersion>
+    <MicrosoftCodeAnalysisExternalAccessOmniSharpCSharpPackageVersion>4.7.0-3.23366.1</MicrosoftCodeAnalysisExternalAccessOmniSharpCSharpPackageVersion>
+    <MicrosoftCodeAnalysisCommonPackageVersion>4.7.0-3.23366.1</MicrosoftCodeAnalysisCommonPackageVersion>
+    <MicrosoftCodeAnalysisCSharpPackageVersion>4.7.0-3.23366.1</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion>4.7.0-3.23366.1</MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.7.0-3.23366.1</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>4.7.0-3.23366.1</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisEditorFeaturesPackageVersion>4.7.0-3.23366.1</MicrosoftCodeAnalysisEditorFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisEditorFeaturesCommonPackageVersion>4.7.0-3.23366.1</MicrosoftCodeAnalysisEditorFeaturesCommonPackageVersion>
+    <MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>4.7.0-3.23366.1</MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>
+    <MicrosoftCodeAnalysisEditorFeaturesWpfPackageVersion>4.7.0-3.23366.1</MicrosoftCodeAnalysisEditorFeaturesWpfPackageVersion>
+    <MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>4.7.0-3.23366.1</MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>
+    <MicrosoftCodeAnalysisTestUtilitiesPackageVersion>4.7.0-3.23366.1</MicrosoftCodeAnalysisTestUtilitiesPackageVersion>
+    <MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>4.7.0-3.23366.1</MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>4.7.0-3.23366.1</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.7.0-3.23366.1</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
+    <MicrosoftVisualStudioLanguageServicesPackageVersion>4.7.0-3.23366.1</MicrosoftVisualStudioLanguageServicesPackageVersion>
     <MicrosoftSourceLinkGitHubPackageVersion>8.0.0-beta.23361.2</MicrosoftSourceLinkGitHubPackageVersion>
     <MicrosoftDotNetXliffTasksPackageVersion>1.0.0-beta.23360.1</MicrosoftDotNetXliffTasksPackageVersion>
     <!--


### PR DESCRIPTION
Noticed that with the merge of PR #8864 (updating dependencies from arcade) the APIScan started failing on [Razor Tooling Compliance](https://devdiv.visualstudio.com/DevDiv/_build?definitionId=16802) pipeline.

Updating some of the .NET Core Tooling Dev in this PR meanwhile trying to understand why this is happening

@jjonescz @jaredpar 