### PR TITLE
Handles `IOException` for `DirectoryHelper.GetDirectories`

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DirectoryHelper.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DirectoryHelper.cs
@@ -106,6 +106,11 @@ internal static class DirectoryHelper
             logger?.LogWarning("PathTooLong: {exception}", ex.Message);
             yield break;
         }
+        catch (IOException ex)
+        {
+            logger?.LogWarning("IOException: {exception}", ex.Message);
+            yield break;
+        }
 
         foreach (var path in directories)
         {


### PR DESCRIPTION
Fixes https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1813770/

Adding the missing `IOException` catch for `DirectoryHelper.GetDirectory` similar to how `DirectoryHelper.GetFiles` already has it.

Related to PR dotnet/razor#8219
