### PR TITLE
Don't log task cancellations to the output window

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -1127,7 +1127,10 @@ internal class DefaultRazorLanguageServerCustomMessageTarget : RazorLanguageServ
         }
         catch (Exception e)
         {
-            _outputWindowLogger?.LogError(e, "Exception thrown in PullDiagnostic delegation");
+            if (e is not OperationCanceledException)
+            {
+                _outputWindowLogger?.LogError(e, "Exception thrown in PullDiagnostic delegation");
+            }
             // Return null if any of the tasks getting diagnostics results in an error
             return null;
         }


### PR DESCRIPTION
It came up at triage today, that a user found a lot of task cancelled exceptions in the output window, and perhaps because of that detail, didn't include much info about the actual issue they were running into. Either way, these serve no useful purpose.