### PR TITLE
Fixes indentation issue caused by regex in onEnterRules

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/language-configuration.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/language-configuration.json
@@ -30,14 +30,14 @@
   },
   "onEnterRules": [
     {
-      "beforeText": "<(?!(?:area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr))([_:\\w][_:\\w-.\\d]*)([^/>]*(?!\\/)>)[^<]*$",
+      "beforeText": "<(?!(?:area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr))([_:\\w][_:\\w-.\\d]*)([^/>]*(?!.*(?<!=>)\\/)>)[^<]*$",
       "afterText": "^<\\/([_:\\w][_:\\w-.\\d]*)\\s*>",
       "action": {
         "indent": "indentOutdent"
       }
     },
     {
-      "beforeText": "<(?!(?:area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr))(\\w[\\w\\d]*)([^/>]*(?!\\/)>)[^<]*$",
+      "beforeText": "<(?!(?:area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr))(\\w[\\w\\d]*)([^/>]*(?!.*(?<!=>)\\/)>)[^<]*$",
       "action": {
         "indent": "indent"
       }

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/language-configuration.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/language-configuration.json
@@ -37,7 +37,7 @@
       }
     },
     {
-      "beforeText": "<(?!(?:area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr))(\\w\\w\\d]*)([^/>]*(=>)*[^/>]*(?<!=)(?!\\/)>)[^<]*$",
+      "beforeText": "<(?!(?:area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr))(\\w[\\w\\d]*)([^/>]*(=>)*[^/>]*(?<!=)(?!\\/)>)[^<]*$",
       "action": {
         "indent": "indent"
       }

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/language-configuration.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/language-configuration.json
@@ -30,14 +30,14 @@
   },
   "onEnterRules": [
     {
-      "beforeText": "<(?!(?:area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr))([_:\\w][_:\\w-.\\d]*)([^/>]*(?!.*(?<!=>)\\/)>)[^<]*$",
+      "beforeText": "<(?!(?:area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr))([_:\\w][_:\\w-.\\d]*)([^/>]*(=>)*[^/>]*(?<!=)(?!\\/)>)[^<]*$",
       "afterText": "^<\\/([_:\\w][_:\\w-.\\d]*)\\s*>",
       "action": {
         "indent": "indentOutdent"
       }
     },
     {
-      "beforeText": "<(?!(?:area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr))(\\w[\\w\\d]*)([^/>]*(?!.*(?<!=>)\\/)>)[^<]*$",
+      "beforeText": "<(?!(?:area|base|br|col|embed|hr|img|input|keygen|link|menuitem|meta|param|source|track|wbr))(\\w\\w\\d]*)([^/>]*(=>)*[^/>]*(?<!=)(?!\\/)>)[^<]*$",
       "action": {
         "indent": "indent"
       }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageConfigurationTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageConfigurationTest.cs
@@ -38,7 +38,7 @@ public class LanguageConfigurationTest
     [Theory]
     [InlineData("""<input>$$""")]
     [InlineData("""<input />$$""")]
-    [InlineData("""<PropertyColumn Value="() => true" />$$""", Skip = "https://github.com/dotnet/razor/issues/8916")]
+    [InlineData("""<PropertyColumn Value="() => true" />$$""")]
     public void OnEnter_WontIndent(string input)
     {
         TestFileMarkupParser.GetPosition(input, out input, out var position);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageConfigurationTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageConfigurationTest.cs
@@ -28,6 +28,8 @@ public class LanguageConfigurationTest
     [InlineData("""<div class="hello">$$</div>""")]
     [InlineData("""<div class="@(() => true)">$$""")]
     [InlineData("""<div class="@(() => true)">$$</div>""")]
+    [InlineData("""<PropertyColumn Value="() => true" >$$""")]
+    [InlineData("""<PropertyColumn Value="() => true" >$$</PropertyColumn>""")]
     public void OnEnter_WillIndent(string input)
     {
         TestFileMarkupParser.GetPosition(input, out input, out var position);
@@ -39,6 +41,7 @@ public class LanguageConfigurationTest
     [InlineData("""<input>$$""")]
     [InlineData("""<input />$$""")]
     [InlineData("""<PropertyColumn Value="() => true" />$$""")]
+    [InlineData("""<PropertyColumn />$$""")]
     public void OnEnter_WontIndent(string input)
     {
         TestFileMarkupParser.GetPosition(input, out input, out var position);


### PR DESCRIPTION
The fix updates the regex in `language-configuration.json`

- Allows a lambda containing "=>" in an attribute
- Makes sure the line does not contain self closing tag

Fixes #8916

