### PR TITLE
Updates/Consolidates the two BDN versions to latest

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -104,7 +104,7 @@
     <SystemTextEncodingsWebPackageVersion>6.0.0</SystemTextEncodingsWebPackageVersion>
     <SystemPrivateUriPackageVersion>4.3.2</SystemPrivateUriPackageVersion>
     <MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>5.0.0-preview.4.20205.1</MicrosoftExtensionsNonCapturingTimerSourcesPackageVersion>
-    <BenchmarkDotNetPackageVersion>0.13.2.2052</BenchmarkDotNetPackageVersion>
+    <BenchmarkDotNetPackageVersion>0.13.5.2136</BenchmarkDotNetPackageVersion>
     <MicrosoftBuildLocatorPackageVersion>1.2.6</MicrosoftBuildLocatorPackageVersion>
     <MicrosoftBuildPackageVersion>16.8.0</MicrosoftBuildPackageVersion>
     <MicrosoftDiaSymReaderVersion>2.0.0</MicrosoftDiaSymReaderVersion>
@@ -168,7 +168,6 @@
     <MicrosoftInternalVisualStudioShellFrameworkPackageVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftInternalVisualStudioShellFrameworkPackageVersion>
     <MicrosoftIORedistPackageVersion>6.0.0</MicrosoftIORedistPackageVersion>
     <!-- Compiler Deps -->
-    <BenchmarkDotNetVersion>0.13.2.1938</BenchmarkDotNetVersion>
     <DiffPlexVersion>1.5.0</DiffPlexVersion>
     <FluentAssertionsVersion>6.7.0</FluentAssertionsVersion>
     <MicrosoftAspNetCoreAppVersion>7.0.7</MicrosoftAspNetCoreAppVersion>

--- a/src/Compiler/Directory.Packages.props
+++ b/src/Compiler/Directory.Packages.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <ItemGroup>
-    <PackageVersion Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
-    <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="$(BenchmarkDotNetVersion)" />
+    <PackageVersion Include="BenchmarkDotNet" Version="$(BenchmarkDotNetPackageVersion)" />
+    <PackageVersion Include="BenchmarkDotNet.Diagnostics.Windows" Version="$(BenchmarkDotNetPackageVersion)" />
     <PackageVersion Include="DiffPlex" Version="$(DiffPlexVersion)" />
     <PackageVersion Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.App.Runtime.$(NetCoreSDKRuntimeIdentifier)" Version="$(MicrosoftAspNetCoreAppVersion)" />

--- a/src/Compiler/perf/Microsoft.AspNetCore.Razor.Microbenchmarks.Generator/Program.cs
+++ b/src/Compiler/perf/Microsoft.AspNetCore.Razor.Microbenchmarks.Generator/Program.cs
@@ -35,7 +35,7 @@ var reports =
     from summary in results
     from report in summary.Reports
     where !summary.IsBaseline(report.BenchmarkCase)
-    let baselineCase = summary.GetBaseline(summary.GetLogicalGroupKey(report.BenchmarkCase))
+    let baselineCase = summary.GetBaseline(summary.GetLogicalGroupKey(report.BenchmarkCase)!)
     let baseline = summary.Reports.Single(r => r.BenchmarkCase == baselineCase)
     select (report, baseline);
 
@@ -45,7 +45,7 @@ foreach ((var benchmark, var baseline) in reports)
     // Note: there are actual statistical tests we could do here, but this should suffice.
     // We can invest more if we see consistent false positives
 
-    var ratio = benchmark.ResultStatistics.Mean / baseline.ResultStatistics.Mean;
+    var ratio = benchmark.ResultStatistics!.Mean / baseline.ResultStatistics!.Mean;
 
     if (ratio > 1.1)
     {


### PR DESCRIPTION
- Noticed two separate versions of BenchmarkDotNet being used not sure if it's really needed to be different.

Traced down when we originally ended up with both versions on this file, it started here: https://github.com/dotnet/razor/commit/108a63cffcd5deadbd045bf0f1f92061bb0c85b2

I think both can be consolidated into one.