### PR TITLE
Update all† of our code to understand that documents can be in multiple projects

### DIFF
--- a/SpellingExclusions.dic
+++ b/SpellingExclusions.dic
@@ -1,2 +1,4 @@
 csharp
 Blazor
+csproj
+cshtml

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/BackgroundDocumentGenerator.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Common/BackgroundDocumentGenerator.cs
@@ -20,7 +20,7 @@ internal class BackgroundDocumentGenerator : ProjectSnapshotChangeTrigger
 
     private readonly ProjectSnapshotManagerDispatcher _dispatcher;
     private readonly IEnumerable<DocumentProcessedListener> _listeners;
-    private readonly Dictionary<string, IDocumentSnapshot> _work;
+    private readonly Dictionary<DocumentKey, IDocumentSnapshot> _work;
     private ProjectSnapshotManagerBase? _projectManager;
     private Timer? _timer;
     private bool _solutionIsClosing;
@@ -31,7 +31,7 @@ internal class BackgroundDocumentGenerator : ProjectSnapshotChangeTrigger
     {
         _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
         _listeners = listeners ?? throw new ArgumentNullException(nameof(listeners));
-        _work = new Dictionary<string, IDocumentSnapshot>(StringComparer.Ordinal);
+        _work = new Dictionary<DocumentKey, IDocumentSnapshot>();
     }
 
     // For testing only
@@ -39,7 +39,7 @@ internal class BackgroundDocumentGenerator : ProjectSnapshotChangeTrigger
         ProjectSnapshotManagerDispatcher dispatcher)
     {
         _dispatcher = dispatcher;
-        _work = new Dictionary<string, IDocumentSnapshot>(StringComparer.Ordinal);
+        _work = new Dictionary<DocumentKey, IDocumentSnapshot>();
         _listeners = Enumerable.Empty<DocumentProcessedListener>();
     }
 
@@ -139,8 +139,8 @@ internal class BackgroundDocumentGenerator : ProjectSnapshotChangeTrigger
         {
             // We only want to store the last 'seen' version of any given document. That way when we pick one to process
             // it's always the best version to use.
-            var filePath = document.FilePath.AssumeNotNull();
-            _work[filePath] = document;
+            var key = new DocumentKey(document.Project.Key, document.FilePath.AssumeNotNull());
+            _work[key] = document;
 
             StartWorker();
         }
@@ -164,7 +164,7 @@ internal class BackgroundDocumentGenerator : ProjectSnapshotChangeTrigger
         {
             OnStartingBackgroundWork();
 
-            KeyValuePair<string, IDocumentSnapshot>[] work;
+            KeyValuePair<DocumentKey, IDocumentSnapshot>[] work;
             List<WorkResult> results = new();
             lock (_work)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultDocumentContextFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultDocumentContextFactory.cs
@@ -43,7 +43,8 @@ internal class DefaultDocumentContextFactory : DocumentContextFactory
 
         var documentAndVersion = await _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(() =>
         {
-            if (_snapshotResolver.TryResolveDocument(filePath,  out var documentSnapshot))
+            // TODO: Supply a ProjectKey from the ProjectContext attached to the Uri somehow
+            if (_snapshotResolver.TryResolveDocumentInAnyProject(filePath,  out var documentSnapshot))
             {
                 if (!versioned)
                 {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentPublisher.cs
@@ -17,8 +17,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
 internal class DefaultGeneratedDocumentPublisher : GeneratedDocumentPublisher
 {
-    private readonly Dictionary<string, PublishData> _publishedCSharpData;
-    private readonly Dictionary<string, PublishData> _publishedHtmlData;
+    private readonly Dictionary<DocumentKey, PublishData> _publishedCSharpData;
+    private readonly Dictionary<DocumentKey, PublishData> _publishedHtmlData;
     private readonly ClientNotifierServiceBase _server;
     private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
     private readonly ILogger _logger;
@@ -55,8 +55,8 @@ internal class DefaultGeneratedDocumentPublisher : GeneratedDocumentPublisher
         _server = server;
         _languageServerFeatureOptions = languageServerFeatureOptions;
         _logger = loggerFactory.CreateLogger<DefaultGeneratedDocumentPublisher>();
-        _publishedCSharpData = new Dictionary<string, PublishData>(FilePathComparer.Instance);
-        _publishedHtmlData = new Dictionary<string, PublishData>(FilePathComparer.Instance);
+        _publishedCSharpData = new Dictionary<DocumentKey, PublishData>();
+        _publishedHtmlData = new Dictionary<DocumentKey, PublishData>();
     }
 
     public override void Initialize(ProjectSnapshotManagerBase projectManager)
@@ -70,7 +70,7 @@ internal class DefaultGeneratedDocumentPublisher : GeneratedDocumentPublisher
         _projectSnapshotManager.Changed += ProjectSnapshotManager_Changed;
     }
 
-    public override void PublishCSharp(string filePath, SourceText sourceText, int hostDocumentVersion)
+    public override void PublishCSharp(ProjectKey projectKey, string filePath, SourceText sourceText, int hostDocumentVersion)
     {
         if (filePath is null)
         {
@@ -84,7 +84,8 @@ internal class DefaultGeneratedDocumentPublisher : GeneratedDocumentPublisher
 
         _projectSnapshotManagerDispatcher.AssertDispatcherThread();
 
-        if (!_publishedCSharpData.TryGetValue(filePath, out var previouslyPublishedData))
+        var key = new DocumentKey(projectKey, filePath);
+        if (!_publishedCSharpData.TryGetValue(key, out var previouslyPublishedData))
         {
             previouslyPublishedData = PublishData.Default;
         }
@@ -102,8 +103,9 @@ internal class DefaultGeneratedDocumentPublisher : GeneratedDocumentPublisher
             var currentDocumentLength = sourceText.Length;
             var documentLengthDelta = sourceText.Length - previousDocumentLength;
             _logger.LogTrace(
-                "Updating C# buffer of {0} to correspond with host document version {1}. {2} -> {3} = Change delta of {4} via {5} text changes.",
+                "Updating C# buffer of {0} for project {1} to correspond with host document version {2}. {3} -> {4} = Change delta of {5} via {6} text changes.",
                 filePath,
+                projectKey,
                 hostDocumentVersion,
                 previousDocumentLength,
                 currentDocumentLength,
@@ -111,11 +113,12 @@ internal class DefaultGeneratedDocumentPublisher : GeneratedDocumentPublisher
                 textChanges.Count);
         }
 
-        _publishedCSharpData[filePath] = new PublishData(sourceText, hostDocumentVersion);
+        _publishedCSharpData[key] = new PublishData(sourceText, hostDocumentVersion);
 
         var request = new UpdateBufferRequest()
         {
             HostDocumentFilePath = filePath,
+            ProjectKeyId = projectKey.Id,
             Changes = textChanges,
             HostDocumentVersion = hostDocumentVersion,
         };
@@ -123,7 +126,7 @@ internal class DefaultGeneratedDocumentPublisher : GeneratedDocumentPublisher
         _ = _server.SendNotificationAsync(RazorLanguageServerCustomMessageTargets.RazorUpdateCSharpBufferEndpoint, request, CancellationToken.None);
     }
 
-    public override void PublishHtml(string filePath, SourceText sourceText, int hostDocumentVersion)
+    public override void PublishHtml(ProjectKey projectKey, string filePath, SourceText sourceText, int hostDocumentVersion)
     {
         if (filePath is null)
         {
@@ -137,7 +140,8 @@ internal class DefaultGeneratedDocumentPublisher : GeneratedDocumentPublisher
 
         _projectSnapshotManagerDispatcher.AssertDispatcherThread();
 
-        if (!_publishedHtmlData.TryGetValue(filePath, out var previouslyPublishedData))
+        var key = new DocumentKey(projectKey, filePath);
+        if (!_publishedHtmlData.TryGetValue(key, out var previouslyPublishedData))
         {
             previouslyPublishedData = PublishData.Default;
         }
@@ -164,11 +168,12 @@ internal class DefaultGeneratedDocumentPublisher : GeneratedDocumentPublisher
                 textChanges.Count);
         }
 
-        _publishedHtmlData[filePath] = new PublishData(sourceText, hostDocumentVersion);
+        _publishedHtmlData[key] = new PublishData(sourceText, hostDocumentVersion);
 
         var request = new UpdateBufferRequest()
         {
             HostDocumentFilePath = filePath,
+            ProjectKeyId = projectKey.Id,
             Changes = textChanges,
             HostDocumentVersion = hostDocumentVersion,
         };
@@ -194,6 +199,7 @@ internal class DefaultGeneratedDocumentPublisher : GeneratedDocumentPublisher
                 Assumes.NotNull(args.DocumentFilePath);
                 if (!_projectSnapshotManager.IsDocumentOpen(args.DocumentFilePath))
                 {
+                    var key = new DocumentKey(args.ProjectKey.AssumeNotNull(), args.DocumentFilePath);
                     // Document closed, evict published source text, unless the server doesn't want us to.
                     if (_languageServerFeatureOptions.UpdateBuffersForClosedDocuments)
                     {
@@ -202,9 +208,9 @@ internal class DefaultGeneratedDocumentPublisher : GeneratedDocumentPublisher
                         return;
                     }
 
-                    if (_publishedCSharpData.ContainsKey(args.DocumentFilePath))
+                    if (_publishedCSharpData.ContainsKey(key))
                     {
-                        var removed = _publishedCSharpData.Remove(args.DocumentFilePath);
+                        var removed = _publishedCSharpData.Remove(key);
                         if (!removed)
                         {
                             _logger.LogError("Published data should be protected by the project snapshot manager's thread and should never fail to remove.");
@@ -212,9 +218,9 @@ internal class DefaultGeneratedDocumentPublisher : GeneratedDocumentPublisher
                         }
                     }
 
-                    if (_publishedHtmlData.ContainsKey(args.DocumentFilePath))
+                    if (_publishedHtmlData.ContainsKey(key))
                     {
-                        var removed = _publishedHtmlData.Remove(args.DocumentFilePath);
+                        var removed = _publishedHtmlData.Remove(key);
                         if (!removed)
                         {
                             _logger.LogError("Published data should be protected by the project snapshot manager's thread and should never fail to remove.");

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/GeneratedDocumentPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/GeneratedDocumentPublisher.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
 internal abstract class GeneratedDocumentPublisher : ProjectSnapshotChangeTrigger
 {
-    public abstract void PublishCSharp(string filePath, SourceText sourceText, int hostDocumentVersion);
+    public abstract void PublishCSharp(ProjectKey projectKey, string filePath, SourceText sourceText, int hostDocumentVersion);
 
-    public abstract void PublishHtml(string filePath, SourceText sourceText, int hostDocumentVersion);
+    public abstract void PublishHtml(ProjectKey projectKey, string filePath, SourceText sourceText, int hostDocumentVersion);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/GeneratedDocumentSynchronizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/GeneratedDocumentSynchronizer.cs
@@ -42,10 +42,10 @@ internal class GeneratedDocumentSynchronizer : DocumentProcessedListener
 
         var htmlText = codeDocument.GetHtmlSourceText();
 
-        _publisher.PublishHtml(filePath, htmlText, hostDocumentVersion.Value);
+        _publisher.PublishHtml(document.Project.Key, filePath, htmlText, hostDocumentVersion.Value);
 
         var csharpText = codeDocument.GetCSharpSourceText();
 
-        _publisher.PublishCSharp(filePath, csharpText, hostDocumentVersion.Value);
+        _publisher.PublishCSharp(document.Project.Key, filePath, csharpText, hostDocumentVersion.Value);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/OpenDocumentGenerator.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/OpenDocumentGenerator.cs
@@ -169,15 +169,14 @@ internal class OpenDocumentGenerator : ProjectSnapshotChangeTrigger, IDisposable
 
                 void TryEnqueue(IDocumentSnapshot document)
                 {
-                    var filePath = document.FilePath.AssumeNotNull();
-
-                    if (!ProjectManager.IsDocumentOpen(filePath) && !_languageServerFeatureOptions.UpdateBuffersForClosedDocuments)
+                    if (!ProjectManager.IsDocumentOpen(document.FilePath) && !_languageServerFeatureOptions.UpdateBuffersForClosedDocuments)
                     {
                         return;
                     }
 
+                    var key = $"{document.Project.Key.Id}:{document.FilePath.AssumeNotNull()}";
                     var workItem = new ProcessWorkItem(document, _documentProcessedListeners, _projectSnapshotManagerDispatcher);
-                    _workQueue.Enqueue(filePath, workItem);
+                    _workQueue.Enqueue(key, workItem);
                 }
         }
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/ISnapshotResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/ISnapshotResolver.cs
@@ -16,7 +16,13 @@ internal interface ISnapshotResolver
     IProjectSnapshot GetMiscellaneousProject();
 
     /// <summary>
-    /// Finds a <see cref="IDocumentSnapshot"/> for the given document path that is contained within a project.
+    /// Finds a <see cref="IDocumentSnapshot"/> for the given document path that is contained within any project, and returns the first
+    /// one found if it does. This method should be avoided where possible, and the overload that takes a <see cref="ProjectKey"/> should be used instead
     /// </summary>
-    bool TryResolveDocument(string documentFilePath, [NotNullWhen(true)] out IDocumentSnapshot? documentSnapshot);
+    bool TryResolveDocumentInAnyProject(string documentFilePath, [NotNullWhen(true)] out IDocumentSnapshot? documentSnapshot);
+
+    /// <summary>
+    /// Finds a <see cref="IDocumentSnapshot"/> for the given document path that is contained within the given project.
+    /// </summary>
+    bool TryResolveDocument(ProjectKey projectKey, string textDocumentPath, [NotNullWhen(true)] out IDocumentSnapshot? documentSnapshot);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/SnapshotResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/SnapshotResolver.cs
@@ -69,7 +69,7 @@ internal class SnapshotResolver : ISnapshotResolver
         return miscellaneousProject;
     }
 
-    public bool TryResolveDocument(string documentFilePath, [NotNullWhen(true)] out IDocumentSnapshot? documentSnapshot)
+    public bool TryResolveDocumentInAnyProject(string documentFilePath, [NotNullWhen(true)] out IDocumentSnapshot? documentSnapshot)
     {
         _logger.LogTrace("Looking for {documentFilePath}.", documentFilePath);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/SnapshotResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/SnapshotResolver.cs
@@ -106,4 +106,30 @@ internal class SnapshotResolver : ISnapshotResolver
         documentSnapshot = null;
         return false;
     }
+
+    public bool TryResolveDocument(ProjectKey projectKey, string documentFilePath, [NotNullWhen(true)] out IDocumentSnapshot? documentSnapshot)
+    {
+        _logger.LogTrace("Looking for {documentFilePath} in {projectKey}.", documentFilePath, projectKey);
+
+        documentSnapshot = null;
+
+        var project = _projectSnapshotManagerAccessor.Instance.GetLoadedProject(projectKey);
+        if (project is null)
+        {
+            _logger.LogTrace("Could not find project {projectKey}", projectKey);
+            return false;
+        }
+
+        var normalizedDocumentPath = FilePathNormalizer.Normalize(documentFilePath);
+
+        if (project.GetDocument(normalizedDocumentPath) is { } document)
+        {
+            documentSnapshot = document;
+            _logger.LogTrace("Found {documentFilePath} in in {projectKey}.", documentFilePath, projectKey);
+            return true;
+        }
+
+        _logger.LogTrace("{documentFilePath} not found in {projectKey}", documentFilePath, projectKey);
+        return false;
+    }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/UpdateBufferRequest.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/UpdateBufferRequest.cs
@@ -10,6 +10,8 @@ public class UpdateBufferRequest
 {
     public int? HostDocumentVersion { get; set; }
 
+    public string? ProjectKeyId { get; set; }
+
     public required string HostDocumentFilePath { get; set; }
 
     public required IReadOnlyList<TextChange> Changes { get; set; }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultRazorDynamicFileInfoProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultRazorDynamicFileInfoProvider.cs
@@ -30,6 +30,8 @@ internal class DefaultRazorDynamicFileInfoProvider : RazorDynamicFileInfoProvide
     private readonly LSPEditorFeatureDetector _lspEditorFeatureDetector;
     private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
 
+    private ProjectSnapshotManagerBase _projectManager;
+
     [ImportingConstructor]
     public DefaultRazorDynamicFileInfoProvider(
         RazorDocumentServiceProviderFactory factory,
@@ -63,6 +65,8 @@ internal class DefaultRazorDynamicFileInfoProvider : RazorDynamicFileInfoProvide
     public override void Initialize(ProjectSnapshotManagerBase projectManager)
     {
         projectManager.Changed += ProjectManager_Changed;
+
+        _projectManager = projectManager;
     }
 
     // Called by us to update LSP document entries
@@ -82,29 +86,34 @@ internal class DefaultRazorDynamicFileInfoProvider : RazorDynamicFileInfoProvide
         // We report diagnostics are supported to Roslyn in this case
         documentContainer.SupportsDiagnostics = true;
 
+        // TODO: This needs to use the project key somehow, rather than assuming all generated content is the same
         var filePath = GetProjectSystemFilePath(documentUri);
-        if (!TryGetKeyAndEntry(filePath, out var associatedKvp))
+
+        var foundAny = false;
+        foreach (var associatedKvp in GetAllKeysForPath(filePath))
         {
-            return;
+            foundAny = true;
+            var associatedKey = associatedKvp.Key;
+            var associatedEntry = associatedKvp.Value;
+
+            lock (associatedEntry.Lock)
+            {
+                associatedEntry.Current = CreateInfo(associatedKey, documentContainer);
+            }
         }
 
-        var associatedKey = associatedKvp.Value.Key;
-        var associatedEntry = associatedKvp.Value.Value;
-
-        lock (associatedEntry.Lock)
+        if (foundAny)
         {
-            associatedEntry.Current = CreateInfo(associatedKey, documentContainer);
+            Updated?.Invoke(this, filePath);
         }
-
-        Updated?.Invoke(this, filePath);
     }
 
     // Called by us to update entries
-    public override void UpdateFileInfo(string projectFilePath, DynamicDocumentContainer documentContainer)
+    public override void UpdateFileInfo(ProjectKey projectKey, DynamicDocumentContainer documentContainer)
     {
-        if (projectFilePath is null)
+        if (projectKey is null)
         {
-            throw new ArgumentNullException(nameof(projectFilePath));
+            throw new ArgumentNullException(nameof(projectKey));
         }
 
         if (documentContainer is null)
@@ -121,7 +130,13 @@ internal class DefaultRazorDynamicFileInfoProvider : RazorDynamicFileInfoProvide
         // There's a possible race condition here where we're processing an update
         // and the project is getting unloaded. So if we don't find an entry we can
         // just ignore it.
-        var key = new Key(projectFilePath, documentContainer.FilePath);
+        var projectId = TryFindProjectIdForProjectKey(projectKey);
+        if (projectId is null)
+        {
+            return;
+        }
+
+        var key = new Key(projectId, documentContainer.FilePath);
         if (_entries.TryGetValue(key, out var entry))
         {
             lock (entry.Lock)
@@ -147,56 +162,51 @@ internal class DefaultRazorDynamicFileInfoProvider : RazorDynamicFileInfoProvide
             throw new ArgumentNullException(nameof(propertiesService));
         }
 
+        // TODO: This needs to use the project key somehow, rather than assuming all generated content is the same
         var filePath = GetProjectSystemFilePath(documentUri);
-        if (!TryGetKeyAndEntry(filePath, out var associatedKvp))
+        foreach (var associatedKvp in GetAllKeysForPath(filePath))
         {
-            return;
-        }
+            var associatedKey = associatedKvp.Key;
+            var associatedEntry = associatedKvp.Value;
 
-        var associatedKey = associatedKvp.Value.Key;
-        var associatedEntry = associatedKvp.Value.Value;
+            var filename = _languageServerFeatureOptions.GetRazorCSharpFilePath(associatedKey.FilePath);
 
-        var filename = _languageServerFeatureOptions.GetRazorCSharpFilePath(associatedKey.FilePath);
+            // To promote the background document, we just need to add the passed in properties service to
+            // the dynamic file info. The properties service contains the client name and allows the C#
+            // server to recognize the document.
+            var documentServiceProvider = associatedEntry.Current.DocumentServiceProvider;
+            var excerptService = documentServiceProvider.GetService<IRazorDocumentExcerptServiceImplementation>();
+            var mappingService = documentServiceProvider.GetService<IRazorSpanMappingService>();
+            var emptyContainer = new PromotedDynamicDocumentContainer(
+                documentUri, propertiesService, excerptService, mappingService, associatedEntry.Current.TextLoader);
 
-        // To promote the background document, we just need to add the passed in properties service to
-        // the dynamic file info. The properties service contains the client name and allows the C#
-        // server to recognize the document.
-        var documentServiceProvider = associatedEntry.Current.DocumentServiceProvider;
-        var excerptService = documentServiceProvider.GetService<IRazorDocumentExcerptServiceImplementation>();
-        var mappingService = documentServiceProvider.GetService<IRazorSpanMappingService>();
-        var emptyContainer = new PromotedDynamicDocumentContainer(
-            documentUri, propertiesService, excerptService, mappingService, associatedEntry.Current.TextLoader);
-
-        lock (associatedEntry.Lock)
-        {
-            associatedEntry.Current = new RazorDynamicFileInfo(
-                filename, associatedEntry.Current.SourceCodeKind, associatedEntry.Current.TextLoader, _factory.Create(emptyContainer));
+            lock (associatedEntry.Lock)
+            {
+                associatedEntry.Current = new RazorDynamicFileInfo(
+                    filename, associatedEntry.Current.SourceCodeKind, associatedEntry.Current.TextLoader, _factory.Create(emptyContainer));
+            }
         }
 
         Updated?.Invoke(this, filePath);
     }
 
-    private bool TryGetKeyAndEntry(string filePath, out KeyValuePair<Key, Entry>? associatedKvp)
+    private IEnumerable<KeyValuePair<Key, Entry>> GetAllKeysForPath(string filePath)
     {
-        associatedKvp = null;
         foreach (var entry in _entries)
         {
             if (FilePathComparer.Instance.Equals(filePath, entry.Key.FilePath))
             {
-                associatedKvp = entry;
-                return true;
+                yield return entry;
             }
         }
-
-        return false;
     }
 
     // Called by us when a document opens in the editor
-    public override void SuppressDocument(string projectFilePath, string documentFilePath)
+    public override void SuppressDocument(ProjectKey projectKey, string documentFilePath)
     {
-        if (projectFilePath is null)
+        if (projectKey is null)
         {
-            throw new ArgumentNullException(nameof(projectFilePath));
+            throw new ArgumentNullException(nameof(projectKey));
         }
 
         if (documentFilePath is null)
@@ -212,7 +222,13 @@ internal class DefaultRazorDynamicFileInfoProvider : RazorDynamicFileInfoProvide
         // There's a possible race condition here where we're processing an update
         // and the project is getting unloaded. So if we don't find an entry we can
         // just ignore it.
-        var key = new Key(projectFilePath, documentFilePath);
+        var projectId = TryFindProjectIdForProjectKey(projectKey);
+        if (projectId is null)
+        {
+            return;
+        }
+
+        var key = new Key(projectId, documentFilePath);
         if (_entries.TryGetValue(key, out var entry))
         {
             var updated = false;
@@ -244,7 +260,7 @@ internal class DefaultRazorDynamicFileInfoProvider : RazorDynamicFileInfoProvide
             throw new ArgumentNullException(nameof(filePath));
         }
 
-        var key = new Key(projectFilePath, filePath);
+        var key = new Key(projectId, filePath);
         var entry = _entries.GetOrAdd(key, _createEmptyEntry);
         return Task.FromResult(entry.Current);
     }
@@ -271,7 +287,7 @@ internal class DefaultRazorDynamicFileInfoProvider : RazorDynamicFileInfoProvide
         //
         // ----------------------------------------------------------------------------------------------------------------------------------------
 
-        var key = new Key(projectFilePath, filePath);
+        var key = new Key(projectId, filePath);
         _entries.TryRemove(key, out _);
         return Task.CompletedTask;
     }
@@ -291,15 +307,37 @@ internal class DefaultRazorDynamicFileInfoProvider : RazorDynamicFileInfoProvide
             case ProjectChangeKind.ProjectRemoved:
                 {
                     var removedProject = args.Older;
-                    foreach (var documentFilePath in removedProject.DocumentFilePaths)
+
+                    if (TryFindProjectIdForProjectKey(removedProject.Key) is { } projectId)
                     {
-                        var key = new Key(removedProject.FilePath, documentFilePath);
-                        _entries.TryRemove(key, out _);
+                        foreach (var documentFilePath in removedProject.DocumentFilePaths)
+                        {
+                            var key = new Key(projectId, documentFilePath);
+                            _entries.TryRemove(key, out _);
+                        }
                     }
 
                     break;
                 }
         }
+    }
+
+    private ProjectId TryFindProjectIdForProjectKey(ProjectKey key)
+    {
+        if (_projectManager?.Workspace is not { } workspace)
+        {
+            throw new InvalidOperationException("Can not map a ProjectKey to a ProjectId before the project is initialized");
+        }
+
+        foreach (var project in workspace.CurrentSolution.Projects)
+        {
+            if (key.Equals(ProjectKey.From(project)))
+            {
+                return project.Id;
+            }
+        }
+
+        return null;
     }
 
     private RazorDynamicFileInfo CreateEmptyInfo(Key key)
@@ -377,19 +415,19 @@ internal class DefaultRazorDynamicFileInfoProvider : RazorDynamicFileInfoProvide
 
     private readonly struct Key : IEquatable<Key>
     {
-        public readonly string ProjectFilePath;
+        public readonly ProjectId ProjectId;
         public readonly string FilePath;
 
-        public Key(string projectFilePath, string filePath)
+        public Key(ProjectId projectId, string filePath)
         {
-            ProjectFilePath = projectFilePath;
+            ProjectId = projectId;
             FilePath = filePath;
         }
 
         public bool Equals(Key other)
         {
             return
-                FilePathComparer.Instance.Equals(ProjectFilePath, other.ProjectFilePath) &&
+                ProjectId.Equals(other.ProjectId) &&
                 FilePathComparer.Instance.Equals(FilePath, other.FilePath);
         }
 
@@ -401,7 +439,7 @@ internal class DefaultRazorDynamicFileInfoProvider : RazorDynamicFileInfoProvide
         public override int GetHashCode()
         {
             var hash = HashCodeCombiner.Start();
-            hash.Add(ProjectFilePath, FilePathComparer.Instance);
+            hash.Add(ProjectId);
             hash.Add(FilePath, FilePathComparer.Instance);
             return hash;
         }
@@ -486,9 +524,9 @@ internal class DefaultRazorDynamicFileInfoProvider : RazorDynamicFileInfoProvide
             _provider = provider;
         }
 
-        public async Task<TestDynamicFileInfoResult> GetDynamicFileInfoAsync(string projectFilePath, string filePath, CancellationToken cancellationToken)
+        public async Task<TestDynamicFileInfoResult> GetDynamicFileInfoAsync(ProjectId projectId, string filePath, CancellationToken cancellationToken)
         {
-            var result = await _provider.GetDynamicFileInfoAsync(ProjectId.CreateNewId(), projectFilePath, filePath, cancellationToken).ConfigureAwait(false);
+            var result = await _provider.GetDynamicFileInfoAsync(projectId, projectFilePath: string.Empty, filePath, cancellationToken).ConfigureAwait(false);
             return new TestDynamicFileInfoResult(result.FilePath, result.TextLoader);
         }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentKey.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentKey.cs
@@ -2,23 +2,24 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.Extensions.Internal;
 
 namespace Microsoft.CodeAnalysis.Razor;
 
-public readonly struct DocumentKey : IEquatable<DocumentKey>
+internal readonly struct DocumentKey : IEquatable<DocumentKey>
 {
-    public string ProjectFilePath { get; }
+    public ProjectKey ProjectKey { get; }
     public string DocumentFilePath { get; }
 
-    public DocumentKey(string projectFilePath, string documentFilePath)
+    public DocumentKey(ProjectKey projectKey, string documentFilePath)
     {
-        ProjectFilePath = projectFilePath;
+        ProjectKey = projectKey;
         DocumentFilePath = documentFilePath;
     }
 
     public bool Equals(DocumentKey other)
-        => FilePathComparer.Instance.Equals(ProjectFilePath, other.ProjectFilePath) &&
+        => ProjectKey.Equals(other.ProjectKey) &&
            FilePathComparer.Instance.Equals(DocumentFilePath, other.DocumentFilePath);
 
     public override bool Equals(object? obj)
@@ -28,7 +29,7 @@ public readonly struct DocumentKey : IEquatable<DocumentKey>
     public override int GetHashCode()
     {
         var hash = new HashCodeCombiner();
-        hash.Add(ProjectFilePath, FilePathComparer.Instance);
+        hash.Add(ProjectKey);
         hash.Add(DocumentFilePath, FilePathComparer.Instance);
         return hash;
     }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/RazorDynamicFileInfoProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/RazorDynamicFileInfoProvider.cs
@@ -12,7 +12,7 @@ internal abstract class RazorDynamicFileInfoProvider : ProjectSnapshotChangeTrig
 {
     public abstract void UpdateLSPFileInfo(Uri documentUri, DynamicDocumentContainer documentContainer);
 
-    public abstract void UpdateFileInfo(string projectFilePath, DynamicDocumentContainer documentContainer);
+    public abstract void UpdateFileInfo(ProjectKey projectKey, DynamicDocumentContainer documentContainer);
 
-    public abstract void SuppressDocument(string projectFilePath, string documentFilePath);
+    public abstract void SuppressDocument(ProjectKey projectKey, string documentFilePath);
 }

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/BackgroundDocumentGenerator.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/BackgroundDocumentGenerator.cs
@@ -148,6 +148,8 @@ internal class BackgroundDocumentGenerator : ProjectSnapshotChangeTrigger
                 return;
             }
 
+            // TODO: This can't use ProjectFilePath in the key
+
             // We only want to store the last 'seen' version of any given document. That way when we pick one to process
             // it's always the best version to use.
             Work[new DocumentKey(project.FilePath, document.FilePath.AssumeNotNull())] = (project, document);
@@ -269,7 +271,7 @@ internal class BackgroundDocumentGenerator : ProjectSnapshotChangeTrigger
             if (_projectManager.IsDocumentOpen(filePath))
             {
                 _suppressedDocuments.Add(filePath);
-                _infoProvider.SuppressDocument(project.FilePath, filePath);
+                _infoProvider.SuppressDocument(project.Key, filePath);
                 return true;
             }
 
@@ -287,7 +289,7 @@ internal class BackgroundDocumentGenerator : ProjectSnapshotChangeTrigger
             if (!_suppressedDocuments.Contains(filePath))
             {
                 var container = new DefaultDynamicDocumentContainer(document);
-                _infoProvider.UpdateFileInfo(project.FilePath, container);
+                _infoProvider.UpdateFileInfo(project.Key, container);
             }
         }
     }

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/BackgroundDocumentGenerator.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/BackgroundDocumentGenerator.cs
@@ -148,11 +148,9 @@ internal class BackgroundDocumentGenerator : ProjectSnapshotChangeTrigger
                 return;
             }
 
-            // TODO: This can't use ProjectFilePath in the key
-
             // We only want to store the last 'seen' version of any given document. That way when we pick one to process
             // it's always the best version to use.
-            Work[new DocumentKey(project.FilePath, document.FilePath.AssumeNotNull())] = (project, document);
+            Work[new DocumentKey(project.Key, document.FilePath.AssumeNotNull())] = (project, document);
 
             StartWorker();
         }

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Documents/EditorDocumentManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Documents/EditorDocumentManager.cs
@@ -13,6 +13,7 @@ internal abstract class EditorDocumentManager : IWorkspaceService
 {
     public abstract EditorDocument GetOrCreateDocument(
         DocumentKey key,
+        string projectFilePath,
         ProjectKey projectKey,
         EventHandler? changedOnDisk,
         EventHandler? changedInEditor,

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Documents/EditorDocumentManagerBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Documents/EditorDocumentManagerBase.cs
@@ -97,6 +97,7 @@ internal abstract class EditorDocumentManagerBase : EditorDocumentManager
 
     public sealed override EditorDocument GetOrCreateDocument(
         DocumentKey key,
+        string projectFilePath,
         ProjectKey projectKey,
         EventHandler? changedOnDisk,
         EventHandler? changedInEditor,
@@ -118,7 +119,7 @@ internal abstract class EditorDocumentManagerBase : EditorDocumentManager
                 this,
                 ProjectSnapshotManagerDispatcher,
                 JoinableTaskContext,
-                key.ProjectFilePath,
+                projectFilePath,
                 key.DocumentFilePath,
                 projectKey,
                 new FileTextLoader(key.DocumentFilePath, defaultEncoding: null),
@@ -215,7 +216,7 @@ internal abstract class EditorDocumentManagerBase : EditorDocumentManager
 
         lock (Lock)
         {
-            var key = new DocumentKey(document.ProjectFilePath, document.DocumentFilePath);
+            var key = new DocumentKey(document.ProjectKey, document.DocumentFilePath);
             if (_documentsByFilePath.TryGetValue(document.DocumentFilePath, out var documents))
             {
                 documents.Remove(key);

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Documents/EditorDocumentManagerListener.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Documents/EditorDocumentManagerListener.cs
@@ -113,13 +113,13 @@ internal class EditorDocumentManagerListener : ProjectSnapshotChangeTrigger
                         return;
                     }
 
-                    var key = new DocumentKey(e.ProjectFilePath.AssumeNotNull(), e.DocumentFilePath.AssumeNotNull());
+                    var key = new DocumentKey(e.ProjectKey.AssumeNotNull(), e.DocumentFilePath.AssumeNotNull());
 
                     // GetOrCreateDocument needs to be run on the UI thread
                     await _joinableTaskContext.Factory.SwitchToMainThreadAsync(cancellationToken);
 
                     var document = DocumentManager.GetOrCreateDocument(
-                        key, e.ProjectKey.AssumeNotNull(), _onChangedOnDisk, _onChangedInEditor, _onOpened, _onClosed);
+                        key, e.ProjectFilePath.AssumeNotNull(), e.ProjectKey.AssumeNotNull(), _onChangedOnDisk, _onChangedInEditor, _onOpened, _onClosed);
                     if (document.IsOpenInEditor)
                     {
                         _onOpened(document, EventArgs.Empty);
@@ -136,7 +136,7 @@ internal class EditorDocumentManagerListener : ProjectSnapshotChangeTrigger
                     await _joinableTaskContext.Factory.SwitchToMainThreadAsync(cancellationToken);
 
                     if (DocumentManager.TryGetDocument(
-                        new DocumentKey(e.ProjectFilePath.AssumeNotNull(), e.DocumentFilePath.AssumeNotNull()), out var document))
+                        new DocumentKey(e.ProjectKey.AssumeNotNull(), e.DocumentFilePath.AssumeNotNull()), out var document))
                     {
                         // This class 'owns' the document entry so it's safe for us to dispose it.
                         document.Dispose();

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/DefaultRazorLanguageServerCustomMessageTarget.cs
@@ -145,6 +145,8 @@ internal class DefaultRazorLanguageServerCustomMessageTarget : RazorLanguageServ
             return;
         }
 
+        // TODO: Use request.ProjectKeyId somehow
+
         var hostDocumentUri = new Uri(request.HostDocumentFilePath);
         _documentManager.UpdateVirtualDocument<CSharpVirtualDocument>(
             hostDocumentUri,
@@ -172,6 +174,8 @@ internal class DefaultRazorLanguageServerCustomMessageTarget : RazorLanguageServ
         {
             return;
         }
+
+        // TODO: Use request.ProjectKeyId somehow
 
         var hostDocumentUri = new Uri(request.HostDocumentFilePath);
         _documentManager.UpdateVirtualDocument<HtmlVirtualDocument>(

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/UpdateBufferRequest.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/UpdateBufferRequest.cs
@@ -10,6 +10,8 @@ internal class UpdateBufferRequest
 {
     public int? HostDocumentVersion { get; init; }
 
+    public string? ProjectKeyId { get; init; }
+
     public string? HostDocumentFilePath { get; init; }
 
     public required IReadOnlyList<TextChange> Changes { get; init; }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Documents/VisualStudioEditorDocumentManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Documents/VisualStudioEditorDocumentManager.cs
@@ -94,7 +94,7 @@ internal class VisualStudioEditorDocumentManager : EditorDocumentManagerBase
         var cookie = _runningDocumentTable.GetDocumentCookie(document.DocumentFilePath);
         if (cookie != VSConstants.VSCOOKIE_NIL)
         {
-            TrackOpenDocument(cookie, new DocumentKey(document.ProjectFilePath, document.DocumentFilePath));
+            TrackOpenDocument(cookie, new DocumentKey(document.ProjectKey, document.DocumentFilePath));
         }
     }
 
@@ -104,7 +104,7 @@ internal class VisualStudioEditorDocumentManager : EditorDocumentManagerBase
 
         EnsureDocumentTableAdvised();
 
-        var key = new DocumentKey(document.ProjectFilePath, document.DocumentFilePath);
+        var key = new DocumentKey(document.ProjectKey, document.DocumentFilePath);
         if (_cookiesByDocument.TryGetValue(key, out var cookie))
         {
             UntrackOpenDocument(cookie, key);

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/ProjectSystem/RazorDynamicDocumentInfoProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/ProjectSystem/RazorDynamicDocumentInfoProvider.cs
@@ -18,7 +18,8 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 [System.Composition.Shared]
 [ExportMetadata("Extensions", new string[] { "cshtml", "razor", })]
 [Export(typeof(IDynamicDocumentInfoProvider))]
-internal class RazorDynamicDocumentInfoProvider : IDynamicDocumentInfoProvider
+[Export(typeof(ProjectSnapshotChangeTrigger))]
+internal class RazorDynamicDocumentInfoProvider : ProjectSnapshotChangeTrigger, IDynamicDocumentInfoProvider
 {
     private readonly ConcurrentDictionary<Key, Entry> _entries;
     private readonly VisualStudioMacDocumentInfoFactory _documentInfoFactory;
@@ -36,6 +37,11 @@ internal class RazorDynamicDocumentInfoProvider : IDynamicDocumentInfoProvider
     }
 
     public event Action<DocumentInfo>? Updated;
+
+    public override void Initialize(ProjectSnapshotManagerBase projectManager)
+    {
+        ((ProjectSnapshotChangeTrigger)_dynamicFileInfoProvider).Initialize(projectManager);
+    }
 
     public DocumentInfo GetDynamicDocumentInfo(ProjectId projectId, string projectFilePath, string filePath)
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestProjectSnapshot.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestProjectSnapshot.cs
@@ -20,10 +20,11 @@ internal class TestProjectSnapshot : ProjectSnapshot
         => Create(filePath, Array.Empty<string>(), projectWorkspaceState);
 
     public static TestProjectSnapshot Create(string filePath, string[] documentFilePaths, ProjectWorkspaceState? projectWorkspaceState = null)
-        => Create(filePath, documentFilePaths, RazorConfiguration.Default, projectWorkspaceState);
+        => Create(filePath, Path.Combine(Path.GetDirectoryName(filePath) ?? "\\\\path", "obj"), documentFilePaths, RazorConfiguration.Default, projectWorkspaceState);
 
     public static TestProjectSnapshot Create(
         string filePath,
+        string intermediateOutputPath,
         string[] documentFilePaths,
         RazorConfiguration configuration,
         ProjectWorkspaceState? projectWorkspaceState)
@@ -37,7 +38,7 @@ internal class TestProjectSnapshot : ProjectSnapshot
 
         var hostServices = TestServices.Create(workspaceServices, languageServices);
         using var workspace = TestWorkspace.Create(hostServices);
-        var hostProject = new HostProject(filePath, Path.Combine(Path.GetDirectoryName(filePath) ?? "\\\\path", "obj"), configuration, "TestRootNamespace");
+        var hostProject = new HostProject(filePath, intermediateOutputPath, configuration, "TestRootNamespace");
         var state = ProjectState.Create(workspace.Services, hostProject);
         foreach (var documentFilePath in documentFilePaths)
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultDocumentContextFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultDocumentContextFactoryTest.cs
@@ -136,7 +136,7 @@ public class DefaultDocumentContextFactoryTest : LanguageServerTestBase
             throw new NotImplementedException();
         }
 
-        public bool TryResolveDocument(string documentFilePath, [NotNullWhen(true)] out IDocumentSnapshot documentSnapshot)
+        public bool TryResolveDocumentInAnyProject(string documentFilePath, [NotNullWhen(true)] out IDocumentSnapshot documentSnapshot)
         {
             if (documentFilePath == _documentSnapshot?.FilePath)
             {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultDocumentContextFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultDocumentContextFactoryTest.cs
@@ -147,5 +147,10 @@ public class DefaultDocumentContextFactoryTest : LanguageServerTestBase
             documentSnapshot = null;
             return false;
         }
+
+        public bool TryResolveDocument(ProjectKey projectKey, string textDocumentPath, [NotNullWhen(true)] out IDocumentSnapshot documentSnapshot)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultGeneratedDocumentPublisherTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultGeneratedDocumentPublisherTest.cs
@@ -39,7 +39,7 @@ public class DefaultGeneratedDocumentPublisherTest : LanguageServerTestBase
         var sourceText = SourceText.From(content);
 
         // Act
-        generatedDocumentPublisher.PublishCSharp("/path/to/file.razor", sourceText, 123);
+        generatedDocumentPublisher.PublishCSharp(_hostProject.Key, "/path/to/file.razor", sourceText, 123);
 
         // Assert
         var updateRequest = Assert.Single(_serverClient.UpdateRequests);
@@ -58,7 +58,7 @@ public class DefaultGeneratedDocumentPublisherTest : LanguageServerTestBase
         var sourceText = SourceText.From(content);
 
         // Act
-        generatedDocumentPublisher.PublishHtml("/path/to/file.razor", sourceText, 123);
+        generatedDocumentPublisher.PublishHtml(_hostProject.Key, "/path/to/file.razor", sourceText, 123);
 
         // Assert
         var updateRequest = Assert.Single(_serverClient.UpdateRequests);
@@ -74,14 +74,14 @@ public class DefaultGeneratedDocumentPublisherTest : LanguageServerTestBase
         // Arrange
         var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         var initialSourceText = SourceText.From("// Initial content\n");
-        generatedDocumentPublisher.PublishCSharp("/path/to/file.razor", initialSourceText, 123);
+        generatedDocumentPublisher.PublishCSharp(_hostProject.Key, "/path/to/file.razor", initialSourceText, 123);
         var change = new TextChange(
             new TextSpan(initialSourceText.Length, 0),
             "// Another line");
         var changedSourceText = initialSourceText.WithChanges(change);
 
         // Act
-        generatedDocumentPublisher.PublishCSharp("/path/to/file.razor", changedSourceText, 124);
+        generatedDocumentPublisher.PublishCSharp(_hostProject.Key, "/path/to/file.razor", changedSourceText, 124);
 
         // Assert
         Assert.Equal(2, _serverClient.UpdateRequests.Count);
@@ -98,14 +98,14 @@ public class DefaultGeneratedDocumentPublisherTest : LanguageServerTestBase
         // Arrange
         var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         var initialSourceText = SourceText.From("HTML content\n");
-        generatedDocumentPublisher.PublishHtml("/path/to/file.razor", initialSourceText, 123);
+        generatedDocumentPublisher.PublishHtml(_hostProject.Key, "/path/to/file.razor", initialSourceText, 123);
         var change = new TextChange(
             new TextSpan(initialSourceText.Length, 0),
             "More content!!");
         var changedSourceText = initialSourceText.WithChanges(change);
 
         // Act
-        generatedDocumentPublisher.PublishHtml("/path/to/file.razor", changedSourceText, 124);
+        generatedDocumentPublisher.PublishHtml(_hostProject.Key, "/path/to/file.razor", changedSourceText, 124);
 
         // Assert
         Assert.Equal(2, _serverClient.UpdateRequests.Count);
@@ -123,11 +123,11 @@ public class DefaultGeneratedDocumentPublisherTest : LanguageServerTestBase
         var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         var sourceTextContent = "// The content";
         var initialSourceText = SourceText.From(sourceTextContent);
-        generatedDocumentPublisher.PublishCSharp("/path/to/file.razor", initialSourceText, 123);
+        generatedDocumentPublisher.PublishCSharp(_hostProject.Key, "/path/to/file.razor", initialSourceText, 123);
         var identicalSourceText = SourceText.From(sourceTextContent);
 
         // Act
-        generatedDocumentPublisher.PublishCSharp("/path/to/file.razor", identicalSourceText, 124);
+        generatedDocumentPublisher.PublishCSharp(_hostProject.Key, "/path/to/file.razor", identicalSourceText, 124);
 
         // Assert
         Assert.Equal(2, _serverClient.UpdateRequests.Count);
@@ -144,11 +144,11 @@ public class DefaultGeneratedDocumentPublisherTest : LanguageServerTestBase
         var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         var sourceTextContent = "HTMl content";
         var initialSourceText = SourceText.From(sourceTextContent);
-        generatedDocumentPublisher.PublishHtml("/path/to/file.razor", initialSourceText, 123);
+        generatedDocumentPublisher.PublishHtml(_hostProject.Key, "/path/to/file.razor", initialSourceText, 123);
         var identicalSourceText = SourceText.From(sourceTextContent);
 
         // Act
-        generatedDocumentPublisher.PublishHtml("/path/to/file.razor", identicalSourceText, 124);
+        generatedDocumentPublisher.PublishHtml(_hostProject.Key, "/path/to/file.razor", identicalSourceText, 124);
 
         // Assert
         Assert.Equal(2, _serverClient.UpdateRequests.Count);
@@ -165,11 +165,11 @@ public class DefaultGeneratedDocumentPublisherTest : LanguageServerTestBase
         var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         var sourceTextContent = "// The content";
         var initialSourceText = SourceText.From(sourceTextContent);
-        generatedDocumentPublisher.PublishCSharp("/path/to/file1.razor", initialSourceText, 123);
+        generatedDocumentPublisher.PublishCSharp(_hostProject.Key, "/path/to/file1.razor", initialSourceText, 123);
         var identicalSourceText = SourceText.From(sourceTextContent);
 
         // Act
-        generatedDocumentPublisher.PublishCSharp("/path/to/file2.razor", identicalSourceText, 123);
+        generatedDocumentPublisher.PublishCSharp(_hostProject.Key, "/path/to/file2.razor", identicalSourceText, 123);
 
         // Assert
         Assert.Equal(2, _serverClient.UpdateRequests.Count);
@@ -187,11 +187,11 @@ public class DefaultGeneratedDocumentPublisherTest : LanguageServerTestBase
         var generatedDocumentPublisher = new DefaultGeneratedDocumentPublisher(LegacyDispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         var sourceTextContent = "HTML content";
         var initialSourceText = SourceText.From(sourceTextContent);
-        generatedDocumentPublisher.PublishHtml("/path/to/file1.razor", initialSourceText, 123);
+        generatedDocumentPublisher.PublishHtml(_hostProject.Key, "/path/to/file1.razor", initialSourceText, 123);
         var identicalSourceText = SourceText.From(sourceTextContent);
 
         // Act
-        generatedDocumentPublisher.PublishHtml("/path/to/file2.razor", identicalSourceText, 123);
+        generatedDocumentPublisher.PublishHtml(_hostProject.Key, "/path/to/file2.razor", identicalSourceText, 123);
 
         // Assert
         Assert.Equal(2, _serverClient.UpdateRequests.Count);
@@ -210,11 +210,11 @@ public class DefaultGeneratedDocumentPublisherTest : LanguageServerTestBase
         generatedDocumentPublisher.Initialize(_projectManager);
         var sourceTextContent = "// The content";
         var initialSourceText = SourceText.From(sourceTextContent);
-        generatedDocumentPublisher.PublishCSharp(_hostDocument.FilePath, initialSourceText, 123);
+        generatedDocumentPublisher.PublishCSharp(_hostProject.Key, _hostDocument.FilePath, initialSourceText, 123);
 
         // Act
         _projectManager.DocumentOpened(_hostProject.Key, _hostDocument.FilePath, initialSourceText);
-        generatedDocumentPublisher.PublishCSharp(_hostDocument.FilePath, initialSourceText, 124);
+        generatedDocumentPublisher.PublishCSharp(_hostProject.Key, _hostDocument.FilePath, initialSourceText, 124);
 
         // Assert
         Assert.Equal(2, _serverClient.UpdateRequests.Count);
@@ -232,11 +232,11 @@ public class DefaultGeneratedDocumentPublisherTest : LanguageServerTestBase
         generatedDocumentPublisher.Initialize(_projectManager);
         var sourceTextContent = "// The content";
         var initialSourceText = SourceText.From(sourceTextContent);
-        generatedDocumentPublisher.PublishCSharp(_hostDocument.FilePath, initialSourceText, 123);
+        generatedDocumentPublisher.PublishCSharp(_hostProject.Key, _hostDocument.FilePath, initialSourceText, 123);
 
         // Act
         _projectManager.DocumentOpened(_hostProject.Key, _hostDocument.FilePath, initialSourceText);
-        generatedDocumentPublisher.PublishCSharp(_hostDocument.FilePath, initialSourceText, 123);
+        generatedDocumentPublisher.PublishCSharp(_hostProject.Key, _hostDocument.FilePath, initialSourceText, 123);
 
         // Assert
         var updateRequest = Assert.Single(_serverClient.UpdateRequests);
@@ -252,11 +252,11 @@ public class DefaultGeneratedDocumentPublisherTest : LanguageServerTestBase
         generatedDocumentPublisher.Initialize(_projectManager);
         var sourceTextContent = "<!-- The content -->";
         var initialSourceText = SourceText.From(sourceTextContent);
-        generatedDocumentPublisher.PublishHtml(_hostDocument.FilePath, initialSourceText, 123);
+        generatedDocumentPublisher.PublishHtml(_hostProject.Key, _hostDocument.FilePath, initialSourceText, 123);
 
         // Act
         _projectManager.DocumentOpened(_hostProject.Key, _hostDocument.FilePath, initialSourceText);
-        generatedDocumentPublisher.PublishHtml(_hostDocument.FilePath, initialSourceText, 124);
+        generatedDocumentPublisher.PublishHtml(_hostProject.Key, _hostDocument.FilePath, initialSourceText, 124);
 
         // Assert
         Assert.Equal(2, _serverClient.UpdateRequests.Count);
@@ -274,11 +274,11 @@ public class DefaultGeneratedDocumentPublisherTest : LanguageServerTestBase
         generatedDocumentPublisher.Initialize(_projectManager);
         var sourceTextContent = "<!-- The content -->";
         var initialSourceText = SourceText.From(sourceTextContent);
-        generatedDocumentPublisher.PublishHtml(_hostDocument.FilePath, initialSourceText, 123);
+        generatedDocumentPublisher.PublishHtml(_hostProject.Key, _hostDocument.FilePath, initialSourceText, 123);
 
         // Act
         _projectManager.DocumentOpened(_hostProject.Key, _hostDocument.FilePath, initialSourceText);
-        generatedDocumentPublisher.PublishHtml(_hostDocument.FilePath, initialSourceText, 123);
+        generatedDocumentPublisher.PublishHtml(_hostProject.Key, _hostDocument.FilePath, initialSourceText, 123);
 
         // Assert
         var updateRequest = Assert.Single(_serverClient.UpdateRequests);
@@ -294,12 +294,12 @@ public class DefaultGeneratedDocumentPublisherTest : LanguageServerTestBase
         generatedDocumentPublisher.Initialize(_projectManager);
         var sourceTextContent = "// The content";
         var initialSourceText = SourceText.From(sourceTextContent);
-        generatedDocumentPublisher.PublishCSharp(_hostDocument.FilePath, initialSourceText, 123);
+        generatedDocumentPublisher.PublishCSharp(_hostProject.Key, _hostDocument.FilePath, initialSourceText, 123);
         _projectManager.DocumentOpened(_hostProject.Key, _hostDocument.FilePath, initialSourceText);
 
         // Act
         _projectManager.DocumentClosed(_hostProject.Key, _hostDocument.FilePath, new EmptyTextLoader(_hostDocument.FilePath));
-        generatedDocumentPublisher.PublishCSharp(_hostDocument.FilePath, initialSourceText, 123);
+        generatedDocumentPublisher.PublishCSharp(_hostProject.Key, _hostDocument.FilePath, initialSourceText, 123);
 
         // Assert
         Assert.Equal(2, _serverClient.UpdateRequests.Count);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorProjectServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorProjectServiceTest.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
@@ -1215,6 +1216,25 @@ public class DefaultRazorProjectServiceTest : LanguageServerTestBase
 
             documentSnapshot = _miscellaneousProject.GetDocument(documentFilePath);
             return documentSnapshot is not null;
+        }
+
+        public bool TryResolveDocument(ProjectKey projectKey, string documentFilePath, [NotNullWhen(true)] out IDocumentSnapshot documentSnapshot)
+        {
+            documentSnapshot = null;
+
+            if (_projectMappings.TryGetValue(documentFilePath, out var projects))
+            {
+                foreach (var project in projects)
+                {
+                    if (project.Key == projectKey)
+                    {
+                        documentSnapshot = project.GetDocument(documentFilePath);
+                        return documentSnapshot is not null;
+                    }
+                }
+            }
+
+            return false;
         }
 
         internal void UpdateProject(string expectedDocumentFilePath, ProjectState projectState)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
@@ -293,6 +293,9 @@ public class FormattingTestBase : RazorIntegrationTestBase
             .Setup(d => d.FilePath)
             .Returns(path);
         documentSnapshot
+            .Setup(d => d.Project.Key)
+            .Returns(TestProjectKey.Create("/obj"));
+        documentSnapshot
             .Setup(d => d.TargetPath)
             .Returns(path);
         documentSnapshot

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/GeneratedDocumentSynchronizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/GeneratedDocumentSynchronizerTest.cs
@@ -70,12 +70,12 @@ public class GeneratedDocumentSynchronizerTest : LanguageServerTestBase
 
         public bool PublishedHtml { get; private set; }
 
-        public override void PublishCSharp(string filePath, SourceText sourceText, int hostDocumentVersion)
+        public override void PublishCSharp(ProjectKey projectKey, string filePath, SourceText sourceText, int hostDocumentVersion)
         {
             PublishedCSharp = true;
         }
 
-        public override void PublishHtml(string filePath, SourceText sourceText, int hostDocumentVersion)
+        public override void PublishHtml(ProjectKey projectKey, string filePath, SourceText sourceText, int hostDocumentVersion)
         {
             PublishedHtml = true;
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SnapshotResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SnapshotResolverTest.cs
@@ -4,13 +4,11 @@
 #nullable disable
 
 using System.IO;
-using System.Threading.Tasks;
+using System.Linq;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Utilities;
-using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
-using Moq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -22,7 +20,46 @@ public class SnapshotResolverTest : LanguageServerTestBase
     }
 
     [Fact]
-    public void TryResolveDocument_AsksPotentialParentProjectForDocumentItsTracking_ReturnsTrue()
+    public void TryResolveDocument_FindsDocumentInProject()
+    {
+        // Arrange
+        var documentFilePath = @"C:\path\to\document.cshtml";
+        var normalizedFilePath = "C:/path/to/document.cshtml";
+        var snapshotResolver = CreateSnapshotResolver(normalizedFilePath, out var snapshotManager);
+
+        var project = snapshotManager.GetProjects().First();
+
+        // Act
+        var result = snapshotResolver.TryResolveDocument(project.Key, documentFilePath, out var document);
+
+        // Assert
+        Assert.True(result);
+        Assert.Equal(normalizedFilePath, document.FilePath);
+        AssertSnapshotsEqual(project, document.Project);
+    }
+
+    [Fact]
+    public void TryResolveDocument_DoesntFindDocumentNotInProject()
+    {
+        // Arrange
+        var documentFilePath = @"C:\path\to\document.cshtml";
+        var normalizedFilePath = "C:/path/to/document.cshtml";
+        var snapshotResolver = CreateSnapshotResolver(normalizedFilePath, out var snapshotManager);
+
+        var project2 = TestProjectSnapshot.Create(FilePathNormalizer.Normalize(@"C:\path\two\project2.csproj"));
+        snapshotManager.ProjectAdded(project2.HostProject);
+        snapshotManager.CreateAndAddDocument(project2, @"C:\path\two\document2.cshtml");
+
+        // Act
+        var result = snapshotResolver.TryResolveDocument(project2.Key, documentFilePath, out var document);
+
+        // Assert
+        Assert.False(result);
+        Assert.Null(document);
+    }
+
+    [Fact]
+    public void TryResolveDocumentInAnyProject_AsksPotentialParentProjectForDocumentItsTracking_ReturnsTrue()
     {
         // Arrange
         var documentFilePath = @"C:\path\to\document.cshtml";
@@ -30,7 +67,7 @@ public class SnapshotResolverTest : LanguageServerTestBase
         var snapshotResolver = CreateSnapshotResolver(normalizedFilePath);
 
         // Act
-        var result = snapshotResolver.TryResolveDocument(documentFilePath, out var document);
+        var result = snapshotResolver.TryResolveDocumentInAnyProject(documentFilePath, out var document);
 
         // Assert
         Assert.True(result);
@@ -38,7 +75,7 @@ public class SnapshotResolverTest : LanguageServerTestBase
     }
 
     [Fact]
-    public void TryResolveDocument_AsksMiscellaneousProjectForDocumentItIsTracking_ReturnsTrue()
+    public void TryResolveDocumentInAnyProject_AsksMiscellaneousProjectForDocumentItIsTracking_ReturnsTrue()
     {
         // Arrange
         var documentFilePath = @"C:\path\to\document.cshtml";
@@ -54,7 +91,7 @@ public class SnapshotResolverTest : LanguageServerTestBase
             new EmptyTextLoader(normalizedFilePath));
 
         // Act
-        var result = snapshotResolver.TryResolveDocument(documentFilePath, out var document);
+        var result = snapshotResolver.TryResolveDocumentInAnyProject(documentFilePath, out var document);
 
         // Assert
         Assert.True(result);
@@ -63,7 +100,7 @@ public class SnapshotResolverTest : LanguageServerTestBase
     }
 
     [Fact]
-    public void TryResolveDocument_AsksPotentialParentProjectForDocumentItsNotTrackingAndMiscellaneousProjectIsNotTrackingEither_ReturnsFalse()
+    public void TryResolveDocumentInAnyProject_AsksPotentialParentProjectForDocumentItsNotTrackingAndMiscellaneousProjectIsNotTrackingEither_ReturnsFalse()
     {
         // Arrange
         var documentFilePath = @"C:\path\to\document.cshtml";
@@ -71,7 +108,7 @@ public class SnapshotResolverTest : LanguageServerTestBase
         var snapshotResolver = new SnapshotResolver(projectSnapshotManagerAccessor, LoggerFactory);
 
         // Act
-        var result = snapshotResolver.TryResolveDocument(documentFilePath, out var document);
+        var result = snapshotResolver.TryResolveDocumentInAnyProject(documentFilePath, out var document);
 
         // Assert
         Assert.False(result);
@@ -79,22 +116,22 @@ public class SnapshotResolverTest : LanguageServerTestBase
     }
 
     [Fact]
-    public void TryResolveProject_NoProjects_ReturnsFalse()
+    public void TryResolveAllProjects_NoProjects_ReturnsFalse()
     {
         // Arrange
         var documentFilePath = "C:/path/to/document.cshtml";
         var snapshotResolver = new SnapshotResolver(new TestProjectSnapshotManagerAccessor(TestProjectSnapshotManager.Create(ErrorReporter)), LoggerFactory);
 
         // Act
-        var result = snapshotResolver.TryResolveProject(documentFilePath, out var project);
+        var result = snapshotResolver.TryResolveAllProjects(documentFilePath, out var projects);
 
         // Assert
         Assert.False(result);
-        Assert.Null(project);
+        Assert.Empty(projects);
     }
 
     [Fact]
-    public void TryResolveProject_OnlyMiscellaneousProjectDoesNotContainDocument_ReturnsFalse()
+    public void TryResolveAllProjects_OnlyMiscellaneousProjectDoesNotContainDocument_ReturnsFalse()
     {
         // Arrange
         var documentFilePath = "C:/path/to/document.cshtml";
@@ -102,30 +139,30 @@ public class SnapshotResolverTest : LanguageServerTestBase
         _ = snapshotResolver.GetMiscellaneousProject();
 
         // Act
-        var result = snapshotResolver.TryResolveProject(documentFilePath, out var project);
+        var result = snapshotResolver.TryResolveAllProjects(documentFilePath, out var projects);
 
         // Assert
         Assert.False(result);
-        Assert.Null(project);
+        Assert.Empty(projects);
     }
 
     [Fact]
-    public void TryResolveProject_OnlyMiscellaneousProjectContainsDocument_ReturnsTrue()
+    public void TryResolveAllProjects_OnlyMiscellaneousProjectContainsDocument_ReturnsTrue()
     {
         // Arrange
         var documentFilePath = Path.Join(TempDirectory.Instance.DirectoryPath, "document.cshtml");
         var snapshotResolver = CreateSnapshotResolver(documentFilePath, addToMiscellaneous: true);
 
         // Act
-        var result = snapshotResolver.TryResolveProject(documentFilePath, out var project);
+        var result = snapshotResolver.TryResolveAllProjects(documentFilePath, out var projects);
 
         // Assert
         Assert.True(result);
-        Assert.Equal(snapshotResolver.GetMiscellaneousProject(), project);
+        Assert.Single(projects, snapshotResolver.GetMiscellaneousProject());
     }
 
     [Fact]
-    public void TryResolveProject_UnrelatedProject_ReturnsFalse()
+    public void TryResolveAllProjects_UnrelatedProject_ReturnsFalse()
     {
         // Arrange
         var documentFilePath = "C:/path/to/document.cshtml";
@@ -134,15 +171,15 @@ public class SnapshotResolverTest : LanguageServerTestBase
         snapshotManager.ProjectAdded(TestProjectSnapshot.Create("C:/other/path/to/project.csproj").HostProject);
 
         // Act
-        var result = snapshotResolver.TryResolveProject(documentFilePath, out var project);
+        var result = snapshotResolver.TryResolveAllProjects(documentFilePath, out var projects);
 
         // Assert
         Assert.False(result);
-        Assert.Null(project);
+        Assert.Empty(projects);
     }
 
     [Fact]
-    public void TryResolveProject_OwnerProjectWithOthers_ReturnsTrue()
+    public void TryResolveAllProjects_OwnerProjectWithOthers_ReturnsTrue()
     {
         // Arrange
         var documentFilePath = "C:/path/to/document.cshtml";
@@ -154,15 +191,15 @@ public class SnapshotResolverTest : LanguageServerTestBase
         var snapshotResolver = new SnapshotResolver(new TestProjectSnapshotManagerAccessor(snapshotManager), LoggerFactory);
 
         // Act
-        var result = snapshotResolver.TryResolveProject(documentFilePath, out var project);
+        var result = snapshotResolver.TryResolveAllProjects(documentFilePath, out var projects);
 
         // Assert
         Assert.True(result);
-        AssertSnapshotsEqual(expectedProject, project);
+        AssertSnapshotsEqual(expectedProject, projects.Single());
     }
 
     [Fact]
-    public void TryResolveProject_MiscellaneousOwnerProjectWithOthers_ReturnsTrue()
+    public void TryResolveAllProjects_MiscellaneousOwnerProjectWithOthers_ReturnsTrue()
     {
         // Arrange
         var documentFilePath = Path.Join(TempDirectory.Instance.DirectoryPath, "file.cshtml");
@@ -175,15 +212,15 @@ public class SnapshotResolverTest : LanguageServerTestBase
         snapshotManager.CreateAndAddProject("C:/path/to/project.csproj");
 
         // Act
-        var result = snapshotResolver.TryResolveProject(documentFilePath, out var project);
+        var result = snapshotResolver.TryResolveAllProjects(documentFilePath, out var projects);
 
         // Assert
         Assert.True(result);
-        AssertSnapshotsEqual(miscProject, project);
+        AssertSnapshotsEqual(miscProject, projects.Single());
     }
 
     [OSSkipConditionFact(new[] { "OSX", "Linux" })]
-    public void TryResolveProject_OwnerProjectDifferentCasing_ReturnsTrue()
+    public void TryResolveAllProjects_OwnerProjectDifferentCasing_ReturnsTrue()
     {
         // Arrange
         var documentFilePath = "c:/path/to/document.cshtml";
@@ -194,11 +231,11 @@ public class SnapshotResolverTest : LanguageServerTestBase
         snapshotManager.CreateAndAddDocument(ownerProject, documentFilePath);
 
         // Act
-        var result = snapshotResolver.TryResolveProject(documentFilePath, out var project);
+        var result = snapshotResolver.TryResolveAllProjects(documentFilePath, out var projects);
 
         // Assert
         Assert.True(result);
-        AssertSnapshotsEqual(ownerProject, project);
+        AssertSnapshotsEqual(ownerProject, projects.Single());
     }
 
     [Fact]

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Documents/EditorDocumentManagerBaseTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Documents/EditorDocumentManagerBaseTest.cs
@@ -6,6 +6,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.VisualStudio.Test;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Threading;
@@ -17,8 +18,10 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents;
 public class EditorDocumentManagerBaseTest : ProjectSnapshotManagerDispatcherTestBase
 {
     private readonly TestEditorDocumentManager _manager;
-    private readonly string _project1;
-    private readonly string _project2;
+    private readonly ProjectKey _projectKey1;
+    private readonly ProjectKey _projectKey2;
+    private readonly string _projectFile1;
+    private readonly string _projectFile2;
     private readonly string _file1;
     private readonly string _file2;
     private readonly TestTextBuffer _textBuffer;
@@ -27,8 +30,10 @@ public class EditorDocumentManagerBaseTest : ProjectSnapshotManagerDispatcherTes
         : base(testOutput)
     {
         _manager = new TestEditorDocumentManager(Dispatcher, JoinableTaskFactory.Context);
-        _project1 = TestProjectData.SomeProject.FilePath;
-        _project2 = TestProjectData.AnotherProject.FilePath;
+        _projectKey1 = TestProjectData.SomeProject.Key;
+        _projectKey2 = TestProjectData.AnotherProject.Key;
+        _projectFile1 = TestProjectData.SomeProject.FilePath;
+        _projectFile2 = TestProjectData.AnotherProject.FilePath;
         _file1 = TestProjectData.SomeProjectFile1.FilePath;
         _file2 = TestProjectData.AnotherProjectFile2.FilePath;
         _textBuffer = new TestTextBuffer(new StringTextSnapshot("HI"));
@@ -38,10 +43,10 @@ public class EditorDocumentManagerBaseTest : ProjectSnapshotManagerDispatcherTes
     public void GetOrCreateDocument_CreatesAndCachesDocument()
     {
         // Arrange
-        var expected = _manager.GetOrCreateDocument(new DocumentKey(_project1, _file1), null, null, null, null, null);
+        var expected = _manager.GetOrCreateDocument(new DocumentKey(_projectKey1, _file1), _projectFile1, _projectKey1, null, null, null, null);
 
         // Act
-        _manager.TryGetDocument(new DocumentKey(_project1, _file1), out var actual);
+        _manager.TryGetDocument(new DocumentKey(_projectKey1, _file1), out var actual);
 
         // Assert
         Assert.Same(expected, actual);
@@ -51,10 +56,10 @@ public class EditorDocumentManagerBaseTest : ProjectSnapshotManagerDispatcherTes
     public void GetOrCreateDocument_NoOp()
     {
         // Arrange
-        var expected = _manager.GetOrCreateDocument(new DocumentKey(_project1, _file1), null, null, null, null, null);
+        var expected = _manager.GetOrCreateDocument(new DocumentKey(_projectKey1, _file1), _projectFile1, _projectKey1, null, null, null, null);
 
         // Act
-        var actual = _manager.GetOrCreateDocument(new DocumentKey(_project1, _file1), null, null, null, null, null);
+        var actual = _manager.GetOrCreateDocument(new DocumentKey(_projectKey1, _file1), _projectFile1, _projectKey1, null, null, null, null);
 
         // Assert
         Assert.Same(expected, actual);
@@ -64,10 +69,10 @@ public class EditorDocumentManagerBaseTest : ProjectSnapshotManagerDispatcherTes
     public void GetOrCreateDocument_SameFile_MulipleProjects()
     {
         // Arrange
-        var document1 = _manager.GetOrCreateDocument(new DocumentKey(_project1, _file1), null, null, null, null, null);
+        var document1 = _manager.GetOrCreateDocument(new DocumentKey(_projectKey1, _file1), _projectFile1, _projectKey1, null, null, null, null);
 
         // Act
-        var document2 = _manager.GetOrCreateDocument(new DocumentKey(_project2, _file1), null, null, null, null, null);
+        var document2 = _manager.GetOrCreateDocument(new DocumentKey(_projectKey2, _file1), _projectFile2, _projectKey2, null, null, null, null);
 
         // Assert
         Assert.NotSame(document1, document2);
@@ -77,10 +82,10 @@ public class EditorDocumentManagerBaseTest : ProjectSnapshotManagerDispatcherTes
     public void GetOrCreateDocument_MulipleFiles_SameProject()
     {
         // Arrange
-        var document1 = _manager.GetOrCreateDocument(new DocumentKey(_project1, _file1), null, null, null, null, null);
+        var document1 = _manager.GetOrCreateDocument(new DocumentKey(_projectKey1, _file1), _projectFile1, _projectKey1, null, null, null, null);
 
         // Act
-        var document2 = _manager.GetOrCreateDocument(new DocumentKey(_project1, _file2), null, null, null, null, null);
+        var document2 = _manager.GetOrCreateDocument(new DocumentKey(_projectKey1, _file2), _projectFile1, _projectKey1, null, null, null, null);
 
         // Assert
         Assert.NotSame(document1, document2);
@@ -93,7 +98,7 @@ public class EditorDocumentManagerBaseTest : ProjectSnapshotManagerDispatcherTes
         _manager.Buffers.Add(_file1, _textBuffer);
 
         // Act
-        var document = _manager.GetOrCreateDocument(new DocumentKey(_project1, _file1), null, null, null, null, null);
+        var document = _manager.GetOrCreateDocument(new DocumentKey(_projectKey1, _file1), _projectFile1, _projectKey1, null, null, null, null);
 
         // Assert
         Assert.True(document.IsOpenInEditor);
@@ -107,8 +112,8 @@ public class EditorDocumentManagerBaseTest : ProjectSnapshotManagerDispatcherTes
     public void TryGetMatchingDocuments_MultipleDocuments()
     {
         // Arrange
-        var document1 = _manager.GetOrCreateDocument(new DocumentKey(_project1, _file1), null, null, null, null, null);
-        var document2 = _manager.GetOrCreateDocument(new DocumentKey(_project2, _file1), null, null, null, null, null);
+        var document1 = _manager.GetOrCreateDocument(new DocumentKey(_projectKey1, _file1), _projectFile1, _projectKey1, null, null, null, null);
+        var document2 = _manager.GetOrCreateDocument(new DocumentKey(_projectKey2, _file1), _projectFile2, _projectKey2, null, null, null, null);
 
         // Act
         _manager.TryGetMatchingDocuments(_file1, out var documents);
@@ -124,8 +129,8 @@ public class EditorDocumentManagerBaseTest : ProjectSnapshotManagerDispatcherTes
     public void RemoveDocument_MultipleDocuments_RemovesOne()
     {
         // Arrange
-        var document1 = _manager.GetOrCreateDocument(new DocumentKey(_project1, _file1), null, null, null, null, null);
-        var document2 = _manager.GetOrCreateDocument(new DocumentKey(_project2, _file1), null, null, null, null, null);
+        var document1 = _manager.GetOrCreateDocument(new DocumentKey(_projectKey1, _file1), _projectFile1, _projectKey1, null, null, null, null);
+        var document2 = _manager.GetOrCreateDocument(new DocumentKey(_projectKey2, _file1), _projectFile2, _projectKey2, null, null, null, null);
 
         // Act
         _manager.RemoveDocument(document1);
@@ -141,8 +146,8 @@ public class EditorDocumentManagerBaseTest : ProjectSnapshotManagerDispatcherTes
     public void DocumentOpened_MultipleDocuments_OpensAll()
     {
         // Arrange
-        var document1 = _manager.GetOrCreateDocument(new DocumentKey(_project1, _file1), null, null, null, null, null);
-        var document2 = _manager.GetOrCreateDocument(new DocumentKey(_project2, _file1), null, null, null, null, null);
+        var document1 = _manager.GetOrCreateDocument(new DocumentKey(_projectKey1, _file1), _projectFile1, _projectKey1, null, null, null, null);
+        var document2 = _manager.GetOrCreateDocument(new DocumentKey(_projectKey2, _file1), _projectFile2, _projectKey2, null, null, null, null);
 
         // Act
         _manager.DocumentOpened(_file1, _textBuffer);
@@ -158,8 +163,8 @@ public class EditorDocumentManagerBaseTest : ProjectSnapshotManagerDispatcherTes
     public void DocumentOpened_MultipleDocuments_ClosesAll()
     {
         // Arrange
-        var document1 = _manager.GetOrCreateDocument(new DocumentKey(_project1, _file1), null, null, null, null, null);
-        var document2 = _manager.GetOrCreateDocument(new DocumentKey(_project2, _file1), null, null, null, null, null);
+        var document1 = _manager.GetOrCreateDocument(new DocumentKey(_projectKey1, _file1), _projectFile1, _projectKey1, null, null, null, null);
+        var document2 = _manager.GetOrCreateDocument(new DocumentKey(_projectKey2, _file1), _projectFile2, _projectKey2, null, null, null, null);
         _manager.DocumentOpened(_file1, _textBuffer);
 
         // Act

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Documents/EditorDocumentManagerListenerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Documents/EditorDocumentManagerListenerTest.cs
@@ -47,9 +47,9 @@ public class EditorDocumentManagerListenerTest : ProjectSnapshotManagerDispatche
 
         var editorDocumentManger = new Mock<EditorDocumentManager>(MockBehavior.Strict);
         editorDocumentManger
-            .Setup(e => e.GetOrCreateDocument(It.IsAny<DocumentKey>(), It.IsAny<ProjectKey>(), It.IsAny<EventHandler>(), It.IsAny<EventHandler>(), It.IsAny<EventHandler>(), It.IsAny<EventHandler>()))
+            .Setup(e => e.GetOrCreateDocument(It.IsAny<DocumentKey>(), It.IsAny<string>(), It.IsAny<ProjectKey>(), It.IsAny<EventHandler>(), It.IsAny<EventHandler>(), It.IsAny<EventHandler>(), It.IsAny<EventHandler>()))
             .Returns(GetEditorDocument())
-            .Callback<DocumentKey, ProjectKey, EventHandler, EventHandler, EventHandler, EventHandler>((key, projectKey, onChangedOnDisk, onChangedInEditor, onOpened, onClosed) =>
+            .Callback<DocumentKey, string, ProjectKey, EventHandler, EventHandler, EventHandler, EventHandler>((key, filePath, projectKey, onChangedOnDisk, onChangedInEditor, onOpened, onClosed) =>
             {
                 Assert.Same(changedOnDisk, onChangedOnDisk);
                 Assert.Same(changedInEditor, onChangedInEditor);
@@ -76,7 +76,7 @@ public class EditorDocumentManagerListenerTest : ProjectSnapshotManagerDispatche
 
         var editorDocumentManger = new Mock<EditorDocumentManager>(MockBehavior.Strict);
         editorDocumentManger
-            .Setup(e => e.GetOrCreateDocument(It.IsAny<DocumentKey>(), It.IsAny<ProjectKey>(), It.IsAny<EventHandler>(), It.IsAny<EventHandler>(), It.IsAny<EventHandler>(), It.IsAny<EventHandler>()))
+            .Setup(e => e.GetOrCreateDocument(It.IsAny<DocumentKey>(), It.IsAny<string>(), It.IsAny<ProjectKey>(), It.IsAny<EventHandler>(), It.IsAny<EventHandler>(), It.IsAny<EventHandler>(), It.IsAny<EventHandler>()))
             .Returns(GetEditorDocument(isOpen: true));
 
         var listener = new EditorDocumentManagerListener(

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DocumentGenerator/BackgroundDocumentGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DocumentGenerator/BackgroundDocumentGeneratorTest.cs
@@ -296,7 +296,7 @@ public class BackgroundDocumentGeneratorTest : ProjectSnapshotManagerDispatcherW
 
         for (var i = 0; i < documents.Length; i++)
         {
-            var key = new DocumentKey(_hostProject1.FilePath, documents[i].FilePath);
+            var key = new DocumentKey(_hostProject1.Key, documents[i].FilePath);
             Assert.True(queue.Work.ContainsKey(key));
         }
 
@@ -350,7 +350,7 @@ public class BackgroundDocumentGeneratorTest : ProjectSnapshotManagerDispatcherW
         Assert.True(queue.HasPendingNotifications, "Queue should have a notification created during Enqueue");
 
         var kvp = Assert.Single(queue.Work);
-        var expectedKey = new DocumentKey(_hostProject1.FilePath, TestProjectData.SomeProjectComponentFile1.FilePath);
+        var expectedKey = new DocumentKey(_hostProject1.Key, TestProjectData.SomeProjectComponentFile1.FilePath);
         Assert.Equal(expectedKey, kvp.Key);
 
         // Allow the background work to start.

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DocumentGenerator/BackgroundDocumentGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DocumentGenerator/BackgroundDocumentGeneratorTest.cs
@@ -387,12 +387,12 @@ public class BackgroundDocumentGeneratorTest : ProjectSnapshotManagerDispatcherW
         {
         }
 
-        public override void SuppressDocument(string projectFilePath, string documentFilePath)
+        public override void SuppressDocument(ProjectKey projectFilePath, string documentFilePath)
         {
             _dynamicDocuments[documentFilePath] = null;
         }
 
-        public override void UpdateFileInfo(string projectFilePath, DynamicDocumentContainer documentContainer)
+        public override void UpdateFileInfo(ProjectKey projectKey, DynamicDocumentContainer documentContainer)
         {
             _dynamicDocuments[documentContainer.FilePath] = documentContainer;
         }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultRazorDynamicFileInfoProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultRazorDynamicFileInfoProviderTest.cs
@@ -4,9 +4,11 @@
 #nullable disable
 
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
@@ -26,6 +28,7 @@ public class DefaultRazorDynamicFileInfoProviderTest : WorkspaceTestBase
     private readonly LSPEditorFeatureDetector _editorFeatureDetector;
     private readonly TestProjectSnapshotManager _projectSnapshotManager;
     private readonly ProjectSnapshot _project;
+    private readonly ProjectId _projectId;
     private readonly DocumentSnapshot _document1;
     private readonly DocumentSnapshot _document2;
     private readonly DynamicDocumentContainer _lspDocumentContainer;
@@ -57,6 +60,15 @@ public class DefaultRazorDynamicFileInfoProviderTest : WorkspaceTestBase
         lspDocumentContainer.SetupSet(c => c.SupportsDiagnostics = true).Verifiable();
         lspDocumentContainer.Setup(container => container.GetTextLoader(It.IsAny<string>())).Returns(new EmptyTextLoader(string.Empty));
         _lspDocumentContainer = lspDocumentContainer.Object;
+
+        _projectId = ProjectId.CreateNewId();
+        Workspace.TryApplyChanges(Workspace.CurrentSolution.AddProject(ProjectInfo.Create(
+           _projectId,
+           new VersionStamp(),
+           "Project",
+           "Assembly",
+           LanguageNames.CSharp,
+           filePath: _project.FilePath).WithCompilationOutputInfo(new CompilationOutputInfo().WithAssemblyPath(Path.Combine(_project.IntermediateOutputPath, "project.dll")))));
     }
 
     [Fact]
@@ -75,7 +87,7 @@ public class DefaultRazorDynamicFileInfoProviderTest : WorkspaceTestBase
     public async Task UpdateLSPFileInfo_Updates()
     {
         // Arrange
-        await _testAccessor.GetDynamicFileInfoAsync(_project.FilePath, _document1.FilePath, DisposalToken);
+        await _testAccessor.GetDynamicFileInfoAsync(_projectId, _document1.FilePath, DisposalToken);
         var called = false;
         _provider.Updated += (sender, args) => called = true;
 
@@ -90,7 +102,7 @@ public class DefaultRazorDynamicFileInfoProviderTest : WorkspaceTestBase
     public async Task UpdateLSPFileInfo_ProjectRemoved_Noops()
     {
         // Arrange
-        await _testAccessor.GetDynamicFileInfoAsync(_project.FilePath, _document1.FilePath, DisposalToken);
+        await _testAccessor.GetDynamicFileInfoAsync(_projectId, _document1.FilePath, DisposalToken);
         var called = false;
         _provider.Updated += (sender, args) => called = true;
         _projectSnapshotManager.ProjectRemoved(_project.Key);
@@ -106,8 +118,8 @@ public class DefaultRazorDynamicFileInfoProviderTest : WorkspaceTestBase
     public async Task UpdateLSPFileInfo_SolutionClosing_ClearsAllDocuments()
     {
         // Arrange
-        await _testAccessor.GetDynamicFileInfoAsync(_project.FilePath, _document1.FilePath, DisposalToken);
-        await _testAccessor.GetDynamicFileInfoAsync(_project.FilePath, _document2.FilePath, DisposalToken);
+        await _testAccessor.GetDynamicFileInfoAsync(_projectId, _document1.FilePath, DisposalToken);
+        await _testAccessor.GetDynamicFileInfoAsync(_projectId, _document2.FilePath, DisposalToken);
         _provider.Updated += (sender, documentFilePath) => throw new InvalidOperationException("Should not have been called!");
 
         _projectSnapshotManager.SolutionClosed();


### PR DESCRIPTION
This is the next part of https://github.com/dotnet/razor/issues/8983

Previous work meant adding multiple projects for each project file, but all document work was unaffected. This updates everything to know that documents exist in multiple as well.

At the moment this is predicated on the assumption that all Razor documents have the same content, which is fair since they represent a file on disk, _and_ that all C# and Html generated documents have the same content. The latter is not a long-term assumption, and the rest of https://github.com/dotnet/razor/issues/8983 is needed to address that. Generally speaking things continue to work if this assumption is violated, though possibly in strange ways.

As a concrete example, if you multi-target and exclude a Razor document from one target, you get component not found errors in the IDE, but component attributes are happy and correctly state they come from multiple targets. Strictly speaking this is actually correct, just not very useful 😁

As usualy, hopefully commit-at-a-time tells a little bit of a story


† some