### PR TITLE
Improvements to `RazorDiagnosticsBenchmark` class

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorDiagnosticsBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorDiagnosticsBenchmark.cs
@@ -53,9 +53,10 @@ public class RazorDiagnosticsBenchmark : RazorLanguageServerBenchmarkBase
         var translateDiagnosticsService = new RazorTranslateDiagnosticsService(razorDocumentMappingService, loggerFactory);
 
         _documentPullDiagnosticsEndpoint = new DocumentPullDiagnosticsEndpoint(
-            languageServerFeatureOptions: languageServerFeatureOptions,
-            translateDiagnosticsService: translateDiagnosticsService,
-            languageServer: new ClientNotifierService(BuildDiagnostics(N)), telemetryReporter: null);
+            languageServerFeatureOptions,
+            translateDiagnosticsService,
+            languageServer: new ClientNotifierService(BuildDiagnostics(N)),
+            telemetryReporter: null);
         var projectRoot = Path.Combine(RepoRoot, "src", "Razor", "test", "testapps", "ComponentApp");
         var projectFilePath = Path.Combine(projectRoot, "ComponentApp.csproj");
         _filePath = Path.Combine(projectRoot, "Components", "Pages", $"Generated.razor");
@@ -76,7 +77,7 @@ public class RazorDiagnosticsBenchmark : RazorLanguageServerBenchmarkBase
         {
             TextDocument = new TextDocumentIdentifier
             {
-                Uri = documentUri!
+                Uri = documentUri
             }
         };
     }
@@ -86,18 +87,18 @@ public class RazorDiagnosticsBenchmark : RazorLanguageServerBenchmarkBase
         return new RazorPullDiagnosticResponse(
             new[]
             {
-                    new VSInternalDiagnosticReport()
+                new VSInternalDiagnosticReport()
+                {
+                    ResultId = "5",
+                    Diagnostics = Enumerable.Range(1000, numDiagnostics).Select(x => new Diagnostic
                     {
-                        ResultId = "5",
-                        Diagnostics = Enumerable.Range(1000, numDiagnostics).Select(x => new Diagnostic
-                        {
-                                Range = _inRange,
-                                Code = "CS" + x,
-                                Severity = DiagnosticSeverity.Error,
-                                Source = "DocumentPullDiagnosticHandler",
-                                Message = "The name 'CallOnMe' does not exist in the current context"
-                        }).ToArray()
-                    }
+                        Range = _inRange,
+                        Code = "CS" + x,
+                        Severity = DiagnosticSeverity.Error,
+                        Source = "DocumentPullDiagnosticHandler",
+                        Message = "The name 'CallOnMe' does not exist in the current context"
+                    }).ToArray()
+                }
             }, Array.Empty<VSInternalDiagnosticReport>());
     }
 

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks.csproj
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks.csproj
@@ -51,6 +51,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="$(BenchmarkDotNetPackageVersion)" />
+    <PackageReference Include="Moq" Version="$(MoqPackageVersion)" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="$(BenchmarkDotNetPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsPackageVersion)" />

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/RazorCodeDocumentExtensions.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/RazorCodeDocumentExtensions.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.AspNetCore.Razor.Microbenchmarks;
+
+internal static class RazorCodeDocumentExtensions
+{
+    private static readonly object s_sourceTextKey = new();
+    private static readonly object s_cSharpSourceTextKey = new();
+    private static readonly object s_htmlSourceTextKey = new();
+
+    public static SourceText GetSourceText(this RazorCodeDocument document)
+    {
+        if (document is null)
+        {
+            throw new ArgumentNullException(nameof(document));
+        }
+
+        var sourceTextObj = document.Items[s_sourceTextKey];
+        if (sourceTextObj is null)
+        {
+            var source = document.Source;
+            var charBuffer = new char[source.Length];
+            source.CopyTo(0, charBuffer, 0, source.Length);
+            var sourceText = SourceText.From(new string(charBuffer));
+            document.Items[s_sourceTextKey] = sourceText;
+
+            return sourceText;
+        }
+
+        return (SourceText)sourceTextObj;
+    }
+
+    public static SourceText GetCSharpSourceText(this RazorCodeDocument document)
+    {
+        if (document is null)
+        {
+            throw new ArgumentNullException(nameof(document));
+        }
+
+        var sourceTextObj = document.Items[s_cSharpSourceTextKey];
+        if (sourceTextObj is null)
+        {
+            var csharpDocument = document.GetCSharpDocument();
+            var sourceText = SourceText.From(csharpDocument.GeneratedCode);
+            document.Items[s_cSharpSourceTextKey] = sourceText;
+
+            return sourceText;
+        }
+
+        return (SourceText)sourceTextObj;
+    }
+
+    public static SourceText GetHtmlSourceText(this RazorCodeDocument document)
+    {
+        if (document is null)
+        {
+            throw new ArgumentNullException(nameof(document));
+        }
+
+        var sourceTextObj = document.Items[s_htmlSourceTextKey];
+        if (sourceTextObj is null)
+        {
+            var htmlDocument = document.GetHtmlDocument();
+            var sourceText = SourceText.From(htmlDocument.GeneratedCode);
+            document.Items[s_htmlSourceTextKey] = sourceText;
+
+            return sourceText;
+        }
+
+        return (SourceText)sourceTextObj;
+    }
+
+    public static SourceText GetGeneratedSourceText(this RazorCodeDocument document, IRazorGeneratedDocument generatedDocument)
+    {
+        if (generatedDocument is RazorCSharpDocument)
+        {
+            return GetCSharpSourceText(document);
+        }
+        else if (generatedDocument is RazorHtmlDocument)
+        {
+            return GetHtmlSourceText(document);
+        }
+
+        throw new InvalidOperationException("Unknown generated document type");
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/DocumentPullDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/DocumentPullDiagnosticsEndpoint.cs
@@ -17,9 +17,6 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics;
 
-/// <summary>
-/// Provides diagnostic information for a Document. Implements an LSP request that pulls all diagnostics for a specific document.
-/// </summary>
 [LanguageServerEndpoint(VSInternalMethods.DocumentPullDiagnosticName)]
 internal class DocumentPullDiagnosticsEndpoint : IRazorRequestHandler<VSInternalDocumentDiagnosticsParams, IEnumerable<VSInternalDiagnosticReport>?>, ICapabilitiesProvider
 {
@@ -28,14 +25,6 @@ internal class DocumentPullDiagnosticsEndpoint : IRazorRequestHandler<VSInternal
     private readonly RazorTranslateDiagnosticsService _translateDiagnosticsService;
     private readonly ITelemetryReporter? _telemetryReporter;
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DocumentPullDiagnosticsEndpoint"/> class.
-    /// </summary>
-    /// <param name="languageServerFeatureOptions">The <see cref="LanguageServerFeatureOptions"/>.</param>
-    /// <param name="translateDiagnosticsService">The <see cref="RazorTranslateDiagnosticsService"/>.</param>
-    /// <param name="languageServer">The <see cref="ClientNotifierServiceBase"/>.</param>
-    /// <param name="telemetryReporter">The <see cref="ITelemetryReporter"/>.</param>
-    /// <exception cref="ArgumentNullException"/>
     public DocumentPullDiagnosticsEndpoint(
         LanguageServerFeatureOptions languageServerFeatureOptions,
         RazorTranslateDiagnosticsService translateDiagnosticsService,
@@ -48,16 +37,13 @@ internal class DocumentPullDiagnosticsEndpoint : IRazorRequestHandler<VSInternal
         _telemetryReporter = telemetryReporter;
     }
 
-    /// <inheritdoc/>
     public bool MutatesSolutionState => false;
 
-    /// <inheritdoc/>
     public void ApplyCapabilities(VSInternalServerCapabilities serverCapabilities, VSInternalClientCapabilities clientCapabilities)
     {
         serverCapabilities.SupportsDiagnosticRequests = true;
     }
 
-    /// <inheritdoc/>
     public TextDocumentIdentifier GetTextDocumentIdentifier(VSInternalDocumentDiagnosticsParams request)
     {
         if (request.TextDocument is null)
@@ -68,7 +54,6 @@ internal class DocumentPullDiagnosticsEndpoint : IRazorRequestHandler<VSInternal
         return request.TextDocument;
     }
 
-    /// <inheritdoc/>
     public async Task<IEnumerable<VSInternalDiagnosticReport>?> HandleRequestAsync(VSInternalDocumentDiagnosticsParams request, RazorRequestContext context, CancellationToken cancellationToken)
     {
         if (!_languageServerFeatureOptions.SingleServerSupport)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/DocumentPullDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/DocumentPullDiagnosticsEndpoint.cs
@@ -17,6 +17,9 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics;
 
+/// <summary>
+/// Provides diagnostic information for a Document. Implements an LSP request that pulls all diagnostics for a specific document.
+/// </summary>
 [LanguageServerEndpoint(VSInternalMethods.DocumentPullDiagnosticName)]
 internal class DocumentPullDiagnosticsEndpoint : IRazorRequestHandler<VSInternalDocumentDiagnosticsParams, IEnumerable<VSInternalDiagnosticReport>?>, ICapabilitiesProvider
 {
@@ -25,6 +28,14 @@ internal class DocumentPullDiagnosticsEndpoint : IRazorRequestHandler<VSInternal
     private readonly RazorTranslateDiagnosticsService _translateDiagnosticsService;
     private readonly ITelemetryReporter? _telemetryReporter;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DocumentPullDiagnosticsEndpoint"/> class.
+    /// </summary>
+    /// <param name="languageServerFeatureOptions">The <see cref="LanguageServerFeatureOptions"/>.</param>
+    /// <param name="translateDiagnosticsService">The <see cref="RazorTranslateDiagnosticsService"/>.</param>
+    /// <param name="languageServer">The <see cref="ClientNotifierServiceBase"/>.</param>
+    /// <param name="telemetryReporter">The <see cref="ITelemetryReporter"/>.</param>
+    /// <exception cref="ArgumentNullException"/>
     public DocumentPullDiagnosticsEndpoint(
         LanguageServerFeatureOptions languageServerFeatureOptions,
         RazorTranslateDiagnosticsService translateDiagnosticsService,
@@ -37,13 +48,16 @@ internal class DocumentPullDiagnosticsEndpoint : IRazorRequestHandler<VSInternal
         _telemetryReporter = telemetryReporter;
     }
 
+    /// <inheritdoc/>
     public bool MutatesSolutionState => false;
 
+    /// <inheritdoc/>
     public void ApplyCapabilities(VSInternalServerCapabilities serverCapabilities, VSInternalClientCapabilities clientCapabilities)
     {
         serverCapabilities.SupportsDiagnosticRequests = true;
     }
 
+    /// <inheritdoc/>
     public TextDocumentIdentifier GetTextDocumentIdentifier(VSInternalDocumentDiagnosticsParams request)
     {
         if (request.TextDocument is null)
@@ -54,6 +68,7 @@ internal class DocumentPullDiagnosticsEndpoint : IRazorRequestHandler<VSInternal
         return request.TextDocument;
     }
 
+    /// <inheritdoc/>
     public async Task<IEnumerable<VSInternalDiagnosticReport>?> HandleRequestAsync(VSInternalDocumentDiagnosticsParams request, RazorRequestContext context, CancellationToken cancellationToken)
     {
         if (!_languageServerFeatureOptions.SingleServerSupport)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorTranslateDiagnosticsService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorTranslateDiagnosticsService.cs
@@ -35,6 +35,13 @@ internal class RazorTranslateDiagnosticsService
         "IDE0005_gen", // Using directive is unnecessary
     };
 
+    /// <summary>
+    /// Contains several methods for mapping and filtering Razor and C# diagnostics. It allows for
+    /// translating code diagnostics from one representation into another, such as from C# to Razor.
+    /// </summary>
+    /// <param name="documentMappingService">The <see cref="IRazorDocumentMappingService"/>.</param>
+    /// <param name="loggerFactory">The <see cref="ILoggerFactory"/>.</param>
+    /// <exception cref="ArgumentNullException"/>
     public RazorTranslateDiagnosticsService(IRazorDocumentMappingService documentMappingService, ILoggerFactory loggerFactory)
     {
         if (documentMappingService is null)
@@ -51,6 +58,14 @@ internal class RazorTranslateDiagnosticsService
         _logger = loggerFactory.CreateLogger<RazorTranslateDiagnosticsService>();
     }
 
+    /// <summary>
+    /// Translates code diagnostics from one representation into another.
+    /// </summary>
+    /// <param name="diagnosticKind">The `RazorLanguageKind` of the `Diagnostic` objects included in `diagnostics`.</param>
+    /// <param name="diagnostics">An array of `Diagnostic` objects to translate.</param>
+    /// <param name="documentContext">The `DocumentContext` for the code document associated with the diagnostics.</param>
+    /// <param name="cancellationToken">A `CancellationToken` to observe while waiting for the task to complete.</param>
+    /// <returns>An array of translated diagnostics</returns>
     internal async Task<Diagnostic[]> TranslateAsync(
         RazorLanguageKind diagnosticKind,
         Diagnostic[] diagnostics,


### PR DESCRIPTION
﻿### Summary of the changes

- Adds `Moq` to the benchmark project
- Mocks `LanguageServerFeatureOptions`, `IRazorDocumentMappingService`, and `ILoggerFactory`
- Moves up `CallOnMe()` to keep the range value fixed, regardless of the `FileType` size
- Move validation check into `CleanupAsync`
- Make Benchmark method more compact
- Adds `ShortRun` job to the Diagnostic benchmark, with that we can run the benchmarks faster locally with smaller IterationCount and WarmupCount to help compare different cases faster:

(Reports below using latest commit  [0fde405](https://github.com/dotnet/razor/pull/9016/commits/0fde405d82e36c6420e2b12fb30349b627300161)  with mocked language server and `IRazorDocumentMappingService`)

```
|      Method |    N |       Mean |      Error |   StdDev |     Median |        Min |        Max | Allocated |
|------------ |----- |-----------:|-----------:|---------:|-----------:|-----------:|-----------:|----------:|
| Diagnostics |    0 |   670.9 us | 4,651.8 us | 255.0 us |   762.2 us |   382.8 us |   867.6 us |   8.25 KB |
| Diagnostics |    1 |   711.0 us | 3,970.6 us | 217.6 us |   656.5 us |   525.9 us |   950.8 us |   8.77 KB |
| Diagnostics | 1000 | 2,582.1 us | 3,068.5 us | 168.2 us | 2,645.1 us | 2,391.5 us | 2,709.7 us | 685.46 KB |
```


