### PR TITLE
Fixes interoperability issues from CVE-2023-33127 and CVE-2023-33170

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -170,7 +170,7 @@
     <!-- Compiler Deps -->
     <DiffPlexVersion>1.5.0</DiffPlexVersion>
     <FluentAssertionsVersion>6.7.0</FluentAssertionsVersion>
-    <MicrosoftAspNetCoreAppVersion>7.0.7</MicrosoftAspNetCoreAppVersion>
+    <MicrosoftAspNetCoreAppVersion>7.0.9</MicrosoftAspNetCoreAppVersion>
     <MicrosoftBuildLocatorVersion>1.4.1</MicrosoftBuildLocatorVersion>
     <MicrosoftBuildVersion>17.3.0-preview-22364-05</MicrosoftBuildVersion>
     <MicrosoftBuildFrameworkVersion>$(MicrosoftBuildVersion)</MicrosoftBuildFrameworkVersion>


### PR DESCRIPTION
﻿### Summary of the changes

- Upgrading to .NET 7.0.9 release to take in security fixes for CVE-2023-33127 and CVE-2023-33170 showing up in our pipeline report here [Pipelines - Run 20230726.1 logs (visualstudio.com)](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=8149094&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=4bb9ee66-d15b-54bf-dea1-47f4e6298783)

release notes [here](https://github.com/dotnet/core/blob/main/release-notes/7.0/7.0.9/7.0.9.md?WT.mc_id=dotnet-35129-website#notable-changes)

Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1802880

@jjonescz 