### PR TITLE
Handle the special case where the start of a razor document is whitespace

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/SyntaxNode.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/SyntaxNode.cs
@@ -601,8 +601,17 @@ internal abstract partial class SyntaxNode
                     }
                 }
 
-                // Got to the end of the node without finding a desired token. Pop up the stack and try again
                 foundToken = null;
+
+                // The start of the document is the only special case:
+                //  - If we're walking backwards and hit the start of the document, we need to treat this as if we should walk forward. There's no
+                //    previous node to attach the token to, so walking forward is the only option.
+                if (walkBackwards && parent!.SpanStart == 0)
+                {
+                    return false;
+                }
+
+                // Got to the end of the node without finding a desired token. Pop up the stack and try again
                 return null;
             }
         }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Syntax/FindTokenTests.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Syntax/FindTokenTests.cs
@@ -47,7 +47,8 @@ public class FindTokenTests
     {
         var text = """
             <div></div>
-             $$
+            $$
+
             """;
         var (tree, position) = ParseWithPosition(text);
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Syntax/FindTokenTests.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Syntax/FindTokenTests.cs
@@ -42,6 +42,33 @@ public class FindTokenTests
         AssertEx.Equal("""EndOfFile;[];""", SyntaxSerializer.Serialize(token).Trim());
     }
 
+    [Fact, WorkItem("https://github.com/dotnet/razor/issues/7505")]
+    public void ReturnsEofOnFileEnd_WithTrailingTrivia()
+    {
+        var text = """
+            <div></div>
+             $$
+            """;
+        var (tree, position) = ParseWithPosition(text);
+
+        var token = tree.Root.FindToken(position);
+
+        AssertEx.Equal("""EndOfFile;[];""", SyntaxSerializer.Serialize(token).Trim());
+    }
+
+    [Fact, WorkItem("https://github.com/dotnet/razor/issues/9040")]
+    public void LeadingWhitespace_BeforeAnyNode()
+    {
+        var text = """
+        $$ <Component></Component>
+        """;
+        var (tree, position) = ParseWithPosition(text);
+
+        var token = tree.Root.FindToken(position);
+
+        AssertEx.Equal("""OpenAngle;[<];""", SyntaxSerializer.Serialize(token).Trim());
+    }
+
     [Fact]
     public void ReturnsOpenAngle()
     {


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/9040.
