### PR TITLE
Don't respond to UI thread bound COM entry points if our LSP server isn't active

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
@@ -32,12 +32,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 
 internal static class IServiceCollectionExtensions
 {
-    public static void AddLifeCycleServices(this IServiceCollection services, RazorLanguageServer razorLanguageServer, ClientNotifierServiceBase serverManager)
+    public static void AddLifeCycleServices(this IServiceCollection services, RazorLanguageServer razorLanguageServer, ClientNotifierServiceBase serverManager, ILspServerActivationTracker? lspServerActivationTracker)
     {
         services.AddHandler<RazorInitializeEndpoint>();
         services.AddHandler<RazorInitializedEndpoint>();
 
-        var razorLifeCycleManager = new RazorLifeCycleManager(razorLanguageServer);
+        var razorLifeCycleManager = new RazorLifeCycleManager(razorLanguageServer, lspServerActivationTracker);
         services.AddSingleton<ILifeCycleManager>(razorLifeCycleManager);
         services.AddSingleton<RazorLifeCycleManager>(razorLifeCycleManager);
         services.AddSingleton<IInitializeManager<InitializeParams, InitializeResult>, CapabilitiesManager>();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -39,6 +39,7 @@ internal class RazorLanguageServer : AbstractLanguageServer<RazorRequestContext>
     private readonly ProjectSnapshotManagerDispatcher? _projectSnapshotManagerDispatcher;
     private readonly Action<IServiceCollection>? _configureServer;
     private readonly RazorLSPOptions _lspOptions;
+    private readonly ILspServerActivationTracker? _lspServerActivationTracker;
     private readonly ITelemetryReporter _telemetryReporter;
 
     // Cached for testing
@@ -51,6 +52,7 @@ internal class RazorLanguageServer : AbstractLanguageServer<RazorRequestContext>
         LanguageServerFeatureOptions? featureOptions,
         Action<IServiceCollection>? configureServer,
         RazorLSPOptions? lspOptions,
+        ILspServerActivationTracker? lspServerActivationTracker,
         ITelemetryReporter telemetryReporter)
         : base(jsonRpc, logger)
     {
@@ -59,6 +61,7 @@ internal class RazorLanguageServer : AbstractLanguageServer<RazorRequestContext>
         _projectSnapshotManagerDispatcher = projectSnapshotManagerDispatcher;
         _configureServer = configureServer;
         _lspOptions = lspOptions ?? RazorLSPOptions.Default;
+        _lspServerActivationTracker = lspServerActivationTracker;
         _telemetryReporter = telemetryReporter;
 
         Initialize();
@@ -123,7 +126,7 @@ internal class RazorLanguageServer : AbstractLanguageServer<RazorRequestContext>
         var featureOptions = _featureOptions ?? new DefaultLanguageServerFeatureOptions();
         services.AddSingleton(featureOptions);
 
-        services.AddLifeCycleServices(this, serverManager);
+        services.AddLifeCycleServices(this, serverManager, _lspServerActivationTracker);
 
         services.AddDiagnosticServices();
         services.AddSemanticTokensServices();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServerWrapper.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServerWrapper.cs
@@ -42,6 +42,7 @@ internal sealed class RazorLanguageServerWrapper : IDisposable
         Action<IServiceCollection>? configure = null,
         LanguageServerFeatureOptions? featureOptions = null,
         RazorLSPOptions? razorLSPOptions = null,
+        ILspServerActivationTracker? lspServerActivationTracker = null,
         TraceSource? traceSource = null)
     {
         var jsonRpc = CreateJsonRpc(input, output);
@@ -59,6 +60,7 @@ internal sealed class RazorLanguageServerWrapper : IDisposable
             featureOptions,
             configure,
             razorLSPOptions,
+            lspServerActivationTracker,
             telemetryReporter);
 
         var razorLanguageServer = new RazorLanguageServerWrapper(server);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ILspServerActivationTracker.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ILspServerActivationTracker.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Razor.Workspaces;
+
+internal interface ILspServerActivationTracker
+{
+    bool IsActive { get; }
+
+    void Activated();
+
+    void Deactivated();
+}

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/LspServerActivationTracker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/LspServerActivationTracker.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Composition;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
+
+namespace Microsoft.VisualStudio.Editor.Razor;
+
+[Shared]
+[Export(typeof(ILspServerActivationTracker))]
+internal class LspServerActivationTracker : ILspServerActivationTracker
+{
+    public bool IsActive { get; private set; }
+
+    public void Activated()
+    {
+        this.IsActive = true;
+    }
+
+    public void Deactivated()
+    {
+        this.IsActive = false;
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
@@ -40,6 +40,7 @@ internal class RazorLanguageServerClient : ILanguageClient, ILanguageClientCusto
     private readonly ILanguageServiceBroker2 _languageServiceBroker;
     private readonly ITelemetryReporter _telemetryReporter;
     private readonly IClientSettingsManager _clientSettingsManager;
+    private readonly ILspServerActivationTracker _lspServerActivationTracker;
     private readonly RazorLanguageServerCustomMessageTarget _customMessageTarget;
     private readonly ILanguageClientMiddleLayer _middleLayer;
     private readonly LSPRequestInvoker _requestInvoker;
@@ -75,6 +76,7 @@ internal class RazorLanguageServerClient : ILanguageClient, ILanguageClientCusto
         ILanguageServiceBroker2 languageServiceBroker,
         ITelemetryReporter telemetryReporter,
         IClientSettingsManager clientSettingsManager,
+        ILspServerActivationTracker lspServerActivationTracker,
         [Import(AllowDefault = true)] VisualStudioHostServicesProvider? vsHostWorkspaceServicesProvider)
     {
         if (customTarget is null)
@@ -132,6 +134,11 @@ internal class RazorLanguageServerClient : ILanguageClient, ILanguageClientCusto
             throw new ArgumentNullException(nameof(clientSettingsManager));
         }
 
+        if (lspServerActivationTracker is null)
+        {
+            throw new ArgumentNullException(nameof(lspServerActivationTracker));
+        }
+
         _customMessageTarget = customTarget;
         _middleLayer = middleLayer;
         _requestInvoker = requestInvoker;
@@ -145,6 +152,7 @@ internal class RazorLanguageServerClient : ILanguageClient, ILanguageClientCusto
         _projectSnapshotManagerDispatcher = projectSnapshotManagerDispatcher;
         _telemetryReporter = telemetryReporter;
         _clientSettingsManager = clientSettingsManager;
+        _lspServerActivationTracker = lspServerActivationTracker;
     }
 
     public string Name => RazorLSPConstants.RazorLanguageServerName;
@@ -193,6 +201,7 @@ internal class RazorLanguageServerClient : ILanguageClient, ILanguageClientCusto
             ConfigureLanguageServer,
             _languageServerFeatureOptions,
             lspOptions,
+            _lspServerActivationTracker,
             traceSource);
 
         // This must not happen on an RPC endpoint due to UIThread concerns, so ActivateAsync was chosen.
@@ -254,6 +263,9 @@ internal class RazorLanguageServerClient : ILanguageClient, ILanguageClientCusto
         }
 
         await Task.WhenAll(clientLoadTasks).ConfigureAwait(false);
+
+        // We only want to mark the server as activated after the delegated language servers have been initialized.
+        _lspServerActivationTracker.Activated();
     }
 
     private void ConfigureLanguageServer(IServiceCollection serviceCollection)
@@ -341,6 +353,8 @@ internal class RazorLanguageServerClient : ILanguageClient, ILanguageClientCusto
 
     public Task<InitializationFailureContext?> OnServerInitializeFailedAsync(ILanguageClientInitializationInfo initializationState)
     {
+        _lspServerActivationTracker.Deactivated();
+
         var initializationFailureContext = new InitializationFailureContext
         {
             FailureMessage = string.Format(SR.LanguageServer_Initialization_Failed,

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
@@ -5,6 +5,7 @@ using System;
 using System.ComponentModel.Design;
 using System.Runtime.InteropServices;
 using System.Threading;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Editor.Razor;
@@ -57,9 +58,10 @@ public sealed class RazorPackage : AsyncPackage
             var proximityExpressionResolver = componentModel.GetService<RazorProximityExpressionResolver>();
             var uiThreadOperationExecutor = componentModel.GetService<IUIThreadOperationExecutor>();
             var editorAdaptersFactory = componentModel.GetService<IVsEditorAdaptersFactoryService>();
+            var lspServerActivationTracker = componentModel.GetService<ILspServerActivationTracker>();
             var joinableTaskContext = componentModel.GetService<JoinableTaskContext>();
 
-            return new RazorLanguageService(breakpointResolver, proximityExpressionResolver, uiThreadOperationExecutor, editorAdaptersFactory, joinableTaskContext.Factory);
+            return new RazorLanguageService(breakpointResolver, proximityExpressionResolver, lspServerActivationTracker, uiThreadOperationExecutor, editorAdaptersFactory, joinableTaskContext.Factory);
         }, promote: true);
 
         // Add our command handlers for menu (commands must exist in the .vsct file).

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Debugging/RazorLanguageService`IVsLanguageDebugInfoTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Debugging/RazorLanguageService`IVsLanguageDebugInfoTest.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Threading;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.VisualStudio.Editor;
+using Microsoft.VisualStudio.Editor.Razor;
 using Microsoft.VisualStudio.Editor.Razor.Debugging;
 using Microsoft.VisualStudio.Test;
 using Microsoft.VisualStudio.Text;
@@ -217,7 +218,10 @@ public class RazorLanguageService_IVsLanguageDebugInfoTest : TestBase
         uiThreadOperationExecutor ??= new TestIUIThreadOperationExecutor();
         editorAdaptersFactory ??= Mock.Of<IVsEditorAdaptersFactoryService>(service => service.GetDataBuffer(It.IsAny<IVsTextBuffer>()) == new TestTextBuffer(new StringTextSnapshot(Environment.NewLine)), MockBehavior.Strict);
 
-        var languageService = new RazorLanguageService(breakpointResolver, proximityExpressionResolver, uiThreadOperationExecutor, editorAdaptersFactory, JoinableTaskFactory);
+        var lspServerActivationTracker = new LspServerActivationTracker();
+        lspServerActivationTracker.Activated();
+
+        var languageService = new RazorLanguageService(breakpointResolver, proximityExpressionResolver, lspServerActivationTracker, uiThreadOperationExecutor, editorAdaptersFactory, JoinableTaskFactory);
         return languageService;
     }
 


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1391983/

Without our language server, we are basically dead in the water, and whilst the code we have now tries to be a good citizen and pre-emptively create our dependent language servers when our server is activated, so that they can hopefully switch to the UI thread and do what they need, if they need, the presence of this bug after previous attempted fixes in https://github.com/dotnet/razor/pull/8027 would imply that it doesn't work. My personal opinion is that it is also not our job or responsibility to be initializing other language servers, and trying to marshall them around.

Further, the two instances where we need this are not what I would call core functionality, so a small window of time where they are unavailable seems fine to me. Additionally, the only scenario that is possible to hit - placing a breakpoint - is not even unavailable with this change. The breakpoint is placed without highlighting the line, but upon pressing F5 the debugger validates it, and it is hit as expected.

![image](https://github.com/dotnet/razor/assets/754264/660882b1-3294-4a22-84f7-75d5ca96c3ce)
