### PR TITLE
Avoid using `Ancestors().FirstOrDefault()`

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ComponentAccessibilityCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ComponentAccessibilityCodeActionProvider.cs
@@ -48,7 +48,7 @@ internal sealed class ComponentAccessibilityCodeActionProvider : IRazorCodeActio
 
         // Find start tag. We allow this code action to work from anywhere in the start tag, which includes
         // embedded C#, so we just have to traverse up the tree to find a start tag if there is one.
-        var startTag = (MarkupStartTagSyntax?)node.Ancestors().FirstOrDefault(n => n is MarkupStartTagSyntax);
+        var startTag = (MarkupStartTagSyntax?)node.Parent?.FirstAncestorOrSelf<SyntaxNode>(n => n is MarkupStartTagSyntax);
         if (startTag is null)
         {
             return s_emptyResult;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/DefinitionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/DefinitionEndpoint.cs
@@ -160,7 +160,7 @@ internal sealed class DefinitionEndpoint : AbstractRazorDelegatingEndpoint<TextD
             return (null, null);
         }
 
-        var node = owner.Ancestors().FirstOrDefault(n =>
+        var node = owner.Parent?.FirstAncestorOrSelf<SyntaxNode>(n =>
             n.Kind == SyntaxKind.MarkupTagHelperStartTag ||
             n.Kind == SyntaxKind.MarkupTagHelperEndTag);
         if (node is null)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpOnTypeFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpOnTypeFormattingPass.cs
@@ -347,7 +347,7 @@ internal class CSharpOnTypeFormattingPass : CSharpFormattingPassBase
 
         if (owner is CSharpStatementLiteralSyntax &&
             owner.TryGetPreviousSibling(out var prevNode) &&
-            prevNode.AncestorsAndSelf().FirstOrDefault(a => a is CSharpTemplateBlockSyntax) is { } template &&
+            prevNode.FirstAncestorOrSelf<SyntaxNode>(a => a is CSharpTemplateBlockSyntax) is { } template &&
             owner.SpanStart == template.Span.End &&
             IsOnSingleLine(template, text))
         {
@@ -502,7 +502,7 @@ internal class CSharpOnTypeFormattingPass : CSharpFormattingPassBase
 
         if (owner is CSharpStatementLiteralSyntax &&
             owner.NextSpan() is { } nextNode &&
-            nextNode.AncestorsAndSelf().FirstOrDefault(a => a is CSharpTemplateBlockSyntax) is { } template &&
+            nextNode.FirstAncestorOrSelf<SyntaxNode>(a => a is CSharpTemplateBlockSyntax) is { } template &&
             template.SpanStart == owner.Span.End &&
             IsOnSingleLine(template, text))
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
@@ -351,7 +351,7 @@ internal sealed class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenamePar
             return null;
         }
 
-        var node = owner.Ancestors().FirstOrDefault(n => n.Kind == SyntaxKind.MarkupTagHelperStartTag);
+        var node = owner.Parent?.FirstAncestorOrSelf<SyntaxNode>(n => n.Kind == SyntaxKind.MarkupTagHelperStartTag);
         if (node is not MarkupTagHelperStartTagSyntax tagHelperStartTag)
         {
             return null;


### PR DESCRIPTION
Small refactoring I noticed to reduce a few unnecessary closure allocations
