### PR TITLE
Remove unnecessary IDE references to GetEditHandler

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/ClassifiedSpan.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/ClassifiedSpan.cs
@@ -7,16 +7,13 @@ namespace Microsoft.VisualStudio.Editor.Razor;
 
 public struct ClassifiedSpan
 {
-    public ClassifiedSpan(SourceSpan span, SourceSpan blockSpan, SpanKind spanKind, BlockKind blockKind, AcceptedCharacters acceptedCharacters)
+    public ClassifiedSpan(SourceSpan span, SourceSpan blockSpan, SpanKind spanKind, BlockKind blockKind)
     {
         Span = span;
         BlockSpan = blockSpan;
         SpanKind = spanKind;
         BlockKind = blockKind;
-        AcceptedCharacters = acceptedCharacters;
     }
-
-    public AcceptedCharacters AcceptedCharacters { get; }
 
     public BlockKind BlockKind { get; }
 

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultRazorSyntaxFactsService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultRazorSyntaxFactsService.cs
@@ -20,8 +20,7 @@ internal class DefaultRazorSyntaxFactsService : RazorSyntaxFactsService
                 item.Span,
                 item.BlockSpan,
                 (SpanKind)item.SpanKind,
-                (BlockKind)item.BlockKind,
-                (AcceptedCharacters)item.AcceptedCharacters)).ToArray();
+                (BlockKind)item.BlockKind)).ToArray();
     }
 
     public override IReadOnlyList<TagHelperSpan> GetTagHelperSpans(RazorSyntaxTree syntaxTree)

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultRazorSyntaxFactsServiceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultRazorSyntaxFactsServiceTest.cs
@@ -26,10 +26,10 @@ public class DefaultRazorSyntaxFactsServiceTest : RazorProjectEngineTestBase
         // Arrange
         var expectedSpans = new[]
         {
-            new ClassifiedSpan(new SourceSpan("test.cshtml", 0, 0, 0, 5), new SourceSpan("test.cshtml", 0, 0, 0, 5), SpanKind.Markup, BlockKind.Tag, AcceptedCharacters.Any),
-            new ClassifiedSpan(new SourceSpan("test.cshtml", 5, 0, 5, 6), new SourceSpan("test.cshtml", 0, 0, 0, 42), SpanKind.Markup, BlockKind.Markup, AcceptedCharacters.Any),
-            new ClassifiedSpan(new SourceSpan("test.cshtml", 34, 1, 27, 2), new SourceSpan("test.cshtml", 0, 0, 0, 42), SpanKind.Markup, BlockKind.Markup, AcceptedCharacters.Any),
-            new ClassifiedSpan(new SourceSpan("test.cshtml", 36, 2, 0, 6), new SourceSpan("test.cshtml", 36, 2, 0, 6), SpanKind.Markup, BlockKind.Tag, AcceptedCharacters.Any),
+            new ClassifiedSpan(new SourceSpan("test.cshtml", 0, 0, 0, 5), new SourceSpan("test.cshtml", 0, 0, 0, 5), SpanKind.Markup, BlockKind.Tag),
+            new ClassifiedSpan(new SourceSpan("test.cshtml", 5, 0, 5, 6), new SourceSpan("test.cshtml", 0, 0, 0, 42), SpanKind.Markup, BlockKind.Markup),
+            new ClassifiedSpan(new SourceSpan("test.cshtml", 34, 1, 27, 2), new SourceSpan("test.cshtml", 0, 0, 0, 42), SpanKind.Markup, BlockKind.Markup),
+            new ClassifiedSpan(new SourceSpan("test.cshtml", 36, 2, 0, 6), new SourceSpan("test.cshtml", 36, 2, 0, 6), SpanKind.Markup, BlockKind.Tag),
         };
         var codeDocument = GetCodeDocument(
 @"<div>
@@ -51,9 +51,9 @@ public class DefaultRazorSyntaxFactsServiceTest : RazorProjectEngineTestBase
         // Arrange
         var expectedSpans = new[]
         {
-            new ClassifiedSpan(new SourceSpan("test.cshtml", 14, 0, 14, 1), new SourceSpan("test.cshtml", 0, 0, 0, 49), SpanKind.Code, BlockKind.Tag, AcceptedCharacters.AnyExceptNewline),
-            new ClassifiedSpan(new SourceSpan("test.cshtml", 23, 0, 23, 2), new SourceSpan("test.cshtml", 0, 0, 0, 49), SpanKind.Markup, BlockKind.Tag, AcceptedCharacters.Any),
-            new ClassifiedSpan(new SourceSpan("test.cshtml", 32, 0, 32, 4), new SourceSpan("test.cshtml", 0, 0, 0, 49), SpanKind.Code, BlockKind.Tag, AcceptedCharacters.AnyExceptNewline),
+            new ClassifiedSpan(new SourceSpan("test.cshtml", 14, 0, 14, 1), new SourceSpan("test.cshtml", 0, 0, 0, 49), SpanKind.Code, BlockKind.Tag),
+            new ClassifiedSpan(new SourceSpan("test.cshtml", 23, 0, 23, 2), new SourceSpan("test.cshtml", 0, 0, 0, 49), SpanKind.Markup, BlockKind.Tag),
+            new ClassifiedSpan(new SourceSpan("test.cshtml", 32, 0, 32, 4), new SourceSpan("test.cshtml", 0, 0, 0, 49), SpanKind.Code, BlockKind.Tag),
         };
         var codeDocument = GetCodeDocument(
 @"<taghelper id=1 class=""th"" show=true></taghelper>");


### PR DESCRIPTION
There are a few simple IDE scenarios that are using GetEditHandler that do no need to do so. This removes them in preparation for turning off calculations entirely.
