### PR TITLE
Revert "Improve Perf for Semantic Tokens (#8968)"

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
@@ -49,29 +49,12 @@ public class RazorLanguageServerBenchmarkBase : ProjectSnapshotManagerBenchmarkB
 
     private protected IRazorLogger Logger { get; }
 
-    /// <summary>
-    /// Adds a file at a path with content from a string (can be a read from disk or from a resource)
-    /// </summary>
-    internal IDocumentSnapshot GetDocumentSnapshot(string projectFilePath, string filePath, string fileContent, string targetPath)
-    {
-        var text = SourceText.From(fileContent);
-        return GetDocumentSnapshot(projectFilePath, filePath, text, targetPath);
-    }
-
-    /// <summary>
-    /// Adds a file at a path with the content from the disk location.
-    /// </summary>
     internal IDocumentSnapshot GetDocumentSnapshot(string projectFilePath, string filePath, string targetPath)
-    {       
-        using var fileStream = new FileStream(filePath, FileMode.Open);
-        var text = SourceText.From(fileStream);
-        return GetDocumentSnapshot(projectFilePath, filePath, text, targetPath);
-    }
-
-    internal IDocumentSnapshot GetDocumentSnapshot(string projectFilePath, string filePath, SourceText text, string targetPath)
     {
         var intermediateOutputPath = Path.Combine(Path.GetDirectoryName(projectFilePath), "obj");
         var hostProject = new HostProject(projectFilePath, intermediateOutputPath, RazorConfiguration.Default, rootNamespace: null);
+        using var fileStream = new FileStream(filePath, FileMode.Open);
+        var text = SourceText.From(fileStream);
         var textLoader = TextLoader.From(TextAndVersion.Create(text, VersionStamp.Create()));
         var hostDocument = new HostDocument(filePath, targetPath, FileKinds.Component);
 

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensBenchmark.cs
@@ -13,7 +13,6 @@ using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer;
 using Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
-using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.Extensions.DependencyInjection;
@@ -140,7 +139,7 @@ public class RazorSemanticTokensBenchmark : RazorLanguageServerBenchmarkBase
         }
 
         // We can't get C# responses without significant amounts of extra work, so let's just shim it for now, any non-Null result is fine.
-        internal override Task<PooledObject<List<SemanticRange>>?> GetCSharpSemanticRangesAsync(
+        internal override Task<List<SemanticRange>> GetCSharpSemanticRangesAsync(
             RazorCodeDocument codeDocument,
             TextDocumentIdentifier textDocumentIdentifier,
             Range razorRange,
@@ -150,7 +149,7 @@ public class RazorSemanticTokensBenchmark : RazorLanguageServerBenchmarkBase
             CancellationToken cancellationToken,
             string previousResultId = null)
         {
-            return Task.FromResult<PooledObject<List<SemanticRange>>?>(ListPool<SemanticRange>.GetPooledObject());
+            return Task.FromResult(new List<SemanticRange>());
         }
     }
 }

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensRangeEndpointBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensRangeEndpointBenchmark.cs
@@ -14,7 +14,6 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
-using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.Extensions.DependencyInjection;
@@ -54,7 +53,7 @@ public class RazorSemanticTokensRangeEndpointBenchmark : RazorLanguageServerBenc
     private RazorRequestContext RequestContext { get; set; }
 
     [Params(0, 100, 1000)]
-    public int CsSemanticRangesToReturn { get; set; }
+    public int NumberOfCsSemanticRangesToReturn { get; set; }
 
     private static List<SemanticRange> PregeneratedRandomSemanticRanges { get; set; }
 
@@ -66,15 +65,11 @@ public class RazorSemanticTokensRangeEndpointBenchmark : RazorLanguageServerBenc
         var projectRoot = Path.Combine(RepoRoot, "src", "Razor", "test", "testapps", "ComponentApp");
         ProjectFilePath = Path.Combine(projectRoot, "ComponentApp.csproj");
         PagesDirectory = Path.Combine(projectRoot, "Components", "Pages");
+        var filePath = Path.Combine(PagesDirectory, $"SemanticTokens.razor");
+        TargetPath = "/Components/Pages/SemanticTokens.razor";
 
-        var largeFileText = Resources.GetResourceText("MSN.cshtml");
-
-        var largeFilePath = Path.Combine(PagesDirectory, $"MSN.cshtml");
-        var documentUri = new Uri(largeFilePath);
-
-        TargetPath = "/Components/Pages/MSN.cshtml";
-
-        var documentSnapshot = GetDocumentSnapshot(ProjectFilePath, largeFilePath, largeFileText, TargetPath);
+        var documentUri = new Uri(filePath);
+        var documentSnapshot = GetDocumentSnapshot(ProjectFilePath, filePath, TargetPath);
         var version = 1;
         DocumentContext = new VersionedDocumentContext(documentUri, documentSnapshot, projectContext: null, version);
         Logger = new NoopLogger();
@@ -97,25 +92,21 @@ public class RazorSemanticTokensRangeEndpointBenchmark : RazorLanguageServerBenc
 
         var random = new Random();
         var codeDocument = await DocumentContext.GetCodeDocumentAsync(CancellationToken);
-        var pooledList = ListPool<SemanticRange>.GetPooledObject(out var pregeneratedRandomSemanticRanges);
-        pregeneratedRandomSemanticRanges.Capacity = CsSemanticRangesToReturn;
-        for (var i = 0; i < CsSemanticRangesToReturn; i++)
+        PregeneratedRandomSemanticRanges = new List<SemanticRange>(NumberOfCsSemanticRangesToReturn);
+        for (var i = 0; i < NumberOfCsSemanticRangesToReturn; i++)
         {
             var startLine = random.Next(Range.Start.Line, Range.End.Line);
             var startChar = random.Next(0, codeDocument.Source.Lines.GetLineLength(startLine));
             var endLine = random.Next(startLine, Range.End.Line);
             var endChar = startLine == endLine
-                ? random.Next(startChar + 1, codeDocument.Source.Lines.GetLineLength(startLine))
+                ? random.Next(startChar, codeDocument.Source.Lines.GetLineLength(startLine))
                 : random.Next(0, codeDocument.Source.Lines.GetLineLength(endLine));
 
-            pregeneratedRandomSemanticRanges.Add(
+            PregeneratedRandomSemanticRanges.Add(
                 new SemanticRange(random.Next(),
                     new Range { Start = new Position(startLine, startChar), End = new Position(endLine, endChar) },
-                    modifier: 0, fromRazor: false));
+                    0, fromRazor: false));
         }
-
-        pregeneratedRandomSemanticRanges.Sort();
-        PregeneratedRandomSemanticRanges = pregeneratedRandomSemanticRanges;
     }
 
     [Benchmark(Description = "Razor Semantic Tokens Range Endpoint")]
@@ -168,7 +159,7 @@ public class RazorSemanticTokensRangeEndpointBenchmark : RazorLanguageServerBenc
         }
 
         // We can't get C# responses without significant amounts of extra work, so let's just shim it for now, any non-Null result is fine.
-        internal override Task<PooledObject<List<SemanticRange>>?> GetCSharpSemanticRangesAsync(
+        internal override Task<List<SemanticRange>> GetCSharpSemanticRangesAsync(
             RazorCodeDocument codeDocument,
             TextDocumentIdentifier textDocumentIdentifier,
             Range razorRange,
@@ -178,11 +169,7 @@ public class RazorSemanticTokensRangeEndpointBenchmark : RazorLanguageServerBenc
             CancellationToken cancellationToken,
             string previousResultId = null)
         {
-            var pooledList = ListPool<SemanticRange>.GetPooledObject(out var randomSemanticRanges);
-            randomSemanticRanges.Capacity = PregeneratedRandomSemanticRanges.Count;
-            randomSemanticRanges.AddRange(PregeneratedRandomSemanticRanges);
-
-            return Task.FromResult<PooledObject<List<SemanticRange>>?>(pooledList);
+            return Task.FromResult(PregeneratedRandomSemanticRanges);
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RangeExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RangeExtensions.cs
@@ -138,19 +138,8 @@ internal static class RangeExtensions
             throw new ArgumentOutOfRangeException($"Range end line {range.End.Line} matches or exceeds SourceText boundary {sourceText.Lines.Count}.");
         }
 
-        var startLine = sourceText.Lines[range.Start.Line];
-        TextLine endLine;
-        if (range.Start.Line == range.End.Line)
-        {
-            endLine = startLine;
-        }
-        else
-        {
-            endLine = sourceText.Lines[range.End.Line];
-        }
-
-        var start = startLine.Start + range.Start.Character;
-        var end = endLine.Start + range.End.Character;
+        var start = sourceText.Lines[range.Start.Line].Start + range.Start.Character;
+        var end = sourceText.Lines[range.End.Line].Start + range.End.Character;
 
         var length = end - start;
         if (length < 0)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/RazorSemanticTokensInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/RazorSemanticTokensInfoService.cs
@@ -58,169 +58,57 @@ internal class RazorSemanticTokensInfoService : IRazorSemanticTokensInfoService
         var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
 
         cancellationToken.ThrowIfCancellationRequested();
-        List<SemanticRange>? razorSemanticRanges = null;
-        PooledObject<List<SemanticRange>>? csharpSemanticRanges = null;
-        
+        var razorSemanticRanges = TagHelperSemanticRangeVisitor.VisitAllNodes(codeDocument, range, razorSemanticTokensLegend, _razorLSPOptionsMonitor.CurrentValue.ColorBackground);
+        List<SemanticRange>? csharpSemanticRanges = null;
+
         try
         {
-            var csharpSemanticRangesTask = GetCSharpSemanticRangesAsync(
-                codeDocument, textDocumentIdentifier, range, razorSemanticTokensLegend, documentContext.Version, correlationId, cancellationToken);
-
-            razorSemanticRanges = TagHelperSemanticRangeVisitor.VisitAllNodes(codeDocument, range, razorSemanticTokensLegend, _razorLSPOptionsMonitor.CurrentValue.ColorBackground);
-            csharpSemanticRanges = await csharpSemanticRangesTask.ConfigureAwait(false);
+            csharpSemanticRanges = await GetCSharpSemanticRangesAsync(codeDocument, textDocumentIdentifier, range, razorSemanticTokensLegend, documentContext.Version, correlationId, cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error thrown while retrieving CSharp semantic range.");
         }
 
-        if (cancellationToken.IsCancellationRequested)
-        {
-            if (csharpSemanticRanges.HasValue)
-            {
-                csharpSemanticRanges.Value.Dispose();
-            }
-
-            return null;
-        }
-
-        using var combinedSemanticRanges = CombineSemanticRanges(razorSemanticRanges, csharpSemanticRanges is not null ? csharpSemanticRanges.Value.Object : null);
+        var combinedSemanticRanges = CombineSemanticRanges(razorSemanticRanges, csharpSemanticRanges);
 
         // We return null when we have an incomplete view of the document.
         // Likely CSharp ahead of us in terms of document versions.
         // We return null (which to the LSP is a no-op) to prevent flashing of CSharp elements.
-        if (combinedSemanticRanges is null || !combinedSemanticRanges.HasValue)
+        if (combinedSemanticRanges is null)
         {
             _logger.LogWarning("Incomplete view of document. C# may be ahead of us in document versions.");
-
-            if (csharpSemanticRanges.HasValue)
-            {
-                csharpSemanticRanges.Value.Dispose();
-            }
-
             return null;
         }
 
-        var data = ConvertSemanticRangesToSemanticTokensData(combinedSemanticRanges.Value.Object, codeDocument);
+        var data = ConvertSemanticRangesToSemanticTokensData(combinedSemanticRanges, codeDocument);
         var tokens = new SemanticTokens { Data = data };
-
-        if (csharpSemanticRanges.HasValue)
-        {
-            csharpSemanticRanges.Value.Dispose();
-        }
 
         return tokens;
     }
 
-    private static PooledObject<List<SemanticRange>>? CombineSemanticRanges(List<SemanticRange>? razorRanges, List<SemanticRange>? csharpRanges)
+    private static List<SemanticRange>? CombineSemanticRanges(List<SemanticRange>? ranges1, List<SemanticRange>? ranges2)
     {
-        if (razorRanges is null || csharpRanges is null)
+        if (ranges1 is null || ranges2 is null)
         {
             // If we have an incomplete view of the situation we should return null so we avoid flashing.
             return null;
         }
 
+        var newList = new List<SemanticRange>(ranges1.Count + ranges2.Count);
+        newList.AddRange(ranges1);
+        newList.AddRange(ranges2);
+
         // Because SemanticToken data is generated relative to the previous token it must be in order.
-        // We have a guarantee of order within any given language server, but when we translate from the ranges
-        // in the C# document to ranges into the Razor document we lose that guarantee.
-        // Having converted them to SemanticRange objects, we can simply do the final round of a merge sort.
-        var pooledList = ListPool<SemanticRange>.GetPooledObject(out var newList);
-        newList.SetCapacityIfLarger(razorRanges.Count + csharpRanges.Count);
+        // We have a guarantee of order within any given language server, but the interweaving of them can be quite complex.
+        // Rather than attempting to reason about transition zones we can simply order our ranges since we know there can be no overlapping range.
+        newList.Sort();
 
-        var indexRazor = 0;
-        var indexCsharp = 0;
-        while (indexRazor < razorRanges.Count && indexCsharp < csharpRanges.Count)
-        {
-            var currentRazorRange = razorRanges[indexRazor];
-            var currentCsharpRange = csharpRanges[indexCsharp];
-
-            var comparison = currentRazorRange.CompareTo(currentCsharpRange);
-
-            if (comparison == 0)
-            {
-                // csharp and razor ranges have the same span; skip the C# item
-                ++indexCsharp;
-            }
-            else if (comparison < 0)
-            {
-                newList.Add(currentRazorRange);
-                ++indexRazor;
-            }
-            else
-            {
-                newList.Add(currentCsharpRange);
-                ++indexCsharp;
-            }
-        }
-
-        while (indexRazor < razorRanges.Count)
-        {
-            newList.Add(razorRanges[indexRazor]);
-            ++indexRazor;
-        }
-
-        while (indexCsharp < csharpRanges.Count)
-        {
-            newList.Add(csharpRanges[indexCsharp]);
-            ++indexCsharp;
-        }
-
-#if DEBUG
-        // Verify that the result of merging above matches the old algorithm of doing a 'full sort'.        
-        using var _2 = ListPool<SemanticRange>.GetPooledObject(out var fullSortList);
-
-        fullSortList.AddRange(razorRanges);
-        fullSortList.AddRange(csharpRanges);
-
-        fullSortList.Sort((left, right) =>
-        {
-            var rangeCompare = left.CompareTo(right);
-            if (rangeCompare != 0)
-            {
-                return rangeCompare;
-            }
-
-            // If we have ranges that are the same, we want a Razor produced token to win over a non-Razor produced token
-            if (left.FromRazor && !right.FromRazor)
-            {
-                return -1;
-            }
-            else if (right.FromRazor && !left.FromRazor)
-            {
-                return 1;
-            }
-
-            return 0;
-        });
-
-        for (var idx = 1; idx < fullSortList.Count; ++idx)
-        {
-            if (fullSortList[idx].CompareTo(fullSortList[idx - 1]) == 0)
-            {
-                fullSortList.RemoveAt(idx);
-                idx--;
-            }
-        }
-
-        Debug.Assert(fullSortList.Count == newList.Count,$"After sort and removing duplicates (favoring Razor over C#), the lists should be equal size.  Fast algorithm: ${newList.Count} Full sort: ${fullSortList.Count}");
-
-        for (var idx = 0; idx < fullSortList.Count; ++idx)
-        {
-            Debug.Assert(Equals(newList[idx], fullSortList[idx]), $"Difference between the full sort and the merge of sorted lists at index ${idx}");
-        }
-#endif
-
-        return pooledList;
+        return newList;
     }
 
-    /// <summary>
-    /// Returns a sorted list of SemanticRange objects representing the semantic info
-    /// for the C# regions of the Razor file.
-    ///
-    /// Internal and virtual to enable testing; for running product, no need to override.
-    /// </summary>
-    /// <returns>List of Semantic range sorted by position</returns>
-    internal virtual async Task<PooledObject<List<SemanticRange>>?> GetCSharpSemanticRangesAsync(
+    // Internal and virtual for testing only
+    internal virtual async Task<List<SemanticRange>?> GetCSharpSemanticRangesAsync(
         RazorCodeDocument codeDocument,
         TextDocumentIdentifier textDocumentIdentifier,
         Range razorRange,
@@ -237,10 +125,9 @@ internal class RazorSemanticTokensInfoService : IRazorSemanticTokensInfoService
             !TryGetMinimalCSharpRange(codeDocument, razorRange, out csharpRange))
         {
             // There's no C# in the range.
-            return ListPool<SemanticRange>.GetPooledObject();
+            return new List<SemanticRange>();
         }
 
-        // We expect that the response is sorted already.
         var csharpResponse = await GetMatchingCSharpResponseAsync(textDocumentIdentifier, documentVersion, csharpRange, correlationId, cancellationToken).ConfigureAwait(false);
 
         // Indicates an issue with retrieving the C# response (e.g. no response or C# is out of sync with us).
@@ -252,10 +139,10 @@ internal class RazorSemanticTokensInfoService : IRazorSemanticTokensInfoService
             return null;
         }
 
+        var razorRanges = new List<SemanticRange>();
         var colorBackground = _razorLSPOptionsMonitor.CurrentValue.ColorBackground;
         var textClassification = razorSemanticTokensLegend.MarkupTextLiteral;
         var razorSource = codeDocument.GetSourceText();
-        var pooledRanges = ListPool<SemanticRange>.GetPooledObject(out var razorRanges);
 
         SemanticRange? previousSemanticRange = null;
         Range? previousRazorSemanticRange = null;
@@ -287,12 +174,7 @@ internal class RazorSemanticTokensInfoService : IRazorSemanticTokensInfoService
             previousSemanticRange = semanticRange;
         }
 
-        // The ranges are sorted by the C# document, but we need to sort them by the Razor
-        // document since we mapped all the ranges and the mapping does not necessarily
-        // maintain the ordering.
-        razorRanges.Sort();
-
-        return pooledRanges;
+        return razorRanges;
     }
 
     private static void AddAdditionalCSharpWhitespaceRanges(List<SemanticRange> razorRanges, int textClassification, SourceText razorSource, Range? previousRazorSemanticRange, Range originalRange, ILogger logger)
@@ -323,7 +205,7 @@ internal class RazorSemanticTokensInfoService : IRazorSemanticTokensInfoService
                 Start = new Position(originalRange.Start.Line, 0),
                 End = originalRange.Start
             };
-            razorRanges.Add(new SemanticRange(textClassification, whitespaceRange, (int)RazorSemanticTokensLegend.RazorTokenModifiers.RazorCode, fromRazor:false));
+            razorRanges.Add(new SemanticRange(textClassification, whitespaceRange, (int)RazorSemanticTokensLegend.RazorTokenModifiers.RazorCode, fromRazor: false));
         }
     }
 
@@ -450,7 +332,7 @@ internal class RazorSemanticTokensInfoService : IRazorSemanticTokensInfoService
             Start = start,
             End = end
         };
-        var semanticRange = new SemanticRange(tokenType, range, tokenModifiers, fromRazor:false);
+        var semanticRange = new SemanticRange(tokenType, range, tokenModifiers, fromRazor: false);
 
         return semanticRange;
     }
@@ -463,31 +345,27 @@ internal class RazorSemanticTokensInfoService : IRazorSemanticTokensInfoService
 
         var sourceText = razorCodeDocument.GetSourceText();
 
-        if (sourceText is null)
-        {
-            return Array.Empty<int>();
-        }
-
-        var data = new int[semanticRanges.Count * TokenSize];
-        var semanticRangeCount = 0;
+        // We don't bother filtering out duplicate ranges (eg, where C# and Razor both have opinions), but instead take advantage of
+        // our sort algorithm to be correct, so we can skip duplicates here. That means our final array may end up smaller than the
+        // expected size, so we have to use a list to build it.
+        using var _ = ListPool<int>.GetPooledObject(out var data);
+        data.SetCapacityIfLarger(semanticRanges.Count * TokenSize);
 
         foreach (var result in semanticRanges)
         {
-            AppendData(result, previousResult, sourceText, data, semanticRangeCount);
-            semanticRangeCount += TokenSize;
+            AppendData(result, previousResult, sourceText, data);
 
             previousResult = result;
         }
 
-        return data;
+        return data.ToArray();
 
         // We purposely capture and manipulate the "data" array here to avoid allocation
         static void AppendData(
             SemanticRange currentRange,
             SemanticRange? previousRange,
             SourceText sourceText,
-            int[] targetArray,
-            int currentCount)
+            List<int> data)
         {
             /*
              * In short, each token takes 5 integers to represent, so a specific token `i` in the file consists of the following array indices:
@@ -519,22 +397,20 @@ internal class RazorSemanticTokensInfoService : IRazorSemanticTokensInfoService
                 deltaStart = currentRange.Range.Start.Character;
             }
 
-            targetArray[currentCount] = deltaLine;
-
-            // deltaStart
-            targetArray[currentCount + 1] = deltaStart;
+            data.Add(deltaLine);
+            data.Add(deltaStart);
 
             // length
             var textSpan = currentRange.Range.AsTextSpan(sourceText);
             var length = textSpan.Length;
             Debug.Assert(length > 0);
-            targetArray[currentCount + 2] = length;
+            data.Add(length);
 
             // tokenType
-            targetArray[currentCount + 3] = currentRange.Kind;
+            data.Add(currentRange.Kind);
 
             // tokenModifiers
-            targetArray[currentCount + 4] = currentRange.Modifier;
+            data.Add(currentRange.Modifier);
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/SemanticRange.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/SemanticRange.cs
@@ -13,9 +13,7 @@ internal sealed class SemanticRange : IComparable<SemanticRange>
         Kind = kind;
         Modifier = modifier;
         Range = range;
-#if DEBUG
         FromRazor = fromRazor;
-#endif
     }
 
     public Range Range { get; }
@@ -24,15 +22,12 @@ internal sealed class SemanticRange : IComparable<SemanticRange>
 
     public int Modifier { get; }
 
-#if DEBUG
     /// <summary>
     /// If we produce a token, and a delegated server produces a token, we want to prefer ours, so we use this flag to help our
     /// sort algorithm, that way we can avoid the perf hit of actually finding duplicates, and just take the first instance that
     /// covers a range.
-    /// Presently used only in Debug
     /// </summary>
     public bool FromRazor { get; }
-#endif
 
     public int CompareTo(SemanticRange? other)
     {
@@ -51,6 +46,16 @@ internal sealed class SemanticRange : IComparable<SemanticRange>
         if (endCompare != 0)
         {
             return endCompare;
+        }
+
+        // If we have ranges that are the same, we want a Razor produced token to win over a non-Razor produced token
+        if (FromRazor && !other.FromRazor)
+        {
+            return -1;
+        }
+        else if (other.FromRazor && !FromRazor)
+        {
+            return 1;
         }
 
         return 0;


### PR DESCRIPTION
This reverts commit 837dc71a2e30a894384ce3d80fa1a8e6603862a4.

﻿### Summary of the changes

-

Fixes:
Developers using debug noted that if they had specific sorts of content, the assert was firing, as that meant the two collections were not merging identically as before.  Undo.