### PR TITLE
Honour the locale name sent through via the parameters to the Initialize LSP method

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -95,7 +95,7 @@
     <Tooling_HtmlEditorPackageVersion>17.5.101-preview-0002</Tooling_HtmlEditorPackageVersion>
     <MicrosoftVisualStudioShellPackagesVersion>17.7.35047-preview.1</MicrosoftVisualStudioShellPackagesVersion>
     <MicrosoftVisualStudioPackagesVersion>17.7.38-preview</MicrosoftVisualStudioPackagesVersion>
-    <VisualStudioLanguageServerProtocolVersion>17.7.8-preview-g8c33dc3a76</VisualStudioLanguageServerProtocolVersion>
+    <VisualStudioLanguageServerProtocolVersion>17.8.3-preview</VisualStudioLanguageServerProtocolVersion>
     <!-- dotnet/runtime packages -->
     <MicrosoftExtensionsPackageVersion>6.0.0</MicrosoftExtensionsPackageVersion>
     <SystemCompositionPackageVersion>7.0.0</SystemCompositionPackageVersion>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CapabilitiesManager.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CapabilitiesManager.cs
@@ -13,6 +13,8 @@ internal class CapabilitiesManager : IInitializeManager<InitializeParams, Initia
     private InitializeParams? _initializeParams;
     private readonly ILspServices _lspServices;
 
+    public bool HasInitialized => _initializeParams is not null;
+
     public CapabilitiesManager(ILspServices lspServices)
     {
         _lspServices = lspServices;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
@@ -40,7 +40,8 @@ internal static class IServiceCollectionExtensions
         var razorLifeCycleManager = new RazorLifeCycleManager(razorLanguageServer, lspServerActivationTracker);
         services.AddSingleton<ILifeCycleManager>(razorLifeCycleManager);
         services.AddSingleton<RazorLifeCycleManager>(razorLifeCycleManager);
-        services.AddSingleton<IInitializeManager<InitializeParams, InitializeResult>, CapabilitiesManager>();
+        services.AddSingleton<CapabilitiesManager>();
+        services.AddSingleton<IInitializeManager<InitializeParams, InitializeResult>, CapabilitiesManager>(sp => sp.GetRequiredService<CapabilitiesManager>());
         services.AddSingleton<IRequestContextFactory<RazorRequestContext>, RazorRequestContextFactory>();
 
         services.AddSingleton<ICapabilitiesProvider, RazorLanguageServerCapability>();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -67,6 +67,15 @@ internal class RazorLanguageServer : AbstractLanguageServer<RazorRequestContext>
         Initialize();
     }
 
+    protected override IRequestExecutionQueue<RazorRequestContext> ConstructRequestExecutionQueue()
+    {
+        var handlerProvider = GetHandlerProvider();
+        var queue = new RazorRequestExecutionQueue(this, _logger, handlerProvider);
+        queue.Start();
+        return queue;
+
+    }
+
     protected override ILspServices ConstructLspServices()
     {
         var services = new ServiceCollection()
@@ -223,6 +232,11 @@ internal class RazorLanguageServer : AbstractLanguageServer<RazorRequestContext>
         public IHandlerProvider GetHandlerProvider()
         {
             return _server.GetHandlerProvider();
+        }
+
+        public RazorRequestExecutionQueue GetRequestExecutionQueue()
+        {
+            return (RazorRequestExecutionQueue)_server.GetRequestExecutionQueue();
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorRequestExecutionQueue.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorRequestExecutionQueue.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Globalization;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
+using Microsoft.CommonLanguageServerProtocol.Framework;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer;
+
+internal class RazorRequestExecutionQueue : RequestExecutionQueue<RazorRequestContext>
+{
+    private CultureInfo? _cultureInfo;
+    private readonly CapabilitiesManager _capabilitiesManager;
+
+    public RazorRequestExecutionQueue(AbstractLanguageServer<RazorRequestContext> languageServer, ILspLogger logger, IHandlerProvider handlerProvider)
+        : base(languageServer, logger, handlerProvider)
+    {
+        _capabilitiesManager = languageServer.GetLspServices().GetRequiredService<CapabilitiesManager>();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD003:Avoid awaiting foreign Tasks", Justification = "<Pending>")]
+    public override Task WrapStartRequestTaskAsync(Task nonMutatingRequestTask, bool rethrowExceptions)
+    {
+        CultureInfo.CurrentUICulture = GetCultureForRequest();
+
+        return nonMutatingRequestTask;
+    }
+
+    private CultureInfo GetCultureForRequest()
+    {
+        // Mostly copied from Roslyn: https://github.com/dotnet/roslyn/blob/6faeaaa5c10472c0ef34c6714659712cd83894b9/src/Features/LanguageServer/Protocol/RoslynRequestExecutionQueue.cs#L45
+        if (_cultureInfo is not null)
+        {
+            return _cultureInfo;
+        }
+
+        if (!_capabilitiesManager.HasInitialized)
+        {
+            // Initialize has not been called yet, no culture to set
+            return CultureInfo.CurrentUICulture;
+        }
+
+        var initializeParams = _capabilitiesManager.GetInitializeParams();
+        var locale = initializeParams.Locale;
+        if (string.IsNullOrWhiteSpace(locale))
+        {
+            // The client did not provide a culture, use the OS configured value
+            // and remember that so we can short-circuit from now on.
+            _cultureInfo = CultureInfo.CurrentUICulture;
+            return _cultureInfo;
+        }
+
+        try
+        {
+            // Parse the LSP locale into a culture and remember it for future requests.
+            _cultureInfo = CultureInfo.CreateSpecificCulture(locale);
+        }
+        catch (CultureNotFoundException)
+        {
+            // We couldn't parse the culture, log a warning and fallback to the OS configured value.
+            // Also remember the fallback so we don't warn on every request.
+            _logger.LogWarning($"Culture {locale} was not found, falling back to OS culture");
+            _cultureInfo = CultureInfo.CurrentUICulture;
+        }
+
+        return _cultureInfo;
+    }
+
+    // Internal for testing
+    internal TestAccessor GetTestAccessor()
+    {
+        return new TestAccessor(this);
+    }
+
+    internal class TestAccessor
+    {
+        private RazorRequestExecutionQueue _queue;
+
+        public TestAccessor(RazorRequestExecutionQueue queue)
+        {
+            _queue = queue;
+        }
+
+        public CultureInfo? GetCultureInfo()
+        {
+            return _queue._cultureInfo;
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/CSharpDiagnosticsEndToEndTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/CSharpDiagnosticsEndToEndTest.cs
@@ -43,11 +43,23 @@ public class CSharpDiagnosticsEndToEndTest : SingleServerDelegatingEndpointTestB
         await ValidateDiagnosticsAsync(input);
     }
 
-    private async Task ValidateDiagnosticsAsync(string input)
+    [Fact]
+    public async Task Handle_Razor()
+    {     
+        var input = """
+
+            {|RZ10012:<NonExistentComponent />|}
+
+            """;
+
+        await ValidateDiagnosticsAsync(input, "File.razor");
+    }
+
+    private async Task ValidateDiagnosticsAsync(string input, string? filePath = null)
     {
         TestFileMarkupParser.GetSpans(input, out input, out ImmutableDictionary<string, ImmutableArray<TextSpan>> spans);
 
-        var codeDocument = CreateCodeDocument(input);
+        var codeDocument = CreateCodeDocument(input, filePath: filePath);
         var sourceText = codeDocument.GetSourceText();
         var razorFilePath = "file://C:/path/test.razor";
         var uri = new Uri(razorFilePath);


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/9064

Proof it works:
<img width="551" alt="image" src="https://github.com/dotnet/razor/assets/754264/9eb3f13b-5b07-4f3c-9b74-80205738fc0d">
