### PR TITLE
Preserve node information for bind:after attributes

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentBindLoweringPass.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentBindLoweringPass.cs
@@ -827,7 +827,7 @@ internal class ComponentBindLoweringPass : ComponentIntermediateNodePassBase, IR
 
             changeExpressionTokens.Add(new IntermediateToken()
             {
-                Content = $"{asyncKeyword} __value => {{ {original.Content} = __value; {awaitKeyword} {invokeDelegateMethod}(",
+                Content = $"{asyncKeyword} __value => {{ {original.Content} = __value; {awaitKeyword}{invokeDelegateMethod}(",
                 Kind = TokenKind.CSharp
             });
             changeExpressionTokens.Add(after);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_Action/TestComponent.codegen.cs
@@ -30,7 +30,7 @@ namespace Test
 #nullable disable
             );
             __o = new global::System.Action<System.Int32>(
-             __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+             __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                               Update

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_Action/TestComponent.codegen.cs
@@ -30,7 +30,15 @@ namespace Test
 #nullable disable
             );
             __o = new global::System.Action<System.Int32>(
-            __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(Update); });
+             __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                              Update
+
+#line default
+#line hidden
+#nullable disable
+            ); });
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
             ));

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_Action/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_Action/TestComponent.ir.txt
@@ -20,7 +20,9 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(Update); }
+                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+                            LazyIntermediateToken - (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
+                            IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
                 HtmlContent - (72:0,72 [2] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_Action/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_Action/TestComponent.ir.txt
@@ -20,7 +20,7 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
                             LazyIntermediateToken - (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
                             IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_Action/TestComponent.mappings.txt
@@ -5,17 +5,17 @@ Generated Location: (1055:25,30 [11] )
 
 Source Location: (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |Update|
-Generated Location: (1476:35,62 [6] )
+Generated Location: (1475:35,62 [6] )
 |Update|
 
 Source Location: (19:0,19 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1900:48,19 [5] )
+Generated Location: (1899:48,19 [5] )
 |Value|
 
 Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2151:57,49 [5] )
+Generated Location: (2150:57,49 [5] )
 |Value|
 
 Source Location: (81:1,7 [82] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -24,7 +24,7 @@ Source Location: (81:1,7 [82] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public void Update() { }
 |
-Generated Location: (2564:75,7 [82] )
+Generated Location: (2563:75,7 [82] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_Action/TestComponent.mappings.txt
@@ -3,14 +3,19 @@
 Generated Location: (1055:25,30 [11] )
 |ParentValue|
 
+Source Location: (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+|Update|
+Generated Location: (1476:35,62 [6] )
+|Update|
+
 Source Location: (19:0,19 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1700:40,19 [5] )
+Generated Location: (1900:48,19 [5] )
 |Value|
 
 Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1951:49,49 [5] )
+Generated Location: (2151:57,49 [5] )
 |Value|
 
 Source Location: (81:1,7 [82] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -19,7 +24,7 @@ Source Location: (81:1,7 [82] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public void Update() { }
 |
-Generated Location: (2364:67,7 [82] )
+Generated Location: (2564:75,7 [82] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_ActionLambda/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_ActionLambda/TestComponent.codegen.cs
@@ -30,7 +30,7 @@ namespace Test
 #nullable disable
             );
             __o = new global::System.Action<System.Int32>(
-             __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+             __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                               () => { }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_ActionLambda/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_ActionLambda/TestComponent.codegen.cs
@@ -30,7 +30,15 @@ namespace Test
 #nullable disable
             );
             __o = new global::System.Action<System.Int32>(
-            __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(() => { }); });
+             __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                              () => { }
+
+#line default
+#line hidden
+#nullable disable
+            ); });
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
             ));

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_ActionLambda/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_ActionLambda/TestComponent.ir.txt
@@ -20,7 +20,9 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(() => { }); }
+                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+                            LazyIntermediateToken - (62:0,62 [9] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - () => { }
+                            IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (62:0,62 [9] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (62:0,62 [9] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - () => { }
                 HtmlContent - (75:0,75 [2] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_ActionLambda/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_ActionLambda/TestComponent.ir.txt
@@ -20,7 +20,7 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
                             LazyIntermediateToken - (62:0,62 [9] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - () => { }
                             IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (62:0,62 [9] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_ActionLambda/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_ActionLambda/TestComponent.mappings.txt
@@ -3,21 +3,26 @@
 Generated Location: (1055:25,30 [11] )
 |ParentValue|
 
+Source Location: (62:0,62 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1476:35,62 [9] )
+|() => { }|
+
 Source Location: (19:0,19 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1703:40,19 [5] )
+Generated Location: (1903:48,19 [5] )
 |Value|
 
 Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1954:49,49 [5] )
+Generated Location: (2154:57,49 [5] )
 |Value|
 
 Source Location: (84:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (2367:67,7 [50] )
+Generated Location: (2567:75,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_ActionLambda/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_ActionLambda/TestComponent.mappings.txt
@@ -5,24 +5,24 @@ Generated Location: (1055:25,30 [11] )
 
 Source Location: (62:0,62 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |() => { }|
-Generated Location: (1476:35,62 [9] )
+Generated Location: (1475:35,62 [9] )
 |() => { }|
 
 Source Location: (19:0,19 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1903:48,19 [5] )
+Generated Location: (1902:48,19 [5] )
 |Value|
 
 Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2154:57,49 [5] )
+Generated Location: (2153:57,49 [5] )
 |Value|
 
 Source Location: (84:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (2567:75,7 [50] )
+Generated Location: (2566:75,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback/TestComponent.codegen.cs
@@ -30,7 +30,15 @@ namespace Test
 #nullable disable
             );
             __o = global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<global::System.Int32>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<global::System.Int32>(this, 
-            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: UpdateValue); }, value: ParentValue), ParentValue)));
+            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                              UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            ); }, value: ParentValue), ParentValue)));
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
             ));

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback/TestComponent.ir.txt
@@ -21,7 +21,9 @@
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: UpdateValue); }, value: ParentValue)
+                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: 
+                            LazyIntermediateToken - (62:0,62 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
+                            IntermediateToken -  - CSharp - ); }, value: ParentValue)
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (62:0,62 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (62:0,62 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback/TestComponent.mappings.txt
@@ -3,14 +3,19 @@
 Generated Location: (1055:25,30 [11] )
 |ParentValue|
 
+Source Location: (62:0,62 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1921:35,62 [11] )
+|UpdateValue|
+
 Source Location: (19:0,19 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2188:40,19 [5] )
+Generated Location: (2386:48,19 [5] )
 |Value|
 
 Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2439:49,49 [5] )
+Generated Location: (2637:57,49 [5] )
 |Value|
 
 Source Location: (86:1,7 [102] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -18,7 +23,7 @@ Source Location: (86:1,7 [102] x:\dir\subdir\Test\TestComponent.cshtml)
     public int ParentValue { get; set; } = 42;
     public EventCallback UpdateValue { get; set; }
 |
-Generated Location: (2852:67,7 [102] )
+Generated Location: (3050:75,7 [102] )
 |
     public int ParentValue { get; set; } = 42;
     public EventCallback UpdateValue { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesAction/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesAction/TestComponent.codegen.cs
@@ -30,7 +30,15 @@ namespace Test
 #nullable disable
             );
             __o = global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<global::System.Int32>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<global::System.Int32>(this, 
-            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: () => { }); }, value: ParentValue), ParentValue)));
+            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                              () => { }
+
+#line default
+#line hidden
+#nullable disable
+            ); }, value: ParentValue), ParentValue)));
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
             ));

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesAction/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesAction/TestComponent.ir.txt
@@ -21,7 +21,9 @@
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: () => { }); }, value: ParentValue)
+                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: 
+                            LazyIntermediateToken - (62:0,62 [9] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - () => { }
+                            IntermediateToken -  - CSharp - ); }, value: ParentValue)
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (62:0,62 [9] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (62:0,62 [9] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - () => { }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesAction/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesAction/TestComponent.mappings.txt
@@ -3,21 +3,26 @@
 Generated Location: (1055:25,30 [11] )
 |ParentValue|
 
+Source Location: (62:0,62 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1921:35,62 [9] )
+|() => { }|
+
 Source Location: (19:0,19 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2186:40,19 [5] )
+Generated Location: (2384:48,19 [5] )
 |Value|
 
 Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2437:49,49 [5] )
+Generated Location: (2635:57,49 [5] )
 |Value|
 
 Source Location: (84:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (2850:67,7 [50] )
+Generated Location: (3048:75,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesFunction/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesFunction/TestComponent.codegen.cs
@@ -30,7 +30,15 @@ namespace Test
 #nullable disable
             );
             __o = global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<global::System.Int32>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<global::System.Int32>(this, 
-            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: UpdateValue); }, value: ParentValue), ParentValue)));
+            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                              UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            ); }, value: ParentValue), ParentValue)));
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
             ));

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesFunction/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesFunction/TestComponent.ir.txt
@@ -21,7 +21,9 @@
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: UpdateValue); }, value: ParentValue)
+                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: 
+                            LazyIntermediateToken - (62:0,62 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
+                            IntermediateToken -  - CSharp - ); }, value: ParentValue)
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (62:0,62 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (62:0,62 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesFunction/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesFunction/TestComponent.mappings.txt
@@ -3,14 +3,19 @@
 Generated Location: (1055:25,30 [11] )
 |ParentValue|
 
+Source Location: (62:0,62 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1921:35,62 [11] )
+|UpdateValue|
+
 Source Location: (19:0,19 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2188:40,19 [5] )
+Generated Location: (2386:48,19 [5] )
 |Value|
 
 Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2439:49,49 [5] )
+Generated Location: (2637:57,49 [5] )
 |Value|
 
 Source Location: (86:1,7 [106] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -19,7 +24,7 @@ Source Location: (86:1,7 [106] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public Task UpdateValue() => Task.CompletedTask;
 |
-Generated Location: (2852:67,7 [106] )
+Generated Location: (3050:75,7 [106] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningDelegate/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningDelegate/TestComponent.codegen.cs
@@ -30,7 +30,15 @@ namespace Test
 #nullable disable
             );
             __o = new global::System.Func<System.Int32, System.Threading.Tasks.Task>(
-            async __value => { ParentValue = __value; await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(Update); });
+            async  __value => { ParentValue = __value; await  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                              Update
+
+#line default
+#line hidden
+#nullable disable
+            ); });
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
             ));

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningDelegate/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningDelegate/TestComponent.codegen.cs
@@ -30,7 +30,7 @@ namespace Test
 #nullable disable
             );
             __o = new global::System.Func<System.Int32, System.Threading.Tasks.Task>(
-            async  __value => { ParentValue = __value; await  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(
+            async  __value => { ParentValue = __value; await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                               Update

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningDelegate/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningDelegate/TestComponent.ir.txt
@@ -20,7 +20,9 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - async __value => { ParentValue = __value; await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(Update); }
+                            IntermediateToken -  - CSharp - async  __value => { ParentValue = __value; await  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(
+                            LazyIntermediateToken - (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
+                            IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
                 HtmlContent - (72:0,72 [2] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningDelegate/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningDelegate/TestComponent.ir.txt
@@ -20,7 +20,7 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - async  __value => { ParentValue = __value; await  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(
+                            IntermediateToken -  - CSharp - async  __value => { ParentValue = __value; await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(
                             LazyIntermediateToken - (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
                             IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningDelegate/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningDelegate/TestComponent.mappings.txt
@@ -5,17 +5,17 @@ Generated Location: (1055:25,30 [11] )
 
 Source Location: (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |Update|
-Generated Location: (1516:35,62 [6] )
+Generated Location: (1515:35,62 [6] )
 |Update|
 
 Source Location: (19:0,19 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1940:48,19 [5] )
+Generated Location: (1939:48,19 [5] )
 |Value|
 
 Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2191:57,49 [5] )
+Generated Location: (2190:57,49 [5] )
 |Value|
 
 Source Location: (81:1,7 [101] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -24,7 +24,7 @@ Source Location: (81:1,7 [101] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public Task Update() => Task.CompletedTask;
 |
-Generated Location: (2604:75,7 [101] )
+Generated Location: (2603:75,7 [101] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningDelegate/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningDelegate/TestComponent.mappings.txt
@@ -3,14 +3,19 @@
 Generated Location: (1055:25,30 [11] )
 |ParentValue|
 
+Source Location: (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+|Update|
+Generated Location: (1516:35,62 [6] )
+|Update|
+
 Source Location: (19:0,19 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1740:40,19 [5] )
+Generated Location: (1940:48,19 [5] )
 |Value|
 
 Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1991:49,49 [5] )
+Generated Location: (2191:57,49 [5] )
 |Value|
 
 Source Location: (81:1,7 [101] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -19,7 +24,7 @@ Source Location: (81:1,7 [101] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public Task Update() => Task.CompletedTask;
 |
-Generated Location: (2404:67,7 [101] )
+Generated Location: (2604:75,7 [101] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningLambda/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningLambda/TestComponent.codegen.cs
@@ -30,7 +30,7 @@ namespace Test
 #nullable disable
             );
             __o = new global::System.Func<System.Int32, System.Threading.Tasks.Task>(
-            async  __value => { ParentValue = __value; await  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(
+            async  __value => { ParentValue = __value; await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                               () => { return Task.CompletedTask; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningLambda/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningLambda/TestComponent.codegen.cs
@@ -30,7 +30,15 @@ namespace Test
 #nullable disable
             );
             __o = new global::System.Func<System.Int32, System.Threading.Tasks.Task>(
-            async __value => { ParentValue = __value; await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(() => { return Task.CompletedTask; }); });
+            async  __value => { ParentValue = __value; await  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                              () => { return Task.CompletedTask; }
+
+#line default
+#line hidden
+#nullable disable
+            ); });
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
             ));

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningLambda/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningLambda/TestComponent.ir.txt
@@ -20,7 +20,9 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - async __value => { ParentValue = __value; await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(() => { return Task.CompletedTask; }); }
+                            IntermediateToken -  - CSharp - async  __value => { ParentValue = __value; await  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(
+                            LazyIntermediateToken - (62:0,62 [36] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - () => { return Task.CompletedTask; }
+                            IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (62:0,62 [36] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (62:0,62 [36] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - () => { return Task.CompletedTask; }
                 HtmlContent - (102:0,102 [2] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningLambda/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningLambda/TestComponent.ir.txt
@@ -20,7 +20,7 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - async  __value => { ParentValue = __value; await  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(
+                            IntermediateToken -  - CSharp - async  __value => { ParentValue = __value; await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(
                             LazyIntermediateToken - (62:0,62 [36] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - () => { return Task.CompletedTask; }
                             IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (62:0,62 [36] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningLambda/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningLambda/TestComponent.mappings.txt
@@ -3,21 +3,26 @@
 Generated Location: (1055:25,30 [11] )
 |ParentValue|
 
+Source Location: (62:0,62 [36] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { return Task.CompletedTask; }|
+Generated Location: (1516:35,62 [36] )
+|() => { return Task.CompletedTask; }|
+
 Source Location: (19:0,19 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1770:40,19 [5] )
+Generated Location: (1970:48,19 [5] )
 |Value|
 
 Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2021:49,49 [5] )
+Generated Location: (2221:57,49 [5] )
 |Value|
 
 Source Location: (111:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (2434:67,7 [50] )
+Generated Location: (2634:75,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningLambda/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningLambda/TestComponent.mappings.txt
@@ -5,24 +5,24 @@ Generated Location: (1055:25,30 [11] )
 
 Source Location: (62:0,62 [36] x:\dir\subdir\Test\TestComponent.cshtml)
 |() => { return Task.CompletedTask; }|
-Generated Location: (1516:35,62 [36] )
+Generated Location: (1515:35,62 [36] )
 |() => { return Task.CompletedTask; }|
 
 Source Location: (19:0,19 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1970:48,19 [5] )
+Generated Location: (1969:48,19 [5] )
 |Value|
 
 Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2221:57,49 [5] )
+Generated Location: (2220:57,49 [5] )
 |Value|
 
 Source Location: (111:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (2634:75,7 [50] )
+Generated Location: (2633:75,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_MixingSetWithAfter/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_MixingSetWithAfter/TestComponent.codegen.cs
@@ -29,7 +29,15 @@ namespace Test
 #line hidden
 #nullable disable
             );
-            __o = global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, callback: async __value => { await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: UpdateValue, value: ParentValue)(); await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: AfterUpdate); }, value: ParentValue), ParentValue);
+            __o = global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, callback: async __value => { await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: UpdateValue, value: ParentValue)(); await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                                   AfterUpdate
+
+#line default
+#line hidden
+#nullable disable
+            ); }, value: ParentValue), ParentValue);
         }
         #pragma warning restore 1998
 #nullable restore

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_MixingSetWithAfter/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_MixingSetWithAfter/TestComponent.ir.txt
@@ -23,7 +23,9 @@
                     HtmlAttribute - (16:0,16 [12] x:\dir\subdir\Test\TestComponent.cshtml) - myevent=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, 
-                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, callback: async __value => { await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: UpdateValue, value: ParentValue)(); await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: AfterUpdate); }, value: ParentValue)
+                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, callback: async __value => { await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: UpdateValue, value: ParentValue)(); await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: 
+                            LazyIntermediateToken - (67:0,67 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - AfterUpdate
+                            IntermediateToken -  - CSharp - ); }, value: ParentValue)
                             IntermediateToken -  - CSharp - , 
                             IntermediateToken -  - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_MixingSetWithAfter/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_MixingSetWithAfter/TestComponent.mappings.txt
@@ -3,6 +3,11 @@
 Generated Location: (1004:25,17 [11] )
 |ParentValue|
 
+Source Location: (67:0,67 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|AfterUpdate|
+Generated Location: (1720:34,67 [11] )
+|AfterUpdate|
+
 Source Location: (91:1,7 [159] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
@@ -10,7 +15,7 @@ Source Location: (91:1,7 [159] x:\dir\subdir\Test\TestComponent.cshtml)
     public void UpdateValue(string value) => ParentValue = value;
     public void AfterUpdate() { }
 |
-Generated Location: (1760:36,7 [159] )
+Generated Location: (1963:44,7 [159] )
 |
     public string ParentValue { get; set; } = "hi";
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithBindAfterAndSuffix/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithBindAfterAndSuffix/TestComponent.codegen.cs
@@ -29,7 +29,15 @@ namespace Test
 #line hidden
 #nullable disable
             );
-            __o = global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: DoSomething); }, value: ParentValue), ParentValue);
+            __o = global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                       DoSomething
+
+#line default
+#line hidden
+#nullable disable
+            ); }, value: ParentValue), ParentValue);
         }
         #pragma warning restore 1998
 #nullable restore

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithBindAfterAndSuffix/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithBindAfterAndSuffix/TestComponent.ir.txt
@@ -25,7 +25,9 @@
                     HtmlAttribute - (20:0,20 [12] x:\dir\subdir\Test\TestComponent.cshtml) - myevent=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, 
-                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: DoSomething); }, value: ParentValue)
+                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: 
+                            LazyIntermediateToken - (55:0,55 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - DoSomething
+                            IntermediateToken -  - CSharp - ); }, value: ParentValue)
                             IntermediateToken -  - CSharp - , 
                             IntermediateToken -  - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithBindAfterAndSuffix/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithBindAfterAndSuffix/TestComponent.mappings.txt
@@ -3,6 +3,11 @@
 Generated Location: (1008:25,21 [11] )
 |ParentValue|
 
+Source Location: (55:0,55 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|DoSomething|
+Generated Location: (1572:34,55 [11] )
+|DoSomething|
+
 Source Location: (85:2,7 [131] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
@@ -12,7 +17,7 @@ Source Location: (85:2,7 [131] x:\dir\subdir\Test\TestComponent.cshtml)
         return Task.CompletedTask;
     }
 |
-Generated Location: (1624:36,7 [131] )
+Generated Location: (1815:44,7 [131] )
 |
     public string ParentValue { get; set; } = "hi";
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.codegen.cs
@@ -39,7 +39,7 @@ namespace Test
 #nullable disable
             );
             __o = new global::System.Action<int>(
-             __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+             __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                                            Update

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.codegen.cs
@@ -39,7 +39,15 @@ namespace Test
 #nullable disable
             );
             __o = new global::System.Action<int>(
-            __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(Update); });
+             __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                                           Update
+
+#line default
+#line hidden
+#nullable disable
+            ); });
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
             ));

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.ir.txt
@@ -22,7 +22,7 @@
                             LazyIntermediateToken - (43:0,43 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (43:0,43 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
                             LazyIntermediateToken - (75:0,75 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
                             IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (75:0,75 [6] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.ir.txt
@@ -22,7 +22,9 @@
                             LazyIntermediateToken - (43:0,43 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (43:0,43 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(Update); }
+                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+                            LazyIntermediateToken - (75:0,75 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
+                            IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (75:0,75 [6] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (75:0,75 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
                 HtmlContent - (85:0,85 [2] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.mappings.txt
@@ -8,14 +8,19 @@ Source Location: (43:0,43 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1240:34,43 [11] )
 |ParentValue|
 
+Source Location: (75:0,75 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+|Update|
+Generated Location: (1665:44,75 [6] )
+|Update|
+
 Source Location: (32:0,32 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1894:49,32 [5] )
+Generated Location: (2107:57,32 [5] )
 |Value|
 
 Source Location: (62:0,62 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2163:58,62 [5] )
+Generated Location: (2376:66,62 [5] )
 |Value|
 
 Source Location: (94:1,7 [82] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -24,7 +29,7 @@ Source Location: (94:1,7 [82] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public void Update() { }
 |
-Generated Location: (2578:76,7 [82] )
+Generated Location: (2791:84,7 [82] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.mappings.txt
@@ -10,17 +10,17 @@ Generated Location: (1240:34,43 [11] )
 
 Source Location: (75:0,75 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |Update|
-Generated Location: (1665:44,75 [6] )
+Generated Location: (1664:44,75 [6] )
 |Update|
 
 Source Location: (32:0,32 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2107:57,32 [5] )
+Generated Location: (2106:57,32 [5] )
 |Value|
 
 Source Location: (62:0,62 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2376:66,62 [5] )
+Generated Location: (2375:66,62 [5] )
 |Value|
 
 Source Location: (94:1,7 [82] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -29,7 +29,7 @@ Source Location: (94:1,7 [82] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public void Update() { }
 |
-Generated Location: (2791:84,7 [82] )
+Generated Location: (2790:84,7 [82] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_InferredType_WithAfter_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_InferredType_WithAfter_Action/TestComponent.codegen.cs
@@ -29,7 +29,15 @@ namespace Test
 #line hidden
 #nullable disable
             , -1, 
-            __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(Update); });
+             __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                              Update
+
+#line default
+#line hidden
+#nullable disable
+            ); });
             #pragma warning disable BL0005
             __typeInference_CreateMyComponent_0.
 #nullable restore

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_InferredType_WithAfter_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_InferredType_WithAfter_Action/TestComponent.codegen.cs
@@ -29,7 +29,7 @@ namespace Test
 #line hidden
 #nullable disable
             , -1, 
-             __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+             __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                               Update

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_InferredType_WithAfter_Action/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_InferredType_WithAfter_Action/TestComponent.ir.txt
@@ -20,7 +20,9 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(Update); }
+                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+                            LazyIntermediateToken - (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
+                            IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
                 HtmlContent - (72:0,72 [2] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_InferredType_WithAfter_Action/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_InferredType_WithAfter_Action/TestComponent.ir.txt
@@ -20,7 +20,7 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
                             LazyIntermediateToken - (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
                             IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_InferredType_WithAfter_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_InferredType_WithAfter_Action/TestComponent.mappings.txt
@@ -5,17 +5,17 @@ Generated Location: (1076:25,30 [11] )
 
 Source Location: (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |Update|
-Generated Location: (1441:34,62 [6] )
+Generated Location: (1440:34,62 [6] )
 |Update|
 
 Source Location: (19:0,19 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1702:44,19 [5] )
+Generated Location: (1701:44,19 [5] )
 |Value|
 
 Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1953:53,49 [5] )
+Generated Location: (1952:53,49 [5] )
 |Value|
 
 Source Location: (81:1,7 [82] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -24,7 +24,7 @@ Source Location: (81:1,7 [82] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public void Update() { }
 |
-Generated Location: (2368:71,7 [82] )
+Generated Location: (2367:71,7 [82] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_InferredType_WithAfter_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_InferredType_WithAfter_Action/TestComponent.mappings.txt
@@ -3,14 +3,19 @@
 Generated Location: (1076:25,30 [11] )
 |ParentValue|
 
+Source Location: (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+|Update|
+Generated Location: (1441:34,62 [6] )
+|Update|
+
 Source Location: (19:0,19 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1502:36,19 [5] )
+Generated Location: (1702:44,19 [5] )
 |Value|
 
 Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1753:45,49 [5] )
+Generated Location: (1953:53,49 [5] )
 |Value|
 
 Source Location: (81:1,7 [82] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -19,7 +24,7 @@ Source Location: (81:1,7 [82] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public void Update() { }
 |
-Generated Location: (2168:63,7 [82] )
+Generated Location: (2368:71,7 [82] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.codegen.cs
@@ -50,7 +50,15 @@ TParam
 #nullable disable
             );
             __o = new global::System.Action<TParam>(
-            __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(Update); });
+             __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+#nullable restore
+#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                                              Update
+
+#line default
+#line hidden
+#nullable disable
+            ); });
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
             ));

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.codegen.cs
@@ -50,7 +50,7 @@ TParam
 #nullable disable
             );
             __o = new global::System.Action<TParam>(
-             __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+             __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                                               Update

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.ir.txt
@@ -23,7 +23,9 @@
                             LazyIntermediateToken - (65:1,46 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (65:1,46 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(Update); }
+                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+                            LazyIntermediateToken - (97:1,78 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
+                            IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (97:1,78 [6] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (97:1,78 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
                 HtmlContent - (107:1,88 [2] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.ir.txt
@@ -23,7 +23,7 @@
                             LazyIntermediateToken - (65:1,46 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (65:1,46 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
                             LazyIntermediateToken - (97:1,78 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
                             IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (97:1,78 [6] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.mappings.txt
@@ -13,14 +13,19 @@ Source Location: (65:1,46 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1453:45,46 [11] )
 |ParentValue|
 
+Source Location: (97:1,78 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+|Update|
+Generated Location: (1884:55,78 [6] )
+|Update|
+
 Source Location: (54:1,35 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2116:60,35 [5] )
+Generated Location: (2332:68,35 [5] )
 |Value|
 
 Source Location: (84:1,65 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2391:69,65 [5] )
+Generated Location: (2607:77,65 [5] )
 |Value|
 
 Source Location: (116:2,7 [79] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -29,7 +34,7 @@ Source Location: (116:2,7 [79] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public void Update() { }
 |
-Generated Location: (2806:87,7 [79] )
+Generated Location: (3022:95,7 [79] )
 |
     public TParam ParentValue { get; set; }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.mappings.txt
@@ -15,17 +15,17 @@ Generated Location: (1453:45,46 [11] )
 
 Source Location: (97:1,78 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |Update|
-Generated Location: (1884:55,78 [6] )
+Generated Location: (1883:55,78 [6] )
 |Update|
 
 Source Location: (54:1,35 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2332:68,35 [5] )
+Generated Location: (2331:68,35 [5] )
 |Value|
 
 Source Location: (84:1,65 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2607:77,65 [5] )
+Generated Location: (2606:77,65 [5] )
 |Value|
 
 Source Location: (116:2,7 [79] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -34,7 +34,7 @@ Source Location: (116:2,7 [79] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public void Update() { }
 |
-Generated Location: (3022:95,7 [79] )
+Generated Location: (3021:95,7 [79] )
 |
     public TParam ParentValue { get; set; }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithAfter_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithAfter_Action/TestComponent.codegen.cs
@@ -40,7 +40,15 @@ TParam
 #line hidden
 #nullable disable
             , -1, 
-            __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(Update); });
+             __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+#nullable restore
+#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                              Update
+
+#line default
+#line hidden
+#nullable disable
+            ); });
             #pragma warning disable BL0005
             __typeInference_CreateMyComponent_0.
 #nullable restore

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithAfter_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithAfter_Action/TestComponent.codegen.cs
@@ -40,7 +40,7 @@ TParam
 #line hidden
 #nullable disable
             , -1, 
-             __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+             __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                               Update

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithAfter_Action/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithAfter_Action/TestComponent.ir.txt
@@ -21,7 +21,7 @@
                             LazyIntermediateToken - (49:1,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (49:1,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
                             LazyIntermediateToken - (81:1,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
                             IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (81:1,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithAfter_Action/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithAfter_Action/TestComponent.ir.txt
@@ -21,7 +21,9 @@
                             LazyIntermediateToken - (49:1,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (49:1,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(Update); }
+                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+                            LazyIntermediateToken - (81:1,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
+                            IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (81:1,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (81:1,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
                 HtmlContent - (91:1,72 [2] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithAfter_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithAfter_Action/TestComponent.mappings.txt
@@ -8,14 +8,19 @@ Source Location: (49:1,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1280:36,30 [11] )
 |ParentValue|
 
+Source Location: (81:1,62 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+|Update|
+Generated Location: (1645:45,62 [6] )
+|Update|
+
 Source Location: (38:1,19 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1706:47,19 [5] )
+Generated Location: (1906:55,19 [5] )
 |Value|
 
 Source Location: (68:1,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1957:56,49 [5] )
+Generated Location: (2157:64,49 [5] )
 |Value|
 
 Source Location: (100:2,7 [79] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -24,7 +29,7 @@ Source Location: (100:2,7 [79] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public void Update() { }
 |
-Generated Location: (2372:74,7 [79] )
+Generated Location: (2572:82,7 [79] )
 |
     public TParam ParentValue { get; set; }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithAfter_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithAfter_Action/TestComponent.mappings.txt
@@ -10,17 +10,17 @@ Generated Location: (1280:36,30 [11] )
 
 Source Location: (81:1,62 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |Update|
-Generated Location: (1645:45,62 [6] )
+Generated Location: (1644:45,62 [6] )
 |Update|
 
 Source Location: (38:1,19 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1906:55,19 [5] )
+Generated Location: (1905:55,19 [5] )
 |Value|
 
 Source Location: (68:1,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2157:64,49 [5] )
+Generated Location: (2156:64,49 [5] )
 |Value|
 
 Source Location: (100:2,7 [79] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -29,7 +29,7 @@ Source Location: (100:2,7 [79] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public void Update() { }
 |
-Generated Location: (2572:82,7 [79] )
+Generated Location: (2571:82,7 [79] )
 |
     public TParam ParentValue { get; set; }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_Action/TestComponent.codegen.cs
@@ -23,7 +23,7 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Action<System.Int32>)( __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Action<System.Int32>)( __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                               Update

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_Action/TestComponent.codegen.cs
@@ -23,7 +23,15 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Action<System.Int32>)(__value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(Update); }));
+            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Action<System.Int32>)( __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                              Update
+
+#line default
+#line hidden
+#nullable disable
+            ); }));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_Action/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_Action/TestComponent.ir.txt
@@ -13,7 +13,7 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
                             LazyIntermediateToken - (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
                             IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_Action/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_Action/TestComponent.ir.txt
@@ -13,7 +13,9 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(Update); }
+                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+                            LazyIntermediateToken - (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
+                            IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
             CSharpCode - (81:1,7 [82] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_Action/TestComponent.mappings.txt
@@ -4,7 +4,7 @@
 
     public void Update() { }
 |
-Generated Location: (1396:31,7 [82] )
+Generated Location: (1596:39,7 [82] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_Action/TestComponent.mappings.txt
@@ -4,7 +4,7 @@
 
     public void Update() { }
 |
-Generated Location: (1596:39,7 [82] )
+Generated Location: (1595:39,7 [82] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_ActionLambda/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_ActionLambda/TestComponent.codegen.cs
@@ -23,7 +23,7 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Action<System.Int32>)( __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Action<System.Int32>)( __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                               () => { }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_ActionLambda/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_ActionLambda/TestComponent.codegen.cs
@@ -23,7 +23,15 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Action<System.Int32>)(__value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(() => { }); }));
+            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Action<System.Int32>)( __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                              () => { }
+
+#line default
+#line hidden
+#nullable disable
+            ); }));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_ActionLambda/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_ActionLambda/TestComponent.ir.txt
@@ -13,7 +13,9 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(() => { }); }
+                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+                            LazyIntermediateToken - (62:0,62 [9] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - () => { }
+                            IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (62:0,62 [9] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (62:0,62 [9] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - () => { }
             CSharpCode - (84:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_ActionLambda/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_ActionLambda/TestComponent.ir.txt
@@ -13,7 +13,7 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
                             LazyIntermediateToken - (62:0,62 [9] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - () => { }
                             IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (62:0,62 [9] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_ActionLambda/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_ActionLambda/TestComponent.mappings.txt
@@ -2,7 +2,7 @@
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1599:39,7 [50] )
+Generated Location: (1598:39,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_ActionLambda/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_ActionLambda/TestComponent.mappings.txt
@@ -2,7 +2,7 @@
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1399:31,7 [50] )
+Generated Location: (1599:39,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback/TestComponent.codegen.cs
@@ -23,7 +23,15 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddComponentParameter(2, "ValueChanged", global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<global::System.Int32>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<global::System.Int32>(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: UpdateValue); }, value: ParentValue), ParentValue))));
+            __builder.AddComponentParameter(2, "ValueChanged", global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<global::System.Int32>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<global::System.Int32>(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                              UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            ); }, value: ParentValue), ParentValue))));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback/TestComponent.ir.txt
@@ -14,7 +14,9 @@
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: UpdateValue); }, value: ParentValue)
+                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: 
+                            LazyIntermediateToken - (62:0,62 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
+                            IntermediateToken -  - CSharp - ); }, value: ParentValue)
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (62:0,62 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (62:0,62 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback/TestComponent.mappings.txt
@@ -3,7 +3,7 @@
     public int ParentValue { get; set; } = 42;
     public EventCallback UpdateValue { get; set; }
 |
-Generated Location: (1886:31,7 [102] )
+Generated Location: (2084:39,7 [102] )
 |
     public int ParentValue { get; set; } = 42;
     public EventCallback UpdateValue { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesAction/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesAction/TestComponent.codegen.cs
@@ -23,7 +23,15 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddComponentParameter(2, "ValueChanged", global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<global::System.Int32>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<global::System.Int32>(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: () => { }); }, value: ParentValue), ParentValue))));
+            __builder.AddComponentParameter(2, "ValueChanged", global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<global::System.Int32>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<global::System.Int32>(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                              () => { }
+
+#line default
+#line hidden
+#nullable disable
+            ); }, value: ParentValue), ParentValue))));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesAction/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesAction/TestComponent.ir.txt
@@ -14,7 +14,9 @@
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: () => { }); }, value: ParentValue)
+                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: 
+                            LazyIntermediateToken - (62:0,62 [9] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - () => { }
+                            IntermediateToken -  - CSharp - ); }, value: ParentValue)
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (62:0,62 [9] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (62:0,62 [9] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - () => { }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesAction/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesAction/TestComponent.mappings.txt
@@ -2,7 +2,7 @@
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1884:31,7 [50] )
+Generated Location: (2082:39,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesFunction/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesFunction/TestComponent.codegen.cs
@@ -23,7 +23,15 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddComponentParameter(2, "ValueChanged", global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<global::System.Int32>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<global::System.Int32>(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: UpdateValue); }, value: ParentValue), ParentValue))));
+            __builder.AddComponentParameter(2, "ValueChanged", global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<global::System.Int32>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<global::System.Int32>(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                              UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            ); }, value: ParentValue), ParentValue))));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesFunction/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesFunction/TestComponent.ir.txt
@@ -14,7 +14,9 @@
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: UpdateValue); }, value: ParentValue)
+                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: 
+                            LazyIntermediateToken - (62:0,62 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
+                            IntermediateToken -  - CSharp - ); }, value: ParentValue)
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (62:0,62 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (62:0,62 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesFunction/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesFunction/TestComponent.mappings.txt
@@ -4,7 +4,7 @@
 
     public Task UpdateValue() => Task.CompletedTask;
 |
-Generated Location: (1886:31,7 [106] )
+Generated Location: (2084:39,7 [106] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningDelegate/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningDelegate/TestComponent.codegen.cs
@@ -23,7 +23,15 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Func<System.Int32, System.Threading.Tasks.Task>)(async __value => { ParentValue = __value; await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(Update); }));
+            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Func<System.Int32, System.Threading.Tasks.Task>)(async  __value => { ParentValue = __value; await  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                              Update
+
+#line default
+#line hidden
+#nullable disable
+            ); }));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningDelegate/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningDelegate/TestComponent.codegen.cs
@@ -23,7 +23,7 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Func<System.Int32, System.Threading.Tasks.Task>)(async  __value => { ParentValue = __value; await  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(
+            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Func<System.Int32, System.Threading.Tasks.Task>)(async  __value => { ParentValue = __value; await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                               Update

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningDelegate/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningDelegate/TestComponent.ir.txt
@@ -13,7 +13,7 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - async  __value => { ParentValue = __value; await  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(
+                            IntermediateToken -  - CSharp - async  __value => { ParentValue = __value; await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(
                             LazyIntermediateToken - (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
                             IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningDelegate/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningDelegate/TestComponent.ir.txt
@@ -13,7 +13,9 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - async __value => { ParentValue = __value; await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(Update); }
+                            IntermediateToken -  - CSharp - async  __value => { ParentValue = __value; await  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(
+                            LazyIntermediateToken - (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
+                            IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
             CSharpCode - (81:1,7 [101] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningDelegate/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningDelegate/TestComponent.mappings.txt
@@ -4,7 +4,7 @@
 
     public Task Update() => Task.CompletedTask;
 |
-Generated Location: (1636:39,7 [101] )
+Generated Location: (1635:39,7 [101] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningDelegate/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningDelegate/TestComponent.mappings.txt
@@ -4,7 +4,7 @@
 
     public Task Update() => Task.CompletedTask;
 |
-Generated Location: (1436:31,7 [101] )
+Generated Location: (1636:39,7 [101] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningLambda/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningLambda/TestComponent.codegen.cs
@@ -23,7 +23,7 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Func<System.Int32, System.Threading.Tasks.Task>)(async  __value => { ParentValue = __value; await  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(
+            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Func<System.Int32, System.Threading.Tasks.Task>)(async  __value => { ParentValue = __value; await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                               () => { return Task.CompletedTask; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningLambda/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningLambda/TestComponent.codegen.cs
@@ -23,7 +23,15 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Func<System.Int32, System.Threading.Tasks.Task>)(async __value => { ParentValue = __value; await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(() => { return Task.CompletedTask; }); }));
+            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Func<System.Int32, System.Threading.Tasks.Task>)(async  __value => { ParentValue = __value; await  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                              () => { return Task.CompletedTask; }
+
+#line default
+#line hidden
+#nullable disable
+            ); }));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningLambda/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningLambda/TestComponent.ir.txt
@@ -13,7 +13,7 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - async  __value => { ParentValue = __value; await  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(
+                            IntermediateToken -  - CSharp - async  __value => { ParentValue = __value; await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(
                             LazyIntermediateToken - (62:0,62 [36] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - () => { return Task.CompletedTask; }
                             IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (62:0,62 [36] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningLambda/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningLambda/TestComponent.ir.txt
@@ -13,7 +13,9 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - async __value => { ParentValue = __value; await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(() => { return Task.CompletedTask; }); }
+                            IntermediateToken -  - CSharp - async  __value => { ParentValue = __value; await  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(
+                            LazyIntermediateToken - (62:0,62 [36] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - () => { return Task.CompletedTask; }
+                            IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (62:0,62 [36] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (62:0,62 [36] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - () => { return Task.CompletedTask; }
             CSharpCode - (111:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningLambda/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningLambda/TestComponent.mappings.txt
@@ -2,7 +2,7 @@
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1466:31,7 [50] )
+Generated Location: (1666:39,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningLambda/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningLambda/TestComponent.mappings.txt
@@ -2,7 +2,7 @@
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1666:39,7 [50] )
+Generated Location: (1665:39,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingSetWithAfter/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingSetWithAfter/TestComponent.codegen.cs
@@ -23,7 +23,15 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddAttribute(2, "myevent", global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, callback: async __value => { await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: UpdateValue, value: ParentValue)(); await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: AfterUpdate); }, value: ParentValue), ParentValue));
+            __builder.AddAttribute(2, "myevent", global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, callback: async __value => { await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: UpdateValue, value: ParentValue)(); await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                                   AfterUpdate
+
+#line default
+#line hidden
+#nullable disable
+            ); }, value: ParentValue), ParentValue));
             __builder.SetUpdatesAttributeName("myvalue");
             __builder.CloseElement();
         }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingSetWithAfter/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingSetWithAfter/TestComponent.ir.txt
@@ -16,7 +16,9 @@
                     HtmlAttribute - (16:0,16 [12] x:\dir\subdir\Test\TestComponent.cshtml) - myevent=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, 
-                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, callback: async __value => { await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: UpdateValue, value: ParentValue)(); await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: AfterUpdate); }, value: ParentValue)
+                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, callback: async __value => { await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: UpdateValue, value: ParentValue)(); await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: 
+                            LazyIntermediateToken - (67:0,67 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - AfterUpdate
+                            IntermediateToken -  - CSharp - ); }, value: ParentValue)
                             IntermediateToken -  - CSharp - , 
                             IntermediateToken -  - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingSetWithAfter/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingSetWithAfter/TestComponent.mappings.txt
@@ -5,7 +5,7 @@
     public void UpdateValue(string value) => ParentValue = value;
     public void AfterUpdate() { }
 |
-Generated Location: (1707:32,7 [159] )
+Generated Location: (1910:40,7 [159] )
 |
     public string ParentValue { get; set; } = "hi";
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithBindAfterAndSuffix/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithBindAfterAndSuffix/TestComponent.codegen.cs
@@ -23,7 +23,15 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddAttribute(2, "myevent", global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: DoSomething); }, value: ParentValue), ParentValue));
+            __builder.AddAttribute(2, "myevent", global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                       DoSomething
+
+#line default
+#line hidden
+#nullable disable
+            ); }, value: ParentValue), ParentValue));
             __builder.SetUpdatesAttributeName("myvalue");
             __builder.CloseElement();
         }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithBindAfterAndSuffix/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithBindAfterAndSuffix/TestComponent.ir.txt
@@ -16,7 +16,9 @@
                     HtmlAttribute - (20:0,20 [12] x:\dir\subdir\Test\TestComponent.cshtml) - myevent=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, 
-                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: DoSomething); }, value: ParentValue)
+                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: __value => { ParentValue = __value; return global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: 
+                            LazyIntermediateToken - (55:0,55 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - DoSomething
+                            IntermediateToken -  - CSharp - ); }, value: ParentValue)
                             IntermediateToken -  - CSharp - , 
                             IntermediateToken -  - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithBindAfterAndSuffix/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithBindAfterAndSuffix/TestComponent.mappings.txt
@@ -7,7 +7,7 @@
         return Task.CompletedTask;
     }
 |
-Generated Location: (1571:32,7 [131] )
+Generated Location: (1762:40,7 [131] )
 |
     public string ParentValue { get; set; } = "hi";
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.codegen.cs
@@ -23,7 +23,7 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Action<int>)( __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Action<int>)( __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                                            Update

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.codegen.cs
@@ -23,7 +23,15 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Action<int>)(__value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(Update); }));
+            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Action<int>)( __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                                           Update
+
+#line default
+#line hidden
+#nullable disable
+            ); }));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.ir.txt
@@ -15,7 +15,9 @@
                             LazyIntermediateToken - (43:0,43 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (43:0,43 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(Update); }
+                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+                            LazyIntermediateToken - (75:0,75 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
+                            IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (75:0,75 [6] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (75:0,75 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
             CSharpCode - (94:1,7 [82] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.ir.txt
@@ -15,7 +15,7 @@
                             LazyIntermediateToken - (43:0,43 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (43:0,43 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
                             LazyIntermediateToken - (75:0,75 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
                             IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (75:0,75 [6] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.mappings.txt
@@ -4,7 +4,7 @@
 
     public void Update() { }
 |
-Generated Location: (1601:39,7 [82] )
+Generated Location: (1600:39,7 [82] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.mappings.txt
@@ -4,7 +4,7 @@
 
     public void Update() { }
 |
-Generated Location: (1388:31,7 [82] )
+Generated Location: (1601:39,7 [82] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithAfter_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithAfter_Action/TestComponent.codegen.cs
@@ -21,7 +21,7 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            , 2,  __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+            , 2,  __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                               Update

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithAfter_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithAfter_Action/TestComponent.codegen.cs
@@ -21,7 +21,15 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            , 2, __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(Update); });
+            , 2,  __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                              Update
+
+#line default
+#line hidden
+#nullable disable
+            ); });
         }
         #pragma warning restore 1998
 #nullable restore

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithAfter_Action/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithAfter_Action/TestComponent.ir.txt
@@ -13,7 +13,7 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
                             LazyIntermediateToken - (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
                             IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithAfter_Action/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithAfter_Action/TestComponent.ir.txt
@@ -13,7 +13,9 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(Update); }
+                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+                            LazyIntermediateToken - (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
+                            IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
             CSharpCode - (81:1,7 [82] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithAfter_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithAfter_Action/TestComponent.mappings.txt
@@ -4,7 +4,7 @@
 
     public void Update() { }
 |
-Generated Location: (1125:28,7 [82] )
+Generated Location: (1325:36,7 [82] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithAfter_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithAfter_Action/TestComponent.mappings.txt
@@ -4,7 +4,7 @@
 
     public void Update() { }
 |
-Generated Location: (1325:36,7 [82] )
+Generated Location: (1324:36,7 [82] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.codegen.cs
@@ -31,7 +31,15 @@ TParam
 #line hidden
 #nullable disable
             ));
-            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Action<TParam>)(__value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(Update); }));
+            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Action<TParam>)( __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+#nullable restore
+#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                                              Update
+
+#line default
+#line hidden
+#nullable disable
+            ); }));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.codegen.cs
@@ -31,7 +31,7 @@ TParam
 #line hidden
 #nullable disable
             ));
-            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Action<TParam>)( __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Action<TParam>)( __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                                               Update

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.ir.txt
@@ -15,7 +15,9 @@
                             LazyIntermediateToken - (65:1,46 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (65:1,46 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(Update); }
+                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+                            LazyIntermediateToken - (97:1,78 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
+                            IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (97:1,78 [6] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (97:1,78 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
             CSharpCode - (116:2,7 [79] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.ir.txt
@@ -15,7 +15,7 @@
                             LazyIntermediateToken - (65:1,46 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (65:1,46 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
                             LazyIntermediateToken - (97:1,78 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
                             IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (97:1,78 [6] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.mappings.txt
@@ -9,7 +9,7 @@ Source Location: (116:2,7 [79] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public void Update() { }
 |
-Generated Location: (1536:39,7 [79] )
+Generated Location: (1752:47,7 [79] )
 |
     public TParam ParentValue { get; set; }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.mappings.txt
@@ -9,7 +9,7 @@ Source Location: (116:2,7 [79] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public void Update() { }
 |
-Generated Location: (1752:47,7 [79] )
+Generated Location: (1751:47,7 [79] )
 |
     public TParam ParentValue { get; set; }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithAfter_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithAfter_Action/TestComponent.codegen.cs
@@ -29,7 +29,7 @@ TParam
 #line default
 #line hidden
 #nullable disable
-            , 2,  __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+            , 2,  __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                               Update

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithAfter_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithAfter_Action/TestComponent.codegen.cs
@@ -29,7 +29,15 @@ TParam
 #line default
 #line hidden
 #nullable disable
-            , 2, __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(Update); });
+            , 2,  __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+#nullable restore
+#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                              Update
+
+#line default
+#line hidden
+#nullable disable
+            ); });
         }
         #pragma warning restore 1998
 #nullable restore

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithAfter_Action/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithAfter_Action/TestComponent.ir.txt
@@ -13,7 +13,7 @@
                             LazyIntermediateToken - (49:1,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (49:1,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
                             LazyIntermediateToken - (81:1,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
                             IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (81:1,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithAfter_Action/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithAfter_Action/TestComponent.ir.txt
@@ -13,7 +13,9 @@
                             LazyIntermediateToken - (49:1,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (49:1,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - __value => { ParentValue = __value; global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(Update); }
+                            IntermediateToken -  - CSharp -  __value => { ParentValue = __value;  global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeSynchronousDelegate(
+                            LazyIntermediateToken - (81:1,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
+                            IntermediateToken -  - CSharp - ); }
                     ComponentAttribute - (81:1,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (81:1,62 [6] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Update
             CSharpCode - (100:2,7 [79] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithAfter_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithAfter_Action/TestComponent.mappings.txt
@@ -9,7 +9,7 @@ Source Location: (100:2,7 [79] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public void Update() { }
 |
-Generated Location: (1261:36,7 [79] )
+Generated Location: (1461:44,7 [79] )
 |
     public TParam ParentValue { get; set; }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithAfter_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithAfter_Action/TestComponent.mappings.txt
@@ -9,7 +9,7 @@ Source Location: (100:2,7 [79] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public void Update() { }
 |
-Generated Location: (1461:44,7 [79] )
+Generated Location: (1460:44,7 [79] )
 |
     public TParam ParentValue { get; set; }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/DefinitionEndpointDelegationTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/DefinitionEndpointDelegationTest.cs
@@ -118,6 +118,25 @@ public class DefinitionEndpointDelegationTest : SingleServerDelegatingEndpointTe
         await VerifyCSharpGoToDefinitionAsync(input, "test.razor");
     }
 
+    [Fact]
+    public async Task Handle_SingleServer_AttributeValue_BindAfter()
+    {
+        var input = """
+            <input type="text" @bind="InputValue" @bind:after="() => Af$$ter()">
+
+            @code
+            {
+                public string InputValue { get; set; }
+
+                public void [|After|]()
+                {
+                }
+            }
+            """;
+
+        await VerifyCSharpGoToDefinitionAsync(input, "test.razor");
+    }
+
     [Theory]
     [InlineData("Ti$$tle")]
     [InlineData("$$@bind-Title")]


### PR DESCRIPTION
Fixes part of https://github.com/dotnet/razor/issues/8552