### PR TITLE
Don't send multiple buffer updates for the same C# generated document

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentPublisher.cs
@@ -127,7 +127,7 @@ internal class DefaultGeneratedDocumentPublisher : GeneratedDocumentPublisher
         // HACK: We know about a document being in multiple projects, but despite having ProjectKeyId in the request, currently the other end
         // of this LSP message only knows about a single document file path. To prevent confusing them, we just send an update for the first project
         // in the list.
-        if (_projectSnapshotManager is { } projectSnapshotManager
+        if (_projectSnapshotManager is { } projectSnapshotManager &&
             projectSnapshotManager.GetLoadedProject(projectKey) is { } projectSnapshot &&
             projectSnapshotManager.GetAllProjectKeys(projectSnapshot.FilePath).First() != projectKey)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentPublisher.cs
@@ -127,8 +127,9 @@ internal class DefaultGeneratedDocumentPublisher : GeneratedDocumentPublisher
         // HACK: We know about a document being in multiple projects, but despite having ProjectKeyId in the request, currently the other end
         // of this LSP message only knows about a single document file path. To prevent confusing them, we just send an update for the first project
         // in the list.
-        var snapshot = _projectSnapshotManager!.GetLoadedProject(projectKey);
-        if (_projectSnapshotManager.GetAllProjectKeys(snapshot.FilePath).First() != projectKey)
+        if (_projectSnapshotManager is not null &&
+            _projectSnapshotManager.GetLoadedProject(projectKey) is { } projectSnapshot &&
+            _projectSnapshotManager.GetAllProjectKeys(projectSnapshot.FilePath).First() != projectKey)
         {
             return;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentPublisher.cs
@@ -127,9 +127,9 @@ internal class DefaultGeneratedDocumentPublisher : GeneratedDocumentPublisher
         // HACK: We know about a document being in multiple projects, but despite having ProjectKeyId in the request, currently the other end
         // of this LSP message only knows about a single document file path. To prevent confusing them, we just send an update for the first project
         // in the list.
-        if (_projectSnapshotManager is not null &&
-            _projectSnapshotManager.GetLoadedProject(projectKey) is { } projectSnapshot &&
-            _projectSnapshotManager.GetAllProjectKeys(projectSnapshot.FilePath).First() != projectKey)
+        if (_projectSnapshotManager is { } projectSnapshotManager
+            projectSnapshotManager.GetLoadedProject(projectKey) is { } projectSnapshot &&
+            projectSnapshotManager.GetAllProjectKeys(projectSnapshot.FilePath).First() != projectKey)
         {
             return;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentPublisher.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.TextDifferencing;
@@ -122,6 +123,15 @@ internal class DefaultGeneratedDocumentPublisher : GeneratedDocumentPublisher
             Changes = textChanges,
             HostDocumentVersion = hostDocumentVersion,
         };
+
+        // HACK: We know about a document being in multiple projects, but despite having ProjectKeyId in the request, currently the other end
+        // of this LSP message only knows about a single document file path. To prevent confusing them, we just send an update for the first project
+        // in the list.
+        var snapshot = _projectSnapshotManager!.GetLoadedProject(projectKey);
+        if (_projectSnapshotManager.GetAllProjectKeys(snapshot.FilePath).First() != projectKey)
+        {
+            return;
+        }
 
         _ = _server.SendNotificationAsync(RazorLanguageServerCustomMessageTargets.RazorUpdateCSharpBufferEndpoint, request, CancellationToken.None);
     }


### PR DESCRIPTION
This fixes the issue with semantic tokens being out-of-whack in multi-targeting projects, and probably a bunch more issues as yet unnoticed too.

The code changes I'm currently working on will remove the hack (or formalize it 😁)