### PR TITLE
Keep source info from intermediate nodes for `@bind:set` attributes

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentBindLoweringPass.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentBindLoweringPass.cs
@@ -806,11 +806,7 @@ internal class ComponentBindLoweringPass : ComponentIntermediateNodePassBase, IR
         }
         else if (setter != null && after == null)
         {
-            changeExpressionTokens.Add(new IntermediateToken()
-            {
-                Content = setter.Content,
-                Kind = TokenKind.CSharp,
-            });
+            changeExpressionTokens.Add(setter);
         }
         else if (after != null && setter == null)
         {
@@ -880,11 +876,7 @@ internal class ComponentBindLoweringPass : ComponentIntermediateNodePassBase, IR
         else if (setter != null && after == null)
         {
             // bind:set only
-            changeExpressionTokens.Add(new IntermediateToken()
-            {
-                Content = setter.Content,
-                Kind = TokenKind.CSharp
-            });
+            changeExpressionTokens.Add(setter);
         }
         else if (setter == null && after != null)
         {
@@ -904,10 +896,15 @@ internal class ComponentBindLoweringPass : ComponentIntermediateNodePassBase, IR
         else
         {
             // bind:set and bind:after create the code even though we disallow this combination through a diagnostic
-            var setToEventCallback = $"{ComponentsApi.RuntimeHelpers.CreateInferredBindSetter}(callback: {setter.Content}, value: {original.Content})";
             changeExpressionTokens.Add(new IntermediateToken()
             {
-                Content = $"{ComponentsApi.RuntimeHelpers.CreateInferredEventCallback}(this, callback: async __value => {{ await {setToEventCallback}; await {ComponentsApi.RuntimeHelpers.InvokeAsynchronousDelegate}(callback: ",
+                Content = $"{ComponentsApi.RuntimeHelpers.CreateInferredEventCallback}(this, callback: async __value => {{ await {ComponentsApi.RuntimeHelpers.CreateInferredBindSetter}(callback: ",
+                Kind = TokenKind.CSharp
+            });
+            changeExpressionTokens.Add(setter);
+            changeExpressionTokens.Add(new IntermediateToken()
+            {
+                Content = $", value: {original.Content}); await {ComponentsApi.RuntimeHelpers.InvokeAsynchronousDelegate}(callback: ",
                 Kind = TokenKind.CSharp
             });
             changeExpressionTokens.Add(after);
@@ -1010,7 +1007,13 @@ internal class ComponentBindLoweringPass : ComponentIntermediateNodePassBase, IR
             // bind:set only
             changeExpressionTokens.Add(new IntermediateToken()
             {
-                Content = $"{ComponentsApi.RuntimeHelpers.CreateInferredBindSetter}(callback: {setter.Content}, value: {original.Content})",
+                Content = $"{ComponentsApi.RuntimeHelpers.CreateInferredBindSetter}(callback: ",
+                Kind = TokenKind.CSharp
+            });
+            changeExpressionTokens.Add(setter);
+            changeExpressionTokens.Add(new IntermediateToken()
+            {
+                Content = $", value: {original.Content})",
                 Kind = TokenKind.CSharp
             });
         }
@@ -1032,10 +1035,15 @@ internal class ComponentBindLoweringPass : ComponentIntermediateNodePassBase, IR
         else
         {
             // bind:set and bind:after create the code even though we disallow this combination through a diagnostic
-            var setterContentInvocation = $"{ComponentsApi.RuntimeHelpers.CreateInferredBindSetter}(callback: {setter.Content}, value: {original.Content})";
             changeExpressionTokens.Add(new IntermediateToken()
             {
-                Content = $"{ComponentsApi.RuntimeHelpers.CreateInferredEventCallback}(this, callback: async __value => {{ await {setterContentInvocation}(); await {ComponentsApi.RuntimeHelpers.InvokeAsynchronousDelegate}(callback: ",
+                Content = $"{ComponentsApi.RuntimeHelpers.CreateInferredEventCallback}(this, callback: async __value => {{ await {ComponentsApi.RuntimeHelpers.CreateInferredBindSetter}(callback: ",
+                Kind = TokenKind.CSharp
+            });
+            changeExpressionTokens.Add(setter);
+            changeExpressionTokens.Add(new IntermediateToken()
+            {
+                Content = $", value: {original.Content})(); await {ComponentsApi.RuntimeHelpers.InvokeAsynchronousDelegate}(callback: ",
                 Kind = TokenKind.CSharp
             });
             changeExpressionTokens.Add(after);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_AsyncLambdaProducesError/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_AsyncLambdaProducesError/TestComponent.codegen.cs
@@ -30,7 +30,14 @@ namespace Test
 #nullable disable
             );
             __o = new global::System.Action<System.Int32>(
-            (value => { ParentValue = value; return Task.CompletedTask; }));
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                            (value => { ParentValue = value; return Task.CompletedTask; })
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
             ));

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_AsyncLambdaProducesError/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_AsyncLambdaProducesError/TestComponent.ir.txt
@@ -20,7 +20,7 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - (value => { ParentValue = value; return Task.CompletedTask; })
+                            LazyIntermediateToken - (60:0,60 [62] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - (value => { ParentValue = value; return Task.CompletedTask; })
                     ComponentAttribute - (60:0,60 [62] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (60:0,60 [62] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - (value => { ParentValue = value; return Task.CompletedTask; })
                 HtmlContent - (126:0,126 [2] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_AsyncLambdaProducesError/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithAfter_AsyncLambdaProducesError/TestComponent.mappings.txt
@@ -3,21 +3,26 @@
 Generated Location: (1055:25,30 [11] )
 |ParentValue|
 
+Source Location: (60:0,60 [62] x:\dir\subdir\Test\TestComponent.cshtml)
+|(value => { ParentValue = value; return Task.CompletedTask; })|
+Generated Location: (1324:34,60 [62] )
+|(value => { ParentValue = value; return Task.CompletedTask; })|
+
 Source Location: (19:0,19 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1618:40,19 [5] )
+Generated Location: (1800:47,19 [5] )
 |Value|
 
 Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1869:49,49 [5] )
+Generated Location: (2051:56,49 [5] )
 |Value|
 
 Source Location: (135:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (2282:67,7 [50] )
+Generated Location: (2464:74,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_Action/TestComponent.codegen.cs
@@ -30,7 +30,14 @@ namespace Test
 #nullable disable
             );
             __o = new global::System.Action<System.Int32>(
-            UpdateValue);
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                            UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
             ));

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_Action/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_Action/TestComponent.ir.txt
@@ -20,7 +20,7 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                     ComponentAttribute - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                 HtmlContent - (75:0,75 [2] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_Action/TestComponent.mappings.txt
@@ -3,14 +3,19 @@
 Generated Location: (1055:25,30 [11] )
 |ParentValue|
 
+Source Location: (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1324:34,60 [11] )
+|UpdateValue|
+
 Source Location: (19:0,19 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1567:40,19 [5] )
+Generated Location: (1749:47,19 [5] )
 |Value|
 
 Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1818:49,49 [5] )
+Generated Location: (2000:56,49 [5] )
 |Value|
 
 Source Location: (84:1,7 [116] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -19,7 +24,7 @@ Source Location: (84:1,7 [116] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public void UpdateValue(int value) => ParentValue = value;
 |
-Generated Location: (2231:67,7 [116] )
+Generated Location: (2413:74,7 [116] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_ActionLambda/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_ActionLambda/TestComponent.codegen.cs
@@ -30,7 +30,14 @@ namespace Test
 #nullable disable
             );
             __o = new global::System.Action<System.Int32>(
-            value => ParentValue = value);
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                            value => ParentValue = value
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
             ));

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_ActionLambda/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_ActionLambda/TestComponent.ir.txt
@@ -20,7 +20,7 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - value => ParentValue = value
+                            LazyIntermediateToken - (60:0,60 [28] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - value => ParentValue = value
                     ComponentAttribute - (60:0,60 [28] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (60:0,60 [28] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - value => ParentValue = value
                 HtmlContent - (92:0,92 [2] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_ActionLambda/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_ActionLambda/TestComponent.mappings.txt
@@ -3,21 +3,26 @@
 Generated Location: (1055:25,30 [11] )
 |ParentValue|
 
+Source Location: (60:0,60 [28] x:\dir\subdir\Test\TestComponent.cshtml)
+|value => ParentValue = value|
+Generated Location: (1324:34,60 [28] )
+|value => ParentValue = value|
+
 Source Location: (19:0,19 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1584:40,19 [5] )
+Generated Location: (1766:47,19 [5] )
 |Value|
 
 Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1835:49,49 [5] )
+Generated Location: (2017:56,49 [5] )
 |Value|
 
 Source Location: (101:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (2248:67,7 [50] )
+Generated Location: (2430:74,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback/TestComponent.codegen.cs
@@ -30,7 +30,15 @@ namespace Test
 #nullable disable
             );
             __o = global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<global::System.Int32>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<global::System.Int32>(this, 
-            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, UpdateValue, ParentValue)));
+            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                            UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , ParentValue)));
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
             ));

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback/TestComponent.ir.txt
@@ -21,7 +21,7 @@
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback/TestComponent.mappings.txt
@@ -3,14 +3,19 @@
 Generated Location: (1055:25,30 [11] )
 |ParentValue|
 
+Source Location: (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1660:35,60 [11] )
+|UpdateValue|
+
 Source Location: (19:0,19 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1904:40,19 [5] )
+Generated Location: (2100:48,19 [5] )
 |Value|
 
 Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2155:49,49 [5] )
+Generated Location: (2351:57,49 [5] )
 |Value|
 
 Source Location: (84:1,7 [107] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -18,7 +23,7 @@ Source Location: (84:1,7 [107] x:\dir\subdir\Test\TestComponent.cshtml)
     public int ParentValue { get; set; } = 42;
     public EventCallback<int> UpdateValue { get; set; }
 |
-Generated Location: (2568:67,7 [107] )
+Generated Location: (2764:75,7 [107] )
 |
     public int ParentValue { get; set; } = 42;
     public EventCallback<int> UpdateValue { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesAction/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesAction/TestComponent.codegen.cs
@@ -30,7 +30,15 @@ namespace Test
 #nullable disable
             );
             __o = global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<global::System.Int32>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<global::System.Int32>(this, 
-            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, value => ParentValue = value, ParentValue)));
+            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                            value => ParentValue = value
+
+#line default
+#line hidden
+#nullable disable
+            , ParentValue)));
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
             ));

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesAction/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesAction/TestComponent.ir.txt
@@ -21,7 +21,7 @@
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - value => ParentValue = value
+                            LazyIntermediateToken - (60:0,60 [28] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - value => ParentValue = value
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (60:0,60 [28] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (60:0,60 [28] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - value => ParentValue = value

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesAction/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesAction/TestComponent.mappings.txt
@@ -3,21 +3,26 @@
 Generated Location: (1055:25,30 [11] )
 |ParentValue|
 
+Source Location: (60:0,60 [28] x:\dir\subdir\Test\TestComponent.cshtml)
+|value => ParentValue = value|
+Generated Location: (1660:35,60 [28] )
+|value => ParentValue = value|
+
 Source Location: (19:0,19 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1921:40,19 [5] )
+Generated Location: (2117:48,19 [5] )
 |Value|
 
 Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2172:49,49 [5] )
+Generated Location: (2368:57,49 [5] )
 |Value|
 
 Source Location: (101:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (2585:67,7 [50] )
+Generated Location: (2781:75,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesFunction/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesFunction/TestComponent.codegen.cs
@@ -30,7 +30,15 @@ namespace Test
 #nullable disable
             );
             __o = global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<global::System.Int32>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<global::System.Int32>(this, 
-            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, UpdateValue, ParentValue)));
+            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                            UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , ParentValue)));
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
             ));

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesFunction/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesFunction/TestComponent.ir.txt
@@ -21,7 +21,7 @@
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesFunction/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesFunction/TestComponent.mappings.txt
@@ -3,14 +3,19 @@
 Generated Location: (1055:25,30 [11] )
 |ParentValue|
 
+Source Location: (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1660:35,60 [11] )
+|UpdateValue|
+
 Source Location: (19:0,19 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1904:40,19 [5] )
+Generated Location: (2100:48,19 [5] )
 |Value|
 
 Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2155:49,49 [5] )
+Generated Location: (2351:57,49 [5] )
 |Value|
 
 Source Location: (84:1,7 [144] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -19,7 +24,7 @@ Source Location: (84:1,7 [144] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public Task UpdateValue(int value) { ParentValue = value; return Task.CompletedTask; }
 |
-Generated Location: (2568:67,7 [144] )
+Generated Location: (2764:75,7 [144] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_ProducesErrorOnOlderLanguageVersions/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_ProducesErrorOnOlderLanguageVersions/TestComponent.codegen.cs
@@ -30,7 +30,14 @@ namespace Test
 #nullable disable
             );
             __o = new global::System.Action<System.Int32>(
-            UpdateValue);
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                            UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
             ));

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_ProducesErrorOnOlderLanguageVersions/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_ProducesErrorOnOlderLanguageVersions/TestComponent.ir.txt
@@ -20,7 +20,7 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                     ComponentAttribute - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                 HtmlContent - (75:0,75 [2] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_ProducesErrorOnOlderLanguageVersions/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_ProducesErrorOnOlderLanguageVersions/TestComponent.mappings.txt
@@ -3,14 +3,19 @@
 Generated Location: (1055:25,30 [11] )
 |ParentValue|
 
+Source Location: (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1324:34,60 [11] )
+|UpdateValue|
+
 Source Location: (19:0,19 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1567:40,19 [5] )
+Generated Location: (1749:47,19 [5] )
 |Value|
 
 Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1818:49,49 [5] )
+Generated Location: (2000:56,49 [5] )
 |Value|
 
 Source Location: (84:1,7 [116] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -19,7 +24,7 @@ Source Location: (84:1,7 [116] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public void UpdateValue(int value) => ParentValue = value;
 |
-Generated Location: (2231:67,7 [116] )
+Generated Location: (2413:74,7 [116] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningDelegate/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningDelegate/TestComponent.codegen.cs
@@ -30,7 +30,14 @@ namespace Test
 #nullable disable
             );
             __o = new global::System.Func<System.Int32, System.Threading.Tasks.Task>(
-            UpdateValue);
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                            UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
             ));

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningDelegate/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningDelegate/TestComponent.ir.txt
@@ -20,7 +20,7 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                     ComponentAttribute - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                 HtmlContent - (75:0,75 [2] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningDelegate/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningDelegate/TestComponent.mappings.txt
@@ -3,14 +3,19 @@
 Generated Location: (1055:25,30 [11] )
 |ParentValue|
 
+Source Location: (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1351:34,60 [11] )
+|UpdateValue|
+
 Source Location: (19:0,19 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1594:40,19 [5] )
+Generated Location: (1776:47,19 [5] )
 |Value|
 
 Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1845:49,49 [5] )
+Generated Location: (2027:56,49 [5] )
 |Value|
 
 Source Location: (84:1,7 [144] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -19,7 +24,7 @@ Source Location: (84:1,7 [144] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public Task UpdateValue(int value) { ParentValue = value; return Task.CompletedTask; }
 |
-Generated Location: (2258:67,7 [144] )
+Generated Location: (2440:74,7 [144] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningLambda/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningLambda/TestComponent.codegen.cs
@@ -30,7 +30,14 @@ namespace Test
 #nullable disable
             );
             __o = new global::System.Func<System.Int32, System.Threading.Tasks.Task>(
-            value => { ParentValue = value; return Task.CompletedTask; });
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                            value => { ParentValue = value; return Task.CompletedTask; }
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
             ));

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningLambda/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningLambda/TestComponent.ir.txt
@@ -20,7 +20,7 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - value => { ParentValue = value; return Task.CompletedTask; }
+                            LazyIntermediateToken - (60:0,60 [60] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - value => { ParentValue = value; return Task.CompletedTask; }
                     ComponentAttribute - (60:0,60 [60] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (60:0,60 [60] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - value => { ParentValue = value; return Task.CompletedTask; }
                 HtmlContent - (124:0,124 [2] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningLambda/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningLambda/TestComponent.mappings.txt
@@ -3,21 +3,26 @@
 Generated Location: (1055:25,30 [11] )
 |ParentValue|
 
+Source Location: (60:0,60 [60] x:\dir\subdir\Test\TestComponent.cshtml)
+|value => { ParentValue = value; return Task.CompletedTask; }|
+Generated Location: (1351:34,60 [60] )
+|value => { ParentValue = value; return Task.CompletedTask; }|
+
 Source Location: (19:0,19 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1643:40,19 [5] )
+Generated Location: (1825:47,19 [5] )
 |Value|
 
 Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1894:49,49 [5] )
+Generated Location: (2076:56,49 [5] )
 |Value|
 
 Source Location: (133:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (2307:67,7 [50] )
+Generated Location: (2489:74,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_MixingBindAndParamBindSet/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_MixingBindAndParamBindSet/TestComponent.codegen.cs
@@ -29,7 +29,15 @@ namespace Test
 #line hidden
 #nullable disable
             );
-            __o = global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: UpdateValue, value: ParentValue), ParentValue);
+            __o = global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                 UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , value: ParentValue), ParentValue);
         }
         #pragma warning restore 1998
 #nullable restore

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_MixingBindAndParamBindSet/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_MixingBindAndParamBindSet/TestComponent.ir.txt
@@ -23,7 +23,9 @@
                     HtmlAttribute - (18:0,18 [12] x:\dir\subdir\Test\TestComponent.cshtml) - myevent=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, 
-                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: UpdateValue, value: ParentValue)
+                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: 
+                            LazyIntermediateToken - (49:0,49 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
+                            IntermediateToken -  - CSharp - , value: ParentValue)
                             IntermediateToken -  - CSharp - , 
                             IntermediateToken -  - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_MixingBindAndParamBindSet/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_MixingBindAndParamBindSet/TestComponent.mappings.txt
@@ -3,13 +3,18 @@
 Generated Location: (1006:25,19 [11] )
 |ParentValue|
 
+Source Location: (49:0,49 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1412:34,49 [11] )
+|UpdateValue|
+
 Source Location: (73:1,7 [124] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 
     public void UpdateValue(string value) => ParentValue = value;
 |
-Generated Location: (1466:36,7 [124] )
+Generated Location: (1651:44,7 [124] )
 |
     public string ParentValue { get; set; } = "hi";
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_MixingBindValueWithGetSet/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_MixingBindValueWithGetSet/TestComponent.codegen.cs
@@ -36,7 +36,15 @@ namespace Test
 #line hidden
 #nullable disable
             );
-            __o = global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: UpdateValue, value: ParentValue), ParentValue);
+            __o = global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                              UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , value: ParentValue), ParentValue);
         }
         #pragma warning restore 1998
 #nullable restore

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_MixingBindValueWithGetSet/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_MixingBindValueWithGetSet/TestComponent.ir.txt
@@ -26,7 +26,9 @@
                     HtmlAttribute - (12:0,12 [12] x:\dir\subdir\Test\TestComponent.cshtml) - myevent=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, 
-                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: UpdateValue, value: ParentValue)
+                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: 
+                            LazyIntermediateToken - (62:0,62 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
+                            IntermediateToken -  - CSharp - , value: ParentValue)
                             IntermediateToken -  - CSharp - , 
                             IntermediateToken -  - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_MixingBindValueWithGetSet/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_MixingBindValueWithGetSet/TestComponent.mappings.txt
@@ -8,13 +8,18 @@ Source Location: (13:0,13 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1172:32,13 [11] )
 |ParentValue|
 
+Source Location: (62:0,62 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1591:41,62 [11] )
+|UpdateValue|
+
 Source Location: (86:1,7 [124] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 
     public void UpdateValue(string value) => ParentValue = value;
 |
-Generated Location: (1632:43,7 [124] )
+Generated Location: (1830:51,7 [124] )
 |
     public string ParentValue { get; set; } = "hi";
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_MixingSetWithAfter/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_MixingSetWithAfter/TestComponent.codegen.cs
@@ -29,7 +29,15 @@ namespace Test
 #line hidden
 #nullable disable
             );
-            __o = global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, callback: async __value => { await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: UpdateValue, value: ParentValue)(); await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: 
+            __o = global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, callback: async __value => { await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                         UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , value: ParentValue)(); await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                                    AfterUpdate

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_MixingSetWithAfter/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_MixingSetWithAfter/TestComponent.ir.txt
@@ -23,7 +23,9 @@
                     HtmlAttribute - (16:0,16 [12] x:\dir\subdir\Test\TestComponent.cshtml) - myevent=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, 
-                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, callback: async __value => { await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: UpdateValue, value: ParentValue)(); await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: 
+                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, callback: async __value => { await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: 
+                            LazyIntermediateToken - (41:0,41 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
+                            IntermediateToken -  - CSharp - , value: ParentValue)(); await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: 
                             LazyIntermediateToken - (67:0,67 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - AfterUpdate
                             IntermediateToken -  - CSharp - ); }, value: ParentValue)
                             IntermediateToken -  - CSharp - , 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_MixingSetWithAfter/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_MixingSetWithAfter/TestComponent.mappings.txt
@@ -3,9 +3,14 @@
 Generated Location: (1004:25,17 [11] )
 |ParentValue|
 
+Source Location: (41:0,41 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1543:34,41 [11] )
+|UpdateValue|
+
 Source Location: (67:0,67 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |AfterUpdate|
-Generated Location: (1720:34,67 [11] )
+Generated Location: (1897:42,67 [11] )
 |AfterUpdate|
 
 Source Location: (91:1,7 [159] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -15,7 +20,7 @@ Source Location: (91:1,7 [159] x:\dir\subdir\Test\TestComponent.cshtml)
     public void UpdateValue(string value) => ParentValue = value;
     public void AfterUpdate() { }
 |
-Generated Location: (1963:44,7 [159] )
+Generated Location: (2140:52,7 [159] )
 |
     public string ParentValue { get; set; } = "hi";
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithGetSetAndSuffix/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithGetSetAndSuffix/TestComponent.codegen.cs
@@ -29,7 +29,15 @@ namespace Test
 #line hidden
 #nullable disable
             );
-            __o = global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: ValueChanged, value: ParentValue), ParentValue);
+            __o = global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                         ValueChanged
+
+#line default
+#line hidden
+#nullable disable
+            , value: ParentValue), ParentValue);
         }
         #pragma warning restore 1998
 #nullable restore

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithGetSetAndSuffix/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithGetSetAndSuffix/TestComponent.ir.txt
@@ -25,7 +25,9 @@
                     HtmlAttribute - (24:0,24 [12] x:\dir\subdir\Test\TestComponent.cshtml) - myevent=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, 
-                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: ValueChanged, value: ParentValue)
+                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: 
+                            LazyIntermediateToken - (57:0,57 [12] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ValueChanged
+                            IntermediateToken -  - CSharp - , value: ParentValue)
                             IntermediateToken -  - CSharp - , 
                             IntermediateToken -  - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithGetSetAndSuffix/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToElement_WithGetSetAndSuffix/TestComponent.mappings.txt
@@ -3,6 +3,11 @@
 Generated Location: (1012:25,25 [11] )
 |ParentValue|
 
+Source Location: (57:0,57 [12] x:\dir\subdir\Test\TestComponent.cshtml)
+|ValueChanged|
+Generated Location: (1426:34,57 [12] )
+|ValueChanged|
+
 Source Location: (88:2,7 [144] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
@@ -12,7 +17,7 @@ Source Location: (88:2,7 [144] x:\dir\subdir\Test\TestComponent.cshtml)
         return Task.CompletedTask;
     }
 |
-Generated Location: (1473:36,7 [144] )
+Generated Location: (1666:44,7 [144] )
 |
     public string ParentValue { get; set; } = "hi";
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.codegen.cs
@@ -39,7 +39,15 @@ namespace Test
 #nullable disable
             );
             __o = global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<CustomValue>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<CustomValue>(this, 
-            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, UpdateValue, ParentValue)));
+            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                                                 UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , ParentValue)));
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
             ));

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.ir.txt
@@ -23,7 +23,7 @@
                     ComponentAttribute - (51:0,51 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (81:0,81 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (81:0,81 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (81:0,81 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.mappings.txt
@@ -8,14 +8,19 @@ Source Location: (51:0,51 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1264:34,51 [11] )
 |ParentValue|
 
+Source Location: (81:0,81 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1872:44,81 [11] )
+|UpdateValue|
+
 Source Location: (40:0,40 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2129:49,40 [5] )
+Generated Location: (2346:57,40 [5] )
 |Value|
 
 Source Location: (70:0,70 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2414:58,70 [5] )
+Generated Location: (2631:66,70 [5] )
 |Value|
 
 Source Location: (105:1,7 [147] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -24,7 +29,7 @@ Source Location: (105:1,7 [147] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public void UpdateValue(CustomValue value) => ParentValue = value;
 |
-Generated Location: (2829:76,7 [147] )
+Generated Location: (3046:84,7 [147] )
 |
     public CustomValue ParentValue { get; set; } = new CustomValue();
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.codegen.cs
@@ -39,7 +39,15 @@ namespace Test
 #nullable disable
             );
             __o = global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<CustomValue>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<CustomValue>(this, 
-            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, UpdateValue, ParentValue)));
+            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                                                 UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , ParentValue)));
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
             ));

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.ir.txt
@@ -23,7 +23,7 @@
                     ComponentAttribute - (51:0,51 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (81:0,81 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (81:0,81 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (81:0,81 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.mappings.txt
@@ -8,14 +8,19 @@ Source Location: (51:0,51 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1264:34,51 [11] )
 |ParentValue|
 
+Source Location: (81:0,81 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1872:44,81 [11] )
+|UpdateValue|
+
 Source Location: (40:0,40 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2129:49,40 [5] )
+Generated Location: (2346:57,40 [5] )
 |Value|
 
 Source Location: (70:0,70 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2414:58,70 [5] )
+Generated Location: (2631:66,70 [5] )
 |Value|
 
 Source Location: (105:1,7 [138] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -23,7 +28,7 @@ Source Location: (105:1,7 [138] x:\dir\subdir\Test\TestComponent.cshtml)
     public CustomValue ParentValue { get; set; } = new CustomValue();
     public EventCallback<CustomValue> UpdateValue { get; set; }
 |
-Generated Location: (2829:76,7 [138] )
+Generated Location: (3046:84,7 [138] )
 |
     public CustomValue ParentValue { get; set; } = new CustomValue();
     public EventCallback<CustomValue> UpdateValue { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.codegen.cs
@@ -39,7 +39,15 @@ namespace Test
 #nullable disable
             );
             __o = global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<CustomValue>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<CustomValue>(this, 
-            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, UpdateValue, ParentValue)));
+            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                                                 UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , ParentValue)));
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
             ));

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.ir.txt
@@ -23,7 +23,7 @@
                     ComponentAttribute - (51:0,51 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (81:0,81 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (81:0,81 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (81:0,81 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.mappings.txt
@@ -8,14 +8,19 @@ Source Location: (51:0,51 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1264:34,51 [11] )
 |ParentValue|
 
+Source Location: (81:0,81 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1872:44,81 [11] )
+|UpdateValue|
+
 Source Location: (40:0,40 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2129:49,40 [5] )
+Generated Location: (2346:57,40 [5] )
 |Value|
 
 Source Location: (70:0,70 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2414:58,70 [5] )
+Generated Location: (2631:66,70 [5] )
 |Value|
 
 Source Location: (105:1,7 [179] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -24,7 +29,7 @@ Source Location: (105:1,7 [179] x:\dir\subdir\Test\TestComponent.cshtml)
 
         public Task UpdateValue(CustomValue value) { ParentValue = value; return Task.CompletedTask; }
 |
-Generated Location: (2829:76,7 [179] )
+Generated Location: (3046:84,7 [179] )
 |
     public CustomValue ParentValue { get; set; } = new CustomValue();
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_Action/TestComponent.codegen.cs
@@ -29,7 +29,15 @@ namespace Test
 #line hidden
 #nullable disable
             , -1, global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
-            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, UpdateValue, ParentValue)));
+            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                            UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , ParentValue)));
             #pragma warning disable BL0005
             __typeInference_CreateMyComponent_0.
 #nullable restore

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_Action/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_Action/TestComponent.ir.txt
@@ -21,7 +21,7 @@
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_Action/TestComponent.mappings.txt
@@ -3,14 +3,19 @@
 Generated Location: (1076:25,30 [11] )
 |ParentValue|
 
+Source Location: (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1484:34,60 [11] )
+|UpdateValue|
+
 Source Location: (19:0,19 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1565:36,19 [5] )
+Generated Location: (1761:44,19 [5] )
 |Value|
 
 Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1816:45,49 [5] )
+Generated Location: (2012:53,49 [5] )
 |Value|
 
 Source Location: (84:1,7 [147] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -19,7 +24,7 @@ Source Location: (84:1,7 [147] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public void UpdateValue(CustomValue value) => ParentValue = value;
 |
-Generated Location: (2231:63,7 [147] )
+Generated Location: (2427:71,7 [147] )
 |
     public CustomValue ParentValue { get; set; } = new CustomValue();
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_EventCallback/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_EventCallback/TestComponent.codegen.cs
@@ -29,7 +29,15 @@ namespace Test
 #line hidden
 #nullable disable
             , -1, global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
-            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, UpdateValue, ParentValue)));
+            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                            UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , ParentValue)));
             #pragma warning disable BL0005
             __typeInference_CreateMyComponent_0.
 #nullable restore

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_EventCallback/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_EventCallback/TestComponent.ir.txt
@@ -21,7 +21,7 @@
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_EventCallback/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_EventCallback/TestComponent.mappings.txt
@@ -3,14 +3,19 @@
 Generated Location: (1076:25,30 [11] )
 |ParentValue|
 
+Source Location: (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1484:34,60 [11] )
+|UpdateValue|
+
 Source Location: (19:0,19 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1565:36,19 [5] )
+Generated Location: (1761:44,19 [5] )
 |Value|
 
 Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1816:45,49 [5] )
+Generated Location: (2012:53,49 [5] )
 |Value|
 
 Source Location: (84:1,7 [138] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -18,7 +23,7 @@ Source Location: (84:1,7 [138] x:\dir\subdir\Test\TestComponent.cshtml)
     public CustomValue ParentValue { get; set; } = new CustomValue();
     public EventCallback<CustomValue> UpdateValue { get; set; }
 |
-Generated Location: (2231:63,7 [138] )
+Generated Location: (2427:71,7 [138] )
 |
     public CustomValue ParentValue { get; set; } = new CustomValue();
     public EventCallback<CustomValue> UpdateValue { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_Function/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_Function/TestComponent.codegen.cs
@@ -29,7 +29,15 @@ namespace Test
 #line hidden
 #nullable disable
             , -1, global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
-            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, UpdateValue, ParentValue)));
+            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                            UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , ParentValue)));
             #pragma warning disable BL0005
             __typeInference_CreateMyComponent_0.
 #nullable restore

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_Function/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_Function/TestComponent.ir.txt
@@ -21,7 +21,7 @@
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_Function/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_Function/TestComponent.mappings.txt
@@ -3,14 +3,19 @@
 Generated Location: (1076:25,30 [11] )
 |ParentValue|
 
+Source Location: (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1484:34,60 [11] )
+|UpdateValue|
+
 Source Location: (19:0,19 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1565:36,19 [5] )
+Generated Location: (1761:44,19 [5] )
 |Value|
 
 Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1816:45,49 [5] )
+Generated Location: (2012:53,49 [5] )
 |Value|
 
 Source Location: (84:1,7 [175] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -19,7 +24,7 @@ Source Location: (84:1,7 [175] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public Task UpdateValue(CustomValue value) { ParentValue = value; return Task.CompletedTask; }
 |
-Generated Location: (2231:63,7 [175] )
+Generated Location: (2427:71,7 [175] )
 |
     public CustomValue ParentValue { get; set; } = new CustomValue();
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.codegen.cs
@@ -50,7 +50,15 @@ TParam
 #nullable disable
             );
             __o = global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<TParam>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<TParam>(this, 
-            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, UpdateValue, ParentValue)));
+            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
+#nullable restore
+#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                                            UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , ParentValue)));
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
             ));

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.ir.txt
@@ -24,7 +24,7 @@
                     ComponentAttribute - (65:1,46 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (95:1,76 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (95:1,76 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (95:1,76 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.mappings.txt
@@ -13,14 +13,19 @@ Source Location: (65:1,46 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1453:45,46 [11] )
 |ParentValue|
 
+Source Location: (95:1,76 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (2046:55,76 [11] )
+|UpdateValue|
+
 Source Location: (54:1,35 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2298:60,35 [5] )
+Generated Location: (2510:68,35 [5] )
 |Value|
 
 Source Location: (84:1,65 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2573:69,65 [5] )
+Generated Location: (2785:77,65 [5] )
 |Value|
 
 Source Location: (119:2,7 [128] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -29,7 +34,7 @@ Source Location: (119:2,7 [128] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public void UpdateValue(TParam value) { ParentValue = value; }
 |
-Generated Location: (2988:87,7 [128] )
+Generated Location: (3200:95,7 [128] )
 |
     public TParam ParentValue { get; set; } = default;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.codegen.cs
@@ -50,7 +50,15 @@ TParam
 #nullable disable
             );
             __o = global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<TParam>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<TParam>(this, 
-            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, UpdateValue, ParentValue)));
+            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
+#nullable restore
+#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                                            UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , ParentValue)));
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
             ));

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.ir.txt
@@ -24,7 +24,7 @@
                     ComponentAttribute - (65:1,46 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (95:1,76 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (95:1,76 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (95:1,76 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.mappings.txt
@@ -13,14 +13,19 @@ Source Location: (65:1,46 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1453:45,46 [11] )
 |ParentValue|
 
+Source Location: (95:1,76 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (2046:55,76 [11] )
+|UpdateValue|
+
 Source Location: (54:1,35 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2298:60,35 [5] )
+Generated Location: (2510:68,35 [5] )
 |Value|
 
 Source Location: (84:1,65 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2573:69,65 [5] )
+Generated Location: (2785:77,65 [5] )
 |Value|
 
 Source Location: (119:2,7 [118] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -28,7 +33,7 @@ Source Location: (119:2,7 [118] x:\dir\subdir\Test\TestComponent.cshtml)
     public TParam ParentValue { get; set; } = default;
     public EventCallback<TParam> UpdateValue { get; set; }
 |
-Generated Location: (2988:87,7 [118] )
+Generated Location: (3200:95,7 [118] )
 |
     public TParam ParentValue { get; set; } = default;
     public EventCallback<TParam> UpdateValue { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.codegen.cs
@@ -50,7 +50,15 @@ TParam
 #nullable disable
             );
             __o = global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<TParam>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<TParam>(this, 
-            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, UpdateValue, ParentValue)));
+            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
+#nullable restore
+#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                                            UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , ParentValue)));
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
             ));

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.ir.txt
@@ -24,7 +24,7 @@
                     ComponentAttribute - (65:1,46 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (95:1,76 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (95:1,76 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (95:1,76 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.mappings.txt
@@ -13,14 +13,19 @@ Source Location: (65:1,46 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1453:45,46 [11] )
 |ParentValue|
 
+Source Location: (95:1,76 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (2046:55,76 [11] )
+|UpdateValue|
+
 Source Location: (54:1,35 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2298:60,35 [5] )
+Generated Location: (2510:68,35 [5] )
 |Value|
 
 Source Location: (84:1,65 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2573:69,65 [5] )
+Generated Location: (2785:77,65 [5] )
 |Value|
 
 Source Location: (119:2,7 [155] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -29,7 +34,7 @@ Source Location: (119:2,7 [155] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public Task UpdateValue(TParam value) { ParentValue = value; return Task.CompletedTask; }
 |
-Generated Location: (2988:87,7 [155] )
+Generated Location: (3200:95,7 [155] )
 |
     public TParam ParentValue { get; set; } = default;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_Action/TestComponent.codegen.cs
@@ -40,7 +40,15 @@ TParam
 #line hidden
 #nullable disable
             , -1, global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
-            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, UpdateValue, ParentValue)));
+            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
+#nullable restore
+#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                            UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , ParentValue)));
             #pragma warning disable BL0005
             __typeInference_CreateMyComponent_0.
 #nullable restore

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_Action/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_Action/TestComponent.ir.txt
@@ -22,7 +22,7 @@
                     ComponentAttribute - (49:1,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (79:1,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (79:1,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (79:1,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_Action/TestComponent.mappings.txt
@@ -8,14 +8,19 @@ Source Location: (49:1,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1280:36,30 [11] )
 |ParentValue|
 
+Source Location: (79:1,60 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1688:45,60 [11] )
+|UpdateValue|
+
 Source Location: (38:1,19 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1769:47,19 [5] )
+Generated Location: (1965:55,19 [5] )
 |Value|
 
 Source Location: (68:1,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2020:56,49 [5] )
+Generated Location: (2216:64,49 [5] )
 |Value|
 
 Source Location: (103:2,7 [128] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -24,7 +29,7 @@ Source Location: (103:2,7 [128] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public void UpdateValue(TParam value) { ParentValue = value; }
 |
-Generated Location: (2435:74,7 [128] )
+Generated Location: (2631:82,7 [128] )
 |
     public TParam ParentValue { get; set; } = default;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_EventCallback/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_EventCallback/TestComponent.codegen.cs
@@ -40,7 +40,15 @@ TParam
 #line hidden
 #nullable disable
             , -1, global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
-            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, UpdateValue, ParentValue)));
+            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
+#nullable restore
+#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                            UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , ParentValue)));
             #pragma warning disable BL0005
             __typeInference_CreateMyComponent_0.
 #nullable restore

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_EventCallback/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_EventCallback/TestComponent.ir.txt
@@ -22,7 +22,7 @@
                     ComponentAttribute - (49:1,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (79:1,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (79:1,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (79:1,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_EventCallback/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_EventCallback/TestComponent.mappings.txt
@@ -8,14 +8,19 @@ Source Location: (49:1,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1280:36,30 [11] )
 |ParentValue|
 
+Source Location: (79:1,60 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1688:45,60 [11] )
+|UpdateValue|
+
 Source Location: (38:1,19 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1769:47,19 [5] )
+Generated Location: (1965:55,19 [5] )
 |Value|
 
 Source Location: (68:1,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2020:56,49 [5] )
+Generated Location: (2216:64,49 [5] )
 |Value|
 
 Source Location: (103:2,7 [118] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -23,7 +28,7 @@ Source Location: (103:2,7 [118] x:\dir\subdir\Test\TestComponent.cshtml)
     public TParam ParentValue { get; set; } = default;
     public EventCallback<TParam> UpdateValue { get; set; }
 |
-Generated Location: (2435:74,7 [118] )
+Generated Location: (2631:82,7 [118] )
 |
     public TParam ParentValue { get; set; } = default;
     public EventCallback<TParam> UpdateValue { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_Function/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_Function/TestComponent.codegen.cs
@@ -40,7 +40,15 @@ TParam
 #line hidden
 #nullable disable
             , -1, global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, 
-            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, UpdateValue, ParentValue)));
+            global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
+#nullable restore
+#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                            UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , ParentValue)));
             #pragma warning disable BL0005
             __typeInference_CreateMyComponent_0.
 #nullable restore

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_Function/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_Function/TestComponent.ir.txt
@@ -22,7 +22,7 @@
                     ComponentAttribute - (49:1,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (79:1,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (79:1,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (79:1,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_Function/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_Function/TestComponent.mappings.txt
@@ -8,14 +8,19 @@ Source Location: (49:1,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1280:36,30 [11] )
 |ParentValue|
 
+Source Location: (79:1,60 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1688:45,60 [11] )
+|UpdateValue|
+
 Source Location: (38:1,19 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (1769:47,19 [5] )
+Generated Location: (1965:55,19 [5] )
 |Value|
 
 Source Location: (68:1,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Value|
-Generated Location: (2020:56,49 [5] )
+Generated Location: (2216:64,49 [5] )
 |Value|
 
 Source Location: (103:2,7 [155] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -24,7 +29,7 @@ Source Location: (103:2,7 [155] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public Task UpdateValue(TParam value) { ParentValue = value; return Task.CompletedTask; }
 |
-Generated Location: (2435:74,7 [155] )
+Generated Location: (2631:82,7 [155] )
 |
     public TParam ParentValue { get; set; } = default;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_AsyncLambdaProducesError/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_AsyncLambdaProducesError/TestComponent.codegen.cs
@@ -23,7 +23,15 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Action<System.Int32>)((value => { ParentValue = value; return Task.CompletedTask; })));
+            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Action<System.Int32>)(
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                            (value => { ParentValue = value; return Task.CompletedTask; })
+
+#line default
+#line hidden
+#nullable disable
+            ));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_AsyncLambdaProducesError/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_AsyncLambdaProducesError/TestComponent.ir.txt
@@ -13,7 +13,7 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - (value => { ParentValue = value; return Task.CompletedTask; })
+                            LazyIntermediateToken - (60:0,60 [62] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - (value => { ParentValue = value; return Task.CompletedTask; })
                     ComponentAttribute - (60:0,60 [62] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (60:0,60 [62] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - (value => { ParentValue = value; return Task.CompletedTask; })
             CSharpCode - (135:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_AsyncLambdaProducesError/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_AsyncLambdaProducesError/TestComponent.mappings.txt
@@ -2,7 +2,7 @@
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1314:31,7 [50] )
+Generated Location: (1510:39,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_Action/TestComponent.codegen.cs
@@ -23,7 +23,15 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Action<System.Int32>)(UpdateValue));
+            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Action<System.Int32>)(
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                            UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            ));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_Action/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_Action/TestComponent.ir.txt
@@ -13,7 +13,7 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                     ComponentAttribute - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
             CSharpCode - (84:1,7 [116] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_Action/TestComponent.mappings.txt
@@ -4,7 +4,7 @@
 
     public void UpdateValue(int value) => ParentValue = value;
 |
-Generated Location: (1263:31,7 [116] )
+Generated Location: (1459:39,7 [116] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_ActionLambda/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_ActionLambda/TestComponent.codegen.cs
@@ -23,7 +23,15 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Action<System.Int32>)(value => ParentValue = value));
+            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Action<System.Int32>)(
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                            value => ParentValue = value
+
+#line default
+#line hidden
+#nullable disable
+            ));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_ActionLambda/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_ActionLambda/TestComponent.ir.txt
@@ -13,7 +13,7 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - value => ParentValue = value
+                            LazyIntermediateToken - (60:0,60 [28] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - value => ParentValue = value
                     ComponentAttribute - (60:0,60 [28] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (60:0,60 [28] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - value => ParentValue = value
             CSharpCode - (101:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_ActionLambda/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_ActionLambda/TestComponent.mappings.txt
@@ -2,7 +2,7 @@
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1280:31,7 [50] )
+Generated Location: (1476:39,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback/TestComponent.codegen.cs
@@ -23,7 +23,15 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddComponentParameter(2, "ValueChanged", global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<global::System.Int32>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<global::System.Int32>(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, UpdateValue, ParentValue))));
+            __builder.AddComponentParameter(2, "ValueChanged", global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<global::System.Int32>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<global::System.Int32>(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                            UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , ParentValue))));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback/TestComponent.ir.txt
@@ -14,7 +14,7 @@
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback/TestComponent.mappings.txt
@@ -3,7 +3,7 @@
     public int ParentValue { get; set; } = 42;
     public EventCallback<int> UpdateValue { get; set; }
 |
-Generated Location: (1602:31,7 [107] )
+Generated Location: (1798:39,7 [107] )
 |
     public int ParentValue { get; set; } = 42;
     public EventCallback<int> UpdateValue { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesAction/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesAction/TestComponent.codegen.cs
@@ -23,7 +23,15 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddComponentParameter(2, "ValueChanged", global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<global::System.Int32>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<global::System.Int32>(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, value => ParentValue = value, ParentValue))));
+            __builder.AddComponentParameter(2, "ValueChanged", global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<global::System.Int32>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<global::System.Int32>(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                            value => ParentValue = value
+
+#line default
+#line hidden
+#nullable disable
+            , ParentValue))));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesAction/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesAction/TestComponent.ir.txt
@@ -14,7 +14,7 @@
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - value => ParentValue = value
+                            LazyIntermediateToken - (60:0,60 [28] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - value => ParentValue = value
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (60:0,60 [28] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (60:0,60 [28] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - value => ParentValue = value

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesAction/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesAction/TestComponent.mappings.txt
@@ -2,7 +2,7 @@
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1619:31,7 [50] )
+Generated Location: (1815:39,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesFunction/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesFunction/TestComponent.codegen.cs
@@ -23,7 +23,15 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddComponentParameter(2, "ValueChanged", global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<global::System.Int32>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<global::System.Int32>(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, UpdateValue, ParentValue))));
+            __builder.AddComponentParameter(2, "ValueChanged", global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<global::System.Int32>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<global::System.Int32>(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                            UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , ParentValue))));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesFunction/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesFunction/TestComponent.ir.txt
@@ -14,7 +14,7 @@
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesFunction/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesFunction/TestComponent.mappings.txt
@@ -4,7 +4,7 @@
 
     public Task UpdateValue(int value) { ParentValue = value; return Task.CompletedTask; }
 |
-Generated Location: (1602:31,7 [144] )
+Generated Location: (1798:39,7 [144] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_ProducesErrorOnOlderLanguageVersions/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_ProducesErrorOnOlderLanguageVersions/TestComponent.codegen.cs
@@ -23,7 +23,15 @@ namespace Test
 #line hidden
 #nullable disable
             )));
-            __builder.AddAttribute(2, "ValueChanged", (object)((global::System.Action<System.Int32>)(UpdateValue)));
+            __builder.AddAttribute(2, "ValueChanged", (object)((global::System.Action<System.Int32>)(
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                            UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            )));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_ProducesErrorOnOlderLanguageVersions/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_ProducesErrorOnOlderLanguageVersions/TestComponent.ir.txt
@@ -13,7 +13,7 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                     ComponentAttribute - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
             CSharpCode - (84:1,7 [116] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_ProducesErrorOnOlderLanguageVersions/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_ProducesErrorOnOlderLanguageVersions/TestComponent.mappings.txt
@@ -4,7 +4,7 @@
 
     public void UpdateValue(int value) => ParentValue = value;
 |
-Generated Location: (1265:31,7 [116] )
+Generated Location: (1461:39,7 [116] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningDelegate/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningDelegate/TestComponent.codegen.cs
@@ -23,7 +23,15 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Func<System.Int32, System.Threading.Tasks.Task>)(UpdateValue));
+            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Func<System.Int32, System.Threading.Tasks.Task>)(
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                            UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            ));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningDelegate/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningDelegate/TestComponent.ir.txt
@@ -13,7 +13,7 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                     ComponentAttribute - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
             CSharpCode - (84:1,7 [144] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningDelegate/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningDelegate/TestComponent.mappings.txt
@@ -4,7 +4,7 @@
 
     public Task UpdateValue(int value) { ParentValue = value; return Task.CompletedTask; }
 |
-Generated Location: (1290:31,7 [144] )
+Generated Location: (1486:39,7 [144] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningLambda/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningLambda/TestComponent.codegen.cs
@@ -23,7 +23,15 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Func<System.Int32, System.Threading.Tasks.Task>)(value => { ParentValue = value; return Task.CompletedTask; }));
+            __builder.AddComponentParameter(2, "ValueChanged", (global::System.Func<System.Int32, System.Threading.Tasks.Task>)(
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                            value => { ParentValue = value; return Task.CompletedTask; }
+
+#line default
+#line hidden
+#nullable disable
+            ));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningLambda/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningLambda/TestComponent.ir.txt
@@ -13,7 +13,7 @@
                             LazyIntermediateToken - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ParentValue
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
-                            IntermediateToken -  - CSharp - value => { ParentValue = value; return Task.CompletedTask; }
+                            LazyIntermediateToken - (60:0,60 [60] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - value => { ParentValue = value; return Task.CompletedTask; }
                     ComponentAttribute - (60:0,60 [60] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (60:0,60 [60] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - value => { ParentValue = value; return Task.CompletedTask; }
             CSharpCode - (133:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningLambda/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningLambda/TestComponent.mappings.txt
@@ -2,7 +2,7 @@
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1339:31,7 [50] )
+Generated Location: (1535:39,7 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingBindAndParamBindSet/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingBindAndParamBindSet/TestComponent.codegen.cs
@@ -23,7 +23,15 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddAttribute(2, "myevent", global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: UpdateValue, value: ParentValue), ParentValue));
+            __builder.AddAttribute(2, "myevent", global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                 UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , value: ParentValue), ParentValue));
             __builder.SetUpdatesAttributeName("myvalue");
             __builder.CloseElement();
         }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingBindAndParamBindSet/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingBindAndParamBindSet/TestComponent.ir.txt
@@ -16,7 +16,9 @@
                     HtmlAttribute - (18:0,18 [12] x:\dir\subdir\Test\TestComponent.cshtml) - myevent=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, 
-                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: UpdateValue, value: ParentValue)
+                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: 
+                            LazyIntermediateToken - (49:0,49 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
+                            IntermediateToken -  - CSharp - , value: ParentValue)
                             IntermediateToken -  - CSharp - , 
                             IntermediateToken -  - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingBindAndParamBindSet/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingBindAndParamBindSet/TestComponent.mappings.txt
@@ -4,7 +4,7 @@
 
     public void UpdateValue(string value) => ParentValue = value;
 |
-Generated Location: (1413:32,7 [124] )
+Generated Location: (1598:40,7 [124] )
 |
     public string ParentValue { get; set; } = "hi";
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingBindValueWithGetSet/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingBindValueWithGetSet/TestComponent.codegen.cs
@@ -23,7 +23,15 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddAttribute(2, "myevent", global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: UpdateValue, value: ParentValue), ParentValue));
+            __builder.AddAttribute(2, "myevent", global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                              UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , value: ParentValue), ParentValue));
             __builder.SetUpdatesAttributeName("myvalue");
 #nullable restore
 #line (1,39)-(1,50) 24 "x:\dir\subdir\Test\TestComponent.cshtml"

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingBindValueWithGetSet/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingBindValueWithGetSet/TestComponent.ir.txt
@@ -19,7 +19,9 @@
                     HtmlAttribute - (12:0,12 [12] x:\dir\subdir\Test\TestComponent.cshtml) - myevent=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, 
-                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: UpdateValue, value: ParentValue)
+                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: 
+                            LazyIntermediateToken - (62:0,62 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
+                            IntermediateToken -  - CSharp - , value: ParentValue)
                             IntermediateToken -  - CSharp - , 
                             IntermediateToken -  - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingBindValueWithGetSet/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingBindValueWithGetSet/TestComponent.mappings.txt
@@ -4,7 +4,7 @@
 
     public void UpdateValue(string value) => ParentValue = value;
 |
-Generated Location: (1581:39,7 [124] )
+Generated Location: (1779:47,7 [124] )
 |
     public string ParentValue { get; set; } = "hi";
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingSetWithAfter/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingSetWithAfter/TestComponent.codegen.cs
@@ -23,7 +23,15 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddAttribute(2, "myevent", global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, callback: async __value => { await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: UpdateValue, value: ParentValue)(); await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: 
+            __builder.AddAttribute(2, "myevent", global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, callback: async __value => { await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                         UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , value: ParentValue)(); await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
                                                                    AfterUpdate

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingSetWithAfter/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingSetWithAfter/TestComponent.ir.txt
@@ -16,7 +16,9 @@
                     HtmlAttribute - (16:0,16 [12] x:\dir\subdir\Test\TestComponent.cshtml) - myevent=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, 
-                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, callback: async __value => { await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: UpdateValue, value: ParentValue)(); await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: 
+                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, callback: async __value => { await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: 
+                            LazyIntermediateToken - (41:0,41 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
+                            IntermediateToken -  - CSharp - , value: ParentValue)(); await global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.InvokeAsynchronousDelegate(callback: 
                             LazyIntermediateToken - (67:0,67 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - AfterUpdate
                             IntermediateToken -  - CSharp - ); }, value: ParentValue)
                             IntermediateToken -  - CSharp - , 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingSetWithAfter/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingSetWithAfter/TestComponent.mappings.txt
@@ -5,7 +5,7 @@
     public void UpdateValue(string value) => ParentValue = value;
     public void AfterUpdate() { }
 |
-Generated Location: (1910:40,7 [159] )
+Generated Location: (2087:48,7 [159] )
 |
     public string ParentValue { get; set; } = "hi";
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithGetSetAndSuffix/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithGetSetAndSuffix/TestComponent.codegen.cs
@@ -23,7 +23,15 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddAttribute(2, "myevent", global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: ValueChanged, value: ParentValue), ParentValue));
+            __builder.AddAttribute(2, "myevent", global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                         ValueChanged
+
+#line default
+#line hidden
+#nullable disable
+            , value: ParentValue), ParentValue));
             __builder.SetUpdatesAttributeName("myvalue");
             __builder.CloseElement();
         }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithGetSetAndSuffix/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithGetSetAndSuffix/TestComponent.ir.txt
@@ -16,7 +16,9 @@
                     HtmlAttribute - (24:0,24 [12] x:\dir\subdir\Test\TestComponent.cshtml) - myevent=" - "
                         CSharpExpressionAttributeValue -  - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.EventCallback.Factory.CreateBinder(this, 
-                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: ValueChanged, value: ParentValue)
+                            IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredBindSetter(callback: 
+                            LazyIntermediateToken - (57:0,57 [12] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - ValueChanged
+                            IntermediateToken -  - CSharp - , value: ParentValue)
                             IntermediateToken -  - CSharp - , 
                             IntermediateToken -  - CSharp - ParentValue
                             IntermediateToken -  - CSharp - )

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithGetSetAndSuffix/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithGetSetAndSuffix/TestComponent.mappings.txt
@@ -7,7 +7,7 @@
         return Task.CompletedTask;
     }
 |
-Generated Location: (1420:32,7 [144] )
+Generated Location: (1613:40,7 [144] )
 |
     public string ParentValue { get; set; } = "hi";
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.codegen.cs
@@ -23,7 +23,15 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddComponentParameter(2, "ValueChanged", global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<CustomValue>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<CustomValue>(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, UpdateValue, ParentValue))));
+            __builder.AddComponentParameter(2, "ValueChanged", global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<CustomValue>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<CustomValue>(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                                                 UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , ParentValue))));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.ir.txt
@@ -16,7 +16,7 @@
                     ComponentAttribute - (51:0,51 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (81:0,81 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (81:0,81 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (81:0,81 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.mappings.txt
@@ -4,7 +4,7 @@
 
     public void UpdateValue(CustomValue value) => ParentValue = value;
 |
-Generated Location: (1609:31,7 [147] )
+Generated Location: (1826:39,7 [147] )
 |
     public CustomValue ParentValue { get; set; } = new CustomValue();
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.codegen.cs
@@ -23,7 +23,15 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddComponentParameter(2, "ValueChanged", global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<CustomValue>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<CustomValue>(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, UpdateValue, ParentValue))));
+            __builder.AddComponentParameter(2, "ValueChanged", global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<CustomValue>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<CustomValue>(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                                                 UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , ParentValue))));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.ir.txt
@@ -16,7 +16,7 @@
                     ComponentAttribute - (51:0,51 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (81:0,81 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (81:0,81 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (81:0,81 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.mappings.txt
@@ -3,7 +3,7 @@
     public CustomValue ParentValue { get; set; } = new CustomValue();
     public EventCallback<CustomValue> UpdateValue { get; set; }
 |
-Generated Location: (1609:31,7 [138] )
+Generated Location: (1826:39,7 [138] )
 |
     public CustomValue ParentValue { get; set; } = new CustomValue();
     public EventCallback<CustomValue> UpdateValue { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.codegen.cs
@@ -23,7 +23,15 @@ namespace Test
 #line hidden
 #nullable disable
             ));
-            __builder.AddComponentParameter(2, "ValueChanged", global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<CustomValue>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<CustomValue>(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, UpdateValue, ParentValue))));
+            __builder.AddComponentParameter(2, "ValueChanged", global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<CustomValue>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<CustomValue>(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                                                 UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , ParentValue))));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.ir.txt
@@ -16,7 +16,7 @@
                     ComponentAttribute - (51:0,51 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (81:0,81 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (81:0,81 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (81:0,81 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.mappings.txt
@@ -4,7 +4,7 @@
 
         public Task UpdateValue(CustomValue value) { ParentValue = value; return Task.CompletedTask; }
 |
-Generated Location: (1609:31,7 [179] )
+Generated Location: (1826:39,7 [179] )
 |
     public CustomValue ParentValue { get; set; } = new CustomValue();
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_Action/TestComponent.codegen.cs
@@ -21,7 +21,15 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            , 2, global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, UpdateValue, ParentValue)));
+            , 2, global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                            UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , ParentValue)));
         }
         #pragma warning restore 1998
 #nullable restore

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_Action/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_Action/TestComponent.ir.txt
@@ -14,7 +14,7 @@
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_Action/TestComponent.mappings.txt
@@ -4,7 +4,7 @@
 
     public void UpdateValue(CustomValue value) => ParentValue = value;
 |
-Generated Location: (1188:28,7 [147] )
+Generated Location: (1384:36,7 [147] )
 |
     public CustomValue ParentValue { get; set; } = new CustomValue();
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_EventCallback/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_EventCallback/TestComponent.codegen.cs
@@ -21,7 +21,15 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            , 2, global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, UpdateValue, ParentValue)));
+            , 2, global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                            UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , ParentValue)));
         }
         #pragma warning restore 1998
 #nullable restore

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_EventCallback/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_EventCallback/TestComponent.ir.txt
@@ -14,7 +14,7 @@
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_EventCallback/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_EventCallback/TestComponent.mappings.txt
@@ -3,7 +3,7 @@
     public CustomValue ParentValue { get; set; } = new CustomValue();
     public EventCallback<CustomValue> UpdateValue { get; set; }
 |
-Generated Location: (1188:28,7 [138] )
+Generated Location: (1384:36,7 [138] )
 |
     public CustomValue ParentValue { get; set; } = new CustomValue();
     public EventCallback<CustomValue> UpdateValue { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_Function/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_Function/TestComponent.codegen.cs
@@ -21,7 +21,15 @@ namespace Test
 #line default
 #line hidden
 #nullable disable
-            , 2, global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, UpdateValue, ParentValue)));
+            , 2, global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                            UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , ParentValue)));
         }
         #pragma warning restore 1998
 #nullable restore

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_Function/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_Function/TestComponent.ir.txt
@@ -14,7 +14,7 @@
                     ComponentAttribute - (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_Function/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_Function/TestComponent.mappings.txt
@@ -4,7 +4,7 @@
 
     public Task UpdateValue(CustomValue value) { ParentValue = value; return Task.CompletedTask; }
 |
-Generated Location: (1188:28,7 [175] )
+Generated Location: (1384:36,7 [175] )
 |
     public CustomValue ParentValue { get; set; } = new CustomValue();
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.codegen.cs
@@ -31,7 +31,15 @@ TParam
 #line hidden
 #nullable disable
             ));
-            __builder.AddComponentParameter(2, "ValueChanged", global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<TParam>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<TParam>(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, UpdateValue, ParentValue))));
+            __builder.AddComponentParameter(2, "ValueChanged", global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<TParam>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<TParam>(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
+#nullable restore
+#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                                            UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , ParentValue))));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.ir.txt
@@ -16,7 +16,7 @@
                     ComponentAttribute - (65:1,46 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (95:1,76 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (95:1,76 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (95:1,76 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.mappings.txt
@@ -9,7 +9,7 @@ Source Location: (119:2,7 [128] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public void UpdateValue(TParam value) { ParentValue = value; }
 |
-Generated Location: (1720:39,7 [128] )
+Generated Location: (1932:47,7 [128] )
 |
     public TParam ParentValue { get; set; } = default;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.codegen.cs
@@ -31,7 +31,15 @@ TParam
 #line hidden
 #nullable disable
             ));
-            __builder.AddComponentParameter(2, "ValueChanged", global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<TParam>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<TParam>(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, UpdateValue, ParentValue))));
+            __builder.AddComponentParameter(2, "ValueChanged", global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<TParam>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<TParam>(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
+#nullable restore
+#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                                            UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , ParentValue))));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.ir.txt
@@ -16,7 +16,7 @@
                     ComponentAttribute - (65:1,46 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (95:1,76 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (95:1,76 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (95:1,76 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.mappings.txt
@@ -8,7 +8,7 @@ Source Location: (119:2,7 [118] x:\dir\subdir\Test\TestComponent.cshtml)
     public TParam ParentValue { get; set; } = default;
     public EventCallback<TParam> UpdateValue { get; set; }
 |
-Generated Location: (1720:39,7 [118] )
+Generated Location: (1932:47,7 [118] )
 |
     public TParam ParentValue { get; set; } = default;
     public EventCallback<TParam> UpdateValue { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.codegen.cs
@@ -31,7 +31,15 @@ TParam
 #line hidden
 #nullable disable
             ));
-            __builder.AddComponentParameter(2, "ValueChanged", global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<TParam>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<TParam>(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, UpdateValue, ParentValue))));
+            __builder.AddComponentParameter(2, "ValueChanged", global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.TypeCheck<global::Microsoft.AspNetCore.Components.EventCallback<TParam>>(global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create<TParam>(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
+#nullable restore
+#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                                            UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , ParentValue))));
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.ir.txt
@@ -16,7 +16,7 @@
                     ComponentAttribute - (65:1,46 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (95:1,76 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (95:1,76 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (95:1,76 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.mappings.txt
@@ -9,7 +9,7 @@ Source Location: (119:2,7 [155] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public Task UpdateValue(TParam value) { ParentValue = value; return Task.CompletedTask; }
 |
-Generated Location: (1720:39,7 [155] )
+Generated Location: (1932:47,7 [155] )
 |
     public TParam ParentValue { get; set; } = default;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_Action/TestComponent.codegen.cs
@@ -29,7 +29,15 @@ TParam
 #line default
 #line hidden
 #nullable disable
-            , 2, global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, UpdateValue, ParentValue)));
+            , 2, global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
+#nullable restore
+#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                            UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , ParentValue)));
         }
         #pragma warning restore 1998
 #nullable restore

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_Action/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_Action/TestComponent.ir.txt
@@ -14,7 +14,7 @@
                     ComponentAttribute - (49:1,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (79:1,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (79:1,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (79:1,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_Action/TestComponent.mappings.txt
@@ -9,7 +9,7 @@ Source Location: (103:2,7 [128] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public void UpdateValue(TParam value) { ParentValue = value; }
 |
-Generated Location: (1324:36,7 [128] )
+Generated Location: (1520:44,7 [128] )
 |
     public TParam ParentValue { get; set; } = default;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_EventCallback/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_EventCallback/TestComponent.codegen.cs
@@ -29,7 +29,15 @@ TParam
 #line default
 #line hidden
 #nullable disable
-            , 2, global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, UpdateValue, ParentValue)));
+            , 2, global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
+#nullable restore
+#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                            UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , ParentValue)));
         }
         #pragma warning restore 1998
 #nullable restore

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_EventCallback/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_EventCallback/TestComponent.ir.txt
@@ -14,7 +14,7 @@
                     ComponentAttribute - (49:1,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (79:1,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (79:1,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (79:1,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_EventCallback/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_EventCallback/TestComponent.mappings.txt
@@ -8,7 +8,7 @@ Source Location: (103:2,7 [118] x:\dir\subdir\Test\TestComponent.cshtml)
     public TParam ParentValue { get; set; } = default;
     public EventCallback<TParam> UpdateValue { get; set; }
 |
-Generated Location: (1324:36,7 [118] )
+Generated Location: (1520:44,7 [118] )
 |
     public TParam ParentValue { get; set; } = default;
     public EventCallback<TParam> UpdateValue { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_Function/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_Function/TestComponent.codegen.cs
@@ -29,7 +29,15 @@ TParam
 #line default
 #line hidden
 #nullable disable
-            , 2, global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, UpdateValue, ParentValue)));
+            , 2, global::Microsoft.AspNetCore.Components.EventCallback.Factory.Create(this, global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
+#nullable restore
+#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
+                                                            UpdateValue
+
+#line default
+#line hidden
+#nullable disable
+            , ParentValue)));
         }
         #pragma warning restore 1998
 #nullable restore

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_Function/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_Function/TestComponent.ir.txt
@@ -14,7 +14,7 @@
                     ComponentAttribute - (49:1,30 [11] x:\dir\subdir\Test\TestComponent.cshtml) - ValueChanged - ValueChanged - AttributeStructure.DoubleQuotes
                         CSharpExpression - 
                             IntermediateToken -  - CSharp - global::Microsoft.AspNetCore.Components.CompilerServices.RuntimeHelpers.CreateInferredEventCallback(this, 
-                            IntermediateToken -  - CSharp - UpdateValue
+                            LazyIntermediateToken - (79:1,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue
                             IntermediateToken -  - CSharp - , ParentValue)
                     ComponentAttribute - (79:1,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - bind-Value - Value - AttributeStructure.DoubleQuotes
                         LazyIntermediateToken - (79:1,60 [11] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - UpdateValue

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_Function/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_Function/TestComponent.mappings.txt
@@ -9,7 +9,7 @@ Source Location: (103:2,7 [155] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public Task UpdateValue(TParam value) { ParentValue = value; return Task.CompletedTask; }
 |
-Generated Location: (1324:36,7 [155] )
+Generated Location: (1520:44,7 [155] )
 |
     public TParam ParentValue { get; set; } = default;
 


### PR DESCRIPTION
Pretty much the same as https://github.com/dotnet/razor/pull/9062, fixes another part of https://github.com/dotnet/razor/issues/8552