### PR TITLE
Fix issue with document version cache missing some snapshots

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultDocumentVersionCache.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultDocumentVersionCache.cs
@@ -128,20 +128,18 @@ internal class DefaultDocumentVersionCache : DocumentVersionCache
             case ProjectChangeKind.DocumentChanged:
                 var documentFilePath = args.DocumentFilePath!;
 
-                if (ProjectSnapshotManager.IsDocumentOpen(documentFilePath))
+                if (!ProjectSnapshotManager.IsDocumentOpen(documentFilePath))
                 {
-                    return;
-                }
-
-                using (upgradeableLock.EnterWriteLock())
-                {
-                    // Document closed, evict all entries.
-                    var keys = DocumentLookup_NeedsLock.Keys.ToArray();
-                    foreach (var key in keys)
+                    using (upgradeableLock.EnterWriteLock())
                     {
-                        if (key.DocumentFilePath == documentFilePath)
+                        // Document closed, evict all entries.
+                        var keys = DocumentLookup_NeedsLock.Keys.ToArray();
+                        foreach (var key in keys)
                         {
-                            DocumentLookup_NeedsLock.Remove(key);
+                            if (key.DocumentFilePath == documentFilePath)
+                            {
+                                DocumentLookup_NeedsLock.Remove(key);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
In my previous PR I incorrectly translated the [old code](https://github.com/dotnet/razor/blob/3fee1cdbdb9df0087107e40003cf3a6b8bf7da0d/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultDocumentVersionCache.cs#L143) to allow for documents to be in multiple projects, and accidentally left us with a gap in our DocumentVersionCache. I had a `return;` statement where there should have been a `break;` statement.

Obviously this huge change has taken me most of the day to track down 🤦‍♂️

This doesn't seem to manifest any issues to the user currently, but does result in errors in the output log when switching tabs between open Razor documents, for example. When things become actually multi-document, then it starts to cause real problems, especially with somewhat flaky project context data from the platform. Thought it would be good to fix separately though, rather than wait.