### PR TITLE
Remove a couple duplicated GetContent calls

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorIntermediateNodeLoweringPhase.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorIntermediateNodeLoweringPhase.cs
@@ -539,7 +539,7 @@ internal class DefaultRazorIntermediateNodeLoweringPhase : RazorEnginePhaseBase,
                 {
                     _builder.Push(new HtmlAttributeIntermediateNode()
                     {
-                        AttributeName = node.Name.GetContent(),
+                        AttributeName = name,
                         Prefix = prefix.GetContent(),
                         Suffix = node.ValueSuffix?.GetContent() ?? string.Empty,
                         Source = BuildSourceSpanFromNode(node),
@@ -1319,7 +1319,7 @@ internal class DefaultRazorIntermediateNodeLoweringPhase : RazorEnginePhaseBase,
             var name = node.Name.GetContent();
             _builder.Push(new HtmlAttributeIntermediateNode()
             {
-                AttributeName = node.Name.GetContent(),
+                AttributeName = name,
                 Prefix = prefix.GetContent(),
                 Suffix = node.ValueSuffix?.GetContent() ?? string.Empty,
                 Source = BuildSourceSpanFromNode(node),
@@ -1338,7 +1338,7 @@ internal class DefaultRazorIntermediateNodeLoweringPhase : RazorEnginePhaseBase,
             var name = node.Name.GetContent();
             _builder.Add(new HtmlAttributeIntermediateNode()
             {
-                AttributeName = node.Name.GetContent(),
+                AttributeName = name,
                 Prefix = prefix.GetContent(),
                 Suffix = null,
                 Source = BuildSourceSpanFromNode(node),


### PR DESCRIPTION
ComponentFileKindVisitor.VisitMarkupAttributeBlock's call to GetContent is duplicated and appears to be about 0.8% of allocations in the customer profile I'm looking at. I looked at the IL in a release version of the assembly and the compiler at least doesn't remove the call (unclear whether the jitter would be able to). Either way, it's clearer and potentially faster to remove the duplicated calls.

Didn't look into whether any of the remaining 1.2% of allocations due to calling GetContent could be optimized.

![image](https://github.com/dotnet/razor/assets/6785178/d80d10df-f492-4a93-b7d1-8d2765bc047f)
