### PR TITLE
Remove a boxed enumerator allocated during TryMapToHostDocumentPosition

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentMappingService.cs
@@ -326,8 +326,9 @@ internal sealed class RazorDocumentMappingService : IRazorDocumentMappingService
             throw new InvalidOperationException("Cannot use document mapping service on a generated document that has a null CodeDocument.");
         }
 
-        foreach (var mapping in generatedDocument.SourceMappings)
+        for (var i = 0; i < generatedDocument.SourceMappings.Count; i++)
         {
+            var mapping = generatedDocument.SourceMappings[i];
             var generatedSpan = mapping.GeneratedSpan;
             var generatedAbsoluteIndex = generatedSpan.AbsoluteIndex;
             if (generatedAbsoluteIndex <= generatedDocumentIndex)


### PR DESCRIPTION
From customer trace:

![image](https://github.com/dotnet/razor/assets/6785178/36c84b99-d58f-413f-812d-83c687f28f9f)
