### PR TITLE
Fix various folding range, and general VS Code issues

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentPublisher.cs
@@ -189,6 +189,16 @@ internal class DefaultGeneratedDocumentPublisher : GeneratedDocumentPublisher
             HostDocumentVersion = hostDocumentVersion,
         };
 
+        // HACK: We know about a document being in multiple projects, but despite having ProjectKeyId in the request, currently the other end
+        // of this LSP message only knows about a single document file path. To prevent confusing them, we just send an update for the first project
+        // in the list.
+        if (_projectSnapshotManager is { } projectSnapshotManager &&
+            projectSnapshotManager.GetLoadedProject(projectKey) is { } projectSnapshot &&
+            projectSnapshotManager.GetAllProjectKeys(projectSnapshot.FilePath).First() != projectKey)
+        {
+            return;
+        }
+
         _ = _server.SendNotificationAsync(CustomMessageNames.RazorUpdateHtmlBufferEndpoint, request, CancellationToken.None);
     }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Folding/FoldingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Folding/FoldingRangeEndpoint.cs
@@ -88,7 +88,7 @@ internal sealed class FoldingRangeEndpoint : IRazorRequestHandler<FoldingRangePa
         return foldingRanges;
     }
 
-    private async Task<IEnumerable<FoldingRange>?> HandleCoreAsync(RazorFoldingRangeRequestParam requestParams, DocumentContext documentContext, CancellationToken cancellationToken)
+    private async Task<List<FoldingRange>?> HandleCoreAsync(RazorFoldingRangeRequestParam requestParams, DocumentContext documentContext, CancellationToken cancellationToken)
     {
         var foldingResponse = await _languageServer.SendRequestAsync<RazorFoldingRangeRequestParam, RazorFoldingRangeResponse?>(
             CustomMessageNames.RazorFoldingRangeEndpoint,
@@ -132,7 +132,7 @@ internal sealed class FoldingRangeEndpoint : IRazorRequestHandler<FoldingRangePa
         return finalRanges;
     }
 
-    private static IEnumerable<FoldingRange> FinalizeFoldingRanges(List<FoldingRange> mappedRanges, RazorCodeDocument codeDocument)
+    private List<FoldingRange> FinalizeFoldingRanges(List<FoldingRange> mappedRanges, RazorCodeDocument codeDocument)
     {
         // Don't allow ranges to be reported if they aren't spanning at least one line
         var validRanges = mappedRanges.Where(r => r.StartLine < r.EndLine);
@@ -144,14 +144,14 @@ internal sealed class FoldingRangeEndpoint : IRazorRequestHandler<FoldingRangePa
             .Select(ranges => ranges.OrderByDescending(r => r.EndLine).First());
 
         // Fix the starting range so the "..." is shown at the end
-        return reducedRanges.Select(r => FixFoldingRangeStart(r, codeDocument));
+        return reducedRanges.Select(r => FixFoldingRangeStart(r, codeDocument)).ToList();
     }
 
     /// <summary>
     /// Fixes the start of a range so that the offset of the first line is the last character on that line. This makes
     /// it so collapsing will still show the text instead of just "..."
     /// </summary>
-    private static FoldingRange FixFoldingRangeStart(FoldingRange range, RazorCodeDocument codeDocument)
+    private FoldingRange FixFoldingRangeStart(FoldingRange range, RazorCodeDocument codeDocument)
     {
         Debug.Assert(range.StartLine < range.EndLine);
 
@@ -165,6 +165,15 @@ internal sealed class FoldingRangeEndpoint : IRazorRequestHandler<FoldingRangePa
 
         var sourceText = codeDocument.GetSourceText();
         var startLine = range.StartLine;
+
+        if (startLine > sourceText.Lines.Count)
+        {
+            // Sometimes VS Code seems to send us wildly out-of-range folding ranges for Html, so log a warning,
+            // but prevent a toast from appearing from an exception.
+            _logger.LogWarning("Got a folding range of ({StartLine}-{EndLine}) but Razor document {filePath} only has {count} lines.", range.StartLine, range.EndLine, codeDocument.Source.FilePath, sourceText.Lines.Count);
+            return range;
+        }
+
         var lineSpan = sourceText.Lines[startLine].Span;
 
         // Search from the end of the line to the beginning for the first non whitespace character. We want that

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
@@ -119,6 +119,16 @@ internal class DefaultRazorProjectService : RazorProjectService
 
             _logger.LogInformation("Adding document '{filePath}' to project '{projectSnapshotFilePath}'.", filePath, projectSnapshot.FilePath);
             _projectSnapshotManagerAccessor.Instance.DocumentAdded(projectSnapshot.Key, hostDocument, textLoader);
+
+            // Adding a document to a project could also happen because a target was added to a project, or we're moving a document
+            // from Misc Project to a real one, and means the newly added document could actually already be open.
+            // If it is, we need to make sure we start generating it so we're ready to handle requests that could start coming in.
+            if (_projectSnapshotManagerAccessor.Instance.IsDocumentOpen(textDocumentPath) &&
+                _projectSnapshotManagerAccessor.Instance.GetLoadedProject(projectSnapshot.Key) is { } project &&
+                project.GetDocument(textDocumentPath) is { } document)
+            {
+                _ = document.GetGeneratedOutputAsync();
+            }
         }
     }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
@@ -117,14 +117,15 @@ internal class DefaultRazorProjectService : RazorProjectService
             var hostDocument = new HostDocument(textDocumentPath, normalizedTargetFilePath);
             var textLoader = _remoteTextLoaderFactory.Create(textDocumentPath);
 
+            var projectSnapshotManager = _projectSnapshotManagerAccessor.Instance;
             _logger.LogInformation("Adding document '{filePath}' to project '{projectSnapshotFilePath}'.", filePath, projectSnapshot.FilePath);
-            _projectSnapshotManagerAccessor.Instance.DocumentAdded(projectSnapshot.Key, hostDocument, textLoader);
+            projectSnapshotManager.DocumentAdded(projectSnapshot.Key, hostDocument, textLoader);
 
             // Adding a document to a project could also happen because a target was added to a project, or we're moving a document
             // from Misc Project to a real one, and means the newly added document could actually already be open.
             // If it is, we need to make sure we start generating it so we're ready to handle requests that could start coming in.
-            if (_projectSnapshotManagerAccessor.Instance.IsDocumentOpen(textDocumentPath) &&
-                _projectSnapshotManagerAccessor.Instance.GetLoadedProject(projectSnapshot.Key) is { } project &&
+            if (projectSnapshotManager.IsDocumentOpen(textDocumentPath) &&
+                projectSnapshotManager.GetLoadedProject(projectSnapshot.Key) is { } project &&
                 project.GetDocument(textDocumentPath) is { } document)
             {
                 _ = document.GetGeneratedOutputAsync();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorProjectServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorProjectServiceTest.cs
@@ -507,6 +507,7 @@ public class DefaultRazorProjectServiceTest : LanguageServerTestBase
             },
             TestProjectSnapshot.Create("C:/__MISC_PROJECT__"));
         var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
+        projectSnapshotManager.Setup(manager => manager.IsDocumentOpen(It.IsAny<string>())).Returns(false);
         projectSnapshotManager.Setup(manager => manager.DocumentAdded(It.IsAny<ProjectKey>(), It.IsAny<HostDocument>(), It.IsAny<TextLoader>()))
             .Callback<ProjectKey, HostDocument, TextLoader>((projectKey, hostDocument, loader) =>
             {
@@ -566,6 +567,7 @@ public class DefaultRazorProjectServiceTest : LanguageServerTestBase
             },
             TestProjectSnapshot.Create("C:/__MISC_PROJECT__"));
         var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
+        projectSnapshotManager.Setup(manager => manager.IsDocumentOpen(It.IsAny<string>())).Returns(false);
         projectSnapshotManager.Setup(manager => manager.DocumentAdded(It.IsAny<ProjectKey>(), It.IsAny<HostDocument>(), It.IsAny<TextLoader>()))
             .Callback<ProjectKey, HostDocument, TextLoader>((projectKey, hostDocument, loader) =>
             {
@@ -590,6 +592,7 @@ public class DefaultRazorProjectServiceTest : LanguageServerTestBase
         var miscellaneousProject = TestProjectSnapshot.Create("C:/__MISC_PROJECT__");
         var projectResolver = new TestSnapshotResolver(new Dictionary<string, IProjectSnapshot>(), miscellaneousProject);
         var projectSnapshotManager = new Mock<ProjectSnapshotManagerBase>(MockBehavior.Strict);
+        projectSnapshotManager.Setup(manager => manager.IsDocumentOpen(It.IsAny<string>())).Returns(false);
         projectSnapshotManager.Setup(manager => manager.DocumentAdded(It.IsAny<ProjectKey>(), It.IsAny<HostDocument>(), It.IsAny<TextLoader>()))
             .Callback<ProjectKey, HostDocument, TextLoader>((projectKey, hostDocument, loader) =>
             {


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1867769 hopefully
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1868418/ probably
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1868479 optimistically
Fixes #9131
Fixes #9125

This is a bit of a strange one, but while investigating the above issue I saw some definite quirks around project handling and folding range handling in VS Code. All of it I suspect is my fault, and most of it I've been able to fix by just pulling a few choice commits out of the dynamic document uri work I'm already doing.

The first commit is something I have done in my other branch, and fixes an issue in multi-targeting in VS. I saw the same issue today when debugging though, where the misc project and real project in our language server act as a sort of multi-targetted set.
The second commit is to fix a surprising experience when debugging folding ranges, where we only "fix" the results well after we'd calculated them. Given things like SourceText can be deferred, it seemed like a bad idea, though I don't think was actually causing the issues necessarily.
The third commit is also pulled out of my other branch, and again is to deal with odd transitions from misc project to real project.
The final commit is what I would call the "real" fix. Previously we saw doubled-up C# content cause issues, and applied a fix for it. My other branch formalizes that fix behind a feature flag. Why we didn't think to apply that fix to Html documents, I do not know, but the symptoms I saw during debugging indicate it was needed.