### PR TITLE
Removes the TelemetryComplexProperty wrapper to allow numeric type

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/TelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/TelemetryReporter.cs
@@ -255,23 +255,21 @@ internal class TelemetryReporter : ITelemetryReporter
     }
 
     private static bool IsNumeric(object? o)
-        => o is not null && IsNumeric(o.GetType());
-       
-    private static bool IsNumeric(this Type type)
-        => !type.IsEnum &&
-        type.GetTypeCode() switch 
+        => o is not null &&
+        !o.GetType().IsEnum &&
+        Type.GetTypeCode(o.GetType()) switch
         {
-        	TypeCode.Char or
+            TypeCode.Char or
             TypeCode.SByte or
             TypeCode.Byte or
             TypeCode.Int16 or
-            TypeCode.Int32 or 
+            TypeCode.Int32 or
             TypeCode.Int64 or
             TypeCode.Double or
             TypeCode.Single or
             TypeCode.UInt16 or
             TypeCode.UInt32 or
-            TypeCode.UInt64 
+            TypeCode.UInt64
             => true,
             _ => false
         };

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/TelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/TelemetryReporter.cs
@@ -48,7 +48,7 @@ internal class TelemetryReporter : ITelemetryReporter
         var telemetryEvent = new TelemetryEvent(GetTelemetryName(name), ToTelemetrySeverity(severity));
         foreach (var (propertyName, propertyValue) in values)
         {
-            telemetryEvent.Properties.Add(GetPropertyName(propertyName), new TelemetryComplexProperty(propertyValue));
+            telemetryEvent.Properties.Add(GetPropertyName(propertyName), propertyValue);
         }
 
         Report(telemetryEvent);

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/TelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/TelemetryReporter.cs
@@ -48,7 +48,14 @@ internal class TelemetryReporter : ITelemetryReporter
         var telemetryEvent = new TelemetryEvent(GetTelemetryName(name), ToTelemetrySeverity(severity));
         foreach (var (propertyName, propertyValue) in values)
         {
-            telemetryEvent.Properties.Add(GetPropertyName(propertyName), propertyValue);
+            if (IsNumeric(propertyValue))
+            {
+                telemetryEvent.Properties.Add(GetPropertyName(propertyName), propertyValue);
+            }
+            else
+            {
+                telemetryEvent.Properties.Add(GetPropertyName(propertyName), new TelemetryComplexProperty(propertyValue));
+            }
         }
 
         Report(telemetryEvent);
@@ -246,6 +253,8 @@ internal class TelemetryReporter : ITelemetryReporter
             new("eventscope.correlationid", correlationId),
         }));
     }
+
+    private static bool IsNumeric(object? value) => double.TryParse(Convert.ToString(value), out _);
 
     private class NullTelemetryScope : IDisposable
     {

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/TelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/TelemetryReporter.cs
@@ -254,7 +254,27 @@ internal class TelemetryReporter : ITelemetryReporter
         }));
     }
 
-    private static bool IsNumeric(object? value) => double.TryParse(Convert.ToString(value), out _);
+    private static bool IsNumeric(object? o)
+        => o is not null && IsNumeric(o.GetType());
+       
+    private static bool IsNumeric(this Type type)
+        => !type.IsEnum &&
+        type.GetTypeCode() switch 
+        {
+        	TypeCode.Char or
+            TypeCode.SByte or
+            TypeCode.Byte or
+            TypeCode.Int16 or
+            TypeCode.Int32 or 
+            TypeCode.Int64 or
+            TypeCode.Double or
+            TypeCode.Single or
+            TypeCode.UInt16 or
+            TypeCode.UInt32 or
+            TypeCode.UInt64 
+            => true,
+            _ => false
+        };
 
     private class NullTelemetryScope : IDisposable
     {


### PR DESCRIPTION
Removes the `TelemetryComplexProperty` wrapper to allow numeric type to show as-is

- The value of [dotnet.razor.eventscope.ellapsedms](https://github.com/dotnet/razor/blob/main/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/TelemetryReporter.cs#L286) is coming through as string but we want them to be numeric.
- As per documentation it seems like the processor `TelemetryComplexProperty` will convert what it's wrapping to the JSON string.

This fix simply removes the `TelemrtyComplexProperty` wrapper around `propertyValue` which is an object type.

Another interesting observation seems to be that we are reporting this values under `Properties` but typically numeric values are expected to be found under `Measures`.

/cc @ToddGrun @ryzngard 