### PR TITLE
Ensure we don't send duplicate changes when unique filenames aren't used

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentPublisher.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.TextDifferencing;
@@ -19,7 +18,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer;
 internal class DefaultGeneratedDocumentPublisher : GeneratedDocumentPublisher
 {
     private readonly Dictionary<DocumentKey, PublishData> _publishedCSharpData;
-    private readonly Dictionary<DocumentKey, PublishData> _publishedHtmlData;
+    private readonly Dictionary<string, PublishData> _publishedHtmlData;
     private readonly ClientNotifierServiceBase _server;
     private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
     private readonly ILogger _logger;
@@ -57,7 +56,12 @@ internal class DefaultGeneratedDocumentPublisher : GeneratedDocumentPublisher
         _languageServerFeatureOptions = languageServerFeatureOptions;
         _logger = loggerFactory.CreateLogger<DefaultGeneratedDocumentPublisher>();
         _publishedCSharpData = new Dictionary<DocumentKey, PublishData>();
-        _publishedHtmlData = new Dictionary<DocumentKey, PublishData>();
+
+        // We don't generate individual Html documents per-project, so in order to ensure diffs are calculated correctly
+        // we don't use the project key for the key for this dictionary. This matches when we send edits to the client,
+        // as they are only tracking a single Html file for each Razor file path, thus edits need to be correct or we'll
+        // get out of sync.
+        _publishedHtmlData = new Dictionary<string, PublishData>(FilePathComparer.Instance);
     }
 
     public override void Initialize(ProjectSnapshotManagerBase projectManager)
@@ -84,6 +88,15 @@ internal class DefaultGeneratedDocumentPublisher : GeneratedDocumentPublisher
         }
 
         _projectSnapshotManagerDispatcher.AssertDispatcherThread();
+
+        // If our generated documents don't have unique file paths, then using project key information is problematic for the client.
+        // For example, when a document moves from the Misc Project to a real project, we will update it here, and each version would
+        // have a different project key. On the receiving end however, there is only one file path, therefore one version of the contents,
+        // so we must ensure we only have a single document to compute diffs from, or things get out of sync.
+        // if (!_languageServerFeatureOptions.IncludeProjectKeyInGeneratedFilePath)
+        {
+            projectKey = default;
+        }
 
         var key = new DocumentKey(projectKey, filePath);
         if (!_publishedCSharpData.TryGetValue(key, out var previouslyPublishedData))
@@ -124,16 +137,6 @@ internal class DefaultGeneratedDocumentPublisher : GeneratedDocumentPublisher
             HostDocumentVersion = hostDocumentVersion,
         };
 
-        // HACK: We know about a document being in multiple projects, but despite having ProjectKeyId in the request, currently the other end
-        // of this LSP message only knows about a single document file path. To prevent confusing them, we just send an update for the first project
-        // in the list.
-        if (_projectSnapshotManager is { } projectSnapshotManager &&
-            projectSnapshotManager.GetLoadedProject(projectKey) is { } projectSnapshot &&
-            projectSnapshotManager.GetAllProjectKeys(projectSnapshot.FilePath).First() != projectKey)
-        {
-            return;
-        }
-
         _ = _server.SendNotificationAsync(CustomMessageNames.RazorUpdateCSharpBufferEndpoint, request, CancellationToken.None);
     }
 
@@ -151,8 +154,7 @@ internal class DefaultGeneratedDocumentPublisher : GeneratedDocumentPublisher
 
         _projectSnapshotManagerDispatcher.AssertDispatcherThread();
 
-        var key = new DocumentKey(projectKey, filePath);
-        if (!_publishedHtmlData.TryGetValue(key, out var previouslyPublishedData))
+        if (!_publishedHtmlData.TryGetValue(filePath, out var previouslyPublishedData))
         {
             previouslyPublishedData = PublishData.Default;
         }
@@ -179,7 +181,7 @@ internal class DefaultGeneratedDocumentPublisher : GeneratedDocumentPublisher
                 textChanges.Count);
         }
 
-        _publishedHtmlData[key] = new PublishData(sourceText, hostDocumentVersion);
+        _publishedHtmlData[filePath] = new PublishData(sourceText, hostDocumentVersion);
 
         var request = new UpdateBufferRequest()
         {
@@ -188,16 +190,6 @@ internal class DefaultGeneratedDocumentPublisher : GeneratedDocumentPublisher
             Changes = textChanges,
             HostDocumentVersion = hostDocumentVersion,
         };
-
-        // HACK: We know about a document being in multiple projects, but despite having ProjectKeyId in the request, currently the other end
-        // of this LSP message only knows about a single document file path. To prevent confusing them, we just send an update for the first project
-        // in the list.
-        if (_projectSnapshotManager is { } projectSnapshotManager &&
-            projectSnapshotManager.GetLoadedProject(projectKey) is { } projectSnapshot &&
-            projectSnapshotManager.GetAllProjectKeys(projectSnapshot.FilePath).First() != projectKey)
-        {
-            return;
-        }
 
         _ = _server.SendNotificationAsync(CustomMessageNames.RazorUpdateHtmlBufferEndpoint, request, CancellationToken.None);
     }
@@ -220,7 +212,13 @@ internal class DefaultGeneratedDocumentPublisher : GeneratedDocumentPublisher
                 Assumes.NotNull(args.DocumentFilePath);
                 if (!_projectSnapshotManager.IsDocumentOpen(args.DocumentFilePath))
                 {
-                    var key = new DocumentKey(args.ProjectKey, args.DocumentFilePath);
+                    var projectKey = args.ProjectKey;
+                    // if (!_languageServerFeatureOptions.IncludeProjectKeyInGeneratedFilePath)
+                    {
+                        projectKey = default;
+                    }
+
+                    var key = new DocumentKey(projectKey, args.DocumentFilePath);
                     // Document closed, evict published source text, unless the server doesn't want us to.
                     if (_languageServerFeatureOptions.UpdateBuffersForClosedDocuments)
                     {
@@ -239,9 +237,9 @@ internal class DefaultGeneratedDocumentPublisher : GeneratedDocumentPublisher
                         }
                     }
 
-                    if (_publishedHtmlData.ContainsKey(key))
+                    if (_publishedHtmlData.ContainsKey(args.DocumentFilePath))
                     {
-                        var removed = _publishedHtmlData.Remove(key);
+                        var removed = _publishedHtmlData.Remove(args.DocumentFilePath);
                         if (!removed)
                         {
                             _logger.LogError("Published data should be protected by the project snapshot manager's thread and should never fail to remove.");

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Folding/FoldingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Folding/FoldingRangeEndpoint.cs
@@ -166,7 +166,7 @@ internal sealed class FoldingRangeEndpoint : IRazorRequestHandler<FoldingRangePa
         var sourceText = codeDocument.GetSourceText();
         var startLine = range.StartLine;
 
-        if (startLine > sourceText.Lines.Count)
+        if (startLine >= sourceText.Lines.Count)
         {
             // Sometimes VS Code seems to send us wildly out-of-range folding ranges for Html, so log a warning,
             // but prevent a toast from appearing from an exception.

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LspLogger.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LspLogger.cs
@@ -37,7 +37,7 @@ internal class LspLogger : IRazorLogger
 
     public bool IsEnabled(LogLevel logLevel)
     {
-        return true;
+        return logLevel >= _logLevel;
     }
 
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LspLogger.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LspLogger.cs
@@ -37,7 +37,7 @@ internal class LspLogger : IRazorLogger
 
     public bool IsEnabled(LogLevel logLevel)
     {
-        return logLevel >= _logLevel;
+        return true;
     }
 
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/SemanticTokensRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/SemanticTokensRangeEndpoint.cs
@@ -59,7 +59,7 @@ internal sealed class SemanticTokensRangeEndpoint : IRazorRequestHandler<Semanti
         var semanticTokens = await semanticTokensInfoService.GetSemanticTokensAsync(request.TextDocument, request.Range, documentContext, _razorSemanticTokensLegend.AssumeNotNull(), correlationId, cancellationToken).ConfigureAwait(false);
         var amount = semanticTokens is null ? "no" : (semanticTokens.Data.Length / 5).ToString(Thread.CurrentThread.CurrentCulture);
 
-        requestContext.Logger.LogInformation("Returned {amount} semantic tokens for range {request.Range} in {request.TextDocument.Uri}.", amount, request.Range, request.TextDocument.Uri);
+        requestContext.Logger.LogInformation("Returned {amount} semantic tokens for range ({startLine},{startChar})-({endLine}-{endChar})} in {request.TextDocument.Uri}.", amount, request.Range.Start.Line, request.Range.Start.Character, request.Range.End.Line, request.Range.End.Character, request.TextDocument.Uri);
 
         if (semanticTokens is not null)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/SemanticTokensRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/SemanticTokensRangeEndpoint.cs
@@ -59,7 +59,7 @@ internal sealed class SemanticTokensRangeEndpoint : IRazorRequestHandler<Semanti
         var semanticTokens = await semanticTokensInfoService.GetSemanticTokensAsync(request.TextDocument, request.Range, documentContext, _razorSemanticTokensLegend.AssumeNotNull(), correlationId, cancellationToken).ConfigureAwait(false);
         var amount = semanticTokens is null ? "no" : (semanticTokens.Data.Length / 5).ToString(Thread.CurrentThread.CurrentCulture);
 
-        requestContext.Logger.LogInformation("Returned {amount} semantic tokens for range ({startLine},{startChar})-({endLine}-{endChar})} in {request.TextDocument.Uri}.", amount, request.Range.Start.Line, request.Range.Start.Character, request.Range.End.Line, request.Range.End.Character, request.TextDocument.Uri);
+        requestContext.Logger.LogInformation("Returned {amount} semantic tokens for range ({startLine},{startChar})-({endLine},{endChar}) in {request.TextDocument.Uri}.", amount, request.Range.Start.Line, request.Range.Start.Character, request.Range.End.Line, request.Range.End.Character, request.TextDocument.Uri);
 
         if (semanticTokens is not null)
         {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.Text;
@@ -19,4 +21,20 @@ internal class CSharpVirtualDocument : VirtualDocumentBase<CSharpVirtualDocument
     }
 
     protected override CSharpVirtualDocumentSnapshot GetUpdatedSnapshot(object? state) => new(_projectKey, Uri, TextBuffer.CurrentSnapshot, HostDocumentVersion);
+
+    public override VirtualDocumentSnapshot Update(IReadOnlyList<ITextChange> changes, int hostDocumentVersion, object? state)
+    {
+        var result = base.Update(changes, hostDocumentVersion, state);
+
+#if DEBUG
+        var text = TextBuffer.CurrentSnapshot.GetText();
+
+        var generatedFileStartIndex = text.IndexOf("#pragma warning disable 1591");
+        var secondGeneratedFileStartIndex = text.IndexOf("#pragma warning disable 1591", generatedFileStartIndex + 20);
+
+        Debug.Assert(secondGeneratedFileStartIndex == -1, "Generated C# file appears to have duplicated file contents. This could indicate a sync problem between language server and client.");
+#endif
+
+        return result;
+    }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+#if DEBUG
 using System.Diagnostics;
+#endif
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.Text;

--- a/src/Razor/src/rzls/Program.cs
+++ b/src/Razor/src/rzls/Program.cs
@@ -60,6 +60,9 @@ public class Program
             logger,
             NoOpTelemetryReporter.Instance,
             featureOptions: languageServerFeatureOptions);
+
+        logger.LogInformation("Razor Language Server started successfully.");
+
         await server.WaitForExitAsync().ConfigureAwait(true);
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/ProjectTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/ProjectTests.cs
@@ -155,4 +155,78 @@ public class ProjectTests(ITestOutputHelper testOutputHelper) : AbstractRazorEdi
         var actualProjectFileName = await TestServices.SolutionExplorer.GetAbsolutePathForProjectRelativeFilePathAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.ProjectFile, ControlledHangMitigatingCancellationToken);
         Assert.Equal(expectedProjectFileName, actualProjectFileName);
     }
+
+    [IdeFact(MaxAttempts = 1)]
+    public async Task OpenExistingProject_WithReopenedFile()
+    {
+        var solutionPath = await TestServices.SolutionExplorer.GetDirectoryNameAsync(ControlledHangMitigatingCancellationToken);
+        var expectedProjectFileName = await TestServices.SolutionExplorer.GetAbsolutePathForProjectRelativeFilePathAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.ProjectFile, ControlledHangMitigatingCancellationToken);
+
+        // Open SurveyPrompt and make sure its all up and running
+        await TestServices.SolutionExplorer.OpenFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.ErrorCshtmlFile, ControlledHangMitigatingCancellationToken);
+        await TestServices.Editor.WaitForSemanticClassificationAsync("class name", ControlledHangMitigatingCancellationToken, count: 1);
+
+        await TestServices.SolutionExplorer.CloseSolutionAsync(ControlledHangMitigatingCancellationToken);
+
+        var solutionFileName = Path.Combine(solutionPath, RazorProjectConstants.BlazorSolutionName + ".sln");
+        await TestServices.SolutionExplorer.OpenSolutionAsync(solutionFileName, ControlledHangMitigatingCancellationToken);
+
+        await TestServices.Workspace.WaitForProjectSystemAsync(ControlledHangMitigatingCancellationToken);
+        await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.LanguageServer, ControlledHangMitigatingCancellationToken);
+        await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.Workspace, ControlledHangMitigatingCancellationToken);
+
+        // Razor extension doesn't launch until a razor file is opened, so wait for it to equalize
+        await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.LanguageServer, ControlledHangMitigatingCancellationToken);
+        await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.Workspace, ControlledHangMitigatingCancellationToken);
+        await TestServices.Workspace.WaitForProjectSystemAsync(ControlledHangMitigatingCancellationToken);
+
+        await TestServices.Editor.WaitForSemanticClassificationAsync("class name", ControlledHangMitigatingCancellationToken, count: 1);
+
+        TestServices.Input.Send("1");
+
+        // Make sure the test framework didn't do something weird and create new project
+        var actualProjectFileName = await TestServices.SolutionExplorer.GetAbsolutePathForProjectRelativeFilePathAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.ProjectFile, ControlledHangMitigatingCancellationToken);
+        Assert.Equal(expectedProjectFileName, actualProjectFileName);
+
+        await TestServices.Editor.CloseCodeFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.ErrorCshtmlFile, saveFile: false, ControlledHangMitigatingCancellationToken);
+    }
+
+    [IdeFact]
+    public async Task OpenExistingProject_WithReopenedFile_NoProjectRazorJson()
+    {
+        var solutionPath = await TestServices.SolutionExplorer.GetDirectoryNameAsync(ControlledHangMitigatingCancellationToken);
+        var expectedProjectFileName = await TestServices.SolutionExplorer.GetAbsolutePathForProjectRelativeFilePathAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.ProjectFile, ControlledHangMitigatingCancellationToken);
+
+        // Open SurveyPrompt and make sure its all up and running
+        await TestServices.SolutionExplorer.OpenFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.ErrorCshtmlFile, ControlledHangMitigatingCancellationToken);
+        await TestServices.Editor.WaitForSemanticClassificationAsync("class name", ControlledHangMitigatingCancellationToken, count: 1);
+
+        await TestServices.SolutionExplorer.CloseSolutionAsync(ControlledHangMitigatingCancellationToken);
+
+        // Clear out the project.razor.json file which ensures our restored file will have to be in the Misc Project
+        var projectRazorJsonFileName = Directory.EnumerateFiles(solutionPath, "project.razor.*.json", SearchOption.AllDirectories).First();
+        File.Delete(projectRazorJsonFileName);
+
+        var solutionFileName = Path.Combine(solutionPath, RazorProjectConstants.BlazorSolutionName + ".sln");
+        await TestServices.SolutionExplorer.OpenSolutionAsync(solutionFileName, ControlledHangMitigatingCancellationToken);
+
+        await TestServices.Workspace.WaitForProjectSystemAsync(ControlledHangMitigatingCancellationToken);
+        await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.LanguageServer, ControlledHangMitigatingCancellationToken);
+        await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.Workspace, ControlledHangMitigatingCancellationToken);
+
+        // Razor extension doesn't launch until a razor file is opened, so wait for it to equalize
+        await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.LanguageServer, ControlledHangMitigatingCancellationToken);
+        await TestServices.Workspace.WaitForAsyncOperationsAsync(FeatureAttribute.Workspace, ControlledHangMitigatingCancellationToken);
+        await TestServices.Workspace.WaitForProjectSystemAsync(ControlledHangMitigatingCancellationToken);
+
+        await TestServices.Editor.WaitForSemanticClassificationAsync("class name", ControlledHangMitigatingCancellationToken, count: 1);
+
+        TestServices.Input.Send("1");
+
+        // Make sure the test framework didn't do something weird and create new project
+        var actualProjectFileName = await TestServices.SolutionExplorer.GetAbsolutePathForProjectRelativeFilePathAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.ProjectFile, ControlledHangMitigatingCancellationToken);
+        Assert.Equal(expectedProjectFileName, actualProjectFileName);
+
+        await TestServices.Editor.CloseCodeFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.ErrorCshtmlFile, saveFile: false, ControlledHangMitigatingCancellationToken);
+    }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/ProjectTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/ProjectTests.cs
@@ -156,7 +156,7 @@ public class ProjectTests(ITestOutputHelper testOutputHelper) : AbstractRazorEdi
         Assert.Equal(expectedProjectFileName, actualProjectFileName);
     }
 
-    [IdeFact(MaxAttempts = 1)]
+    [IdeFact]
     public async Task OpenExistingProject_WithReopenedFile()
     {
         var solutionPath = await TestServices.SolutionExplorer.GetDirectoryNameAsync(ControlledHangMitigatingCancellationToken);


### PR DESCRIPTION
Second attempt at fixing various issues: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1867769, https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1868418, https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1868479, #9131, #9125 and https://github.com/dotnet/razor/issues/9060

Also fixes https://github.com/dotnet/razor/issues/9138

Turns out my previous fix, which I pulled out of my other PR, didn't quite go far enough and specifically failed for documents that were restored to their open state in VS Code/VS and for documents that were seen to be in the "Misc Files" project before appearing in a real project.