### PR TITLE
Add Compiler Warning for Unknown Attributes in Razor Components

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentDiagnosticFactory.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentDiagnosticFactory.cs
@@ -541,6 +541,17 @@ internal static class ComponentDiagnosticFactory
         () => "Attribute '{0}' can only be used with RazorLanguageVersion 7.0 or higher.",
         RazorDiagnosticSeverity.Error);
 
+    public static readonly RazorDiagnosticDescriptor UnknownMarkupAttribute =
+        new RazorDiagnosticDescriptor(
+            $"{DiagnosticPrefix}10021",
+            () => "The attribute '{0}' does not correspond to any of the parent component's parameters.",
+            RazorDiagnosticSeverity.Warning);
+
+    public static RazorDiagnostic Create_UnknownMarkupAttribute(string attributeName, SourceSpan? source = null)
+    {
+        return RazorDiagnostic.Create(UnknownMarkupAttribute, source ?? SourceSpan.Undefined, attributeName);
+    }
+
     public static RazorDiagnostic CreateBindAttributeParameter_UnsupportedSyntaxBindGetSet(SourceSpan? source, string attribute)
     {
         var diagnostic = RazorDiagnostic.Create(

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentMetadata.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentMetadata.cs
@@ -124,6 +124,7 @@ internal static class ComponentMetadata
         public const string FullyQualifiedNameMatch = "Components.FullyQualifiedNameMatch";
 
         public const string InitOnlyProperty = "Components.InitOnlyProperty";
+        public const string CaptureUnmatchedValues = "Components.CaptureUnmatchedValues";
     }
 
     public static class EventHandler

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentUnknownAttributeDiagnosticPass.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentUnknownAttributeDiagnosticPass.cs
@@ -1,0 +1,47 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Razor.Language.Intermediate;
+
+namespace Microsoft.AspNetCore.Razor.Language.Components;
+internal sealed class ComponentUnknownAttributeDiagnosticPass : ComponentIntermediateNodePassBase, IRazorOptimizationPass
+{
+    protected override void ExecuteCore(RazorCodeDocument codeDocument, DocumentIntermediateNode documentNode)
+    {
+        var visitor = new Visitor();
+        visitor.Visit(documentNode);
+    }
+
+    private class Visitor : IntermediateNodeWalker
+    {
+        public override void VisitComponent(ComponentIntermediateNode node)
+        {
+            // First, check if there is a property of type 'IDictionary<string, object>'
+            // with 'CaptureUnmatchedValues' set to 'true'
+            var component = node.Component;
+            var boundComponentAttributes = component.BoundAttributes;
+            for (var i = 0; i < boundComponentAttributes.Count; i++)
+            {
+                var attribute = boundComponentAttributes[i];
+                // [HELP NEEDED] I would need to access component Type information here in order to check for CaptureUnmatchedValues
+            }
+
+
+            // If no arbitrary attributes can be accepted by the component, check if all
+            // the user-specified attribute names map to an underlying property
+            for (var i = 0; i < node.Children.Count; i++)
+            {
+                if (node.Children[i] is ComponentAttributeIntermediateNode attribute && attribute.AttributeName != null)
+                {
+                    if (attribute.BoundAttribute == null)
+                    {
+                        attribute.Diagnostics.Add(ComponentDiagnosticFactory.Create_UnknownMarkupAttribute(
+                            attribute.AttributeName, attribute.Source));
+                    }
+                }
+            }
+
+            base.VisitComponent(node);
+        }
+    }
+}

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorProjectEngine.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorProjectEngine.cs
@@ -262,6 +262,7 @@ public abstract class RazorProjectEngine
         builder.Features.Add(new ComponentMarkupDiagnosticPass());
         builder.Features.Add(new ComponentMarkupBlockPass());
         builder.Features.Add(new ComponentMarkupEncodingPass());
+        builder.Features.Add(new ComponentUnknownAttributeDiagnosticPass());
     }
 
     private static void LoadExtensions(RazorProjectEngineBuilder builder, IReadOnlyList<RazorExtension> extensions)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentUnknownAttributeDiagnosticPassTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentUnknownAttributeDiagnosticPassTest.cs
@@ -1,0 +1,148 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language.Components;
+using Microsoft.AspNetCore.Razor.Language.IntegrationTests;
+using Microsoft.AspNetCore.Razor.Language.Intermediate;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests;
+
+public class ComponentUnknownAttributeDiagnosticPassTest : RazorIntegrationTestBase
+{
+    public ComponentUnknownAttributeDiagnosticPassTest()
+    {
+        Pass = new ComponentUnknownAttributeDiagnosticPass();
+        ProjectEngine = (DefaultRazorProjectEngine)RazorProjectEngine.Create(
+            RazorConfiguration.Default,
+            RazorProjectFileSystem.Create(Environment.CurrentDirectory),
+            b =>
+            {
+                // Don't run the markup mutating passes.
+                b.Features.Remove(b.Features.OfType<ComponentMarkupDiagnosticPass>().Single());
+                b.Features.Remove(b.Features.OfType<ComponentMarkupBlockPass>().Single());
+                b.Features.Remove(b.Features.OfType<ComponentMarkupEncodingPass>().Single());
+            });
+        Engine = ProjectEngine.Engine;
+
+        Pass.Engine = Engine;
+    }
+
+    private DefaultRazorProjectEngine ProjectEngine { get; }
+    private RazorEngine Engine { get; }
+    private ComponentUnknownAttributeDiagnosticPass Pass { get; set; }
+    internal override string FileKind => FileKinds.Component;
+    internal override bool UseTwoPhaseCompilation => true;
+
+    [Fact]
+    public void Execute_NoInvalidAttributes()
+    {
+        // Arrange
+        AdditionalSyntaxTrees.Add(Parse(@"
+using System;
+using Microsoft.AspNetCore.Components;
+
+namespace Test
+{
+    public class MyComponent : ComponentBase
+    {
+        [Parameter] public int Value { get; set; }
+    }
+}
+"));
+        var result = CompileToCSharp(@"<MyComponent Value=""123"" />");
+        var document = result.CodeDocument;
+        var documentNode = Lower(document);
+
+        // Act
+        Pass.Execute(document, documentNode);
+
+        // Assert
+        Assert.Empty(documentNode.GetAllDiagnostics());
+    }
+
+    [Fact]
+    public void Execute_OneInvalidAttribute()
+    {
+        // Arrange
+        AdditionalSyntaxTrees.Add(Parse(@"
+using System;
+using Microsoft.AspNetCore.Components;
+
+namespace Test
+{
+    public class MyComponent : ComponentBase
+    {
+        [Parameter] public int Value { get; set; }
+    }
+}
+"));
+        var result = CompileToCSharp(@"<MyComponent InvalidAttribute=""123"" />");
+        var document = result.CodeDocument;
+        var documentNode = Lower(document);
+
+        // Act
+        Pass.Execute(document, documentNode);
+
+        // Assert
+        var diagnostic = Assert.Single(documentNode.GetAllDiagnostics());
+        Assert.Equal(ComponentDiagnosticFactory.UnknownMarkupAttribute.Id, diagnostic.Id);
+
+        var node = documentNode.FindDescendantNodes<ComponentAttributeIntermediateNode>().Where(n => n.HasDiagnostics).Single();
+        Assert.Equal("InvalidAttribute", node.AttributeName);
+    }
+
+    [Fact]
+    public void Execute_CaptureAdditionalAttributes()
+    {
+        // Arrange
+        AdditionalSyntaxTrees.Add(Parse(@"
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Components;
+
+namespace Test
+{
+    public class MyComponent : ComponentBase
+    {
+        [Parameter] public int Value { get; set; }
+
+        [Parameter(CaptureUnmatchedValues = true)]
+        public IDictionary<string, object> AdditionalAttributes { get; set; }
+    }
+}
+"));
+        var result = CompileToCSharp(@"<MyComponent InvalidAttribute=""123"" />");
+        var document = result.CodeDocument;
+        var documentNode = Lower(document);
+
+        // Act
+        Pass.Execute(document, documentNode);
+
+        // Assert
+        Assert.Empty(documentNode.GetAllDiagnostics());
+    }
+
+    private DocumentIntermediateNode Lower(RazorCodeDocument codeDocument)
+    {
+        for (var i = 0; i < Engine.Phases.Count; i++)
+        {
+            var phase = Engine.Phases[i];
+            if (phase is IRazorCSharpLoweringPhase)
+            {
+                break;
+            }
+
+            phase.Execute(codeDocument);
+        }
+
+        var document = codeDocument.GetDocumentIntermediateNode();
+        Engine.Features.OfType<ComponentDocumentClassifierPass>().Single().Execute(codeDocument, document);
+        return document;
+    }
+}

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentUnknownAttributeDiagnosticPassTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentUnknownAttributeDiagnosticPassTest.cs
@@ -2,12 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language.Components;
-using Microsoft.AspNetCore.Razor.Language.IntegrationTests;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 using Xunit;
 
@@ -56,6 +52,39 @@ namespace Test
 }
 "));
         var result = CompileToCSharp(@"<MyComponent Value=""123"" />");
+        var document = result.CodeDocument;
+        var documentNode = Lower(document);
+
+        // Act
+        Pass.Execute(document, documentNode);
+
+        // Assert
+        Assert.Empty(documentNode.GetAllDiagnostics());
+    }
+
+    [Fact]
+    public void Execute_AttributeBinding()
+    {
+        // Arrange
+        AdditionalSyntaxTrees.Add(Parse(@"
+using System;
+using Microsoft.AspNetCore.Components;
+
+namespace Test
+{
+    public class MyComponent : ComponentBase
+    {
+        [Parameter] public int Value { get; set; }
+        [Parameter] public EventCallback<int> ValueChanged { get; set; }
+    }
+}
+"));
+        var result = CompileToCSharp(@"
+<MyComponent @bind-Value=""@_value"" />
+@code {
+    private int _value = 0;
+}
+");
         var document = result.CodeDocument;
         var documentNode = Lower(document);
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/RazorProjectEngineTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/RazorProjectEngineTest.cs
@@ -67,6 +67,7 @@ public class RazorProjectEngineTest
             feature => Assert.IsType<ComponentReferenceCaptureLoweringPass>(feature),
             feature => Assert.IsType<ComponentSplatLoweringPass>(feature),
             feature => Assert.IsType<ComponentTemplateDiagnosticPass>(feature),
+            feature => Assert.IsType<ComponentUnknownAttributeDiagnosticPass>(feature),
             feature => Assert.IsType<ComponentWhitespacePass>(feature),
             feature => Assert.IsType<DefaultDirectiveSyntaxTreePass>(feature),
             feature => Assert.IsType<DefaultDocumentClassifierPass>(feature),

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentTagHelperDescriptorProvider.cs
@@ -203,6 +203,19 @@ internal class ComponentTagHelperDescriptorProvider : RazorEngineFeatureBase, IT
             pb.IsEditorRequired = property.GetAttributes().Any(
                 static a => a.AttributeClass.HasFullName("Microsoft.AspNetCore.Components.EditorRequiredAttribute"));
 
+            // Check if the parameter sets 'CaptureUnmatchedValues' to 'true'
+            var propertyAttribute = property.GetAttributes()
+                .FirstOrDefault(a => a.AttributeClass.HasFullName("Microsoft.AspNetCore.Components.ParameterAttribute"));
+            if (propertyAttribute != null)
+            {
+                var captureUnmatchedValuesParameter = propertyAttribute.NamedArguments
+                    .FirstOrDefault(a => a.Key == "CaptureUnmatchedValues");
+                if (captureUnmatchedValuesParameter is { Value.Value: true })
+                {
+                    metadata.Add(MakeTrue(ComponentMetadata.Component.CaptureUnmatchedValues));
+                }
+            }
+
             metadata.Add(PropertyName(property.Name));
             metadata.Add(GloballyQualifiedTypeName(property.Type.ToDisplayString(GloballyQualifiedFullNameTypeDisplayFormat)));
 


### PR DESCRIPTION
﻿### Summary

This PR introduces a new compiler warning that will be triggered when a Razor component uses an attribute that does not correspond to any known property on the component. This warning aids in early detection of potential mistakes, such as mistyping an attribute name, improving code quality and robustness.
___

### Background
Razor components allow developers to define parameters to receive data from the parent component. Without any feedback, mistakes like mistyping an attribute name or using an attribute that doesn't correspond to any property can lead to unexpected behavior at runtime.
___

### Changes
- **New Warning Diagnostic:** Introduced a new Razor Diagnostic: `RZ10021: The attribute 'AttributeName' does not correspond to any of the parent component's parameters.`
- **New Diagnostic Pass:** Added `ComponentUnknownAttributeDiagnosticPass`, a new intermediate node pass that checks for unknown attributes.
- **Tests:** Included unit tests to verify that the warning is triggered in the correct scenarios and not triggered in valid cases.
___

### Incomplete Feature: Handling Arbitrary Parameter Matching
I'm seeking guidance on handling a Razor component's ability to capture unmatched values using a parameter with type `IDictionary<string, object>` and the `CaptureUnmatchedValues` attribute set to `true` ([Documentation](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/splat-attributes-and-arbitrary-parameters?view=aspnetcore-7.0#arbitrary-attributes)).

In order to correctly handle this case in my diagnostic pass, I would need to access some form of Type information about the given component either via Reflection, or component metadata. However, I was so far unable to find relevant information in the `IntermediateNodeWalker`'s component visitor mechanism. The relevant part of the code can be found [here](https://github.com/SparkyTD/razor/blob/main/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentUnknownAttributeDiagnosticPass.cs#L26).
___
### Request for Feedback
I'm particularly interested in feedback on:
- The logic used to detect unknown attributes.
- The wording and formatting of the warning message.
- Potential edge cases that may lead to breaking changes (e.g., when `<TreatWarningsAsErrors>` is enabled).