### PR TITLE
Allow range to extend past the end of the last line, per LSP spec

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RangeExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RangeExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -128,18 +129,8 @@ internal static class RangeExtensions
             throw new ArgumentNullException(nameof(sourceText));
         }
 
-        if (range.Start.Line >= sourceText.Lines.Count)
-        {
-            throw new ArgumentOutOfRangeException($"Range start line {range.Start.Line} matches or exceeds SourceText boundary {sourceText.Lines.Count}.");
-        }
-
-        if (range.End.Line >= sourceText.Lines.Count)
-        {
-            throw new ArgumentOutOfRangeException($"Range end line {range.End.Line} matches or exceeds SourceText boundary {sourceText.Lines.Count}.");
-        }
-
-        var start = sourceText.Lines[range.Start.Line].Start + range.Start.Character;
-        var end = sourceText.Lines[range.End.Line].Start + range.End.Character;
+        var start = GetAbsolutePosition(range.Start, sourceText);
+        var end = GetAbsolutePosition(range.End, sourceText);
 
         var length = end - start;
         if (length < 0)
@@ -148,40 +139,32 @@ internal static class RangeExtensions
         }
 
         return new TextSpan(start, length);
+
+        static int GetAbsolutePosition(Position position, SourceText sourceText, [CallerArgumentExpression(nameof(position))] string? argName = null)
+        {
+            var line = position.Line;
+            var character = position.Character;
+            var lineCount = sourceText.Lines.Count;
+            if (line > lineCount ||
+                (line == lineCount && character > 0))
+            {
+                throw new ArgumentOutOfRangeException($"{argName} ({line},{character}) matches or exceeds SourceText boundary {lineCount}.");
+            }
+
+            // LSP spec allowed a Range to end one line past the end, and character 0. SourceText does not, so we adjust to the final char position
+            if (line == lineCount)
+            {
+                return sourceText.Length;
+            }
+
+            return sourceText.Lines[line].Start + character;
+        }
     }
 
     public static Language.Syntax.TextSpan AsRazorTextSpan(this Range range, SourceText sourceText)
     {
-        if (range is null)
-        {
-            throw new ArgumentNullException(nameof(range));
-        }
-
-        if (sourceText is null)
-        {
-            throw new ArgumentNullException(nameof(sourceText));
-        }
-
-        if (range.Start.Line >= sourceText.Lines.Count)
-        {
-            throw new ArgumentOutOfRangeException($"Range start line {range.Start.Line} matches or exceeds SourceText boundary {sourceText.Lines.Count}.");
-        }
-
-        if (range.End.Line >= sourceText.Lines.Count)
-        {
-            throw new ArgumentOutOfRangeException($"Range end line {range.End.Line} matches or exceeds SourceText boundary {sourceText.Lines.Count}.");
-        }
-
-        var start = sourceText.Lines[range.Start.Line].Start + range.Start.Character;
-        var end = sourceText.Lines[range.End.Line].Start + range.End.Character;
-
-        var length = end - start;
-        if (length < 0)
-        {
-            throw new ArgumentOutOfRangeException($"{range} resolved to zero or negative length.");
-        }
-
-        return new Language.Syntax.TextSpan(start, length);
+        var span = range.AsTextSpan(sourceText);
+        return new Language.Syntax.TextSpan(span.Start, span.Length);
     }
 
     public static bool IsUndefined(this Range range)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/RazorSemanticTokenInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/RazorSemanticTokenInfoServiceTest.cs
@@ -889,13 +889,11 @@ public class RazorSemanticTokenInfoServiceTest : SemanticTokenTestBase
     private static Range GetRange(string text)
     {
         var lines = text.Split(Environment.NewLine);
-        var lastLineIndex = lines.Length - 1;
-        var lastLineCharacterIndex = lines[lastLineIndex].Length;
 
         var range = new Range
         {
             Start = new Position { Line = 0, Character = 0 },
-            End = new Position { Line = lastLineIndex, Character = lastLineCharacterIndex }
+            End = new Position { Line = lines.Length, Character = 0 }
         };
 
         return range;


### PR DESCRIPTION
Fixes the following exception, reported in https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1868418 (though I couldn't repro it 🤷‍♂️)

```
[Error - 4:03:22 PM] System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'Range end line 50 matches or exceeds SourceText boundary 50.')
   at Microsoft.AspNetCore.Razor.LanguageServer.Extensions.RangeExtensions.AsRazorTextSpan(Range range, SourceText sourceText) in /_/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RangeExtensions.cs:line 172
   at Microsoft.AspNetCore.Razor.LanguageServer.Semantic.TagHelperSemanticRangeVisitor.VisitAllNodes(RazorCodeDocument razorCodeDocument, Range range, RazorSemanticTokensLegend razorSemanticTokensLegend, Boolean colorCodeBackground) in /_/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/TagHelperSemanticRangeVisitor.cs:line 40
   at Microsoft.AspNetCore.Razor.LanguageServer.Semantic.RazorSemanticTokensInfoService.GetSemanticTokensAsync(TextDocumentIdentifier textDocumentIdentifier, Range range, VersionedDocumentContext documentContext, RazorSemanticTokensLegend razorSemanticTokensLegend, Guid correlationId, CancellationToken cancellationToken) in /_/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/RazorSemanticTokensInfoService.cs:line 88
   at Microsoft.AspNetCore.Razor.LanguageServer.Semantic.SemanticTokensRangeEndpoint.HandleRequestAsync(SemanticTokensRangeParams request, RazorRequestContext requestContext, CancellationToken cancellationToken) in /_/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/SemanticTokensRangeEndpoint.cs:line 71
   at Microsoft.CommonLanguageServerProtocol.Framework.QueueItem`3.StartRequestAsync(TRequestContext context, CancellationToken cancellationToken)
[Error - 4:03:22 PM] Request textDocument/semanticTokens/range failed.
  Message: Specified argument was out of the range of valid values. (Parameter 'Range end line 50 matches or exceeds SourceText boundary 50.')
  Code: -32000 
```