### PR TITLE
Remap and translate diagnostics on the server

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Common/CustomMessageNames.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Common/CustomMessageNames.cs
@@ -21,6 +21,7 @@ internal static class CustomMessageNames
     public const string RazorUriPresentationEndpoint = "razor/uriPresentation";
     public const string RazorSpellCheckEndpoint = "razor/spellCheck";
     public const string RazorProjectContextsEndpoint = "razor/projectContexts";
+    public const string RazorPullDiagnosticEndpointName = "razor/pullDiagnostics";
 
     // VS Windows and VS Code
     public const string RazorUpdateCSharpBufferEndpoint = "razor/updateCSharpBuffer";
@@ -29,7 +30,6 @@ internal static class CustomMessageNames
     public const string RazorResolveCodeActionsEndpoint = "razor/resolveCodeActions";
     public const string RazorProvideHtmlColorPresentationEndpoint = "razor/provideHtmlColorPresentation";
     public const string RazorProvideHtmlDocumentColorEndpoint = "razor/provideHtmlDocumentColor";
-    public const string RazorPullDiagnosticEndpointName = "razor/pullDiagnostics";
     public const string RazorProvideSemanticTokensRangeEndpoint = "razor/provideSemanticTokensRange";
     public const string RazorFoldingRangeEndpoint = "razor/foldingRange";
     public const string RazorHtmlFormattingEndpoint = "razor/htmlFormatting";
@@ -53,4 +53,7 @@ internal static class CustomMessageNames
     public const string RazorReferencesEndpointName = "razor/references";
 
     public const string RazorSimplifyMethodEndpointName = "razor/simplifyMethod";
+
+    // Called to get C# diagnostics from Roslyn when publishing diagnostics for VS Code
+    public const string RazorCSharpPullDiagnosticsEndpointName = "razor/csharpPullDiagnostics";
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ConfigurableLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ConfigurableLanguageServerFeatureOptions.cs
@@ -17,7 +17,7 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
     private readonly bool? _singleServerCompletionSupport;
     private readonly bool? _singleServerSupport;
     private readonly bool? _supportsDelegatedCodeActions;
-    private readonly bool? _supportsDelegatedDiagnostics;
+    private readonly bool? _delegateToCSharpOnDiagnosticPublish;
     private readonly bool? _returnCodeActionAndRenamePathsWithPrefixedSlash;
     private readonly bool? _showAllCSharpCodeActions;
     private readonly bool? _updateBuffersForClosedDocuments;
@@ -29,7 +29,7 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
     public override bool SingleServerCompletionSupport => _singleServerCompletionSupport ?? _defaults.SingleServerCompletionSupport;
     public override bool SingleServerSupport => _singleServerSupport ?? _defaults.SingleServerSupport;
     public override bool SupportsDelegatedCodeActions => _supportsDelegatedCodeActions ?? _defaults.SupportsDelegatedCodeActions;
-    public override bool SupportsDelegatedDiagnostics => _supportsDelegatedDiagnostics ?? _defaults.SupportsDelegatedDiagnostics;
+    public override bool DelegateToCSharpOnDiagnosticPublish => _delegateToCSharpOnDiagnosticPublish ?? _defaults.DelegateToCSharpOnDiagnosticPublish;
     public override bool ReturnCodeActionAndRenamePathsWithPrefixedSlash => _returnCodeActionAndRenamePathsWithPrefixedSlash ?? _defaults.ReturnCodeActionAndRenamePathsWithPrefixedSlash;
     public override bool ShowAllCSharpCodeActions => _showAllCSharpCodeActions ?? _defaults.ShowAllCSharpCodeActions;
     public override bool UpdateBuffersForClosedDocuments => _updateBuffersForClosedDocuments ?? _defaults.UpdateBuffersForClosedDocuments;
@@ -50,7 +50,7 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
             TryProcessBoolOption(nameof(SingleServerCompletionSupport), ref _singleServerCompletionSupport, option, args, i);
             TryProcessBoolOption(nameof(SingleServerSupport), ref _singleServerSupport, option, args, i);
             TryProcessBoolOption(nameof(SupportsDelegatedCodeActions), ref _supportsDelegatedCodeActions, option, args, i);
-            TryProcessBoolOption(nameof(SupportsDelegatedDiagnostics), ref _supportsDelegatedDiagnostics, option, args, i);
+            TryProcessBoolOption(nameof(DelegateToCSharpOnDiagnosticPublish), ref _delegateToCSharpOnDiagnosticPublish, option, args, i);
             TryProcessBoolOption(nameof(ReturnCodeActionAndRenamePathsWithPrefixedSlash), ref _returnCodeActionAndRenamePathsWithPrefixedSlash, option, args, i);
             TryProcessBoolOption(nameof(ShowAllCSharpCodeActions), ref _showAllCSharpCodeActions, option, args, i);
             TryProcessBoolOption(nameof(UpdateBuffersForClosedDocuments), ref _updateBuffersForClosedDocuments, option, args, i);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
@@ -23,7 +23,7 @@ internal class DefaultLanguageServerFeatureOptions : LanguageServerFeatureOption
 
     public override bool SupportsDelegatedCodeActions => false;
 
-    public override bool SupportsDelegatedDiagnostics => false;
+    public override bool DelegateToCSharpOnDiagnosticPublish => false;
 
     public override bool UpdateBuffersForClosedDocuments => false;
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.cs
@@ -225,7 +225,7 @@ internal class RazorDiagnosticsPublisher : DocumentProcessedListener
             };
 
             var delegatedResponse = await _languageServer.SendRequestAsync<DocumentDiagnosticParams, SumType<FullDocumentDiagnosticReport, UnchangedDocumentDiagnosticReport>?>(
-                CustomMessageNames.RazorPullDiagnosticEndpointName,
+                CustomMessageNames.RazorCSharpPullDiagnosticsEndpointName,
                 delegatedParams,
                 CancellationToken.None).ConfigureAwait(false);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.cs
@@ -210,7 +210,7 @@ internal class RazorDiagnosticsPublisher : DocumentProcessedListener
         var result = await document.GetGeneratedOutputAsync().ConfigureAwait(false);
 
         Diagnostic[]? csharpDiagnostics = null;
-        if (_languageServerFeatureOptions.SupportsDelegatedDiagnostics)
+        if (_languageServerFeatureOptions.DelegateToCSharpOnDiagnosticPublish)
         {
             var uriBuilder = new UriBuilder()
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.cs
@@ -35,11 +35,15 @@ internal class RazorDiagnosticsPublisher : DocumentProcessedListener
     private readonly ILogger<RazorDiagnosticsPublisher> _logger;
     private ProjectSnapshotManager? _projectManager;
     private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
+    private readonly Lazy<RazorTranslateDiagnosticsService> _razorTranslateDiagnosticsService;
+    private readonly Lazy<DocumentContextFactory> _documentContextFactory;
 
     public RazorDiagnosticsPublisher(
         ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,
         ClientNotifierServiceBase languageServer,
         LanguageServerFeatureOptions languageServerFeatureOptions,
+        Lazy<RazorTranslateDiagnosticsService> razorTranslateDiagnosticsService,
+        Lazy<DocumentContextFactory> documentContextFactory,
         ILoggerFactory loggerFactory)
     {
         if (projectSnapshotManagerDispatcher is null)
@@ -57,6 +61,16 @@ internal class RazorDiagnosticsPublisher : DocumentProcessedListener
             throw new ArgumentNullException(nameof(languageServerFeatureOptions));
         }
 
+        if (razorTranslateDiagnosticsService is null)
+        {
+            throw new ArgumentNullException(nameof(razorTranslateDiagnosticsService));
+        }
+
+        if (documentContextFactory is null)
+        {
+            throw new ArgumentNullException(nameof(documentContextFactory));
+        }
+
         if (loggerFactory is null)
         {
             throw new ArgumentNullException(nameof(loggerFactory));
@@ -65,6 +79,8 @@ internal class RazorDiagnosticsPublisher : DocumentProcessedListener
         _projectSnapshotManagerDispatcher = projectSnapshotManagerDispatcher;
         _languageServer = languageServer;
         _languageServerFeatureOptions = languageServerFeatureOptions;
+        _razorTranslateDiagnosticsService = razorTranslateDiagnosticsService;
+        _documentContextFactory = documentContextFactory;
         PublishedRazorDiagnostics = new Dictionary<string, IReadOnlyList<RazorDiagnostic>>(FilePathComparer.Instance);
         PublishedCSharpDiagnostics = new Dictionary<string, IReadOnlyList<Diagnostic>>(FilePathComparer.Instance);
         _work = new Dictionary<string, IDocumentSnapshot>(FilePathComparer.Instance);
@@ -193,7 +209,7 @@ internal class RazorDiagnosticsPublisher : DocumentProcessedListener
     {
         var result = await document.GetGeneratedOutputAsync().ConfigureAwait(false);
 
-        SumType<FullDocumentDiagnosticReport, UnchangedDocumentDiagnosticReport>? delegatedResponse = null;
+        Diagnostic[]? csharpDiagnostics = null;
         if (_languageServerFeatureOptions.SupportsDelegatedDiagnostics)
         {
             var uriBuilder = new UriBuilder()
@@ -208,23 +224,26 @@ internal class RazorDiagnosticsPublisher : DocumentProcessedListener
                 TextDocument = new TextDocumentIdentifier { Uri = uriBuilder.Uri },
             };
 
-            delegatedResponse = await _languageServer.SendRequestAsync<DocumentDiagnosticParams, SumType<FullDocumentDiagnosticReport, UnchangedDocumentDiagnosticReport>?>(
+            var delegatedResponse = await _languageServer.SendRequestAsync<DocumentDiagnosticParams, SumType<FullDocumentDiagnosticReport, UnchangedDocumentDiagnosticReport>?>(
                 CustomMessageNames.RazorPullDiagnosticEndpointName,
                 delegatedParams,
                 CancellationToken.None).ConfigureAwait(false);
+
+            if (delegatedResponse.HasValue &&
+                delegatedResponse.Value.TryGetFirst(out var fullDiagnostics) &&
+                fullDiagnostics.Items is not null &&
+                _documentContextFactory.Value.TryCreate(delegatedParams.TextDocument.Uri, projectContext: null) is { } documentContext)
+            {
+                csharpDiagnostics = await _razorTranslateDiagnosticsService.Value.TranslateAsync(Protocol.RazorLanguageKind.CSharp, fullDiagnostics.Items, documentContext, CancellationToken.None).ConfigureAwait(false);
+            }
         }
 
         var razorDiagnostics = result.GetCSharpDocument().Diagnostics;
-        IReadOnlyList<Diagnostic>? csharpDiagnostics = null;
 
         lock (PublishedRazorDiagnostics)
         lock (PublishedCSharpDiagnostics)
         {
             var filePath = document.FilePath.AssumeNotNull();
-            if (delegatedResponse != null && delegatedResponse.Value.TryGetFirst(out var fullDocumentDiagnosticReport))
-            {
-                csharpDiagnostics = fullDocumentDiagnosticReport.Items;
-            }
 
             if (PublishedRazorDiagnostics.TryGetValue(filePath, out var previousRazorDiagnostics) && razorDiagnostics.SequenceEqual(previousRazorDiagnostics)
                 && (csharpDiagnostics == null || (PublishedCSharpDiagnostics.TryGetValue(filePath, out var previousCsharpDiagnostics) && csharpDiagnostics.SequenceEqual(previousCsharpDiagnostics))))

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
@@ -108,6 +108,7 @@ internal static class IServiceCollectionExtensions
         services.AddHandlerWithCapabilities<DocumentPullDiagnosticsEndpoint>();
         services.AddHandler<WorkspacePullDiagnosticsEndpoint>();
         services.AddSingleton<RazorTranslateDiagnosticsService>();
+        services.AddSingleton(sp => new Lazy<RazorTranslateDiagnosticsService>(sp.GetRequiredService<RazorTranslateDiagnosticsService>));
     }
 
     public static void AddHoverServices(this IServiceCollection services)
@@ -191,6 +192,7 @@ internal static class IServiceCollectionExtensions
         services.AddSingleton<GeneratedDocumentPublisher, DefaultGeneratedDocumentPublisher>();
         services.AddSingleton<IProjectSnapshotChangeTrigger>((services) => services.GetRequiredService<GeneratedDocumentPublisher>());
         services.AddSingleton<DocumentContextFactory, DefaultDocumentContextFactory>();
+        services.AddSingleton(sp => new Lazy<DocumentContextFactory>(sp.GetRequiredService<DocumentContextFactory>));
 
         services.AddSingleton<DocumentVersionCache, DefaultDocumentVersionCache>();
         services.AddSingleton<IProjectSnapshotChangeTrigger>((services) => services.GetRequiredService<DocumentVersionCache>());

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
@@ -21,7 +21,7 @@ internal abstract class LanguageServerFeatureOptions
 
     public abstract bool SupportsDelegatedCodeActions { get; }
 
-    public abstract bool SupportsDelegatedDiagnostics { get; }
+    public abstract bool DelegateToCSharpOnDiagnosticPublish { get; }
 
     public abstract bool ShowAllCSharpCodeActions { get; }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
@@ -51,7 +51,7 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
 
     public override bool SupportsDelegatedCodeActions => true;
 
-    public override bool SupportsDelegatedDiagnostics => false;
+    public override bool DelegateToCSharpOnDiagnosticPublish => false;
 
     public override bool ReturnCodeActionAndRenamePathsWithPrefixedSlash => false;
 

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacLanguageServerFeatureOptions.cs
@@ -39,7 +39,7 @@ internal class VisualStudioMacLanguageServerFeatureOptions : LanguageServerFeatu
 
     public override bool SupportsDelegatedCodeActions => true;
 
-    public override bool SupportsDelegatedDiagnostics => false;
+    public override bool DelegateToCSharpOnDiagnosticPublish => false;
 
     public override bool ShowAllCSharpCodeActions => false;
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsPublisherTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsPublisherTest.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor;
@@ -39,7 +40,12 @@ public class RazorDiagnosticsPublisherTest : LanguageServerTestBase
         {
             Code = "TestCode",
             Severity = DiagnosticSeverity.Error,
-            Message = "TestMessage"
+            Message = "TestMessage",
+            Range = new Range()
+            {
+                Start = new Position(0,0),
+                End = new Position(0, 1)
+            }
         }
     };
 
@@ -95,13 +101,16 @@ public class RazorDiagnosticsPublisherTest : LanguageServerTestBase
             .Verifiable();
         Mock.Get(languageServerDocument)
             .Setup(d => d.SendRequestAsync<DocumentDiagnosticParams, SumType<FullDocumentDiagnosticReport, UnchangedDocumentDiagnosticReport>?>(
-                CustomMessageNames.RazorPullDiagnosticEndpointName,
+                CustomMessageNames.RazorCSharpPullDiagnosticsEndpointName,
                 It.IsAny<DocumentDiagnosticParams>(),
                 It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult(new SumType<FullDocumentDiagnosticReport, UnchangedDocumentDiagnosticReport>?(new FullDocumentDiagnosticReport())))
             .Verifiable();
 
-        using var publisher = new TestRazorDiagnosticsPublisher(LegacyDispatcher, languageServerDocument, TestLanguageServerFeatureOptions.Instance, LoggerFactory)
+        var documentContextFactory = new TestDocumentContextFactory(_openedDocument.FilePath, codeDocument);
+        var translateDiagnosticsService = new RazorTranslateDiagnosticsService(Mock.Of<IRazorDocumentMappingService>(MockBehavior.Strict), LoggerFactory);
+
+        using var publisher = new TestRazorDiagnosticsPublisher(LegacyDispatcher, languageServerDocument, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory)
         {
             BlockBackgroundWorkCompleting = new ManualResetEventSlim(initialState: true),
             NotifyBackgroundWorkCompleting = new ManualResetEventSlim(initialState: false),
@@ -128,6 +137,21 @@ public class RazorDiagnosticsPublisherTest : LanguageServerTestBase
     public async Task PublishDiagnosticsAsync_NewDocumentDiagnosticsGetPublished(bool shouldContainCSharpDiagnostic, bool shouldContainRazorDiagnostic)
     {
         // Arrange
+        var singleCSharpDiagnostic = new Diagnostic[]
+        {
+            new Diagnostic()
+            {
+                Code = "TestCode",
+                Severity = DiagnosticSeverity.Error,
+                Message = "TestMessage",
+                Range = new Range()
+                {
+                    Start = new Position(0,0),
+                    End = new Position(0, 1)
+                }
+            }
+        };
+
         Assert.NotNull(_openedDocument.FilePath);
         var processedOpenDocument = TestDocumentSnapshot.Create(_openedDocument.FilePath);
         var codeDocument = CreateCodeDocument(shouldContainRazorDiagnostic ? s_singleRazorDiagnostic : s_emptyRazorDiagnostics);
@@ -137,12 +161,12 @@ public class RazorDiagnosticsPublisherTest : LanguageServerTestBase
         var requestResult = new FullDocumentDiagnosticReport();
         if (shouldContainCSharpDiagnostic)
         {
-            requestResult.Items = s_singleCSharpDiagnostic;
+            requestResult.Items = singleCSharpDiagnostic;
         }
 
         languageServer
             .Setup(server => server.SendRequestAsync<DocumentDiagnosticParams, SumType<FullDocumentDiagnosticReport, UnchangedDocumentDiagnosticReport>?>(
-                CustomMessageNames.RazorPullDiagnosticEndpointName,
+                CustomMessageNames.RazorCSharpPullDiagnosticsEndpointName,
                 It.IsAny<DocumentDiagnosticParams>(),
                 It.IsAny<CancellationToken>()))
             .Callback<string, DocumentDiagnosticParams, CancellationToken>((method, @params, cancellationToken) =>
@@ -161,7 +185,7 @@ public class RazorDiagnosticsPublisherTest : LanguageServerTestBase
                 Assert.Equal(shouldContainCSharpDiagnostic && shouldContainRazorDiagnostic ? 2 : 1, @params.Diagnostics.Length);
                 if (shouldContainCSharpDiagnostic)
                 {
-                    Assert.Equal(s_singleCSharpDiagnostic[0], shouldContainRazorDiagnostic ? @params.Diagnostics[1] : @params.Diagnostics[0]);
+                    Assert.Equal(singleCSharpDiagnostic[0], shouldContainRazorDiagnostic ? @params.Diagnostics[1] : @params.Diagnostics[0]);
                 }
 
                 if (shouldContainRazorDiagnostic)
@@ -177,7 +201,11 @@ public class RazorDiagnosticsPublisherTest : LanguageServerTestBase
             })
             .Returns(Task.CompletedTask);
 
-        using var publisher = new TestRazorDiagnosticsPublisher(LegacyDispatcher, languageServer.Object, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
+        var documentContextFactory = new TestDocumentContextFactory(_openedDocument.FilePath, codeDocument);
+        var documentMappingService = new RazorDocumentMappingService(TestLanguageServerFeatureOptions.Instance, documentContextFactory, LoggerFactory);
+        var translateDiagnosticsService = new RazorTranslateDiagnosticsService(documentMappingService, LoggerFactory);
+
+        using var publisher = new TestRazorDiagnosticsPublisher(LegacyDispatcher, languageServer.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
         publisher.Initialize(_projectManager);
 
         // Act
@@ -198,7 +226,7 @@ public class RazorDiagnosticsPublisherTest : LanguageServerTestBase
         var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
         languageServer
             .Setup(server => server.SendRequestAsync<DocumentDiagnosticParams, SumType<FullDocumentDiagnosticReport, UnchangedDocumentDiagnosticReport>?>(
-                CustomMessageNames.RazorPullDiagnosticEndpointName,
+                CustomMessageNames.RazorCSharpPullDiagnosticsEndpointName,
                 It.IsAny<DocumentDiagnosticParams>(),
                 It.IsAny<CancellationToken>()))
             .Callback<string, DocumentDiagnosticParams, CancellationToken>((method, @params, cancellationToken) =>
@@ -225,7 +253,10 @@ public class RazorDiagnosticsPublisherTest : LanguageServerTestBase
             })
             .Returns(Task.CompletedTask);
 
-        using var publisher = new TestRazorDiagnosticsPublisher(LegacyDispatcher, languageServer.Object, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
+        var documentContextFactory = new TestDocumentContextFactory(_openedDocument.FilePath, codeDocument);
+        var translateDiagnosticsService = new RazorTranslateDiagnosticsService(Mock.Of<IRazorDocumentMappingService>(MockBehavior.Strict), LoggerFactory);
+
+        using var publisher = new TestRazorDiagnosticsPublisher(LegacyDispatcher, languageServer.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
         publisher.PublishedRazorDiagnostics[processedOpenDocument.FilePath] = s_emptyRazorDiagnostics;
         publisher.Initialize(_projectManager);
 
@@ -248,7 +279,7 @@ public class RazorDiagnosticsPublisherTest : LanguageServerTestBase
         var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
         languageServer
             .Setup(server => server.SendRequestAsync<DocumentDiagnosticParams, SumType<FullDocumentDiagnosticReport, UnchangedDocumentDiagnosticReport>?>(
-                CustomMessageNames.RazorPullDiagnosticEndpointName,
+                CustomMessageNames.RazorCSharpPullDiagnosticsEndpointName,
                 It.IsAny<DocumentDiagnosticParams>(),
                 It.IsAny<CancellationToken>()))
             .Callback<string, DocumentDiagnosticParams, CancellationToken>((method, @params, cancellationToken) =>
@@ -280,7 +311,10 @@ public class RazorDiagnosticsPublisherTest : LanguageServerTestBase
             })
             .Returns(Task.CompletedTask);
 
-        using var publisher = new TestRazorDiagnosticsPublisher(LegacyDispatcher, languageServer.Object, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
+        var documentContextFactory = new TestDocumentContextFactory(_openedDocument.FilePath, codeDocument);
+        var translateDiagnosticsService = new RazorTranslateDiagnosticsService(Mock.Of<IRazorDocumentMappingService>(MockBehavior.Strict), LoggerFactory);
+
+        using var publisher = new TestRazorDiagnosticsPublisher(LegacyDispatcher, languageServer.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
         publisher.Initialize(_projectManager);
         await publisher.PublishDiagnosticsAsync(processedOpenDocument);
         arranging = false;
@@ -299,7 +333,7 @@ public class RazorDiagnosticsPublisherTest : LanguageServerTestBase
         var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
         languageServer
             .Setup(server => server.SendRequestAsync<DocumentDiagnosticParams, SumType<FullDocumentDiagnosticReport, UnchangedDocumentDiagnosticReport>?>(
-                CustomMessageNames.RazorPullDiagnosticEndpointName,
+                CustomMessageNames.RazorCSharpPullDiagnosticsEndpointName,
                 It.IsAny<DocumentDiagnosticParams>(),
                 It.IsAny<CancellationToken>()))
             .Callback<string, DocumentDiagnosticParams, CancellationToken>((method, @params, cancellationToken) =>
@@ -312,7 +346,11 @@ public class RazorDiagnosticsPublisherTest : LanguageServerTestBase
         var codeDocument = CreateCodeDocument(s_singleRazorDiagnostic);
         processedOpenDocument.With(codeDocument);
 
-        using var publisher = new TestRazorDiagnosticsPublisher(LegacyDispatcher, languageServer.Object, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
+        var documentContextFactory = new TestDocumentContextFactory(_openedDocument.FilePath, codeDocument);
+        var documentMappingService = new RazorDocumentMappingService(TestLanguageServerFeatureOptions.Instance, documentContextFactory, LoggerFactory);
+        var translateDiagnosticsService = new RazorTranslateDiagnosticsService(documentMappingService, LoggerFactory);
+
+        using var publisher = new TestRazorDiagnosticsPublisher(LegacyDispatcher, languageServer.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
         publisher.PublishedRazorDiagnostics[processedOpenDocument.FilePath] = s_singleRazorDiagnostic;
         publisher.Initialize(_projectManager);
 
@@ -333,7 +371,7 @@ public class RazorDiagnosticsPublisherTest : LanguageServerTestBase
 
         languageServer
             .Setup(server => server.SendRequestAsync<DocumentDiagnosticParams, SumType<FullDocumentDiagnosticReport, UnchangedDocumentDiagnosticReport>?>(
-                CustomMessageNames.RazorPullDiagnosticEndpointName,
+                CustomMessageNames.RazorCSharpPullDiagnosticsEndpointName,
                 It.IsAny<DocumentDiagnosticParams>(),
                 It.IsAny<CancellationToken>()))
             .Callback<string, DocumentDiagnosticParams, CancellationToken>((method, @params, cancellationToken) =>
@@ -360,7 +398,10 @@ public class RazorDiagnosticsPublisherTest : LanguageServerTestBase
             })
             .Returns(Task.CompletedTask);
 
-        using var publisher = new TestRazorDiagnosticsPublisher(LegacyDispatcher, languageServer.Object, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
+        var documentContextFactory = new TestDocumentContextFactory(_openedDocument.FilePath, codeDocument);
+        var translateDiagnosticsService = new RazorTranslateDiagnosticsService(Mock.Of<IRazorDocumentMappingService>(MockBehavior.Strict), LoggerFactory);
+
+        using var publisher = new TestRazorDiagnosticsPublisher(LegacyDispatcher, languageServer.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
         publisher.Initialize(_projectManager);
         await publisher.PublishDiagnosticsAsync(processedOpenDocument);
         arranging = false;
@@ -387,7 +428,10 @@ public class RazorDiagnosticsPublisherTest : LanguageServerTestBase
             })
             .Returns(Task.CompletedTask);
 
-        using var publisher = new TestRazorDiagnosticsPublisher(LegacyDispatcher, languageServer.Object, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
+        var documentContextFactory = new TestDocumentContextFactory();
+        var translateDiagnosticsService = new RazorTranslateDiagnosticsService(Mock.Of<IRazorDocumentMappingService>(MockBehavior.Strict), LoggerFactory);
+
+        using var publisher = new TestRazorDiagnosticsPublisher(LegacyDispatcher, languageServer.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
         Assert.NotNull(_closedDocument.FilePath);
         publisher.PublishedRazorDiagnostics[_closedDocument.FilePath] = s_singleRazorDiagnostic;
         publisher.PublishedCSharpDiagnostics[_closedDocument.FilePath] = s_singleCSharpDiagnostic;
@@ -405,7 +449,10 @@ public class RazorDiagnosticsPublisherTest : LanguageServerTestBase
     {
         // Arrange
         var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
-        using var publisher = new TestRazorDiagnosticsPublisher(LegacyDispatcher, languageServer.Object, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
+        var documentContextFactory = new TestDocumentContextFactory();
+        var translateDiagnosticsService = new RazorTranslateDiagnosticsService(Mock.Of<IRazorDocumentMappingService>(MockBehavior.Strict), LoggerFactory);
+
+        using var publisher = new TestRazorDiagnosticsPublisher(LegacyDispatcher, languageServer.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
         Assert.NotNull(_openedDocument.FilePath);
         publisher.PublishedRazorDiagnostics[_openedDocument.FilePath] = s_singleRazorDiagnostic;
         publisher.PublishedCSharpDiagnostics[_openedDocument.FilePath] = s_singleCSharpDiagnostic;
@@ -420,7 +467,10 @@ public class RazorDiagnosticsPublisherTest : LanguageServerTestBase
     {
         // Arrange
         var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
-        using var publisher = new TestRazorDiagnosticsPublisher(LegacyDispatcher, languageServer.Object, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
+        var documentContextFactory = new TestDocumentContextFactory();
+        var translateDiagnosticsService = new RazorTranslateDiagnosticsService(Mock.Of<IRazorDocumentMappingService>(MockBehavior.Strict), LoggerFactory);
+
+        using var publisher = new TestRazorDiagnosticsPublisher(LegacyDispatcher, languageServer.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
         Assert.NotNull(_closedDocument.FilePath);
         publisher.PublishedRazorDiagnostics[_closedDocument.FilePath] = s_emptyRazorDiagnostics;
         publisher.PublishedCSharpDiagnostics[_closedDocument.FilePath] = s_emptyCSharpDiagnostics;
@@ -435,7 +485,10 @@ public class RazorDiagnosticsPublisherTest : LanguageServerTestBase
     {
         // Arrange
         var languageServer = new Mock<ClientNotifierServiceBase>(MockBehavior.Strict);
-        using var publisher = new TestRazorDiagnosticsPublisher(LegacyDispatcher, languageServer.Object, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
+        var documentContextFactory = new TestDocumentContextFactory();
+        var translateDiagnosticsService = new RazorTranslateDiagnosticsService(Mock.Of<IRazorDocumentMappingService>(MockBehavior.Strict), LoggerFactory);
+
+        using var publisher = new TestRazorDiagnosticsPublisher(LegacyDispatcher, languageServer.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
         Assert.NotNull(_closedDocument.FilePath);
         Assert.NotNull(_openedDocument.FilePath);
         publisher.PublishedRazorDiagnostics[_closedDocument.FilePath] = s_emptyRazorDiagnostics;
@@ -453,8 +506,8 @@ public class RazorDiagnosticsPublisherTest : LanguageServerTestBase
 
     private static RazorCodeDocument CreateCodeDocument(params RazorDiagnostic[] diagnostics)
     {
-        var codeDocument = TestRazorCodeDocument.CreateEmpty();
-        var razorCSharpDocument = RazorCSharpDocument.Create(codeDocument, string.Empty, RazorCodeGenerationOptions.CreateDefault(), diagnostics);
+        var codeDocument = TestRazorCodeDocument.Create("hello");
+        var razorCSharpDocument = RazorCSharpDocument.Create(codeDocument, "hello", RazorCodeGenerationOptions.CreateDefault(), diagnostics);
         codeDocument.SetCSharpDocument(razorCSharpDocument);
 
         return codeDocument;
@@ -466,8 +519,10 @@ public class RazorDiagnosticsPublisherTest : LanguageServerTestBase
             ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,
             ClientNotifierServiceBase languageServer,
             LanguageServerFeatureOptions languageServerFeatureOptions,
+            RazorTranslateDiagnosticsService razorTranslateDiagnosticsService,
+            DocumentContextFactory documentContextFactory,
             ILoggerFactory loggerFactory)
-            : base(projectSnapshotManagerDispatcher, languageServer, languageServerFeatureOptions, loggerFactory)
+            : base(projectSnapshotManagerDispatcher, languageServer, languageServerFeatureOptions, new Lazy<RazorTranslateDiagnosticsService>(razorTranslateDiagnosticsService), new Lazy<DocumentContextFactory>(documentContextFactory), loggerFactory)
         {
             // The diagnostics publisher by default will wait 2 seconds until publishing diagnostics. For testing purposes we reduce
             // the amount of time we wait for diagnostic publishing because we have more concrete control of the timer and its lifecycle.

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common/TestLanguageServerFeatureOptions.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common/TestLanguageServerFeatureOptions.cs
@@ -27,7 +27,7 @@ internal class TestLanguageServerFeatureOptions : LanguageServerFeatureOptions
 
     public override bool SupportsDelegatedCodeActions => false;
 
-    public override bool SupportsDelegatedDiagnostics => true;
+    public override bool DelegateToCSharpOnDiagnosticPublish => true;
 
     public override bool ReturnCodeActionAndRenamePathsWithPrefixedSlash => false;
 


### PR DESCRIPTION
Server side of https://github.com/dotnet/vscode-csharp/pull/6209

Found an issue in the logs where 2 seconds after a .razor document close, we try to update diagnostics for the document, which then tries to remap the ranges for those diagnostics, but we've just closed the file, the so it fails. This was actually quite wasteful, as the remapping has to happen on the server anyway, so its better to just do it after the results have come back. Additionally, it meant that VS Code diagnostics weren't going through our translation service, which excludes some diagnostics and fixes ranges on others, so the experience would have been generally worse than in VS.

Also renamed a couple of things to make a bit more sense, so the changes are slightly bigger than they first seem.