### PR TITLE
Rework BoundAttributeDescriptionInfo to avoid failures due to unexpected inputs

### DIFF
--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Tooltip/BoundAttributeDescriptionInfoTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Tooltip/BoundAttributeDescriptionInfoTest.cs
@@ -9,18 +9,13 @@ using Xunit.Abstractions;
 
 namespace Microsoft.CodeAnalysis.Razor.Tooltip;
 
-public class BoundAttributeDescriptionInfoTest : TestBase
+public class BoundAttributeDescriptionInfoTest(ITestOutputHelper testOutput) : TestBase(testOutput)
 {
-    public BoundAttributeDescriptionInfoTest(ITestOutputHelper testOutput)
-        : base(testOutput)
-    {
-    }
-
     [Fact]
     public void ResolveTagHelperTypeName_ExtractsTypeName_SimpleReturnType()
     {
         // Arrange & Act
-        var typeName = BoundAttributeDescriptionInfo.ResolveTagHelperTypeName("System.String", "SomePropertyName", "string SomeTypeName.SomePropertyName");
+        var typeName = BoundAttributeDescriptionInfo.ResolveTagHelperTypeName("SomePropertyName", "string SomeTypeName.SomePropertyName");
 
         // Assert
         Assert.Equal("SomeTypeName", typeName);
@@ -30,7 +25,7 @@ public class BoundAttributeDescriptionInfoTest : TestBase
     public void ResolveTagHelperTypeName_ExtractsTypeName_ComplexReturnType()
     {
         // Arrange & Act
-        var typeName = BoundAttributeDescriptionInfo.ResolveTagHelperTypeName("SomeReturnTypeName", "SomePropertyName", "SomeReturnTypeName SomeTypeName.SomePropertyName");
+        var typeName = BoundAttributeDescriptionInfo.ResolveTagHelperTypeName("SomePropertyName", "SomeReturnTypeName SomeTypeName.SomePropertyName");
 
         // Assert
         Assert.Equal("SomeTypeName", typeName);


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1872609

This change defends against invalid assumptions about the inputs of `BoundAttributeDescriptionInfo.ResolveTagHelperTypeName(...)`. This method is a bit of a hack that tries to retrieve the parent tag helper's type name from the display string of a bound attribute. It assumes that _every_ `BoundAttributeDescriptor.DisplayName` has the same form of `<return-type> <type-name>.<property-name>`, which isn't always the case:

https://github.com/dotnet/razor/blob/6949e3a5f99d0978a6a6d07a4e4072a11a84ce3a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultBoundAttributeDescriptorBuilder.cs#L159-L190

To avoid exceptions being thrown when trying to call `string.Substring(...)` when the assumptions fail, I've rewritten the method to be more defensive and use `ReadOnlySpan<char>`.