### PR TITLE
Defend against bad input in the Inferred mapping

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentMappingService.cs
@@ -714,6 +714,12 @@ internal sealed class RazorDocumentMappingService : IRazorDocumentMappingService
 
         hostDocumentRange = default;
         var csharpSourceText = GetGeneratedSourceText(generatedDocument);
+
+        if (!IsRangeWithinDocument(generatedDocumentRange, csharpSourceText))
+        {
+            return false;
+        }
+
         var generatedRangeAsSpan = generatedDocumentRange.AsTextSpan(csharpSourceText);
         SourceMapping? mappingBeforeGeneratedRange = null;
         SourceMapping? mappingAfterGeneratedRange = null;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDocumentMappingServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDocumentMappingServiceTest.cs
@@ -30,7 +30,7 @@ public class RazorDocumentMappingServiceTest : TestBase
     }
 
     [Fact]
-    public void TryMapFromProjectedDocumentRange_Strict_StartOnlyMaps_ReturnsFalse()
+    public void TryMapToHostDocumentRange_Strict_StartOnlyMaps_ReturnsFalse()
     {
         // Arrange
         var service = new RazorDocumentMappingService(_filePathService, new TestDocumentContextFactory(), LoggerFactory);
@@ -57,7 +57,7 @@ public class RazorDocumentMappingServiceTest : TestBase
     }
 
     [Fact]
-    public void TryMapFromProjectedDocumentRange_Strict_EndOnlyMaps_ReturnsFalse()
+    public void TryMapToHostDocumentRange_Strict_EndOnlyMaps_ReturnsFalse()
     {
         // Arrange
         var service = new RazorDocumentMappingService(_filePathService, new TestDocumentContextFactory(), LoggerFactory);
@@ -84,7 +84,7 @@ public class RazorDocumentMappingServiceTest : TestBase
     }
 
     [Fact]
-    public void TryMapFromProjectedDocumentRange_Strict_StartAndEndMap_ReturnsTrue()
+    public void TryMapToHostDocumentRange_Strict_StartAndEndMap_ReturnsTrue()
     {
         // Arrange
         var service = new RazorDocumentMappingService(_filePathService, new TestDocumentContextFactory(), LoggerFactory);
@@ -116,7 +116,7 @@ public class RazorDocumentMappingServiceTest : TestBase
     }
 
     [Fact]
-    public void TryMapFromProjectedDocumentRange_Inclusive_DirectlyMaps_ReturnsTrue()
+    public void TryMapToHostDocumentRange_Inclusive_DirectlyMaps_ReturnsTrue()
     {
         // Arrange
         var service = new RazorDocumentMappingService(_filePathService, new TestDocumentContextFactory(), LoggerFactory);
@@ -148,7 +148,7 @@ public class RazorDocumentMappingServiceTest : TestBase
     }
 
     [Fact]
-    public void TryMapFromProjectedDocumentRange_Inclusive_StartSinglyIntersects_ReturnsTrue()
+    public void TryMapToHostDocumentRange_Inclusive_StartSinglyIntersects_ReturnsTrue()
     {
         // Arrange
         var service = new RazorDocumentMappingService(_filePathService, new TestDocumentContextFactory(), LoggerFactory);
@@ -180,7 +180,7 @@ public class RazorDocumentMappingServiceTest : TestBase
     }
 
     [Fact]
-    public void TryMapFromProjectedDocumentRange_Inclusive_EndSinglyIntersects_ReturnsTrue()
+    public void TryMapToHostDocumentRange_Inclusive_EndSinglyIntersects_ReturnsTrue()
     {
         // Arrange
         var service = new RazorDocumentMappingService(_filePathService, new TestDocumentContextFactory(), LoggerFactory);
@@ -212,7 +212,7 @@ public class RazorDocumentMappingServiceTest : TestBase
     }
 
     [Fact]
-    public void TryMapFromProjectedDocumentRange_Inclusive_StartDoublyIntersects_ReturnsFalse()
+    public void TryMapToHostDocumentRange_Inclusive_StartDoublyIntersects_ReturnsFalse()
     {
         // Arrange
         var service = new RazorDocumentMappingService(_filePathService, new TestDocumentContextFactory(), LoggerFactory);
@@ -243,7 +243,7 @@ public class RazorDocumentMappingServiceTest : TestBase
     }
 
     [Fact]
-    public void TryMapFromProjectedDocumentRange_Inclusive_EndDoublyIntersects_ReturnsFalse()
+    public void TryMapToHostDocumentRange_Inclusive_EndDoublyIntersects_ReturnsFalse()
     {
         // Arrange
         var service = new RazorDocumentMappingService(_filePathService, new TestDocumentContextFactory(), LoggerFactory);
@@ -274,7 +274,7 @@ public class RazorDocumentMappingServiceTest : TestBase
     }
 
     [Fact]
-    public void TryMapFromProjectedDocumentRange_Inclusive_OverlapsSingleMapping_ReturnsTrue()
+    public void TryMapToHostDocumentRange_Inclusive_OverlapsSingleMapping_ReturnsTrue()
     {
         // Arrange
         var service = new RazorDocumentMappingService(_filePathService, new TestDocumentContextFactory(), LoggerFactory);
@@ -306,7 +306,7 @@ public class RazorDocumentMappingServiceTest : TestBase
     }
 
     [Fact]
-    public void TryMapFromProjectedDocumentRange_Inclusive_OverlapsTwoMappings_ReturnsFalse()
+    public void TryMapToHostDocumentRange_Inclusive_OverlapsTwoMappings_ReturnsFalse()
     {
         // Arrange
         var service = new RazorDocumentMappingService(_filePathService, new TestDocumentContextFactory(), LoggerFactory);
@@ -337,7 +337,7 @@ public class RazorDocumentMappingServiceTest : TestBase
     }
 
     [Fact]
-    public void TryMapFromProjectedDocumentRange_Inferred_DirectlyMaps_ReturnsTrue()
+    public void TryMapToHostDocumentRange_Inferred_DirectlyMaps_ReturnsTrue()
     {
         // Arrange
         var service = new RazorDocumentMappingService(_filePathService, new TestDocumentContextFactory(), LoggerFactory);
@@ -369,7 +369,7 @@ public class RazorDocumentMappingServiceTest : TestBase
     }
 
     [Fact]
-    public void TryMapFromProjectedDocumentRange_Inferred_BeginningOfDocAndProjection_ReturnsFalse()
+    public void TryMapToHostDocumentRange_Inferred_BeginningOfDocAndProjection_ReturnsFalse()
     {
         // Arrange
         var service = new RazorDocumentMappingService(_filePathService, new TestDocumentContextFactory(), LoggerFactory);
@@ -396,7 +396,7 @@ public class RazorDocumentMappingServiceTest : TestBase
     }
 
     [Fact]
-    public void TryMapFromProjectedDocumentRange_Inferred_InbetweenProjections_ReturnsTrue()
+    public void TryMapToHostDocumentRange_Inferred_InbetweenProjections_ReturnsTrue()
     {
         // Arrange
         var service = new RazorDocumentMappingService(_filePathService, new TestDocumentContextFactory(), LoggerFactory);
@@ -431,7 +431,7 @@ public class RazorDocumentMappingServiceTest : TestBase
     }
 
     [Fact]
-    public void TryMapFromProjectedDocumentRange_Inferred_InbetweenProjectionAndEndOfDoc_ReturnsTrue()
+    public void TryMapToHostDocumentRange_Inferred_InbetweenProjectionAndEndOfDoc_ReturnsTrue()
     {
         // Arrange
         var service = new RazorDocumentMappingService(_filePathService, new TestDocumentContextFactory(), LoggerFactory);
@@ -463,7 +463,7 @@ public class RazorDocumentMappingServiceTest : TestBase
     }
 
     [Fact]
-    public void TryMapFromProjectedDocumentRange_Inferred_OutsideDoc_ReturnsFalse()
+    public void TryMapToHostDocumentRange_Inferred_OutsideDoc_ReturnsFalse()
     {
         // Arrange
         var service = new RazorDocumentMappingService(_filePathService, new TestDocumentContextFactory(), LoggerFactory);
@@ -489,7 +489,7 @@ public class RazorDocumentMappingServiceTest : TestBase
     }
 
     [Fact]
-    public void TryMapToProjectedDocumentPosition_NotMatchingAnyMapping()
+    public void TryMapToGeneratedDocumentPosition_NotMatchingAnyMapping()
     {
         // Arrange
         var service = new RazorDocumentMappingService(_filePathService, new TestDocumentContextFactory(), LoggerFactory);
@@ -512,7 +512,7 @@ public class RazorDocumentMappingServiceTest : TestBase
     }
 
     [Fact]
-    public void TryMapToProjectedDocumentPosition_CSharp_OnLeadingEdge()
+    public void TryMapToGeneratedDocumentPosition_CSharp_OnLeadingEdge()
     {
         // Arrange
         var service = new RazorDocumentMappingService(_filePathService, new TestDocumentContextFactory(), LoggerFactory);
@@ -542,7 +542,7 @@ public class RazorDocumentMappingServiceTest : TestBase
     }
 
     [Fact]
-    public void TryMapToProjectedDocumentPosition_CSharp_InMiddle()
+    public void TryMapToGeneratedDocumentPosition_CSharp_InMiddle()
     {
         // Arrange
         var service = new RazorDocumentMappingService(_filePathService, new TestDocumentContextFactory(), LoggerFactory);
@@ -567,12 +567,12 @@ public class RazorDocumentMappingServiceTest : TestBase
         }
         else
         {
-            Assert.False(true, "TryMapToProjectedDocumentPosition should have been true");
+            Assert.False(true, "TryMapToGeneratedDocumentPosition should have been true");
         }
     }
 
     [Fact]
-    public void TryMapToProjectedDocumentPosition_CSharp_OnTrailingEdge()
+    public void TryMapToGeneratedDocumentPosition_CSharp_OnTrailingEdge()
     {
         // Arrange
         var service = new RazorDocumentMappingService(_filePathService, new TestDocumentContextFactory(), LoggerFactory);
@@ -597,12 +597,12 @@ public class RazorDocumentMappingServiceTest : TestBase
         }
         else
         {
-            Assert.True(false, "TryMapToProjectedDocumentPosition should have returned true");
+            Assert.True(false, "TryMapToGeneratedDocumentPosition should have returned true");
         }
     }
 
     [Fact]
-    public void TryMapFromProjectedDocumentPosition_NotMatchingAnyMapping()
+    public void TryMapToHostDocumentPosition_NotMatchingAnyMapping()
     {
         // Arrange
         var service = new RazorDocumentMappingService(_filePathService, new TestDocumentContextFactory(), LoggerFactory);
@@ -625,7 +625,7 @@ public class RazorDocumentMappingServiceTest : TestBase
     }
 
     [Fact]
-    public void TryMapFromProjectedDocumentPosition_CSharp_OnLeadingEdge()
+    public void TryMapToHostDocumentPosition_CSharp_OnLeadingEdge()
     {
         // Arrange
         var service = new RazorDocumentMappingService(_filePathService, new TestDocumentContextFactory(), LoggerFactory);
@@ -655,7 +655,7 @@ public class RazorDocumentMappingServiceTest : TestBase
     }
 
     [Fact]
-    public void TryMapFromProjectedDocumentPosition_CSharp_InMiddle()
+    public void TryMapToHostDocumentPosition_CSharp_InMiddle()
     {
         // Arrange
         var service = new RazorDocumentMappingService(_filePathService, new TestDocumentContextFactory(), LoggerFactory);
@@ -685,7 +685,7 @@ public class RazorDocumentMappingServiceTest : TestBase
     }
 
     [Fact]
-    public void TryMapFromProjectedDocumentPosition_CSharp_OnTrailingEdge()
+    public void TryMapToHostDocumentPosition_CSharp_OnTrailingEdge()
     {
         // Arrange
         var service = new RazorDocumentMappingService(_filePathService, new TestDocumentContextFactory(), LoggerFactory);
@@ -715,7 +715,7 @@ public class RazorDocumentMappingServiceTest : TestBase
     }
 
     [Fact]
-    public void TryMapToProjectedDocumentRange_CSharp()
+    public void TryMapToGeneratedDocumentRange_CSharp()
     {
         // Arrange
         var service = new RazorDocumentMappingService(_filePathService, new TestDocumentContextFactory(), LoggerFactory);
@@ -746,7 +746,7 @@ public class RazorDocumentMappingServiceTest : TestBase
     }
 
     [Fact]
-    public void TryMapToProjectedDocumentRange_CSharp_MissingSourceMappings()
+    public void TryMapToGeneratedDocumentRange_CSharp_MissingSourceMappings()
     {
         // Arrange
         var service = new RazorDocumentMappingService(_filePathService, new TestDocumentContextFactory(), LoggerFactory);
@@ -770,7 +770,7 @@ public class RazorDocumentMappingServiceTest : TestBase
     }
 
     [Fact]
-    public void TryMapToProjectedDocumentRange_CSharp_End_LessThan_Start()
+    public void TryMapToGeneratedDocumentRange_CSharp_End_LessThan_Start()
     {
         // Arrange
         var service = new RazorDocumentMappingService(_filePathService, new TestDocumentContextFactory(), LoggerFactory);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDocumentMappingServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDocumentMappingServiceTest.cs
@@ -463,6 +463,32 @@ public class RazorDocumentMappingServiceTest : TestBase
     }
 
     [Fact]
+    public void TryMapFromProjectedDocumentRange_Inferred_OutsideDoc_ReturnsFalse()
+    {
+        // Arrange
+        var service = new RazorDocumentMappingService(_filePathService, new TestDocumentContextFactory(), LoggerFactory);
+        var codeDoc = CreateCodeDocumentWithCSharpProjection(
+            "@{ var abc = @<unclosed></unclosed>",
+            " var abc =  (__builder) => { }",
+            new[] { new SourceMapping(new SourceSpan(2, 11), new SourceSpan(0, 11)), });
+        var projectedRange = new Range()
+        {
+            Start = new Position(2, 12),
+            End = new Position(2, 29),
+        };
+
+        // Act
+        var result = service.TryMapToHostDocumentRange(
+            codeDoc.GetCSharpDocument(),
+            projectedRange,
+            MappingBehavior.Inferred,
+            out var originalRange);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Fact]
     public void TryMapToProjectedDocumentPosition_NotMatchingAnyMapping()
     {
         // Arrange


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1753830

All of the other mapping methods had checks for `IsRangeWithinDocument` except this one.

Root cause here is probably duplicated C# code, fixed by other recent PRs, but even if there is still a case of that in the wild, the mapping service being defensive against bad data is not a bad thing IMO.