### PR TITLE
Convert SemanticRange to a struct + add RazorRange

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensRangeEndpointBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensRangeEndpointBenchmark.cs
@@ -103,9 +103,7 @@ public class RazorSemanticTokensRangeEndpointBenchmark : RazorLanguageServerBenc
                 : random.Next(0, codeDocument.Source.Lines.GetLineLength(endLine));
 
             PregeneratedRandomSemanticRanges.Add(
-                new SemanticRange(random.Next(),
-                    new Range { Start = new Position(startLine, startChar), End = new Position(endLine, endChar) },
-                    0, fromRazor: false));
+                new SemanticRange(random.Next(), startLine, startChar, endLine, endChar, 0, fromRazor: false));
         }
     }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RangeExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RangeExtensions.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -129,8 +128,8 @@ internal static class RangeExtensions
             throw new ArgumentNullException(nameof(sourceText));
         }
 
-        var start = GetAbsolutePosition(range.Start, sourceText);
-        var end = GetAbsolutePosition(range.End, sourceText);
+        var start = sourceText.GetAbsolutePosition(range.Start.Line, range.Start.Character);
+        var end = sourceText.GetAbsolutePosition(range.End.Line, range.End.Character);
 
         var length = end - start;
         if (length < 0)
@@ -139,26 +138,6 @@ internal static class RangeExtensions
         }
 
         return new TextSpan(start, length);
-
-        static int GetAbsolutePosition(Position position, SourceText sourceText, [CallerArgumentExpression(nameof(position))] string? argName = null)
-        {
-            var line = position.Line;
-            var character = position.Character;
-            var lineCount = sourceText.Lines.Count;
-            if (line > lineCount ||
-                (line == lineCount && character > 0))
-            {
-                throw new ArgumentOutOfRangeException($"{argName} ({line},{character}) matches or exceeds SourceText boundary {lineCount}.");
-            }
-
-            // LSP spec allowed a Range to end one line past the end, and character 0. SourceText does not, so we adjust to the final char position
-            if (line == lineCount)
-            {
-                return sourceText.Length;
-            }
-
-            return sourceText.Lines[line].Start + character;
-        }
     }
 
     public static Language.Syntax.TextSpan AsRazorTextSpan(this Range range, SourceText sourceText)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/SourceTextExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/SourceTextExtensions.cs
@@ -201,4 +201,22 @@ internal static class SourceTextExtensions
 
         return null;
     }
+
+    public static int GetAbsolutePosition(this SourceText source, int line, int character)
+    {
+        var lineCount = source.Lines.Count;
+        if (line > lineCount ||
+            (line == lineCount && character > 0))
+        {
+            throw new ArgumentOutOfRangeException($"computed range ({line},{character}) matches or exceeds SourceText boundary {lineCount}.");
+        }
+
+        // LSP spec allowed a Range to end one line past the end, and character 0. SourceText does not, so we adjust to the final char position
+        if (line == lineCount)
+        {
+            return source.Length;
+        }
+
+        return source.Lines[line].Start + character;
+    }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Models/RazorRange.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Models/RazorRange.cs
@@ -3,13 +3,4 @@
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
 
-internal record RazorRange
-{
-    public int StartLine { get; init; }
-
-    public int StartCharacter { get; init; }
-
-    public int EndLine { get; init; }
-
-    public int EndCharacter { get; init; }
-}
+internal record struct RazorRange(int StartLine, int StartCharacter, int EndLine, int EndCharacter);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Models/RazorRange.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Models/RazorRange.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
+
+internal record RazorRange
+{
+    public int StartLine { get; init; }
+
+    public int StartCharacter { get; init; }
+
+    public int EndLine { get; init; }
+
+    public int EndCharacter { get; init; }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Models/RazorRange.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Models/RazorRange.cs
@@ -1,6 +1,0 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
-// Licensed under the MIT license. See License.txt in the project root for license information.
-
-namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
-
-internal record struct RazorRange(int StartLine, int StartCharacter, int EndLine, int EndCharacter);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/RazorSemanticTokensInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/RazorSemanticTokensInfoService.cs
@@ -350,19 +350,10 @@ internal class RazorSemanticTokensInfoService : IRazorSemanticTokensInfoService
         return semanticRange;
     }
 
-    private static RazorRange EmptyRazorRange = new RazorRange()
-    {
-        EndCharacter = 0,
-        EndLine = 0,
-        StartCharacter = 0,
-        StartLine = 0
-    };
-
     private static int[] ConvertSemanticRangesToSemanticTokensData(
         List<SemanticRange> semanticRanges,
         RazorCodeDocument razorCodeDocument)
     {
-        var previousResult = EmptyRazorRange;
         var sourceText = razorCodeDocument.GetSourceText();
         var hasPrevious = false;
         var previousStartLine = 0;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/RazorSemanticTokensInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/RazorSemanticTokensInfoService.cs
@@ -12,7 +12,6 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Semantic.Models;
 using Microsoft.AspNetCore.Razor.PooledObjects;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.CodeAnalysis.Text;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/RazorSemanticTokensInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/RazorSemanticTokensInfoService.cs
@@ -145,12 +145,9 @@ internal class RazorSemanticTokensInfoService : IRazorSemanticTokensInfoService
         var razorSource = codeDocument.GetSourceText();
 
         var previousSemanticRange = new SemanticRange(0, 0, 0, 0, 0, modifier: 0, fromRazor: false);
+        var hasPreviousSemanticRange = false;
         Range? previousRazorSemanticRange = null;
-        var tempRange = new Range()
-        {
-            End = new Position(0, 0),
-            Start = new Position(0, 0)
-        };
+        Range? tempRange = null;
         for (var i = 0; i < csharpResponse.Length; i += TokenSize)
         {
             var lineDelta = csharpResponse[i];
@@ -159,8 +156,16 @@ internal class RazorSemanticTokensInfoService : IRazorSemanticTokensInfoService
             var tokenType = csharpResponse[i + 3];
             var tokenModifiers = csharpResponse[i + 4];
 
+            if (!hasPreviousSemanticRange)
+            {
+                tempRange = new Range()
+                {
+                    End = new Position(0, 0),
+                    Start = new Position(0, 0)
+                };
+            }
             var semanticRange = CSharpDataToSemanticRange(lineDelta, charDelta, length, tokenType, tokenModifiers, previousSemanticRange);
-            tempRange.Start.Line = semanticRange.StartLine;
+            tempRange!.Start.Line = semanticRange.StartLine;
             tempRange.Start.Character = semanticRange.StartCharacter;
             tempRange.End.Line = semanticRange.EndLine;
             tempRange.End.Character = semanticRange.EndCharacter;
@@ -187,6 +192,7 @@ internal class RazorSemanticTokensInfoService : IRazorSemanticTokensInfoService
                 previousRazorSemanticRange = originalRange;
             }
 
+            hasPreviousSemanticRange = true;
             previousSemanticRange = semanticRange;
         }
 
@@ -339,11 +345,8 @@ internal class RazorSemanticTokensInfoService : IRazorSemanticTokensInfoService
         var startLine = previousSemanticRange.EndLine + lineDelta;
         var previousEndChar = lineDelta == 0 ? previousSemanticRange.StartCharacter : 0;
         var startCharacter = previousEndChar + charDelta;
-        var start = new Position(startLine, startCharacter);
-
         var endLine = startLine;
         var endCharacter = startCharacter + length;
-        var end = new Position(endLine, endCharacter);
 
         var semanticRange = new SemanticRange(tokenType, startLine, startCharacter, endLine, endCharacter, tokenModifiers, fromRazor: false);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/SemanticRange.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/SemanticRange.cs
@@ -2,21 +2,31 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
 
-internal sealed class SemanticRange : IComparable<SemanticRange>
+internal struct SemanticRange : IComparable<SemanticRange>
 {
     public SemanticRange(int kind, Range range, int modifier, bool fromRazor)
+    : this(kind, new RazorRange() { EndCharacter = range.End.Character, EndLine = range.End.Line, StartCharacter = range.Start.Character, StartLine = range.Start.Line }, modifier, fromRazor)
+    {
+    }
+
+    public SemanticRange(int kind, int startLine, int startCharacter, int endLine, int endCharacter, int modifier, bool fromRazor)
+    : this(kind, new RazorRange() { EndCharacter = endCharacter, EndLine = endLine, StartCharacter = startCharacter, StartLine = startLine }, modifier, fromRazor)
+    {
+    }
+
+    public SemanticRange(int kind, RazorRange razorRange, int modifier, bool fromRazor)
     {
         Kind = kind;
         Modifier = modifier;
-        Range = range;
+        Range = razorRange;
         FromRazor = fromRazor;
     }
 
-    public Range Range { get; }
+
+    public RazorRange Range { get; }
 
     public int Kind { get; }
 
@@ -29,20 +39,27 @@ internal sealed class SemanticRange : IComparable<SemanticRange>
     /// </summary>
     public bool FromRazor { get; }
 
-    public int CompareTo(SemanticRange? other)
+    public int CompareTo(SemanticRange other)
     {
-        if (other is null)
-        {
-            return 1;
-        }
-
-        var startCompare = Range.Start.CompareTo(other.Range.Start);
+        var startCompare = Range.StartCharacter.CompareTo(other.Range.StartCharacter);
         if (startCompare != 0)
         {
             return startCompare;
         }
 
-        var endCompare = Range.End.CompareTo(other.Range.End);
+        startCompare = Range.StartLine.CompareTo(other.Range.StartLine);
+        if (startCompare != 0)
+        {
+            return startCompare;
+        }
+
+        var endCompare = Range.EndCharacter.CompareTo(other.Range.EndCharacter);
+        if (endCompare != 0)
+        {
+            return endCompare;
+        }
+
+        endCompare = Range.EndLine.CompareTo(other.Range.EndLine);
         if (endCompare != 0)
         {
             return endCompare;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/SemanticRange.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/SemanticRange.cs
@@ -41,25 +41,25 @@ internal struct SemanticRange : IComparable<SemanticRange>
 
     public int CompareTo(SemanticRange other)
     {
-        var startCompare = Range.StartCharacter.CompareTo(other.Range.StartCharacter);
+        var startCompare = Range.StartLine.CompareTo(other.Range.StartLine);
         if (startCompare != 0)
         {
             return startCompare;
         }
 
-        startCompare = Range.StartLine.CompareTo(other.Range.StartLine);
+        startCompare = Range.StartCharacter.CompareTo(other.Range.StartCharacter);
         if (startCompare != 0)
         {
             return startCompare;
         }
 
-        var endCompare = Range.EndCharacter.CompareTo(other.Range.EndCharacter);
+        var endCompare = Range.EndLine.CompareTo(other.Range.EndLine);
         if (endCompare != 0)
         {
             return endCompare;
         }
 
-        endCompare = Range.EndLine.CompareTo(other.Range.EndLine);
+        endCompare = Range.EndCharacter.CompareTo(other.Range.EndCharacter);
         if (endCompare != 0)
         {
             return endCompare;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/SemanticRange.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/SemanticRange.cs
@@ -7,26 +7,25 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
 
 internal struct SemanticRange : IComparable<SemanticRange>
 {
-    public SemanticRange(int kind, Range range, int modifier, bool fromRazor)
-    : this(kind, new RazorRange() { EndCharacter = range.End.Character, EndLine = range.End.Line, StartCharacter = range.Start.Character, StartLine = range.Start.Line }, modifier, fromRazor)
-    {
-    }
-
     public SemanticRange(int kind, int startLine, int startCharacter, int endLine, int endCharacter, int modifier, bool fromRazor)
-    : this(kind, new RazorRange() { EndCharacter = endCharacter, EndLine = endLine, StartCharacter = startCharacter, StartLine = startLine }, modifier, fromRazor)
-    {
-    }
-
-    public SemanticRange(int kind, RazorRange razorRange, int modifier, bool fromRazor)
     {
         Kind = kind;
         Modifier = modifier;
-        Range = razorRange;
+        StartLine = startLine;
+        StartCharacter = startCharacter;
+        EndLine = endLine;
+        EndCharacter = endCharacter;
         FromRazor = fromRazor;
     }
 
 
-    public RazorRange Range { get; }
+    public int StartLine { get; }
+
+    public int StartCharacter { get; }
+
+    public int EndLine { get; }
+
+    public int EndCharacter { get; }
 
     public int Kind { get; }
 
@@ -41,25 +40,25 @@ internal struct SemanticRange : IComparable<SemanticRange>
 
     public int CompareTo(SemanticRange other)
     {
-        var startCompare = Range.StartLine.CompareTo(other.Range.StartLine);
+        var startCompare = StartLine.CompareTo(other.StartLine);
         if (startCompare != 0)
         {
             return startCompare;
         }
 
-        startCompare = Range.StartCharacter.CompareTo(other.Range.StartCharacter);
+        startCompare = StartCharacter.CompareTo(other.StartCharacter);
         if (startCompare != 0)
         {
             return startCompare;
         }
 
-        var endCompare = Range.EndLine.CompareTo(other.Range.EndLine);
+        var endCompare = EndLine.CompareTo(other.EndLine);
         if (endCompare != 0)
         {
             return endCompare;
         }
 
-        endCompare = Range.EndCharacter.CompareTo(other.Range.EndCharacter);
+        endCompare = EndCharacter.CompareTo(other.EndCharacter);
         if (endCompare != 0)
         {
             return endCompare;
@@ -79,5 +78,5 @@ internal struct SemanticRange : IComparable<SemanticRange>
     }
 
     public override string ToString()
-        => $"[Kind: {Kind}, Range: {Range}]";
+        => $"[Kind: {Kind}, StartLine: {StartLine}, StartCharacter: {StartCharacter}, EndLine: {EndLine}, EndCharacter: {EndCharacter}]";
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/TagHelperSemanticRangeVisitor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/TagHelperSemanticRangeVisitor.cs
@@ -544,13 +544,8 @@ internal sealed class TagHelperSemanticRangeVisitor : SyntaxWalker
                         continue;
                     }
 
-                    var endPosition = new Position(lineNumber, endChar);
-                    var lineRange = new Range
-                    {
-                        Start = startPosition,
-                        End = endPosition
-                    };
-                    var semantic = new SemanticRange(semanticKind, lineRange, tokenModifier, fromRazor: true);
+                    // line range
+                    var semantic = new SemanticRange(semanticKind, startPosition.Line, startPosition.Character, lineNumber, endChar, tokenModifier, fromRazor: true);
                     AddRange(semantic);
                 }
             }
@@ -566,7 +561,8 @@ internal sealed class TagHelperSemanticRangeVisitor : SyntaxWalker
                     {
                         var tokenRange = token.GetRange(source);
 
-                        var semantic = new SemanticRange(semanticKind, tokenRange, tokenModifier, fromRazor: true);
+                        // token range
+                        var semantic = new SemanticRange(semanticKind, tokenRange.Start.Line, tokenRange.Start.Character, tokenRange.End.Line, tokenRange.End.Character, tokenModifier, fromRazor: true);
                         AddRange(semantic);
                     }
                 }
@@ -574,13 +570,13 @@ internal sealed class TagHelperSemanticRangeVisitor : SyntaxWalker
         }
         else
         {
-            var semanticRange = new SemanticRange(semanticKind, range, tokenModifier, fromRazor: true);
+            var semanticRange = new SemanticRange(semanticKind, range.Start.Line, range.Start.Character, range.End.Line, range.End.Character, tokenModifier, fromRazor: true);
             AddRange(semanticRange);
         }
 
         void AddRange(SemanticRange semanticRange)
         {
-            if (semanticRange.Range.StartLine != semanticRange.Range.EndLine || semanticRange.Range.StartCharacter != semanticRange.Range.EndCharacter)
+            if (semanticRange.StartLine != semanticRange.EndLine || semanticRange.StartCharacter != semanticRange.EndCharacter)
             {
                 _semanticRanges.Add(semanticRange);
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/TagHelperSemanticRangeVisitor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/TagHelperSemanticRangeVisitor.cs
@@ -580,7 +580,7 @@ internal sealed class TagHelperSemanticRangeVisitor : SyntaxWalker
 
         void AddRange(SemanticRange semanticRange)
         {
-            if (semanticRange.Range.Start != semanticRange.Range.End)
+            if (semanticRange.Range.StartLine != semanticRange.Range.EndLine || semanticRange.Range.StartCharacter != semanticRange.Range.EndCharacter)
             {
                 _semanticRanges.Add(semanticRange);
             }


### PR DESCRIPTION
Contributes to https://github.com/dotnet/razor/issues/9092

- [ ] WIP

I noticed even by just making `SemanticRange` struct from the original class actually increases allocation size for our existing benchmarks.

At first I thought it has to do with copy allocations but even making `readonly struct` from `struct` does not change the allocation size.

This could be due to having List operations on `SemanticRange` in `TagHelperSemanticRangeVisitor` and `RazorSemanticTokensInfoService`.

- when a class
```
|                                 Method | WithMultiLineComment |     Mean |    Error |   StdDev |   Median |      Min |      Max | Allocated |
|--------------------------------------- |--------------------- |---------:|---------:|---------:|---------:|---------:|---------:|----------:|
| 'Razor Semantic Tokens Range Handling' |                False | 13.59 us | 14.44 us | 0.792 us | 13.39 us | 12.92 us | 14.47 us |   3.66 KB |
| 'Razor Semantic Tokens Range Handling' |                 True | 40.02 us | 20.20 us | 1.107 us | 39.64 us | 39.15 us | 41.27 us |  13.09 KB |

|                                 Method | NumberOfCsSemanticRangesToReturn |      Mean |      Error |    StdDev |    Median |       Min |       Max |   Gen0 | Allocated |
|--------------------------------------- |--------------------------------- |----------:|-----------:|----------:|----------:|----------:|----------:|-------:|----------:|
| 'Razor Semantic Tokens Range Endpoint' |                                0 |  4.362 us |  1.9576 us | 0.1073 us |  4.378 us |  4.247 us |  4.460 us |      - |   3.19 KB |
| 'Razor Semantic Tokens Range Endpoint' |                              100 |  9.209 us |  0.2243 us | 0.0123 us |  9.211 us |  9.195 us |  9.220 us | 0.0153 |   4.48 KB |
| 'Razor Semantic Tokens Range Endpoint' |                             1000 | 83.039 us | 39.3322 us | 2.1559 us | 84.094 us | 80.558 us | 84.464 us |      - |  11.74 KB |

|                                  Method |     Mean |    Error |  StdDev |   Median |      Min |      Max | Allocated |
|---------------------------------------- |---------:|---------:|--------:|---------:|---------:|---------:|----------:|
| 'Razor Semantic Tokens Range Scrolling' | 936.4 us | 126.3 us | 6.92 us | 938.9 us | 928.5 us | 941.7 us | 177.92 KB |
```


- when a readonly struct
```
|                                 Method | WithMultiLineComment |     Mean |    Error |   StdDev |   Median |      Min |      Max | Allocated |
|--------------------------------------- |--------------------- |---------:|---------:|---------:|---------:|---------:|---------:|----------:|
| 'Razor Semantic Tokens Range Handling' |                False | 31.60 us | 1.444 us | 0.079 us | 31.62 us | 31.51 us | 31.66 us |    3.9 KB |
| 'Razor Semantic Tokens Range Handling' |                 True | 49.31 us | 6.292 us | 0.345 us | 49.51 us | 48.91 us | 49.52 us |  16.02 KB |

|                                 Method | NumberOfCsSemanticRangesToReturn |      Mean |     Error |    StdDev |    Median |       Min |        Max |   Gen0 | Allocated |
|--------------------------------------- |--------------------------------- |----------:|----------:|----------:|----------:|----------:|-----------:|-------:|----------:|
| 'Razor Semantic Tokens Range Endpoint' |                                0 |  4.758 us |  2.579 us | 0.1413 us |  4.733 us |  4.630 us |   4.910 us | 0.0076 |   3.38 KB |
| 'Razor Semantic Tokens Range Endpoint' |                              100 | 11.168 us |  4.366 us | 0.2393 us | 11.168 us | 10.928 us |  11.407 us | 0.0153 |   6.63 KB |
| 'Razor Semantic Tokens Range Endpoint' |                             1000 | 98.349 us | 44.810 us | 2.4562 us | 98.288 us | 95.924 us | 100.836 us | 0.1221 |  31.47 KB |

|                                  Method |     Mean |     Error |    StdDev |   Median |      Min |      Max | Allocated |
|---------------------------------------- |---------:|----------:|----------:|---------:|---------:|---------:|----------:|
| 'Razor Semantic Tokens Range Scrolling' | 1.039 ms | 0.0958 ms | 0.0052 ms | 1.038 ms | 1.034 ms | 1.045 ms | 197.91 KB |
```