### PR TITLE
Rendermode errors

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/ComponentResources.resx
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/ComponentResources.resx
@@ -222,6 +222,9 @@
   <data name="RefTagHelper_Documentation" xml:space="preserve">
     <value>Populates the specified field or property with a reference to the element or component.</value>
   </data>
+  <data name="RenderModeTagHelper_Documentation" xml:space="preserve">
+    <value>Specified the render mode for a component.</value>
+  </data>
   <data name="SplatTagHelper_Documentation" xml:space="preserve">
     <value>Merges a collection of attributes into the current element or component.</value>
   </data>

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/ComponentResources.resx
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/ComponentResources.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -222,8 +222,17 @@
   <data name="RefTagHelper_Documentation" xml:space="preserve">
     <value>Populates the specified field or property with a reference to the element or component.</value>
   </data>
+  <data name="RenderModeDirective_Documentation" xml:space="preserve">
+    <value>Specifies the render mode for this component.</value>
+  </data>
+  <data name="RenderModeDirective_Token_Description" xml:space="preserve">
+    <value>An identifier that resolves to a render mode that should be applied to this component.</value>
+  </data>
+  <data name="RenderModeDirective_Token_Name" xml:space="preserve">
+    <value>Render mode</value>
+  </data>
   <data name="RenderModeTagHelper_Documentation" xml:space="preserve">
-    <value>Specified the render mode for a component.</value>
+    <value>Specifies the render mode for a component.</value>
   </data>
   <data name="SplatTagHelper_Documentation" xml:space="preserve">
     <value>Merges a collection of attributes into the current element or component.</value>

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentDiagnosticFactory.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentDiagnosticFactory.cs
@@ -566,10 +566,10 @@ internal static class ComponentDiagnosticFactory
     }
 
     public static readonly RazorDiagnosticDescriptor RenderModeAttribute_ComponentDeclaredRenderMode =
-    new RazorDiagnosticDescriptor(
-    $"{DiagnosticPrefix}10022",
-    () => "Cannot override render mode for component '{0}'.",
-    RazorDiagnosticSeverity.Error);
+        new RazorDiagnosticDescriptor(
+        $"{DiagnosticPrefix}10022",
+        () => "Cannot override render mode for component '{0}' as it explicitly declares one.",
+        RazorDiagnosticSeverity.Error);
 
     public static RazorDiagnostic CreateRenderModeAttribute_ComponentDeclaredRenderMode(SourceSpan? source, string component)
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentDiagnosticFactory.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentDiagnosticFactory.cs
@@ -564,4 +564,19 @@ internal static class ComponentDiagnosticFactory
             attribute);
         return diagnostic;
     }
+
+    public static readonly RazorDiagnosticDescriptor RenderModeAttribute_ComponentDeclaredRenderMode =
+    new RazorDiagnosticDescriptor(
+    $"{DiagnosticPrefix}10022",
+    () => "Cannot override render mode for component '{0}'.",
+    RazorDiagnosticSeverity.Error);
+
+    public static RazorDiagnostic CreateRenderModeAttribute_ComponentDeclaredRenderMode(SourceSpan? source, string component)
+    {
+        var diagnostic = RazorDiagnostic.Create(
+            RenderModeAttribute_ComponentDeclaredRenderMode,
+            source ?? SourceSpan.Undefined,
+            component);
+        return diagnostic;
+    }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentMetadata.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentMetadata.cs
@@ -121,6 +121,8 @@ internal static class ComponentMetadata
 
         public const string NameMatchKey = "Components.NameMatch";
 
+        public const string HasRenderModeDirectiveKey = "Components.HasRenderModeDirective";
+
         public const string FullyQualifiedNameMatch = "Components.FullyQualifiedNameMatch";
 
         public const string InitOnlyProperty = "Components.InitOnlyProperty";

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentRenderModeDirective.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentRenderModeDirective.cs
@@ -13,7 +13,7 @@ internal sealed class ComponentRenderModeDirective
        DirectiveKind.SingleLine,
        builder =>
        {
-           // PROTOTYPE: we only support the identifier version right now
+           // https://github.com/dotnet/razor/issues/9181: we only support the identifier version right now
            builder.AddNamespaceToken(ComponentResources.RenderModeDirective_Token_Name, ComponentResources.RenderModeDirective_Token_Description);
            builder.Usage = DirectiveUsage.FileScopedSinglyOccurring;
            builder.Description = ComponentResources.RenderModeDirective_Documentation;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentRenderModeDirective.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentRenderModeDirective.cs
@@ -8,17 +8,15 @@ namespace Microsoft.AspNetCore.Razor.Language.Components;
 
 internal sealed class ComponentRenderModeDirective
 {
-    // PROTOTYPE: localization
-
     public static readonly DirectiveDescriptor Directive = DirectiveDescriptor.CreateDirective(
        "rendermode",
        DirectiveKind.SingleLine,
        builder =>
        {
            // PROTOTYPE: we only support the identifier version right now
-           builder.AddNamespaceToken("RenderMode", "The RenderMode to use");
+           builder.AddNamespaceToken(ComponentResources.RenderModeDirective_Token_Name, ComponentResources.RenderModeDirective_Token_Description);
            builder.Usage = DirectiveUsage.FileScopedSinglyOccurring;
-           builder.Description = "Set the render mode for this component.";
+           builder.Description = ComponentResources.RenderModeDirective_Documentation;
        });
 
     public static void Register(RazorProjectEngineBuilder builder)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentRenderModeLoweringPass.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentRenderModeLoweringPass.cs
@@ -25,7 +25,7 @@ internal sealed class ComponentRenderModeLoweringPass : ComponentIntermediateNod
             {
                 Debug.Assert(node.Diagnostics.Count == 0);
 
-                if (parentNode is not ComponentIntermediateNode)
+                if (parentNode is not ComponentIntermediateNode componentNode)
                 {
                     node.Diagnostics.Add(ComponentDiagnosticFactory.CreateAttribute_ValidOnlyOnComponent(node.Source, node.OriginalAttributeName));
                     continue;
@@ -37,7 +37,16 @@ internal sealed class ComponentRenderModeLoweringPass : ComponentIntermediateNod
                     IntermediateNode token => token
                 };
 
-                reference.Replace(new RenderModeIntermediateNode() { Source = node.Source, Children = { expression } });
+                var renderModeNode = new RenderModeIntermediateNode() { Source = node.Source, Children = { expression } };
+
+                if (componentNode.Component.Metadata.ContainsKey(ComponentMetadata.Component.HasRenderModeDirectiveKey))
+                {
+                    renderModeNode.Diagnostics.Add(ComponentDiagnosticFactory.CreateRenderModeAttribute_ComponentDeclaredRenderMode(
+                       node.Source,
+                       componentNode.Component.Name));
+                }
+
+                reference.Replace(renderModeNode);
             }
         }
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DocumentationDescriptor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DocumentationDescriptor.cs
@@ -27,6 +27,7 @@ internal abstract partial class DocumentationDescriptor : IEquatable<Documentati
     public static readonly DocumentationDescriptor KeyTagHelper = new SimpleDescriptor(DocumentationId.KeyTagHelper);
     public static readonly DocumentationDescriptor RefTagHelper = new SimpleDescriptor(DocumentationId.RefTagHelper);
     public static readonly DocumentationDescriptor SplatTagHelper = new SimpleDescriptor(DocumentationId.SplatTagHelper);
+    public static readonly DocumentationDescriptor RenderModeTagHelper = new SimpleDescriptor(DocumentationId.RenderModeTagHelper);
 
     public static DocumentationDescriptor From(DocumentationId id, params object?[]? args)
     {
@@ -60,6 +61,7 @@ internal abstract partial class DocumentationDescriptor : IEquatable<Documentati
                 DocumentationId.KeyTagHelper => KeyTagHelper,
                 DocumentationId.RefTagHelper => RefTagHelper,
                 DocumentationId.SplatTagHelper => SplatTagHelper,
+                DocumentationId.RenderModeTagHelper => RenderModeTagHelper,
 
                 // If this exception is thrown, there are two potential problems:
                 //
@@ -120,6 +122,7 @@ internal abstract partial class DocumentationDescriptor : IEquatable<Documentati
             DocumentationId.KeyTagHelper => ComponentResources.KeyTagHelper_Documentation,
             DocumentationId.RefTagHelper => ComponentResources.RefTagHelper_Documentation,
             DocumentationId.SplatTagHelper => ComponentResources.SplatTagHelper_Documentation,
+            DocumentationId.RenderModeTagHelper => ComponentResources.RenderModeTagHelper_Documentation,
 
             // If this exception is thrown, a new DocumentationId was added that needs an entry added in
             // the switch expression above to return a resource string.

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DocumentationId.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DocumentationId.cs
@@ -28,6 +28,7 @@ internal enum DocumentationId
     KeyTagHelper,
     RefTagHelper,
     SplatTagHelper,
+    RenderModeTagHelper,
 
-    Last = SplatTagHelper
+    Last = RenderModeTagHelper
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentCodeGenerationTestBase.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentCodeGenerationTestBase.cs
@@ -10006,8 +10006,6 @@ Time: @DateTime.Now
         // Assert
         AssertDocumentNodeMatchesBaseline(generated.CodeDocument);
         AssertCSharpDocumentMatchesBaseline(generated.CodeDocument);
-
-        // add the required attributes
         CompileToAssembly(generated, throwOnFailure: true);
     }
 
@@ -10065,20 +10063,6 @@ Time: @DateTime.Now
     }
 
     [Fact]
-    public void RenderMode_Attribute_On_Html_Element()
-    {
-        var generated = CompileToCSharp("""
-                <input @rendermode="Microsoft.AspNetCore.Components.Web.RenderMode.Server" />
-                """, throwOnFailure: false);
-
-        // Assert
-        //x:\dir\subdir\Test\TestComponent.cshtml(1,21): Error RZ10021: Attribute 'rendermode' is only valid when used on a component.
-        var diag = Assert.Single(generated.Diagnostics);
-        Assert.Equal("RZ10021", diag.Id);
-
-    }
-
-    [Fact]
     public void Duplicate_RenderMode()
     {
         var generated = CompileToCSharp($$"""
@@ -10131,20 +10115,6 @@ Time: @DateTime.Now
         AssertDocumentNodeMatchesBaseline(generated.CodeDocument);
         AssertCSharpDocumentMatchesBaseline(generated.CodeDocument);
         CompileToAssembly(generated, throwOnFailure: true);
-    }
-
-    [Fact]
-    public void RenderMode_With_Diagnostics()
-    {
-        var generated = CompileToCSharp($$"""
-                <{{ComponentName}} @rendermode="@Microsoft.AspNetCore.Components.Web.RenderMode.Server)" />
-                """, throwOnFailure: true);
-
-        // Assert
-
-        //x:\dir\subdir\Test\TestComponent.cshtml(1, 29): Error RZ9986: Component attributes do not support complex content(mixed C# and markup). Attribute: '@rendermode', text: 'Microsoft.AspNetCore.Components.Web.RenderMode.Server)'
-        var diagnostic = Assert.Single(generated.Diagnostics);
-        Assert.Equal("RZ9986", diagnostic.Id);
     }
 
     [Fact]

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentRenderModeAttributeIntegrationTests.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentRenderModeAttributeIntegrationTests.cs
@@ -34,7 +34,7 @@ public class ComponentRenderModeAttributeIntegrationTests : RazorIntegrationTest
     {
         var generated = CompileToCSharp("""
                 <input @rendermode="Microsoft.AspNetCore.Components.Web.RenderMode.Server" />
-                """, throwOnFailure: false);
+                """, throwOnFailure: true);
 
         // Assert
         //x:\dir\subdir\Test\TestComponent.cshtml(1,21): Error RZ10021: Attribute 'rendermode' is only valid when used on a component.
@@ -46,11 +46,14 @@ public class ComponentRenderModeAttributeIntegrationTests : RazorIntegrationTest
     public void RenderMode_Attribute_On_Component_With_Directive()
     {
         var generated = CompileToCSharp($$"""
-                @rendermode Microsoft.AspNetCore.Components.DefaultRenderModes.Server
+                @rendermode Microsoft.AspNetCore.Components.Web.RenderMode.Server
 
-                <{{ComponentName}} @rendermode="Microsoft.AspNetCore.Components.DefaultRenderModes.Server" />
-                """, throwOnFailure: false);
+                <{{ComponentName}} @rendermode="Microsoft.AspNetCore.Components.Web.RenderMode.Server" />
+                """, throwOnFailure: true);
 
+        // Assert
+
+        // x:\dir\subdir\Test\TestComponent.cshtml(3,29): Error RZ10022: Cannot override render mode for component 'Test.TestComponent' as it explicitly declares one.
         var diagnostic = Assert.Single(generated.Diagnostics);
         Assert.Equal("RZ10022", diagnostic.Id);
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentRenderModeAttributeIntegrationTests.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentRenderModeAttributeIntegrationTests.cs
@@ -1,0 +1,58 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests;
+
+public class ComponentRenderModeAttributeIntegrationTests : RazorIntegrationTestBase
+{
+    internal override string FileKind => FileKinds.Component;
+
+    internal string ComponentName = "TestComponent";
+
+    internal override string DefaultFileName => ComponentName + ".cshtml";
+
+    internal override bool UseTwoPhaseCompilation => true;
+
+    [Fact]
+    public void RenderMode_Attribute_With_Diagnostics()
+    {
+        var generated = CompileToCSharp($$"""
+                <{{ComponentName}} @rendermode="@Microsoft.AspNetCore.Components.Web.RenderMode.Server)" />
+                """, throwOnFailure: true);
+
+        // Assert
+
+        //x:\dir\subdir\Test\TestComponent.cshtml(1, 29): Error RZ9986: Component attributes do not support complex content(mixed C# and markup). Attribute: '@rendermode', text: 'Microsoft.AspNetCore.Components.Web.RenderMode.Server)'
+        var diagnostic = Assert.Single(generated.Diagnostics);
+        Assert.Equal("RZ9986", diagnostic.Id);
+    }
+
+    [Fact]
+    public void RenderMode_Attribute_On_Html_Element()
+    {
+        var generated = CompileToCSharp("""
+                <input @rendermode="Microsoft.AspNetCore.Components.Web.RenderMode.Server" />
+                """, throwOnFailure: false);
+
+        // Assert
+        //x:\dir\subdir\Test\TestComponent.cshtml(1,21): Error RZ10021: Attribute 'rendermode' is only valid when used on a component.
+        var diag = Assert.Single(generated.Diagnostics);
+        Assert.Equal("RZ10021", diag.Id);
+    }
+
+    [Fact]
+    public void RenderMode_Attribute_On_Component_With_Directive()
+    {
+        var generated = CompileToCSharp($$"""
+                @rendermode Microsoft.AspNetCore.Components.DefaultRenderModes.Server
+
+                <{{ComponentName}} @rendermode="Microsoft.AspNetCore.Components.DefaultRenderModes.Server" />
+                """, throwOnFailure: false);
+
+        var diagnostic = Assert.Single(generated.Diagnostics);
+        Assert.Equal("RZ10022", diagnostic.Id);
+    }
+}
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentRenderModeDirectiveIntegrationTests.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentRenderModeDirectiveIntegrationTests.cs
@@ -176,4 +176,64 @@ public class ComponentRenderModeDirectiveIntegrationTests : RazorIntegrationTest
             Diagnostic(ErrorCode.WRN_UnreferencedFieldAssg, "rendermode").WithArguments("Test.TestComponent.rendermode").WithLocation(5, 12)
             );
     }
+
+
+    [Fact]
+    public void RenderMode_Referencing_Instance_Code()
+    {
+        var compilationResult = CompileToCSharp($$"""
+                @rendermode myRenderMode
+                @code
+                {
+                    Microsoft.AspNetCore.Components.IComponentRenderMode myRenderMode = new Microsoft.AspNetCore.Components.Web.ServerRenderMode();
+                }
+                """, throwOnFailure: true);
+
+        Assert.Empty(compilationResult.Diagnostics);
+
+        var assemblyResult = CompileToAssembly(compilationResult, throwOnFailure: false);
+        assemblyResult.Diagnostics.Verify(
+            // x:\dir\subdir\Test\TestComponent.cshtml(1,13): error CS0103: The name 'myRenderMode' does not exist in the current context
+            //             myRenderMode
+            Diagnostic(ErrorCode.ERR_NameNotInContext, "myRenderMode").WithArguments("myRenderMode").WithLocation(1, 13)
+            );
+    }
+
+    [Fact]
+    public void RenderMode_Referencing_Static_Code()
+    {
+        var compilationResult = CompileToCSharp($$"""
+                @rendermode myRenderMode
+                @code
+                {
+                    static Microsoft.AspNetCore.Components.IComponentRenderMode myRenderMode = new Microsoft.AspNetCore.Components.Web.ServerRenderMode();
+                }
+                """, throwOnFailure: true);
+
+        Assert.Empty(compilationResult.Diagnostics);
+
+        var assemblyResult = CompileToAssembly(compilationResult, throwOnFailure: false);
+        assemblyResult.Diagnostics.Verify(
+            // x:\dir\subdir\Test\TestComponent.cshtml(1,13): error CS0103: The name 'myRenderMode' does not exist in the current context
+            //             myRenderMode
+            Diagnostic(ErrorCode.ERR_NameNotInContext, "myRenderMode").WithArguments("myRenderMode").WithLocation(1, 13)
+            );
+    }
+
+    [Fact]
+    public void RenderMode_Referencing_Internal_Static_Code()
+    {
+        var compilationResult = CompileToCSharp($$"""
+                @rendermode TestComponent.myRenderMode
+                @code
+                {
+                    internal static Microsoft.AspNetCore.Components.IComponentRenderMode myRenderMode = new Microsoft.AspNetCore.Components.Web.ServerRenderMode();
+                }
+                """, throwOnFailure: true);
+
+        Assert.Empty(compilationResult.Diagnostics);
+
+        var assemblyResult = CompileToAssembly(compilationResult, throwOnFailure: false);
+        assemblyResult.Diagnostics.Verify();
+    }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentRenderModeDirectiveIntegrationTests.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentRenderModeDirectiveIntegrationTests.cs
@@ -177,4 +177,3 @@ public class ComponentRenderModeDirectiveIntegrationTests : RazorIntegrationTest
             );
     }
 }
-

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentTagHelperDescriptorProvider.cs
@@ -162,6 +162,11 @@ internal class ComponentTagHelperDescriptorProvider : RazorEngineFeatureBase, IT
             }
         }
 
+        if (HasRenderModeDirective(type))
+        {
+            metadata.Add(MakeTrue(ComponentMetadata.Component.HasRenderModeDirectiveKey));
+        }
+
         var xml = type.GetDocumentationCommentXml();
         if (!string.IsNullOrEmpty(xml))
         {
@@ -691,6 +696,25 @@ internal class ComponentTagHelperDescriptorProvider : RazorEngineFeatureBase, IT
         {
             return property.Type.TypeKind == TypeKind.Delegate;
         }
+    }
+
+    private static bool HasRenderModeDirective(INamedTypeSymbol type)
+    {
+        var attributes = type.GetAttributes();
+        foreach (var attribute in attributes)
+        {
+            var attributeClass = attribute.AttributeClass;
+            while (attributeClass is not null)
+            {
+                if (attributeClass.HasFullName(ComponentsApi.RenderModeAttribute.FullTypeName))
+                {
+                    return true;
+                }
+
+                attributeClass = attributeClass.BaseType;
+            }
+        }
+        return false;
     }
 
     private enum PropertyKind

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/RenderModeTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/RenderModeTagHelperDescriptorProvider.cs
@@ -57,8 +57,7 @@ internal sealed class RenderModeTagHelperDescriptorProvider : ITagHelperDescript
 
         builder.CaseSensitive = true;
 
-        // PROTOTYPE: docs
-        //builder.SetDocumentation(DocumentationDescriptor.RenderModeTagHelper);
+        builder.SetDocumentation(DocumentationDescriptor.RenderModeTagHelper);
 
         builder.SetMetadata(
             SpecialKind(ComponentMetadata.RenderMode.TagHelperKind),
@@ -78,8 +77,7 @@ internal sealed class RenderModeTagHelperDescriptorProvider : ITagHelperDescript
 
         builder.BindAttribute(attribute =>
         {
-            // PROTOTYPE: docs
-            //attribute.SetDocumentation(DocumentationDescriptor.RenderModeTagHelper);
+            attribute.SetDocumentation(DocumentationDescriptor.RenderModeTagHelper);
             attribute.Name = "@rendermode";
 
             attribute.TypeName = ComponentsApi.IComponentRenderMode.FullTypeName;


### PR DESCRIPTION
Make it an error to specify a rendermode for a component that has explicltly declared one.

Cleans up the remaining prototype comments.