### PR TITLE
Ensure that directive nodes always have at least one token child

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
@@ -47,6 +47,16 @@ MyService<TModel> __typeHelper = default;
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {
+#line 3 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+      
+
+#line default
+#line hidden
+#line 6 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+       
+
+#line default
+#line hidden
         }
         #pragma warning restore 1998
         [global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
@@ -34,6 +34,8 @@
                 HtmlContent - (85:1,0 [2] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (85:1,0 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (87:2,0 [6] IncompleteDirectives.cshtml) - model
+                    CSharpCode - (93:2,6 [0] IncompleteDirectives.cshtml)
+                        LazyIntermediateToken - (93:2,6 [0] IncompleteDirectives.cshtml) - CSharp - 
                 HtmlContent - (93:2,6 [2] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (93:2,6 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (95:3,0 [7] IncompleteDirectives.cshtml) - model
@@ -41,6 +43,8 @@
                 HtmlContent - (102:3,7 [4] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (102:3,7 [4] IncompleteDirectives.cshtml) - Html - \n\n
                 MalformedDirective - (106:5,0 [7] IncompleteDirectives.cshtml) - inject
+                    CSharpCode - (113:5,7 [0] IncompleteDirectives.cshtml)
+                        LazyIntermediateToken - (113:5,7 [0] IncompleteDirectives.cshtml) - CSharp - 
                 HtmlContent - (113:5,7 [2] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (113:5,7 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (115:6,0 [8] IncompleteDirectives.cshtml) - inject

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
@@ -13,3 +13,13 @@ Source Location: (133:7,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrat
 Generated Location: (1180:35,0 [17] )
 |MyService<TModel>|
 
+Source Location: (93:2,6 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+||
+Generated Location: (1680:50,6 [0] )
+||
+
+Source Location: (113:5,7 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+||
+Generated Location: (1816:55,7 [0] )
+||
+

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
@@ -55,6 +55,21 @@ MyService<TModel> __typeHelper = default;
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {
+#line 7 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+      
+
+#line default
+#line hidden
+#line 10 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+       
+
+#line default
+#line hidden
+#line 14 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+          
+
+#line default
+#line hidden
         }
         #pragma warning restore 1998
         [global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
@@ -41,6 +41,8 @@
                 HtmlContent - (108:4,6 [5] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (108:4,6 [5] IncompleteDirectives.cshtml) - Html - "\n\n
                 MalformedDirective - (113:6,0 [6] IncompleteDirectives.cshtml) - model
+                    CSharpCode - (119:6,6 [0] IncompleteDirectives.cshtml)
+                        LazyIntermediateToken - (119:6,6 [0] IncompleteDirectives.cshtml) - CSharp - 
                 HtmlContent - (119:6,6 [2] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (119:6,6 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (121:7,0 [7] IncompleteDirectives.cshtml) - model
@@ -48,6 +50,8 @@
                 HtmlContent - (128:7,7 [4] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (128:7,7 [4] IncompleteDirectives.cshtml) - Html - \n\n
                 MalformedDirective - (132:9,0 [7] IncompleteDirectives.cshtml) - inject
+                    CSharpCode - (139:9,7 [0] IncompleteDirectives.cshtml)
+                        LazyIntermediateToken - (139:9,7 [0] IncompleteDirectives.cshtml) - CSharp - 
                 HtmlContent - (139:9,7 [2] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (139:9,7 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (141:10,0 [8] IncompleteDirectives.cshtml) - inject
@@ -59,6 +63,8 @@
                 HtmlContent - (176:11,25 [4] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (176:11,25 [4] IncompleteDirectives.cshtml) - Html - \n\n
                 MalformedDirective - (180:13,0 [10] IncompleteDirectives.cshtml) - namespace
+                    CSharpCode - (190:13,10 [0] IncompleteDirectives.cshtml)
+                        LazyIntermediateToken - (190:13,10 [0] IncompleteDirectives.cshtml) - CSharp - 
                 HtmlContent - (190:13,10 [2] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (190:13,10 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (192:14,0 [11] IncompleteDirectives.cshtml) - namespace

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
@@ -18,3 +18,18 @@ Source Location: (203:14,11 [0] TestFiles/IntegrationTests/CodeGenerationIntegra
 Generated Location: (1412:43,0 [0] )
 ||
 
+Source Location: (119:6,6 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+||
+Generated Location: (1872:58,6 [0] )
+||
+
+Source Location: (139:9,7 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+||
+Generated Location: (2009:63,7 [0] )
+||
+
+Source Location: (190:13,10 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+||
+Generated Location: (2149:68,10 [0] )
+||
+

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
@@ -28,6 +28,8 @@
                 CSharpCode - 
                     IntermediateToken -  - CSharp - EndContext();
                 MalformedDirective - (113:6,0 [6] IncompleteDirectives.cshtml) - model
+                    CSharpCode - (119:6,6 [0] IncompleteDirectives.cshtml)
+                        LazyIntermediateToken - (119:6,6 [0] IncompleteDirectives.cshtml) - CSharp - 
                 CSharpCode - 
                     IntermediateToken -  - CSharp - BeginContext(119, 2, true);
                 HtmlContent - (119:6,6 [2] IncompleteDirectives.cshtml)
@@ -43,6 +45,8 @@
                 CSharpCode - 
                     IntermediateToken -  - CSharp - EndContext();
                 MalformedDirective - (132:9,0 [7] IncompleteDirectives.cshtml) - inject
+                    CSharpCode - (139:9,7 [0] IncompleteDirectives.cshtml)
+                        LazyIntermediateToken - (139:9,7 [0] IncompleteDirectives.cshtml) - CSharp - 
                 CSharpCode - 
                     IntermediateToken -  - CSharp - BeginContext(139, 2, true);
                 HtmlContent - (139:9,7 [2] IncompleteDirectives.cshtml)
@@ -66,6 +70,8 @@
                 CSharpCode - 
                     IntermediateToken -  - CSharp - EndContext();
                 MalformedDirective - (180:13,0 [10] IncompleteDirectives.cshtml) - namespace
+                    CSharpCode - (190:13,10 [0] IncompleteDirectives.cshtml)
+                        LazyIntermediateToken - (190:13,10 [0] IncompleteDirectives.cshtml) - CSharp - 
                 CSharpCode - 
                     IntermediateToken -  - CSharp - BeginContext(190, 2, true);
                 HtmlContent - (190:13,10 [2] IncompleteDirectives.cshtml)

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
@@ -67,6 +67,27 @@ MyService<TModel> __typeHelper = default!;
         #pragma warning disable 1998
         public async override global::System.Threading.Tasks.Task ExecuteAsync()
         {
+#nullable restore
+#line 7 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+      
+
+#line default
+#line hidden
+#nullable disable
+#nullable restore
+#line 10 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+       
+
+#line default
+#line hidden
+#nullable disable
+#nullable restore
+#line 14 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+          
+
+#line default
+#line hidden
+#nullable disable
         }
         #pragma warning restore 1998
         #nullable restore

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
@@ -43,6 +43,8 @@
                 HtmlContent - (108:4,6 [5] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (108:4,6 [5] IncompleteDirectives.cshtml) - Html - "\n\n
                 MalformedDirective - (113:6,0 [6] IncompleteDirectives.cshtml) - model
+                    CSharpCode - (119:6,6 [0] IncompleteDirectives.cshtml)
+                        LazyIntermediateToken - (119:6,6 [0] IncompleteDirectives.cshtml) - CSharp - 
                 HtmlContent - (119:6,6 [2] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (119:6,6 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (121:7,0 [7] IncompleteDirectives.cshtml) - model
@@ -50,6 +52,8 @@
                 HtmlContent - (128:7,7 [4] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (128:7,7 [4] IncompleteDirectives.cshtml) - Html - \n\n
                 MalformedDirective - (132:9,0 [7] IncompleteDirectives.cshtml) - inject
+                    CSharpCode - (139:9,7 [0] IncompleteDirectives.cshtml)
+                        LazyIntermediateToken - (139:9,7 [0] IncompleteDirectives.cshtml) - CSharp - 
                 HtmlContent - (139:9,7 [2] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (139:9,7 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (141:10,0 [8] IncompleteDirectives.cshtml) - inject
@@ -61,6 +65,8 @@
                 HtmlContent - (176:11,25 [4] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (176:11,25 [4] IncompleteDirectives.cshtml) - Html - \n\n
                 MalformedDirective - (180:13,0 [10] IncompleteDirectives.cshtml) - namespace
+                    CSharpCode - (190:13,10 [0] IncompleteDirectives.cshtml)
+                        LazyIntermediateToken - (190:13,10 [0] IncompleteDirectives.cshtml) - CSharp - 
                 HtmlContent - (190:13,10 [2] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (190:13,10 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (192:14,0 [11] IncompleteDirectives.cshtml) - namespace

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
@@ -18,3 +18,18 @@ Source Location: (203:14,11 [0] TestFiles/IntegrationTests/CodeGenerationIntegra
 Generated Location: (1918:54,0 [0] )
 ||
 
+Source Location: (119:6,6 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+||
+Generated Location: (2416:71,6 [0] )
+||
+
+Source Location: (139:9,7 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+||
+Generated Location: (2591:78,7 [0] )
+||
+
+Source Location: (190:13,10 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+||
+Generated Location: (2769:85,10 [0] )
+||
+

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
@@ -20,6 +20,8 @@
                 HtmlContent - (108:4,6 [5] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (108:4,6 [5] IncompleteDirectives.cshtml) - Html - "\n\n
                 MalformedDirective - (113:6,0 [6] IncompleteDirectives.cshtml) - model
+                    CSharpCode - (119:6,6 [0] IncompleteDirectives.cshtml)
+                        LazyIntermediateToken - (119:6,6 [0] IncompleteDirectives.cshtml) - CSharp - 
                 HtmlContent - (119:6,6 [2] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (119:6,6 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (121:7,0 [7] IncompleteDirectives.cshtml) - model
@@ -27,6 +29,8 @@
                 HtmlContent - (128:7,7 [4] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (128:7,7 [4] IncompleteDirectives.cshtml) - Html - \n\n
                 MalformedDirective - (132:9,0 [7] IncompleteDirectives.cshtml) - inject
+                    CSharpCode - (139:9,7 [0] IncompleteDirectives.cshtml)
+                        LazyIntermediateToken - (139:9,7 [0] IncompleteDirectives.cshtml) - CSharp - 
                 HtmlContent - (139:9,7 [2] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (139:9,7 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (141:10,0 [8] IncompleteDirectives.cshtml) - inject
@@ -38,6 +42,8 @@
                 HtmlContent - (176:11,25 [4] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (176:11,25 [4] IncompleteDirectives.cshtml) - Html - \n\n
                 MalformedDirective - (180:13,0 [10] IncompleteDirectives.cshtml) - namespace
+                    CSharpCode - (190:13,10 [0] IncompleteDirectives.cshtml)
+                        LazyIntermediateToken - (190:13,10 [0] IncompleteDirectives.cshtml) - CSharp - 
                 HtmlContent - (190:13,10 [2] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (190:13,10 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (192:14,0 [11] IncompleteDirectives.cshtml) - namespace

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/CSharpCodeParser.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/CSharpCodeParser.cs
@@ -1360,7 +1360,7 @@ internal class CSharpCodeParser : TokenizerBackedParser<CSharpTokenizer>
                             RazorDiagnosticFactory.CreateParsing_DirectiveTokensMustBeSeparatedByWhitespace(
                                 new SourceSpan(CurrentStart, CurrentToken.Content.Length), descriptor.Directive));
 
-                        builder.Add(BuildDirective());
+                        builder.Add(BuildDirective(SyntaxKind.Whitespace));
                         return;
                     }
 
@@ -1409,7 +1409,7 @@ internal class CSharpCodeParser : TokenizerBackedParser<CSharpTokenizer>
                                 new SourceSpan(CurrentStart, contentLength: 1),
                                 descriptor.Directive,
                                 tokenDescriptor.Kind.ToString().ToLowerInvariant()));
-                        builder.Add(BuildDirective());
+                        builder.Add(BuildDirective(SyntaxKind.Identifier));
                         return;
                     }
 
@@ -1422,7 +1422,7 @@ internal class CSharpCodeParser : TokenizerBackedParser<CSharpTokenizer>
                                     RazorDiagnosticFactory.CreateParsing_DirectiveExpectsTypeName(
                                         new SourceSpan(CurrentStart, CurrentToken.Content.Length), descriptor.Directive));
 
-                                builder.Add(BuildDirective());
+                                builder.Add(BuildDirective(SyntaxKind.Identifier));
                                 return;
                             }
                             break;
@@ -1434,7 +1434,7 @@ internal class CSharpCodeParser : TokenizerBackedParser<CSharpTokenizer>
                                     RazorDiagnosticFactory.CreateParsing_DirectiveExpectsNamespace(
                                         new SourceSpan(CurrentStart, identifierLength), descriptor.Directive));
 
-                                builder.Add(BuildDirective());
+                                builder.Add(BuildDirective(SyntaxKind.Identifier));
                                 return;
                             }
                             break;
@@ -1450,7 +1450,7 @@ internal class CSharpCodeParser : TokenizerBackedParser<CSharpTokenizer>
                                 Context.ErrorSink.OnError(
                                     RazorDiagnosticFactory.CreateParsing_DirectiveExpectsIdentifier(
                                         new SourceSpan(CurrentStart, CurrentToken.Content.Length), descriptor.Directive));
-                                builder.Add(BuildDirective());
+                                builder.Add(BuildDirective(SyntaxKind.Identifier));
                                 return;
                             }
                             break;
@@ -1465,7 +1465,7 @@ internal class CSharpCodeParser : TokenizerBackedParser<CSharpTokenizer>
                                 Context.ErrorSink.OnError(
                                     RazorDiagnosticFactory.CreateParsing_DirectiveExpectsQuotedStringLiteral(
                                         new SourceSpan(CurrentStart, CurrentToken.Content.Length), descriptor.Directive));
-                                builder.Add(BuildDirective());
+                                builder.Add(BuildDirective(SyntaxKind.StringLiteral));
                                 return;
                             }
                             break;
@@ -1480,7 +1480,7 @@ internal class CSharpCodeParser : TokenizerBackedParser<CSharpTokenizer>
                                 Context.ErrorSink.OnError(
                                     RazorDiagnosticFactory.CreateParsing_DirectiveExpectsBooleanLiteral(
                                         new SourceSpan(CurrentStart, CurrentToken.Content.Length), descriptor.Directive));
-                                builder.Add(BuildDirective());
+                                builder.Add(BuildDirective(SyntaxKind.CSharpExpressionLiteral));
                                 return;
                             }
                             break;
@@ -1498,7 +1498,7 @@ internal class CSharpCodeParser : TokenizerBackedParser<CSharpTokenizer>
                                 Context.ErrorSink.OnError(
                                     RazorDiagnosticFactory.CreateParsing_DirectiveExpectsCSharpAttribute(
                                         new SourceSpan(CurrentStart, CurrentToken.Content.Length), descriptor.Directive));
-                                builder.Add(BuildDirective());
+                                builder.Add(BuildDirective(SyntaxKind.LeftBracket));
                                 return;
                             }
 
@@ -1519,7 +1519,7 @@ internal class CSharpCodeParser : TokenizerBackedParser<CSharpTokenizer>
                                     Context.ErrorSink.OnError(
                                         RazorDiagnosticFactory.CreateParsing_GenericTypeParameterIdentifierMismatch(
                                             new SourceSpan(CurrentStart, CurrentToken.Content.Length), descriptor.Directive, CurrentToken.Content, lastSeenMemberIdentifier));
-                                    builder.Add(BuildDirective());
+                                    builder.Add(BuildDirective(SyntaxKind.Identifier));
                                     return;
                                 }
                                 else
@@ -1552,7 +1552,7 @@ internal class CSharpCodeParser : TokenizerBackedParser<CSharpTokenizer>
                                         CurrentToken.Content,
                                         CSharpLanguageCharacteristics.GetKeyword(CSharpKeyword.Where)));
 
-                                builder.Add(BuildDirective());
+                                builder.Add(BuildDirective(SyntaxKind.Keyword));
                                 return;
                             }
 
@@ -1660,11 +1660,16 @@ internal class CSharpCodeParser : TokenizerBackedParser<CSharpTokenizer>
                 Context.ErrorSink = savedErrorSink;
             }
 
-            builder.Add(BuildDirective());
+            builder.Add(BuildDirective(SyntaxKind.Identifier));
 
-            RazorDirectiveSyntax BuildDirective()
+            RazorDirectiveSyntax BuildDirective(SyntaxKind expectedTokenKindIfMissing)
             {
-                directiveBuilder.Add(OutputTokensAsStatementLiteral());
+                var node = OutputTokensAsStatementLiteral();
+                if (node == null && directiveBuilder.Count == 0)
+                {
+                    node = SyntaxFactory.CSharpStatementLiteral(new SyntaxList<SyntaxToken>(SyntaxFactory.MissingToken(expectedTokenKindIfMissing)), chunkGenerator);
+                }
+                directiveBuilder.Add(node);
                 var directiveCodeBlock = SyntaxFactory.CSharpCodeBlock(directiveBuilder.ToList());
 
                 var directiveBody = SyntaxFactory.RazorDirectiveBody(keywordBlock, directiveCodeBlock);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/FindTokenIntegrationTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/FindTokenIntegrationTest.cs
@@ -1,0 +1,25 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Razor.Language.IntegrationTests;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Language.Test;
+
+public class FindTokenIntegrationTest : IntegrationTestBase
+{
+    [Fact, WorkItem("https://github.com/dotnet/razor/issues/9177")]
+    public void EmptyDirective()
+    {
+        var projectEngine = CreateProjectEngine();
+        var projectItem = CreateProjectItemFromFile();
+
+        var codeDocument = projectEngine.Process(projectItem);
+
+        var root = codeDocument.GetSyntaxTree().Root;
+        var token = root.FindToken(27);
+        AssertEx.Equal("Identifier;[<Missing>];", SyntaxSerializer.Serialize(token).Trim());
+    }
+}

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
@@ -126,6 +126,20 @@ global::System.Object __typeHelper = ";
         public async System.Threading.Tasks.Task ExecuteAsync()
         {
 #nullable restore
+#line 15 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+         
+
+#line default
+#line hidden
+#nullable disable
+#nullable restore
+#line 21 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+        
+
+#line default
+#line hidden
+#nullable disable
+#nullable restore
 #line 25 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
             
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
@@ -59,6 +59,8 @@
                 HtmlContent - (251:12,18 [4] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (251:12,18 [4] IncompleteDirectives.cshtml) - Html - \n\n
                 MalformedDirective - (255:14,0 [9] IncompleteDirectives.cshtml) - inherits
+                    CSharpCode - (264:14,9 [0] IncompleteDirectives.cshtml)
+                        LazyIntermediateToken - (264:14,9 [0] IncompleteDirectives.cshtml) - CSharp - 
                 HtmlContent - (264:14,9 [2] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (264:14,9 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (266:15,0 [10] IncompleteDirectives.cshtml) - inherits
@@ -68,6 +70,8 @@
                 MalformedDirective - (280:17,0 [12] IncompleteDirectives.cshtml) - functions
                 MalformedDirective - (292:18,0 [15] IncompleteDirectives.cshtml) - functions
                 MalformedDirective - (307:20,0 [8] IncompleteDirectives.cshtml) - section
+                    CSharpCode - (315:20,8 [0] IncompleteDirectives.cshtml)
+                        LazyIntermediateToken - (315:20,8 [0] IncompleteDirectives.cshtml) - CSharp - 
                 HtmlContent - (315:20,8 [2] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (315:20,8 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (317:21,0 [9] IncompleteDirectives.cshtml) - section

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
@@ -53,8 +53,18 @@ Source Location: (326:21,9 [0] TestFiles/IntegrationTests/CodeGenerationIntegrat
 Generated Location: (3225:112,0 [0] )
 ||
 
+Source Location: (264:14,9 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+||
+Generated Location: (3710:129,9 [0] )
+||
+
+Source Location: (315:20,8 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+||
+Generated Location: (3886:136,8 [0] )
+||
+
 Source Location: (354:24,12 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (3713:129,12 [0] )
+Generated Location: (4066:143,12 [0] )
 ||
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
@@ -31,6 +31,8 @@
                 HtmlContent - (253:13,0 [2] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (253:13,0 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (255:14,0 [9] IncompleteDirectives.cshtml) - inherits
+                    CSharpCode - (264:14,9 [0] IncompleteDirectives.cshtml)
+                        LazyIntermediateToken - (264:14,9 [0] IncompleteDirectives.cshtml) - CSharp - 
                 HtmlContent - (264:14,9 [2] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (264:14,9 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (266:15,0 [10] IncompleteDirectives.cshtml) - inherits
@@ -40,6 +42,8 @@
                 MalformedDirective - (280:17,0 [12] IncompleteDirectives.cshtml) - functions
                 MalformedDirective - (292:18,0 [15] IncompleteDirectives.cshtml) - functions
                 MalformedDirective - (307:20,0 [8] IncompleteDirectives.cshtml) - section
+                    CSharpCode - (315:20,8 [0] IncompleteDirectives.cshtml)
+                        LazyIntermediateToken - (315:20,8 [0] IncompleteDirectives.cshtml) - CSharp - 
                 HtmlContent - (315:20,8 [2] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (315:20,8 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (317:21,0 [9] IncompleteDirectives.cshtml) - section

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/FindTokenIntegrationTest/EmptyDirective.cshtml
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/FindTokenIntegrationTest/EmptyDirective.cshtml
@@ -1,0 +1,31 @@
+@page "/counter"
+@inherits
+
+<PageTitle>Counter</PageTitle>
+
+<h1>Counter</h1>
+
+<p role="status">Current count: @currentCount</p>
+
+<button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
+
+@code {
+    private int currentCount = 0;
+
+    private void IncrementCount()
+    {
+        currentCount++;
+
+        var x = ImmutableArray<string>.Empty;
+
+    }
+
+    [DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]
+    public class Goo
+    {
+        private string GetDebuggerDisplay()
+        {
+            return ToString();
+        }
+    }
+}

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/ParserTests/CSharpSectionTest/CapturesNewlineImmediatelyFollowing.stree.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/ParserTests/CSharpSectionTest/CapturesNewlineImmediatelyFollowing.stree.txt
@@ -10,6 +10,8 @@
                     RazorMetaCode - [1..8)::7 - Gen<None> - SpanEditHandler;Accepts:None
                         Identifier;[section];
                     CSharpCodeBlock - [8..8)::0
+                        CSharpStatementLiteral - [8..8)::0 - [] - Gen<Stmt>
+                            Identifier;[<Missing>];
         MarkupTextLiteral - [8..10)::2 - [LF] - Gen<Markup> - SpanEditHandler;Accepts:Any
             NewLine;[LF];
     EndOfFile;[];

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/ParserTests/RazorDirectivesTest/Directives_CanUseReservedWord_Class.stree.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/ParserTests/RazorDirectivesTest/Directives_CanUseReservedWord_Class.stree.txt
@@ -10,6 +10,8 @@
                     RazorMetaCode - [1..6)::5 - Gen<None> - SpanEditHandler;Accepts:None
                         Keyword;[class];
                     CSharpCodeBlock - [6..6)::0
+                        CSharpStatementLiteral - [6..6)::0 - [] - Gen<None>
+                            Identifier;[<Missing>];
         MarkupTextLiteral - [6..6)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
             Marker;[];
     EndOfFile;[];

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/ParserTests/RazorDirectivesTest/Directives_CanUseReservedWord_Namespace.stree.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/ParserTests/RazorDirectivesTest/Directives_CanUseReservedWord_Namespace.stree.txt
@@ -10,6 +10,8 @@
                     RazorMetaCode - [1..10)::9 - Gen<None> - SpanEditHandler;Accepts:None
                         Keyword;[namespace];
                     CSharpCodeBlock - [10..10)::0
+                        CSharpStatementLiteral - [10..10)::0 - [] - Gen<None>
+                            Identifier;[<Missing>];
         MarkupTextLiteral - [10..10)::0 - [] - Gen<Markup> - SpanEditHandler;Accepts:Any
             Marker;[];
     EndOfFile;[];


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/9177. The parser was violating an invariant that nodes cannot be terminal nodes, and must always have at least one token child. This is likely not the only variant of this problem, but is a very common one, as typing in the editor will often result in incomplete directives some of the time. We now add a missing token in such cases to avoid violating the invariant.
