### PR TITLE
Fire telemetry if language server and client get out of sync

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultGeneratedDocumentPublisher.cs
@@ -136,6 +136,7 @@ internal class DefaultGeneratedDocumentPublisher : GeneratedDocumentPublisher
             ProjectKeyId = projectKey.Id,
             Changes = textChanges,
             HostDocumentVersion = hostDocumentVersion,
+            PreviousWasEmpty = previouslyPublishedData.SourceText.Length == 0
         };
 
         _ = _server.SendNotificationAsync(CustomMessageNames.RazorUpdateCSharpBufferEndpoint, request, CancellationToken.None);
@@ -190,6 +191,7 @@ internal class DefaultGeneratedDocumentPublisher : GeneratedDocumentPublisher
             ProjectKeyId = projectKey.Id,
             Changes = textChanges,
             HostDocumentVersion = hostDocumentVersion,
+            PreviousWasEmpty = previouslyPublishedData.SourceText.Length == 0
         };
 
         _ = _server.SendNotificationAsync(CustomMessageNames.RazorUpdateHtmlBufferEndpoint, request, CancellationToken.None);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/UpdateBufferRequest.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/UpdateBufferRequest.cs
@@ -15,4 +15,6 @@ internal class UpdateBufferRequest
     public required string HostDocumentFilePath { get; set; }
 
     public required IReadOnlyList<TextChange> Changes { get; set; }
+
+    public bool PreviousWasEmpty { get; set; }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
@@ -8,7 +8,7 @@ using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor;
 
-internal class CSharpVirtualDocument(ProjectKey projectKey, Uri uri, ITextBuffer textBuffer, ITelemetryReporter? telemetryReporter)
+internal class CSharpVirtualDocument(ProjectKey projectKey, Uri uri, ITextBuffer textBuffer, ITelemetryReporter telemetryReporter)
     : GeneratedVirtualDocument<CSharpVirtualDocumentSnapshot>(uri, textBuffer, telemetryReporter)
 {
     // NOTE: The base constructor calls GetUpdateSnapshot, so this only works because we're using primary constructors, which

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocument.cs
@@ -2,53 +2,20 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Diagnostics;
 using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
-using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor;
 
 internal class CSharpVirtualDocument(ProjectKey projectKey, Uri uri, ITextBuffer textBuffer, ITelemetryReporter? telemetryReporter)
-    : VirtualDocumentBase<CSharpVirtualDocumentSnapshot>(uri, textBuffer)
+    : GeneratedVirtualDocument<CSharpVirtualDocumentSnapshot>(uri, textBuffer, telemetryReporter)
 {
     // NOTE: The base constructor calls GetUpdateSnapshot, so this only works because we're using primary constructors, which
     //       will initialize the field before calling the base constructor.
     private readonly ProjectKey _projectKey = projectKey;
-    private readonly ITelemetryReporter? _telemetryReporter = telemetryReporter;
 
     internal ProjectKey ProjectKey => _projectKey;
 
     protected override CSharpVirtualDocumentSnapshot GetUpdatedSnapshot(object? state) => new(_projectKey, Uri, TextBuffer.CurrentSnapshot, HostDocumentVersion);
-
-    public override VirtualDocumentSnapshot Update(IReadOnlyList<ITextChange> changes, int hostDocumentVersion, object? state)
-    {
-        var currentSnapshotLength = CurrentSnapshot.Snapshot.Length;
-        if (state is bool previousWasEmpty &&
-            previousWasEmpty != (currentSnapshotLength == 0))
-        {
-            Debug.Fail($"The language server is sending us changes for what it/we thought was an empty file, but their/our copy is not empty. Generated C# file may have corrupted file contents after this update.");
-
-            var recoverable = false;
-            if (previousWasEmpty && changes is [{ OldPosition: 0, OldEnd: 0 } change])
-            {
-                recoverable = true;
-                // The LSP server thought the file was empty, but we have some contents. That's not good, but we can recover
-                // by adjusting the range for the change (which would be (0,0)-(0,0) from the LSP server point of view) to
-                // cover the whole buffer, essentially just taking the LSP server as the source of truth.
-                changes = new[] { new VisualStudioTextChange(0, currentSnapshotLength, change.NewText) };
-            }
-
-            var data = ImmutableDictionary<string, object?>.Empty
-                .Add("version", hostDocumentVersion)
-                .Add("recoverable", recoverable);
-
-            _telemetryReporter?.ReportEvent("sync", Severity.High, data);
-        }
-
-        return base.Update(changes, hostDocumentVersion, state);
-    }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocumentFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocumentFactory.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
@@ -35,6 +36,7 @@ internal class CSharpVirtualDocumentFactory : VirtualDocumentFactoryBase
     private readonly ProjectSnapshotManagerAccessor _projectSnapshotManagerAccessor;
     private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
     private readonly IOutputWindowLogger _logger;
+    private readonly ITelemetryReporter _telemetryReporter;
 
     [ImportingConstructor]
     public CSharpVirtualDocumentFactory(
@@ -45,7 +47,8 @@ internal class CSharpVirtualDocumentFactory : VirtualDocumentFactoryBase
         FilePathService filePathService,
         ProjectSnapshotManagerAccessor projectSnapshotManagerAccessor,
         LanguageServerFeatureOptions languageServerFeatureOptions,
-        IOutputWindowLogger logger)
+        IOutputWindowLogger logger,
+        ITelemetryReporter telemetryReporter)
         : base(contentTypeRegistry, textBufferFactory, textDocumentFactory, fileUriProvider)
     {
         _fileUriProvider = fileUriProvider;
@@ -53,6 +56,7 @@ internal class CSharpVirtualDocumentFactory : VirtualDocumentFactoryBase
         _projectSnapshotManagerAccessor = projectSnapshotManagerAccessor;
         _languageServerFeatureOptions = languageServerFeatureOptions;
         _logger = logger;
+        _telemetryReporter = telemetryReporter;
     }
 
     protected override IContentType LanguageContentType
@@ -218,7 +222,7 @@ internal class CSharpVirtualDocumentFactory : VirtualDocumentFactoryBase
 
         var languageBuffer = CreateVirtualDocumentTextBuffer(virtualLanguageFilePath, virtualLanguageUri);
 
-        return new CSharpVirtualDocument(projectKey, virtualLanguageUri, languageBuffer);
+        return new CSharpVirtualDocument(projectKey, virtualLanguageUri, languageBuffer, _telemetryReporter);
     }
 
     private class RemoteContentDefinitionType : IContentType

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Endpoints/UpdateCSharpBuffer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Endpoints/UpdateCSharpBuffer.cs
@@ -86,7 +86,7 @@ internal partial class RazorCustomMessageTarget
                         virtualDocument.Uri,
                         request.Changes.Select(change => change.ToVisualStudioTextChange()).ToArray(),
                         request.HostDocumentVersion.Value,
-                        state: null);
+                        state: request.PreviousWasEmpty);
                     return;
                 }
             }
@@ -112,6 +112,6 @@ internal partial class RazorCustomMessageTarget
             hostDocumentUri,
             request.Changes.Select(change => change.ToVisualStudioTextChange()).ToArray(),
             request.HostDocumentVersion.Value,
-            state: null);
+            state: request.PreviousWasEmpty);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Endpoints/UpdateHtmlBuffer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Endpoints/UpdateHtmlBuffer.cs
@@ -41,6 +41,6 @@ internal partial class RazorCustomMessageTarget
             hostDocumentUri,
             request.Changes.Select(change => change.ToVisualStudioTextChange()).ToArray(),
             request.HostDocumentVersion.Value,
-            state: null);
+            state: request.PreviousWasEmpty);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/GeneratedVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/GeneratedVirtualDocument.cs
@@ -11,9 +11,9 @@ using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor;
 
-internal abstract class GeneratedVirtualDocument<T>(Uri uri, ITextBuffer textBuffer, ITelemetryReporter? telemetryReporter) : VirtualDocumentBase<T>(uri, textBuffer) where T : VirtualDocumentSnapshot
+internal abstract class GeneratedVirtualDocument<T>(Uri uri, ITextBuffer textBuffer, ITelemetryReporter telemetryReporter) : VirtualDocumentBase<T>(uri, textBuffer) where T : VirtualDocumentSnapshot
 {
-    private readonly ITelemetryReporter? _telemetryReporter = telemetryReporter;
+    private readonly ITelemetryReporter _telemetryReporter = telemetryReporter;
 
     public override VirtualDocumentSnapshot Update(IReadOnlyList<ITextChange> changes, int hostDocumentVersion, object? state)
     {
@@ -38,7 +38,7 @@ internal abstract class GeneratedVirtualDocument<T>(Uri uri, ITextBuffer textBuf
                 .Add("type", typeof(T).Name)
                 .Add("recoverable", recoverable);
 
-            _telemetryReporter?.ReportEvent("sync", Severity.High, data);
+            _telemetryReporter.ReportEvent("sync", Severity.High, data);
         }
 
         return base.Update(changes, hostDocumentVersion, state);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/GeneratedVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/GeneratedVirtualDocument.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.AspNetCore.Razor.Telemetry;
+using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor;
+
+internal abstract class GeneratedVirtualDocument<T>(Uri uri, ITextBuffer textBuffer, ITelemetryReporter? telemetryReporter) : VirtualDocumentBase<T>(uri, textBuffer) where T : VirtualDocumentSnapshot
+{
+    private readonly ITelemetryReporter? _telemetryReporter = telemetryReporter;
+
+    public override VirtualDocumentSnapshot Update(IReadOnlyList<ITextChange> changes, int hostDocumentVersion, object? state)
+    {
+        var currentSnapshotLength = CurrentSnapshot.Snapshot.Length;
+        if (state is bool previousWasEmpty &&
+            previousWasEmpty != (currentSnapshotLength == 0))
+        {
+            Debug.Fail($"The language server is sending us changes for what it/we thought was an empty file, but their/our copy is not empty. Generated C# file may have corrupted file contents after this update.");
+
+            var recoverable = false;
+            if (previousWasEmpty && changes is [{ OldPosition: 0, OldEnd: 0 } change])
+            {
+                recoverable = true;
+                // The LSP server thought the file was empty, but we have some contents. That's not good, but we can recover
+                // by adjusting the range for the change (which would be (0,0)-(0,0) from the LSP server point of view) to
+                // cover the whole buffer, essentially just taking the LSP server as the source of truth.
+                changes = new[] { new VisualStudioTextChange(0, currentSnapshotLength, change.NewText) };
+            }
+
+            var data = ImmutableDictionary<string, object?>.Empty
+                .Add("version", hostDocumentVersion)
+                .Add("type", typeof(T).Name)
+                .Add("recoverable", recoverable);
+
+            _telemetryReporter?.ReportEvent("sync", Severity.High, data);
+        }
+
+        return base.Update(changes, hostDocumentVersion, state);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocument.cs
@@ -2,16 +2,13 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
+using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor;
 
-internal class HtmlVirtualDocument : VirtualDocumentBase<HtmlVirtualDocumentSnapshot>
+internal class HtmlVirtualDocument(Uri uri, ITextBuffer textBuffer, ITelemetryReporter telemetryReporter)
+    : GeneratedVirtualDocument<HtmlVirtualDocumentSnapshot>(uri, textBuffer, telemetryReporter)
 {
-    public HtmlVirtualDocument(Uri uri, ITextBuffer textBuffer) : base(uri, textBuffer)
-    {
-    }
-
     protected override HtmlVirtualDocumentSnapshot GetUpdatedSnapshot(object? state) => new(Uri, TextBuffer.CurrentSnapshot, HostDocumentVersion);
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocumentFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/HtmlVirtualDocumentFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel.Composition;
+using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.Editor.Razor;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
@@ -17,6 +18,7 @@ internal class HtmlVirtualDocumentFactory : VirtualDocumentFactoryBase
 {
     private static IContentType? s_htmlLSPContentType;
     private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
+    private readonly ITelemetryReporter _telemetryReporter;
 
     [ImportingConstructor]
     public HtmlVirtualDocumentFactory(
@@ -24,10 +26,12 @@ internal class HtmlVirtualDocumentFactory : VirtualDocumentFactoryBase
         ITextBufferFactoryService textBufferFactory,
         ITextDocumentFactoryService textDocumentFactory,
         FileUriProvider filePathProvider,
-        LanguageServerFeatureOptions languageServerFeatureOptions)
+        LanguageServerFeatureOptions languageServerFeatureOptions,
+        ITelemetryReporter telemetryReporter)
         : base(contentTypeRegistry, textBufferFactory, textDocumentFactory, filePathProvider)
     {
         _languageServerFeatureOptions = languageServerFeatureOptions;
+        _telemetryReporter = telemetryReporter;
     }
 
     protected override IContentType LanguageContentType
@@ -42,5 +46,5 @@ internal class HtmlVirtualDocumentFactory : VirtualDocumentFactoryBase
 
     protected override string HostDocumentContentTypeName => RazorConstants.RazorLSPContentTypeName;
     protected override string LanguageFileNameSuffix => _languageServerFeatureOptions.HtmlVirtualDocumentSuffix;
-    protected override VirtualDocument CreateVirtualDocument(Uri uri, ITextBuffer textBuffer) => new HtmlVirtualDocument(uri, textBuffer);
+    protected override VirtualDocument CreateVirtualDocument(Uri uri, ITextBuffer textBuffer) => new HtmlVirtualDocument(uri, textBuffer, _telemetryReporter);
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/UpdateBufferRequest.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/UpdateBufferRequest.cs
@@ -15,4 +15,6 @@ internal class UpdateBufferRequest
     public string? HostDocumentFilePath { get; init; }
 
     public required IReadOnlyList<TextChange> Changes { get; init; }
+
+    public bool PreviousWasEmpty { get; set; }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/CSharpVirtualDocumentFactoryTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/CSharpVirtualDocumentFactoryTest.cs
@@ -67,7 +67,7 @@ public class CSharpVirtualDocumentFactoryTest : TestBase
         var uri = new Uri("C:/path/to/file.razor");
         var uriProvider = Mock.Of<FileUriProvider>(provider => provider.GetOrCreate(It.IsAny<ITextBuffer>()) == uri, MockBehavior.Strict);
         var projectSnapshotManagerAccessor = Mock.Of<ProjectSnapshotManagerAccessor>(MockBehavior.Strict);
-        var factory = new CSharpVirtualDocumentFactory(_contentTypeRegistryService, _textBufferFactoryService, TextDocumentFactoryService, uriProvider, _filePathService, projectSnapshotManagerAccessor, TestLanguageServerFeatureOptions.Instance, new TestOutputWindowLogger());
+        var factory = new CSharpVirtualDocumentFactory(_contentTypeRegistryService, _textBufferFactoryService, TextDocumentFactoryService, uriProvider, _filePathService, projectSnapshotManagerAccessor, TestLanguageServerFeatureOptions.Instance, new TestOutputWindowLogger(), telemetryReporter: null);
 
         // Act
         var result = factory.TryCreateMultipleFor(_nonRazorLSPBuffer, out var virtualDocuments);
@@ -90,7 +90,7 @@ public class CSharpVirtualDocumentFactoryTest : TestBase
         projectSnapshotManager.CreateAndAddDocument(project, @"C:\path\to\file.razor");
         var projectSnapshotManagerAccessor = Mock.Of<ProjectSnapshotManagerAccessor>(a => a.Instance == projectSnapshotManager, MockBehavior.Strict);
 
-        var factory = new CSharpVirtualDocumentFactory(_contentTypeRegistryService, _textBufferFactoryService, TextDocumentFactoryService, uriProvider, _filePathService, projectSnapshotManagerAccessor, TestLanguageServerFeatureOptions.Instance, new TestOutputWindowLogger());
+        var factory = new CSharpVirtualDocumentFactory(_contentTypeRegistryService, _textBufferFactoryService, TextDocumentFactoryService, uriProvider, _filePathService, projectSnapshotManagerAccessor, TestLanguageServerFeatureOptions.Instance, new TestOutputWindowLogger(), telemetryReporter: null);
 
         // Act
         var result = factory.TryCreateMultipleFor(_razorLSPBuffer, out var virtualDocuments);
@@ -120,7 +120,7 @@ public class CSharpVirtualDocumentFactoryTest : TestBase
 
         var languageServerFeatureOptions = new TestLanguageServerFeatureOptions(includeProjectKeyInGeneratedFilePath: true);
         var filePathService = new FilePathService(languageServerFeatureOptions);
-        var factory = new CSharpVirtualDocumentFactory(_contentTypeRegistryService, _textBufferFactoryService, TextDocumentFactoryService, uriProvider, filePathService, projectSnapshotManagerAccessor, languageServerFeatureOptions, new TestOutputWindowLogger());
+        var factory = new CSharpVirtualDocumentFactory(_contentTypeRegistryService, _textBufferFactoryService, TextDocumentFactoryService, uriProvider, filePathService, projectSnapshotManagerAccessor, languageServerFeatureOptions, new TestOutputWindowLogger(), telemetryReporter: null);
 
         // Act
         var result = factory.TryCreateMultipleFor(_razorLSPBuffer, out var virtualDocuments);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlVirtualDocumentFactoryTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/HtmlVirtualDocumentFactoryTest.cs
@@ -54,7 +54,7 @@ public class HtmlVirtualDocumentFactoryTest : TestBase
         // Arrange
         var uri = new Uri("C:/path/to/file.razor");
         var uriProvider = Mock.Of<FileUriProvider>(provider => provider.GetOrCreate(It.IsAny<ITextBuffer>()) == uri, MockBehavior.Strict);
-        var factory = new HtmlVirtualDocumentFactory(_contentTypeRegistryService, _textBufferFactoryService, _textDocumentFactoryService, uriProvider, TestLanguageServerFeatureOptions.Instance);
+        var factory = new HtmlVirtualDocumentFactory(_contentTypeRegistryService, _textBufferFactoryService, _textDocumentFactoryService, uriProvider, TestLanguageServerFeatureOptions.Instance, telemetryReporter: null);
 
         // Act
         var result = factory.TryCreateFor(_nonRazorLSPBuffer, out var virtualDocument);
@@ -74,7 +74,7 @@ public class HtmlVirtualDocumentFactoryTest : TestBase
         var uri = new Uri("C:/path/to/file.razor");
         var uriProvider = Mock.Of<FileUriProvider>(provider => provider.GetOrCreate(_razorLSPBuffer) == uri, MockBehavior.Strict);
         Mock.Get(uriProvider).Setup(p => p.AddOrUpdate(It.IsAny<ITextBuffer>(), It.IsAny<Uri>())).Verifiable();
-        var factory = new HtmlVirtualDocumentFactory(_contentTypeRegistryService, _textBufferFactoryService, _textDocumentFactoryService, uriProvider, TestLanguageServerFeatureOptions.Instance);
+        var factory = new HtmlVirtualDocumentFactory(_contentTypeRegistryService, _textBufferFactoryService, _textDocumentFactoryService, uriProvider, TestLanguageServerFeatureOptions.Instance, telemetryReporter: null);
 
         // Act
         var result = factory.TryCreateFor(_razorLSPBuffer, out var virtualDocument);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestDocumentManager.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestDocumentManager.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.LanguageServer.Test.Common;
+using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage.Test.Common.Extensions;
@@ -58,7 +59,7 @@ internal class TestDocumentManager : TrackingLSPDocumentManager
             return;
         }
 
-        using var virtualDocument = new CSharpVirtualDocument(projectKey: default, virtualDocumentSnapshot.Uri, virtualDocumentSnapshot.Snapshot.TextBuffer, telemetryReporter: null);
+        using var virtualDocument = new CSharpVirtualDocument(projectKey: default, virtualDocumentSnapshot.Uri, virtualDocumentSnapshot.Snapshot.TextBuffer, NoOpTelemetryReporter.Instance);
         virtualDocument.Update(changes, hostDocumentVersion, state);
         _documents[hostDocumentUri] = new TestLSPDocumentSnapshot(hostDocumentUri, documentSnapshot.Version, new[] { virtualDocument.CurrentSnapshot });
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestDocumentManager.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/TestDocumentManager.cs
@@ -58,7 +58,7 @@ internal class TestDocumentManager : TrackingLSPDocumentManager
             return;
         }
 
-        using var virtualDocument = new CSharpVirtualDocument(projectKey: default, virtualDocumentSnapshot.Uri, virtualDocumentSnapshot.Snapshot.TextBuffer);
+        using var virtualDocument = new CSharpVirtualDocument(projectKey: default, virtualDocumentSnapshot.Uri, virtualDocumentSnapshot.Snapshot.TextBuffer, telemetryReporter: null);
         virtualDocument.Update(changes, hostDocumentVersion, state);
         _documents[hostDocumentUri] = new TestLSPDocumentSnapshot(hostDocumentUri, documentSnapshot.Version, new[] { virtualDocument.CurrentSnapshot });
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/9148

This also should prevent users from noticing, and the system from getting into a bad state, some of the time.