### PR TITLE
Remove SupportsDelegatedCodeActions option

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorDiagnosticsBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorDiagnosticsBenchmark.cs
@@ -107,7 +107,6 @@ public class RazorDiagnosticsBenchmark : RazorLanguageServerBenchmarkBase
     {
         return Mock.Of<LanguageServerFeatureOptions>(options =>
             options.SupportsFileManipulation == true &&
-            options.SupportsDelegatedCodeActions == true &&
             options.SingleServerSupport == true &&
             options.SingleServerCompletionSupport == true &&
             options.CSharpVirtualDocumentSuffix == ".ide.g.cs" &&

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
@@ -92,11 +92,7 @@ internal sealed class CodeActionEndpoint : IRazorRequestHandler<VSCodeActionPara
 
         cancellationToken.ThrowIfCancellationRequested();
 
-        // HTML code actions aren't currently supported in VS Code:
-        // https://github.com/dotnet/razor/issues/8062
-        var delegatedCodeActions = _languageServerFeatureOptions.SupportsDelegatedCodeActions
-            ? await GetDelegatedCodeActionsAsync(documentContext, razorCodeActionContext, correlationId, requestContext.Logger, cancellationToken).ConfigureAwait(false)
-            : ImmutableArray.Create<RazorVSInternalCodeAction>();
+        var delegatedCodeActions = await GetDelegatedCodeActionsAsync(documentContext, razorCodeActionContext, correlationId, requestContext.Logger, cancellationToken).ConfigureAwait(false);
 
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ConfigurableLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ConfigurableLanguageServerFeatureOptions.cs
@@ -16,7 +16,6 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
     private readonly string? _htmlVirtualDocumentSuffix;
     private readonly bool? _singleServerCompletionSupport;
     private readonly bool? _singleServerSupport;
-    private readonly bool? _supportsDelegatedCodeActions;
     private readonly bool? _delegateToCSharpOnDiagnosticPublish;
     private readonly bool? _returnCodeActionAndRenamePathsWithPrefixedSlash;
     private readonly bool? _showAllCSharpCodeActions;
@@ -29,7 +28,6 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
     public override string HtmlVirtualDocumentSuffix => _htmlVirtualDocumentSuffix ?? DefaultLanguageServerFeatureOptions.DefaultHtmlVirtualDocumentSuffix;
     public override bool SingleServerCompletionSupport => _singleServerCompletionSupport ?? _defaults.SingleServerCompletionSupport;
     public override bool SingleServerSupport => _singleServerSupport ?? _defaults.SingleServerSupport;
-    public override bool SupportsDelegatedCodeActions => _supportsDelegatedCodeActions ?? _defaults.SupportsDelegatedCodeActions;
     public override bool DelegateToCSharpOnDiagnosticPublish => _delegateToCSharpOnDiagnosticPublish ?? _defaults.DelegateToCSharpOnDiagnosticPublish;
     public override bool ReturnCodeActionAndRenamePathsWithPrefixedSlash => _returnCodeActionAndRenamePathsWithPrefixedSlash ?? _defaults.ReturnCodeActionAndRenamePathsWithPrefixedSlash;
     public override bool ShowAllCSharpCodeActions => _showAllCSharpCodeActions ?? _defaults.ShowAllCSharpCodeActions;
@@ -51,7 +49,6 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
             TryProcessStringOption(nameof(HtmlVirtualDocumentSuffix), ref _htmlVirtualDocumentSuffix, option, args, i);
             TryProcessBoolOption(nameof(SingleServerCompletionSupport), ref _singleServerCompletionSupport, option, args, i);
             TryProcessBoolOption(nameof(SingleServerSupport), ref _singleServerSupport, option, args, i);
-            TryProcessBoolOption(nameof(SupportsDelegatedCodeActions), ref _supportsDelegatedCodeActions, option, args, i);
             TryProcessBoolOption(nameof(DelegateToCSharpOnDiagnosticPublish), ref _delegateToCSharpOnDiagnosticPublish, option, args, i);
             TryProcessBoolOption(nameof(ReturnCodeActionAndRenamePathsWithPrefixedSlash), ref _returnCodeActionAndRenamePathsWithPrefixedSlash, option, args, i);
             TryProcessBoolOption(nameof(ShowAllCSharpCodeActions), ref _showAllCSharpCodeActions, option, args, i);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
@@ -24,8 +24,6 @@ internal class DefaultLanguageServerFeatureOptions : LanguageServerFeatureOption
 
     public override bool SingleServerSupport => false;
 
-    public override bool SupportsDelegatedCodeActions => false;
-
     public override bool DelegateToCSharpOnDiagnosticPublish => false;
 
     public override bool UpdateBuffersForClosedDocuments => false;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
@@ -17,8 +17,6 @@ internal abstract class LanguageServerFeatureOptions
 
     public abstract bool SingleServerSupport { get; }
 
-    public abstract bool SupportsDelegatedCodeActions { get; }
-
     public abstract bool DelegateToCSharpOnDiagnosticPublish { get; }
 
     public abstract bool ShowAllCSharpCodeActions { get; }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
@@ -58,8 +58,6 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
 
     public override bool SingleServerSupport => true;
 
-    public override bool SupportsDelegatedCodeActions => true;
-
     public override bool DelegateToCSharpOnDiagnosticPublish => false;
 
     public override bool ReturnCodeActionAndRenamePathsWithPrefixedSlash => false;

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacLanguageServerFeatureOptions.cs
@@ -37,8 +37,6 @@ internal class VisualStudioMacLanguageServerFeatureOptions : LanguageServerFeatu
 
     public override bool SingleServerSupport => true;
 
-    public override bool SupportsDelegatedCodeActions => true;
-
     public override bool DelegateToCSharpOnDiagnosticPublish => false;
 
     public override bool ShowAllCSharpCodeActions => false;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
@@ -41,7 +41,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             MockBehavior.Strict);
 
         _languageServerFeatureOptions = Mock.Of<LanguageServerFeatureOptions>(
-            l => l.SupportsFileManipulation == true && l.SupportsDelegatedCodeActions == true,
+            l => l.SupportsFileManipulation == true,
             MockBehavior.Strict);
 
         _languageServer = Mock.Of<ClientNotifierServiceBase>(MockBehavior.Strict);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ConfigurableLanguageServerFeatureOptionsTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ConfigurableLanguageServerFeatureOptionsTest.cs
@@ -2,11 +2,6 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
@@ -26,7 +21,6 @@ public class ConfigurableLanguageServerFeatureOptionsTest
         Assert.Equal(expected.HtmlVirtualDocumentSuffix, actual.HtmlVirtualDocumentSuffix);
         Assert.Equal(expected.SingleServerCompletionSupport, actual.SingleServerCompletionSupport);
         Assert.Equal(expected.SingleServerSupport, actual.SingleServerSupport);
-        Assert.Equal(expected.SupportsDelegatedCodeActions, actual.SupportsDelegatedCodeActions);
         Assert.Equal(expected.ReturnCodeActionAndRenamePathsWithPrefixedSlash, actual.ReturnCodeActionAndRenamePathsWithPrefixedSlash);
     }
 
@@ -47,7 +41,6 @@ public class ConfigurableLanguageServerFeatureOptionsTest
         Assert.Equal(expected.HtmlVirtualDocumentSuffix, actual.HtmlVirtualDocumentSuffix);
         Assert.Equal(expected.SingleServerCompletionSupport, actual.SingleServerCompletionSupport);
         Assert.Equal(expected.SingleServerSupport, actual.SingleServerSupport);
-        Assert.Equal(expected.SupportsDelegatedCodeActions, actual.SupportsDelegatedCodeActions);
         Assert.Equal(expected.ReturnCodeActionAndRenamePathsWithPrefixedSlash, actual.ReturnCodeActionAndRenamePathsWithPrefixedSlash);
     }
 
@@ -68,7 +61,6 @@ public class ConfigurableLanguageServerFeatureOptionsTest
         Assert.Equal(expected.HtmlVirtualDocumentSuffix, actual.HtmlVirtualDocumentSuffix);
         Assert.Equal(expected.SingleServerCompletionSupport, actual.SingleServerCompletionSupport);
         Assert.Equal(expected.SingleServerSupport, actual.SingleServerSupport);
-        Assert.Equal(expected.SupportsDelegatedCodeActions, actual.SupportsDelegatedCodeActions);
         Assert.Equal(expected.ReturnCodeActionAndRenamePathsWithPrefixedSlash, actual.ReturnCodeActionAndRenamePathsWithPrefixedSlash);
     }
 
@@ -90,7 +82,6 @@ public class ConfigurableLanguageServerFeatureOptionsTest
         Assert.Equal(expected.CSharpVirtualDocumentSuffix, actual.CSharpVirtualDocumentSuffix);
         Assert.Equal(expected.HtmlVirtualDocumentSuffix, actual.HtmlVirtualDocumentSuffix);
         Assert.Equal(expected.SingleServerCompletionSupport, actual.SingleServerCompletionSupport);
-        Assert.Equal(expected.SupportsDelegatedCodeActions, actual.SupportsDelegatedCodeActions);
         Assert.Equal(expected.ReturnCodeActionAndRenamePathsWithPrefixedSlash, actual.ReturnCodeActionAndRenamePathsWithPrefixedSlash);
     }
 
@@ -112,7 +103,6 @@ public class ConfigurableLanguageServerFeatureOptionsTest
         Assert.Equal(expected.CSharpVirtualDocumentSuffix, actual.CSharpVirtualDocumentSuffix);
         Assert.Equal(expected.HtmlVirtualDocumentSuffix, actual.HtmlVirtualDocumentSuffix);
         Assert.Equal(expected.SingleServerCompletionSupport, actual.SingleServerCompletionSupport);
-        Assert.Equal(expected.SupportsDelegatedCodeActions, actual.SupportsDelegatedCodeActions);
         Assert.Equal(expected.ReturnCodeActionAndRenamePathsWithPrefixedSlash, actual.ReturnCodeActionAndRenamePathsWithPrefixedSlash);
     }
 
@@ -134,7 +124,6 @@ public class ConfigurableLanguageServerFeatureOptionsTest
         Assert.Equal(expected.CSharpVirtualDocumentSuffix, actual.CSharpVirtualDocumentSuffix);
         Assert.Equal(expected.HtmlVirtualDocumentSuffix, actual.HtmlVirtualDocumentSuffix);
         Assert.Equal(expected.SingleServerCompletionSupport, actual.SingleServerCompletionSupport);
-        Assert.Equal(expected.SupportsDelegatedCodeActions, actual.SupportsDelegatedCodeActions);
         Assert.Equal(expected.ReturnCodeActionAndRenamePathsWithPrefixedSlash, actual.ReturnCodeActionAndRenamePathsWithPrefixedSlash);
     }
 
@@ -156,7 +145,6 @@ public class ConfigurableLanguageServerFeatureOptionsTest
         Assert.Equal(expected.HtmlVirtualDocumentSuffix, actual.HtmlVirtualDocumentSuffix);
         Assert.Equal(expected.SingleServerCompletionSupport, actual.SingleServerCompletionSupport);
         Assert.Equal(expected.SingleServerSupport, actual.SingleServerSupport);
-        Assert.Equal(expected.SupportsDelegatedCodeActions, actual.SupportsDelegatedCodeActions);
         Assert.Equal(expected.ReturnCodeActionAndRenamePathsWithPrefixedSlash, actual.ReturnCodeActionAndRenamePathsWithPrefixedSlash);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SingleServerDelegatingEndpointTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SingleServerDelegatingEndpointTestBase.cs
@@ -86,7 +86,6 @@ public abstract class SingleServerDelegatingEndpointTestBase : LanguageServerTes
         DocumentContextFactory = new TestDocumentContextFactory(razorFilePath, codeDocument, version: 1337);
         LanguageServerFeatureOptions = Mock.Of<LanguageServerFeatureOptions>(options =>
             options.SupportsFileManipulation == true &&
-            options.SupportsDelegatedCodeActions == true &&
             options.SingleServerSupport == true &&
             options.CSharpVirtualDocumentSuffix == DefaultLanguageServerFeatureOptions.DefaultCSharpVirtualDocumentSuffix &&
             options.HtmlVirtualDocumentSuffix == DefaultLanguageServerFeatureOptions.DefaultHtmlVirtualDocumentSuffix,

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common/TestLanguageServerFeatureOptions.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common/TestLanguageServerFeatureOptions.cs
@@ -29,8 +29,6 @@ internal class TestLanguageServerFeatureOptions : LanguageServerFeatureOptions
 
     public override bool SingleServerSupport => false;
 
-    public override bool SupportsDelegatedCodeActions => false;
-
     public override bool DelegateToCSharpOnDiagnosticPublish => true;
 
     public override bool ReturnCodeActionAndRenamePathsWithPrefixedSlash => false;


### PR DESCRIPTION
OmniSharp was the only thing that didn't set it to false.