### PR TITLE
Don't add a semicolon to using statements when we insert them

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/AddUsingsCodeActionProviderHelper.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/AddUsingsCodeActionProviderHelper.cs
@@ -60,10 +60,11 @@ internal static class AddUsingsCodeActionProviderHelper
         var usings = syntaxRoot.DescendantNodes(n => n is BaseNamespaceDeclarationSyntax or CompilationUnitSyntax)
             // Filter to using directives
             .OfType<UsingDirectiveSyntax>()
-            // Select everything after the initial "using " part of the statement. This is slightly lazy, for sure, but has
+            // Select everything after the initial "using " part of the statement, and excluding the ending semi-colon. The
+            // semi-colon is valid in Razor, but users find it surprising. This is slightly lazy, for sure, but has
             // the advantage of us not caring about changes to C# syntax, we just grab whatever Roslyn wanted to put in, so
             // we should still work in C# v26
-            .Select(u => u.ToString()["using ".Length..]);
+            .Select(u => u.ToString()["using ".Length..^1]);
 
         return usings;
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeActionFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeActionFormattingTest.cs
@@ -38,7 +38,7 @@ Edit(72, 5, 72, 5, "\r\n            private string GetDebuggerDisplay()\r\n     
 Edit(73, 0, 73, 0, "                return ToString();\r\n            }\r\n"),
 Edit(73, 8, 74, 4, "")
 },
-expected: @"@using System.Diagnostics;
+expected: @"@using System.Diagnostics
 
 @functions {
     [DebuggerDisplay($""{{{nameof(GetDebuggerDisplay)}(),nq}}"")]  

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/CSharpCodeActionsTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/CSharpCodeActionsTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests;
 
 public class CSharpCodeActionsTests(ITestOutputHelper testOutputHelper) : AbstractRazorEditorTest(testOutputHelper)
 {
-    [IdeFact(Skip = "https://github.com/dotnet/razor/issues/8409")]
+    [IdeFact]
     public async Task CSharpCodeActionsTests_MakeExpressionBodiedMethod()
     {
         // Open the file
@@ -88,7 +88,7 @@ public class CSharpCodeActionsTests(ITestOutputHelper testOutputHelper) : Abstra
         await TestServices.Editor.InvokeCodeActionAsync(codeAction, ControlledHangMitigatingCancellationToken);
 
         await TestServices.Editor.WaitForTextChangeAsync("""
-            @using System.Data;
+            @using System.Data
 
             @{
                 var x = ConflictOption.CompareAllSearchableValues;
@@ -124,7 +124,7 @@ public class CSharpCodeActionsTests(ITestOutputHelper testOutputHelper) : Abstra
         await TestServices.Editor.InvokeCodeActionAsync(codeAction, ControlledHangMitigatingCancellationToken);
 
         await TestServices.Editor.WaitForTextChangeAsync("""
-            @using System.Data;
+            @using System.Data
 
             @{
                 var x = ConflictOption.CompareAllSearchableValues;


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/9210
Also fixes #8409 because I was surprised it was skipped, and assume it was because of a Roslyn incompatibility. We'll see :)