### PR TITLE
Fix SolutionClosing_CancelsActiveWork

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectStateChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectStateChangeDetectorTest.cs
@@ -785,7 +785,7 @@ namespace Microsoft.AspNetCore.Components
         public TestProjectSnapshotManager(
             IEnumerable<IProjectSnapshotChangeTrigger> triggers,
             Workspace workspace)
-            : base(Mock.Of<IErrorReporter>(MockBehavior.Strict), triggers, workspace, new TestProjectSnapshotManagerDispatcher())
+            : base(Mock.Of<IErrorReporter>(MockBehavior.Strict), triggers, workspace, s_dispatcher)
         {
         }
     }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/VsSolutionUpdatesProjectSnapshotChangeTriggerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/VsSolutionUpdatesProjectSnapshotChangeTriggerTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor;
 
 public class VsSolutionUpdatesProjectSnapshotChangeTriggerTest : TestBase
 {
-    private static readonly ProjectSnapshotManagerDispatcher s_dispatcher = new TestProjectSnapshotManagerDispatcher();
+    private static readonly ProjectSnapshotManagerDispatcher s_dispatcher = new TestDispatcher();
 
     private readonly HostProject _someProject;
     private readonly HostProject _someOtherProject;
@@ -264,5 +264,12 @@ public class VsSolutionUpdatesProjectSnapshotChangeTriggerTest : TestBase
         {
             return null;
         }
+    }
+
+    private class TestDispatcher : ProjectSnapshotManagerDispatcher
+    {
+        public override bool IsDispatcherThread => true;
+
+        public override TaskScheduler DispatcherScheduler => TaskScheduler.Default;
     }
 }


### PR DESCRIPTION
SolutionClosing_CancelsActiveWork was failing because the test dispatcher does not work correctly even with RunOnDispatcherThread async. It would cause the test to try to complete before change notifications required to mutate state.

The fix is to use a dispatcher that just always reports it is on the correct thread. This can be removed in the future when a better fix around change notifications comes in so we can remove thread asserts.