### PR TITLE
Improve logging of semantic tokens responses, so things don't look broken

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentMappingService.cs
@@ -799,7 +799,7 @@ internal sealed class RazorDocumentMappingService : IRazorDocumentMappingService
         {
             s_haveAsserted = true;
             var sourceTextLinesCount = sourceText.Lines.Count;
-            _logger.LogWarning("Attempted to map a range {range} outside of the Source (line count {sourceTextLinesCount}.) This could happen if the Roslyn and Razor LSP servers are not in sync.", range, sourceTextLinesCount);
+            _logger.LogWarning("Attempted to map a range ({startLine},{startChar})-({endLine},{endChar}) outside of the Source (line count {sourceTextLinesCount}.) This could happen if the Roslyn and Razor LSP servers are not in sync.", range.Start.Line, range.Start.Character, range.End.Line, range.End.Character, sourceTextLinesCount);
         }
 
         return result;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Models/ProvideSemanticTokensResponse.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Models/ProvideSemanticTokensResponse.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
 /// </summary>
 internal class ProvideSemanticTokensResponse
 {
-    public ProvideSemanticTokensResponse(int[]? tokens, long? hostDocumentSyncVersion)
+    public ProvideSemanticTokensResponse(int[]? tokens, long hostDocumentSyncVersion)
     {
         Tokens = tokens;
         HostDocumentSyncVersion = hostDocumentSyncVersion;
@@ -19,7 +19,7 @@ internal class ProvideSemanticTokensResponse
 
     public int[]? Tokens { get; }
 
-    public long? HostDocumentSyncVersion { get; }
+    public long HostDocumentSyncVersion { get; }
 
     public override bool Equals(object? obj)
     {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Endpoints/SemanticTokens.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Endpoints/SemanticTokens.cs
@@ -41,7 +41,7 @@ internal partial class RazorCustomMessageTarget
         {
             // If we're unable to synchronize we won't produce useful results, but we have to indicate
             // it's due to out of sync by providing the old version
-            return new ProvideSemanticTokensResponse(tokens: null, hostDocumentSyncVersion: -1);
+            return new ProvideSemanticTokensResponse(tokens: null, hostDocumentSyncVersion: csharpDoc.HostDocumentSyncVersion ?? -1);
         }
 
         semanticTokensParams.TextDocument.Uri = csharpDoc.Uri;
@@ -70,7 +70,7 @@ internal partial class RazorCustomMessageTarget
         if (result is null)
         {
             // Weren't able to re-invoke C# semantic tokens but we have to indicate it's due to out of sync by providing the old version
-            return new ProvideSemanticTokensResponse(tokens: null, hostDocumentSyncVersion: csharpDoc.HostDocumentSyncVersion);
+            return new ProvideSemanticTokensResponse(tokens: null, hostDocumentSyncVersion: csharpDoc.HostDocumentSyncVersion ?? -1);
         }
 
         var response = new ProvideSemanticTokensResponse(result.Data, semanticTokensParams.RequiredHostDocumentVersion);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorCustomMessageTarget.cs
@@ -169,7 +169,7 @@ internal partial class RazorCustomMessageTarget
        TextDocumentIdentifier hostDocument,
        CancellationToken cancellationToken,
        bool rejectOnNewerParallelRequest = true,
-       [CallerMemberName]string? caller = null)
+       [CallerMemberName] string? caller = null)
        where TVirtualDocumentSnapshot : VirtualDocumentSnapshot
     {
         // For Html documents we don't do anything fancy, just call the standard service
@@ -205,6 +205,7 @@ internal partial class RazorCustomMessageTarget
         }
 
         var result = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<TVirtualDocumentSnapshot>(requiredHostDocumentVersion, hostDocument.Uri, virtualDocument.Uri, rejectOnNewerParallelRequest, cancellationToken).ConfigureAwait(false);
+        _logger?.LogDebug("{result} synchronize for {caller}: Version {version} for {document}", result.Synchronized ? "Did" : "Did NOT", caller, requiredHostDocumentVersion, result.VirtualSnapshot.Uri);
 
         // If we failed to sync on version 1, then it could be that we got new information while waiting, so try again
         if (requiredHostDocumentVersion == 1 && !result.Synchronized)
@@ -222,6 +223,7 @@ internal partial class RazorCustomMessageTarget
 
             // try again
             result = await _documentSynchronizer.TrySynchronizeVirtualDocumentAsync<TVirtualDocumentSnapshot>(requiredHostDocumentVersion, hostDocument.Uri, virtualDocument.Uri, rejectOnNewerParallelRequest, cancellationToken).ConfigureAwait(false);
+            _logger?.LogDebug("{result} synchronize for {caller}: Version {version} for {document}", result.Synchronized ? "Did" : "Did NOT", caller, requiredHostDocumentVersion, result.VirtualSnapshot.Uri);
         }
 
         return result;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/RazorSemanticTokenInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/RazorSemanticTokenInfoServiceTest.cs
@@ -85,7 +85,7 @@ public class RazorSemanticTokenInfoServiceTest : SemanticTokenTestBase
                 """;
 
         var razorRange = GetRange(documentText);
-        var csharpTokens = new ProvideSemanticTokensResponse(tokens: Array.Empty<int>(), hostDocumentSyncVersion: null);
+        var csharpTokens = new ProvideSemanticTokensResponse(tokens: Array.Empty<int>(), hostDocumentSyncVersion: 1);
         await AssertSemanticTokensAsync(documentText, isRazorFile: false, razorRange, csharpTokens: csharpTokens, documentVersion: 1);
     }
 
@@ -825,7 +825,7 @@ public class RazorSemanticTokenInfoServiceTest : SemanticTokenTestBase
         // Arrange
         if (csharpTokens is null)
         {
-            csharpTokens = new ProvideSemanticTokensResponse(tokens: null, csharpTokens?.HostDocumentSyncVersion);
+            csharpTokens = new ProvideSemanticTokensResponse(tokens: null, -1);
         }
 
         var (documentContexts, textDocumentIdentifiers) = CreateDocumentContext(


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/9229

Part of me was really hoping the above issue was an actual bug, as it could have been a cause of some odd behaviour, but after digging in it turns out its just our logging making things look bad. What is actually happening is that everything is working just fine: While typing we get requests for semantic tokens for various versions, and when a request comes in (happens to be completion in this case) for a higher version, the old requests are cancelled because they are obviously no longer valid. For semantic tokens this was logging 3 warning messages and making things look bad.

After reviewing logs and debugging etc. its actually all fine, and we cancel those requests, but future ones come in, we update buffers fine, and wait appropriately for said buffers to be updated. There is probably an argument to be made that the client could cancel the old requests when typing happens, but its a non-mutating request so its not the end of the world that they don't.

This PR adds a little bit of info to our semantic tokens response, so we can dial down the logging from Warning to Debug in this specific scenario.