### PR TITLE
Remove LocateOwner in formatting

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPassBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPassBase.cs
@@ -540,26 +540,6 @@ internal abstract class CSharpFormattingPassBase : FormattingPassBase
         }
     }
 
-    private static SyntaxNode FixOwnerToWorkaroundCompilerQuirks(SyntaxNode owner)
-    {
-        // Workaround for https://github.com/dotnet/aspnetcore/issues/36689
-        // A tags owner comes back as itself if it is preceeded by a HTML comment,
-        // because the whitespace between the comment and the tag is reported as not editable
-
-        // Get to the outermost node first. eg in "<span" we might be on the node for the "<", which is parented
-        // by some other intermediate node, which is parented by the actual start tag node. We need to get out to
-        // the start tag node, in order to reason about its siblings. The siblings of the "<" are not helpful :)
-        var outerNode = owner.GetOutermostNode();
-        if (outerNode is not null &&
-            outerNode.TryGetPreviousSibling(out var whiteSpace) && whiteSpace.ContainsOnlyWhitespace() &&
-            whiteSpace.TryGetPreviousSibling(out var comment) && comment is MarkupCommentBlockSyntax)
-        {
-            return whiteSpace;
-        }
-
-        return owner;
-    }
-
     private class IndentationData
     {
         private readonly int _offset;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPassBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPassBase.cs
@@ -314,18 +314,9 @@ internal abstract class CSharpFormattingPassBase : FormattingPassBase
         var sourceText = context.SourceText;
         var absoluteIndex = mappingSpan.Start;
 
-        if (mappingSpan.Length > 0)
-        {
-            // Slightly ugly hack to get around the behavior of LocateOwner.
-            // In some cases, using the start of a mapping doesn't work well
-            // because LocateOwner returns the previous node due to it owning the edge.
-            // So, if we can try to find the owner using a position that fully belongs to the current mapping.
-            absoluteIndex = mappingSpan.Start + 1;
-        }
-
-        var change = new SourceChange(absoluteIndex, 0, string.Empty);
         var syntaxTree = context.CodeDocument.GetSyntaxTree();
-        var owner = syntaxTree.Root.LocateOwner(change);
+        var span = new Language.Syntax.TextSpan(mappingSpan.Start, mappingSpan.Length);
+        var owner = syntaxTree.Root.FindNode(span, getInnermostNodeForTie: true);
         if (owner is null)
         {
             // Can't determine owner of this position. Optimistically allow formatting.

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPassBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPassBase.cs
@@ -338,14 +338,42 @@ internal abstract class CSharpFormattingPassBase : FormattingPassBase
             return true;
         }
 
-        if (IsRazorComment() ||
-            IsInBoundComponentAttributeName() ||
-            IsInHtmlAttributeValue() ||
-            IsInDirectiveWithNoKind() ||
-            IsInSingleLineDirective() ||
-            IsImplicitExpression() ||
-            IsInSectionDirectiveCloseBrace() ||
-            (!allowImplicitStatements && IsImplicitStatementStart()))
+        if (IsRazorComment())
+        {
+            return false;
+        }
+
+        if (IsInBoundComponentAttributeName())
+        {
+            return false;
+        }
+
+        if (IsInHtmlAttributeValue())
+        {
+            return false;
+        }
+
+        if (IsInDirectiveWithNoKind())
+        {
+            return false;
+        }
+
+        if (IsInSingleLineDirective())
+        {
+            return false;
+        }
+
+        if (IsImplicitExpression())
+        {
+            return false;
+        }
+
+        if (IsInSectionDirectiveCloseBrace())
+        {
+            return false;
+        }
+
+        if (!allowImplicitStatements && IsImplicitStatementStart())
         {
             return false;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormattingPass.cs
@@ -224,8 +224,7 @@ internal class HtmlFormattingPass : FormattingPassBase
     private static bool IsPartOfHtmlTag(FormattingContext context, int position)
     {
         var syntaxTree = context.CodeDocument.GetSyntaxTree();
-        var change = new SourceChange(position, 0, string.Empty);
-        var owner = syntaxTree.Root.LocateOwner(change);
+        var owner = syntaxTree.Root.FindInnermostNode(position, includeWhitespace: true);
         if (owner is null)
         {
             // Can't determine owner of this position.

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormattingPass.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeEndpoint.cs
@@ -111,8 +111,7 @@ internal class LinkedEditingRangeEndpoint : IRazorRequestHandler<LinkedEditingRa
             [NotNullWhen(true)] out SyntaxToken? startTagNameToken,
             [NotNullWhen(true)] out SyntaxToken? endTagNameToken)
         {
-            var change = new SourceChange(location.AbsoluteIndex, length: 0, newText: "");
-            var owner = syntaxTree.Root.LocateOwner(change);
+            var owner = syntaxTree.Root.FindInnermostNode(location.AbsoluteIndex);
             var element = owner?.FirstAncestorOrSelf<MarkupSyntaxNode>(
                 a => a.Kind is SyntaxKind.MarkupTagHelperElement || a.Kind is SyntaxKind.MarkupElement);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeEndpoint.cs
@@ -6,7 +6,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Formatting/TestFiles/Expected/FormatSelection.cshtml
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Formatting/TestFiles/Expected/FormatSelection.cshtml
@@ -12,7 +12,7 @@
             <div class="navbar-collapse collapse">
                 <ul class="nav ">
                     <li>@Html.ActionLink("Home", "Index", "Home")</li>
-                    <li>@Html.ActionLink( "About", "About", "Home")</li>
+                    <li>@Html.ActionLink("About", "About", "Home")</li>
                     <li>@Html.ActionLink("Contact", "Contact", "Home")</li>
                 </ul>
             </div>


### PR DESCRIPTION
Also in linked ranges, because no fixes were needed (at least according to tests?)