### PR TITLE
Request options from the client when the server starts

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultClientNotifierService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultClientNotifierService.cs
@@ -31,8 +31,7 @@ internal class DefaultClientNotifierService : ClientNotifierServiceBase
     public override async Task<TResponse> SendRequestAsync<TParams, TResponse>(string method, TParams @params, CancellationToken cancellationToken)
     {
         await _initializedCompletionSource.Task.ConfigureAwait(false);
-        var arguments = new object[] { @params! };
-        var result = await _jsonRpc.InvokeWithCancellationAsync<TResponse>(method, arguments, cancellationToken).ConfigureAwait(false);
+        var result = await _jsonRpc.InvokeWithParameterObjectAsync<TResponse>(method, @params, cancellationToken).ConfigureAwait(false);
 
         return result;
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorConfigurationEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorConfigurationEndpoint.cs
@@ -9,7 +9,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
-internal class RazorConfigurationEndpoint : IDidChangeConfigurationEndpoint
+internal class RazorConfigurationEndpoint : IDidChangeConfigurationEndpoint, IOnInitialized
 {
     private readonly RazorLSPOptionsMonitor _optionsMonitor;
 
@@ -30,5 +30,13 @@ internal class RazorConfigurationEndpoint : IDidChangeConfigurationEndpoint
         requestContext.Logger.LogInformation("Settings changed. Updating the server.");
 
         await _optionsMonitor.UpdateAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task OnInitializedAsync(VSInternalClientCapabilities clientCapabilities, CancellationToken cancellationToken)
+    {
+        if (clientCapabilities.Workspace?.Configuration == true)
+        {
+            await _optionsMonitor.UpdateAsync(cancellationToken).ConfigureAwait(false);
+        }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -180,10 +180,15 @@ internal class RazorLanguageServer : AbstractLanguageServer<RazorRequestContext>
 
         static void AddHandlers(IServiceCollection services)
         {
+            // Not calling AddHandler because we want to register this endpoint as an IOnIntialized too
+            services.AddSingleton<RazorConfigurationEndpoint>();
+            services.AddSingleton<IMethodHandler, RazorConfigurationEndpoint>(s => s.GetRequiredService<RazorConfigurationEndpoint>());
+            // Transient because it should only be used once and I'm hoping it doesn't stick around.
+            services.AddTransient<IOnInitialized>(sp => sp.GetRequiredService<RazorConfigurationEndpoint>());
+
             services.AddHandlerWithCapabilities<ImplementationEndpoint>();
             services.AddHandlerWithCapabilities<SignatureHelpEndpoint>();
             services.AddHandlerWithCapabilities<DocumentHighlightEndpoint>();
-            services.AddHandler<RazorConfigurationEndpoint>();
             services.AddHandlerWithCapabilities<OnAutoInsertEndpoint>();
             services.AddHandler<MonitorProjectConfigurationFilePathEndpoint>();
             services.AddHandlerWithCapabilities<RenameEndpoint>();


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/9224 by honouring the `razor.format.enable` setting