### PR TITLE
Add test to validate existing behaviour

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
@@ -1670,6 +1670,58 @@ public class CodeDirectiveFormattingTest : FormattingTestBase
     }
 
     [Fact]
+    public async Task Formats_MultilineExpressions()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                    @{
+                        var icon = "/images/bootstrap-icons.svg#"
+                            + GetIconName(login.ProviderDisplayName!);
+
+                        var x = DateTime
+                                .Now
+                            .ToString();
+                    }
+
+                    @code
+                    {
+                        public void M()
+                        {
+                            var icon2 = "/images/bootstrap-icons.svg#"
+                                + GetIconName(login.ProviderDisplayName!);
+                    
+                            var x2 = DateTime
+                                    .Now
+                                .ToString();
+                        }
+                    }
+                    """,
+            expected: """
+                    @{
+                        var icon = "/images/bootstrap-icons.svg#"
+                            + GetIconName(login.ProviderDisplayName!);
+
+                        var x = DateTime
+                                .Now
+                            .ToString();
+                    }
+                    
+                    @code
+                    {
+                        public void M()
+                        {
+                            var icon2 = "/images/bootstrap-icons.svg#"
+                                + GetIconName(login.ProviderDisplayName!);
+                    
+                            var x2 = DateTime
+                                    .Now
+                                .ToString();
+                        }
+                    }
+                    """);
+    }
+
+    [Fact]
     public async Task Formats_MultilineExpressionAtStartOfBlock()
     {
         await RunFormattingTestAsync(


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/8964

Couldn't repro this one, so added a test to verify continued non-reproing. The issue is pretty light on context so it could be we have some edge case where these constructs don't work, in which case this will be helpful to ensure we don't fix one thing and break another.