### PR TITLE
Be opinionated about the formatting of section blocks

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingPass.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.Extensions.Logging;
@@ -90,12 +91,76 @@ internal class RazorFormattingPass : FormattingPassBase
         return edits;
     }
 
-    private static bool TryFormatBlocks(FormattingContext context, IList<TextEdit> edits, RazorSourceDocument source, SyntaxNode node)
+    private static void TryFormatBlocks(FormattingContext context, List<TextEdit> edits, RazorSourceDocument source, SyntaxNode node)
     {
-        return TryFormatFunctionsBlock(context, edits, source, node) ||
+        // We only want to run one of these
+        _ = TryFormatFunctionsBlock(context, edits, source, node) ||
             TryFormatCSharpExplicitTransition(context, edits, source, node) ||
             TryFormatHtmlInCSharp(context, edits, source, node) ||
-            TryFormatComplexCSharpBlock(context, edits, source, node);
+            TryFormatComplexCSharpBlock(context, edits, source, node) ||
+            TryFormatSectionBlock(context, edits, source, node);
+    }
+
+    private static bool TryFormatSectionBlock(FormattingContext context, List<TextEdit> edits, RazorSourceDocument source, SyntaxNode node)
+    {
+        // @section Goo {
+        // }
+        //
+        // or
+        //
+        // @section Goo
+        // {
+        // }
+        if (node is CSharpCodeBlockSyntax directiveCode &&
+            directiveCode.Children is [RazorDirectiveSyntax directive] &&
+            directive.DirectiveDescriptor?.Directive == SectionDirective.Directive.Directive &&
+            directive.Body is RazorDirectiveBodySyntax { CSharpCode: { } code })
+        {
+            var children = code.Children;
+            if (TryGetWhitespace(children, out var whitespaceBeforeSectionName, out var whitespaceAfterSectionName))
+            {
+                // For whitespace we normalize it differently depending on if its multi-line or not
+                FormatWhitespaceBetweenDirectiveAndBrace(whitespaceBeforeSectionName, directive, edits, source, context);
+                FormatWhitespaceBetweenDirectiveAndBrace(whitespaceAfterSectionName, directive, edits, source, context);
+
+                return true;
+            }
+            else if (children.TryGetOpenBraceToken(out var brace))
+            {
+                // If there is no whitespace at all we normalize to a single space
+                var start = brace.GetRange(source).Start;
+                var edit = new TextEdit
+                {
+                    Range = new Range { Start = start, End = start },
+                    NewText = " "
+                };
+                edits.Add(edit);
+
+                return true;
+            }
+        }
+
+        return false;
+
+        static bool TryGetWhitespace(SyntaxList<RazorSyntaxNode> children, [NotNullWhen(true)] out CSharpStatementLiteralSyntax? whitespaceBeforeSectionName, [NotNullWhen(true)] out UnclassifiedTextLiteralSyntax? whitespaceAfterSectionName)
+        {
+            // If there is whitespace between the directive and the section name, and the section name and the brace, they will be in the first child
+            // and third child of the 6 total children
+            whitespaceBeforeSectionName = null;
+            whitespaceAfterSectionName = null;
+            if (children.Count == 6 &&
+                children[0] is CSharpStatementLiteralSyntax before &&
+                before.ContainsOnlyWhitespace() &&
+                children[2] is UnclassifiedTextLiteralSyntax after &&
+                after.ContainsOnlyWhitespace())
+            {
+                whitespaceBeforeSectionName = before;
+                whitespaceAfterSectionName = after;
+
+            }
+
+            return whitespaceBeforeSectionName != null;
+        }
     }
 
     private static bool TryFormatFunctionsBlock(FormattingContext context, IList<TextEdit> edits, RazorSourceDocument source, SyntaxNode node)
@@ -140,8 +205,8 @@ internal class RazorFormattingPass : FormattingPassBase
         // @{
         //     var x = 1;
         // }
-        if (node is CSharpCodeBlockSyntax expliciteCode &&
-            expliciteCode.Children.FirstOrDefault() is CSharpStatementSyntax statement &&
+        if (node is CSharpCodeBlockSyntax explicitCode &&
+            explicitCode.Children.FirstOrDefault() is CSharpStatementSyntax statement &&
             statement.Body is CSharpStatementBodySyntax csharpStatementBody)
         {
             var openBraceNode = csharpStatementBody.OpenBrace;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/CodeDirectiveFormattingTest.cs
@@ -511,6 +511,52 @@ public class CodeDirectiveFormattingTest : FormattingTestBase
     }
 
     [Fact]
+    public async Task Format_SectionDirectiveBlock7()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                    @functions {
+                     public class Foo{
+                    void Method() {  }
+                        }
+                    }
+
+                    @section Scripts
+                    {
+                    <meta property="a" content="b">
+                    <meta property="a" content="b"/>
+                    <meta property="a" content="b">
+
+                    @if(true)
+                    {
+                    <p>this is a paragraph</p>
+                    }
+                    }
+                    """,
+            expected: """
+                    @functions {
+                        public class Foo
+                        {
+                            void Method() { }
+                        }
+                    }
+
+                    @section Scripts
+                    {
+                        <meta property="a" content="b">
+                        <meta property="a" content="b" />
+                        <meta property="a" content="b">
+
+                        @if (true)
+                        {
+                            <p>this is a paragraph</p>
+                        }
+                    }
+                    """,
+            fileKind: FileKinds.Legacy);
+    }
+
+    [Fact]
     public async Task Formats_CodeBlockDirectiveWithRazorComments()
     {
         await RunFormattingTestAsync(

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingTest.cs
@@ -19,6 +19,42 @@ public class RazorFormattingTest : FormattingTestBase
     }
 
     [Fact]
+    public async Task Section_BraceOnNextLine()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                    @section    Scripts
+                        {
+                    <meta property="a" content="b">
+                    }
+                    """,
+            expected: """
+                    @section Scripts
+                    {
+                        <meta property="a" content="b">
+                    }
+                    """,
+            fileKind: FileKinds.Legacy);
+    }
+
+    [Fact]
+    public async Task Section_BraceOnSameLine()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                    @section        Scripts                         {
+                    <meta property="a" content="b">
+                    }
+                    """,
+            expected: """
+                    @section Scripts {
+                        <meta property="a" content="b">
+                    }
+                    """,
+            fileKind: FileKinds.Legacy);
+    }
+
+    [Fact]
     public async Task CodeBlock_SpansMultipleLines()
     {
         await RunFormattingTestAsync(


### PR DESCRIPTION
While investigating https://github.com/dotnet/razor/issues/7038#issuecomment-1411578609 I noticed the open brace of the section moving, and could repro that bit at least, so this is a partial fix for the bugs seen in that video.