### PR TITLE
Keep whitespace in extract to code behind

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
@@ -184,8 +184,8 @@ internal sealed class ExtractToCodeBehindCodeActionResolver : IRazorCodeActionRe
         using var _ = StringBuilderPool.GetPooledObject(out var builder);
 
         var usingDirectives = razorCodeDocument
-                    .GetDocumentIntermediateNode()
-                    .FindDescendantNodes<UsingDirectiveIntermediateNode>();
+            .GetDocumentIntermediateNode()
+            .FindDescendantNodes<UsingDirectiveIntermediateNode>();
         foreach (var usingDirective in usingDirectives)
         {
             builder.Append("using ");

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
@@ -181,7 +181,16 @@ internal sealed class ExtractToCodeBehindCodeActionResolver : IRazorCodeActionRe
         return razorCodeDocument
             .GetDocumentIntermediateNode()
             .FindDescendantNodes<UsingDirectiveIntermediateNode>()
-            .Select(n => n.Content);
+            .Select(n =>
+            {
+                var content = n.Content;
+                if (content.StartsWith("global::", StringComparison.Ordinal))
+                {
+                    return content.Substring(8);
+                }
+
+                return content;
+            });
     }
 
     /// <summary>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
@@ -205,9 +205,8 @@ internal sealed class ExtractToCodeBehindCodeActionResolver : IRazorCodeActionRe
         builder.AppendLine(namespaceName);
         builder.Append('{');
         builder.AppendLine();
-        builder.Append("    public partial class ");
+        builder.Append("public partial class ");
         builder.AppendLine(className);
-        builder.Append("    ");
         builder.AppendLine(contents);
         builder.Append('}');
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
@@ -59,7 +59,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
     {
         // Arrange
         var documentPath = new Uri("c:\\Test.razor");
-        var contents = $"@page \"/test\"{Environment.NewLine}@code {{ private var x = 1; }}";
+        var contents = $"@page \"/test\"{Environment.NewLine}@code {{ private int x = 1; }}";
         var codeDocument = CreateCodeDocument(contents);
         codeDocument.SetUnsupported();
 
@@ -78,7 +78,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
     {
         // Arrange
         var documentPath = new Uri("c:\\Test.razor");
-        var contents = $"@page \"/test\"{Environment.NewLine}@code {{ private var x = 1; }}";
+        var contents = $"@page \"/test\"{Environment.NewLine}@code {{ private int x = 1; }}";
         var codeDocument = CreateCodeDocument(contents);
         codeDocument.SetFileKind(FileKinds.Legacy);
 
@@ -101,7 +101,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
             @page "/test"
 
             @code {
-                private var x = 1;
+                private int x = 1;
             }
             """;
         var codeDocument = CreateCodeDocument(contents);
@@ -146,7 +146,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
             {
                 public partial class Test
                 {
-                    private var x = 1;
+                    private int x = 1;
                 }
             }
             """,
@@ -163,7 +163,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
 
             @code
             {
-                private var x = 1;
+                private int x = 1;
             }
             """;
         var codeDocument = CreateCodeDocument(contents);
@@ -208,7 +208,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
             {
                 public partial class Test
                 {
-                    private var x = 1;
+                    private int x = 1;
                 }
             }
             """,
@@ -465,7 +465,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
             @page "/test"
 
             @functions {
-                private var x = 1;
+                private int x = 1;
             }
             """; var codeDocument = CreateCodeDocument(contents);
         Assert.True(codeDocument.TryComputeNamespace(fallbackToRootNamespace: true, out var @namespace));
@@ -509,7 +509,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
             {
                 public partial class Test
                 {
-                    private var x = 1;
+                    private int x = 1;
                 }
             }
             """,
@@ -526,7 +526,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
             @using System.Diagnostics
 
             @code {
-                private var x = 1;
+                private int x = 1;
             }
             """;
         var codeDocument = CreateCodeDocument(contents);
@@ -572,7 +572,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
             {
                 public partial class Test
                 {
-                    private var x = 1;
+                    private int x = 1;
                 }
             }
             """,
@@ -589,7 +589,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
 
             @code {
             #region TestRegion 
-                    private var x = 1;
+                    private int x = 1;
             #endregion
             }
             """;
@@ -636,7 +636,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
                 public partial class Test
                 {
                     #region TestRegion 
-                    private var x = 1;
+                    private int x = 1;
                     #endregion
                 }
             }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
+using Microsoft.AspNetCore.Razor.LanguageServer.Test;
 using Microsoft.AspNetCore.Razor.LanguageServer.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis;
@@ -21,18 +22,21 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
 public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
 {
     private readonly DocumentContextFactory _emptyDocumentContextFactory;
+    private TestProjectSnapshotManagerAccessor _projectSnapshotManagerAccessor;
 
     public ExtractToCodeBehindCodeActionResolverTest(ITestOutputHelper testOutput)
         : base(testOutput)
     {
         _emptyDocumentContextFactory = new TestDocumentContextFactory();
+        var manager = TestProjectSnapshotManager.Create(ErrorReporter, Dispatcher);
+        _projectSnapshotManagerAccessor = new TestProjectSnapshotManagerAccessor(manager);
     }
 
     [Fact]
     public async Task Handle_MissingFile()
     {
         // Arrange
-        var resolver = new ExtractToCodeBehindCodeActionResolver(_emptyDocumentContextFactory, TestLanguageServerFeatureOptions.Instance);
+        var resolver = new ExtractToCodeBehindCodeActionResolver(_emptyDocumentContextFactory, TestLanguageServerFeatureOptions.Instance, _projectSnapshotManagerAccessor);
         var data = JObject.FromObject(new ExtractToCodeBehindCodeActionParams()
         {
             Uri = new Uri("c:/Test.razor"),
@@ -59,7 +63,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
         var codeDocument = CreateCodeDocument(contents);
         codeDocument.SetUnsupported();
 
-        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance);
+        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance, _projectSnapshotManagerAccessor);
         var data = JObject.FromObject(CreateExtractToCodeBehindCodeActionParams(new Uri("c:/Test.razor"), contents, "@code", "Test"));
 
         // Act
@@ -78,7 +82,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
         var codeDocument = CreateCodeDocument(contents);
         codeDocument.SetFileKind(FileKinds.Legacy);
 
-        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance);
+        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance, _projectSnapshotManagerAccessor);
         var data = JObject.FromObject(CreateExtractToCodeBehindCodeActionParams(new Uri("c:/Test.razor"), contents, "@code", "Test"));
 
         // Act
@@ -103,7 +107,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
         var codeDocument = CreateCodeDocument(contents);
         Assert.True(codeDocument.TryComputeNamespace(fallbackToRootNamespace: true, out var @namespace));
 
-        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance);
+        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance, _projectSnapshotManagerAccessor);
         var actionParams = CreateExtractToCodeBehindCodeActionParams(documentPath, contents, "@code", @namespace);
         var data = JObject.FromObject(actionParams);
 
@@ -165,7 +169,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
         var codeDocument = CreateCodeDocument(contents);
         Assert.True(codeDocument.TryComputeNamespace(fallbackToRootNamespace: true, out var @namespace));
 
-        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance);
+        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance, _projectSnapshotManagerAccessor);
         var actionParams = CreateExtractToCodeBehindCodeActionParams(documentPath, contents, "@code", @namespace);
         var data = JObject.FromObject(actionParams);
 
@@ -235,7 +239,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
         var codeDocument = CreateCodeDocument(contents);
         Assert.True(codeDocument.TryComputeNamespace(fallbackToRootNamespace: true, out var @namespace));
 
-        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance);
+        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance, _projectSnapshotManagerAccessor);
         var actionParams = CreateExtractToCodeBehindCodeActionParams(documentPath, contents, "@code", @namespace);
         var data = JObject.FromObject(actionParams);
 
@@ -276,11 +280,13 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
                 {
                     private int x = 1;
                     private int z = 2;
+
                     private string y = "hello";
+
                     // Here is a comment
                     private void M()
                     {
-                    // okay
+                        // okay
                     }
                 }
             }
@@ -313,7 +319,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
         var codeDocument = CreateCodeDocument(contents);
         Assert.True(codeDocument.TryComputeNamespace(fallbackToRootNamespace: true, out var @namespace));
 
-        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance);
+        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance, _projectSnapshotManagerAccessor);
         var actionParams = CreateExtractToCodeBehindCodeActionParams(documentPath, contents, "@code", @namespace);
         var data = JObject.FromObject(actionParams);
 
@@ -354,11 +360,13 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
                 {
                     private int x = 1;
                     private int z = 2;
+
                     private string y = "hello";
+
                     // Here is a comment
                     private void M()
                     {
-                    // okay
+                        // okay
                     }
                 }
             }
@@ -380,7 +388,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
             """; var codeDocument = CreateCodeDocument(contents);
         Assert.True(codeDocument.TryComputeNamespace(fallbackToRootNamespace: true, out var @namespace));
 
-        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance);
+        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance, _projectSnapshotManagerAccessor);
         var actionParams = CreateExtractToCodeBehindCodeActionParams(documentPath, contents, "@functions", @namespace);
         var data = JObject.FromObject(actionParams);
 
@@ -442,7 +450,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
         var codeDocument = CreateCodeDocument(contents);
         Assert.True(codeDocument.TryComputeNamespace(fallbackToRootNamespace: true, out var @namespace));
 
-        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance);
+        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance, _projectSnapshotManagerAccessor);
         var actionParams = CreateExtractToCodeBehindCodeActionParams(documentPath, contents, "@code", @namespace);
         var data = JObject.FromObject(actionParams);
 
@@ -506,7 +514,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
         var codeDocument = CreateCodeDocument(contents);
         Assert.True(codeDocument.TryComputeNamespace(fallbackToRootNamespace: true, out var @namespace));
 
-        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance);
+        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance, _projectSnapshotManagerAccessor);
         var actionParams = CreateExtractToCodeBehindCodeActionParams(documentPath, contents, "@code", @namespace);
         var data = JObject.FromObject(actionParams);
 
@@ -545,9 +553,9 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
             {
                 public partial class Test
                 {
-            #region TestRegion 
+                    #region TestRegion 
                     private var x = 1;
-            #endregion
+                    #endregion
                 }
             }
             """,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
@@ -93,6 +93,74 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
     }
 
     [Fact]
+    public async Task Handle_ExtractCodeBlock_Tabs()
+    {
+        // Arrange
+        var documentPath = new Uri("c:/Test.razor");
+        var contents = """
+            @page "/test"
+
+            @code {
+            	private int x = 1;
+            }
+            """;
+
+        var workspace = _projectSnapshotManagerAccessor.Instance.Workspace;
+        var newOptions = workspace.Options.WithChangedOption(CodeAnalysis.Formatting.FormattingOptions.TabSize, LanguageNames.CSharp, 4)
+                         .WithChangedOption(CodeAnalysis.Formatting.FormattingOptions.IndentationSize, LanguageNames.CSharp, 4)
+                         .WithChangedOption(CodeAnalysis.Formatting.FormattingOptions.UseTabs, LanguageNames.CSharp, true);
+        workspace.TryApplyChanges(workspace.CurrentSolution.WithOptions(newOptions));
+
+        var codeDocument = CreateCodeDocument(contents);
+        Assert.True(codeDocument.TryComputeNamespace(fallbackToRootNamespace: true, out var @namespace));
+
+        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance, _projectSnapshotManagerAccessor);
+        var actionParams = CreateExtractToCodeBehindCodeActionParams(documentPath, contents, "@code", @namespace);
+        var data = JObject.FromObject(actionParams);
+
+        // Act
+        var workspaceEdit = await resolver.ResolveAsync(data, default);
+
+        // Assert
+        Assert.NotNull(workspaceEdit);
+        Assert.NotNull(workspaceEdit!.DocumentChanges);
+        Assert.Equal(3, workspaceEdit.DocumentChanges!.Value.Count());
+
+        var documentChanges = workspaceEdit.DocumentChanges!.Value.ToArray();
+        var createFileChange = documentChanges[0];
+        Assert.True(createFileChange.TryGetSecond(out var _));
+
+        var editCodeDocumentChange = documentChanges[1];
+        Assert.True(editCodeDocumentChange.TryGetFirst(out var textDocumentEdit1));
+        var editCodeDocumentEdit = textDocumentEdit1!.Edits.First();
+        Assert.True(editCodeDocumentEdit.Range.Start.TryGetAbsoluteIndex(codeDocument.GetSourceText(), Logger, out var removeStart));
+        Assert.Equal(actionParams.RemoveStart, removeStart);
+        Assert.True(editCodeDocumentEdit.Range.End.TryGetAbsoluteIndex(codeDocument.GetSourceText(), Logger, out var removeEnd));
+        Assert.Equal(actionParams.RemoveEnd, removeEnd);
+
+        var editCodeBehindChange = documentChanges[2];
+        Assert.True(editCodeBehindChange.TryGetFirst(out var textDocumentEdit2));
+        var editCodeBehindEdit = textDocumentEdit2!.Edits.First();
+
+        AssertEx.EqualOrDiff("""
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+            using System.Threading.Tasks;
+            using Microsoft.AspNetCore.Components;
+            
+            namespace test.Pages
+            {
+            	public partial class Test
+            	{
+            		private int x = 1;
+            	}
+            }
+            """,
+            editCodeBehindEdit.NewText);
+    }
+
+    [Fact]
     public async Task Handle_ExtractCodeBlock()
     {
         // Arrange

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
@@ -132,11 +132,11 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
         var editCodeBehindEdit = textDocumentEdit2!.Edits.First();
 
         AssertEx.EqualOrDiff("""
-            using global::System;
-            using global::System.Collections.Generic;
-            using global::System.Linq;
-            using global::System.Threading.Tasks;
-            using global::Microsoft.AspNetCore.Components;
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+            using System.Threading.Tasks;
+            using Microsoft.AspNetCore.Components;
             
             namespace test.Pages
             {
@@ -194,11 +194,11 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
         var editCodeBehindEdit = textDocumentEdit2!.Edits.First();
 
         AssertEx.EqualOrDiff("""
-            using global::System;
-            using global::System.Collections.Generic;
-            using global::System.Linq;
-            using global::System.Threading.Tasks;
-            using global::Microsoft.AspNetCore.Components;
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+            using System.Threading.Tasks;
+            using Microsoft.AspNetCore.Components;
             
             namespace test.Pages
             {
@@ -264,11 +264,11 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
         var editCodeBehindEdit = textDocumentEdit2!.Edits.First();
 
         AssertEx.EqualOrDiff("""
-            using global::System;
-            using global::System.Collections.Generic;
-            using global::System.Linq;
-            using global::System.Threading.Tasks;
-            using global::Microsoft.AspNetCore.Components;
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+            using System.Threading.Tasks;
+            using Microsoft.AspNetCore.Components;
             
             namespace test.Pages
             {
@@ -342,11 +342,11 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
         var editCodeBehindEdit = textDocumentEdit2!.Edits.First();
 
         AssertEx.EqualOrDiff("""
-            using global::System;
-            using global::System.Collections.Generic;
-            using global::System.Linq;
-            using global::System.Threading.Tasks;
-            using global::Microsoft.AspNetCore.Components;
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+            using System.Threading.Tasks;
+            using Microsoft.AspNetCore.Components;
             
             namespace test.Pages
             {
@@ -409,11 +409,11 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
         var editCodeBehindEdit = editCodeBehind!.Edits.First();
 
         AssertEx.EqualOrDiff("""
-            using global::System;
-            using global::System.Collections.Generic;
-            using global::System.Linq;
-            using global::System.Threading.Tasks;
-            using global::Microsoft.AspNetCore.Components;
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+            using System.Threading.Tasks;
+            using Microsoft.AspNetCore.Components;
             
             namespace test.Pages
             {
@@ -471,11 +471,11 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
         var editCodeBehindEdit = editCodeBehind!.Edits.First();
 
         AssertEx.EqualOrDiff("""
-            using global::System;
-            using global::System.Collections.Generic;
-            using global::System.Linq;
-            using global::System.Threading.Tasks;
-            using global::Microsoft.AspNetCore.Components;
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+            using System.Threading.Tasks;
+            using Microsoft.AspNetCore.Components;
             using System.Diagnostics;
             
             namespace test.Pages
@@ -535,11 +535,11 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
         var editCodeBehindEdit = textDocumentEdit2!.Edits.First();
 
         AssertEx.EqualOrDiff("""
-            using global::System;
-            using global::System.Collections.Generic;
-            using global::System.Linq;
-            using global::System.Threading.Tasks;
-            using global::Microsoft.AspNetCore.Components;
+            using System;
+            using System.Collections.Generic;
+            using System.Linq;
+            using System.Threading.Tasks;
+            using Microsoft.AspNetCore.Components;
      
             namespace test.Pages
             {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
@@ -150,6 +150,223 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
     }
 
     [Fact]
+    public async Task Handle_ExtractCodeBlock2()
+    {
+        // Arrange
+        var documentPath = new Uri("c:/Test.razor");
+        var contents = """
+            @page "/test"
+
+            @code
+            {
+                private var x = 1;
+            }
+            """;
+        var codeDocument = CreateCodeDocument(contents);
+        Assert.True(codeDocument.TryComputeNamespace(fallbackToRootNamespace: true, out var @namespace));
+
+        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance);
+        var actionParams = CreateExtractToCodeBehindCodeActionParams(documentPath, contents, "@code", @namespace);
+        var data = JObject.FromObject(actionParams);
+
+        // Act
+        var workspaceEdit = await resolver.ResolveAsync(data, default);
+
+        // Assert
+        Assert.NotNull(workspaceEdit);
+        Assert.NotNull(workspaceEdit!.DocumentChanges);
+        Assert.Equal(3, workspaceEdit.DocumentChanges!.Value.Count());
+
+        var documentChanges = workspaceEdit.DocumentChanges!.Value.ToArray();
+        var createFileChange = documentChanges[0];
+        Assert.True(createFileChange.TryGetSecond(out var _));
+
+        var editCodeDocumentChange = documentChanges[1];
+        Assert.True(editCodeDocumentChange.TryGetFirst(out var textDocumentEdit1));
+        var editCodeDocumentEdit = textDocumentEdit1!.Edits.First();
+        Assert.True(editCodeDocumentEdit.Range.Start.TryGetAbsoluteIndex(codeDocument.GetSourceText(), Logger, out var removeStart));
+        Assert.Equal(actionParams.RemoveStart, removeStart);
+        Assert.True(editCodeDocumentEdit.Range.End.TryGetAbsoluteIndex(codeDocument.GetSourceText(), Logger, out var removeEnd));
+        Assert.Equal(actionParams.RemoveEnd, removeEnd);
+
+        var editCodeBehindChange = documentChanges[2];
+        Assert.True(editCodeBehindChange.TryGetFirst(out var textDocumentEdit2));
+        var editCodeBehindEdit = textDocumentEdit2!.Edits.First();
+
+        AssertEx.EqualOrDiff("""
+            using global::System;
+            using global::System.Collections.Generic;
+            using global::System.Linq;
+            using global::System.Threading.Tasks;
+            using global::Microsoft.AspNetCore.Components;
+            
+            namespace test.Pages
+            {
+                public partial class Test
+                {
+                    private var x = 1;
+                }
+            }
+            """,
+            editCodeBehindEdit.NewText);
+    }
+
+    [Fact]
+    public async Task Handle_ExtractCodeBlock_MultipleMembers()
+    {
+        // Arrange
+        var documentPath = new Uri("c:/Test.razor");
+        var contents = """
+            @page "/test"
+
+            @code {
+                private int x = 1;
+                private int z = 2;
+
+                private string y = "hello";
+
+                // Here is a comment
+                private void M()
+                {
+                    // okay
+                }
+            }
+            """;
+        var codeDocument = CreateCodeDocument(contents);
+        Assert.True(codeDocument.TryComputeNamespace(fallbackToRootNamespace: true, out var @namespace));
+
+        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance);
+        var actionParams = CreateExtractToCodeBehindCodeActionParams(documentPath, contents, "@code", @namespace);
+        var data = JObject.FromObject(actionParams);
+
+        // Act
+        var workspaceEdit = await resolver.ResolveAsync(data, default);
+
+        // Assert
+        Assert.NotNull(workspaceEdit);
+        Assert.NotNull(workspaceEdit!.DocumentChanges);
+        Assert.Equal(3, workspaceEdit.DocumentChanges!.Value.Count());
+
+        var documentChanges = workspaceEdit.DocumentChanges!.Value.ToArray();
+        var createFileChange = documentChanges[0];
+        Assert.True(createFileChange.TryGetSecond(out var _));
+
+        var editCodeDocumentChange = documentChanges[1];
+        Assert.True(editCodeDocumentChange.TryGetFirst(out var textDocumentEdit1));
+        var editCodeDocumentEdit = textDocumentEdit1!.Edits.First();
+        Assert.True(editCodeDocumentEdit.Range.Start.TryGetAbsoluteIndex(codeDocument.GetSourceText(), Logger, out var removeStart));
+        Assert.Equal(actionParams.RemoveStart, removeStart);
+        Assert.True(editCodeDocumentEdit.Range.End.TryGetAbsoluteIndex(codeDocument.GetSourceText(), Logger, out var removeEnd));
+        Assert.Equal(actionParams.RemoveEnd, removeEnd);
+
+        var editCodeBehindChange = documentChanges[2];
+        Assert.True(editCodeBehindChange.TryGetFirst(out var textDocumentEdit2));
+        var editCodeBehindEdit = textDocumentEdit2!.Edits.First();
+
+        AssertEx.EqualOrDiff("""
+            using global::System;
+            using global::System.Collections.Generic;
+            using global::System.Linq;
+            using global::System.Threading.Tasks;
+            using global::Microsoft.AspNetCore.Components;
+            
+            namespace test.Pages
+            {
+                public partial class Test
+                {
+                    private int x = 1;
+                    private int z = 2;
+                    private string y = "hello";
+                    // Here is a comment
+                    private void M()
+                    {
+                    // okay
+                    }
+                }
+            }
+            """,
+            editCodeBehindEdit.NewText);
+    }
+
+    [Fact]
+    public async Task Handle_ExtractCodeBlock_MultipleMembers2()
+    {
+        // Arrange
+        var documentPath = new Uri("c:/Test.razor");
+        var contents = """
+            @page "/test"
+
+            @code
+            {
+                private int x = 1;
+                private int z = 2;
+
+                private string y = "hello";
+
+                // Here is a comment
+                private void M()
+                {
+                    // okay
+                }
+            }
+            """;
+        var codeDocument = CreateCodeDocument(contents);
+        Assert.True(codeDocument.TryComputeNamespace(fallbackToRootNamespace: true, out var @namespace));
+
+        var resolver = new ExtractToCodeBehindCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance);
+        var actionParams = CreateExtractToCodeBehindCodeActionParams(documentPath, contents, "@code", @namespace);
+        var data = JObject.FromObject(actionParams);
+
+        // Act
+        var workspaceEdit = await resolver.ResolveAsync(data, default);
+
+        // Assert
+        Assert.NotNull(workspaceEdit);
+        Assert.NotNull(workspaceEdit!.DocumentChanges);
+        Assert.Equal(3, workspaceEdit.DocumentChanges!.Value.Count());
+
+        var documentChanges = workspaceEdit.DocumentChanges!.Value.ToArray();
+        var createFileChange = documentChanges[0];
+        Assert.True(createFileChange.TryGetSecond(out var _));
+
+        var editCodeDocumentChange = documentChanges[1];
+        Assert.True(editCodeDocumentChange.TryGetFirst(out var textDocumentEdit1));
+        var editCodeDocumentEdit = textDocumentEdit1!.Edits.First();
+        Assert.True(editCodeDocumentEdit.Range.Start.TryGetAbsoluteIndex(codeDocument.GetSourceText(), Logger, out var removeStart));
+        Assert.Equal(actionParams.RemoveStart, removeStart);
+        Assert.True(editCodeDocumentEdit.Range.End.TryGetAbsoluteIndex(codeDocument.GetSourceText(), Logger, out var removeEnd));
+        Assert.Equal(actionParams.RemoveEnd, removeEnd);
+
+        var editCodeBehindChange = documentChanges[2];
+        Assert.True(editCodeBehindChange.TryGetFirst(out var textDocumentEdit2));
+        var editCodeBehindEdit = textDocumentEdit2!.Edits.First();
+
+        AssertEx.EqualOrDiff("""
+            using global::System;
+            using global::System.Collections.Generic;
+            using global::System.Linq;
+            using global::System.Threading.Tasks;
+            using global::Microsoft.AspNetCore.Components;
+            
+            namespace test.Pages
+            {
+                public partial class Test
+                {
+                    private int x = 1;
+                    private int z = 2;
+                    private string y = "hello";
+                    // Here is a comment
+                    private void M()
+                    {
+                    // okay
+                    }
+                }
+            }
+            """,
+            editCodeBehindEdit.NewText);
+    }
+
+    [Fact]
     public async Task Handle_ExtractFunctionsBlock()
     {
         // Arrange
@@ -351,7 +568,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
     private static ExtractToCodeBehindCodeActionParams CreateExtractToCodeBehindCodeActionParams(Uri uri, string contents, string removeStart, string @namespace)
     {
         // + 1 to ensure we do not cut off the '}'.
-        var endIndex = contents.IndexOf("}", StringComparison.Ordinal) + 1;
+        var endIndex = contents.LastIndexOf("}", StringComparison.Ordinal) + 1;
         return new ExtractToCodeBehindCodeActionParams
         {
             Uri = uri,


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/8750

The main fix here is to not use NormalizeWhitespace, but the formatter instead, as the former clobbers too much of the users code. Commit-at-a-time is probably the way to go, to see how the test output changes (or doesn't 😛)