### PR TITLE
Rework PooledArrayBuilder<T> for small arrays

### DIFF
--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/EnumerableExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/EnumerableExtensions.cs
@@ -29,4 +29,28 @@ internal static class EnumerableExtensions
             return results.DrainToImmutable();
         }
     }
+
+    public static bool TryGetCount<T>(this IEnumerable<T> sequence, out int count)
+        => TryGetCount<T>((IEnumerable)sequence, out count);
+
+    public static bool TryGetCount<T>(this IEnumerable sequence, out int count)
+    {
+        switch (sequence)
+        {
+            case ICollection collection:
+                count = collection.Count;
+                return true;
+
+            case ICollection<T> collection:
+                count = collection.Count;
+                return true;
+
+            case IReadOnlyCollection<T> collection:
+                count = collection.Count;
+                return true;
+        }
+
+        count = 0;
+        return false;
+    }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledObjects/PooledArrayBuilder`1.Enumerator.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledObjects/PooledArrayBuilder`1.Enumerator.cs
@@ -1,51 +1,29 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System.Collections;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-
 namespace Microsoft.AspNetCore.Razor.PooledObjects;
 
-internal ref partial struct PooledArrayBuilder<T>
+internal partial struct PooledArrayBuilder<T>
 {
-    public struct Enumerator : IEnumerator<T>
+    public struct Enumerator(in PooledArrayBuilder<T> builder)
     {
-        private readonly ImmutableArray<T>.Builder? _builder;
-        private int _index;
-        private T? _current;
+        // Enumerate a copy of the original.
+        private readonly PooledArrayBuilder<T> _builder = new(builder);
+        private int _index = 0;
+        private T _current = default!;
 
-        public Enumerator(ImmutableArray<T>.Builder builder)
-        {
-            _builder = builder;
-            _index = 0;
-            _current = default;
-        }
-
-        public T Current => _current!;
-
-        object? IEnumerator.Current => Current;
-
-        public readonly void Dispose()
-        {
-        }
+        public readonly T Current => _current;
 
         public bool MoveNext()
         {
-            if (_builder is { } builder && _index < builder.Count)
+            if (_index >= _builder.Count)
             {
-                _current = builder[_index];
-                _index++;
-                return true;
+                return false;
             }
 
-            return false;
-        }
-
-        void IEnumerator.Reset()
-        {
-            _index = 0;
-            _current = default;
+            _current = _builder[_index];
+            _index++;
+            return true;
         }
     }
 }


### PR DESCRIPTION
This change uses a similar approach to Roslyn's `TemporaryArray<T>` to avoid retrieving an `ImmutableArray<T>.Builder` from the pool for arrays of 4 or fewer elements. The first four items added to the builder are stored on the stack.
