### PR TITLE
Use message pack for `project.razor.*` configuration file

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace/RazorProjectInfoSerializer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace/RazorProjectInfoSerializer.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.AspNetCore.Razor.ProjectEngineHost;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Serialization;
-using Microsoft.AspNetCore.Razor.Serialization.Json;
 using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.AspNetCore.Razor.Utilities;
 using Microsoft.CodeAnalysis;
@@ -35,7 +34,7 @@ internal static class RazorProjectInfoSerializer
         s_projectEngineFactories = ProjectEngineFactories.Factories.Select(f => (f.Item1.Value, f.Item2)).ToArray();
     }
 
-    public static async Task SerializeAsync(Project project, string projectRazorJsonFileName, CancellationToken cancellationToken)
+    public static async Task SerializeAsync(Project project, string configurationFileName, CancellationToken cancellationToken)
     {
         var projectPath = Path.GetDirectoryName(project.FilePath);
         if (projectPath is null)
@@ -88,17 +87,17 @@ internal static class RazorProjectInfoSerializer
 
         var projectWorkspaceState = new ProjectWorkspaceState(tagHelpers, csharpLanguageVersion);
 
-        var jsonFilePath = Path.Combine(intermediateOutputPath, projectRazorJsonFileName);
+        var configurationFilePath = Path.Combine(intermediateOutputPath, configurationFileName);
 
         var projectInfo = new RazorProjectInfo(
-            serializedFilePath: jsonFilePath,
+            serializedFilePath: configurationFilePath,
             filePath: project.FilePath!,
             configuration: configuration,
             rootNamespace: defaultNamespace,
             projectWorkspaceState: projectWorkspaceState,
             documents: documents);
 
-        WriteJsonFile(jsonFilePath, projectInfo);
+        WriteToFile(configurationFilePath, projectInfo);
     }
 
     private static RazorConfiguration ComputeRazorConfigurationOptions(AnalyzerConfigOptionsProvider options, out string defaultNamespace)
@@ -126,11 +125,11 @@ internal static class RazorProjectInfoSerializer
         return razorConfiguration;
     }
 
-    private static void WriteJsonFile(string publishFilePath, RazorProjectInfo projectInfo)
+    private static void WriteToFile(string configurationFilePath, RazorProjectInfo projectInfo)
     {
         // We need to avoid having an incomplete file at any point, but our
         // project configuration is large enough that it will be written as multiple operations.
-        var tempFilePath = string.Concat(publishFilePath, ".temp");
+        var tempFilePath = string.Concat(configurationFilePath, ".temp");
         var tempFileInfo = new FileInfo(tempFilePath);
 
         if (tempFileInfo.Exists)
@@ -141,18 +140,18 @@ internal static class RazorProjectInfoSerializer
 
         // This needs to be in explicit brackets because the operation needs to be completed
         // by the time we move the temp file into its place
-        using (var writer = tempFileInfo.CreateText())
+        using (var stream = tempFileInfo.Create())
         {
-            JsonDataConvert.SerializeObject(writer, projectInfo, ObjectWriters.WriteProperties);
+            projectInfo.SerializeTo(stream);
         }
 
-        var fileInfo = new FileInfo(publishFilePath);
+        var fileInfo = new FileInfo(configurationFilePath);
         if (fileInfo.Exists)
         {
             fileInfo.Delete();
         }
 
-        File.Move(tempFileInfo.FullName, publishFilePath);
+        File.Move(tempFileInfo.FullName, configurationFilePath);
     }
 
     private static ImmutableArray<DocumentSnapshotHandle> GetDocuments(Project project, string projectPath)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Common/LanguageServerConstants.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Common/LanguageServerConstants.cs
@@ -7,7 +7,7 @@ internal static class LanguageServerConstants
 {
     public const int VSCompletionItemKindOffset = 118115;
 
-    public const string DefaultProjectConfigurationFile = "project.razor.json";
+    public const string DefaultProjectConfigurationFile = "project.razor.bin";
 
     public const string RazorSemanticTokensLegendEndpoint = "_vs_/textDocument/semanticTokensLegend";
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
@@ -195,7 +195,7 @@ internal class DefaultRazorProjectService : RazorProjectService
 
             // If the document is open, we can't remove it, because we could still get a request for it, and that
             // request would fail. Instead we move it to the miscellaneous project, just like if we got notified of
-            // a remove via the project.razor.json
+            // a remove via the project.razor.bin
             if (_projectSnapshotManagerAccessor.Instance.IsDocumentOpen(textDocumentPath))
             {
                 _logger.LogInformation("Moving document '{textDocumentPath}' from project '{projectKey}' to misc files because it is open.", textDocumentPath, projectSnapshot.Key);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Serialization/RazorProjectInfoDeserializer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Serialization/RazorProjectInfoDeserializer.cs
@@ -3,7 +3,6 @@
 
 using System.IO;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
-using Microsoft.AspNetCore.Razor.Serialization.Json;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Serialization;
 
@@ -18,11 +17,10 @@ internal sealed class RazorProjectInfoDeserializer : IRazorProjectInfoDeserializ
     public RazorProjectInfo? DeserializeFromFile(string filePath)
     {
         using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
-        using var reader = new StreamReader(stream);
 
         try
         {
-            return JsonDataConvert.DeserializeObject(reader, ObjectReaders.ReadProjectInfoFromProperties);
+            return RazorProjectInfo.DeserializeFrom(stream);
         }
         catch
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/ProjectSystem/RazorProjectInfo.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/ProjectSystem/RazorProjectInfo.cs
@@ -2,13 +2,23 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.IO;
+using MessagePack;
+using MessagePack.Resolvers;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Serialization;
+using Microsoft.AspNetCore.Razor.Serialization.MessagePack.Resolvers;
+using Microsoft.CodeAnalysis;
 
 namespace Microsoft.AspNetCore.Razor.ProjectSystem;
 
 internal sealed class RazorProjectInfo
 {
+    private static readonly MessagePackSerializerOptions s_options = MessagePackSerializerOptions.Standard
+        .WithResolver(CompositeResolver.Create(
+            RazorProjectInfoResolver.Instance,
+            StandardResolver.Instance));
+
     public string SerializedFilePath { get; }
     public string FilePath { get; }
     public RazorConfiguration? Configuration { get; }
@@ -31,4 +41,10 @@ internal sealed class RazorProjectInfo
         ProjectWorkspaceState = projectWorkspaceState;
         Documents = documents.NullToEmpty();
     }
+
+    public void SerializeTo(Stream stream)
+        => MessagePackSerializer.Serialize(stream, this, s_options);
+
+    public static RazorProjectInfo? DeserializeFrom(Stream stream)
+        => MessagePackSerializer.Deserialize<RazorProjectInfo>(stream, s_options);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/CachedStringFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/CachedStringFormatter.cs
@@ -13,7 +13,7 @@ internal sealed class CachedStringFormatter : ValueFormatter<string?>
     {
     }
 
-    protected override string? Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
+    public override string? Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
     {
         if (reader.NextMessagePackType == MessagePackType.Integer)
         {
@@ -31,7 +31,7 @@ internal sealed class CachedStringFormatter : ValueFormatter<string?>
         return result;
     }
 
-    protected override void Serialize(ref MessagePackWriter writer, string? value, SerializerCachingOptions options)
+    public override void Serialize(ref MessagePackWriter writer, string? value, SerializerCachingOptions options)
     {
         if (value is null)
         {
@@ -45,6 +45,22 @@ internal sealed class CachedStringFormatter : ValueFormatter<string?>
         {
             writer.Write(value);
             options.Strings.Add(value);
+        }
+    }
+
+    public override void Skim(ref MessagePackReader reader, SerializerCachingOptions options)
+    {
+        if (reader.NextMessagePackType == MessagePackType.Integer)
+        {
+            reader.Skip(); // Reference Id
+            return;
+        }
+
+        var result = reader.ReadString();
+
+        if (result is not null)
+        {
+            options.Strings.Add(result);
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/DocumentSnapshotFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/DocumentSnapshotFormatter.cs
@@ -13,7 +13,7 @@ internal sealed class DocumentSnapshotHandleFormatter : ValueFormatter<DocumentS
     {
     }
 
-    protected override DocumentSnapshotHandle Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
+    public override DocumentSnapshotHandle Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
     {
         reader.ReadArrayHeaderAndVerify(3);
 
@@ -24,7 +24,7 @@ internal sealed class DocumentSnapshotHandleFormatter : ValueFormatter<DocumentS
         return new DocumentSnapshotHandle(filePath, targetPath, fileKind);
     }
 
-    protected override void Serialize(ref MessagePackWriter writer, DocumentSnapshotHandle value, SerializerCachingOptions options)
+    public override void Serialize(ref MessagePackWriter writer, DocumentSnapshotHandle value, SerializerCachingOptions options)
     {
         writer.WriteArrayHeader(3);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/Extensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/Extensions.cs
@@ -54,7 +54,7 @@ internal static class ExtraExtensions
 {
     // C# allows extension method overloads to differ only by generic constraints, but they must be declared on
     // different classes, since they'll have the same signature.
-    public static void SerializeObject<T>(this ref MessagePackWriter writer, T value, MessagePackSerializerOptions options)
+    public static void Serialize<T>(this ref MessagePackWriter writer, T value, MessagePackSerializerOptions options)
         where T : struct
     {
         options.Resolver.GetFormatterWithVerify<T>().Serialize(ref writer, value, options);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/FetchTagHelpersResultFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/FetchTagHelpersResultFormatter.cs
@@ -15,15 +15,15 @@ internal sealed class FetchTagHelpersResultFormatter : TopLevelFormatter<FetchTa
     {
     }
 
-    protected override FetchTagHelpersResult Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
+    public override FetchTagHelpersResult Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
     {
         var tagHelpers = reader.Deserialize<ImmutableArray<TagHelperDescriptor>>(options);
 
         return new(tagHelpers);
     }
 
-    protected override void Serialize(ref MessagePackWriter writer, FetchTagHelpersResult value, SerializerCachingOptions options)
+    public override void Serialize(ref MessagePackWriter writer, FetchTagHelpersResult value, SerializerCachingOptions options)
     {
-        writer.SerializeObject(value.TagHelpers, options);
+        writer.Serialize(value.TagHelpers, options);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/ProjectSnapshotHandleFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/ProjectSnapshotHandleFormatter.cs
@@ -16,7 +16,7 @@ internal sealed class ProjectSnapshotHandleFormatter : TopLevelFormatter<Project
     {
     }
 
-    protected override ProjectSnapshotHandle Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
+    public override ProjectSnapshotHandle Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
     {
         reader.ReadArrayHeaderAndVerify(3);
 
@@ -29,7 +29,7 @@ internal sealed class ProjectSnapshotHandleFormatter : TopLevelFormatter<Project
         return new(projectId, configuration, rootNamespace);
     }
 
-    protected override void Serialize(ref MessagePackWriter writer, ProjectSnapshotHandle value, SerializerCachingOptions options)
+    public override void Serialize(ref MessagePackWriter writer, ProjectSnapshotHandle value, SerializerCachingOptions options)
     {
         writer.WriteArrayHeader(3);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/ProjectWorkspaceStateFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/ProjectWorkspaceStateFormatter.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using System.Diagnostics;
 using MessagePack;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.PooledObjects;
@@ -28,10 +27,9 @@ internal sealed class ProjectWorkspaceStateFormatter : ValueFormatter<ProjectWor
 
         var checksums = reader.Deserialize<ImmutableArray<Checksum>>(options);
 
-        var length = reader.ReadArrayHeader();
-        Debug.Assert(checksums.Length == length);
+        reader.ReadArrayHeaderAndVerify(checksums.Length);
 
-        using var builder = new PooledArrayBuilder<TagHelperDescriptor>(capacity: length);
+        using var builder = new PooledArrayBuilder<TagHelperDescriptor>(capacity: checksums.Length);
         var cache = TagHelperCache.Default;
 
         foreach (var checksum in checksums)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/ProjectWorkspaceStateFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/ProjectWorkspaceStateFormatter.cs
@@ -2,10 +2,15 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.Diagnostics;
 using MessagePack;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
+using Microsoft.AspNetCore.Razor.Serialization.MessagePack.Formatters.TagHelpers;
+using Microsoft.AspNetCore.Razor.Utilities;
 using Microsoft.CodeAnalysis.CSharp;
+using Checksum = Microsoft.AspNetCore.Razor.Utilities.Checksum;
 
 namespace Microsoft.AspNetCore.Razor.Serialization.MessagePack.Formatters;
 
@@ -17,21 +22,47 @@ internal sealed class ProjectWorkspaceStateFormatter : ValueFormatter<ProjectWor
     {
     }
 
-    protected override ProjectWorkspaceState Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
+    public override ProjectWorkspaceState Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
     {
-        reader.ReadArrayHeaderAndVerify(2);
+        reader.ReadArrayHeaderAndVerify(3);
 
-        var tagHelpers = reader.Deserialize<ImmutableArray<TagHelperDescriptor>>(options);
+        var checksums = reader.Deserialize<ImmutableArray<Checksum>>(options);
+
+        var length = reader.ReadArrayHeader();
+        Debug.Assert(checksums.Length == length);
+
+        using var builder = new PooledArrayBuilder<TagHelperDescriptor>(capacity: length);
+        var cache = TagHelperCache.Default;
+
+        foreach (var checksum in checksums)
+        {
+            if (!cache.TryGet(checksum, out var tagHelper))
+            {
+                tagHelper = TagHelperFormatter.Instance.Deserialize(ref reader, options);
+                cache.TryAdd(checksum, tagHelper);
+            }
+            else
+            {
+                TagHelperFormatter.Instance.Skim(ref reader, options);
+            }
+
+            builder.Add(tagHelper);
+        }
+
+        var tagHelpers = builder.DrainToImmutable();
         var csharpLanguageVersion = (LanguageVersion)reader.ReadInt32();
 
         return new ProjectWorkspaceState(tagHelpers, csharpLanguageVersion);
     }
 
-    protected override void Serialize(ref MessagePackWriter writer, ProjectWorkspaceState value, SerializerCachingOptions options)
+    public override void Serialize(ref MessagePackWriter writer, ProjectWorkspaceState value, SerializerCachingOptions options)
     {
-        writer.WriteArrayHeader(2);
+        writer.WriteArrayHeader(3);
 
-        writer.SerializeObject(value.TagHelpers, options);
+        var checksums = value.TagHelpers.SelectAsArray(x => x.GetChecksum());
+
+        writer.Serialize(checksums, options);
+        writer.Serialize(value.TagHelpers, options);
         writer.Write((int)value.CSharpLanguageVersion);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/RazorConfigurationFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/RazorConfigurationFormatter.cs
@@ -15,7 +15,7 @@ internal sealed class RazorConfigurationFormatter : ValueFormatter<RazorConfigur
     {
     }
 
-    protected override RazorConfiguration Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
+    public override RazorConfiguration Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
     {
         var count = reader.ReadArrayHeader();
 
@@ -41,7 +41,7 @@ internal sealed class RazorConfigurationFormatter : ValueFormatter<RazorConfigur
         return RazorConfiguration.Create(languageVersion, configurationName, extensions);
     }
 
-    protected override void Serialize(ref MessagePackWriter writer, RazorConfiguration value, SerializerCachingOptions options)
+    public override void Serialize(ref MessagePackWriter writer, RazorConfiguration value, SerializerCachingOptions options)
     {
         // Write two values + one value per extension.
         var extensions = value.Extensions;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/RazorDiagnosticFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/RazorDiagnosticFormatter.cs
@@ -16,7 +16,7 @@ internal sealed class RazorDiagnosticFormatter : ValueFormatter<RazorDiagnostic>
     {
     }
 
-    protected override RazorDiagnostic Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
+    public override RazorDiagnostic Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
     {
         reader.ReadArrayHeaderAndVerify(8);
 
@@ -41,7 +41,7 @@ internal sealed class RazorDiagnosticFormatter : ValueFormatter<RazorDiagnostic>
         }
     }
 
-    protected override void Serialize(ref MessagePackWriter writer, RazorDiagnostic value, SerializerCachingOptions options)
+    public override void Serialize(ref MessagePackWriter writer, RazorDiagnostic value, SerializerCachingOptions options)
     {
         writer.WriteArrayHeader(8);
 
@@ -55,5 +55,20 @@ internal sealed class RazorDiagnosticFormatter : ValueFormatter<RazorDiagnostic>
         writer.Write(span.LineIndex);
         writer.Write(span.CharacterIndex);
         writer.Write(span.Length);
+    }
+
+    public override void Skim(ref MessagePackReader reader, SerializerCachingOptions options)
+    {
+        reader.ReadArrayHeaderAndVerify(8);
+
+        CachedStringFormatter.Instance.Skim(ref reader, options); // Id
+        reader.Skip(); // Severity
+        CachedStringFormatter.Instance.Skim(ref reader, options); // Message
+
+        CachedStringFormatter.Instance.Skim(ref reader, options); // FilePath
+        reader.Skip(); // AbsoluteIndex
+        reader.Skip(); // LineIndex
+        reader.Skip(); // CharacterIndex
+        reader.Skip(); // Length
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/RazorProjectInfoFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/RazorProjectInfoFormatter.cs
@@ -16,7 +16,7 @@ internal sealed class RazorProjectInfoFormatter : TopLevelFormatter<RazorProject
     {
     }
 
-    protected override RazorProjectInfo Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
+    public override RazorProjectInfo Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
     {
         reader.ReadArrayHeaderAndVerify(7);
 
@@ -37,7 +37,7 @@ internal sealed class RazorProjectInfoFormatter : TopLevelFormatter<RazorProject
         return new RazorProjectInfo(serializedFilePath, filePath, configuration, rootNamespace, projectWorkspaceState, documents);
     }
 
-    protected override void Serialize(ref MessagePackWriter writer, RazorProjectInfo value, SerializerCachingOptions options)
+    public override void Serialize(ref MessagePackWriter writer, RazorProjectInfo value, SerializerCachingOptions options)
     {
         writer.WriteArrayHeader(7);
 
@@ -47,6 +47,6 @@ internal sealed class RazorProjectInfoFormatter : TopLevelFormatter<RazorProject
         writer.Serialize(value.Configuration, options);
         writer.Serialize(value.ProjectWorkspaceState, options);
         CachedStringFormatter.Instance.Serialize(ref writer, value.RootNamespace, options);
-        writer.SerializeObject(value.Documents, options);
+        writer.Serialize(value.Documents, options);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/TagHelperDeltaResultFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/TagHelperDeltaResultFormatter.cs
@@ -15,7 +15,7 @@ internal sealed class TagHelperDeltaResultFormatter : TopLevelFormatter<TagHelpe
     {
     }
 
-    protected override TagHelperDeltaResult Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
+    public override TagHelperDeltaResult Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
     {
         reader.ReadArrayHeaderAndVerify(4);
 
@@ -27,13 +27,13 @@ internal sealed class TagHelperDeltaResultFormatter : TopLevelFormatter<TagHelpe
         return new(isDelta, resultId, added, removed);
     }
 
-    protected override void Serialize(ref MessagePackWriter writer, TagHelperDeltaResult value, SerializerCachingOptions options)
+    public override void Serialize(ref MessagePackWriter writer, TagHelperDeltaResult value, SerializerCachingOptions options)
     {
         writer.WriteArrayHeader(4);
 
         writer.Write(value.IsDelta);
         writer.Write(value.ResultId);
-        writer.SerializeObject(value.Added, options);
-        writer.SerializeObject(value.Removed, options);
+        writer.Serialize(value.Added, options);
+        writer.Serialize(value.Removed, options);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/TagHelpers/AllowChildTagFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/TagHelpers/AllowChildTagFormatter.cs
@@ -14,7 +14,7 @@ internal sealed class AllowedChildTagFormatter : ValueFormatter<AllowedChildTagD
     {
     }
 
-    protected override AllowedChildTagDescriptor Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
+    public override AllowedChildTagDescriptor Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
     {
         reader.ReadArrayHeaderAndVerify(3);
 
@@ -25,12 +25,21 @@ internal sealed class AllowedChildTagFormatter : ValueFormatter<AllowedChildTagD
         return new DefaultAllowedChildTagDescriptor(name, displayName, diagnostics);
     }
 
-    protected override void Serialize(ref MessagePackWriter writer, AllowedChildTagDescriptor value, SerializerCachingOptions options)
+    public override void Serialize(ref MessagePackWriter writer, AllowedChildTagDescriptor value, SerializerCachingOptions options)
     {
         writer.WriteArrayHeader(3);
 
         CachedStringFormatter.Instance.Serialize(ref writer, value.Name, options);
         CachedStringFormatter.Instance.Serialize(ref writer, value.DisplayName, options);
         writer.Serialize(value.Diagnostics, options);
+    }
+
+    public override void Skim(ref MessagePackReader reader, SerializerCachingOptions options)
+    {
+        reader.ReadArrayHeaderAndVerify(3);
+
+        CachedStringFormatter.Instance.Skim(ref reader, options); // Name
+        CachedStringFormatter.Instance.Skim(ref reader, options); // DisplayName
+        RazorDiagnosticFormatter.Instance.SkimArray(ref reader, options); // Diagnostics
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/TagHelpers/BoundAttributeFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/TagHelpers/BoundAttributeFormatter.cs
@@ -14,7 +14,7 @@ internal sealed class BoundAttributeFormatter : ValueFormatter<BoundAttributeDes
     {
     }
 
-    protected override BoundAttributeDescriptor Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
+    public override BoundAttributeDescriptor Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
     {
         reader.ReadArrayHeaderAndVerify(14);
 
@@ -41,7 +41,7 @@ internal sealed class BoundAttributeFormatter : ValueFormatter<BoundAttributeDes
             parameters, metadata, diagnostics);
     }
 
-    protected override void Serialize(ref MessagePackWriter writer, BoundAttributeDescriptor value, SerializerCachingOptions options)
+    public override void Serialize(ref MessagePackWriter writer, BoundAttributeDescriptor value, SerializerCachingOptions options)
     {
         writer.WriteArrayHeader(14);
 
@@ -53,12 +53,33 @@ internal sealed class BoundAttributeFormatter : ValueFormatter<BoundAttributeDes
         CachedStringFormatter.Instance.Serialize(ref writer, value.IndexerNamePrefix, options);
         CachedStringFormatter.Instance.Serialize(ref writer, value.IndexerTypeName, options);
         CachedStringFormatter.Instance.Serialize(ref writer, value.DisplayName, options);
-        writer.SerializeObject(value.DocumentationObject, options);
+        writer.Serialize(value.DocumentationObject, options);
         writer.Write(value.CaseSensitive);
         writer.Write(value.IsEditorRequired);
         writer.Serialize(value.BoundAttributeParameters, options);
 
         writer.Serialize((MetadataCollection)value.Metadata, options);
         writer.Serialize((RazorDiagnostic[])value.Diagnostics, options);
+    }
+
+    public override void Skim(ref MessagePackReader reader, SerializerCachingOptions options)
+    {
+        reader.ReadArrayHeaderAndVerify(14);
+
+        CachedStringFormatter.Instance.Skim(ref reader, options); // Kind;
+        CachedStringFormatter.Instance.Skim(ref reader, options); // Name
+        CachedStringFormatter.Instance.Skim(ref reader, options); // TypeName
+        reader.Skip(); // IsEnum
+        reader.Skip(); // HasIndexer
+        CachedStringFormatter.Instance.Skim(ref reader, options); // IndexerNamePrefix
+        CachedStringFormatter.Instance.Skim(ref reader, options); // IndexerTypeName
+        CachedStringFormatter.Instance.Skim(ref reader, options); // DisplayName
+        DocumentationObjectFormatter.Instance.Skim(ref reader, options); // DocumentationObject
+        reader.Skip(); // CaseSenstive
+        reader.Skip(); // IsEditorRequired
+        BoundAttributeParameterFormatter.Instance.SkimArray(ref reader, options); // BoundAttributeParameters
+
+        MetadataCollectionFormatter.Instance.Skim(ref reader, options); // Metadata
+        RazorDiagnosticFormatter.Instance.SkimArray(ref reader, options); // Diagnostics
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/TagHelpers/BoundAttributeParameterFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/TagHelpers/BoundAttributeParameterFormatter.cs
@@ -14,7 +14,7 @@ internal sealed class BoundAttributeParameterFormatter : ValueFormatter<BoundAtt
     {
     }
 
-    protected override BoundAttributeParameterDescriptor Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
+    public override BoundAttributeParameterDescriptor Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
     {
         reader.ReadArrayHeaderAndVerify(9);
 
@@ -35,7 +35,7 @@ internal sealed class BoundAttributeParameterFormatter : ValueFormatter<BoundAtt
             metadata, diagnostics);
     }
 
-    protected override void Serialize(ref MessagePackWriter writer, BoundAttributeParameterDescriptor value, SerializerCachingOptions options)
+    public override void Serialize(ref MessagePackWriter writer, BoundAttributeParameterDescriptor value, SerializerCachingOptions options)
     {
         writer.WriteArrayHeader(9);
 
@@ -44,10 +44,26 @@ internal sealed class BoundAttributeParameterFormatter : ValueFormatter<BoundAtt
         CachedStringFormatter.Instance.Serialize(ref writer, value.TypeName, options);
         writer.Write(value.IsEnum);
         CachedStringFormatter.Instance.Serialize(ref writer, value.DisplayName, options);
-        writer.SerializeObject(value.DocumentationObject, options);
+        writer.Serialize(value.DocumentationObject, options);
         writer.Write(value.CaseSensitive);
 
         writer.Serialize((MetadataCollection)value.Metadata, options);
         writer.Serialize((RazorDiagnostic[])value.Diagnostics, options);
+    }
+
+    public override void Skim(ref MessagePackReader reader, SerializerCachingOptions options)
+    {
+        reader.ReadArrayHeaderAndVerify(9);
+
+        CachedStringFormatter.Instance.Skim(ref reader, options); // Kind
+        CachedStringFormatter.Instance.Skim(ref reader, options); // Name
+        CachedStringFormatter.Instance.Skim(ref reader, options); // TypeName
+        reader.Skip(); // IsEnum
+        CachedStringFormatter.Instance.Skim(ref reader, options); // DisplayName
+        DocumentationObjectFormatter.Instance.Skim(ref reader, options); // DocumentationObject
+        reader.Skip(); // CaseSensitive
+
+        MetadataCollectionFormatter.Instance.Skim(ref reader, options); // Metadata
+        RazorDiagnosticFormatter.Instance.SkimArray(ref reader, options); // Diagnostics
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/TagHelpers/RequiredAttributeFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/TagHelpers/RequiredAttributeFormatter.cs
@@ -15,7 +15,7 @@ internal sealed class RequiredAttributeFormatter : ValueFormatter<RequiredAttrib
     {
     }
 
-    protected override RequiredAttributeDescriptor Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
+    public override RequiredAttributeDescriptor Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
     {
         reader.ReadArrayHeaderAndVerify(8);
 
@@ -36,7 +36,7 @@ internal sealed class RequiredAttributeFormatter : ValueFormatter<RequiredAttrib
             displayName!, diagnostics, metadata);
     }
 
-    protected override void Serialize(ref MessagePackWriter writer, RequiredAttributeDescriptor value, SerializerCachingOptions options)
+    public override void Serialize(ref MessagePackWriter writer, RequiredAttributeDescriptor value, SerializerCachingOptions options)
     {
         writer.WriteArrayHeader(8);
 
@@ -49,5 +49,20 @@ internal sealed class RequiredAttributeFormatter : ValueFormatter<RequiredAttrib
 
         writer.Serialize((MetadataCollection)value.Metadata, options);
         writer.Serialize((RazorDiagnostic[])value.Diagnostics, options);
+    }
+
+    public override void Skim(ref MessagePackReader reader, SerializerCachingOptions options)
+    {
+        reader.ReadArrayHeaderAndVerify(8);
+
+        CachedStringFormatter.Instance.Skim(ref reader, options); // Name
+        reader.Skip(); // NameComparison
+        reader.Skip(); // CaseSensitive
+        CachedStringFormatter.Instance.Skim(ref reader, options); // Value
+        reader.Skip(); // ValueComparison
+        CachedStringFormatter.Instance.Skim(ref reader, options); // DisplayName
+
+        MetadataCollectionFormatter.Instance.Skim(ref reader, options); // Metadata
+        RazorDiagnosticFormatter.Instance.SkimArray(ref reader, options); // Diagnostics
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/TagHelpers/TagHelperFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/TagHelpers/TagHelperFormatter.cs
@@ -14,7 +14,7 @@ internal sealed class TagHelperFormatter : ValueFormatter<TagHelperDescriptor>
     {
     }
 
-    protected override TagHelperDescriptor Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
+    public override TagHelperDescriptor Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
     {
         reader.ReadArrayHeaderAndVerify(12);
 
@@ -42,7 +42,7 @@ internal sealed class TagHelperFormatter : ValueFormatter<TagHelperDescriptor>
             metadata, diagnostics);
     }
 
-    protected override void Serialize(ref MessagePackWriter writer, TagHelperDescriptor value, SerializerCachingOptions options)
+    public override void Serialize(ref MessagePackWriter writer, TagHelperDescriptor value, SerializerCachingOptions options)
     {
         writer.WriteArrayHeader(12);
 
@@ -51,7 +51,7 @@ internal sealed class TagHelperFormatter : ValueFormatter<TagHelperDescriptor>
         CachedStringFormatter.Instance.Serialize(ref writer, value.AssemblyName, options);
 
         CachedStringFormatter.Instance.Serialize(ref writer, value.DisplayName, options);
-        writer.SerializeObject(value.DocumentationObject, options);
+        writer.Serialize(value.DocumentationObject, options);
         CachedStringFormatter.Instance.Serialize(ref writer, value.TagOutputHint, options);
         writer.Write(value.CaseSensitive);
 
@@ -61,5 +61,26 @@ internal sealed class TagHelperFormatter : ValueFormatter<TagHelperDescriptor>
 
         writer.Serialize((MetadataCollection)value.Metadata, options);
         writer.Serialize((RazorDiagnostic[])value.Diagnostics, options);
+    }
+
+    public override void Skim(ref MessagePackReader reader, SerializerCachingOptions options)
+    {
+        reader.ReadArrayHeaderAndVerify(12);
+
+        CachedStringFormatter.Instance.Skim(ref reader, options); // Kind
+        CachedStringFormatter.Instance.Skim(ref reader, options); // Name
+        CachedStringFormatter.Instance.Skim(ref reader, options); // AssemblyName
+
+        CachedStringFormatter.Instance.Skim(ref reader, options); // DisplayName
+        DocumentationObjectFormatter.Instance.Skim(ref reader, options); // DocumentationObject
+        CachedStringFormatter.Instance.Skim(ref reader, options); // TagOutputHint
+        reader.Skip(); // CaseSensitive
+
+        TagMatchingRuleFormatter.Instance.SkimArray(ref reader, options); // TagMatchingRules
+        BoundAttributeFormatter.Instance.SkimArray(ref reader, options); // BoundAttributes
+        AllowedChildTagFormatter.Instance.SkimArray(ref reader, options); // AllowedChildTags
+
+        MetadataCollectionFormatter.Instance.Skim(ref reader, options); // Metadata
+        RazorDiagnosticFormatter.Instance.SkimArray(ref reader, options); // Diagnostics
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/TagHelpers/TagMatchingRuleFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/TagHelpers/TagMatchingRuleFormatter.cs
@@ -14,7 +14,7 @@ internal sealed class TagMatchingRuleFormatter : ValueFormatter<TagMatchingRuleD
     {
     }
 
-    protected override TagMatchingRuleDescriptor Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
+    public override TagMatchingRuleDescriptor Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
     {
         reader.ReadArrayHeaderAndVerify(6);
 
@@ -31,7 +31,7 @@ internal sealed class TagMatchingRuleFormatter : ValueFormatter<TagMatchingRuleD
             attributes, diagnostics);
     }
 
-    protected override void Serialize(ref MessagePackWriter writer, TagMatchingRuleDescriptor value, SerializerCachingOptions options)
+    public override void Serialize(ref MessagePackWriter writer, TagMatchingRuleDescriptor value, SerializerCachingOptions options)
     {
         writer.WriteArrayHeader(6);
 
@@ -41,5 +41,17 @@ internal sealed class TagMatchingRuleFormatter : ValueFormatter<TagMatchingRuleD
         writer.Write(value.CaseSensitive);
         writer.Serialize((RequiredAttributeDescriptor[])value.Attributes, options);
         writer.Serialize((RazorDiagnostic[])value.Diagnostics, options);
+    }
+
+    public override void Skim(ref MessagePackReader reader, SerializerCachingOptions options)
+    {
+        reader.ReadArrayHeaderAndVerify(6);
+
+        CachedStringFormatter.Instance.Skim(ref reader, options); // TagName
+        CachedStringFormatter.Instance.Skim(ref reader, options); // ParentTag
+        reader.Skip(); // TagStructure
+        reader.Skip(); // CaseSensitive
+        RequiredAttributeFormatter.Instance.SkimArray(ref reader, options); // Attributes
+        RazorDiagnosticFormatter.Instance.SkimArray(ref reader, options); // Diagnostics
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/TopLevelFormatter`1.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/TopLevelFormatter`1.cs
@@ -43,6 +43,6 @@ internal abstract partial class TopLevelFormatter<T> : IMessagePackFormatter<T>
         }
     }
 
-    protected abstract T Deserialize(ref MessagePackReader reader, SerializerCachingOptions options);
-    protected abstract void Serialize(ref MessagePackWriter writer, T value, SerializerCachingOptions options);
+    public abstract T Deserialize(ref MessagePackReader reader, SerializerCachingOptions options);
+    public abstract void Serialize(ref MessagePackWriter writer, T value, SerializerCachingOptions options);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Resolvers/RazorProjectInfoResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Resolvers/RazorProjectInfoResolver.cs
@@ -39,6 +39,7 @@ internal sealed class RazorProjectInfoResolver : IFormatterResolver
         {
             RazorProjectInfoFormatter.Instance,
 
+            ChecksumFormatter.Instance,
             DocumentSnapshotHandleFormatter.Instance,
             ProjectWorkspaceStateFormatter.Instance,
             RazorConfigurationFormatter.Instance,

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/HostProject.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/HostProject.cs
@@ -29,7 +29,7 @@ internal class HostProject
     public string FilePath { get; }
 
     /// <summary>
-    /// Gets the full path to the folder under 'obj' where the project.razor.json file will live
+    /// Gets the full path to the folder under 'obj' where the project.razor.bin file will live
     /// </summary>
     public string IntermediateOutputPath { get; }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshot.cs
@@ -22,7 +22,7 @@ internal interface IProjectSnapshot
     string FilePath { get; }
 
     /// <summary>
-    /// Gets the full path to the folder under 'obj' where the project.razor.json file will live
+    /// Gets the full path to the folder under 'obj' where the project.razor.bin file will live
     /// </summary>
     string IntermediateOutputPath { get; }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectKey.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectKey.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 [DebuggerDisplay("id: {Id}")]
 internal readonly record struct ProjectKey : IEquatable<ProjectKey>
 {
-    // ProjectKey represents the path of the intermediate output path, which is where the project.razor.json file will
+    // ProjectKey represents the path of the intermediate output path, which is where the project.razor.bin file will
     // end up. All creation logic is here in one place to ensure this is consistent.
     public static ProjectKey From(HostProject hostProject) => new(hostProject.IntermediateOutputPath);
     public static ProjectKey From(IProjectSnapshot project) => new(project.IntermediateOutputPath);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Endpoints/UpdateCSharpBuffer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Endpoints/UpdateCSharpBuffer.cs
@@ -101,7 +101,7 @@ internal partial class RazorCustomMessageTarget
 
             _logger?.LogDebug("UpdateCSharpBuffer couldn't find any virtual docs for {version} of {uri}", request.HostDocumentVersion.Value, hostDocumentUri);
 
-            // Don't know about document, no-op. This can happen if the language server found a project.razor.json from an old build
+            // Don't know about document, no-op. This can happen if the language server found a project.razor.bin from an old build
             // and is sending us updates.
             return;
         }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorProjectInfoPublisher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorProjectInfoPublisher.cs
@@ -16,7 +16,7 @@ using Shared = System.Composition.SharedAttribute;
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor;
 
 /// <summary>
-/// Publishes project.razor.json files.
+/// Publishes project.razor.bin files.
 /// </summary>
 [Shared]
 [Export(typeof(IProjectSnapshotChangeTrigger))]

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
@@ -166,7 +166,7 @@ internal abstract class WindowsRazorProjectHostBase : OnceInitializedOnceDispose
                 // This is a new slice that we didn't previously know about, either because its a new target framework, or how dimensions
                 // are calculated has changed. We simply subscribe to updates for it, and let our action block code handle whether the
                 // distinction is important. To put it another way, we may end up having multiple subscriptions and events that would be
-                // affect about the same project.razor.json file, but our event handling code ensures we don't handle them more than
+                // affect about the same project.razor.bin file, but our event handling code ensures we don't handle them more than
                 // necessary.
                 var subscription = source.JointRuleSource.SourceBlock.LinkTo(
                     DataflowBlockSlim.CreateActionBlock<IProjectVersionedValue<IProjectSubscriptionUpdate>>(v => OnProjectChangedAsync(dimensions, v), nameFormat: "OnProjectChanged {1}"),

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
@@ -57,7 +57,7 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
     public override bool SupportsFileManipulation => !IsCodespacesOrLiveshare;
 
     // In VS we override the project configuration file name because we don't want our serialized state to clash with other platforms (VSCode)
-    public override string ProjectConfigurationFileName => "project.razor.vs.json";
+    public override string ProjectConfigurationFileName => "project.razor.vs.bin";
 
     public override string CSharpVirtualDocumentSuffix => ".ide.g.cs";
 

--- a/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Mac.LanguageServices.Razor/VisualStudioMacLanguageServerFeatureOptions.cs
@@ -27,7 +27,7 @@ internal class VisualStudioMacLanguageServerFeatureOptions : LanguageServerFeatu
     public override bool SupportsFileManipulation => !IsCodespacesOrLiveshare;
 
     // In VS we override the project configuration file name because we don't want our serialized state to clash with other platforms (VSCode)
-    public override string ProjectConfigurationFileName => "project.razor.vs.json";
+    public override string ProjectConfigurationFileName => "project.razor.vs.bin";
 
     public override string CSharpVirtualDocumentSuffix => ".ide.g.cs";
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ConfigurableLanguageServerFeatureOptionsTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ConfigurableLanguageServerFeatureOptionsTest.cs
@@ -29,12 +29,12 @@ public class ConfigurableLanguageServerFeatureOptionsTest
     {
         var expected = new DefaultLanguageServerFeatureOptions();
 
-        var projectRazorJsonFilename = "project.razor.test.only.file.json";
-        var args = new[] { "--projectConfigurationFilename", projectRazorJsonFilename };
+        var projectRazorBinFilename = "project.razor.test.only.file.bin";
+        var args = new[] { "--projectConfigurationFilename", projectRazorBinFilename };
 
         var actual = new ConfigurableLanguageServerFeatureOptions(args);
 
-        Assert.Equal(projectRazorJsonFilename, actual.ProjectConfigurationFileName);
+        Assert.Equal(projectRazorBinFilename, actual.ProjectConfigurationFileName);
 
         Assert.Equal(expected.SupportsFileManipulation, actual.SupportsFileManipulation);
         Assert.Equal(expected.CSharpVirtualDocumentSuffix, actual.CSharpVirtualDocumentSuffix);
@@ -49,12 +49,12 @@ public class ConfigurableLanguageServerFeatureOptionsTest
     {
         var expected = new DefaultLanguageServerFeatureOptions();
 
-        var projectRazorJsonFilename = "project.razor.test.only.file.json";
-        var args = new[] { "noise", "--projectConfigurationFilename", projectRazorJsonFilename, "ignore", "this" };
+        var projectRazorBinFilename = "project.razor.test.only.file.bin";
+        var args = new[] { "noise", "--projectConfigurationFilename", projectRazorBinFilename, "ignore", "this" };
 
         var actual = new ConfigurableLanguageServerFeatureOptions(args);
 
-        Assert.Equal(projectRazorJsonFilename, actual.ProjectConfigurationFileName);
+        Assert.Equal(projectRazorBinFilename, actual.ProjectConfigurationFileName);
 
         Assert.Equal(expected.SupportsFileManipulation, actual.SupportsFileManipulation);
         Assert.Equal(expected.CSharpVirtualDocumentSuffix, actual.CSharpVirtualDocumentSuffix);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DirectoryHelperTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DirectoryHelperTest.cs
@@ -25,16 +25,16 @@ public class DirectoryHelperTest : TagHelperServiceTestBase
     public void GetFilteredFiles_FindsFiles()
     {
         // Arrange
-        var firstProjectRazorJson = @"HigherDirectory\project.razor.json";
-        var secondProjectRazorJson = @"HigherDirectory\RealDirectory\project.razor.json";
+        var firstProjectRazorJson = @"HigherDirectory\project.razor.bin";
+        var secondProjectRazorJson = @"HigherDirectory\RealDirectory\project.razor.bin";
 
         var workspaceDirectory = Path.Combine("LowerDirectory");
-        var searchPattern = "project.razor.json";
+        var searchPattern = "project.razor.bin";
         var ignoredDirectories = new[] { "node_modules" };
         var fileResults = new Dictionary<string, IEnumerable<string>>() {
             { "HigherDirectory", new []{ firstProjectRazorJson } },
             { "RealDirectory", new []{ secondProjectRazorJson } },
-            { "LongDirectory", new[]{ "LONGPATH", "LONGPATH\\project.razor.json"} },
+            { "LongDirectory", new[]{ "LONGPATH", "LONGPATH\\project.razor.bin" } },
             { "node_modules", null },
         };
         var directoryResults = new Dictionary<string, IEnumerable<string>>() {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/MonitorProjectConfigurationFilePathEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/MonitorProjectConfigurationFilePathEndpointTest.cs
@@ -46,7 +46,7 @@ public class MonitorProjectConfigurationFilePathEndpointTest : LanguageServerTes
         var request = new MonitorProjectConfigurationFilePathParams()
         {
             ProjectKeyId = TestProjectKey.Create("C:/dir/obj").Id,
-            ConfigurationFilePath = "C:/dir/obj/Debug/project.razor.json",
+            ConfigurationFilePath = "C:/dir/obj/Debug/project.razor.bin",
         };
         var requestContext = CreateRazorRequestContext(documentContext: null);
 
@@ -92,7 +92,7 @@ public class MonitorProjectConfigurationFilePathEndpointTest : LanguageServerTes
         var startRequest = new MonitorProjectConfigurationFilePathParams()
         {
             ProjectKeyId = TestProjectKey.Create("C:/dir/obj").Id,
-            ConfigurationFilePath = "C:/externaldir/obj/Debug/project.razor.json",
+            ConfigurationFilePath = "C:/externaldir/obj/Debug/project.razor.bin",
         };
         var requestContext = CreateRazorRequestContext(documentContext: null);
         await configurationFileEndpoint.HandleNotificationAsync(startRequest, requestContext, DisposalToken);
@@ -124,7 +124,7 @@ public class MonitorProjectConfigurationFilePathEndpointTest : LanguageServerTes
         var startRequest = new MonitorProjectConfigurationFilePathParams()
         {
             ProjectKeyId = TestProjectKey.Create("C:/dir/obj").Id,
-            ConfigurationFilePath = "C:/dir/obj/Debug/project.razor.json",
+            ConfigurationFilePath = "C:/dir/obj/Debug/project.razor.bin",
         };
         var requestContext = CreateRazorRequestContext(documentContext: null);
 
@@ -149,7 +149,7 @@ public class MonitorProjectConfigurationFilePathEndpointTest : LanguageServerTes
         var startRequest = new MonitorProjectConfigurationFilePathParams()
         {
             ProjectKeyId = TestProjectKey.Create("C:/dir/obj").Id,
-            ConfigurationFilePath = "C:/externaldir/obj/Debug/project.razor.json",
+            ConfigurationFilePath = "C:/externaldir/obj/Debug/project.razor.bin",
         };
         var requestContext = CreateRazorRequestContext(documentContext: null);
 
@@ -176,12 +176,12 @@ public class MonitorProjectConfigurationFilePathEndpointTest : LanguageServerTes
         var debugOutputPath = new MonitorProjectConfigurationFilePathParams()
         {
             ProjectKeyId = TestProjectKey.Create("C:/dir/obj").Id,
-            ConfigurationFilePath = "C:\\externaldir\\obj\\Debug\\project.razor.json",
+            ConfigurationFilePath = "C:\\externaldir\\obj\\Debug\\project.razor.bin",
         };
         var releaseOutputPath = new MonitorProjectConfigurationFilePathParams()
         {
             ProjectKeyId = debugOutputPath.ProjectKeyId,
-            ConfigurationFilePath = "C:\\externaldir\\obj\\Release\\project.razor.json",
+            ConfigurationFilePath = "C:\\externaldir\\obj\\Release\\project.razor.bin",
         };
         var requestContext = CreateRazorRequestContext(documentContext: null);
 
@@ -208,12 +208,12 @@ public class MonitorProjectConfigurationFilePathEndpointTest : LanguageServerTes
         var externalRequest = new MonitorProjectConfigurationFilePathParams()
         {
             ProjectKeyId = TestProjectKey.Create("C:\\dir\\obj").Id,
-            ConfigurationFilePath = "C:\\externaldir\\obj\\Debug\\project.razor.json",
+            ConfigurationFilePath = "C:\\externaldir\\obj\\Debug\\project.razor.bin",
         };
         var internalRequest = new MonitorProjectConfigurationFilePathParams()
         {
             ProjectKeyId = externalRequest.ProjectKeyId,
-            ConfigurationFilePath = "C:\\dir\\obj\\Release\\project.razor.json",
+            ConfigurationFilePath = "C:\\dir\\obj\\Release\\project.razor.bin",
         };
         var requestContext = CreateRazorRequestContext(documentContext: null);
 
@@ -244,12 +244,12 @@ public class MonitorProjectConfigurationFilePathEndpointTest : LanguageServerTes
         var debugOutputPath = new MonitorProjectConfigurationFilePathParams()
         {
             ProjectKeyId = TestProjectKey.Create("C:\\dir\\obj").Id,
-            ConfigurationFilePath = "C:\\externaldir1\\obj\\Debug\\project.razor.json",
+            ConfigurationFilePath = "C:\\externaldir1\\obj\\Debug\\project.razor.bin",
         };
         var releaseOutputPath = new MonitorProjectConfigurationFilePathParams()
         {
             ProjectKeyId = debugOutputPath.ProjectKeyId,
-            ConfigurationFilePath = "C:\\externaldir1\\obj\\Release\\project.razor.json",
+            ConfigurationFilePath = "C:\\externaldir1\\obj\\Release\\project.razor.bin",
         };
         var requestContext = CreateRazorRequestContext(documentContext: null);
 
@@ -291,17 +291,17 @@ public class MonitorProjectConfigurationFilePathEndpointTest : LanguageServerTes
         var debugOutputPath1 = new MonitorProjectConfigurationFilePathParams()
         {
             ProjectKeyId = TestProjectKey.Create("C:\\dir\\obj").Id,
-            ConfigurationFilePath = "C:\\externaldir1\\obj\\Debug\\project.razor.json",
+            ConfigurationFilePath = "C:\\externaldir1\\obj\\Debug\\project.razor.bin",
         };
         var releaseOutputPath1 = new MonitorProjectConfigurationFilePathParams()
         {
             ProjectKeyId = debugOutputPath1.ProjectKeyId,
-            ConfigurationFilePath = "C:\\externaldir1\\obj\\Release\\project.razor.json",
+            ConfigurationFilePath = "C:\\externaldir1\\obj\\Release\\project.razor.bin",
         };
         var debugOutputPath2 = new MonitorProjectConfigurationFilePathParams()
         {
             ProjectKeyId = TestProjectKey.Create("C:\\dir\\obj2").Id,
-            ConfigurationFilePath = "C:\\externaldir2\\obj\\Debug\\project.razor.json",
+            ConfigurationFilePath = "C:\\externaldir2\\obj\\Debug\\project.razor.bin",
         };
         var requestContext = CreateRazorRequestContext(documentContext: null);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationFileChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationFileChangeDetectorTest.cs
@@ -35,7 +35,7 @@ public class ProjectConfigurationFileChangeDetectorTest : LanguageServerTestBase
         var listener2 = new Mock<IProjectConfigurationFileChangeListener>(MockBehavior.Strict);
         listener2.Setup(l => l.ProjectConfigurationFileChanged(It.IsAny<ProjectConfigurationFileChangeEventArgs>()))
             .Callback<ProjectConfigurationFileChangeEventArgs>(args => eventArgs2.Add(args));
-        var existingConfigurationFiles = new[] { "c:/path/to/project.razor.json", "c:/other/path/project.razor.json" };
+        var existingConfigurationFiles = new[] { "c:/path/to/project.razor.json", "c:/other/path/project.razor.bin" };
         var cts = new CancellationTokenSource();
         var detector = new TestProjectConfigurationFileChangeDetector(
             cts,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationFileChangeEventArgsTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationFileChangeEventArgsTest.cs
@@ -23,7 +23,7 @@ public class ProjectConfigurationFileChangeEventArgsTest(ITestOutputHelper testO
         deserializerMock
             .Setup(x => x.DeserializeFromFile(It.IsAny<string>()))
             .Returns(new RazorProjectInfo(
-                "/path/to/obj/project.razor.json",
+                "/path/to/obj/project.razor.bin",
                 "c:/path/to/project.csproj",
                 configuration: null,
                 rootNamespace: null,
@@ -31,7 +31,7 @@ public class ProjectConfigurationFileChangeEventArgsTest(ITestOutputHelper testO
                 documents: ImmutableArray<DocumentSnapshotHandle>.Empty));
 
         var args = new ProjectConfigurationFileChangeEventArgs(
-            configurationFilePath: "/path/to/obj/project.razor.json",
+            configurationFilePath: "/path/to/obj/project.razor.bin",
             kind: RazorFileChangeKind.Removed,
             projectInfoDeserializer: deserializerMock.Object);
 
@@ -50,7 +50,7 @@ public class ProjectConfigurationFileChangeEventArgsTest(ITestOutputHelper testO
         // Arrange
         var deserializerMock = new Mock<IRazorProjectInfoDeserializer>(MockBehavior.Strict);
         var projectInfo = new RazorProjectInfo(
-            "/path/to/ORIGINAL/obj/project.razor.json",
+            "/path/to/ORIGINAL/obj/project.razor.bin",
             "c:/path/to/project.csproj",
             configuration: null,
             rootNamespace: null,
@@ -62,7 +62,7 @@ public class ProjectConfigurationFileChangeEventArgsTest(ITestOutputHelper testO
             .Returns(projectInfo);
 
         var args = new ProjectConfigurationFileChangeEventArgs(
-            configurationFilePath: "/path/to/DIFFERENT/obj/project.razor.json",
+            configurationFilePath: "/path/to/DIFFERENT/obj/project.razor.bin",
             kind: RazorFileChangeKind.Added,
             projectInfoDeserializer: deserializerMock.Object);
 
@@ -80,7 +80,7 @@ public class ProjectConfigurationFileChangeEventArgsTest(ITestOutputHelper testO
         // Arrange
         var deserializerMock = new Mock<IRazorProjectInfoDeserializer>(MockBehavior.Strict);
         var projectInfo = new RazorProjectInfo(
-            "/path/to/obj/project.razor.json",
+            "/path/to/obj/project.razor.bin",
             "c:/path/to/project.csproj",
             configuration: null,
             rootNamespace: null,
@@ -92,7 +92,7 @@ public class ProjectConfigurationFileChangeEventArgsTest(ITestOutputHelper testO
             .Returns(projectInfo);
 
         var args = new ProjectConfigurationFileChangeEventArgs(
-            configurationFilePath: "/path/to/obj/project.razor.json",
+            configurationFilePath: "/path/to/obj/project.razor.bin",
             kind: RazorFileChangeKind.Added,
             projectInfoDeserializer: deserializerMock.Object);
 
@@ -118,7 +118,7 @@ public class ProjectConfigurationFileChangeEventArgsTest(ITestOutputHelper testO
             .Callback(() => callCount++)
             .Returns<RazorProjectInfo>(null);
 
-        var args = new ProjectConfigurationFileChangeEventArgs("/path/to/obj/project.razor.json", RazorFileChangeKind.Changed, deserializerMock.Object);
+        var args = new ProjectConfigurationFileChangeEventArgs("/path/to/obj/project.razor.bin", RazorFileChangeKind.Changed, deserializerMock.Object);
 
         // Act
         var result1 = args.TryDeserialize(out var handle1);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationStateSynchronizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationStateSynchronizerTest.cs
@@ -33,7 +33,7 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
         var synchronizer = GetSynchronizer(projectService.Object);
         var deserializerMock = new Mock<IRazorProjectInfoDeserializer>(MockBehavior.Strict);
         var args = new ProjectConfigurationFileChangeEventArgs(
-            configurationFilePath: "/path/to/project.razor.json",
+            configurationFilePath: "/path/to/project.razor.bin",
             kind: RazorFileChangeKind.Removed,
             projectInfoDeserializer: deserializerMock.Object);
 
@@ -50,7 +50,7 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
     {
         // Arrange
         var projectInfo = new RazorProjectInfo(
-            "/path/to/obj/project.razor.json",
+            "/path/to/obj/project.razor.bin",
             "path/to/project.csproj",
             RazorConfiguration.Default,
             rootNamespace: "TestRootNamespace",
@@ -78,7 +78,7 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
                  ImmutableArray<DocumentSnapshotHandle>.Empty)).Verifiable();
         var synchronizer = GetSynchronizer(projectService.Object);
         var jsonFileDeserializer = CreateDeserializer(projectInfo);
-        var addArgs = new ProjectConfigurationFileChangeEventArgs("/path/to\\obj/project.razor.json", RazorFileChangeKind.Added, jsonFileDeserializer);
+        var addArgs = new ProjectConfigurationFileChangeEventArgs("/path/to\\obj/project.razor.bin", RazorFileChangeKind.Added, jsonFileDeserializer);
         var enqueueTask = await Dispatcher.RunOnDispatcherThreadAsync(async () =>
         {
             synchronizer.ProjectConfigurationFileChanged(addArgs);
@@ -87,7 +87,7 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
         await enqueueTask;
 
         var removeArgs = new ProjectConfigurationFileChangeEventArgs(
-            configurationFilePath: "/path/to/obj/project.razor.json",
+            configurationFilePath: "/path/to/obj/project.razor.bin",
             kind: RazorFileChangeKind.Removed,
             projectInfoDeserializer: Mock.Of<IRazorProjectInfoDeserializer>(MockBehavior.Strict));
 
@@ -116,7 +116,7 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
             .Returns((RazorProjectInfo)null);
 
         var args = new ProjectConfigurationFileChangeEventArgs(
-            configurationFilePath: "/path/to/project.razor.json",
+            configurationFilePath: "/path/to/project.razor.bin",
             kind: RazorFileChangeKind.Added,
             projectInfoDeserializer: deserializerMock.Object);
 
@@ -133,7 +133,7 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
     {
         // Arrange
         var projectInfo = new RazorProjectInfo(
-            "/path/to/obj/project.razor.json",
+            "/path/to/obj/project.razor.bin",
             "path/to/project.csproj",
             RazorConfiguration.Default,
             rootNamespace: "TestRootNamespace",
@@ -151,7 +151,7 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
             projectInfo.Documents)).Verifiable();
         var synchronizer = GetSynchronizer(projectService.Object);
         var jsonFileDeserializer = CreateDeserializer(projectInfo);
-        var args = new ProjectConfigurationFileChangeEventArgs("/path/to/obj/project.razor.json", RazorFileChangeKind.Added, jsonFileDeserializer);
+        var args = new ProjectConfigurationFileChangeEventArgs("/path/to/obj/project.razor.bin", RazorFileChangeKind.Added, jsonFileDeserializer);
 
         // Act
         var enqueueTask = await Dispatcher.RunOnDispatcherThreadAsync(async () =>
@@ -170,7 +170,7 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
     {
         // Arrange
         var projectInfo = new RazorProjectInfo(
-            "/path/to/obj/project.razor.json",
+            "/path/to/obj/project.razor.bin",
             "path/to/project.csproj",
             RazorConfiguration.Default,
             rootNamespace: "TestRootNamespace",
@@ -194,7 +194,7 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
              Array.Empty<DocumentSnapshotHandle>())).Verifiable();
         var synchronizer = GetSynchronizer(projectService.Object);
         var deserializer = CreateDeserializer(projectInfo);
-        var addArgs = new ProjectConfigurationFileChangeEventArgs("/path/to/obj/project.razor.json", RazorFileChangeKind.Added, deserializer);
+        var addArgs = new ProjectConfigurationFileChangeEventArgs("/path/to/obj/project.razor.bin", RazorFileChangeKind.Added, deserializer);
         var enqueueTask = await Dispatcher.RunOnDispatcherThreadAsync(async () =>
         {
             synchronizer.ProjectConfigurationFileChanged(addArgs);
@@ -203,7 +203,7 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
         await enqueueTask;
 
         var removeArgs = new ProjectConfigurationFileChangeEventArgs(
-            configurationFilePath: "/path/to/obj/project.razor.json",
+            configurationFilePath: "/path/to/obj/project.razor.bin",
             kind: RazorFileChangeKind.Removed,
             projectInfoDeserializer: Mock.Of<IRazorProjectInfoDeserializer>(MockBehavior.Strict));
 
@@ -224,7 +224,7 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
     {
         // Arrange
         var initialProjectInfo = new RazorProjectInfo(
-            "/path/to/obj/project.razor.json",
+            "/path/to/obj/project.razor.bin",
             "path/to/project.csproj",
             RazorConfiguration.Default,
             rootNamespace: "TestRootNamespace",
@@ -241,7 +241,7 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
             initialProjectInfo.ProjectWorkspaceState,
             initialProjectInfo.Documents)).Verifiable();
         var changedProjectInfo = new RazorProjectInfo(
-            "/path/to/obj/project.razor.json",
+            "/path/to/obj/project.razor.bin",
             "path/to/project.csproj",
             RazorConfiguration.Create(
                 RazorLanguageVersion.Experimental,
@@ -258,7 +258,7 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
             changedProjectInfo.Documents)).Verifiable();
         var synchronizer = GetSynchronizer(projectService.Object);
         var addDeserializer = CreateDeserializer(initialProjectInfo);
-        var addArgs = new ProjectConfigurationFileChangeEventArgs("path/to/obj/project.razor.json", RazorFileChangeKind.Added, addDeserializer);
+        var addArgs = new ProjectConfigurationFileChangeEventArgs("path/to/obj/project.razor.bin", RazorFileChangeKind.Added, addDeserializer);
 
         var enqueueTask = await Dispatcher.RunOnDispatcherThreadAsync(async () =>
         {
@@ -268,7 +268,7 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
         await enqueueTask;
 
         var changedDeserializer = CreateDeserializer(changedProjectInfo);
-        var changedArgs = new ProjectConfigurationFileChangeEventArgs("path/to/obj/project.razor.json", RazorFileChangeKind.Changed, changedDeserializer);
+        var changedArgs = new ProjectConfigurationFileChangeEventArgs("path/to/obj/project.razor.bin", RazorFileChangeKind.Changed, changedDeserializer);
 
         // Act
         enqueueTask = await Dispatcher.RunOnDispatcherThreadAsync(async () =>
@@ -287,7 +287,7 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
     {
         // Arrange
         var initialProjectInfo = new RazorProjectInfo(
-            "/path/to/obj/project.razor.json",
+            "/path/to/obj/project.razor.bin",
             "path/to/project.csproj",
             RazorConfiguration.Default,
             rootNamespace: "TestRootNamespace",
@@ -304,7 +304,7 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
             initialProjectInfo.ProjectWorkspaceState,
             initialProjectInfo.Documents)).Verifiable();
         var changedProjectInfo = new RazorProjectInfo(
-            "/path/to/obj/project.razor.json",
+            "/path/to/obj/project.razor.bin",
             "path/to/project.csproj",
             RazorConfiguration.Create(
                 RazorLanguageVersion.Experimental,
@@ -323,7 +323,7 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
              Array.Empty<DocumentSnapshotHandle>())).Verifiable();
         var synchronizer = GetSynchronizer(projectService.Object);
         var addDeserializer = CreateDeserializer(initialProjectInfo);
-        var addArgs = new ProjectConfigurationFileChangeEventArgs("/path/to/obj/project.razor.json", RazorFileChangeKind.Added, addDeserializer);
+        var addArgs = new ProjectConfigurationFileChangeEventArgs("/path/to/obj/project.razor.bin", RazorFileChangeKind.Added, addDeserializer);
         var enqueueTask = await Dispatcher.RunOnDispatcherThreadAsync(async () =>
         {
             synchronizer.ProjectConfigurationFileChanged(addArgs);
@@ -337,7 +337,7 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
             .Returns((RazorProjectInfo)null);
 
         var changedArgs = new ProjectConfigurationFileChangeEventArgs(
-            configurationFilePath: "/path/to/obj/project.razor.json",
+            configurationFilePath: "/path/to/obj/project.razor.bin",
             kind: RazorFileChangeKind.Changed,
             projectInfoDeserializer: changedDeserializerMock.Object);
 
@@ -366,7 +366,7 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
             .Returns((RazorProjectInfo)null);
 
         var changedArgs = new ProjectConfigurationFileChangeEventArgs(
-            configurationFilePath: "/path/to/project.razor.json",
+            configurationFilePath: "/path/to/project.razor.bin",
             kind: RazorFileChangeKind.Changed,
             projectInfoDeserializer: changedDeserializerMock.Object);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/SerializationTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/SerializationTest.cs
@@ -40,7 +40,7 @@ public class SerializationTest : TestBase
     {
         // Arrange
         var projectInfo = new RazorProjectInfo(
-            "/path/to/obj/project.razor.json",
+            "/path/to/obj/project.razor.bin",
             "/path/to/project.csproj",
             _configuration,
             rootNamespace: "TestProject",
@@ -72,7 +72,7 @@ public class SerializationTest : TestBase
     {
         // Arrange
         var projectInfo = new RazorProjectInfo(
-            "/path/to/obj/project.razor.json",
+            "/path/to/obj/project.razor.bin",
             "/path/to/project.csproj",
             _configuration,
             rootNamespace: "TestProject",
@@ -106,7 +106,7 @@ public class SerializationTest : TestBase
         var legacyDocument = new DocumentSnapshotHandle("/path/to/file.cshtml", "file.cshtml", FileKinds.Legacy);
         var componentDocument = new DocumentSnapshotHandle("/path/to/otherfile.razor", "otherfile.razor", FileKinds.Component);
         var projectInfo = new RazorProjectInfo(
-            "/path/to/obj/project.razor.json",
+            "/path/to/obj/project.razor.bin",
             "/path/to/project.csproj",
             _configuration,
             rootNamespace: "TestProject",

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common/TestLanguageServerFeatureOptions.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.Common/TestLanguageServerFeatureOptions.cs
@@ -19,7 +19,7 @@ internal class TestLanguageServerFeatureOptions : LanguageServerFeatureOptions
 
     public override bool SupportsFileManipulation => false;
 
-    public override string ProjectConfigurationFileName => "project.razor.json";
+    public override string ProjectConfigurationFileName => "project.razor.bin";
 
     public override string CSharpVirtualDocumentSuffix => ".ide.g.cs";
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultProjectConfigurationFilePathStoreTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/DefaultProjectConfigurationFilePathStoreTest.cs
@@ -27,13 +27,13 @@ public class DefaultProjectConfigurationFilePathStoreTest : TestBase
         var store = new DefaultProjectConfigurationFilePathStore();
         var projectFilePath = @"C:\project.csproj";
         var hostProject = new HostProject(projectFilePath, @"C:\project\obj", RazorConfiguration.Default, null);
-        var configurationFilePath = @"C:\project\subpath\..\obj\project.razor.json";
+        var configurationFilePath = @"C:\project\subpath\..\obj\project.razor.bin";
         var called = false;
         store.Changed += (sender, args) =>
         {
             called = true;
             Assert.Equal(hostProject.Key, args.ProjectKey);
-            Assert.Equal(@"C:\project\obj\project.razor.json", args.ConfigurationFilePath);
+            Assert.Equal(@"C:\project\obj\project.razor.bin", args.ConfigurationFilePath);
         };
 
         // Act
@@ -50,7 +50,7 @@ public class DefaultProjectConfigurationFilePathStoreTest : TestBase
         var store = new DefaultProjectConfigurationFilePathStore();
         var projectFilePath = @"C:\project.csproj";
         var hostProject = new HostProject(projectFilePath, @"C:\project\obj", RazorConfiguration.Default, null);
-        var configurationFilePath = @"C:\project\obj\project.razor.json";
+        var configurationFilePath = @"C:\project\obj\project.razor.bin";
         var called = false;
         store.Changed += (sender, args) =>
         {
@@ -73,7 +73,7 @@ public class DefaultProjectConfigurationFilePathStoreTest : TestBase
         var store = new DefaultProjectConfigurationFilePathStore();
         var projectFilePath = @"C:\project.csproj";
         var hostProject = new HostProject(projectFilePath, @"C:\project\obj", RazorConfiguration.Default, null);
-        var configurationFilePath = @"C:\project\obj\project.razor.json";
+        var configurationFilePath = @"C:\project\obj\project.razor.bin";
         store.Set(hostProject.Key, configurationFilePath);
         var called = false;
         store.Changed += (sender, args) => called = true;
@@ -92,7 +92,7 @@ public class DefaultProjectConfigurationFilePathStoreTest : TestBase
         var store = new DefaultProjectConfigurationFilePathStore();
         var projectFilePath = @"C:\project.csproj";
         var hostProject = new HostProject(projectFilePath, @"C:\project\obj", RazorConfiguration.Default, null);
-        var expectedConfigurationFilePath = @"C:\project\obj\project.razor.json";
+        var expectedConfigurationFilePath = @"C:\project\obj\project.razor.bin";
         store.Set(hostProject.Key, expectedConfigurationFilePath);
 
         // Act
@@ -110,10 +110,10 @@ public class DefaultProjectConfigurationFilePathStoreTest : TestBase
         var store = new DefaultProjectConfigurationFilePathStore();
         var projectFilePath = @"C:\project.csproj";
         var hostProject = new HostProject(projectFilePath, @"C:\project\obj", RazorConfiguration.Default, null);
-        var expectedConfigurationFilePath = @"C:\project\obj\project.razor.json";
+        var expectedConfigurationFilePath = @"C:\project\obj\project.razor.bin";
 
         // Act
-        store.Set(hostProject.Key, @"C:\other\obj\project.razor.json");
+        store.Set(hostProject.Key, @"C:\other\obj\project.razor.bin");
         store.Set(hostProject.Key, expectedConfigurationFilePath);
 
         // Assert
@@ -131,7 +131,7 @@ public class DefaultProjectConfigurationFilePathStoreTest : TestBase
         // Act
         var mappings = store.GetMappings();
         var hostProject = new HostProject(@"C:\project.csproj", @"C:\project\obj", RazorConfiguration.Default, null);
-        store.Set(hostProject.Key, @"C:\project\obj\project.razor.json");
+        store.Set(hostProject.Key, @"C:\project\obj\project.razor.bin");
 
         // Assert
         Assert.Empty(mappings);
@@ -144,8 +144,7 @@ public class DefaultProjectConfigurationFilePathStoreTest : TestBase
         var store = new DefaultProjectConfigurationFilePathStore();
         var expectedMappings = new Dictionary<ProjectKey, string>()
         {
-            [TestProjectKey.Create(@"C:\project1\obj")] = @"C:\project1\obj\project.razor.json",
-            [TestProjectKey.Create(@"C:\project2\obj")] = @"C:\project2\obj\project.razor.json"
+            [TestProjectKey.Create(@"C:\project1\obj")] = @"C:\project1\obj\project.razor.bin"
         };
         foreach (var mapping in expectedMappings)
         {
@@ -166,7 +165,7 @@ public class DefaultProjectConfigurationFilePathStoreTest : TestBase
         var store = new DefaultProjectConfigurationFilePathStore();
         var projectFilePath = @"C:\project.csproj";
         var hostProject = new HostProject(projectFilePath, @"C:\project\obj", RazorConfiguration.Default, null);
-        store.Set(hostProject.Key, @"C:\project\obj\project.razor.json");
+        store.Set(hostProject.Key, @"C:\project\obj\project.razor.bin");
         var called = false;
         store.Changed += (sender, args) =>
         {
@@ -204,7 +203,7 @@ public class DefaultProjectConfigurationFilePathStoreTest : TestBase
         var store = new DefaultProjectConfigurationFilePathStore();
         var projectFilePath = @"C:\project.csproj";
         var hostProject = new HostProject(projectFilePath, @"C:\project\obj", RazorConfiguration.Default, null);
-        store.Set(hostProject.Key, @"C:\project\obj\project.razor.json");
+        store.Set(hostProject.Key, @"C:\project\obj\project.razor.bin");
 
         // Act
         store.Remove(hostProject.Key);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/RazorProjectInfoPublisherTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/RazorProjectInfoPublisherTest.cs
@@ -44,7 +44,7 @@ public class RazorProjectInfoPublisherTest : LanguageServerTestBase
 
         var initialProjectSnapshot = CreateProjectSnapshot(@"C:\path\to\project.csproj", new ProjectWorkspaceState(tagHelpers, CodeAnalysis.CSharp.LanguageVersion.Preview));
         var expectedProjectSnapshot = CreateProjectSnapshot(@"C:\path\to\project.csproj", new ProjectWorkspaceState(ImmutableArray<TagHelperDescriptor>.Empty, CodeAnalysis.CSharp.LanguageVersion.Preview));
-        var expectedConfigurationFilePath = @"C:\path\to\obj\bin\Debug\project.razor.json";
+        var expectedConfigurationFilePath = @"C:\path\to\obj\bin\Debug\project.razor.bin";
         var publisher = new TestRazorProjectInfoPublisher(
             _projectConfigurationFilePathStore,
             onSerializeToFile: (snapshot, configurationFilePath) =>
@@ -132,7 +132,7 @@ public class RazorProjectInfoPublisherTest : LanguageServerTestBase
         _projectSnapshotManager.ProjectWorkspaceStateChanged(hostProject.Key, ProjectWorkspaceState.Default);
         _projectSnapshotManager.DocumentAdded(hostProject.Key, hostDocument, new EmptyTextLoader(hostDocument.FilePath));
         var projectSnapshot = _projectSnapshotManager.GetProjects()[0];
-        var expectedConfigurationFilePath = @"C:\path\to\obj\bin\Debug\project.razor.json";
+        var expectedConfigurationFilePath = @"C:\path\to\obj\bin\Debug\project.razor.bin";
         _projectConfigurationFilePathStore.Set(projectSnapshot.Key, expectedConfigurationFilePath);
         var publisher = new TestRazorProjectInfoPublisher(
             _projectConfigurationFilePathStore,
@@ -167,7 +167,7 @@ public class RazorProjectInfoPublisherTest : LanguageServerTestBase
         // Arrange
         var serializationSuccessful = false;
         var projectSnapshot = CreateProjectSnapshot(@"C:\path\to\project.csproj", new ProjectWorkspaceState(ImmutableArray<TagHelperDescriptor>.Empty, CodeAnalysis.CSharp.LanguageVersion.CSharp7_3));
-        var expectedConfigurationFilePath = @"C:\path\to\obj\bin\Debug\project.razor.json";
+        var expectedConfigurationFilePath = @"C:\path\to\obj\bin\Debug\project.razor.bin";
         var publisher = new TestRazorProjectInfoPublisher(
             _projectConfigurationFilePathStore,
             onSerializeToFile: (snapshot, configurationFilePath) =>
@@ -200,7 +200,7 @@ public class RazorProjectInfoPublisherTest : LanguageServerTestBase
         var serializationSuccessful = false;
         var projectSnapshot = CreateProjectSnapshot(@"C:\path\to\project.csproj", new ProjectWorkspaceState(ImmutableArray<TagHelperDescriptor>.Empty, CodeAnalysis.CSharp.LanguageVersion.Default));
         var changedProjectSnapshot = CreateProjectSnapshot(@"C:\path\to\project.csproj", new ProjectWorkspaceState(ImmutableArray<TagHelperDescriptor>.Empty, CodeAnalysis.CSharp.LanguageVersion.CSharp8));
-        var expectedConfigurationFilePath = @"C:\path\to\obj\bin\Debug\project.razor.json";
+        var expectedConfigurationFilePath = @"C:\path\to\obj\bin\Debug\project.razor.bin";
         var aboutToChange = false;
         var publisher = new TestRazorProjectInfoPublisher(
             _projectConfigurationFilePathStore,
@@ -246,7 +246,7 @@ public class RazorProjectInfoPublisherTest : LanguageServerTestBase
         // Arrange
         var attemptedToSerialize = false;
         var projectSnapshot = CreateProjectSnapshot(@"C:\path\to\project.csproj");
-        var expectedConfigurationFilePath = @"C:\path\to\obj\bin\Debug\project.razor.json";
+        var expectedConfigurationFilePath = @"C:\path\to\obj\bin\Debug\project.razor.bin";
         var publisher = new TestRazorProjectInfoPublisher(
             _projectConfigurationFilePathStore,
             onSerializeToFile: (snapshot, configurationFilePath) => attemptedToSerialize = true)
@@ -276,7 +276,7 @@ public class RazorProjectInfoPublisherTest : LanguageServerTestBase
         var serializationSuccessful = false;
         var firstSnapshot = CreateProjectSnapshot(@"C:\path\to\project.csproj");
         var secondSnapshot = CreateProjectSnapshot(@"C:\path\to\project.csproj", new[] { @"C:\path\to\file.cshtml" });
-        var expectedConfigurationFilePath = @"C:\path\to\obj\bin\Debug\project.razor.json";
+        var expectedConfigurationFilePath = @"C:\path\to\obj\bin\Debug\project.razor.bin";
         var publisher = new TestRazorProjectInfoPublisher(
             _projectConfigurationFilePathStore,
             onSerializeToFile: (snapshot, configurationFilePath) =>
@@ -309,7 +309,7 @@ public class RazorProjectInfoPublisherTest : LanguageServerTestBase
         var serializationSuccessful = false;
         var firstSnapshot = CreateProjectSnapshot(@"C:\path\to\project.csproj");
         var secondSnapshot = CreateProjectSnapshot(@"C:\path\to\project.csproj", new[] { @"C:\path\to\file.cshtml" });
-        var expectedConfigurationFilePath = @"C:\path\to\objbin\Debug\project.razor.json";
+        var expectedConfigurationFilePath = @"C:\path\to\objbin\Debug\project.razor.bin";
         var publisher = new TestRazorProjectInfoPublisher(
             _projectConfigurationFilePathStore,
             onSerializeToFile: (snapshot, configurationFilePath) =>
@@ -348,7 +348,7 @@ public class RazorProjectInfoPublisherTest : LanguageServerTestBase
         var secondSnapshot = CreateProjectSnapshot(@"C:\path\to\project.csproj", new ProjectWorkspaceState(tagHelpers, CodeAnalysis.CSharp.LanguageVersion.CSharp8), new string[]{
             "FileName.razor"
         });
-        var expectedConfigurationFilePath = @"C:\path\to\obj\bin\Debug\project.razor.json";
+        var expectedConfigurationFilePath = @"C:\path\to\obj\bin\Debug\project.razor.bin";
         var publisher = new TestRazorProjectInfoPublisher(
             _projectConfigurationFilePathStore,
             onSerializeToFile: (snapshot, configurationFilePath) =>
@@ -396,7 +396,7 @@ public class RazorProjectInfoPublisherTest : LanguageServerTestBase
         // Arrange
         var serializationSuccessful = false;
         var omniSharpProjectSnapshot = CreateProjectSnapshot(@"C:\path\to\project.csproj");
-        var expectedConfigurationFilePath = @"C:\path\to\obj\bin\Debug\project.razor.json";
+        var expectedConfigurationFilePath = @"C:\path\to\obj\bin\Debug\project.razor.bin";
         var publisher = new TestRazorProjectInfoPublisher(
             _projectConfigurationFilePathStore,
             onSerializeToFile: (snapshot, configurationFilePath) =>
@@ -423,7 +423,7 @@ public class RazorProjectInfoPublisherTest : LanguageServerTestBase
     {
         // Arrange
         var serializationSuccessful = false;
-        var expectedConfigurationFilePath = @"C:\path\to\obj\bin\Debug\project.razor.json";
+        var expectedConfigurationFilePath = @"C:\path\to\obj\bin\Debug\project.razor.bin";
 
         var publisher = new TestRazorProjectInfoPublisher(
             _projectConfigurationFilePathStore,
@@ -457,7 +457,7 @@ public class RazorProjectInfoPublisherTest : LanguageServerTestBase
     {
         // Arrange
         var serializationSuccessful = false;
-        var expectedConfigurationFilePath = @"C:\path\to\obj\bin\Debug\project.razor.json";
+        var expectedConfigurationFilePath = @"C:\path\to\obj\bin\Debug\project.razor.bin";
 
         var publisher = new TestRazorProjectInfoPublisher(
             _projectConfigurationFilePathStore,
@@ -506,7 +506,7 @@ public class RazorProjectInfoPublisherTest : LanguageServerTestBase
     {
         // Arrange
         var serializationSuccessful = false;
-        var expectedConfigurationFilePath = @"C:\path\to\obj\bin\Debug\project.razor.json";
+        var expectedConfigurationFilePath = @"C:\path\to\obj\bin\Debug\project.razor.bin";
 
         var publisher = new TestRazorProjectInfoPublisher(
             _projectConfigurationFilePathStore,

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/SolutionExplorerInProcess.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/SolutionExplorerInProcess.cs
@@ -163,7 +163,7 @@ internal partial class SolutionExplorerInProcess
         var style = "Debug";
         var framework = "net6.0";
 
-        var razorJsonPath = Path.Combine(localPath, "obj", style, framework, "project.razor.vs.json");
+        var razorJsonPath = Path.Combine(localPath, "obj", style, framework, "project.razor.vs.bin");
 
         await Helper.RetryAsync(ct =>
         {

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/ProjectTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/ProjectTests.cs
@@ -54,11 +54,11 @@ public class ProjectTests(ITestOutputHelper testOutputHelper) : AbstractRazorEdi
         await TestServices.Editor.WaitForComponentClassificationAsync(ControlledHangMitigatingCancellationToken, count: 3);
 
         // This is a little odd, but there is no "real" way to check this via VS, and one of the most important things this test can do
-        // is ensure that each target framework gets its own project.razor.json file, and doesn't share one from a cache or anything.
+        // is ensure that each target framework gets its own project.razor.bin file, and doesn't share one from a cache or anything.
         Assert.Equal(2, GetProjectRazorJsonFileCount());
 
         int GetProjectRazorJsonFileCount()
-            => Directory.EnumerateFiles(solutionPath, "project.razor.*.json", SearchOption.AllDirectories).Count();
+            => Directory.EnumerateFiles(solutionPath, "project.razor.*.bin", SearchOption.AllDirectories).Count();
     }
 
     [IdeFact]
@@ -110,11 +110,11 @@ public class ProjectTests(ITestOutputHelper testOutputHelper) : AbstractRazorEdi
         await TestServices.Editor.WaitForComponentClassificationAsync(ControlledHangMitigatingCancellationToken, count: 3);
 
         // This is a little odd, but there is no "real" way to check this via VS, and one of the most important things this test can do
-        // is ensure that each target framework gets its own project.razor.json file, and doesn't share one from a cache or anything.
+        // is ensure that each target framework gets its own project.razor.bin file, and doesn't share one from a cache or anything.
         Assert.Equal(2, GetProjectRazorJsonFileCount());
 
         int GetProjectRazorJsonFileCount()
-            => Directory.EnumerateFiles(solutionPath, "project.razor.*.json", SearchOption.AllDirectories).Count();
+            => Directory.EnumerateFiles(solutionPath, "project.razor.*.bin", SearchOption.AllDirectories).Count();
     }
 
     [IdeFact]
@@ -184,8 +184,8 @@ public class ProjectTests(ITestOutputHelper testOutputHelper) : AbstractRazorEdi
 
         await TestServices.SolutionExplorer.CloseSolutionAsync(ControlledHangMitigatingCancellationToken);
 
-        // Clear out the project.razor.json file which ensures our restored file will have to be in the Misc Project
-        var projectRazorJsonFileName = Directory.EnumerateFiles(solutionPath, "project.razor.*.json", SearchOption.AllDirectories).First();
+        // Clear out the project.razor.bin file which ensures our restored file will have to be in the Misc Project
+        var projectRazorJsonFileName = Directory.EnumerateFiles(solutionPath, "project.razor.*.bin", SearchOption.AllDirectories).First();
         File.Delete(projectRazorJsonFileName);
 
         var solutionFileName = Path.Combine(solutionPath, RazorProjectConstants.BlazorSolutionName + ".sln");


### PR DESCRIPTION
This change uses the message pack formatters to serialize and deserialize the project configuration file. Of particular note, I added support to the message pack formatters for "skimming". The idea is that, when deserializing tag helpers, we look at the checksum first and determine whether that tag helper is in our cache. If it is, partially deserialize the tag helper by skimming through the byte stream. While skipping, we ensure that the `SerializerCachingOptions` are populated correctly with cached streams and `MetadataCollections`. In addition, because we're no longer serializing the file as "json", I've changed the file extension to ".bin".