### PR TITLE
Further reduce allocations in semantic tokens

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCSharpFormattingBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCSharpFormattingBenchmark.cs
@@ -124,7 +124,7 @@ public class RazorCSharpFormattingBenchmark : RazorLanguageServerBenchmarkBase
 
 #if DEBUG
         // For debugging purposes only.
-        var changedText = DocumentText.WithChanges(edits.Select(e => e.AsTextChange(DocumentText)));
+        var changedText = DocumentText.WithChanges(edits.Select(e => e.ToTextChange(DocumentText)));
         _ = changedText.ToString();
 #endif
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AbstractRazorDelegatingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AbstractRazorDelegatingEndpoint.cs
@@ -139,7 +139,7 @@ internal abstract class AbstractRazorDelegatingEndpoint<TRequest, TResponse> : I
             // C# properties, even though they appear entirely in a Html context. Since remapping is pretty cheap
             // it's easier to just try mapping, and see what happens, rather than checking for specific syntax nodes.
             var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
-            if (_documentMappingService.TryMapToGeneratedDocumentPosition(codeDocument.GetCSharpDocument(), positionInfo.HostDocumentIndex, out var csharpPosition, out _))
+            if (_documentMappingService.TryMapToGeneratedDocumentPosition(codeDocument.GetCSharpDocument(), positionInfo.HostDocumentIndex, out Position? csharpPosition, out _))
             {
                 // We're just gonna pretend this mapped perfectly normally onto C#. Moving this logic to the actual position info
                 // calculating code is possible, but could have untold effects, so opt-in is better (for now?)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/TypeAccessibilityCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/TypeAccessibilityCodeActionProvider.cs
@@ -98,7 +98,7 @@ internal sealed class TypeAccessibilityCodeActionProvider : ICSharpCodeActionPro
                 continue;
             }
 
-            var diagnosticSpan = diagnostic.Range.AsTextSpan(context.SourceText);
+            var diagnosticSpan = diagnostic.Range.ToTextSpan(context.SourceText);
 
             // Based on how we compute `Range.AsTextSpan` it's possible to have a span
             // which goes beyond the end of the source text. Something likely changed

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/DefinitionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/DefinitionEndpoint.cs
@@ -295,7 +295,7 @@ internal sealed class DefinitionEndpoint : AbstractRazorDelegatingEndpoint<TextD
                 return null;
             }
 
-            var range = property.Identifier.Span.AsRange(csharpText);
+            var range = property.Identifier.Span.ToRange(csharpText);
             if (documentMappingService.TryMapToHostDocumentRange(codeDocument.GetCSharpDocument(), range, out var originalRange))
             {
                 return originalRange;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorTranslateDiagnosticsService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorTranslateDiagnosticsService.cs
@@ -171,7 +171,7 @@ internal class RazorTranslateDiagnosticsService
         }
 
         
-        var owner = syntaxTree.Root.FindNode(d.Range.AsRazorTextSpan(sourceText), getInnermostNodeForTie: true);
+        var owner = syntaxTree.Root.FindNode(d.Range.ToRazorTextSpan(sourceText), getInnermostNodeForTie: true);
         if (IsCsharpKind(owner))
         {
             return true;
@@ -509,7 +509,7 @@ internal class RazorTranslateDiagnosticsService
         // semi-intelligent way.
 
         var syntaxTree = codeDocument.GetSyntaxTree();
-        var span = diagnosticRange.AsRazorTextSpan(codeDocument.GetSourceText());
+        var span = diagnosticRange.ToRazorTextSpan(codeDocument.GetSourceText());
         var owner = syntaxTree.Root.FindNode(span, getInnermostNodeForTie: true);
 
         switch (owner?.Kind)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IRazorDocumentMappingServiceExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IRazorDocumentMappingServiceExtensions.cs
@@ -1,18 +1,23 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
 internal static class IRazorDocumentMappingServiceExtensions
 {
+    public static bool TryMapToHostDocumentRange(this IRazorDocumentMappingService service, IRazorGeneratedDocument generatedDocument, LinePositionSpan projectedRange, out LinePositionSpan originalRange)
+        => service.TryMapToHostDocumentRange(generatedDocument, projectedRange, MappingBehavior.Strict, out originalRange);
+
     public static bool TryMapToHostDocumentRange(this IRazorDocumentMappingService service, IRazorGeneratedDocument generatedDocument, Range projectedRange, [NotNullWhen(true)] out Range? originalRange)
         => service.TryMapToHostDocumentRange(generatedDocument, projectedRange, MappingBehavior.Strict, out originalRange);
 
@@ -46,5 +51,51 @@ internal static class IRazorDocumentMappingServiceExtensions
         }
 
         return new DocumentPositionInfo(languageKind, position, hostDocumentIndex);
+    }
+
+    public static bool TryMapToHostDocumentRange(this IRazorDocumentMappingService service, IRazorGeneratedDocument generatedDocument, Range generatedDocumentRange, MappingBehavior mappingBehavior, [NotNullWhen(true)] out Range? hostDocumentRange)
+    {
+        var result = service.TryMapToHostDocumentRange(generatedDocument, generatedDocumentRange.AsLinePositionSpan(), mappingBehavior, out var hostDocumentLinePositionSpan);
+        hostDocumentRange = result ? hostDocumentLinePositionSpan.AsRange() : null;
+        return result;
+    }
+
+    public static bool TryMapToGeneratedDocumentRange(this IRazorDocumentMappingService service, IRazorGeneratedDocument generatedDocument, Range hostDocumentRange, [NotNullWhen(true)] out Range? generatedDocumentRange)
+    {
+        var result = service.TryMapToGeneratedDocumentRange(generatedDocument, hostDocumentRange.AsLinePositionSpan(), out var generatedDocumentLinePositionSpan);
+        generatedDocumentRange = result ? generatedDocumentLinePositionSpan.AsRange() : null;
+        return result;
+    }
+
+    public static bool TryMapToHostDocumentPosition(this IRazorDocumentMappingService service, IRazorGeneratedDocument generatedDocument, int generatedDocumentIndex, [NotNullWhen(true)] out Position? hostDocumentPosition, out int hostDocumentIndex)
+    {
+        var result = service.TryMapToHostDocumentPosition(generatedDocument, generatedDocumentIndex,  out var hostDocumentLinePosition, out hostDocumentIndex);
+        hostDocumentPosition = result ? hostDocumentLinePosition.AsPosition() : null;
+        return result;
+    }
+
+    public static bool TryMapToGeneratedDocumentPosition(this IRazorDocumentMappingService service, IRazorGeneratedDocument generatedDocument, int hostDocumentIndex, [NotNullWhen(true)] out Position? generatedPosition, out int generatedIndex)
+    {
+        var result = service.TryMapToGeneratedDocumentPosition(generatedDocument, hostDocumentIndex, out var generatedLinePosition, out generatedIndex);
+        generatedPosition = result ? generatedLinePosition.AsPosition() : null;
+        return result;
+    }
+
+    public static bool TryMapToGeneratedDocumentOrNextCSharpPosition(this IRazorDocumentMappingService service, IRazorGeneratedDocument generatedDocument, int hostDocumentIndex, [NotNullWhen(true)] out Position? generatedPosition, out int generatedIndex)
+    {
+        var result = service.TryMapToGeneratedDocumentOrNextCSharpPosition(generatedDocument, hostDocumentIndex, out var generatedLinePosition, out generatedIndex);
+        generatedPosition = result ? generatedLinePosition.AsPosition() : null;
+        return result;
+    }
+
+    /// <summary>
+    /// Maps a range in the specified generated document uri to a range in the Razor document that owns the
+    /// generated document. If the uri passed in is not for a generated document, or the range cannot be mapped
+    /// for some other reason, the original passed in range is returned unchanged.
+    /// </summary>
+    public static async Task<(Uri MappedDocumentUri, Range MappedRange)> MapToHostDocumentUriAndRangeAsync(this IRazorDocumentMappingService service, Uri generatedDocumentUri, Range generatedDocumentRange, CancellationToken cancellationToken)
+    {
+        var result = await service.MapToHostDocumentUriAndRangeAsync(generatedDocumentUri, generatedDocumentRange.AsLinePositionSpan(), cancellationToken).ConfigureAwait(false);
+        return (result.MappedDocumentUri, result.MappedRange.AsRange());
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IRazorDocumentMappingServiceExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IRazorDocumentMappingServiceExtensions.cs
@@ -55,36 +55,36 @@ internal static class IRazorDocumentMappingServiceExtensions
 
     public static bool TryMapToHostDocumentRange(this IRazorDocumentMappingService service, IRazorGeneratedDocument generatedDocument, Range generatedDocumentRange, MappingBehavior mappingBehavior, [NotNullWhen(true)] out Range? hostDocumentRange)
     {
-        var result = service.TryMapToHostDocumentRange(generatedDocument, generatedDocumentRange.AsLinePositionSpan(), mappingBehavior, out var hostDocumentLinePositionSpan);
-        hostDocumentRange = result ? hostDocumentLinePositionSpan.AsRange() : null;
+        var result = service.TryMapToHostDocumentRange(generatedDocument, generatedDocumentRange.ToLinePositionSpan(), mappingBehavior, out var hostDocumentLinePositionSpan);
+        hostDocumentRange = result ? hostDocumentLinePositionSpan.ToRange() : null;
         return result;
     }
 
     public static bool TryMapToGeneratedDocumentRange(this IRazorDocumentMappingService service, IRazorGeneratedDocument generatedDocument, Range hostDocumentRange, [NotNullWhen(true)] out Range? generatedDocumentRange)
     {
-        var result = service.TryMapToGeneratedDocumentRange(generatedDocument, hostDocumentRange.AsLinePositionSpan(), out var generatedDocumentLinePositionSpan);
-        generatedDocumentRange = result ? generatedDocumentLinePositionSpan.AsRange() : null;
+        var result = service.TryMapToGeneratedDocumentRange(generatedDocument, hostDocumentRange.ToLinePositionSpan(), out var generatedDocumentLinePositionSpan);
+        generatedDocumentRange = result ? generatedDocumentLinePositionSpan.ToRange() : null;
         return result;
     }
 
     public static bool TryMapToHostDocumentPosition(this IRazorDocumentMappingService service, IRazorGeneratedDocument generatedDocument, int generatedDocumentIndex, [NotNullWhen(true)] out Position? hostDocumentPosition, out int hostDocumentIndex)
     {
         var result = service.TryMapToHostDocumentPosition(generatedDocument, generatedDocumentIndex, out var hostDocumentLinePosition, out hostDocumentIndex);
-        hostDocumentPosition = result ? hostDocumentLinePosition.AsPosition() : null;
+        hostDocumentPosition = result ? hostDocumentLinePosition.ToPosition() : null;
         return result;
     }
 
     public static bool TryMapToGeneratedDocumentPosition(this IRazorDocumentMappingService service, IRazorGeneratedDocument generatedDocument, int hostDocumentIndex, [NotNullWhen(true)] out Position? generatedPosition, out int generatedIndex)
     {
         var result = service.TryMapToGeneratedDocumentPosition(generatedDocument, hostDocumentIndex, out var generatedLinePosition, out generatedIndex);
-        generatedPosition = result ? generatedLinePosition.AsPosition() : null;
+        generatedPosition = result ? generatedLinePosition.ToPosition() : null;
         return result;
     }
 
     public static bool TryMapToGeneratedDocumentOrNextCSharpPosition(this IRazorDocumentMappingService service, IRazorGeneratedDocument generatedDocument, int hostDocumentIndex, [NotNullWhen(true)] out Position? generatedPosition, out int generatedIndex)
     {
         var result = service.TryMapToGeneratedDocumentOrNextCSharpPosition(generatedDocument, hostDocumentIndex, out var generatedLinePosition, out generatedIndex);
-        generatedPosition = result ? generatedLinePosition.AsPosition() : null;
+        generatedPosition = result ? generatedLinePosition.ToPosition() : null;
         return result;
     }
 
@@ -95,7 +95,7 @@ internal static class IRazorDocumentMappingServiceExtensions
     /// </summary>
     public static async Task<(Uri MappedDocumentUri, Range MappedRange)> MapToHostDocumentUriAndRangeAsync(this IRazorDocumentMappingService service, Uri generatedDocumentUri, Range generatedDocumentRange, CancellationToken cancellationToken)
     {
-        var result = await service.MapToHostDocumentUriAndRangeAsync(generatedDocumentUri, generatedDocumentRange.AsLinePositionSpan(), cancellationToken).ConfigureAwait(false);
-        return (result.MappedDocumentUri, result.MappedRange.AsRange());
+        var result = await service.MapToHostDocumentUriAndRangeAsync(generatedDocumentUri, generatedDocumentRange.ToLinePositionSpan(), cancellationToken).ConfigureAwait(false);
+        return (result.MappedDocumentUri, result.MappedRange.ToRange());
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IRazorDocumentMappingServiceExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IRazorDocumentMappingServiceExtensions.cs
@@ -35,7 +35,7 @@ internal static class IRazorDocumentMappingServiceExtensions
             var generatedDocument = languageKind is RazorLanguageKind.CSharp
                 ? (IRazorGeneratedDocument)codeDocument.GetCSharpDocument()
                 : codeDocument.GetHtmlDocument();
-            if (service.TryMapToGeneratedDocumentPosition(generatedDocument, hostDocumentIndex, out var mappedPosition, out _))
+            if (service.TryMapToGeneratedDocumentPosition(generatedDocument, hostDocumentIndex, out Position? mappedPosition, out _))
             {
                 // For C# locations, we attempt to return the corresponding position
                 // within the projected document
@@ -69,7 +69,7 @@ internal static class IRazorDocumentMappingServiceExtensions
 
     public static bool TryMapToHostDocumentPosition(this IRazorDocumentMappingService service, IRazorGeneratedDocument generatedDocument, int generatedDocumentIndex, [NotNullWhen(true)] out Position? hostDocumentPosition, out int hostDocumentIndex)
     {
-        var result = service.TryMapToHostDocumentPosition(generatedDocument, generatedDocumentIndex,  out var hostDocumentLinePosition, out hostDocumentIndex);
+        var result = service.TryMapToHostDocumentPosition(generatedDocument, generatedDocumentIndex, out var hostDocumentLinePosition, out hostDocumentIndex);
         hostDocumentPosition = result ? hostDocumentLinePosition.AsPosition() : null;
         return result;
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/LinePositionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/LinePositionExtensions.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
+
+internal static class LinePositionExtensions
+{
+    public static Position AsPosition(this LinePosition linePosition)
+        => new Position(linePosition.Line, linePosition.Character);
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/LinePositionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/LinePositionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
@@ -10,4 +11,10 @@ internal static class LinePositionExtensions
 {
     public static Position AsPosition(this LinePosition linePosition)
         => new Position(linePosition.Line, linePosition.Character);
+
+    public static bool TryGetAbsoluteIndex(this LinePosition position, SourceText sourceText, ILogger logger, out int absoluteIndex)
+        => sourceText.TryGetAbsoluteIndex(position.Line, position.Character, logger, out absoluteIndex);
+
+    public static int GetRequiredAbsoluteIndex(this LinePosition position, SourceText sourceText, ILogger? logger = null)
+        => sourceText.GetRequiredAbsoluteIndex(position.Line, position.Character, logger);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/LinePositionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/LinePositionExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 
 internal static class LinePositionExtensions
 {
-    public static Position AsPosition(this LinePosition linePosition)
+    public static Position ToPosition(this LinePosition linePosition)
         => new Position(linePosition.Line, linePosition.Character);
 
     public static bool TryGetAbsoluteIndex(this LinePosition position, SourceText sourceText, ILogger logger, out int absoluteIndex)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/LinePositionSpanExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/LinePositionSpanExtensions.cs
@@ -13,4 +13,7 @@ internal static class LinePositionSpanExtensions
             Start = linePositionSpan.Start.AsPosition(),
             End = linePositionSpan.End.AsPosition()
         };
+
+    public static TextSpan AsTextSpan(this LinePositionSpan linePositionSpan, SourceText sourceText)
+        => sourceText.GetTextSpan(linePositionSpan.Start.Line, linePositionSpan.Start.Character, linePositionSpan.End.Line, linePositionSpan.End.Character);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/LinePositionSpanExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/LinePositionSpanExtensions.cs
@@ -2,20 +2,15 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 
 internal static class LinePositionSpanExtensions
 {
     public static Range AsRange(this LinePositionSpan linePositionSpan)
-    {
-        var range = new Range
+        => new Range
         {
-            Start = new Position { Line = linePositionSpan.Start.Line, Character = linePositionSpan.Start.Character },
-            End = new Position { Line = linePositionSpan.End.Line, Character = linePositionSpan.End.Character }
+            Start = linePositionSpan.Start.AsPosition(),
+            End = linePositionSpan.End.AsPosition()
         };
-
-        return range;
-    }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/LinePositionSpanExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/LinePositionSpanExtensions.cs
@@ -7,14 +7,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 
 internal static class LinePositionSpanExtensions
 {
-    public static Range AsRange(this LinePositionSpan linePositionSpan)
+    public static Range ToRange(this LinePositionSpan linePositionSpan)
         => new Range
         {
-            Start = linePositionSpan.Start.AsPosition(),
-            End = linePositionSpan.End.AsPosition()
+            Start = linePositionSpan.Start.ToPosition(),
+            End = linePositionSpan.End.ToPosition()
         };
 
-    public static TextSpan AsTextSpan(this LinePositionSpan linePositionSpan, SourceText sourceText)
+    public static TextSpan ToTextSpan(this LinePositionSpan linePositionSpan, SourceText sourceText)
         => sourceText.GetTextSpan(linePositionSpan.Start.Line, linePositionSpan.Start.Character, linePositionSpan.End.Line, linePositionSpan.End.Character);
 
     public static bool OverlapsWith(this LinePositionSpan range, LinePositionSpan other)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/LinePositionSpanExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/LinePositionSpanExtensions.cs
@@ -16,4 +16,22 @@ internal static class LinePositionSpanExtensions
 
     public static TextSpan AsTextSpan(this LinePositionSpan linePositionSpan, SourceText sourceText)
         => sourceText.GetTextSpan(linePositionSpan.Start.Line, linePositionSpan.Start.Character, linePositionSpan.End.Line, linePositionSpan.End.Character);
+
+    public static bool OverlapsWith(this LinePositionSpan range, LinePositionSpan other)
+    {
+        var overlapStart = range.Start;
+        if (range.Start.CompareTo(other.Start) < 0)
+        {
+            overlapStart = other.Start;
+        }
+
+        var overlapEnd = range.End;
+        if (range.End.CompareTo(other.End) > 0)
+        {
+            overlapEnd = other.End;
+        }
+
+        // Empty ranges do not overlap with any range.
+        return overlapStart.CompareTo(overlapEnd) < 0;
+    }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/PositionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/PositionExtensions.cs
@@ -25,7 +25,7 @@ internal static class PositionExtensions
             throw new ArgumentNullException(nameof(sourceText));
         }
 
-        return TryGetAbsoluteIndex(position.Character, position.Line, sourceText, logger, out absoluteIndex);
+        return sourceText.TryGetAbsoluteIndex(position.Line, position.Character, logger, out absoluteIndex);
     }
 
     public static int GetRequiredAbsoluteIndex(this Position position, SourceText sourceText, ILogger logger)
@@ -66,27 +66,6 @@ internal static class PositionExtensions
             throw new ArgumentNullException(nameof(sourceText));
         }
 
-        return position.Line >= 0 &&
-            position.Character >= 0 &&
-            position.Line < sourceText.Lines.Count &&
-            sourceText.Lines[position.Line].Start + position.Character <= sourceText.Length;
-    }
-
-    private static bool TryGetAbsoluteIndex(int character, int line, SourceText sourceText, ILogger logger, out int absoluteIndex)
-    {
-        var linePosition = new LinePosition(line, character);
-        if (linePosition.Line >= sourceText.Lines.Count)
-        {
-#pragma warning disable CA2254 // Template should be a static expression.
-// This is actually static, the compiler just doesn't know it.
-            logger?.LogError(SR.FormatPositionIndex_Outside_Range(line, nameof(sourceText), sourceText.Lines.Count));
-#pragma warning restore CA2254 // Template should be a static expression
-            absoluteIndex = -1;
-            return false;
-        }
-
-        var index = sourceText.Lines.GetPosition(linePosition);
-        absoluteIndex = index;
-        return true;
+        return sourceText.TryGetAbsoluteIndex(position.Line, position.Character, out _);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/PositionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/PositionExtensions.cs
@@ -10,6 +10,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 
 internal static class PositionExtensions
 {
+    public static LinePosition AsLinePosition(this Position position)
+        => new LinePosition(position.Line, position.Character);
+
     public static bool TryGetAbsoluteIndex(this Position position, SourceText sourceText, ILogger logger, out int absoluteIndex)
     {
         if (position is null)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/PositionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/PositionExtensions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 
 internal static class PositionExtensions
 {
-    public static LinePosition AsLinePosition(this Position position)
+    public static LinePosition ToLinePosition(this Position position)
         => new LinePosition(position.Line, position.Character);
 
     public static bool TryGetAbsoluteIndex(this Position position, SourceText sourceText, ILogger logger, out int absoluteIndex)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RangeExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RangeExtensions.cs
@@ -48,20 +48,7 @@ internal static class RangeExtensions
             throw new ArgumentNullException(nameof(other));
         }
 
-        var overlapStart = range.Start;
-        if (range.Start.CompareTo(other.Start) < 0)
-        {
-            overlapStart = other.Start;
-        }
-
-        var overlapEnd = range.End;
-        if (range.End.CompareTo(other.End) > 0)
-        {
-            overlapEnd = other.End;
-        }
-
-        // Empty ranges do not overlap with any range.
-        return overlapStart.CompareTo(overlapEnd) < 0;
+        return range.AsLinePositionSpan().OverlapsWith(other.AsLinePositionSpan());
     }
 
     public static bool LineOverlapsWith(this Range range, Range other)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RangeExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RangeExtensions.cs
@@ -48,7 +48,7 @@ internal static class RangeExtensions
             throw new ArgumentNullException(nameof(other));
         }
 
-        return range.AsLinePositionSpan().OverlapsWith(other.AsLinePositionSpan());
+        return range.ToLinePositionSpan().OverlapsWith(other.ToLinePositionSpan());
     }
 
     public static bool LineOverlapsWith(this Range range, Range other)
@@ -103,17 +103,17 @@ internal static class RangeExtensions
         return range.Start.Line != range.End.Line;
     }
 
-    public static TextSpan AsTextSpan(this Range range, SourceText sourceText)
+    public static TextSpan ToTextSpan(this Range range, SourceText sourceText)
         => sourceText.GetTextSpan(range.Start.Line, range.Start.Character, range.End.Line, range.End.Character);
 
-    public static Language.Syntax.TextSpan AsRazorTextSpan(this Range range, SourceText sourceText)
+    public static Language.Syntax.TextSpan ToRazorTextSpan(this Range range, SourceText sourceText)
     {
-        var span = range.AsTextSpan(sourceText);
+        var span = range.ToTextSpan(sourceText);
         return new Language.Syntax.TextSpan(span.Start, span.Length);
     }
 
-    public static LinePositionSpan AsLinePositionSpan(this Range range)
-        => new LinePositionSpan(range.Start.AsLinePosition(), range.End.AsLinePosition());
+    public static LinePositionSpan ToLinePositionSpan(this Range range)
+        => new LinePositionSpan(range.Start.ToLinePosition(), range.End.ToLinePosition());
 
     public static bool IsUndefined(this Range range)
     {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RangeExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RangeExtensions.cs
@@ -159,6 +159,9 @@ internal static class RangeExtensions
         return new Language.Syntax.TextSpan(span.Start, span.Length);
     }
 
+    public static LinePositionSpan AsLinePositionSpan(this Range range)
+        => new LinePositionSpan(range.Start.AsLinePosition(), range.End.AsLinePosition());
+
     public static bool IsUndefined(this Range range)
     {
         if (range is null)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RangeExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RangeExtensions.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -118,40 +117,7 @@ internal static class RangeExtensions
     }
 
     public static TextSpan AsTextSpan(this Range range, SourceText sourceText)
-    {
-        if (range is null)
-        {
-            throw new ArgumentNullException(nameof(range));
-        }
-
-        if (sourceText is null)
-        {
-            throw new ArgumentNullException(nameof(sourceText));
-        }
-
-        var start = GetAbsoluteIndex(range.Start, sourceText);
-        var end = GetAbsoluteIndex(range.End, sourceText);
-
-        var length = end - start;
-        if (length < 0)
-        {
-            throw new ArgumentOutOfRangeException($"{range} resolved to zero or negative length.");
-        }
-
-        return new TextSpan(start, length);
-
-        static int GetAbsoluteIndex(Position position, SourceText sourceText, [CallerArgumentExpression(nameof(position))] string? argName = null)
-        {
-            var line = position.Line;
-            var character = position.Character;
-            if (!sourceText.TryGetAbsoluteIndex(line, character, out var absolutePosition))
-            {
-                throw new ArgumentOutOfRangeException($"{argName} ({line},{character}) matches or exceeds SourceText boundary {sourceText.Lines.Count}.");
-            }
-
-            return absolutePosition;
-        }
-    }
+        => sourceText.GetTextSpan(range.Start.Line, range.Start.Character, range.End.Line, range.End.Character);
 
     public static Language.Syntax.TextSpan AsRazorTextSpan(this Range range, SourceText sourceText)
     {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/SourceSpanExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/SourceSpanExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 
 internal static class SourceSpanExtensions
 {
-    public static Range AsRange(this SourceSpan sourceSpan, SourceText sourceText)
+    public static Range ToRange(this SourceSpan sourceSpan, SourceText sourceText)
     {
         sourceText.GetLinesAndOffsets(sourceSpan, out var startLine, out var startChar, out var endLine, out var endChar);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/SourceTextExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/SourceTextExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 
@@ -223,5 +224,59 @@ internal static class SourceTextExtensions
         }
 
         return true;
+    }
+
+    public static bool TryGetAbsoluteIndex(this SourceText sourceText, int line, int character, ILogger? logger, out int absoluteIndex)
+    {
+        if (!TryGetAbsoluteIndex(sourceText, line, character, out absoluteIndex))
+        {
+#pragma warning disable CA2254 // Template should be a static expression.
+            // This is actually static, the compiler just doesn't know it.
+            logger?.LogError(SR.FormatPositionIndex_Outside_Range(line, nameof(sourceText), sourceText.Lines.Count));
+#pragma warning restore CA2254 // Template should be a static expression
+            absoluteIndex = -1;
+            return false;
+        }
+
+        return true;
+    }
+
+    public static int GetRequiredAbsoluteIndex(this SourceText sourceText, int line, int character, ILogger? logger = null)
+    {
+        if (!sourceText.TryGetAbsoluteIndex(line, character, logger, out var absolutePosition))
+        {
+            throw new ArgumentOutOfRangeException($"({line},{character}) matches or exceeds SourceText boundary {sourceText.Lines.Count}.");
+        }
+
+        return absolutePosition;
+    }
+
+    public static TextSpan GetTextSpan(this SourceText sourceText, int startLine, int startCharacter, int endLine, int endCharacter)
+    {
+        if (sourceText is null)
+        {
+            throw new ArgumentNullException(nameof(sourceText));
+        }
+
+        var start = GetAbsoluteIndex(startLine, startCharacter, sourceText, "Start");
+        var end = GetAbsoluteIndex(endLine, endCharacter, sourceText, "End");
+
+        var length = end - start;
+        if (length < 0)
+        {
+            throw new ArgumentOutOfRangeException($"({startLine},{startCharacter})-({endLine},{endCharacter}) resolved to zero or negative length.");
+        }
+
+        return new TextSpan(start, length);
+
+        static int GetAbsoluteIndex(int line, int character, SourceText sourceText, string argName)
+        {
+            if (!sourceText.TryGetAbsoluteIndex(line, character, out var absolutePosition))
+            {
+                throw new ArgumentOutOfRangeException($"{argName} ({line},{character}) matches or exceeds SourceText boundary {sourceText.Lines.Count}.");
+            }
+
+            return absolutePosition;
+        }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/TextChangeExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/TextChangeExtensions.cs
@@ -9,14 +9,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 
 internal static class TextChangeExtensions
 {
-    public static TextEdit AsTextEdit(this TextChange textChange, SourceText sourceText)
+    public static TextEdit ToTextEdit(this TextChange textChange, SourceText sourceText)
     {
         if (sourceText is null)
         {
             throw new ArgumentNullException(nameof(sourceText));
         }
 
-        var range = textChange.Span.AsRange(sourceText);
+        var range = textChange.Span.ToRange(sourceText);
 
         Assumes.NotNull(textChange.NewText);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/TextEditExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/TextEditExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 
 internal static class TextEditExtensions
 {
-    public static TextChange AsTextChange(this TextEdit textEdit, SourceText sourceText)
+    public static TextChange ToTextChange(this TextEdit textEdit, SourceText sourceText)
     {
         if (textEdit is null)
         {
@@ -21,7 +21,7 @@ internal static class TextEditExtensions
             throw new ArgumentNullException(nameof(sourceText));
         }
 
-        var span = textEdit.Range.AsTextSpan(sourceText);
+        var span = textEdit.Range.ToTextSpan(sourceText);
         return new TextChange(span, textEdit.NewText);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/TextSpanExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/TextSpanExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 
 internal static class TextSpanExtensions
 {
-    public static Range AsRange(this TextSpan span, SourceText sourceText)
+    public static Range ToRange(this TextSpan span, SourceText sourceText)
     {
         if (sourceText is null)
         {
@@ -27,6 +27,6 @@ internal static class TextSpanExtensions
         return range;
     }
 
-    public static Range AsRange(this Language.Syntax.TextSpan span, SourceText sourceText)
-        => new TextSpan(span.Start, span.Length).AsRange(sourceText);
+    public static Range ToRange(this Language.Syntax.TextSpan span, SourceText sourceText)
+        => new TextSpan(span.Start, span.Length).ToRange(sourceText);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormatter.cs
@@ -98,7 +98,7 @@ internal class CSharpFormatter
     private static async Task<TextEdit[]> GetFormattingEditsAsync(FormattingContext context, Range projectedRange, CancellationToken cancellationToken)
     {
         var csharpSourceText = context.CodeDocument.GetCSharpSourceText();
-        var spanToFormat = projectedRange.AsTextSpan(csharpSourceText);
+        var spanToFormat = projectedRange.ToTextSpan(csharpSourceText);
         var root = await context.CSharpWorkspaceDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
         Assumes.NotNull(root);
 
@@ -107,7 +107,7 @@ internal class CSharpFormatter
         // Formatting options will already be set in the workspace.
         var changes = CodeAnalysis.Formatting.Formatter.GetFormattedTextChanges(root, spanToFormat, workspace, cancellationToken: cancellationToken);
 
-        var edits = changes.Select(c => c.AsTextEdit(csharpSourceText)).ToArray();
+        var edits = changes.Select(c => c.ToTextEdit(csharpSourceText)).ToArray();
         return edits;
     }
 
@@ -285,7 +285,7 @@ internal class CSharpFormatter
 
         static bool SpansMultipleLines(SyntaxNode node, SourceText text)
         {
-            var range = node.Span.AsRange(text);
+            var range = node.Span.ToRange(text);
             return range.Start.Line != range.End.Line;
         }
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormatter.cs
@@ -11,7 +11,6 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPass.cs
@@ -50,7 +50,7 @@ internal class CSharpFormattingPass : CSharpFormattingPassBase
         var changedContext = context;
         if (result.Edits.Length > 0)
         {
-            var changes = result.Edits.Select(e => e.AsTextChange(originalText)).ToArray();
+            var changes = result.Edits.Select(e => e.ToTextChange(originalText)).ToArray();
             changedText = changedText.WithChanges(changes);
             changedContext = await context.WithTextAsync(changedText).ConfigureAwait(false);
         }
@@ -61,7 +61,7 @@ internal class CSharpFormattingPass : CSharpFormattingPassBase
         var csharpEdits = await FormatCSharpAsync(changedContext, cancellationToken).ConfigureAwait(false);
         if (csharpEdits.Count > 0)
         {
-            var csharpChanges = csharpEdits.Select(c => c.AsTextChange(changedText));
+            var csharpChanges = csharpEdits.Select(c => c.ToTextChange(changedText));
             changedText = changedText.WithChanges(csharpChanges);
             changedContext = await changedContext.WithTextAsync(changedText).ConfigureAwait(false);
 
@@ -82,7 +82,7 @@ internal class CSharpFormattingPass : CSharpFormattingPassBase
         _logger.LogTestOnly("Generated C#:\r\n{context.CSharpSourceText}", context.CSharpSourceText);
 
         var finalChanges = changedText.GetTextChanges(originalText);
-        var finalEdits = finalChanges.Select(f => f.AsTextEdit(originalText)).ToArray();
+        var finalEdits = finalChanges.Select(f => f.ToTextEdit(originalText)).ToArray();
 
         return new FormattingResult(finalEdits);
     }
@@ -101,7 +101,7 @@ internal class CSharpFormattingPass : CSharpFormattingPassBase
             }
 
             // These should already be remapped.
-            var range = span.AsRange(sourceText);
+            var range = span.ToRange(sourceText);
             var edits = await CSharpFormatter.FormatAsync(context, range, cancellationToken).ConfigureAwait(false);
             csharpEdits.AddRange(edits.Where(e => range.Contains(e.Range)));
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPassBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPassBase.cs
@@ -38,7 +38,7 @@ internal abstract class CSharpFormattingPassBase : FormattingPassBase
         // 2. The indentation due to Razor and HTML constructs
 
         var text = context.SourceText;
-        range ??= TextSpan.FromBounds(0, text.Length).AsRange(text);
+        range ??= TextSpan.FromBounds(0, text.Length).ToRange(text);
 
         // To help with figuring out the correct indentation, first we will need the indentation
         // that the C# formatter wants to apply in the following locations,
@@ -69,7 +69,7 @@ internal abstract class CSharpFormattingPassBase : FormattingPassBase
             // loop will find them. Sadly the ShouldFormat method is used in too many places, for too many
             // different purposes, to put this check there.
             if (owner is { Parent.Parent.Parent: CSharpExplicitExpressionSyntax explicitExpression } &&
-                explicitExpression.Span.AsRange(text) is { } exprRange &&
+                explicitExpression.Span.ToRange(text) is { } exprRange &&
                 exprRange.Start.Line == exprRange.End.Line)
             {
                 continue;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpOnTypeFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpOnTypeFormattingPass.cs
@@ -92,7 +92,7 @@ internal class CSharpOnTypeFormattingPass : CSharpFormattingPassBase
                 return result;
             }
 
-            textEdits = formattingChanges.Select(change => change.AsTextEdit(csharpText)).ToArray();
+            textEdits = formattingChanges.Select(change => change.ToTextEdit(csharpText)).ToArray();
             _logger.LogInformation("Received {textEditsLength} results from C#.", textEdits.Length);
         }
 
@@ -129,12 +129,12 @@ internal class CSharpOnTypeFormattingPass : CSharpFormattingPassBase
 
         // Find the lines that were affected by these edits.
         var originalText = codeDocument.GetSourceText();
-        var changes = filteredEdits.Select(e => e.AsTextChange(originalText));
+        var changes = filteredEdits.Select(e => e.ToTextChange(originalText));
 
         // Apply the format on type edits sent over by the client.
         var formattedText = ApplyChangesAndTrackChange(originalText, changes, out _, out var spanAfterFormatting);
         var changedContext = await context.WithTextAsync(formattedText).ConfigureAwait(false);
-        var rangeAfterFormatting = spanAfterFormatting.AsRange(formattedText);
+        var rangeAfterFormatting = spanAfterFormatting.ToRange(formattedText);
 
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -212,7 +212,7 @@ internal class CSharpOnTypeFormattingPass : CSharpFormattingPassBase
 
         // Now that we have made all the necessary changes to the document. Let's diff the original vs final version and return the diff.
         var finalChanges = cleanedText.GetTextChanges(originalText);
-        var finalEdits = finalChanges.Select(f => f.AsTextEdit(originalText)).ToArray();
+        var finalEdits = finalChanges.Select(f => f.ToTextEdit(originalText)).ToArray();
 
         finalEdits = await AddUsingStatementEditsIfNecessaryAsync(context, codeDocument, csharpText, textEdits, originalTextWithChanges, finalEdits, cancellationToken).ConfigureAwait(false);
 
@@ -250,7 +250,7 @@ internal class CSharpOnTypeFormattingPass : CSharpFormattingPassBase
     {
         var filteredEdits = edits.Where(e =>
         {
-            var span = e.Range.AsTextSpan(context.SourceText);
+            var span = e.Range.ToTextSpan(context.SourceText);
             return ShouldFormat(context, span, allowImplicitStatements: false);
         }).ToArray();
 
@@ -269,7 +269,7 @@ internal class CSharpOnTypeFormattingPass : CSharpFormattingPassBase
         {
             var newLineCount = change.NewText is null ? 0 : change.NewText.Split('\n').Length - 1;
 
-            var range = change.Span.AsRange(text);
+            var range = change.Span.ToRange(text);
             Debug.Assert(range.Start.Line <= range.End.Line, "Invalid range.");
 
             // For convenience, since we're already iterating through things, we also find the extremes
@@ -295,14 +295,14 @@ internal class CSharpOnTypeFormattingPass : CSharpFormattingPassBase
     private static List<TextChange> CleanupDocument(FormattingContext context, Range? range = null)
     {
         var text = context.SourceText;
-        range ??= TextSpan.FromBounds(0, text.Length).AsRange(text);
+        range ??= TextSpan.FromBounds(0, text.Length).ToRange(text);
         var csharpDocument = context.CodeDocument.GetCSharpDocument();
 
         var changes = new List<TextChange>();
         foreach (var mapping in csharpDocument.SourceMappings)
         {
             var mappingSpan = new TextSpan(mapping.OriginalSpan.AbsoluteIndex, mapping.OriginalSpan.Length);
-            var mappingRange = mappingSpan.AsRange(text);
+            var mappingRange = mappingSpan.ToRange(text);
             if (!range.LineOverlapsWith(mappingRange))
             {
                 // We don't care about this range. It didn't change.
@@ -338,7 +338,7 @@ internal class CSharpOnTypeFormattingPass : CSharpFormattingPassBase
         //
 
         var text = context.SourceText;
-        var sourceMappingSpan = sourceMappingRange.AsTextSpan(text);
+        var sourceMappingSpan = sourceMappingRange.ToTextSpan(text);
         if (!ShouldFormat(context, sourceMappingSpan, allowImplicitStatements: false, out var owner))
         {
             // We don't want to run cleanup on this range.
@@ -466,7 +466,7 @@ internal class CSharpOnTypeFormattingPass : CSharpFormattingPassBase
         //
 
         var text = context.SourceText;
-        var sourceMappingSpan = sourceMappingRange.AsTextSpan(text);
+        var sourceMappingSpan = sourceMappingRange.ToTextSpan(text);
         var mappingEndLineIndex = sourceMappingRange.End.Line;
 
         var indentations = context.GetIndentations();
@@ -548,10 +548,10 @@ internal class CSharpOnTypeFormattingPass : CSharpFormattingPassBase
 
     private static TextEdit[] NormalizeTextEdits(SourceText originalText, TextEdit[] edits, out SourceText originalTextWithChanges)
     {
-        var changes = edits.Select(e => e.AsTextChange(originalText));
+        var changes = edits.Select(e => e.ToTextChange(originalText));
         originalTextWithChanges = originalText.WithChanges(changes);
         var cleanChanges = SourceTextDiffer.GetMinimalTextChanges(originalText, originalTextWithChanges, DiffKind.Char);
-        var cleanEdits = cleanChanges.Select(c => c.AsTextEdit(originalText)).ToArray();
+        var cleanEdits = cleanChanges.Select(c => c.ToTextEdit(originalText)).ToArray();
         return cleanEdits;
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContentValidationPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContentValidationPass.cs
@@ -49,7 +49,7 @@ internal class FormattingContentValidationPass : FormattingPassBase
 
         var text = context.SourceText;
         var edits = result.Edits;
-        var changes = edits.Select(e => e.AsTextChange(text));
+        var changes = edits.Select(e => e.ToTextChange(text));
         var changedText = text.WithChanges(changes);
 
         if (!text.NonWhitespaceContentEquals(changedText))

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingDiagnosticValidationPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingDiagnosticValidationPass.cs
@@ -53,7 +53,7 @@ internal class FormattingDiagnosticValidationPass : FormattingPassBase
 
         var text = context.SourceText;
         var edits = result.Edits;
-        var changes = edits.Select(e => e.AsTextChange(text));
+        var changes = edits.Select(e => e.ToTextChange(text));
         var changedText = text.WithChanges(changes);
         var changedContext = await context.WithTextAsync(changedText).ConfigureAwait(false);
         var changedDiagnostics = changedContext.CodeDocument.GetSyntaxTree().Diagnostics;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormatter.cs
@@ -98,12 +98,12 @@ internal class HtmlFormatter
             return edits;
 
         // First we apply the edits that the Html language server wanted, to the Html document
-        var textChanges = edits.Select(e => e.AsTextChange(htmlSourceText));
+        var textChanges = edits.Select(e => e.ToTextChange(htmlSourceText));
         var changedText = htmlSourceText.WithChanges(textChanges);
 
         // Now we use our minimal text differ algorithm to get the bare minimum of edits
         var minimalChanges = SourceTextDiffer.GetMinimalTextChanges(htmlSourceText, changedText, DiffKind.Char);
-        var minimalEdits = minimalChanges.Select(f => f.AsTextEdit(htmlSourceText)).ToArray();
+        var minimalEdits = minimalChanges.Select(f => f.ToTextEdit(htmlSourceText)).ToArray();
 
         return minimalEdits;
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormattingPass.cs
@@ -76,7 +76,7 @@ internal class HtmlFormattingPass : FormattingPassBase
 
         if (htmlEdits.Length > 0)
         {
-            var changes = htmlEdits.Select(e => e.AsTextChange(originalText));
+            var changes = htmlEdits.Select(e => e.ToTextChange(originalText));
             changedText = originalText.WithChanges(changes);
             // Create a new formatting context for the changed razor document.
             changedContext = await context.WithTextAsync(changedText).ConfigureAwait(false);
@@ -98,7 +98,7 @@ internal class HtmlFormattingPass : FormattingPassBase
         }
 
         var finalChanges = changedText.GetTextChanges(originalText);
-        var finalEdits = finalChanges.Select(f => f.AsTextEdit(originalText)).ToArray();
+        var finalEdits = finalChanges.Select(f => f.ToTextEdit(originalText)).ToArray();
 
         return new FormattingResult(finalEdits);
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingPass.cs
@@ -53,7 +53,7 @@ internal class RazorFormattingPass : FormattingPassBase
         var changedContext = context;
         if (result.Edits.Length > 0)
         {
-            var changes = result.Edits.Select(e => e.AsTextChange(originalText)).ToArray();
+            var changes = result.Edits.Select(e => e.ToTextChange(originalText)).ToArray();
             changedText = changedText.WithChanges(changes);
             changedContext = await context.WithTextAsync(changedText).ConfigureAwait(false);
 
@@ -65,11 +65,11 @@ internal class RazorFormattingPass : FormattingPassBase
         var edits = FormatRazor(changedContext, syntaxTree);
 
         // Compute the final combined set of edits
-        var formattingChanges = edits.Select(e => e.AsTextChange(changedText));
+        var formattingChanges = edits.Select(e => e.ToTextChange(changedText));
         changedText = changedText.WithChanges(formattingChanges);
 
         var finalChanges = changedText.GetTextChanges(originalText);
-        var finalEdits = finalChanges.Select(f => f.AsTextEdit(originalText)).ToArray();
+        var finalEdits = finalChanges.Select(f => f.ToTextEdit(originalText)).ToArray();
 
         return new FormattingResult(finalEdits);
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingService.cs
@@ -57,7 +57,7 @@ internal class RazorFormattingService : IRazorFormattingService
         // Despite what it looks like, codeDocument.GetCSharpDocument().Diagnostics is actually the
         // Razor diagnostics, not the C# diagnostics 🤦‍
         if (range is not null &&
-            codeDocument.GetCSharpDocument().Diagnostics.Any(d => range.OverlapsWith(d.Span.AsRange(codeDocument.GetSourceText()))))
+            codeDocument.GetCSharpDocument().Diagnostics.Any(d => range.OverlapsWith(d.Span.ToRange(codeDocument.GetSourceText()))))
         {
             return Array.Empty<TextEdit>();
         }
@@ -85,7 +85,7 @@ internal class RazorFormattingService : IRazorFormattingService
     private static TextEdit[] GetMinimalEdits(SourceText originalText, IEnumerable<TextEdit> filteredEdits)
     {
         // Make sure the edits actually change something, or its not worth responding
-        var textChanges = filteredEdits.Select(e => e.AsTextChange(originalText));
+        var textChanges = filteredEdits.Select(e => e.ToTextChange(originalText));
         var changedText = originalText.WithChanges(textChanges);
         if (changedText.ContentEquals(originalText))
         {
@@ -94,7 +94,7 @@ internal class RazorFormattingService : IRazorFormattingService
 
         // Only send back the minimum edits
         var minimalChanges = SourceTextDiffer.GetMinimalTextChanges(originalText, changedText, DiffKind.Char);
-        var finalEdits = minimalChanges.Select(f => f.AsTextEdit(originalText)).ToArray();
+        var finalEdits = minimalChanges.Select(f => f.ToTextEdit(originalText)).ToArray();
 
         return finalEdits;
     }
@@ -195,7 +195,7 @@ internal class RazorFormattingService : IRazorFormattingService
         var textChanges = new List<TextChange>();
         foreach (var edit in edits)
         {
-            var change = new TextChange(edit.Range.AsTextSpan(sourceText), edit.NewText);
+            var change = new TextChange(edit.Range.ToTextSpan(sourceText), edit.NewText);
             textChanges.Add(change);
         }
 
@@ -207,7 +207,7 @@ internal class RazorFormattingService : IRazorFormattingService
 
         var encompassingChange = new TextChange(spanBeforeChange, newText);
 
-        return encompassingChange.AsTextEdit(sourceText);
+        return encompassingChange.ToTextEdit(sourceText);
     }
 
     private static void WrapCSharpSnippets(TextEdit[] snippetEdits)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/HoverEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/HoverEndpoint.cs
@@ -99,7 +99,7 @@ internal sealed class HoverEndpoint : AbstractRazorDelegatingEndpoint<TextDocume
         if (RazorSyntaxFacts.TryGetFullAttributeNameSpan(codeDocument, positionInfo.HostDocumentIndex, out var originalAttributeRange))
         {
             var sourceText = await documentContext.GetSourceTextAsync(cancellationToken).ConfigureAwait(false);
-            response.Range = originalAttributeRange.AsRange(sourceText);
+            response.Range = originalAttributeRange.ToRange(sourceText);
         }
         else if (positionInfo.LanguageKind == RazorLanguageKind.CSharp)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IRazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IRazorDocumentMappingService.cs
@@ -2,11 +2,11 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
@@ -15,15 +15,15 @@ internal interface IRazorDocumentMappingService
 {
     TextEdit[] GetHostDocumentEdits(IRazorGeneratedDocument generatedDocument, TextEdit[] generatedDocumentEdits);
 
-    bool TryMapToHostDocumentRange(IRazorGeneratedDocument generatedDocument, Range generatedDocumentRange, MappingBehavior mappingBehavior, [NotNullWhen(true)] out Range? hostDocumentRange);
+    bool TryMapToHostDocumentRange(IRazorGeneratedDocument generatedDocument, LinePositionSpan generatedDocumentRange, MappingBehavior mappingBehavior, out LinePositionSpan hostDocumentRange);
 
-    bool TryMapToGeneratedDocumentRange(IRazorGeneratedDocument generatedDocument, Range hostDocumentRange, [NotNullWhen(true)] out Range? generatedDocumentRange);
+    bool TryMapToGeneratedDocumentRange(IRazorGeneratedDocument generatedDocument, LinePositionSpan hostDocumentRange, out LinePositionSpan generatedDocumentRange);
 
-    bool TryMapToHostDocumentPosition(IRazorGeneratedDocument generatedDocument, int generatedDocumentIndex, [NotNullWhen(true)] out Position? hostDocumentPosition, out int hostDocumentIndex);
+    bool TryMapToHostDocumentPosition(IRazorGeneratedDocument generatedDocument, int generatedDocumentIndex, out LinePosition hostDocumentPosition, out int hostDocumentIndex);
 
-    bool TryMapToGeneratedDocumentPosition(IRazorGeneratedDocument generatedDocument, int hostDocumentIndex, [NotNullWhen(true)] out Position? generatedPosition, out int generatedIndex);
+    bool TryMapToGeneratedDocumentPosition(IRazorGeneratedDocument generatedDocument, int hostDocumentIndex, out LinePosition generatedPosition, out int generatedIndex);
 
-    bool TryMapToGeneratedDocumentOrNextCSharpPosition(IRazorGeneratedDocument generatedDocument, int hostDocumentIndex, [NotNullWhen(true)] out Position? generatedPosition, out int generatedIndex);
+    bool TryMapToGeneratedDocumentOrNextCSharpPosition(IRazorGeneratedDocument generatedDocument, int hostDocumentIndex, out LinePosition generatedPosition, out int generatedIndex);
 
     RazorLanguageKind GetLanguageKind(RazorCodeDocument codeDocument, int hostDocumentIndex, bool rightAssociative);
 
@@ -34,5 +34,5 @@ internal interface IRazorDocumentMappingService
     /// generated document. If the uri passed in is not for a generated document, or the range cannot be mapped
     /// for some other reason, the original passed in range is returned unchanged.
     /// </summary>
-    Task<(Uri MappedDocumentUri, Range MappedRange)> MapToHostDocumentUriAndRangeAsync(Uri generatedDocumentUri, Range generatedDocumentRange, CancellationToken cancellationToken);
+    Task<(Uri MappedDocumentUri, LinePositionSpan MappedRange)> MapToHostDocumentUriAndRangeAsync(Uri generatedDocumentUri, LinePositionSpan generatedDocumentRange, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlineCompletion/InlineCompletionEndPoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlineCompletion/InlineCompletionEndPoint.cs
@@ -89,7 +89,7 @@ internal sealed class InlineCompletionEndpoint : IRazorRequestHandler<VSInternal
 
         // Map to the location in the C# document.
         if (languageKind != RazorLanguageKind.CSharp ||
-            !_documentMappingService.TryMapToGeneratedDocumentPosition(codeDocument.GetCSharpDocument(), hostDocumentIndex, out var projectedPosition, out _))
+            !_documentMappingService.TryMapToGeneratedDocumentPosition(codeDocument.GetCSharpDocument(), hostDocumentIndex, out Position? projectedPosition, out _))
         {
             requestContext.Logger.LogInformation("Unsupported location for {textDocumentUri}.", request.TextDocument.Uri);
             return null;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeEndpoint.cs
@@ -79,7 +79,7 @@ internal class LinkedEditingRangeEndpoint : IRazorRequestHandler<LinkedEditingRa
         {
             var startSpan = startTagNameToken.GetLinePositionSpan(codeDocument.Source);
             var endSpan = endTagNameToken.GetLinePositionSpan(codeDocument.Source);
-            var ranges = new Range[2] { startSpan.AsRange(), endSpan.AsRange() };
+            var ranges = new Range[2] { startSpan.ToRange(), endSpan.ToRange() };
 
             return new LinkedEditingRanges
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Mapping/RazorLanguageQueryEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Mapping/RazorLanguageQueryEndpoint.cs
@@ -63,7 +63,7 @@ internal sealed class RazorLanguageQueryEndpoint : IRazorRequestHandler<RazorLan
         var languageKind = _documentMappingService.GetLanguageKind(codeDocument, hostDocumentIndex, rightAssociative: false);
         if (languageKind == RazorLanguageKind.CSharp)
         {
-            if (_documentMappingService.TryMapToGeneratedDocumentPosition(codeDocument.GetCSharpDocument(), hostDocumentIndex, out var projectedPosition, out var projectedIndex))
+            if (_documentMappingService.TryMapToGeneratedDocumentPosition(codeDocument.GetCSharpDocument(), hostDocumentIndex, out Position? projectedPosition, out var projectedIndex))
             {
                 // For C# locations, we attempt to return the corresponding position
                 // within the projected document

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentMappingService.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -58,8 +57,8 @@ internal sealed class RazorDocumentMappingService : IRazorDocumentMappingService
                 break;
             }
 
-            var mappedStart = this.TryMapToHostDocumentPosition(generatedDocument, startIndex, out var hostDocumentStart, out _);
-            var mappedEnd = this.TryMapToHostDocumentPosition(generatedDocument, endIndex, out var hostDocumentEnd, out _);
+            var mappedStart = this.TryMapToHostDocumentPosition(generatedDocument, startIndex, out Position? hostDocumentStart, out _);
+            var mappedEnd = this.TryMapToHostDocumentPosition(generatedDocument, endIndex, out Position? hostDocumentEnd, out _);
 
             // Ideal case, both start and end can be mapped so just return the edit
             if (mappedStart && mappedEnd)
@@ -168,7 +167,7 @@ internal sealed class RazorDocumentMappingService : IRazorDocumentMappingService
 
                 // Only do anything if the end of the line in question is a valid mapping point (ie, a transition)
                 var endOfLine = line.Span.End;
-                if (this.TryMapToHostDocumentPosition(generatedDocument, endOfLine, out var hostDocumentIndex, out _))
+                if (this.TryMapToHostDocumentPosition(generatedDocument, endOfLine, out Position? hostDocumentIndex, out _))
                 {
                     if (range.Start.Line == lastNewLineAddedToLine)
                     {
@@ -200,16 +199,11 @@ internal sealed class RazorDocumentMappingService : IRazorDocumentMappingService
         return hostDocumentEdits.ToArray();
     }
 
-    public bool TryMapToHostDocumentRange(IRazorGeneratedDocument generatedDocument, Range generatedDocumentRange, MappingBehavior mappingBehavior, [NotNullWhen(true)] out Range? hostDocumentRange)
+    public bool TryMapToHostDocumentRange(IRazorGeneratedDocument generatedDocument, LinePositionSpan generatedDocumentRange, MappingBehavior mappingBehavior, out LinePositionSpan hostDocumentRange)
     {
         if (generatedDocument is null)
         {
             throw new ArgumentNullException(nameof(generatedDocument));
-        }
-
-        if (generatedDocumentRange is null)
-        {
-            throw new ArgumentNullException(nameof(generatedDocumentRange));
         }
 
         if (mappingBehavior == MappingBehavior.Strict)
@@ -230,16 +224,11 @@ internal sealed class RazorDocumentMappingService : IRazorDocumentMappingService
         }
     }
 
-    public bool TryMapToGeneratedDocumentRange(IRazorGeneratedDocument generatedDocument, Range hostDocumentRange, [NotNullWhen(true)] out Range? generatedDocumentRange)
+    public bool TryMapToGeneratedDocumentRange(IRazorGeneratedDocument generatedDocument, LinePositionSpan hostDocumentRange, out LinePositionSpan generatedDocumentRange)
     {
         if (generatedDocument is null)
         {
             throw new ArgumentNullException(nameof(generatedDocument));
-        }
-
-        if (hostDocumentRange is null)
-        {
-            throw new ArgumentNullException(nameof(hostDocumentRange));
         }
 
         if (generatedDocument.CodeDocument is not { } codeDocument)
@@ -290,16 +279,12 @@ internal sealed class RazorDocumentMappingService : IRazorDocumentMappingService
             return false;
         }
 
-        generatedDocumentRange = new Range
-        {
-            Start = generatedRangeStart,
-            End = generatedRangeEnd,
-        };
+        generatedDocumentRange = new LinePositionSpan(generatedRangeStart, generatedRangeEnd);
 
         return true;
     }
 
-    public bool TryMapToHostDocumentPosition(IRazorGeneratedDocument generatedDocument, int generatedDocumentIndex, [NotNullWhen(true)] out Position? hostDocumentPosition, out int hostDocumentIndex)
+    public bool TryMapToHostDocumentPosition(IRazorGeneratedDocument generatedDocument, int generatedDocumentIndex, out LinePosition hostDocumentPosition, out int hostDocumentIndex)
     {
         if (generatedDocument is null)
         {
@@ -327,7 +312,7 @@ internal sealed class RazorDocumentMappingService : IRazorDocumentMappingService
 
                     hostDocumentIndex = mapping.OriginalSpan.AbsoluteIndex + distanceIntoGeneratedSpan;
                     var originalLocation = codeDocument.Source.Lines.GetLocation(hostDocumentIndex);
-                    hostDocumentPosition = new Position(originalLocation.LineIndex, originalLocation.CharacterIndex);
+                    hostDocumentPosition = new LinePosition(originalLocation.LineIndex, originalLocation.CharacterIndex);
                     return true;
                 }
             }
@@ -338,13 +323,13 @@ internal sealed class RazorDocumentMappingService : IRazorDocumentMappingService
         return false;
     }
 
-    public bool TryMapToGeneratedDocumentOrNextCSharpPosition(IRazorGeneratedDocument generatedDocument, int hostDocumentIndex, [NotNullWhen(true)] out Position? generatedPosition, out int generatedIndex)
+    public bool TryMapToGeneratedDocumentOrNextCSharpPosition(IRazorGeneratedDocument generatedDocument, int hostDocumentIndex, out LinePosition generatedPosition, out int generatedIndex)
         => TryMapToGeneratedDocumentPositionInternal(generatedDocument, hostDocumentIndex, nextCSharpPositionOnFailure: true, out generatedPosition, out generatedIndex);
 
-    public bool TryMapToGeneratedDocumentPosition(IRazorGeneratedDocument generatedDocument, int hostDocumentIndex, [NotNullWhen(true)] out Position? generatedPosition, out int generatedIndex)
+    public bool TryMapToGeneratedDocumentPosition(IRazorGeneratedDocument generatedDocument, int hostDocumentIndex, out LinePosition generatedPosition, out int generatedIndex)
         => TryMapToGeneratedDocumentPositionInternal(generatedDocument, hostDocumentIndex, nextCSharpPositionOnFailure: false, out generatedPosition, out generatedIndex);
 
-    private static bool TryMapToGeneratedDocumentPositionInternal(IRazorGeneratedDocument generatedDocument, int hostDocumentIndex, bool nextCSharpPositionOnFailure, [NotNullWhen(true)] out Position? generatedPosition, out int generatedIndex)
+    private static bool TryMapToGeneratedDocumentPositionInternal(IRazorGeneratedDocument generatedDocument, int hostDocumentIndex, bool nextCSharpPositionOnFailure, out LinePosition generatedPosition, out int generatedIndex)
     {
         if (generatedDocument is null)
         {
@@ -395,12 +380,10 @@ internal sealed class RazorDocumentMappingService : IRazorDocumentMappingService
         generatedIndex = default;
         return false;
 
-        static Position GetGeneratedPosition(IRazorGeneratedDocument generatedDocument, int generatedIndex)
+        static LinePosition GetGeneratedPosition(IRazorGeneratedDocument generatedDocument, int generatedIndex)
         {
             var generatedSource = GetGeneratedSourceText(generatedDocument);
-            var generatedLinePosition = generatedSource.Lines.GetLinePosition(generatedIndex);
-            var generatedPosition = new Position(generatedLinePosition.Line, generatedLinePosition.Character);
-            return generatedPosition;
+            return generatedSource.Lines.GetLinePosition(generatedIndex);
         }
     }
 
@@ -442,7 +425,7 @@ internal sealed class RazorDocumentMappingService : IRazorDocumentMappingService
         return workspaceEdit;
     }
 
-    public async Task<(Uri MappedDocumentUri, Range MappedRange)> MapToHostDocumentUriAndRangeAsync(Uri generatedDocumentUri, Range generatedDocumentRange, CancellationToken cancellationToken)
+    public async Task<(Uri MappedDocumentUri, LinePositionSpan MappedRange)> MapToHostDocumentUriAndRangeAsync(Uri generatedDocumentUri, LinePositionSpan generatedDocumentRange, CancellationToken cancellationToken)
     {
         var razorDocumentUri = _documentFilePathService.GetRazorDocumentUri(generatedDocumentUri);
 
@@ -575,7 +558,7 @@ internal sealed class RazorDocumentMappingService : IRazorDocumentMappingService
         }
     }
 
-    private bool TryMapToHostDocumentRangeStrict(IRazorGeneratedDocument generatedDocument, Range generatedDocumentRange, [NotNullWhen(returnValue: true)] out Range? hostDocumentRange)
+    private bool TryMapToHostDocumentRangeStrict(IRazorGeneratedDocument generatedDocument, LinePositionSpan generatedDocumentRange, out LinePositionSpan hostDocumentRange)
     {
         hostDocumentRange = default;
 
@@ -598,16 +581,12 @@ internal sealed class RazorDocumentMappingService : IRazorDocumentMappingService
             return false;
         }
 
-        hostDocumentRange = new Range
-        {
-            Start = hostDocumentStart,
-            End = hostDocumentEnd
-        };
+        hostDocumentRange = new LinePositionSpan(hostDocumentStart, hostDocumentEnd);
 
         return true;
     }
 
-    private bool TryMapToHostDocumentRangeInclusive(IRazorGeneratedDocument generatedDocument, Range generatedDocumentRange, [NotNullWhen(returnValue: true)] out Range? hostDocumentRange)
+    private bool TryMapToHostDocumentRangeInclusive(IRazorGeneratedDocument generatedDocument, LinePositionSpan generatedDocumentRange, out LinePositionSpan hostDocumentRange)
     {
         if (generatedDocument.CodeDocument is not { } codeDocument)
         {
@@ -623,22 +602,16 @@ internal sealed class RazorDocumentMappingService : IRazorDocumentMappingService
             return false;
         }
 
-        var generatedRangeAsSpan = generatedDocumentRange.AsTextSpan(generatedSourceText);
-        var range = generatedDocumentRange;
-        var startIndex = generatedRangeAsSpan.Start;
+        var startIndex = generatedDocumentRange.Start.GetRequiredAbsoluteIndex(generatedSourceText);
         var startMappedDirectly = TryMapToHostDocumentPosition(generatedDocument, startIndex, out var hostDocumentStart, out _);
 
-        var endIndex = generatedRangeAsSpan.End;
+        var endIndex = generatedDocumentRange.End.GetRequiredAbsoluteIndex(generatedSourceText);
         var endMappedDirectly = TryMapToHostDocumentPosition(generatedDocument, endIndex, out var hostDocumentEnd, out _);
 
         if (startMappedDirectly && endMappedDirectly)
         {
             // We strictly mapped the start/end of the generated range.
-            hostDocumentRange = new Range
-            {
-                Start = hostDocumentStart!,
-                End = hostDocumentEnd!
-            };
+            hostDocumentRange = new LinePositionSpan(hostDocumentStart, hostDocumentEnd);
             return true;
         }
 
@@ -656,7 +629,7 @@ internal sealed class RazorDocumentMappingService : IRazorDocumentMappingService
         else
         {
             // Our range does not intersect with any mapping; we should see if it overlaps generated locations
-            candidateMappings = generatedDocument.SourceMappings.Where(mapping => Overlaps(generatedRangeAsSpan, mapping.GeneratedSpan)).ToList();
+            candidateMappings = generatedDocument.SourceMappings.Where(mapping => Overlaps(generatedDocumentRange.AsTextSpan(generatedSourceText), mapping.GeneratedSpan)).ToList();
         }
 
         if (candidateMappings.Count == 1)
@@ -686,20 +659,18 @@ internal sealed class RazorDocumentMappingService : IRazorDocumentMappingService
             return unchecked((uint)(position - span.AbsoluteIndex) <= (uint)span.Length);
         }
 
-        static Range ConvertMapping(RazorSourceDocument sourceDocument, SourceMapping mapping)
+        static LinePositionSpan ConvertMapping(RazorSourceDocument sourceDocument, SourceMapping mapping)
         {
             var startLocation = sourceDocument.Lines.GetLocation(mapping.OriginalSpan.AbsoluteIndex);
             var endLocation = sourceDocument.Lines.GetLocation(mapping.OriginalSpan.AbsoluteIndex + mapping.OriginalSpan.Length);
-            var convertedRange = new Range
-            {
-                Start = new Position(startLocation.LineIndex, startLocation.CharacterIndex),
-                End = new Position(endLocation.LineIndex, endLocation.CharacterIndex)
-            };
+            var convertedRange = new LinePositionSpan(
+                new LinePosition(startLocation.LineIndex, startLocation.CharacterIndex),
+                new LinePosition(endLocation.LineIndex, endLocation.CharacterIndex));
             return convertedRange;
         }
     }
 
-    private bool TryMapToHostDocumentRangeInferred(IRazorGeneratedDocument generatedDocument, Range generatedDocumentRange, [NotNullWhen(returnValue: true)] out Range? hostDocumentRange)
+    private bool TryMapToHostDocumentRangeInferred(IRazorGeneratedDocument generatedDocument, LinePositionSpan generatedDocumentRange, out LinePositionSpan hostDocumentRange)
     {
         if (generatedDocument.CodeDocument is not { } codeDocument)
         {
@@ -755,7 +726,7 @@ internal sealed class RazorDocumentMappingService : IRazorDocumentMappingService
         var originalSpanBeforeGeneratedRange = mappingBeforeGeneratedRange.OriginalSpan;
         var originalEndBeforeGeneratedRange = originalSpanBeforeGeneratedRange.AbsoluteIndex + originalSpanBeforeGeneratedRange.Length;
         var originalEndPositionBeforeGeneratedRange = sourceDocument.Lines.GetLocation(originalEndBeforeGeneratedRange);
-        var inferredStartPosition = new Position(originalEndPositionBeforeGeneratedRange.LineIndex, originalEndPositionBeforeGeneratedRange.CharacterIndex);
+        var inferredStartPosition = new LinePosition(originalEndPositionBeforeGeneratedRange.LineIndex, originalEndPositionBeforeGeneratedRange.CharacterIndex);
 
         if (mappingAfterGeneratedRange != null)
         {
@@ -763,14 +734,11 @@ internal sealed class RazorDocumentMappingService : IRazorDocumentMappingService
 
             var originalSpanAfterGeneratedRange = mappingAfterGeneratedRange.OriginalSpan;
             var originalStartPositionAfterGeneratedRange = sourceDocument.Lines.GetLocation(originalSpanAfterGeneratedRange.AbsoluteIndex);
-            var inferredEndPosition = new Position(originalStartPositionAfterGeneratedRange.LineIndex, originalStartPositionAfterGeneratedRange.CharacterIndex);
+            var inferredEndPosition = new LinePosition(originalStartPositionAfterGeneratedRange.LineIndex, originalStartPositionAfterGeneratedRange.CharacterIndex);
 
-            hostDocumentRange = new Range()
-            {
-                Start = inferredStartPosition,
-                End = inferredEndPosition,
-            };
+            hostDocumentRange = new LinePositionSpan(inferredStartPosition, inferredEndPosition);
             return true;
+
         }
 
         // There was no projection after the "generated range". Therefore, lets fallback to the end-document location.
@@ -778,19 +746,18 @@ internal sealed class RazorDocumentMappingService : IRazorDocumentMappingService
         Debug.Assert(sourceDocument.Length > 0, "Source document length should be greater than 0 here because there's a mapping before us");
 
         var endOfDocumentLocation = sourceDocument.Lines.GetLocation(sourceDocument.Length);
-        var endOfDocumentPosition = new Position(endOfDocumentLocation.LineIndex, endOfDocumentLocation.CharacterIndex);
+        var endOfDocumentPosition = new LinePosition(endOfDocumentLocation.LineIndex, endOfDocumentLocation.CharacterIndex);
 
-        hostDocumentRange = new Range()
-        {
-            Start = inferredStartPosition,
-            End = endOfDocumentPosition,
-        };
+        hostDocumentRange = new LinePositionSpan(inferredStartPosition, endOfDocumentPosition);
         return true;
     }
 
     private static bool s_haveAsserted = false;
 
     private bool IsRangeWithinDocument(Range range, SourceText sourceText)
+        => IsRangeWithinDocument(range.AsLinePositionSpan(), sourceText);
+
+    private bool IsRangeWithinDocument(LinePositionSpan range, SourceText sourceText)
     {
         // This might happen when the document that ranges were created against was not the same as the document we're consulting.
         var result = IsPositionWithinDocument(range.Start, sourceText) && IsPositionWithinDocument(range.End, sourceText);
@@ -804,9 +771,9 @@ internal sealed class RazorDocumentMappingService : IRazorDocumentMappingService
 
         return result;
 
-        static bool IsPositionWithinDocument(Position position, SourceText sourceText)
+        static bool IsPositionWithinDocument(LinePosition linePosition, SourceText sourceText)
         {
-            return position.Line < sourceText.Lines.Count;
+            return sourceText.TryGetAbsoluteIndex(linePosition.Line, linePosition.Character, out _);
         }
     }
 
@@ -903,7 +870,7 @@ internal sealed class RazorDocumentMappingService : IRazorDocumentMappingService
         for (var i = 0; i < edits.Length; i++)
         {
             var generatedRange = edits[i].Range;
-            if (!TryMapToHostDocumentRange(generatedDocument, generatedRange, MappingBehavior.Strict, out var originalRange))
+            if (!this.TryMapToHostDocumentRange(generatedDocument, generatedRange, MappingBehavior.Strict, out var originalRange))
             {
                 // Can't map range. Discard this edit.
                 continue;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentMappingService.cs
@@ -630,7 +630,7 @@ internal sealed class RazorDocumentMappingService : IRazorDocumentMappingService
         else
         {
             // Our range does not intersect with any mapping; we should see if it overlaps generated locations
-            candidateMappings.AddRange(generatedDocument.SourceMappings.Where(mapping => Overlaps(generatedDocumentRange.AsTextSpan(generatedSourceText), mapping.GeneratedSpan)));
+            candidateMappings.AddRange(generatedDocument.SourceMappings.Where(mapping => Overlaps(generatedDocumentRange.ToTextSpan(generatedSourceText), mapping.GeneratedSpan)));
         }
 
         if (candidateMappings.Count == 1)
@@ -694,7 +694,7 @@ internal sealed class RazorDocumentMappingService : IRazorDocumentMappingService
             return false;
         }
 
-        var generatedRangeAsSpan = generatedDocumentRange.AsTextSpan(generatedSourceText);
+        var generatedRangeAsSpan = generatedDocumentRange.ToTextSpan(generatedSourceText);
         SourceMapping? mappingBeforeGeneratedRange = null;
         SourceMapping? mappingAfterGeneratedRange = null;
 
@@ -756,7 +756,7 @@ internal sealed class RazorDocumentMappingService : IRazorDocumentMappingService
     private static bool s_haveAsserted = false;
 
     private bool IsRangeWithinDocument(Range range, SourceText sourceText)
-        => IsRangeWithinDocument(range.AsLinePositionSpan(), sourceText);
+        => IsRangeWithinDocument(range.ToLinePositionSpan(), sourceText);
 
     private bool IsRangeWithinDocument(LinePositionSpan range, SourceText sourceText)
     {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/RazorSemanticTokensInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/RazorSemanticTokensInfoService.cs
@@ -201,7 +201,7 @@ internal class RazorSemanticTokensInfoService : IRazorSemanticTokensInfoService
             var semanticRange = CSharpDataToSemanticRange(lineDelta, charDelta, length, tokenType, tokenModifiers, previousSemanticRange);
             if (_documentMappingService.TryMapToHostDocumentRange(generatedDocument, semanticRange.AsLinePositionSpan(), out var originalRange))
             {
-                if (razorRange is null || razorRange.AsLinePositionSpan().OverlapsWith(originalRange))
+                if (razorRange is null || razorRange.ToLinePositionSpan().OverlapsWith(originalRange))
                 {
                     if (colorBackground)
                     {
@@ -265,7 +265,7 @@ internal class RazorSemanticTokensInfoService : IRazorSemanticTokensInfoService
         SourceSpan? maxGeneratedSpan = null;
 
         var sourceText = codeDocument.GetSourceText();
-        var textSpan = razorRange.AsTextSpan(sourceText);
+        var textSpan = razorRange.ToTextSpan(sourceText);
         var csharpDoc = codeDocument.GetCSharpDocument();
 
         // We want to find the min and max C# source mapping that corresponds with our Razor range.
@@ -292,8 +292,8 @@ internal class RazorSemanticTokensInfoService : IRazorSemanticTokensInfoService
         if (minGeneratedSpan is not null && maxGeneratedSpan is not null)
         {
             var csharpSourceText = codeDocument.GetCSharpSourceText();
-            var startRange = minGeneratedSpan.Value.AsRange(csharpSourceText);
-            var endRange = maxGeneratedSpan.Value.AsRange(csharpSourceText);
+            var startRange = minGeneratedSpan.Value.ToRange(csharpSourceText);
+            var endRange = maxGeneratedSpan.Value.ToRange(csharpSourceText);
 
             csharpRange = new Range { Start = startRange.Start, End = endRange.End };
             Debug.Assert(csharpRange.Start.CompareTo(csharpRange.End) <= 0, "Range.Start should not be larger than Range.End");
@@ -428,7 +428,7 @@ internal class RazorSemanticTokensInfoService : IRazorSemanticTokensInfoService
         using var _ = ListPool<Range>.GetPooledObject(out var csharpRanges);
         var csharpSourceText = codeDocument.GetCSharpSourceText();
         var sourceText = codeDocument.GetSourceText();
-        var textSpan = razorRange.AsTextSpan(sourceText);
+        var textSpan = razorRange.ToTextSpan(sourceText);
         var csharpDoc = codeDocument.GetCSharpDocument();
 
         // We want to find the min and max C# source mapping that corresponds with our Razor range.
@@ -438,7 +438,7 @@ internal class RazorSemanticTokensInfoService : IRazorSemanticTokensInfoService
 
             if (textSpan.OverlapsWith(mappedTextSpan))
             {
-                var mappedRange = mapping.GeneratedSpan.AsRange(csharpSourceText);
+                var mappedRange = mapping.GeneratedSpan.ToRange(csharpSourceText);
                 csharpRanges.Add(mappedRange);
             }
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/SemanticRange.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/SemanticRange.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
 
@@ -33,6 +34,9 @@ internal readonly struct SemanticRange : IComparable<SemanticRange>
     /// covers a range.
     /// </summary>
     public bool FromRazor { get; }
+
+    public LinePositionSpan AsLinePositionSpan()
+        => new(new(StartLine, StartCharacter), new(EndLine, EndCharacter));
 
     public int CompareTo(SemanticRange other)
     {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/TagHelperSemanticRangeVisitor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/TagHelperSemanticRangeVisitor.cs
@@ -37,7 +37,7 @@ internal sealed class TagHelperSemanticRangeVisitor : SyntaxWalker
         if (range is not null)
         {
             var sourceText = razorCodeDocument.GetSourceText();
-            rangeAsTextSpan = range.AsRazorTextSpan(sourceText);
+            rangeAsTextSpan = range.ToRazorTextSpan(sourceText);
         }
 
         using var _ = ArrayBuilderPool<SemanticRange>.GetPooledObject(out var builder);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/WrapWithTag/WrapWithTagEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/WrapWithTag/WrapWithTagEndpoint.cs
@@ -83,13 +83,13 @@ internal class WrapWithTagEndpoint : IRazorRequestHandler<WrapWithTagParams, Wra
             // <p>[|@currentCount|]</p>
 
             var tree = await documentContext.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-            var requestSpan = request.Range.AsRazorTextSpan(sourceText);
+            var requestSpan = request.Range.ToRazorTextSpan(sourceText);
             var node = tree.Root.FindNode(requestSpan, includeWhitespace: false, getInnermostNodeForTie: true);
             if (node?.FirstAncestorOrSelf<CSharpImplicitExpressionSyntax>() is { Parent: CSharpCodeBlockSyntax codeBlock } &&
                 (requestSpan == codeBlock.FullSpan || requestSpan.Length == 0))
             {
                 // Pretend we're in Html so the rest of the logic can continue
-                request.Range = codeBlock.FullSpan.AsRange(sourceText);
+                request.Range = codeBlock.FullSpan.ToRange(sourceText);
                 languageKind = RazorLanguageKind.Html;
             }
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/OnAutoInsertEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/OnAutoInsertEndpointTest.cs
@@ -541,7 +541,7 @@ public class OnAutoInsertEndpointTest : SingleServerDelegatingEndpointTestBase
         Assert.False(insertProvider.Called);
         Assert.Equal(1, LanguageServer.RequestCount);
 
-        var edits = new[] { result!.TextEdit.AsTextChange(codeDocument.GetSourceText()) };
+        var edits = new[] { result!.TextEdit.ToTextChange(codeDocument.GetSourceText()) };
         var newText = codeDocument.GetSourceText().WithChanges(edits).ToString();
         Assert.Equal(expected, newText);
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/RazorOnAutoInsertProviderTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/RazorOnAutoInsertProviderTestBase.cs
@@ -65,7 +65,7 @@ public abstract class RazorOnAutoInsertProviderTestBase : LanguageServerTestBase
 
     private static SourceText ApplyEdit(SourceText source, TextEdit edit)
     {
-        var change = edit.AsTextChange(source);
+        var change = edit.ToTextChange(source);
         return source.WithChanges(change);
     }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndToEndTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndToEndTest.cs
@@ -868,11 +868,11 @@ public class CodeActionEndToEndTest : SingleServerDelegatingEndpointTestBase
             {
                 if (FilePathNormalizer.Normalize(change.TextDocument.Uri.GetAbsoluteOrUNCPath()) == codeBehindFilePath)
                 {
-                    codeBehindEdits.AddRange(change.Edits.Select(e => e.AsTextChange(codeBehindSourceText)));
+                    codeBehindEdits.AddRange(change.Edits.Select(e => e.ToTextChange(codeBehindSourceText)));
                 }
                 else
                 {
-                    razorEdits.AddRange(change.Edits.Select(e => e.AsTextChange(razorSourceText)));
+                    razorEdits.AddRange(change.Edits.Select(e => e.ToTextChange(razorSourceText)));
                 }
             }
 
@@ -919,7 +919,7 @@ public class CodeActionEndToEndTest : SingleServerDelegatingEndpointTestBase
         var edits = new List<TextChange>();
         foreach (var change in changes)
         {
-            edits.AddRange(change.Edits.Select(e => e.AsTextChange(sourceText)));
+            edits.AddRange(change.Edits.Select(e => e.ToTextChange(sourceText)));
         }
 
         var actual = sourceText.WithChanges(edits).ToString();
@@ -957,7 +957,7 @@ public class CodeActionEndToEndTest : SingleServerDelegatingEndpointTestBase
         var @params = new VSCodeActionParams
         {
             TextDocument = new VSTextDocumentIdentifier { Uri = uri },
-            Range = textSpan.AsRange(sourceText),
+            Range = textSpan.ToRange(sourceText),
             Context = new VSInternalCodeActionContext() { Diagnostics = diagnostics ?? Array.Empty<Diagnostic>() }
         };
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Moq;
 using Newtonsoft.Json.Linq;
@@ -33,8 +34,8 @@ public class CodeActionEndpointTest : LanguageServerTestBase
         _documentMappingService = Mock.Of<IRazorDocumentMappingService>(
             s => s.TryMapToGeneratedDocumentRange(
                 It.IsAny<IRazorGeneratedDocument>(),
-                It.IsAny<Range>(),
-                out It.Ref<Range?>.IsAny) == false &&
+                It.IsAny<LinePositionSpan>(),
+                out It.Ref<LinePositionSpan>.IsAny) == false &&
 
                 s.GetLanguageKind(It.IsAny<RazorCodeDocument>(), It.IsAny<int>(), It.IsAny<bool>()) == RazorLanguageKind.CSharp,
 
@@ -614,9 +615,9 @@ public class CodeActionEndpointTest : LanguageServerTestBase
         var documentPath = new Uri("C:/path/to/Page.razor");
         var codeDocument = CreateCodeDocument("@code {}");
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
-        Range? projectedRange = null;
+        LinePositionSpan projectedRange = default;
         var documentMappingService = Mock.Of<IRazorDocumentMappingService>(
-            d => d.TryMapToGeneratedDocumentRange(It.IsAny<IRazorGeneratedDocument>(), It.IsAny<Range>(), out projectedRange) == false
+            d => d.TryMapToGeneratedDocumentRange(It.IsAny<IRazorGeneratedDocument>(), It.IsAny<LinePositionSpan>(), out projectedRange) == false
         , MockBehavior.Strict);
         var codeActionEndpoint = new CodeActionEndpoint(
             documentMappingService,
@@ -659,7 +660,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
         var codeDocument = CreateCodeDocument("@code {}");
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
         var projectedRange = new Range { Start = new Position(15, 2), End = new Position(15, 2) };
-        var documentMappingService = CreateDocumentMappingService(projectedRange);
+        var documentMappingService = CreateDocumentMappingService(projectedRange.AsLinePositionSpan());
         var languageServer = CreateLanguageServer();
         var codeActionEndpoint = new CodeActionEndpoint(
             documentMappingService,
@@ -707,11 +708,15 @@ public class CodeActionEndpointTest : LanguageServerTestBase
         Assert.Equal(projectedRange, diagnostics[1].Range);
     }
 
-    private static IRazorDocumentMappingService CreateDocumentMappingService(Range? projectedRange = null)
+    private static IRazorDocumentMappingService CreateDocumentMappingService(LinePositionSpan projectedRange = default)
     {
-        projectedRange ??= new Range { Start = new Position(5, 2), End = new Position(5, 2) };
+        if (projectedRange == default)
+        {
+            projectedRange = new LinePositionSpan(new(5, 2), new(5, 2));
+        }
+
         var documentMappingService = Mock.Of<IRazorDocumentMappingService>(
-            d => d.TryMapToGeneratedDocumentRange(It.IsAny<IRazorGeneratedDocument>(), It.IsAny<Range>(), out projectedRange) == true &&
+            d => d.TryMapToGeneratedDocumentRange(It.IsAny<IRazorGeneratedDocument>(), It.IsAny<LinePositionSpan>(), out projectedRange) == true &&
                  d.GetLanguageKind(It.IsAny<RazorCodeDocument>(), It.IsAny<int>(), It.IsAny<bool>()) == RazorLanguageKind.CSharp
         , MockBehavior.Strict);
         return documentMappingService;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
@@ -660,7 +660,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
         var codeDocument = CreateCodeDocument("@code {}");
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
         var projectedRange = new Range { Start = new Position(15, 2), End = new Position(15, 2) };
-        var documentMappingService = CreateDocumentMappingService(projectedRange.AsLinePositionSpan());
+        var documentMappingService = CreateDocumentMappingService(projectedRange.ToLinePositionSpan());
         var languageServer = CreateLanguageServer();
         var codeActionEndpoint = new CodeActionEndpoint(
             documentMappingService,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Html/DefaultHtmlCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Html/DefaultHtmlCodeActionProviderTest.cs
@@ -89,7 +89,7 @@ public class DefaultHtmlCodeActionProviderTest : LanguageServerTestBase
                     TextDocument = new OptionalVersionedTextDocumentIdentifier { Uri= new Uri(documentPath), Version = 1 },
                     Edits = new TextEdit[]
                     {
-                        new TextEdit { NewText = "Goo ~~~~~~~~~~~~~~~ Bar", Range = span.AsRange(context.SourceText) }
+                        new TextEdit { NewText = "Goo ~~~~~~~~~~~~~~~ Bar", Range = span.ToRange(context.SourceText) }
                     }
                 }
             }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Html/DefaultHtmlCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Html/DefaultHtmlCodeActionResolverTest.cs
@@ -46,7 +46,7 @@ public class DefaultHtmlCodeActionResolverTest : LanguageServerTestBase
                     TextDocument = new OptionalVersionedTextDocumentIdentifier { Uri= documentUri, Version = 1 },
                     Edits = new TextEdit[]
                     {
-                        new TextEdit { NewText = "Goo ~~~~~~~~~~~~~~~ Bar", Range = span.AsRange(sourceText) }
+                        new TextEdit { NewText = "Goo ~~~~~~~~~~~~~~~ Bar", Range = span.ToRange(sourceText) }
                     }
                 }
            }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionItemResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionItemResolverTest.cs
@@ -176,7 +176,7 @@ public class DelegatedCompletionItemResolverTest : LanguageServerTestBase
         var resolvedItem = await ResolveCompletionItemAsync(input, itemToResolve: "await", DisposalToken);
 
         // Assert
-        var textChange = resolvedItem.TextEdit.Value.First.AsTextChange(originalSourceText);
+        var textChange = resolvedItem.TextEdit.Value.First.ToTextChange(originalSourceText);
         var actualSourceText = originalSourceText.WithChanges(textChange);
         Assert.True(expectedSourceText.ContentEquals(actualSourceText));
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Debugging/ValidateBreakpointRangeEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Debugging/ValidateBreakpointRangeEndpointTest.cs
@@ -108,7 +108,7 @@ public class ValidateBreakpointRangeEndpointTest : SingleServerDelegatingEndpoin
         Assert.True(spans.TryGetValue("expected", out var expectedSpans), "Expected at least one span named 'expected'.");
         Assert.True(expectedSpans.Length == 1, "Expected only one 'expected' span.");
 
-        var expectedRange = expectedSpans[0].AsRange(codeDocument.GetSourceText());
+        var expectedRange = expectedSpans[0].ToRange(codeDocument.GetSourceText());
         Assert.Equal(expectedRange, result);
     }
 
@@ -124,7 +124,7 @@ public class ValidateBreakpointRangeEndpointTest : SingleServerDelegatingEndpoin
             {
                 Uri = new Uri(razorFilePath)
             },
-            Range = breakpointSpan.AsRange(codeDocument.GetSourceText())
+            Range = breakpointSpan.ToRange(codeDocument.GetSourceText())
         };
 
         var documentContext = DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/DefinitionEndpointDelegationTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/DefinitionEndpointDelegationTest.cs
@@ -198,7 +198,7 @@ public class DefinitionEndpointDelegationTest : SingleServerDelegatingEndpointTe
 
         // We can still expect the character to be correct, even if the line won't match
         var surveyPromptSourceText = SourceText.From(surveyPrompt);
-        var range = expectedSpan.AsRange(surveyPromptSourceText);
+        var range = expectedSpan.ToRange(surveyPromptSourceText);
         Assert.Equal(range.Start.Character, location.Range.Start.Character);
     }
 
@@ -219,7 +219,7 @@ public class DefinitionEndpointDelegationTest : SingleServerDelegatingEndpointTe
         var location = Assert.Single(locations);
         Assert.Equal(new Uri(razorFilePath), location.Uri);
 
-        var expectedRange = expectedSpan.AsRange(codeDocument.GetSourceText());
+        var expectedRange = expectedSpan.ToRange(codeDocument.GetSourceText());
         Assert.Equal(expectedRange, location.Range);
     }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/DefinitionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/DefinitionEndpointTest.cs
@@ -399,7 +399,7 @@ public class DefinitionEndpointTest : TagHelperServiceTestBase
         TestFileMarkupParser.GetSpan(content, out content, out var selection);
 
         SetupDocument(out var codeDocument, out _, content);
-        var expectedRange = selection.AsRange(codeDocument.GetSourceText());
+        var expectedRange = selection.ToRange(codeDocument.GetSourceText());
 
         var mappingService = new RazorDocumentMappingService(FilePathService, new TestDocumentContextFactory(), LoggerFactory);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/CSharpDiagnosticsEndToEndTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/CSharpDiagnosticsEndToEndTest.cs
@@ -85,7 +85,7 @@ public class CSharpDiagnosticsEndToEndTest : SingleServerDelegatingEndpointTestB
         {
             // If any future test requires multiple diagnostics of the same type, please change this code :)
             var diagnostic = Assert.Single(actual, d => d.Code == code);
-            Assert.Equal(span.First(), diagnostic.Range.AsTextSpan(sourceText));
+            Assert.Equal(span.First(), diagnostic.Range.ToTextSpan(sourceText));
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticConverterTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticConverterTest.cs
@@ -73,7 +73,7 @@ public class RazorDiagnosticConverterTest
         var range = RazorDiagnosticConverter.ConvertSpanToRange(sourceSpan, sourceText);
 
         // Assert
-        Assert.Equal("lo W", sourceText.GetSubTextString(range.AsTextSpan(sourceText)));
+        Assert.Equal("lo W", sourceText.GetSubTextString(range.ToTextSpan(sourceText)));
         Assert.Equal(expectedRange, range);
     }
 
@@ -93,7 +93,7 @@ public class RazorDiagnosticConverterTest
         var range = RazorDiagnosticConverter.ConvertSpanToRange(sourceSpan, sourceText);
 
         // Assert
-        Assert.Equal("", sourceText.GetSubTextString(range.AsTextSpan(sourceText)));
+        Assert.Equal("", sourceText.GetSubTextString(range.ToTextSpan(sourceText)));
         Assert.Equal(expectedRange, range);
     }
 
@@ -113,7 +113,7 @@ public class RazorDiagnosticConverterTest
         var range = RazorDiagnosticConverter.ConvertSpanToRange(sourceSpan, sourceText);
 
         // Assert
-        Assert.Equal("", sourceText.GetSubTextString(range.AsTextSpan(sourceText)));
+        Assert.Equal("", sourceText.GetSubTextString(range.ToTextSpan(sourceText)));
         Assert.Equal(expectedRange, range);
     }
 
@@ -133,7 +133,7 @@ public class RazorDiagnosticConverterTest
         var range = RazorDiagnosticConverter.ConvertSpanToRange(sourceSpan, sourceText);
 
         // Assert
-        Assert.Equal("World", sourceText.GetSubTextString(range.AsTextSpan(sourceText)));
+        Assert.Equal("World", sourceText.GetSubTextString(range.ToTextSpan(sourceText)));
         Assert.Equal(expectedRange, range);
     }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentHighlighting/DocumentHighlightEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentHighlighting/DocumentHighlightEndpointTest.cs
@@ -152,7 +152,7 @@ public class DocumentHighlightEndpointTest : LanguageServerTestBase
         // Assert
         var sourceText = codeDocument.GetSourceText();
         var expected = spans
-            .Select(s => s.AsRange(sourceText))
+            .Select(s => s.ToRange(sourceText))
             .OrderBy(s => s.Start.Line)
             .ThenBy(s => s.Start.Character)
             .ToArray();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentPresentation/TextDocumentTextPresentationEndpointTests.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentPresentation/TextDocumentTextPresentationEndpointTests.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Moq;
 using Xunit;
@@ -75,10 +76,10 @@ public class TextDocumentTextPresentationEndpointTests : LanguageServerTestBase
         var csharpDocument = codeDocument.GetCSharpDocument();
         var uri = new Uri("file://path/test.razor");
         var documentContext = CreateDocumentContext(uri, codeDocument);
-        var projectedRange = It.IsAny<Range>();
+        var projectedRange = It.IsAny<LinePositionSpan>();
         var documentMappingService = Mock.Of<IRazorDocumentMappingService>(
             s => s.GetLanguageKind(codeDocument, It.IsAny<int>(), It.IsAny<bool>()) == RazorLanguageKind.CSharp &&
-            s.TryMapToGeneratedDocumentRange(csharpDocument, It.IsAny<Range>(), out projectedRange) == true, MockBehavior.Strict);
+            s.TryMapToGeneratedDocumentRange(csharpDocument, It.IsAny<LinePositionSpan>(), out projectedRange) == true, MockBehavior.Strict);
 
         var response = (WorkspaceEdit?)null;
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentPresentation/TextDocumentUriPresentationEndpointTests.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentPresentation/TextDocumentUriPresentationEndpointTests.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Moq;
 using Xunit;
@@ -465,10 +466,10 @@ public class TextDocumentUriPresentationEndpointTests : LanguageServerTestBase
         var csharpDocument = codeDocument.GetCSharpDocument();
         var uri = new Uri("file://path/test.razor");
         var documentContext = CreateDocumentContext(uri, codeDocument);
-        var projectedRange = It.IsAny<Range>();
+        var projectedRange = It.IsAny<LinePositionSpan>();
         var documentMappingService = Mock.Of<IRazorDocumentMappingService>(
             s => s.GetLanguageKind(codeDocument, It.IsAny<int>(), It.IsAny<bool>()) == RazorLanguageKind.CSharp &&
-            s.TryMapToGeneratedDocumentRange(csharpDocument, It.IsAny<Range>(), out projectedRange) == true, MockBehavior.Strict);
+            s.TryMapToGeneratedDocumentRange(csharpDocument, It.IsAny<LinePositionSpan>(), out projectedRange) == true, MockBehavior.Strict);
         var searchEngine = Mock.Of<RazorComponentSearchEngine>(MockBehavior.Strict);
 
         var documentSnapshot = Mock.Of<IDocumentSnapshot>(s => s.GetGeneratedOutputAsync() == Task.FromResult(codeDocument), MockBehavior.Strict);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentSymbols/DocumentSymbolEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentSymbols/DocumentSymbolEndpointTest.cs
@@ -106,7 +106,7 @@ public class DocumentSymbolEndpointTest : SingleServerDelegatingEndpointTestBase
         {
             Assert.True(spansDict.TryGetValue(symbolInformation.Name, out var spans), $"Expected {symbolInformation.Name} to be in test provided markers");
             Assert.Single(spans);
-            var expectedRange = spans.Single().AsRange(sourceText);
+            var expectedRange = spans.Single().ToRange(sourceText);
             Assert.Equal(expectedRange, symbolInformation.Location.Range);
         }
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/FindReferences/FindAllReferencesEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/FindReferences/FindAllReferencesEndpointTest.cs
@@ -96,7 +96,7 @@ public class FindAllReferencesEndpointTest : SingleServerDelegatingEndpointTestB
         {
             Assert.Equal(new Uri(razorFilePath), referenceItem.Location.Uri);
 
-            var expectedRange = expectedSpans[i].AsRange(codeDocument.GetSourceText());
+            var expectedRange = expectedSpans[i].ToRange(codeDocument.GetSourceText());
             Assert.Equal(expectedRange, referenceItem.Location.Range);
 
             i++;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/FormattingTestBase.cs
@@ -76,7 +76,7 @@ public class FormattingTestBase : RazorIntegrationTestBase
         var source = SourceText.From(input);
         var range = spans.IsEmpty
             ? null
-            : spans.Single().AsRange(source);
+            : spans.Single().ToRange(source);
 
         var path = "file:///path/to/Document." + fileKind;
         var uri = new Uri(path);
@@ -228,7 +228,7 @@ public class FormattingTestBase : RazorIntegrationTestBase
 
     private static SourceText ApplyEdits(SourceText source, TextEdit[] edits)
     {
-        var changes = edits.Select(e => e.AsTextChange(source));
+        var changes = edits.Select(e => e.ToTextChange(source));
         return source.WithChanges(changes);
     }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/RazorFormattingServiceTest.cs
@@ -48,8 +48,8 @@ public class Foo{}
         var collapsedEdit = RazorFormattingService.MergeEdits(edits, sourceText);
 
         // Assert
-        var multiEditChange = sourceText.WithChanges(edits.Select(e => e.AsTextChange(sourceText)));
-        var singleEditChange = sourceText.WithChanges(collapsedEdit.AsTextChange(sourceText));
+        var multiEditChange = sourceText.WithChanges(edits.Select(e => e.ToTextChange(sourceText)));
+        var singleEditChange = sourceText.WithChanges(collapsedEdit.ToTextChange(sourceText));
 
         Assert.Equal(multiEditChange.ToString(), singleEditChange.ToString());
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverInfoServiceTest.cs
@@ -639,12 +639,12 @@ public class HoverInfoServiceTest : TagHelperServiceTestBase
             .Setup(c => c.GetLanguageKind(It.IsAny<RazorCodeDocument>(), It.IsAny<int>(), It.IsAny<bool>()))
             .Returns(RazorLanguageKind.CSharp);
 
-        var outRange = new Range();
+        var outRange = new LinePositionSpan();
         documentMappingServiceMock
-            .Setup(c => c.TryMapToGeneratedDocumentRange(It.IsAny<IRazorGeneratedDocument>(), It.IsAny<Range>(), out outRange))
+            .Setup(c => c.TryMapToGeneratedDocumentRange(It.IsAny<IRazorGeneratedDocument>(), It.IsAny<LinePositionSpan>(), out outRange))
             .Returns(true);
 
-        var projectedPosition = new Position(1, 1);
+        var projectedPosition = new LinePosition(1, 1);
         var projectedIndex = 1;
         documentMappingServiceMock.Setup(
             c => c.TryMapToGeneratedDocumentPosition(It.IsAny<IRazorGeneratedDocument>(), It.IsAny<int>(), out projectedPosition, out projectedIndex))

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Implementation/ImplementationEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Implementation/ImplementationEndpointTest.cs
@@ -129,7 +129,7 @@ public class ImplementationEndpointTest : SingleServerDelegatingEndpointTestBase
         {
             Assert.Equal(new Uri(razorFilePath), location.Uri);
 
-            var expectedRange = expectedSpans[i].AsRange(codeDocument.GetSourceText());
+            var expectedRange = expectedSpans[i].ToRange(codeDocument.GetSourceText());
             Assert.Equal(expectedRange, location.Range);
 
             i++;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDocumentMappingServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDocumentMappingServiceTest.cs
@@ -12,7 +12,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.AspNetCore.Razor.LanguageServer.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
-using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.CodeAnalysis.Text;
 using Xunit;
 using Xunit.Abstractions;
 using static Microsoft.AspNetCore.Razor.Language.CommonMetadata;
@@ -38,11 +38,7 @@ public class RazorDocumentMappingServiceTest : TestBase
             "<p>@DateTime.Now</p>",
             "__o = DateTime.Now;",
             new[] { new SourceMapping(new SourceSpan(4, 12), new SourceSpan(6, 12)) });
-        var projectedRange = new Range()
-        {
-            Start = new Position(0, 10),
-            End = new Position(0, 19),
-        };
+        var projectedRange = new LinePositionSpan(new LinePosition(0, 10), new LinePosition(0, 19));
 
         // Act
         var result = service.TryMapToHostDocumentRange(
@@ -65,11 +61,7 @@ public class RazorDocumentMappingServiceTest : TestBase
             "<p>@DateTime.Now</p>",
             "__o = DateTime.Now;",
             new[] { new SourceMapping(new SourceSpan(4, 12), new SourceSpan(6, 12)) });
-        var projectedRange = new Range()
-        {
-            Start = new Position(0, 0),
-            End = new Position(0, 12),
-        };
+        var projectedRange = new LinePositionSpan(new LinePosition(0, 0), new LinePosition(0, 12));
 
         // Act
         var result = service.TryMapToHostDocumentRange(
@@ -92,16 +84,8 @@ public class RazorDocumentMappingServiceTest : TestBase
             "<p>@DateTime.Now</p>",
             "__o = DateTime.Now;",
             new[] { new SourceMapping(new SourceSpan(4, 12), new SourceSpan(6, 12)) });
-        var projectedRange = new Range()
-        {
-            Start = new Position(0, 6),
-            End = new Position(0, 18),
-        };
-        var expectedOriginalRange = new Range()
-        {
-            Start = new Position(0, 4),
-            End = new Position(0, 16)
-        };
+        var projectedRange = new LinePositionSpan(new LinePosition(0, 6), new LinePosition(0, 18));
+        var expectedOriginalRange = new LinePositionSpan(new LinePosition(0, 4), new LinePosition(0, 16));
 
         // Act
         var result = service.TryMapToHostDocumentRange(
@@ -124,16 +108,8 @@ public class RazorDocumentMappingServiceTest : TestBase
             "<p>@DateTime.Now</p>",
             "__o = DateTime.Now;",
             new[] { new SourceMapping(new SourceSpan(4, 12), new SourceSpan(6, 12)) });
-        var projectedRange = new Range()
-        {
-            Start = new Position(0, 6),
-            End = new Position(0, 18),
-        };
-        var expectedOriginalRange = new Range()
-        {
-            Start = new Position(0, 4),
-            End = new Position(0, 16)
-        };
+        var projectedRange = new LinePositionSpan(new LinePosition(0, 6), new LinePosition(0, 18));
+        var expectedOriginalRange = new LinePositionSpan(new LinePosition(0, 4), new LinePosition(0, 16));
 
         // Act
         var result = service.TryMapToHostDocumentRange(
@@ -156,16 +132,8 @@ public class RazorDocumentMappingServiceTest : TestBase
             "<p>@DateTime.Now</p>",
             "__o = DateTime.Now;",
             new[] { new SourceMapping(new SourceSpan(4, 12), new SourceSpan(6, 12)) });
-        var projectedRange = new Range()
-        {
-            Start = new Position(0, 10),
-            End = new Position(0, 19),
-        };
-        var expectedOriginalRange = new Range()
-        {
-            Start = new Position(0, 4),
-            End = new Position(0, 16)
-        };
+        var projectedRange = new LinePositionSpan(new LinePosition(0, 10), new LinePosition(0, 19));
+        var expectedOriginalRange = new LinePositionSpan(new LinePosition(0, 4), new LinePosition(0, 16));
 
         // Act
         var result = service.TryMapToHostDocumentRange(
@@ -188,16 +156,8 @@ public class RazorDocumentMappingServiceTest : TestBase
             "<p>@DateTime.Now</p>",
             "__o = DateTime.Now;",
             new[] { new SourceMapping(new SourceSpan(4, 12), new SourceSpan(6, 12)) });
-        var projectedRange = new Range()
-        {
-            Start = new Position(0, 0),
-            End = new Position(0, 10),
-        };
-        var expectedOriginalRange = new Range()
-        {
-            Start = new Position(0, 4),
-            End = new Position(0, 16)
-        };
+        var projectedRange = new LinePositionSpan(new LinePosition(0, 0), new LinePosition(0, 10));
+        var expectedOriginalRange = new LinePositionSpan(new LinePosition(0, 4), new LinePosition(0, 16));
 
         // Act
         var result = service.TryMapToHostDocumentRange(
@@ -224,11 +184,7 @@ public class RazorDocumentMappingServiceTest : TestBase
                 new SourceMapping(new SourceSpan(4, 8), new SourceSpan(6, 8)), // DateTime
                 new SourceMapping(new SourceSpan(12, 4), new SourceSpan(14, 4)) // .Now
             });
-        var projectedRange = new Range()
-        {
-            Start = new Position(0, 14),
-            End = new Position(0, 19),
-        };
+        var projectedRange = new LinePositionSpan(new LinePosition(0, 14), new LinePosition(0, 19));
 
         // Act
         var result = service.TryMapToHostDocumentRange(
@@ -255,11 +211,7 @@ public class RazorDocumentMappingServiceTest : TestBase
                 new SourceMapping(new SourceSpan(4, 8), new SourceSpan(6, 8)), // DateTime
                 new SourceMapping(new SourceSpan(12, 4), new SourceSpan(14, 4)) // .Now
             });
-        var projectedRange = new Range()
-        {
-            Start = new Position(0, 0),
-            End = new Position(0, 14),
-        };
+        var projectedRange = new LinePositionSpan(new LinePosition(0, 0), new LinePosition(0, 14));
 
         // Act
         var result = service.TryMapToHostDocumentRange(
@@ -282,16 +234,8 @@ public class RazorDocumentMappingServiceTest : TestBase
             "<p>@DateTime.Now</p>",
             "__o = DateTime.Now;",
             new[] { new SourceMapping(new SourceSpan(4, 12), new SourceSpan(6, 12)) });
-        var projectedRange = new Range()
-        {
-            Start = new Position(0, 0),
-            End = new Position(0, 19),
-        };
-        var expectedOriginalRange = new Range()
-        {
-            Start = new Position(0, 4),
-            End = new Position(0, 16)
-        };
+        var projectedRange = new LinePositionSpan(new LinePosition(0, 0), new LinePosition(0, 19));
+        var expectedOriginalRange = new LinePositionSpan(new LinePosition(0, 4), new LinePosition(0, 16));
 
         // Act
         var result = service.TryMapToHostDocumentRange(
@@ -318,11 +262,7 @@ public class RazorDocumentMappingServiceTest : TestBase
                 new SourceMapping(new SourceSpan(4, 8), new SourceSpan(6, 8)), // DateTime
                 new SourceMapping(new SourceSpan(12, 4), new SourceSpan(14, 4)) // .Now
             });
-        var projectedRange = new Range()
-        {
-            Start = new Position(0, 0),
-            End = new Position(0, 19),
-        };
+        var projectedRange = new LinePositionSpan(new LinePosition(0, 0), new LinePosition(0, 19));
 
         // Act
         var result = service.TryMapToHostDocumentRange(
@@ -345,16 +285,8 @@ public class RazorDocumentMappingServiceTest : TestBase
             "<p>@DateTime.Now</p>",
             "__o = DateTime.Now;",
             new[] { new SourceMapping(new SourceSpan(4, 12), new SourceSpan(6, 12)) });
-        var projectedRange = new Range()
-        {
-            Start = new Position(0, 6),
-            End = new Position(0, 18),
-        };
-        var expectedOriginalRange = new Range()
-        {
-            Start = new Position(0, 4),
-            End = new Position(0, 16)
-        };
+        var projectedRange = new LinePositionSpan(new LinePosition(0, 6), new LinePosition(0, 18));
+        var expectedOriginalRange = new LinePositionSpan(new LinePosition(0, 4), new LinePosition(0, 16));
 
         // Act
         var result = service.TryMapToHostDocumentRange(
@@ -377,11 +309,7 @@ public class RazorDocumentMappingServiceTest : TestBase
             "@<unclosed></unclosed><p>@DateTime.Now</p>",
             "(__builder) => { };__o = DateTime.Now;",
             new[] { new SourceMapping(new SourceSpan(26, 12), new SourceSpan(25, 12)) });
-        var projectedRange = new Range()
-        {
-            Start = new Position(0, 0),
-            End = new Position(0, 19),
-        };
+        var projectedRange = new LinePositionSpan(new LinePosition(0, 0), new LinePosition(0, 19));
 
         // Act
         var result = service.TryMapToHostDocumentRange(
@@ -392,7 +320,7 @@ public class RazorDocumentMappingServiceTest : TestBase
 
         // Assert
         Assert.False(result);
-        Assert.Null(originalRange);
+        Assert.Equal(default, originalRange);
     }
 
     [Fact]
@@ -407,16 +335,8 @@ public class RazorDocumentMappingServiceTest : TestBase
                 new SourceMapping(new SourceSpan(2, 11), new SourceSpan(0, 11)),
                 new SourceMapping(new SourceSpan(35, 1), new SourceSpan(30, 1)),
             });
-        var projectedRange = new Range()
-        {
-            Start = new Position(0, 12),
-            End = new Position(0, 29),
-        };
-        var expectedOriginalRange = new Range()
-        {
-            Start = new Position(0, 13),
-            End = new Position(0, 35)
-        };
+        var projectedRange = new LinePositionSpan(new LinePosition(0, 12), new LinePosition(0, 29));
+        var expectedOriginalRange = new LinePositionSpan(new LinePosition(0, 13), new LinePosition(0, 35));
 
         // Act
         var result = service.TryMapToHostDocumentRange(
@@ -439,16 +359,8 @@ public class RazorDocumentMappingServiceTest : TestBase
             "@{ var abc = @<unclosed></unclosed>",
             " var abc =  (__builder) => { }",
             new[] { new SourceMapping(new SourceSpan(2, 11), new SourceSpan(0, 11)), });
-        var projectedRange = new Range()
-        {
-            Start = new Position(0, 12),
-            End = new Position(0, 29),
-        };
-        var expectedOriginalRange = new Range()
-        {
-            Start = new Position(0, 13),
-            End = new Position(0, 35)
-        };
+        var projectedRange = new LinePositionSpan(new LinePosition(0, 12), new LinePosition(0, 29));
+        var expectedOriginalRange = new LinePositionSpan(new LinePosition(0, 13), new LinePosition(0, 35));
 
         // Act
         var result = service.TryMapToHostDocumentRange(
@@ -471,11 +383,7 @@ public class RazorDocumentMappingServiceTest : TestBase
             "@{ var abc = @<unclosed></unclosed>",
             " var abc =  (__builder) => { }",
             new[] { new SourceMapping(new SourceSpan(2, 11), new SourceSpan(0, 11)), });
-        var projectedRange = new Range()
-        {
-            Start = new Position(2, 12),
-            End = new Position(2, 29),
-        };
+        var projectedRange = new LinePositionSpan(new LinePosition(2, 12), new LinePosition(2, 29));
 
         // Act
         var result = service.TryMapToHostDocumentRange(
@@ -537,7 +445,7 @@ public class RazorDocumentMappingServiceTest : TestBase
         }
         else
         {
-            Assert.False(true, $"{service.TryMapToGeneratedDocumentPosition} should have returned true");
+            Assert.False(true, $"{nameof(service.TryMapToGeneratedDocumentPosition)} should have returned true");
         }
     }
 
@@ -726,7 +634,7 @@ public class RazorDocumentMappingServiceTest : TestBase
                 new SourceMapping(new SourceSpan(0, 1), new SourceSpan(0, 1)),
                 new SourceMapping(new SourceSpan(16, 19), new SourceSpan(11, 19))
             });
-        var range = new Range { Start = new Position(1, 10), End = new Position(1, 13) };
+        var range = new LinePositionSpan(new LinePosition(1, 10), new LinePosition(1, 13));
 
         // Act & Assert
         if (service.TryMapToGeneratedDocumentRange(
@@ -756,7 +664,7 @@ public class RazorDocumentMappingServiceTest : TestBase
             new[] {
                 new SourceMapping(new SourceSpan(0, 1), new SourceSpan(0, 1)),
             });
-        var range = new Range { Start = new Position(1, 10), End = new Position(1, 13) };
+        var range = new LinePositionSpan(new LinePosition(1, 10), new LinePosition(1, 13));
 
         // Act
         var result = service.TryMapToGeneratedDocumentRange(
@@ -782,7 +690,7 @@ public class RazorDocumentMappingServiceTest : TestBase
                 new SourceMapping(new SourceSpan(16, 3), new SourceSpan(11, 3)),
                 new SourceMapping(new SourceSpan(19, 10), new SourceSpan(5, 10))
             });
-        var range = new Range { Start = new Position(1, 10), End = new Position(1, 13) };
+        var range = new LinePositionSpan(new LinePosition(1, 10), new LinePosition(1, 13));
 
         // Act
         var result = service.TryMapToGeneratedDocumentRange(

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointDelegationTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointDelegationTest.cs
@@ -93,7 +93,7 @@ public class RenameEndpointDelegationTest: SingleServerDelegatingEndpointTestBas
         var result = await endpoint.HandleRequestAsync(request, requestContext, DisposalToken);
 
         // Assert
-        var edits = result.DocumentChanges.Value.First.FirstOrDefault().Edits.Select(e => e.AsTextChange(codeDocument.GetSourceText()));
+        var edits = result.DocumentChanges.Value.First.FirstOrDefault().Edits.Select(e => e.ToTextChange(codeDocument.GetSourceText()));
         var newText = codeDocument.GetSourceText().WithChanges(edits).ToString();
         Assert.Equal(expected, newText);
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
@@ -500,7 +500,7 @@ public class RenameEndpointTest : LanguageServerTestBase
             .Setup(c => c.RemapWorkspaceEditAsync(It.IsAny<WorkspaceEdit>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(delegatedEdit);
 
-        var projectedPosition = new Position(1, 1);
+        var projectedPosition = new LinePosition(1, 1);
         var projectedIndex = 1;
         documentMappingServiceMock.Setup(c => c.TryMapToGeneratedDocumentPosition(It.IsAny<IRazorGeneratedDocument>(), It.IsAny<int>(), out projectedPosition, out projectedIndex)).Returns(true);
 
@@ -707,7 +707,7 @@ public class RenameEndpointTest : LanguageServerTestBase
         documentMappingServiceMock
             .Setup(c => c.GetLanguageKind(It.IsAny<RazorCodeDocument>(), It.IsAny<int>(), It.IsAny<bool>()))
             .Returns(Protocol.RazorLanguageKind.Html);
-        var projectedPosition = new Position(1, 1);
+        var projectedPosition = new LinePosition(1, 1);
         var projectedIndex = 1;
         documentMappingServiceMock
             .Setup(c => c.TryMapToGeneratedDocumentPosition(It.IsAny<IRazorGeneratedDocument>(), It.IsAny<int>(), out projectedPosition, out projectedIndex))

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/RazorSemanticTokensInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/RazorSemanticTokensInfoServiceTest.cs
@@ -1016,7 +1016,7 @@ public abstract class RazorSemanticTokensInfoServiceTest : SemanticTokenTestBase
             for (var i = 0; i < csharpRanges.Length; i++)
             {
                 var csharpRange = csharpRanges[i];
-                var textSpan = csharpRange.AsTextSpan(csharpSourceText);
+                var textSpan = csharpRange.ToTextSpan(csharpSourceText);
                 Assert.Equal(expectedCsharpRangeLengths[i], textSpan.Length);
             }
         }
@@ -1024,7 +1024,7 @@ public abstract class RazorSemanticTokensInfoServiceTest : SemanticTokenTestBase
         {
             var expectedCsharpRangeLength = 970;
             Assert.True(RazorSemanticTokensInfoService.TryGetMinimalCSharpRange(codeDocument, razorRange, out var csharpRange));
-            var textSpan = csharpRange.AsTextSpan(csharpSourceText);
+            var textSpan = csharpRange.ToTextSpan(csharpSourceText);
             Assert.Equal(expectedCsharpRangeLength, textSpan.Length);
         }
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/WrapWithTag/WrapWithTagEndpointTests.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/WrapWithTag/WrapWithTagEndpointTests.cs
@@ -295,7 +295,7 @@ public class WrapWithTagEndpointTest : LanguageServerTestBase
         var edits = HtmlFormatter.FixHtmlTestEdits(htmlSourceText, computedEdits);
         Assert.Same(computedEdits, edits);
 
-        var finalText = inputSourceText.WithChanges(edits.Select(e => e.AsTextChange(inputSourceText)));
+        var finalText = inputSourceText.WithChanges(edits.Select(e => e.ToTextChange(inputSourceText)));
         Assert.Equal(expected, finalText.ToString());
     }
 
@@ -346,7 +346,7 @@ public class WrapWithTagEndpointTest : LanguageServerTestBase
         var edits = HtmlFormatter.FixHtmlTestEdits(htmlSourceText, computedEdits);
         Assert.NotSame(computedEdits, edits);
 
-        var finalText = inputSourceText.WithChanges(edits.Select(e => e.AsTextChange(inputSourceText)));
+        var finalText = inputSourceText.WithChanges(edits.Select(e => e.ToTextChange(inputSourceText)));
         Assert.Equal(expected, finalText.ToString());
     }
 
@@ -397,7 +397,7 @@ public class WrapWithTagEndpointTest : LanguageServerTestBase
         var edits = HtmlFormatter.FixHtmlTestEdits(htmlSourceText, computedEdits);
         Assert.NotSame(computedEdits, edits);
 
-        var finalText = inputSourceText.WithChanges(edits.Select(e => e.AsTextChange(inputSourceText)));
+        var finalText = inputSourceText.WithChanges(edits.Select(e => e.ToTextChange(inputSourceText)));
         Assert.Equal(expected, finalText.ToString());
     }
 }


### PR DESCRIPTION
Follow up to https://github.com/dotnet/razor/pull/9280

This creates a struct based API for document mapping, and moves semantic tokens to it. I did it in a source-compatible way so we can upgrade existing features as necessary. I suspect most won't get the benefit that semantic tokens gets, as most things just ferry ranges and positions around, and don't process them much. Logged https://github.com/dotnet/razor/issues/9284 to follow up though.

Commit-at-a-time might be easiest.

Results for semantic tokens are pretty good though:
![image](https://github.com/dotnet/razor/assets/754264/7316e5db-0e90-4b32-a807-d4ee5d40741a)
