### PR TITLE
Reduce allocations and array copies in the Razor source generator

### DIFF
--- a/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators/RazorSourceGenerator.AllTagHelpers.cs
+++ b/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators/RazorSourceGenerator.AllTagHelpers.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Razor.Language;
+
+namespace Microsoft.NET.Sdk.Razor.SourceGenerators
+{
+    public partial class RazorSourceGenerator
+    {
+        /// <summary>
+        ///  Helper class that joins together two lists of tag heleprs to avoids allocating
+        ///  a new array to copy them to.
+        /// </summary>
+        private sealed class AllTagHelpers : IReadOnlyList<TagHelperDescriptor>
+        {
+            private static readonly List<TagHelperDescriptor> s_emptyList = new();
+
+            public static readonly AllTagHelpers Empty = new(
+                tagHelpersFromCompilation: null,
+                tagHelpersFromReferences: null);
+
+            private readonly List<TagHelperDescriptor> _tagHelpersFromCompilation;
+            private readonly List<TagHelperDescriptor> _tagHelpersFromReferences;
+
+            private AllTagHelpers(
+                List<TagHelperDescriptor>? tagHelpersFromCompilation,
+                List<TagHelperDescriptor>? tagHelpersFromReferences)
+            {
+                _tagHelpersFromCompilation = tagHelpersFromCompilation ?? s_emptyList;
+                _tagHelpersFromReferences = tagHelpersFromReferences ?? s_emptyList;
+            }
+
+            public static AllTagHelpers Create(
+                List<TagHelperDescriptor>? tagHelpersFromCompilation,
+                List<TagHelperDescriptor>? tagHelpersFromReferences)
+            {
+                return tagHelpersFromCompilation is [] && tagHelpersFromReferences is []
+                    ? Empty
+                    : new(tagHelpersFromCompilation, tagHelpersFromReferences);
+            }
+
+            public TagHelperDescriptor this[int index]
+            {
+                get
+                {
+                    if (index >= 0)
+                    {
+                        return index < _tagHelpersFromCompilation.Count
+                            ? _tagHelpersFromCompilation[index]
+                            : _tagHelpersFromReferences[index - _tagHelpersFromCompilation.Count];
+                    }
+
+                    throw new IndexOutOfRangeException();
+                }
+            }
+
+            public int Count
+                => _tagHelpersFromCompilation.Count + _tagHelpersFromReferences.Count;
+
+            public IEnumerator<TagHelperDescriptor> GetEnumerator()
+            {
+                foreach (var tagHelper in _tagHelpersFromCompilation)
+                {
+                    yield return tagHelper;
+                }
+
+                foreach (var tagHelper in _tagHelpersFromReferences)
+                {
+                    yield return tagHelper;
+                }
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+                => GetEnumerator();
+        }
+    }
+}

--- a/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators/RazorSourceGenerator.AllTagHelpers.cs
+++ b/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators/RazorSourceGenerator.AllTagHelpers.cs
@@ -11,7 +11,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
     public partial class RazorSourceGenerator
     {
         /// <summary>
-        ///  Helper class that joins together two lists of tag heleprs to avoids allocating
+        ///  Helper class that joins together two lists of tag helpers to avoid allocating
         ///  a new array to copy them to.
         /// </summary>
         private sealed class AllTagHelpers : IReadOnlyList<TagHelperDescriptor>

--- a/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators/RazorSourceGenerator.AllTagHelpers.cs
+++ b/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators/RazorSourceGenerator.AllTagHelpers.cs
@@ -37,7 +37,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                 List<TagHelperDescriptor>? tagHelpersFromCompilation,
                 List<TagHelperDescriptor>? tagHelpersFromReferences)
             {
-                return tagHelpersFromCompilation is [] && tagHelpersFromReferences is []
+                return tagHelpersFromCompilation is null or [] && tagHelpersFromReferences is null or []
                     ? Empty
                     : new(tagHelpersFromCompilation, tagHelpersFromReferences);
             }

--- a/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators/RazorSourceGenerator.cs
+++ b/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators/RazorSourceGenerator.cs
@@ -124,7 +124,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                     var tagHelperFeature = GetStaticTagHelperFeature(compilation);
                     var results = new List<TagHelperDescriptor>();
 
-                    tagHelperFeature.GetDescriptors(compilation.Assembly, results);
+                    tagHelperFeature.CollectDescriptors(compilation.Assembly, results);
 
                     RazorSourceGeneratorEventSource.Log.DiscoverTagHelpersFromCompilationStop();
 
@@ -184,7 +184,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                     {
                         if (compilation.GetAssemblyOrModuleSymbol(reference) is IAssemblySymbol assembly)
                         {
-                            tagHelperFeature.GetDescriptors(assembly, results);
+                            tagHelperFeature.CollectDescriptors(assembly, results);
                         }
                     }
 

--- a/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators/RazorSourceGenerator.cs
+++ b/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators/RazorSourceGenerator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
@@ -167,6 +168,9 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                     // Note: compilation.References just enumerates compilation.ExternalReferences and compilation.DirectiveReferences.
                     if (compilation.ExternalReferences is [] && compilation.DirectiveReferences is [])
                     {
+                        Debug.Assert(
+                            !compilation.References.Any(),
+                            "Compilation.References returns references other than ExternalReferences and DirectiveReferences");
                         return null;
                     }
 

--- a/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators/RazorSourceGenerator.cs
+++ b/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators/RazorSourceGenerator.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
@@ -80,7 +79,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
             var generatedDeclarationCode = componentFiles
                 .Combine(importFiles.Collect())
                 .Combine(razorSourceGeneratorOptions)
-                .WithLambdaComparer((old, @new) => (old.Right.Equals(@new.Right) && old.Left.Left.Equals(@new.Left.Left) && old.Left.Right.SequenceEqual(@new.Left.Right)))
+                .WithLambdaComparer((old, @new) => old.Right.Equals(@new.Right) && old.Left.Left.Equals(@new.Left.Left) && old.Left.Right.SequenceEqual(@new.Left.Right))
                 .Select(static (pair, _) =>
                 {
                     var ((sourceItem, importFiles), razorSourceGeneratorOptions) = pair;
@@ -122,28 +121,15 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                     var (compilation, razorSourceGeneratorOptions) = pair;
 
                     var tagHelperFeature = GetStaticTagHelperFeature(compilation);
-                    var result = tagHelperFeature.GetDescriptors(compilation.Assembly);
-                    
+                    var results = new List<TagHelperDescriptor>();
+
+                    tagHelperFeature.GetDescriptors(compilation.Assembly, results);
+
                     RazorSourceGeneratorEventSource.Log.DiscoverTagHelpersFromCompilationStop();
-                    return result;
+
+                    return results;
                 })
-                .WithLambdaComparer(static (a, b) =>
-                {
-                    if (a.Count != b.Count)
-                    {
-                        return false;
-                    }
-
-                    for (var i = 0; i < a.Count; i++)
-                    {
-                        if (!a[i].Equals(b[i]))
-                        {
-                            return false;
-                        }
-                    }
-
-                    return true;
-                });
+                .WithLambdaComparer(static (a, b) => a.SequenceEqual(b));
 
             var tagHelpersFromReferences = compilation
                 .Combine(razorSourceGeneratorOptions)
@@ -174,40 +160,40 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                     {
                         // If there's no razor code in this app, don't do anything.
                         RazorSourceGeneratorEventSource.Log.DiscoverTagHelpersFromReferencesStop();
-                        return ImmutableArray<TagHelperDescriptor>.Empty;
+                        return null;
+                    }
+
+                    // If there aren't any references, we can bail out early.
+                    // Note: compilation.References just enuemrators compilation.ExternalReferences and compilation.DirectiveReferences.
+                    if (compilation.ExternalReferences is [] && compilation.DirectiveReferences is [])
+                    {
+                        return null;
                     }
 
                     var tagHelperFeature = GetStaticTagHelperFeature(compilation);
 
-                    List<TagHelperDescriptor> descriptors = new();
+                    // Typically a project with Razor files will have maany tag helpers in references/
+                    // So, we start with a larger capacity to avoid extra array copies.
+                    var results = new List<TagHelperDescriptor>(capacity: 128);
+
                     foreach (var reference in compilation.References)
                     {
                         if (compilation.GetAssemblyOrModuleSymbol(reference) is IAssemblySymbol assembly)
                         {
-                            descriptors.AddRange(tagHelperFeature.GetDescriptors(assembly));
+                            tagHelperFeature.GetDescriptors(assembly, results);
                         }
                     }
 
                     RazorSourceGeneratorEventSource.Log.DiscoverTagHelpersFromReferencesStop();
-                    return (ICollection<TagHelperDescriptor>)descriptors;
+
+                    return results;
                 });
 
             var allTagHelpers = tagHelpersFromCompilation
                 .Combine(tagHelpersFromReferences)
                 .Select(static (pair, _) =>
                 {
-                    var (tagHelpersFromCompilation, tagHelpersFromReferences) = pair;
-                    var count = tagHelpersFromCompilation.Count + tagHelpersFromReferences.Count;
-                    if (count == 0)
-                    {
-                        return Array.Empty<TagHelperDescriptor>();
-                    }
-
-                    var allTagHelpers = new TagHelperDescriptor[count];
-                    tagHelpersFromCompilation.CopyTo(allTagHelpers, 0);
-                    tagHelpersFromReferences.CopyTo(allTagHelpers, tagHelpersFromCompilation.Count);
-
-                    return allTagHelpers;
+                    return AllTagHelpers.Create(tagHelpersFromCompilation: pair.Left, tagHelpersFromReferences: pair.Right);
                 });
 
             var withOptions = sourceItems
@@ -231,60 +217,62 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                             t.GetMembers("AddComponentParameter").Any(static m => m.DeclaredAccessibility == Accessibility.Public), compilation);
                 });
 
-            IncrementalValuesProvider<(string, SourceGeneratorRazorCodeDocument)> processed(bool designTime) => (designTime ? withOptionsDesignTime : withOptions)
-                .Combine(isAddComponentParameterAvailable)
-                .Select((pair, _) =>
-                {
-                    var (((sourceItem, imports), razorSourceGeneratorOptions), isAddComponentParameterAvailable) = pair;
+            IncrementalValuesProvider<(string, SourceGeneratorRazorCodeDocument)> processed(bool designTime)
+            {
+                return (designTime ? withOptionsDesignTime : withOptions)
+                    .Combine(isAddComponentParameterAvailable)
+                    .Select((pair, _) =>
+                    {
+                        var (((sourceItem, imports), razorSourceGeneratorOptions), isAddComponentParameterAvailable) = pair;
 
-                    RazorSourceGeneratorEventSource.Log.ParseRazorDocumentStart(sourceItem.RelativePhysicalPath);
+                        RazorSourceGeneratorEventSource.Log.ParseRazorDocumentStart(sourceItem.RelativePhysicalPath);
 
-                    var projectEngine = GetGenerationProjectEngine(sourceItem, imports, razorSourceGeneratorOptions, isAddComponentParameterAvailable);
+                        var projectEngine = GetGenerationProjectEngine(sourceItem, imports, razorSourceGeneratorOptions, isAddComponentParameterAvailable);
 
-                    var document = projectEngine.ProcessInitialParse(sourceItem, designTime);
+                        var document = projectEngine.ProcessInitialParse(sourceItem, designTime);
 
-                    RazorSourceGeneratorEventSource.Log.ParseRazorDocumentStop(sourceItem.RelativePhysicalPath);
-                    return (projectEngine, sourceItem.RelativePhysicalPath, document);
-                })
+                        RazorSourceGeneratorEventSource.Log.ParseRazorDocumentStop(sourceItem.RelativePhysicalPath);
+                        return (projectEngine, sourceItem.RelativePhysicalPath, document);
+                    })
 
-                // Add the tag helpers in, but ignore if they've changed or not, only reprocessing the actual document changed
-                .Combine(allTagHelpers)
-                .WithLambdaComparer((old, @new) => old.Left.Equals(@new.Left))
-                .Select(static (pair, _) =>
-                {
-                    var ((projectEngine, filePath, codeDocument), allTagHelpers) = pair;
-                    RazorSourceGeneratorEventSource.Log.RewriteTagHelpersStart(filePath);
+                    // Add the tag helpers in, but ignore if they've changed or not, only reprocessing the actual document changed
+                    .Combine(allTagHelpers)
+                    .WithLambdaComparer((old, @new) => old.Left.Equals(@new.Left))
+                    .Select(static (pair, _) =>
+                    {
+                        var ((projectEngine, filePath, codeDocument), allTagHelpers) = pair;
+                        RazorSourceGeneratorEventSource.Log.RewriteTagHelpersStart(filePath);
 
-                    codeDocument = projectEngine.ProcessTagHelpers(codeDocument, allTagHelpers, checkForIdempotency: false);
+                        codeDocument = projectEngine.ProcessTagHelpers(codeDocument, allTagHelpers, checkForIdempotency: false);
 
-                    RazorSourceGeneratorEventSource.Log.RewriteTagHelpersStop(filePath);
-                    return (projectEngine, filePath, codeDocument);
-                })
+                        RazorSourceGeneratorEventSource.Log.RewriteTagHelpersStop(filePath);
+                        return (projectEngine, filePath, codeDocument);
+                    })
 
-                // next we do a second parse, along with the helpers, but check for idempotency. If the tag helpers used on the previous parse match, the compiler can skip re-writing them
-                .Combine(allTagHelpers)
-                .Select(static (pair, _) =>
-                {
+                    // next we do a second parse, along with the helpers, but check for idempotency. If the tag helpers used on the previous parse match, the compiler can skip re-writing them
+                    .Combine(allTagHelpers)
+                    .Select(static (pair, _) =>
+                    {
+                        var ((projectEngine, filePath, document), allTagHelpers) = pair;
+                        RazorSourceGeneratorEventSource.Log.CheckAndRewriteTagHelpersStart(filePath);
 
-                    var ((projectEngine, filePath, document), allTagHelpers) = pair;
-                    RazorSourceGeneratorEventSource.Log.CheckAndRewriteTagHelpersStart(filePath);
+                        document = projectEngine.ProcessTagHelpers(document, allTagHelpers, checkForIdempotency: true);
 
-                    document = projectEngine.ProcessTagHelpers(document, allTagHelpers, checkForIdempotency: true);
+                        RazorSourceGeneratorEventSource.Log.CheckAndRewriteTagHelpersStop(filePath);
+                        return (projectEngine, filePath, document);
+                    })
+                    .Select((pair, _) =>
+                    {
+                        var (projectEngine, filePath, document) = pair;
 
-                    RazorSourceGeneratorEventSource.Log.CheckAndRewriteTagHelpersStop(filePath);
-                    return (projectEngine, filePath, document);
-                })
-                .Select((pair, _) =>
-                {
-                    var (projectEngine, filePath, document) = pair;
+                        var kind = designTime ? "DesignTime" : "Runtime";
+                        RazorSourceGeneratorEventSource.Log.RazorCodeGenerateStart(filePath, kind);
+                        document = projectEngine.ProcessRemaining(document);
 
-                    var kind = designTime ? "DesignTime" : "Runtime";
-                    RazorSourceGeneratorEventSource.Log.RazorCodeGenerateStart(filePath, kind);
-                    document = projectEngine.ProcessRemaining(document);
-                    
-                    RazorSourceGeneratorEventSource.Log.RazorCodeGenerateStop(filePath, kind);
-                    return (filePath, document);
-                });
+                        RazorSourceGeneratorEventSource.Log.RazorCodeGenerateStop(filePath, kind);
+                        return (filePath, document);
+                    });
+                }
 
             var csharpDocuments = processed(designTime: false)
                 .Select(static (pair, _) =>

--- a/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators/RazorSourceGenerator.cs
+++ b/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators/RazorSourceGenerator.cs
@@ -272,7 +272,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                         RazorSourceGeneratorEventSource.Log.RazorCodeGenerateStop(filePath, kind);
                         return (filePath, document);
                     });
-                }
+            }
 
             var csharpDocuments = processed(designTime: false)
                 .Select(static (pair, _) =>

--- a/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators/RazorSourceGenerator.cs
+++ b/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators/RazorSourceGenerator.cs
@@ -164,7 +164,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                     }
 
                     // If there aren't any references, we can bail out early.
-                    // Note: compilation.References just enuemrators compilation.ExternalReferences and compilation.DirectiveReferences.
+                    // Note: compilation.References just enumerates compilation.ExternalReferences and compilation.DirectiveReferences.
                     if (compilation.ExternalReferences is [] && compilation.DirectiveReferences is [])
                     {
                         return null;
@@ -172,7 +172,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
 
                     var tagHelperFeature = GetStaticTagHelperFeature(compilation);
 
-                    // Typically a project with Razor files will have maany tag helpers in references/
+                    // Typically a project with Razor files will have many tag helpers in references.
                     // So, we start with a larger capacity to avoid extra array copies.
                     var results = new List<TagHelperDescriptor>(capacity: 128);
 

--- a/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators/RazorSourceGenerator.cs
+++ b/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators/RazorSourceGenerator.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
@@ -161,16 +160,6 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                     {
                         // If there's no razor code in this app, don't do anything.
                         RazorSourceGeneratorEventSource.Log.DiscoverTagHelpersFromReferencesStop();
-                        return null;
-                    }
-
-                    // If there aren't any references, we can bail out early.
-                    // Note: compilation.References just enumerates compilation.ExternalReferences and compilation.DirectiveReferences.
-                    if (compilation.ExternalReferences is [] && compilation.DirectiveReferences is [])
-                    {
-                        Debug.Assert(
-                            !compilation.References.Any(),
-                            "Compilation.References returns references other than ExternalReferences and DirectiveReferences");
                         return null;
                     }
 

--- a/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators/StaticCompilationTagHelperFeature.cs
+++ b/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators/StaticCompilationTagHelperFeature.cs
@@ -15,8 +15,13 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
     {
         private ImmutableArray<ITagHelperDescriptorProvider> _providers;
 
-        public void GetDescriptors(ISymbol? targetSymbol, List<TagHelperDescriptor> results)
+        public void CollectDescriptors(ISymbol? targetSymbol, List<TagHelperDescriptor> results)
         {
+            if (_providers.IsDefault)
+            {
+                return;
+            }
+
             var context = TagHelperDescriptorProviderContext.Create(results);
             context.SetCompilation(compilation);
 
@@ -34,7 +39,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
         IReadOnlyList<TagHelperDescriptor> ITagHelperFeature.GetDescriptors()
         {
             var results = new List<TagHelperDescriptor>();
-            GetDescriptors(targetSymbol: null, results);
+            CollectDescriptors(targetSymbol: null, results);
 
             return results;
         }

--- a/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators/StaticCompilationTagHelperFeature.cs
+++ b/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators/StaticCompilationTagHelperFeature.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis;
@@ -12,31 +13,38 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
     internal sealed class StaticCompilationTagHelperFeature(Compilation compilation)
         : RazorEngineFeatureBase, ITagHelperFeature
     {
-        private ITagHelperDescriptorProvider[]? _providers;
+        private ImmutableArray<ITagHelperDescriptorProvider> _providers;
 
-        public List<TagHelperDescriptor> GetDescriptors(ISymbol? targetSymbol)
+        public void GetDescriptors(ISymbol? targetSymbol, List<TagHelperDescriptor> results)
         {
-            var results = new List<TagHelperDescriptor>();
             var context = TagHelperDescriptorProviderContext.Create(results);
             context.SetCompilation(compilation);
+
             if (targetSymbol is not null)
             {
                 context.Items.SetTargetSymbol(targetSymbol);
             }
 
-            for (var i = 0; i < _providers?.Length; i++)
+            foreach (var provider in _providers)
             {
-                _providers[i].Execute(context);
+                provider.Execute(context);
             }
+        }
+
+        IReadOnlyList<TagHelperDescriptor> ITagHelperFeature.GetDescriptors()
+        {
+            var results = new List<TagHelperDescriptor>();
+            GetDescriptors(targetSymbol: null, results);
 
             return results;
         }
 
-        IReadOnlyList<TagHelperDescriptor> ITagHelperFeature.GetDescriptors() => GetDescriptors(targetSymbol: null);
-
         protected override void OnInitialized()
         {
-            _providers = Engine.Features.OfType<ITagHelperDescriptorProvider>().OrderBy(f => f.Order).ToArray();
+            _providers = Engine.Features
+                .OfType<ITagHelperDescriptorProvider>()
+                .OrderBy(f => f.Order)
+                .ToImmutableArray();
         }
     }
 }


### PR DESCRIPTION
I was looking at a trace the other week and noticed that the source generator was a significant source of `TagHelperDescriptor[]` allocations and copying. This pull request fixes a bunch of low-hanging fruit in this area.

* Don't allocate a new `List<TagHelperDescriptor>` for every reference on a compilation. Instead, pass int the same list.
* Don't create a new array and copy two `List<TagHelperDescriptor>` into it. Instead, create an object that implements `IReadOnlyList<TagHelperDescriptor>` and wraps the two lists.
* Start with a list with a larger capacity when collecting the tag helpers in compilation references.
* Avoid boxing an `ImmutableArray<TagHelperDescriptor>.Empty` to an `ICollection<TagHelperDescriptor>`.