### PR TITLE
Don't crash if there are diagnostics without spans

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/SourceSpanExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/SourceSpanExtensions.cs
@@ -19,4 +19,11 @@ internal static class SourceSpanExtensions
             End = new Position(endLine, endChar),
         };
     }
+
+    public static LinePositionSpan ToLinePositionSpan(this SourceSpan sourceSpan, SourceText sourceText)
+    {
+        sourceText.GetLinesAndOffsets(sourceSpan, out var startLine, out var startChar, out var endLine, out var endChar);
+
+        return new LinePositionSpan(new(startLine, startChar), new(endLine, endChar));
+    }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingService.cs
@@ -56,10 +56,13 @@ internal class RazorFormattingService : IRazorFormattingService
 
         // Despite what it looks like, codeDocument.GetCSharpDocument().Diagnostics is actually the
         // Razor diagnostics, not the C# diagnostics 🤦‍
-        if (range is not null &&
-            codeDocument.GetCSharpDocument().Diagnostics.Any(d => range.OverlapsWith(d.Span.ToRange(codeDocument.GetSourceText()))))
+        if (range is not null)
         {
-            return Array.Empty<TextEdit>();
+            var sourceText = codeDocument.GetSourceText();
+            if (codeDocument.GetCSharpDocument().Diagnostics.Any(d => d.Span != SourceSpan.Undefined && range.ToLinePositionSpan().OverlapsWith(d.Span.ToLinePositionSpan(sourceText))))
+            {
+                return Array.Empty<TextEdit>();
+            }
         }
 
         var uri = documentContext.Uri;


### PR DESCRIPTION
Fixes 61% of https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1883434

The compiler will happily create diagnostics with a source span that is undefined (AbsoluteIndex of -1):
https://github.com/dotnet/razor/blob/main/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/src/RazorExtensionsDiagnosticFactory.cs#L26

Also snuck in a removal of one-allocation-per-diagnostic just because I'm in the mood.