### PR TITLE
Use a binary search when trying to find source mappings

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorDocumentMappingBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorDocumentMappingBenchmark.cs
@@ -1,0 +1,179 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+#nullable disable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.AspNetCore.Razor.Microbenchmarks.LanguageServer;
+
+public class RazorDocumentMappingBenchmark : RazorLanguageServerBenchmarkBase
+{
+    private string _filePath;
+
+    private IRazorDocumentMappingService DocumentMappingService { get; set; }
+
+    private IDocumentSnapshot DocumentSnapshot { get; set; }
+
+    private RazorCSharpDocument CSharpDocument { get; set; }
+
+    private List<int> Indexes { get; set; }
+
+    /// <summary>
+    /// How many blocks of 25 lines of code should be formatted
+    /// </summary>
+    [Params(1, 2, 3, 4, 5, 10, 20, 30, 40, 100)]
+    public int Blocks { get; set; }
+
+    [GlobalSetup]
+    public async Task InitializeRazorCSharpFormattingAsync()
+    {
+        EnsureServicesInitialized();
+
+        var projectRoot = Path.Combine(RepoRoot, "src", "Razor", "test", "testapps", "ComponentApp");
+        var projectFilePath = Path.Combine(projectRoot, "ComponentApp.csproj");
+        _filePath = Path.Combine(projectRoot, "Components", "Pages", $"Generated.razor");
+
+        WriteSampleFile(_filePath, Blocks, out var indexes);
+
+        Indexes = indexes;
+
+        var targetPath = "/Components/Pages/Generated.razor";
+
+        DocumentSnapshot = GetDocumentSnapshot(projectFilePath, _filePath, targetPath);
+
+        var codeDocument = await DocumentSnapshot.GetGeneratedOutputAsync();
+        CSharpDocument = codeDocument.GetCSharpDocument();
+    }
+
+    private static void WriteSampleFile(string filePath, int blocks, out List<int> indexes)
+    {
+        indexes = new List<int>();
+        var data = @"
+@{
+    y = 456;
+}
+
+<div>
+    <span>@DateTime.Now</span>
+    @if (true)
+    {
+        var x = 123;
+        <span>@x</span>
+    }
+</div>
+
+@code {
+    public string Prop$INDEX$ { get; set; }
+
+    public string[] SomeList$INDEX$ { get; set; }
+
+    public class Foo$INDEX$
+    {
+        @* This is a Razor Comment *@
+        void Method() { }
+    }
+}
+
+";
+        using var fileStream = File.CreateText(filePath);
+
+        var index = 0;
+        for (var i = 0; i < blocks; i++)
+        {
+            var fileSegment = data.Replace("$INDEX$", i.ToString());
+            fileStream.WriteLine(fileSegment);
+            index += fileSegment.Length;
+            indexes.Add(index);
+        }
+    }
+
+    [Benchmark]
+    public LinePosition Loop()
+    {
+        LinePosition position = default;
+        foreach (var index in Indexes)
+        {
+            TryMapToHostDocumentPosition(CSharpDocument, index, out position, out _);
+        }
+
+        return position;
+    }
+
+    [Benchmark]
+    public LinePosition BinarySearch()
+    {
+        LinePosition position = default;
+        foreach (var index in Indexes)
+        {
+            DocumentMappingService.TryMapToHostDocumentPosition(CSharpDocument, index, out position, out _);
+        }
+
+        return position;
+    }
+
+    // old code, copied from RazorDocumentMappingService before making changes
+    private bool TryMapToHostDocumentPosition(IRazorGeneratedDocument generatedDocument, int generatedDocumentIndex, out LinePosition hostDocumentPosition, out int hostDocumentIndex)
+    {
+        if (generatedDocument is null)
+        {
+            throw new ArgumentNullException(nameof(generatedDocument));
+        }
+
+        if (generatedDocument.CodeDocument is not { } codeDocument)
+        {
+            throw new InvalidOperationException("Cannot use document mapping service on a generated document that has a null CodeDocument.");
+        }
+
+        for (var i = 0; i < generatedDocument.SourceMappings.Count; i++)
+        {
+            var mapping = generatedDocument.SourceMappings[i];
+            var generatedSpan = mapping.GeneratedSpan;
+            var generatedAbsoluteIndex = generatedSpan.AbsoluteIndex;
+            if (generatedAbsoluteIndex <= generatedDocumentIndex)
+            {
+                // Treat the mapping as owning the edge at its end (hence <= originalSpan.Length),
+                // otherwise we wouldn't handle the cursor being right after the final C# char
+                var distanceIntoGeneratedSpan = generatedDocumentIndex - generatedAbsoluteIndex;
+                if (distanceIntoGeneratedSpan <= generatedSpan.Length)
+                {
+                    // Found the generated span that contains the generated absolute index
+
+                    hostDocumentIndex = mapping.OriginalSpan.AbsoluteIndex + distanceIntoGeneratedSpan;
+                    var originalLocation = codeDocument.Source.Lines.GetLocation(hostDocumentIndex);
+                    hostDocumentPosition = new LinePosition(originalLocation.LineIndex, originalLocation.CharacterIndex);
+                    return true;
+                }
+            }
+        }
+
+        hostDocumentPosition = default;
+        hostDocumentIndex = default;
+        return false;
+    }
+
+    [GlobalCleanup]
+    public async Task CleanupServerAsync()
+    {
+        File.Delete(_filePath);
+
+        var innerServer = RazorLanguageServer.GetInnerLanguageServerForTesting();
+
+        await innerServer.ShutdownAsync();
+        await innerServer.ExitAsync();
+    }
+
+    private void EnsureServicesInitialized()
+    {
+        var languageServer = RazorLanguageServer.GetInnerLanguageServerForTesting();
+        DocumentMappingService = languageServer.GetRequiredService<IRazorDocumentMappingService>();
+    }
+}

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ArrayExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ArrayExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 
@@ -12,4 +13,42 @@ internal static class ArrayExtensions
         this (TKey key, TValue value)[] array, IEqualityComparer<TKey> keyComparer)
         where TKey : notnull
         => array.ToImmutableDictionary(keySelector: t => t.key, elementSelector: t => t.value, keyComparer);
+
+    /// <summary>
+    /// Executes a binary search over an array, but allows the caller to decide what constitutes a match
+    /// </summary>
+    /// <typeparam name="T">Type of the elements in the array</typeparam>
+    /// <typeparam name="TArg">Type of the argument to pass to the comparer</typeparam>
+    /// <param name="array">The array to search</param>
+    /// <param name="arg">An argument to pass to the comparison function</param>
+    /// <param name="comparer">A comparison function that evaluates an item in the array. Return 0 if the item is a match,
+    /// or -1 if the item indicates a successful match will be found in the left branch, or 1 if the item indicates a successful
+    /// match will be found in the right branch.</param>
+    /// <returns>The index of the element found</returns>
+    public static int BinarySearchBy<T, TArg>(this T[] array, TArg arg, Func<T, TArg, int> comparer)
+    {
+        var min = 0;
+        var max = array.Length - 1;
+
+        while (min <= max)
+        {
+            var mid = (min + max) / 2;
+            var comparison = comparer(array[mid], arg);
+            if (comparison == 0)
+            {
+                return mid;
+            }
+
+            if (comparison < 0)
+            {
+                min = mid + 1;
+            }
+            else
+            {
+                max = mid - 1;
+            }
+        }
+
+        return ~min;
+    }
 }


### PR DESCRIPTION
Last one before I go :)

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1886121 which is the first non-compiler stack when searching PRISM for "Razor" 😁

The benchmark results look pretty good, but are actually probably worse than real world, as the benchmark code has the number of locations being mapped increases with the size of the file. In the real world, I expect large files will get a huge speed boost in normal scenarios, which just map one or two positions. I could write another benchmark that just maps one location, but that feels unnecssary.

|       Method |        Job |            Toolchain | Blocks |          Mean |        Error |       StdDev |        Median |           Min |           Max | Allocated |
|------------- |----------- |--------------------- |------- |--------------:|-------------:|-------------:|--------------:|--------------:|--------------:|----------:|
|         Loop | Job-EJEXYW |             .NET 7.0 |      1 |     121.41 ns |     1.919 ns |     1.971 ns |     121.31 ns |     119.08 ns |     126.19 ns |         - |
| BinarySearch | Job-EJEXYW |             .NET 7.0 |      1 |      28.79 ns |     0.599 ns |     1.064 ns |      28.43 ns |      27.52 ns |      31.64 ns |         - |
|         Loop | Job-DSHCRS | .NET Framework 4.7.2 |      1 |     142.07 ns |     1.635 ns |     1.529 ns |     141.90 ns |     140.08 ns |     144.52 ns |         - |
| BinarySearch | Job-DSHCRS | .NET Framework 4.7.2 |      1 |      94.94 ns |     0.402 ns |     0.376 ns |      94.80 ns |      94.52 ns |      95.58 ns |         - |
|         Loop | Job-EJEXYW |             .NET 7.0 |      2 |     449.88 ns |     4.307 ns |     3.818 ns |     448.83 ns |     443.90 ns |     457.20 ns |         - |
| BinarySearch | Job-EJEXYW |             .NET 7.0 |      2 |      55.77 ns |     1.152 ns |     1.183 ns |      55.39 ns |      54.30 ns |      57.89 ns |         - |
|         Loop | Job-DSHCRS | .NET Framework 4.7.2 |      2 |     497.05 ns |     9.147 ns |     8.556 ns |     496.95 ns |     480.13 ns |     512.26 ns |         - |
| BinarySearch | Job-DSHCRS | .NET Framework 4.7.2 |      2 |     163.87 ns |     1.271 ns |     1.127 ns |     163.58 ns |     162.38 ns |     166.17 ns |         - |
|         Loop | Job-EJEXYW |             .NET 7.0 |      3 |   1,011.49 ns |    11.453 ns |    10.153 ns |   1,008.33 ns |     995.00 ns |   1,034.09 ns |         - |
| BinarySearch | Job-EJEXYW |             .NET 7.0 |      3 |      97.23 ns |     0.657 ns |     0.582 ns |      97.06 ns |      96.46 ns |      98.49 ns |         - |
|         Loop | Job-DSHCRS | .NET Framework 4.7.2 |      3 |     996.09 ns |     4.405 ns |     3.904 ns |     995.91 ns |     991.04 ns |   1,004.37 ns |         - |
| BinarySearch | Job-DSHCRS | .NET Framework 4.7.2 |      3 |     285.21 ns |     1.583 ns |     1.403 ns |     285.13 ns |     283.20 ns |     287.96 ns |         - |
|         Loop | Job-EJEXYW |             .NET 7.0 |      4 |   1,405.87 ns |    16.051 ns |    13.403 ns |   1,406.58 ns |   1,382.90 ns |   1,435.57 ns |         - |
| BinarySearch | Job-EJEXYW |             .NET 7.0 |      4 |     183.43 ns |     1.812 ns |     1.606 ns |     183.30 ns |     180.03 ns |     185.58 ns |         - |
|         Loop | Job-DSHCRS | .NET Framework 4.7.2 |      4 |   1,416.94 ns |     7.961 ns |     6.216 ns |   1,417.48 ns |   1,403.39 ns |   1,425.49 ns |         - |
| BinarySearch | Job-DSHCRS | .NET Framework 4.7.2 |      4 |     433.39 ns |     4.250 ns |     3.549 ns |     433.57 ns |     422.44 ns |     436.62 ns |         - |
|         Loop | Job-EJEXYW |             .NET 7.0 |      5 |   2,202.38 ns |    25.393 ns |    22.510 ns |   2,193.64 ns |   2,162.36 ns |   2,251.37 ns |         - |
| BinarySearch | Job-EJEXYW |             .NET 7.0 |      5 |     250.77 ns |     1.980 ns |     1.852 ns |     250.79 ns |     247.58 ns |     254.48 ns |         - |
|         Loop | Job-DSHCRS | .NET Framework 4.7.2 |      5 |   2,357.81 ns |    23.776 ns |    21.076 ns |   2,354.44 ns |   2,333.86 ns |   2,397.57 ns |         - |
| BinarySearch | Job-DSHCRS | .NET Framework 4.7.2 |      5 |     595.56 ns |     4.201 ns |     3.508 ns |     593.86 ns |     591.79 ns |     602.14 ns |         - |
|         Loop | Job-EJEXYW |             .NET 7.0 |     10 |   9,368.65 ns |    49.970 ns |    44.297 ns |   9,355.35 ns |   9,315.63 ns |   9,442.22 ns |         - |
| BinarySearch | Job-EJEXYW |             .NET 7.0 |     10 |     480.49 ns |     3.440 ns |     2.873 ns |     479.57 ns |     476.41 ns |     485.98 ns |         - |
|         Loop | Job-DSHCRS | .NET Framework 4.7.2 |     10 |   9,078.03 ns |    74.415 ns |    69.608 ns |   9,066.05 ns |   8,993.93 ns |   9,217.77 ns |         - |
| BinarySearch | Job-DSHCRS | .NET Framework 4.7.2 |     10 |   1,314.53 ns |    24.266 ns |    54.772 ns |   1,295.18 ns |   1,251.01 ns |   1,462.78 ns |         - |
|         Loop | Job-EJEXYW |             .NET 7.0 |     20 |  39,055.48 ns |   774.517 ns | 1,825.628 ns |  38,457.61 ns |  36,896.37 ns |  43,645.76 ns |         - |
| BinarySearch | Job-EJEXYW |             .NET 7.0 |     20 |   1,127.51 ns |    21.360 ns |    18.935 ns |   1,121.38 ns |   1,106.39 ns |   1,182.33 ns |         - |
|         Loop | Job-DSHCRS | .NET Framework 4.7.2 |     20 |  35,422.53 ns |   220.508 ns |   184.134 ns |  35,422.35 ns |  35,079.98 ns |  35,730.04 ns |         - |
| BinarySearch | Job-DSHCRS | .NET Framework 4.7.2 |     20 |   2,840.21 ns |    16.334 ns |    13.639 ns |   2,841.09 ns |   2,820.72 ns |   2,868.34 ns |         - |
|         Loop | Job-EJEXYW |             .NET 7.0 |     30 |  82,537.95 ns |   468.859 ns |   415.631 ns |  82,460.77 ns |  81,912.99 ns |  83,465.56 ns |         - |
| BinarySearch | Job-EJEXYW |             .NET 7.0 |     30 |   2,014.56 ns |    24.341 ns |    22.768 ns |   2,016.66 ns |   1,970.81 ns |   2,055.29 ns |         - |
|         Loop | Job-DSHCRS | .NET Framework 4.7.2 |     30 |  78,869.85 ns |   797.527 ns |   706.987 ns |  78,931.62 ns |  76,675.37 ns |  79,690.09 ns |         - |
| BinarySearch | Job-DSHCRS | .NET Framework 4.7.2 |     30 |   4,575.58 ns |    28.790 ns |    25.522 ns |   4,567.62 ns |   4,535.05 ns |   4,623.71 ns |         - |
|         Loop | Job-EJEXYW |             .NET 7.0 |     40 | 143,284.01 ns | 1,612.976 ns | 1,346.908 ns | 142,920.01 ns | 141,638.59 ns | 146,687.81 ns |         - |
| BinarySearch | Job-EJEXYW |             .NET 7.0 |     40 |   2,748.96 ns |    51.230 ns |    52.610 ns |   2,738.13 ns |   2,693.60 ns |   2,875.02 ns |         - |
|         Loop | Job-DSHCRS | .NET Framework 4.7.2 |     40 | 137,274.99 ns | 1,108.642 ns |   982.782 ns | 137,014.59 ns | 135,858.52 ns | 139,426.73 ns |         - |
| BinarySearch | Job-DSHCRS | .NET Framework 4.7.2 |     40 |   6,500.32 ns |    63.546 ns |    56.332 ns |   6,502.47 ns |   6,352.88 ns |   6,585.41 ns |         - |
|         Loop | Job-EJEXYW |             .NET 7.0 |    100 | 900,451.51 ns | 3,086.598 ns | 2,887.205 ns | 899,910.60 ns | 896,588.23 ns | 906,437.74 ns |         - |
| BinarySearch | Job-EJEXYW |             .NET 7.0 |    100 |   9,992.34 ns |   170.209 ns |   150.886 ns |   9,979.46 ns |   9,794.22 ns |  10,284.17 ns |         - |
|         Loop | Job-DSHCRS | .NET Framework 4.7.2 |    100 | 935,231.61 ns | 4,127.210 ns | 3,860.595 ns | 935,746.78 ns | 926,698.73 ns | 942,571.48 ns |         - |
| BinarySearch | Job-DSHCRS | .NET Framework 4.7.2 |    100 |  20,033.10 ns |   221.366 ns |   184.851 ns |  19,969.20 ns |  19,801.28 ns |  20,436.52 ns |         - |