### PR TITLE
Fix empty parentheses in nav bar

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Endpoints/ProjectContexts.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Endpoints/ProjectContexts.cs
@@ -40,7 +40,7 @@ internal partial class RazorCustomMessageTarget
                 {
                     Id = project.Key.Id,
                     Kind = VSProjectKind.CSharp,
-                    Label = snapshot.HostProject.DisplayName is { } displayName
+                    Label = snapshot.HostProject.DisplayName is { Length: > 0 } displayName
                         ? $"{projectFileName} ({displayName})"
                         : projectFileName
                 });


### PR DESCRIPTION
Editor fixed the Nav Bar. Yay!
David had a bug. Boo!

Before:
![image](https://github.com/dotnet/razor/assets/754264/e0687090-af13-4967-a956-8c2148fa61fa)

After:
<img width="260" alt="image" src="https://github.com/dotnet/razor/assets/754264/b0a06854-cc2d-42b7-a2c2-94e744ffd8fc">

