### PR TITLE
Upgrade Shell package version

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -92,7 +92,7 @@
   <PropertyGroup Label="Manual">
     <!-- Several packages from the editor are used for testing HTML support, and share the following version. -->
     <Tooling_HtmlEditorPackageVersion>17.5.101-preview-0002</Tooling_HtmlEditorPackageVersion>
-    <MicrosoftVisualStudioShellPackagesVersion>17.7.36673</MicrosoftVisualStudioShellPackagesVersion>
+    <MicrosoftVisualStudioShellPackagesVersion>17.7.37349</MicrosoftVisualStudioShellPackagesVersion>
     <MicrosoftVisualStudioPackagesVersion>17.7.188</MicrosoftVisualStudioPackagesVersion>
     <VisualStudioLanguageServerProtocolVersion>17.8.9-preview</VisualStudioLanguageServerProtocolVersion>
     <!-- dotnet/runtime packages -->


### PR DESCRIPTION
Fixes this error while restoring Razor.sln:
![image](https://github.com/dotnet/razor/assets/16968319/db49708c-b7d5-43a5-9813-b526b1435a06)
