### PR TITLE
Reduce allocations in file path normalization

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/FilePathComparer.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/FilePathComparer.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Runtime.InteropServices;
-using Microsoft.AspNetCore.Razor;
 
 namespace Microsoft.CodeAnalysis.Razor;
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/FilePathComparer.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/FilePathComparer.cs
@@ -15,14 +15,9 @@ internal static class FilePathComparer
     {
         get
         {
-            return _instance ?? InterlockedOperations.Initialize(ref _instance, GetComparer());
-
-            static StringComparer GetComparer()
-            {
-                return RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
-                    ? StringComparer.Ordinal
-                    : StringComparer.OrdinalIgnoreCase;
-            }
+            return _instance ??= RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+                ? StringComparer.Ordinal
+                : StringComparer.OrdinalIgnoreCase;
         }
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/FilePathComparer.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/FilePathComparer.cs
@@ -1,31 +1,28 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System;
 using System.Runtime.InteropServices;
+using Microsoft.AspNetCore.Razor;
 
 namespace Microsoft.CodeAnalysis.Razor;
 
 internal static class FilePathComparer
 {
-    private static StringComparer _instance;
+    private static StringComparer? _instance;
 
     public static StringComparer Instance
     {
         get
         {
-            if (_instance == null && RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                _instance = StringComparer.Ordinal;
-            }
-            else if (_instance == null)
-            {
-                _instance = StringComparer.OrdinalIgnoreCase;
-            }
+            return _instance ?? InterlockedOperations.Initialize(ref _instance, GetComparer());
 
-            return _instance;
+            static StringComparer GetComparer()
+            {
+                return RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+                    ? StringComparer.Ordinal
+                    : StringComparer.OrdinalIgnoreCase;
+            }
         }
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/FilePathComparison.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/FilePathComparison.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Runtime.InteropServices;
-using System.Threading;
 
 namespace Microsoft.CodeAnalysis.Razor;
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/FilePathComparison.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/FilePathComparison.cs
@@ -1,31 +1,33 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace Microsoft.CodeAnalysis.Razor;
 
 internal static class FilePathComparison
 {
-    private static StringComparison? _instance;
+    private static int _instance = -1;
 
     public static StringComparison Instance
     {
         get
         {
-            if (_instance == null && RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            if (_instance == -1)
             {
-                _instance = StringComparison.Ordinal;
-            }
-            else if (_instance == null)
-            {
-                _instance = StringComparison.OrdinalIgnoreCase;
+                Interlocked.CompareExchange(ref _instance, (int)GetComparison(), -1);
             }
 
-            return _instance.Value;
+            return (StringComparison)_instance;
+
+            static StringComparison GetComparison()
+            {
+                return RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+                    ? StringComparison.Ordinal
+                    : StringComparison.OrdinalIgnoreCase;
+            }
         }
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/FilePathComparison.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/FilePathComparison.cs
@@ -9,25 +9,15 @@ namespace Microsoft.CodeAnalysis.Razor;
 
 internal static class FilePathComparison
 {
-    private static int _instance = -1;
+    private static StringComparison? _instance;
 
     public static StringComparison Instance
     {
         get
         {
-            if (_instance == -1)
-            {
-                Interlocked.CompareExchange(ref _instance, (int)GetComparison(), -1);
-            }
-
-            return (StringComparison)_instance;
-
-            static StringComparison GetComparison()
-            {
-                return RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
-                    ? StringComparison.Ordinal
-                    : StringComparison.OrdinalIgnoreCase;
-            }
+            return _instance ??= RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+                ? StringComparison.Ordinal
+                : StringComparison.OrdinalIgnoreCase;
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
@@ -105,7 +105,7 @@ internal class DefaultRazorProjectService : RazorProjectService
             }
 
             var targetFilePath = textDocumentPath;
-            var projectDirectory = FilePathNormalizer.GetDirectory(projectSnapshot.FilePath);
+            var projectDirectory = FilePathNormalizer.GetNormalizedDirectoryName(projectSnapshot.FilePath);
             if (targetFilePath.StartsWith(projectDirectory, FilePathComparison.Instance))
             {
                 // Make relative
@@ -324,7 +324,7 @@ internal class DefaultRazorProjectService : RazorProjectService
 
         var project = (ProjectSnapshot)_projectSnapshotManagerAccessor.Instance.GetLoadedProject(projectKey);
         var currentHostProject = project.HostProject;
-        var projectDirectory = FilePathNormalizer.GetDirectory(project.FilePath);
+        var projectDirectory = FilePathNormalizer.GetNormalizedDirectoryName(project.FilePath);
         var documentMap = documents.ToDictionary(document => EnsureFullPath(document.FilePath, projectDirectory), FilePathComparer.Instance);
         var miscellaneousProject = (ProjectSnapshot)_snapshotResolver.GetMiscellaneousProject();
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/SnapshotResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/SnapshotResolver.cs
@@ -50,7 +50,7 @@ internal class SnapshotResolver : ISnapshotResolver
                 continue;
             }
 
-            var projectDirectory = FilePathNormalizer.GetDirectory(projectSnapshot.FilePath);
+            var projectDirectory = FilePathNormalizer.GetNormalizedDirectoryName(projectSnapshot.FilePath);
             if (normalizedDocumentPath.StartsWith(projectDirectory, FilePathComparison.Instance))
             {
                 yield return projectSnapshot;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/FilePathNormalizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/FilePathNormalizer.cs
@@ -81,7 +81,7 @@ internal static class FilePathNormalizer
         using var _1 = ArrayPool<char>.Shared.GetPooledArray(filePathSpan.Length, out var array);
         var arraySpan = array.AsSpan(0, filePathSpan.Length);
 
-        var (start, length) = NormalizeCore(filePathSpan, array.AsSpan(0, filePathSpan.Length));
+        var (start, length) = NormalizeCore(filePathSpan, arraySpan);
         var normalizedSpan = arraySpan.Slice(start, length);
 
         var lastSlashIndex = normalizedSpan.LastIndexOf('/');

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/FilePathNormalizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/FilePathNormalizer.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using System.Net;
+using System.Buffers;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.Razor;
 
@@ -24,27 +24,94 @@ internal static class FilePathNormalizer
 
     public static string Normalize(string? filePath)
     {
-        if (string.IsNullOrEmpty(filePath))
+        var filePathSpan = filePath.AsSpanOrDefault();
+
+        if (filePathSpan.IsEmpty)
         {
             return "/";
         }
 
-        var decodedPath = filePath.AssumeNotNull().Contains("%") ? WebUtility.UrlDecode(filePath) : filePath;
-        var normalized = decodedPath.Replace('\\', '/');
+        // Rent a buffer for Normalize to write to.
+        using var _ = ArrayPool<char>.Shared.GetPooledArray(filePathSpan.Length, out var array);
+        var destination = array.AsSpan(0, filePathSpan.Length);
+
+        Normalize(filePathSpan, destination, out var offset, out var charsWritten);
+        destination = destination.Slice(offset, charsWritten);
+
+        // If we didn't change anything, just return the original string.
+        if (filePathSpan.Equals(destination, StringComparison.Ordinal))
+        {
+            return filePath.AssumeNotNull();
+        }
+
+        // Otherwise, create a new string from our normalized char buffer.
+        unsafe
+        {
+            fixed (char* buffer = destination)
+            {
+                return new string(buffer, 0, destination.Length);
+            }
+        }
+    }
+
+    /// <summary>
+    ///  Normalizes the given <paramref name="source"/> file path and writes the result in <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The span to normalize.</param>
+    /// <param name="destination">The span to write to.</param>
+    /// <param name="offset">The offset in <paramref name="destination"/> that was written to.</param>
+    /// <param name="charsWritten">The number of characters written to <paramref name="destination"/>.</param>
+    private static void Normalize(ReadOnlySpan<char> source, Span<char> destination, out int offset, out int charsWritten)
+    {
+        offset = 0;
+        charsWritten = 0;
+
+        if (source.IsEmpty)
+        {
+            if (destination.Length < 1)
+            {
+                throw new ArgumentException("Destination length must be at least 1 if the source is empty.", nameof(destination));
+            }
+
+            destination[0] = '/';
+            charsWritten = 1;
+            return;
+        }
+
+        if (destination.Length < source.Length)
+        {
+            throw new ArgumentException("Destination length must be greater or equal to the source length.", nameof(destination));
+        }
+
+        // Note: We check for '%' characters before calling UrlDecoder.Decode to ensure that we *only*
+        // decode when there are '%XX' entities. So, calling Normalize on a path and then calling Normalize
+        // on the result will not call Decode twice.
+        if (source.Contains("%".AsSpan(), StringComparison.Ordinal))
+        {
+            UrlDecoder.Decode(source, destination, out charsWritten);
+        }
+        else
+        {
+            source.CopyTo(destination);
+            charsWritten = source.Length;
+        }
+
+        // Ensure that we only replace slashes in the range that was written to.
+        destination[..charsWritten].Replace('\\', '/');
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
-            normalized[0] == '/' &&
-            !normalized.StartsWith("//", StringComparison.OrdinalIgnoreCase))
+            destination is ['/', ..] &&
+            destination is not ['/', '/', ..])
         {
-            // We've been provided a path that probably looks something like /C:/path/to
-            normalized = normalized[1..];
+            // We've been provided a path that probably looks something like /C:/path/to.
+            // So, we adjust offset and charsWritten to inform callers to ignore the first '/'.
+            offset++;
+            charsWritten--;
         }
         else
         {
             // Already a valid path like C:/path or //path
         }
-
-        return normalized;
     }
 
     public static string GetDirectory(string filePath)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/FilePathNormalizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/FilePathNormalizer.cs
@@ -34,6 +34,11 @@ internal static class FilePathNormalizer
             normalizedSpan = arraySpan.Slice(start, length + 1);
         }
 
+        if (directoryFilePathSpan.Equals(normalizedSpan, StringComparison.Ordinal))
+        {
+            return directoryFilePath.AssumeNotNull();
+        }
+
         return CreateString(normalizedSpan);
     }
 
@@ -62,12 +67,15 @@ internal static class FilePathNormalizer
         return CreateString(normalizedSpan);
     }
 
-    public static string GetDirectory(string filePath)
+    /// <summary>
+    ///  Returns the directory portion of the given file path in normalized form.
+    /// </summary>
+    public static string GetNormalizedDirectoryName(string? filePath)
     {
         var filePathSpan = filePath.AsSpanOrDefault();
         if (filePathSpan.IsEmpty)
         {
-            throw new ArgumentNullException(nameof(filePath));
+            return "/";
         }
 
         using var _1 = ArrayPool<char>.Shared.GetPooledArray(filePathSpan.Length, out var array);
@@ -81,6 +89,11 @@ internal static class FilePathNormalizer
         var directoryNameSpan = lastSlashIndex >= 0
             ? normalizedSpan[..(lastSlashIndex + 1)] // Include trailiing slash
             : normalizedSpan;
+
+        if (filePathSpan.Equals(directoryNameSpan, StringComparison.Ordinal))
+        {
+            return filePath.AssumeNotNull();
+        }
 
         return CreateString(directoryNameSpan);
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/FilePathNormalizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/FilePathNormalizer.cs
@@ -169,8 +169,7 @@ internal static class FilePathNormalizer
         destination[..charsWritten].Replace('\\', '/');
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
-            destination is ['/', ..] &&
-            destination is not ['/', '/', ..])
+            destination is ['/', not '/', ..])
         {
             // We've been provided a path that probably looks something like /C:/path/to.
             // So, we adjust the result to skip the leading '/'.

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/FilePathNormalizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/FilePathNormalizer.cs
@@ -12,20 +12,34 @@ internal static class FilePathNormalizer
 {
     public static string NormalizeDirectory(string? directoryFilePath)
     {
-        var normalized = Normalize(directoryFilePath);
-
-        if (!normalized.EndsWith("/", StringComparison.Ordinal))
+        var directoryFilePathSpan = directoryFilePath.AsSpanOrDefault();
+        if (directoryFilePathSpan.IsEmpty)
         {
-            normalized += '/';
+            return "/";
         }
 
-        return normalized;
+        // Ensure that the array is at least 1 character larger, so that we can add
+        // a trailing space after normalization if necessary.
+        var arrayLength = directoryFilePathSpan.Length + 1;
+        using var _ = ArrayPool<char>.Shared.GetPooledArray(arrayLength, out var array);
+        var arraySpan = array.AsSpan(0, arrayLength);
+
+        var (start, length) = NormalizeCore(directoryFilePathSpan, arraySpan);
+        ReadOnlySpan<char> normalizedSpan = arraySpan.Slice(start, length);
+
+        // Add a trailing slash if the normalized span doesn't end in one.
+        if (normalizedSpan[^1] != '/')
+        {
+            arraySpan[start + length] = '/';
+            normalizedSpan = arraySpan.Slice(start, length + 1);
+        }
+
+        return CreateString(normalizedSpan);
     }
 
     public static string Normalize(string? filePath)
     {
         var filePathSpan = filePath.AsSpanOrDefault();
-
         if (filePathSpan.IsEmpty)
         {
             return "/";
@@ -33,9 +47,10 @@ internal static class FilePathNormalizer
 
         // Rent a buffer for Normalize to write to.
         using var _ = ArrayPool<char>.Shared.GetPooledArray(filePathSpan.Length, out var array);
-        var destinationSpan = array.AsSpan(0, filePathSpan.Length);
+        var arraySpan = array.AsSpan(0, filePathSpan.Length);
 
-        var normalizedSpan = Normalize(filePathSpan, destinationSpan);
+        var (start, length) = NormalizeCore(filePathSpan, arraySpan);
+        var normalizedSpan = arraySpan.Slice(start, length);
 
         // If we didn't change anything, just return the original string.
         if (filePathSpan.Equals(normalizedSpan, StringComparison.Ordinal))
@@ -44,74 +59,7 @@ internal static class FilePathNormalizer
         }
 
         // Otherwise, create a new string from our normalized char buffer.
-        unsafe
-        {
-            fixed (char* buffer = normalizedSpan)
-            {
-                return new string(buffer, 0, normalizedSpan.Length);
-            }
-        }
-    }
-
-    /// <summary>
-    ///  Normalizes the given <paramref name="source"/> file path and writes the result in <paramref name="destination"/>.
-    /// </summary>
-    /// <param name="source">The span to normalize.</param>
-    /// <param name="destination">The span to write to.</param>
-    /// <returns>
-    ///  Returns the normalized span within <paramref name="destination"/>.
-    /// </returns>
-    private static ReadOnlySpan<char> Normalize(ReadOnlySpan<char> source, Span<char> destination)
-    {
-        if (source.IsEmpty)
-        {
-            if (destination.Length < 1)
-            {
-                throw new ArgumentException("Destination length must be at least 1 if the source is empty.", nameof(destination));
-            }
-
-            destination[0] = '/';
-
-            return destination[..1];
-        }
-
-        if (destination.Length < source.Length)
-        {
-            throw new ArgumentException("Destination length must be greater or equal to the source length.", nameof(destination));
-        }
-
-        Span<char> normalizedSpan;
-
-        // Note: We check for '%' characters before calling UrlDecoder.Decode to ensure that we *only*
-        // decode when there are '%XX' entities. So, calling Normalize on a path and then calling Normalize
-        // on the result will not call Decode twice.
-        if (source.Contains("%".AsSpan(), StringComparison.Ordinal))
-        {
-            UrlDecoder.Decode(source, destination, out var charsWritten);
-            normalizedSpan = destination[..charsWritten];
-        }
-        else
-        {
-            source.CopyTo(destination);
-            normalizedSpan = destination[..source.Length];
-        }
-
-        // Replace slashes in our normalized span.
-        normalizedSpan.Replace('\\', '/');
-
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
-            normalizedSpan is ['/', ..] &&
-            normalizedSpan is not ['/', '/', ..])
-        {
-            // We've been provided a path that probably looks something like /C:/path/to.
-            // So, we adjust resulting span to skip the leading '/'.
-            return normalizedSpan[1..];
-        }
-        else
-        {
-            // Already a valid path like C:/path or //path
-            return normalizedSpan;
-        }
+        return CreateString(normalizedSpan);
     }
 
     public static string GetDirectory(string filePath)
@@ -123,7 +71,10 @@ internal static class FilePathNormalizer
         }
 
         using var _1 = ArrayPool<char>.Shared.GetPooledArray(filePathSpan.Length, out var array);
-        var normalizedSpan = Normalize(filePathSpan, array.AsSpan(0, filePathSpan.Length));
+        var arraySpan = array.AsSpan(0, filePathSpan.Length);
+
+        var (start, length) = NormalizeCore(filePathSpan, array.AsSpan(0, filePathSpan.Length));
+        var normalizedSpan = arraySpan.Slice(start, length);
 
         var lastSlashIndex = normalizedSpan.LastIndexOf('/');
 
@@ -131,13 +82,7 @@ internal static class FilePathNormalizer
             ? normalizedSpan[..(lastSlashIndex + 1)] // Include trailiing slash
             : normalizedSpan;
 
-        unsafe
-        {
-            fixed (char* buffer = directoryNameSpan)
-            {
-                return new string(buffer, 0, directoryNameSpan.Length);
-            }
-        }
+        return CreateString(directoryNameSpan);
     }
 
     public static bool FilePathsEquivalent(string? filePath1, string? filePath2)
@@ -155,11 +100,88 @@ internal static class FilePathNormalizer
         }
 
         using var _1 = ArrayPool<char>.Shared.GetPooledArray(filePathSpan1.Length, out var array1);
-        using var _2 = ArrayPool<char>.Shared.GetPooledArray(filePathSpan2.Length, out var array2);
+        var arraySpan1 = array1.AsSpan(0, filePathSpan1.Length);
+        var (start1, length1) = NormalizeCore(filePathSpan1, arraySpan1);
+        ReadOnlySpan<char> normalizedSpan1 = arraySpan1.Slice(start1, length1);
 
-        var normalizedSpan1 = Normalize(filePathSpan1, array1.AsSpan(0, filePathSpan1.Length));
-        var normalizedSpan2 = Normalize(filePathSpan2, array2.AsSpan(0, filePathSpan2.Length));
+        using var _2 = ArrayPool<char>.Shared.GetPooledArray(filePathSpan2.Length, out var array2);
+        var arraySpan2 = array2.AsSpan(0, filePathSpan2.Length);
+        var (start2, length2) = NormalizeCore(filePathSpan2, arraySpan2);
+        ReadOnlySpan<char> normalizedSpan2 = arraySpan2.Slice(start2, length2);
 
         return normalizedSpan1.Equals(normalizedSpan2, FilePathComparison.Instance);
+    }
+
+    /// <summary>
+    ///  Normalizes the given <paramref name="source"/> file path and writes the result in <paramref name="destination"/>.
+    /// </summary>
+    /// <param name="source">The span to normalize.</param>
+    /// <param name="destination">The span to write to.</param>
+    /// <returns>
+    ///  Returns a tuple containing the start index and length of the normalized path within <paramref name="destination"/>.
+    /// </returns>
+    private static (int start, int length) NormalizeCore(ReadOnlySpan<char> source, Span<char> destination)
+    {
+        if (source.IsEmpty)
+        {
+            if (destination.Length < 1)
+            {
+                throw new ArgumentException("Destination length must be at least 1 if the source is empty.", nameof(destination));
+            }
+
+            destination[0] = '/';
+
+            return (start: 0, length: 1);
+        }
+
+        if (destination.Length < source.Length)
+        {
+            throw new ArgumentException("Destination length must be greater or equal to the source length.", nameof(destination));
+        }
+
+        int charsWritten;
+
+        // Note: We check for '%' characters before calling UrlDecoder.Decode to ensure that we *only*
+        // decode when there are '%XX' entities. So, calling Normalize on a path and then calling Normalize
+        // on the result will not call Decode twice.
+        if (source.Contains("%".AsSpan(), StringComparison.Ordinal))
+        {
+            UrlDecoder.Decode(source, destination, out charsWritten);
+        }
+        else
+        {
+            source.CopyTo(destination);
+            charsWritten = source.Length;
+        }
+
+        // Replace slashes in our normalized span.
+        destination[..charsWritten].Replace('\\', '/');
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
+            destination is ['/', ..] &&
+            destination is not ['/', '/', ..])
+        {
+            // We've been provided a path that probably looks something like /C:/path/to.
+            // So, we adjust result to skip the leading '/'.
+            return (start: 1, length: charsWritten - 1);
+        }
+        else
+        {
+            // Already a valid path like C:/path or //path
+            return (start: 0, length: charsWritten);
+        }
+    }
+
+    private static unsafe string CreateString(ReadOnlySpan<char> source)
+    {
+        if (source.IsEmpty)
+        {
+            return string.Empty;
+        }
+
+        fixed (char* ptr = source)
+        {
+            return new string(ptr, 0, source.Length);
+        }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/UrlDecoder.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/UrlDecoder.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+// Note: This was refactored from http://github.com/dotnet/runtime. The original algorithm is located at
+// https://github.com/dotnet/runtime/blob/876f763a8ff8345b61897ff6297876445b2b484f/src/libraries/System.Private.CoreLib/src/System/Net/WebUtility.cs#L483-L543
+
 using System;
 using System.Buffers;
 using System.Diagnostics;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/UrlDecoder.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/UrlDecoder.cs
@@ -1,0 +1,201 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Microsoft.AspNetCore.Razor.Utilities;
+
+internal static class UrlDecoder
+{
+    /// <summary>
+    ///  Map from an ASCII char to its hex value, e.g. arr['b'] == 11. 0xFF means it's not a hex digit.
+    /// </summary>
+    private static ReadOnlySpan<byte> CharToHexLookup => new byte[]
+    {
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 15
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 31
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 47
+        0x0,  0x1,  0x2,  0x3,  0x4,  0x5,  0x6,  0x7,  0x8,  0x9,  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 63
+        0xFF, 0xA,  0xB,  0xC,  0xD,  0xE,  0xF,  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 79
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 95
+        0xFF, 0xa,  0xb,  0xc,  0xd,  0xe,  0xf,  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 111
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 127
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 143
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 159
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 175
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 191
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 207
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 223
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // 239
+        0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF  // 255
+    };
+
+    private static int CharToHexValue(int ch)
+        => ch >= CharToHexLookup.Length ? 0xff : CharToHexLookup[ch];
+
+    private ref struct ByteBuffer(int size)
+    {
+        private readonly int _size = size;
+
+        private byte[]? _bytes;
+        private int _bytesWritten;
+
+        public readonly bool HasBytes => _bytesWritten > 0;
+
+        public readonly void Dispose()
+        {
+            if (_bytes is byte[] bytes)
+            {
+                ArrayPool<byte>.Shared.Return(bytes);
+            }
+        }
+
+        public void Add(byte b)
+        {
+            _bytes ??= ArrayPool<byte>.Shared.Rent(_size);
+            _bytes[_bytesWritten++] = b;
+        }
+
+        public unsafe int Flush(Span<char> chars)
+        {
+            if (_bytesWritten == 0)
+            {
+                return 0;
+            }
+
+            fixed (byte* bytesPtr = _bytes)
+            fixed (char* charsPtr = chars)
+            {
+                var charsWritten = Encoding.UTF8.GetChars(bytesPtr, _bytesWritten, charsPtr, chars.Length);
+                _bytesWritten = 0;
+
+                return charsWritten;
+            }
+        }
+    }
+
+    public static void Decode(ReadOnlySpan<char> source, Span<char> destination, out int charsWritten)
+    {
+        charsWritten = 0;
+
+        if (source.IsEmpty)
+        {
+            return;
+        }
+
+        if (destination.Length < source.Length)
+        {
+            throw new ArgumentException("Destination length must be greater or equal to the source length.", nameof(destination));
+        }
+
+        var count = source.Length;
+        ref var src = ref MemoryMarshal.GetReference(source);
+
+        using var buffer = new ByteBuffer(count);
+
+        // Go through the string's chars collapsing %XX and appending each char
+        // as char, with exception %XX constructs that are appended as bytes
+        var needsDecodingUnsafe = false;
+        var needsDecodingSpaces = false;
+
+        // Walk through chars, collapsing %XX
+        for (var i = 0; i < count; i++)
+        {
+            var ch = Unsafe.Add(ref src, i);
+
+            if (ch == '+')
+            {
+                needsDecodingSpaces = true;
+                ch = ' ';
+            }
+            else if (ch == '%' && i < count - 2)
+            {
+                // Get the hex values of the next two characters. These are 'nibble' values (i.e. half-bytes).
+                // So, we need to contruct the real byte out of them.
+                var h1 = CharToHexValue(Unsafe.Add(ref src, i + 1));
+                var h2 = CharToHexValue(Unsafe.Add(ref src, i + 2));
+
+                if ((h1 | h2) != 0xff)
+                {
+                    // Valid 2 hex character
+                    var b = (byte)((h1 << 4) | h2);
+                    i += 2;
+
+                    // Add to our byte buffer.
+                    buffer.Add(b);
+                    needsDecodingUnsafe = true;
+                    continue;
+                }
+            }
+
+            if ((ch & 0xff80) == 0)
+            {
+                // 7-bit chars have to be handled as bytes.
+                buffer.Add((byte)ch);
+            }
+            else
+            {
+                if (buffer.HasBytes)
+                {
+                    charsWritten += buffer.Flush(destination[charsWritten..]);
+                }
+
+                destination[charsWritten++] = ch;
+            }
+        }
+
+        if (buffer.HasBytes)
+        {
+            charsWritten += buffer.Flush(destination[charsWritten..]);
+        }
+
+        if (!needsDecodingUnsafe)
+        {
+            // If we didn't do any significant decoding we should have written the entire source
+            // to the destination buffer.
+            Debug.Assert(charsWritten == source.Length);
+
+            if (needsDecodingSpaces)
+            {
+                // It's possible that we *do* need to decode +'s as spaces.
+                for (var i = 0; i < charsWritten; i++)
+                {
+                    var ch = destination[i];
+
+                    if (ch == '+')
+                    {
+                        destination[i] = ' ';
+                    }
+                }
+            }
+        }
+    }
+
+    public static ReadOnlyMemory<char> Decode(ReadOnlyMemory<char> value)
+    {
+        if (value.IsEmpty)
+        {
+            return value;
+        }
+
+        var source = value.Span;
+        using var _ = ArrayPool<char>.Shared.GetPooledArray(source.Length, out var destination);
+
+        Decode(source, destination, out var charsWritten);
+
+        // Go ahead and create a new string so that ReadOnlyMemory<char>.ToString() is non-allocating.
+        return new string(destination, 0, charsWritten).AsMemory();
+    }
+
+    public static string Decode(string value)
+    {
+        return value.Length > 0
+            ? Decode(value.AsMemory()).ToString()
+            : value;
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/UrlDecoder.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/UrlDecoder.cs
@@ -116,7 +116,7 @@ internal static class UrlDecoder
             else if (ch == '%' && i < count - 2)
             {
                 // Get the hex values of the next two characters. These are 'nibble' values (i.e. half-bytes).
-                // So, we need to contruct the real byte out of them.
+                // So, we need to construct the real byte out of them.
                 var h1 = CharToHexValue(Unsafe.Add(ref src, i + 1));
                 var h2 = CharToHexValue(Unsafe.Add(ref src, i + 2));
 
@@ -162,16 +162,9 @@ internal static class UrlDecoder
 
             if (needsDecodingSpaces)
             {
-                // It's possible that we *do* need to decode +'s as spaces.
-                for (var i = 0; i < charsWritten; i++)
-                {
-                    var ch = destination[i];
-
-                    if (ch == '+')
-                    {
-                        destination[i] = ' ';
-                    }
-                }
+                // It's possible that we still need to decode +'s as spaces. However, be sure to
+                // only replace chars in the range that was written.
+                destination[..charsWritten].Replace('+', ' ');
             }
         }
     }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectKey.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectKey.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using System.IO;
 using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Utilities;
 
@@ -14,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 /// identifier for a project.
 /// </summary>
 [DebuggerDisplay("id: {Id}")]
-internal readonly record struct ProjectKey : IEquatable<ProjectKey>
+internal readonly record struct ProjectKey
 {
     // ProjectKey represents the path of the intermediate output path, which is where the project.razor.bin file will
     // end up. All creation logic is here in one place to ensure this is consistent.
@@ -22,8 +21,8 @@ internal readonly record struct ProjectKey : IEquatable<ProjectKey>
     public static ProjectKey From(IProjectSnapshot project) => new(project.IntermediateOutputPath);
     public static ProjectKey? From(Project project)
     {
-        var intermediateOutputPath = Path.GetDirectoryName(project.CompilationOutputInfo.AssemblyPath);
-        return intermediateOutputPath is null ? null : new(intermediateOutputPath);
+        var intermediateOutputPath = FilePathNormalizer.GetNormalizedDirectoryName(project.CompilationOutputInfo.AssemblyPath);
+        return new(intermediateOutputPath);
     }
 
     internal static ProjectKey FromString(string projectKeyId) => new(projectKeyId);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestDocumentSnapshot.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestDocumentSnapshot.cs
@@ -50,7 +50,7 @@ internal class TestDocumentSnapshot : DocumentSnapshot
         version ??= VersionStamp.Default;
 
         var targetPath = FilePathNormalizer.Normalize(filePath);
-        var projectDirectory = FilePathNormalizer.GetDirectory(projectSnapshot.FilePath);
+        var projectDirectory = FilePathNormalizer.GetNormalizedDirectoryName(projectSnapshot.FilePath);
         if (targetPath.StartsWith(projectDirectory))
         {
             targetPath = targetPath[projectDirectory.Length..];

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SnapshotResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SnapshotResolverTest.cs
@@ -246,7 +246,7 @@ public class SnapshotResolverTest : LanguageServerTestBase
         }
         else
         {
-            var projectDirectory = FilePathNormalizer.GetDirectory(filePath);
+            var projectDirectory = FilePathNormalizer.GetNormalizedDirectoryName(filePath);
             var projectSnapshot = TestProjectSnapshot.Create(Path.Join(projectDirectory, "proj.csproj"));
 
             snapshotManager.ProjectAdded(projectSnapshot.HostProject);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/FilePathNormalizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/FilePathNormalizerTest.cs
@@ -97,7 +97,7 @@ public class FilePathNormalizerTest(ITestOutputHelper testOutput) : TestBase(tes
         var filePath = "C:/path/to/document.cshtml";
 
         // Act
-        var normalized = FilePathNormalizer.GetDirectory(filePath);
+        var normalized = FilePathNormalizer.GetNormalizedDirectoryName(filePath);
 
         // Assert
         Assert.Equal("C:/path/to/", normalized);
@@ -110,7 +110,7 @@ public class FilePathNormalizerTest(ITestOutputHelper testOutput) : TestBase(tes
         var filePath = "C:/document.cshtml";
 
         // Act
-        var normalized = FilePathNormalizer.GetDirectory(filePath);
+        var normalized = FilePathNormalizer.GetNormalizedDirectoryName(filePath);
 
         // Assert
         Assert.Equal("C:/", normalized);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/Utilities/UrlDecoderTests.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/Utilities/UrlDecoderTests.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.AspNetCore.Razor.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.Razor.ProjectEngineHost.Test.Utilities;
+
+public class UrlDecoderTests(ITestOutputHelper testOutput) : TestBase(testOutput)
+{
+    public static IEnumerable<object[]> UrlDecodeData =>
+        new[]
+        {
+            new object[] { "http://127.0.0.1:8080/appDir/page.aspx?foo=bar", "http://127.0.0.1:8080/appDir/page.aspx?foo=b%61r" },
+            new object[] { "http://127.0.0.1:8080/appDir/page.aspx?foo=b%ar", "http://127.0.0.1:8080/appDir/page.aspx?foo=b%%61r" },
+            new object[] { "http://127.0.0.1:8080/app%Dir/page.aspx?foo=b%ar", "http://127.0.0.1:8080/app%Dir/page.aspx?foo=b%%61r" },
+            new object[] { "http://127.0.0.1:8080/app%%Dir/page.aspx?foo=b%%r", "http://127.0.0.1:8080/app%%Dir/page.aspx?foo=b%%r" },
+            new object[] { "http://127.0.0.1:8080/appDir/page.aspx?foo=ba%r", "http://127.0.0.1:8080/appDir/page.aspx?foo=b%61%r" },
+            new object[] { "http://127.0.0.1:8080/appDir/page.aspx?foo=bar baz", "http://127.0.0.1:8080/appDir/page.aspx?foo=bar+baz" },
+            new object[] { "http://example.net/\U00010000", "http://example.net/\U00010000" },
+            new object[] { "http://example.net/\uD800", "http://example.net/\uD800" },
+            new object[] { "http://example.net/\uD800a", "http://example.net/\uD800a" },
+            // The "Baz" portion of "http://example.net/Baz" has been double-encoded - one iteration of UrlDecode() should produce a once-encoded string.
+            new object[] { "http://example.net/%42%61%7A", "http://example.net/%2542%2561%257A"},
+            // The second iteration should return the original string
+            new object[] { "http://example.net/Baz", "http://example.net/%42%61%7A"}
+        };
+
+    [Theory]
+    [MemberData(nameof(UrlDecodeData))]
+    public void Decode(string decoded, string encoded)
+    {
+        Assert.Equal(UrlDecoder.Decode(encoded), decoded);
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/Utilities/UrlDecoderTests.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/Utilities/UrlDecoderTests.cs
@@ -26,9 +26,11 @@ public class UrlDecoderTests(ITestOutputHelper testOutput) : TestBase(testOutput
             new object[] { "http://example.net/\uD800", "http://example.net/\uD800" },
             new object[] { "http://example.net/\uD800a", "http://example.net/\uD800a" },
             // The "Baz" portion of "http://example.net/Baz" has been double-encoded - one iteration of UrlDecode() should produce a once-encoded string.
-            new object[] { "http://example.net/%42%61%7A", "http://example.net/%2542%2561%257A"},
+            new object[] { "http://example.net/%6A%6B%6C", "http://example.net/%256A%256B%256C"},
             // The second iteration should return the original string
-            new object[] { "http://example.net/Baz", "http://example.net/%42%61%7A"}
+            new object[] { "http://example.net/jkl", "http://example.net/%6A%6B%6C"},
+            // This example uses lowercase hex characters
+            new object[] { "http://example.net/jkl", "http://example.net/%6a%6b%6c"}
         };
 
     [Theory]

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/BufferExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/BufferExtensions.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Razor.PooledObjects;
+
+namespace System.Buffers;
+
+internal static class BufferExtensions
+{
+    public static PooledArray<T> GetPooledArray<T>(this ArrayPool<T> pool, int minimumLength, out T[] array)
+    {
+        var result = new PooledArray<T>(pool, minimumLength);
+        array = result.Array;
+        return result;
+    }
+}

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/MemoryExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/MemoryExtensions.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
+
+#if !NET8_0_OR_GREATER
+using System.Runtime.InteropServices;
+#endif
+
+namespace System;
+
+internal static class MemoryExtensions
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static unsafe void Replace(this ReadOnlySpan<char> source, Span<char> destination, char oldValue, char newValue)
+    {
+#if NET8_0_OR_GREATER
+        source.Replace(destination, oldValue, newValue);
+#else
+        var length = source.Length;
+        if (length == 0)
+        {
+            return;
+        }
+
+        if (length > destination.Length)
+        {
+            throw new ArgumentException(SR.Destination_is_too_short, nameof(destination));
+        }
+
+        ref var src = ref MemoryMarshal.GetReference(source);
+        ref var dst = ref MemoryMarshal.GetReference(destination);
+
+        for (var i = 0; i < length; i++)
+        {
+            var original = Unsafe.Add(ref src, i);
+            Unsafe.Add(ref dst, i) = original == oldValue ? newValue : original;
+        }
+#endif
+    }
+}

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.csproj
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.csproj
@@ -8,6 +8,7 @@
     <ExcludeFromSourceBuild>false</ExcludeFromSourceBuild>
     <RootNamespace>Microsoft.AspNetCore.Razor</RootNamespace>
     <IsPackable Condition="'$(OS)' != 'Windows_NT'">false</IsPackable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledObjects/PooledArrayBuilderExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledObjects/PooledArrayBuilderExtensions.cs
@@ -33,5 +33,7 @@ internal static class PooledArrayBuilderExtensions
     /// <param name="builder">A read-only reference to a pooled array builder which is part of a <c>using</c> statement.</param>
     /// <returns>A mutable reference to the pooled array builder.</returns>
     public static ref PooledArrayBuilder<T> AsRef<T>(this in PooledArrayBuilder<T> builder)
+#pragma warning disable RS0042
         => ref Unsafe.AsRef(in builder);
+#pragma warning restore RS0042
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledObjects/PooledArray`1.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledObjects/PooledArray`1.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Buffers;
+
+namespace Microsoft.AspNetCore.Razor.PooledObjects;
+
+internal struct PooledArray<T> : IDisposable
+{
+    private readonly ArrayPool<T> _pool;
+    private T[]? _array;
+
+    // Because of how this API is intended to be used, we don't want the consumption code to have
+    // to deal with Array being a nullable reference type. Instead, the guarantee is that this is
+    // non-null until this is disposed.
+    public readonly T[] Array => _array!;
+
+    public PooledArray(ArrayPool<T> pool, int minimumLength)
+        : this()
+    {
+        _pool = pool;
+        _array = pool.Rent(minimumLength);
+    }
+
+    public void Dispose()
+    {
+        if (_array is T[] array)
+        {
+            _pool.Return(array);
+            _array = null;
+        }
+    }
+}

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledObjects/PooledObject`1.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledObjects/PooledObject`1.cs
@@ -15,9 +15,9 @@ internal struct PooledObject<T> : IDisposable
     private T? _object;
 
     // Because of how this API is intended to be used, we don't want the consumption code to have
-    // to deal with Object being a nullable reference type. Intead, the guarantee is that this is
+    // to deal with Object being a nullable reference type. Instead, the guarantee is that this is
     // non-null until this is disposed.
-    public T Object => _object!;
+    public readonly T Object => _object!;
 
     public PooledObject(ObjectPool<T> pool)
         : this()

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/SR.resx
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/SR.resx
@@ -123,6 +123,9 @@
   <data name="Cannot_allocate_a_buffer_of_size_0" xml:space="preserve">
     <value>Cannot allocate a buffer of size {0}.</value>
   </data>
+  <data name="Destination_is_too_short" xml:space="preserve">
+    <value>Destination is too short.</value>
+  </data>
   <data name="Non_negative_number_required" xml:space="preserve">
     <value>Non-negative number required.</value>
   </data>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.cs.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.cs.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Nelze přidělit vyrovnávací paměť o velikosti {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Destination_is_too_short">
+        <source>Destination is too short.</source>
+        <target state="new">Destination is too short.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Non_negative_number_required">
         <source>Non-negative number required.</source>
         <target state="translated">Vyžaduje se nezáporné číslo.</target>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.de.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.de.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Ein Puffer der Größe {0} kann nicht zugeordnet werden.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Destination_is_too_short">
+        <source>Destination is too short.</source>
+        <target state="new">Destination is too short.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Non_negative_number_required">
         <source>Non-negative number required.</source>
         <target state="translated">Nicht negative Zahl erforderlich.</target>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.es.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.es.xlf
@@ -12,6 +12,11 @@
         <target state="translated">No se puede asignar un búfer de tamaño {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Destination_is_too_short">
+        <source>Destination is too short.</source>
+        <target state="new">Destination is too short.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Non_negative_number_required">
         <source>Non-negative number required.</source>
         <target state="translated">Se requiere un número no negativo.</target>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.fr.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.fr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Impossible d’allouer une mémoire tampon de taille {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Destination_is_too_short">
+        <source>Destination is too short.</source>
+        <target state="new">Destination is too short.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Non_negative_number_required">
         <source>Non-negative number required.</source>
         <target state="translated">Nombre non négatif obligatoire.</target>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.it.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.it.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Impossibile allocare un buffer di dimensioni {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Destination_is_too_short">
+        <source>Destination is too short.</source>
+        <target state="new">Destination is too short.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Non_negative_number_required">
         <source>Non-negative number required.</source>
         <target state="translated">Numero non negativo obbligatorio.</target>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.ja.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.ja.xlf
@@ -12,6 +12,11 @@
         <target state="translated">サイズ {0} のバッファーを割り当てることができません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Destination_is_too_short">
+        <source>Destination is too short.</source>
+        <target state="new">Destination is too short.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Non_negative_number_required">
         <source>Non-negative number required.</source>
         <target state="translated">負でない数値が必要です。</target>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.ko.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.ko.xlf
@@ -12,6 +12,11 @@
         <target state="translated">{0} 크기의 버퍼를 할당할 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Destination_is_too_short">
+        <source>Destination is too short.</source>
+        <target state="new">Destination is too short.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Non_negative_number_required">
         <source>Non-negative number required.</source>
         <target state="translated">음수가 아닌 수가 필요합니다.</target>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.pl.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.pl.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Nie można przydzielić buforu o rozmiarze {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Destination_is_too_short">
+        <source>Destination is too short.</source>
+        <target state="new">Destination is too short.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Non_negative_number_required">
         <source>Non-negative number required.</source>
         <target state="translated">Wymagana jest liczba nieujemna.</target>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.pt-BR.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.pt-BR.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Não é possível alocar um buffer de tamanho {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Destination_is_too_short">
+        <source>Destination is too short.</source>
+        <target state="new">Destination is too short.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Non_negative_number_required">
         <source>Non-negative number required.</source>
         <target state="translated">É necessário um número não negativo.</target>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.ru.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.ru.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Невозможно выделить буфер размером {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Destination_is_too_short">
+        <source>Destination is too short.</source>
+        <target state="new">Destination is too short.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Non_negative_number_required">
         <source>Non-negative number required.</source>
         <target state="translated">Требуется неотрицательное число.</target>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.tr.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.tr.xlf
@@ -12,6 +12,11 @@
         <target state="translated">Boyutu {0} olan arabellek ayrılamıyor</target>
         <note />
       </trans-unit>
+      <trans-unit id="Destination_is_too_short">
+        <source>Destination is too short.</source>
+        <target state="new">Destination is too short.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Non_negative_number_required">
         <source>Non-negative number required.</source>
         <target state="translated">Negatif olmayan sayı gerekiyor.</target>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.zh-Hans.xlf
@@ -12,6 +12,11 @@
         <target state="translated">无法分配大小为 {0} 的缓冲区。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Destination_is_too_short">
+        <source>Destination is too short.</source>
+        <target state="new">Destination is too short.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Non_negative_number_required">
         <source>Non-negative number required.</source>
         <target state="translated">需要提供非负数。</target>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.zh-Hant.xlf
@@ -12,6 +12,11 @@
         <target state="translated">無法配置大小為 {0} 的緩衝區。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Destination_is_too_short">
+        <source>Destination is too short.</source>
+        <target state="new">Destination is too short.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Non_negative_number_required">
         <source>Non-negative number required.</source>
         <target state="translated">需要非負數。</target>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/SpanExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/SpanExtensions.cs
@@ -1,21 +1,19 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System.Runtime.CompilerServices;
-
 #if !NET8_0_OR_GREATER
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 #endif
 
 namespace System;
 
-internal static class MemoryExtensions
+internal static class SpanExtensions
 {
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static unsafe void Replace(this ReadOnlySpan<char> source, Span<char> destination, char oldValue, char newValue)
     {
 #if NET8_0_OR_GREATER
-        source.Replace(destination, oldValue, newValue);
+        source.Replace<char>(destination, oldValue, newValue);
 #else
         var length = source.Length;
         if (length == 0)
@@ -35,6 +33,31 @@ internal static class MemoryExtensions
         {
             var original = Unsafe.Add(ref src, i);
             Unsafe.Add(ref dst, i) = original == oldValue ? newValue : original;
+        }
+#endif
+    }
+
+    public static unsafe void Replace(this Span<char> span, char oldValue, char newValue)
+    {
+#if NET8_0_OR_GREATER
+        span.Replace<char>(oldValue, newValue);
+#else
+        var length = span.Length;
+        if (length == 0)
+        {
+            return;
+        }
+
+        ref var src = ref MemoryMarshal.GetReference(span);
+
+        for (var i = 0; i < length; i++)
+        {
+            ref var slot = ref Unsafe.Add(ref src, i);
+
+            if (slot == oldValue)
+            {
+                slot = newValue;
+            }
         }
 #endif
     }


### PR DESCRIPTION
This change is a rewrite of tooling's `FilePathNormalizer` helper methods to avoid extra allocations associated with string manipulation. These started showing up in perf tests recently because the new `ProjectKey` type uses them to construct itself. These changes should reduce the allocations in those perf tests.