### PR TITLE
Skip reporting fault for OperationCanceledException

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Telemetry/TelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Telemetry/TelemetryReporter.cs
@@ -55,7 +55,6 @@ internal abstract class TelemetryReporter : ITelemetryReporter
         {
             if (exception is OperationCanceledException { InnerException: { } oceInnerException })
             {
-                ReportFault(oceInnerException, message, @params);
                 return;
             }
 


### PR DESCRIPTION
Skips fault reporting when the exception is `OperationCanceledException`.

Resolves: [WorkItem#1774918](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1774918/)