### PR TITLE
Fix formatting of minimized tag helper attributes

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPassBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPassBase.cs
@@ -436,7 +436,9 @@ internal abstract class CSharpFormattingPassBase : FormattingPassBase
             return owner is MarkupTextLiteralSyntax
             {
                 Parent: MarkupTagHelperAttributeSyntax { TagHelperAttributeInfo: { Bound: true } } or
-                        MarkupTagHelperDirectiveAttributeSyntax { TagHelperAttributeInfo: { Bound: true } }
+                        MarkupTagHelperDirectiveAttributeSyntax { TagHelperAttributeInfo: { Bound: true } } or
+                        MarkupMinimizedTagHelperAttributeSyntax { TagHelperAttributeInfo: { Bound: true } } or
+                        MarkupMinimizedTagHelperDirectiveAttributeSyntax { TagHelperAttributeInfo: { Bound: true } }
             } && !isLineRequest;
         }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting/HtmlFormattingTest.cs
@@ -1664,6 +1664,50 @@ public class HtmlFormattingTest : FormattingTestBase
     }
 
     [Fact]
+    [WorkItem("https://github.com/dotnet/razor/issues/9337")]
+    public async Task FormatMinimizedTagHelperAttributes()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                    @using Microsoft.AspNetCore.Components.Forms;
+
+                    @code {
+                        private bool _id {get;set;}
+                    }
+
+                    <div>
+                        @if (true)
+                        {
+                            <div>
+                                <InputCheckbox CssClass="goo"
+                                   Value
+                                   accesskey="F" />
+                            </div>
+                        }
+                    </div>
+                    """,
+            expected: """
+                    @using Microsoft.AspNetCore.Components.Forms;
+
+                    @code {
+                        private bool _id { get; set; }
+                    }
+
+                    <div>
+                        @if (true)
+                        {
+                            <div>
+                                <InputCheckbox CssClass="goo"
+                                               Value
+                                               accesskey="F" />
+                            </div>
+                        }
+                    </div>
+                    """,
+            fileKind: FileKinds.Component);
+    }
+
+    [Fact]
     [WorkItem("https://github.com/dotnet/razor/issues/6211")]
     public async Task FormatCascadingValueWithCascadingTypeParameter()
     {


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/9337

If only there was some kind of base class that represented everything common about an attribute 🤦‍♂️