### PR TITLE
Mark list as incomplete if delegated server couldn't respond

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionListProvider.cs
@@ -85,7 +85,11 @@ internal class DelegatedCompletionListProvider
 
         if (delegatedResponse is null)
         {
-            return null;
+            // If we don't get a response from the delegated server, we have to make sure to return an incomplete completion
+            // list. When a user is typing quickly, the delegated request from the first keystroke will fail to synchronize,
+            // so if we return a "complete" list then the query won't re-query us for completion once the typing stops/slows
+            // so we'd only ever return Razor completion items.
+            return new VSInternalCompletionList() { IsIncomplete = true, Items = [] };
         }
 
         var rewrittenResponse = delegatedResponse;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/TestDelegatedCompletionListProvider.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/TestDelegatedCompletionListProvider.cs
@@ -67,6 +67,15 @@ internal class TestDelegatedCompletionListProvider : DelegatedCompletionListProv
         return provider;
     }
 
+    public static TestDelegatedCompletionListProvider CreateWithNullResponse(
+        ILoggerFactory loggerFactory,
+        params DelegatedCompletionResponseRewriter[] responseRewriters)
+    {
+        var requestResponseFactory = new StaticCompletionRequestResponseFactory(null);
+        var provider = new TestDelegatedCompletionListProvider(responseRewriters, requestResponseFactory, loggerFactory);
+        return provider;
+    }
+
     public DelegatedCompletionParams DelegatedParams => _completionFactory.DelegatedParams;
 
     private class StaticCompletionRequestResponseFactory : CompletionRequestResponseFactory


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/9211

When typing quickly, completion requests get dropped because we try to wait for the correct version of the generated C#, which is correct, but because we return Razor completion items, and because the client doesn't re-request completion during typing, we end up with "broken completion", by just never showing anything from Html or C#.

Before:
![RazorCompletionBug](https://github.com/dotnet/razor/assets/754264/1256e569-27b3-48f6-a2e7-c807f7c89c0d)

After:
![SlightlyBetterCompletion](https://github.com/dotnet/razor/assets/754264/955dfdb5-2d26-4253-8357-a388af02337b)
