### PR TITLE
Allow render mode attribute to be null

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentDesignTimeNodeWriter.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentDesignTimeNodeWriter.cs
@@ -1272,7 +1272,6 @@ internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
         // __o = (global::Microsoft.AspNetCore.Components.IComponentRenderMode)(expression);
         WriteCSharpCode(context, new CSharpCodeIntermediateNode
         {
-            Source = node.Source,
             Children =
             {
                 new IntermediateToken
@@ -1280,7 +1279,11 @@ internal class ComponentDesignTimeNodeWriter : ComponentNodeWriter
                     Kind = TokenKind.CSharp,
                     Content = $"{DesignTimeVariable} = (global::{ComponentsApi.IComponentRenderMode.FullTypeName})(" 
                 },
-                node.Children[0],
+                new CSharpCodeIntermediateNode
+                {
+                    Source = node.Source,
+                    Children = { node.Children[0] }
+                },
                 new IntermediateToken
                 {
                     Kind = TokenKind.CSharp,

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentRuntimeNodeWriter.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentRuntimeNodeWriter.cs
@@ -1010,7 +1010,6 @@ internal class ComponentRuntimeNodeWriter : ComponentNodeWriter
         // global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode0 = expression;
         WriteCSharpCode(context, new CSharpCodeIntermediateNode
         {
-            Source = node.Source,
             Children =
             {
                 new IntermediateToken
@@ -1018,7 +1017,11 @@ internal class ComponentRuntimeNodeWriter : ComponentNodeWriter
                     Kind = TokenKind.CSharp,
                     Content = $"global::{ComponentsApi.IComponentRenderMode.FullTypeName} {_scopeStack.RenderModeVarName} = "
                 },
-                node.Children[0],
+                new CSharpCodeIntermediateNode
+                {
+                    Source = node.Source,
+                    Children = { node.Children[0] }
+                },
                 new IntermediateToken
                 {
                     Kind = TokenKind.CSharp,

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentCodeGenerationTestBase.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentCodeGenerationTestBase.cs
@@ -10300,6 +10300,60 @@ Time: @DateTime.Now
         CompileToAssembly(generated, throwOnFailure: true);
     }
 
+    [Fact]
+    public void RenderMode_With_Null_Nullable_Disabled()
+    {
+        var generated = CompileToCSharp($$"""
+                <{{ComponentName}} @rendermode="null" />
+                """, throwOnFailure: true, nullableEnable: false);
+
+        // Assert
+        AssertDocumentNodeMatchesBaseline(generated.CodeDocument);
+        AssertCSharpDocumentMatchesBaseline(generated.CodeDocument);
+        CompileToAssembly(generated, throwOnFailure: true);
+    }
+
+    [Fact]
+    public void RenderMode_With_Null_Nullable_Enabled()
+    {
+        var generated = CompileToCSharp($$"""
+                <{{ComponentName}} @rendermode="null" />
+                """, throwOnFailure: true, nullableEnable: true);
+
+        // Assert
+        AssertDocumentNodeMatchesBaseline(generated.CodeDocument);
+        AssertCSharpDocumentMatchesBaseline(generated.CodeDocument);
+        CompileToAssembly(generated, throwOnFailure: true);
+    }
+
+    [Fact]
+    public void RenderMode_With_Nullable_Receiver()
+    {
+        var generated = CompileToCSharp($$"""
+                @code
+                {
+                    public class RenderModeContainer
+                    {
+                        public Microsoft.AspNetCore.Components.IComponentRenderMode RenderMode => Microsoft.AspNetCore.Components.Web.RenderMode.Server;
+                    }
+
+                    RenderModeContainer? Container => null;
+                }
+                <{{ComponentName}} @rendermode="@(Container.RenderMode)" />
+                """, throwOnFailure: true, nullableEnable: true);
+
+        // Assert
+        AssertDocumentNodeMatchesBaseline(generated.CodeDocument);
+        AssertCSharpDocumentMatchesBaseline(generated.CodeDocument);
+        var result = CompileToAssembly(generated, throwOnFailure: false);
+
+        result.Diagnostics.Verify(
+            // x:\dir\subdir\Test\TestComponent.cshtml(10,29): warning CS8602: Dereference of a possibly null reference.
+            //                             Container.RenderMode
+            Diagnostic(ErrorCode.WRN_NullReferenceReceiver, "Container").WithLocation(10, 29)
+            );
+    }
+
     #endregion
 
     #region FormName

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Duplicate_RenderMode/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Duplicate_RenderMode/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 ﻿Source Location: (28:0,28 [53] x:\dir\subdir\Test\TestComponent.cshtml)
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
-Generated Location: (998:24,97 [53] )
+Generated Location: (1012:25,28 [53] )
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_Attribute_With_Existing_Attributes/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_Attribute_With_Existing_Attributes/TestComponent.codegen.cs
@@ -21,13 +21,15 @@ namespace Test
         protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
             __o = "";
+            __o = (global::Microsoft.AspNetCore.Components.IComponentRenderMode)(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                                     __o = (global::Microsoft.AspNetCore.Components.IComponentRenderMode)(Microsoft.AspNetCore.Components.Web.RenderMode.Server);
+                                     Microsoft.AspNetCore.Components.Web.RenderMode.Server
 
 #line default
 #line hidden
 #nullable disable
+            );
             __o = "";
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_Attribute_With_Existing_Attributes/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_Attribute_With_Existing_Attributes/TestComponent.mappings.txt
@@ -1,16 +1,16 @@
 ﻿Source Location: (37:0,37 [53] x:\dir\subdir\Test\TestComponent.cshtml)
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
-Generated Location: (1030:25,106 [53] )
+Generated Location: (1044:26,37 [53] )
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
 
 Source Location: (15:0,15 [2] x:\dir\subdir\Test\TestComponent.cshtml)
 |P2|
-Generated Location: (1504:38,15 [2] )
+Generated Location: (1532:40,15 [2] )
 |P2|
 
 Source Location: (92:0,92 [2] x:\dir\subdir\Test\TestComponent.cshtml)
 |P1|
-Generated Location: (1797:47,92 [2] )
+Generated Location: (1825:49,92 [2] )
 |P1|
 
 Source Location: (115:3,1 [94] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -19,7 +19,7 @@ Source Location: (115:3,1 [94] x:\dir\subdir\Test\TestComponent.cshtml)
 
     [Parameter]public string P2 {get; set;}
 |
-Generated Location: (2203:65,1 [94] )
+Generated Location: (2231:67,1 [94] )
 |
     [Parameter]public string P1 {get; set;}
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_Attribute_With_Expression/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_Attribute_With_Expression/TestComponent.codegen.cs
@@ -20,13 +20,15 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
+            __o = (global::Microsoft.AspNetCore.Components.IComponentRenderMode)(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                            __o = (global::Microsoft.AspNetCore.Components.IComponentRenderMode)(new MyRenderMode() { Extra = "Hello" });
+                            new MyRenderMode() { Extra = "Hello" }
 
 #line default
 #line hidden
 #nullable disable
+            );
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
             ));

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_Attribute_With_Expression/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_Attribute_With_Expression/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 ﻿Source Location: (30:0,30 [38] x:\dir\subdir\Test\TestComponent.cshtml)
 |new MyRenderMode() { Extra = "Hello" }|
-Generated Location: (998:24,97 [38] )
+Generated Location: (1012:25,28 [38] )
 |new MyRenderMode() { Extra = "Hello" }|
 
 Source Location: (83:2,1 [135] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -10,7 +10,7 @@ Source Location: (83:2,1 [135] x:\dir\subdir\Test\TestComponent.cshtml)
         public string Extra {get;set;}
     }
 |
-Generated Location: (1536:43,1 [135] )
+Generated Location: (1564:45,1 [135] )
 |
     class MyRenderMode : Microsoft.AspNetCore.Components.IComponentRenderMode
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_Attribute_With_SimpleIdentifier/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_Attribute_With_SimpleIdentifier/TestComponent.codegen.cs
@@ -20,13 +20,15 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
+            __o = (global::Microsoft.AspNetCore.Components.IComponentRenderMode)(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                            __o = (global::Microsoft.AspNetCore.Components.IComponentRenderMode)(Microsoft.AspNetCore.Components.Web.RenderMode.Server);
+                            Microsoft.AspNetCore.Components.Web.RenderMode.Server
 
 #line default
 #line hidden
 #nullable disable
+            );
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
             ));

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_Attribute_With_SimpleIdentifier/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_Attribute_With_SimpleIdentifier/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 ﻿Source Location: (28:0,28 [53] x:\dir\subdir\Test\TestComponent.cshtml)
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
-Generated Location: (998:24,97 [53] )
+Generated Location: (1012:25,28 [53] )
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_Child_Components/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_Child_Components/TestComponent.codegen.cs
@@ -20,29 +20,35 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
+            __o = (global::Microsoft.AspNetCore.Components.IComponentRenderMode)(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                            __o = (global::Microsoft.AspNetCore.Components.IComponentRenderMode)(Microsoft.AspNetCore.Components.Web.RenderMode.Server);
+                            Microsoft.AspNetCore.Components.Web.RenderMode.Server
 
 #line default
 #line hidden
 #nullable disable
+            );
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
+                __o = (global::Microsoft.AspNetCore.Components.IComponentRenderMode)(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
-                                __o = (global::Microsoft.AspNetCore.Components.IComponentRenderMode)(Microsoft.AspNetCore.Components.Web.RenderMode.Server);
+                                Microsoft.AspNetCore.Components.Web.RenderMode.Server
 
 #line default
 #line hidden
 #nullable disable
+                );
                 __builder2.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder3) => {
+                    __o = (global::Microsoft.AspNetCore.Components.IComponentRenderMode)(
 #nullable restore
 #line 3 "x:\dir\subdir\Test\TestComponent.cshtml"
-                                    __o = (global::Microsoft.AspNetCore.Components.IComponentRenderMode)(Microsoft.AspNetCore.Components.Web.RenderMode.Server);
+                                    Microsoft.AspNetCore.Components.Web.RenderMode.Server
 
 #line default
 #line hidden
 #nullable disable
+                    );
                     __builder3.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder4) => {
                     }
                     ));
@@ -62,21 +68,25 @@ __o = typeof(global::Test.TestComponent);
 #line default
 #line hidden
 #nullable disable
+                __o = (global::Microsoft.AspNetCore.Components.IComponentRenderMode)(
 #nullable restore
 #line 5 "x:\dir\subdir\Test\TestComponent.cshtml"
-                             __o = (global::Microsoft.AspNetCore.Components.IComponentRenderMode)(Microsoft.AspNetCore.Components.Web.RenderMode.Server);
+                             Microsoft.AspNetCore.Components.Web.RenderMode.Server
 
 #line default
 #line hidden
 #nullable disable
+                );
                 __builder2.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder3) => {
+                    __o = (global::Microsoft.AspNetCore.Components.IComponentRenderMode)(
 #nullable restore
 #line 6 "x:\dir\subdir\Test\TestComponent.cshtml"
-                                    __o = (global::Microsoft.AspNetCore.Components.IComponentRenderMode)(Microsoft.AspNetCore.Components.Web.RenderMode.Server);
+                                    Microsoft.AspNetCore.Components.Web.RenderMode.Server
 
 #line default
 #line hidden
 #nullable disable
+                    );
                     __builder3.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder4) => {
                     }
                     ));
@@ -87,13 +97,15 @@ __o = typeof(global::Test.TestComponent);
 #line default
 #line hidden
 #nullable disable
+                    __o = (global::Microsoft.AspNetCore.Components.IComponentRenderMode)(
 #nullable restore
 #line 7 "x:\dir\subdir\Test\TestComponent.cshtml"
-                                    __o = (global::Microsoft.AspNetCore.Components.IComponentRenderMode)(Microsoft.AspNetCore.Components.Web.RenderMode.Server);
+                                    Microsoft.AspNetCore.Components.Web.RenderMode.Server
 
 #line default
 #line hidden
 #nullable disable
+                    );
                     __builder3.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder4) => {
                     }
                     ));

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_Child_Components/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_Child_Components/TestComponent.mappings.txt
@@ -1,31 +1,31 @@
 ﻿Source Location: (28:0,28 [53] x:\dir\subdir\Test\TestComponent.cshtml)
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
-Generated Location: (998:24,97 [53] )
+Generated Location: (1012:25,28 [53] )
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
 
 Source Location: (117:1,32 [53] x:\dir\subdir\Test\TestComponent.cshtml)
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
-Generated Location: (1407:32,101 [53] )
+Generated Location: (1453:35,32 [53] )
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
 
 Source Location: (210:2,36 [53] x:\dir\subdir\Test\TestComponent.cshtml)
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
-Generated Location: (1825:40,105 [53] )
+Generated Location: (1911:45,36 [53] )
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
 
 Source Location: (320:4,29 [53] x:\dir\subdir\Test\TestComponent.cshtml)
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
-Generated Location: (2654:66,98 [53] )
+Generated Location: (2780:73,29 [53] )
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
 
 Source Location: (413:5,36 [53] x:\dir\subdir\Test\TestComponent.cshtml)
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
-Generated Location: (3072:74,105 [53] )
+Generated Location: (3238:83,36 [53] )
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
 
 Source Location: (508:6,36 [53] x:\dir\subdir\Test\TestComponent.cshtml)
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
-Generated Location: (3705:91,105 [53] )
+Generated Location: (3915:102,36 [53] )
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
 
 Source Location: (617:11,1 [73] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -33,7 +33,7 @@ Source Location: (617:11,1 [73] x:\dir\subdir\Test\TestComponent.cshtml)
     [Parameter]
     public RenderFragment ChildContent { get; set; }
 |
-Generated Location: (4682:128,1 [73] )
+Generated Location: (4914:140,1 [73] )
 |
     [Parameter]
     public RenderFragment ChildContent { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_Multiple_Components/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_Multiple_Components/TestComponent.codegen.cs
@@ -20,13 +20,15 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
+            __o = (global::Microsoft.AspNetCore.Components.IComponentRenderMode)(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                            __o = (global::Microsoft.AspNetCore.Components.IComponentRenderMode)(Microsoft.AspNetCore.Components.Web.RenderMode.Server);
+                            Microsoft.AspNetCore.Components.Web.RenderMode.Server
 
 #line default
 #line hidden
 #nullable disable
+            );
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
             ));
@@ -37,13 +39,15 @@ __o = typeof(global::Test.TestComponent);
 #line default
 #line hidden
 #nullable disable
+            __o = (global::Microsoft.AspNetCore.Components.IComponentRenderMode)(
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
-                            __o = (global::Microsoft.AspNetCore.Components.IComponentRenderMode)(Microsoft.AspNetCore.Components.Web.RenderMode.Server);
+                            Microsoft.AspNetCore.Components.Web.RenderMode.Server
 
 #line default
 #line hidden
 #nullable disable
+            );
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
             ));

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_Multiple_Components/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_Multiple_Components/TestComponent.mappings.txt
@@ -1,10 +1,10 @@
 ﻿Source Location: (28:0,28 [53] x:\dir\subdir\Test\TestComponent.cshtml)
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
-Generated Location: (998:24,97 [53] )
+Generated Location: (1012:25,28 [53] )
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
 
 Source Location: (115:1,28 [53] x:\dir\subdir\Test\TestComponent.cshtml)
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
-Generated Location: (1598:41,97 [53] )
+Generated Location: (1640:44,28 [53] )
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_With_Null/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_With_Null/TestComponent.codegen.cs
@@ -10,21 +10,33 @@ namespace Test
     using global::Microsoft.AspNetCore.Components;
     public partial class TestComponent : global::Microsoft.AspNetCore.Components.ComponentBase
     {
+        #pragma warning disable 219
+        private void __RazorDirectiveTokenHelpers__() {
+        }
+        #pragma warning restore 219
+        #pragma warning disable 0414
+        private static object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
-            __builder.OpenComponent<global::Test.TestComponent>(0);
-            global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode = 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                            true ? Microsoft.AspNetCore.Components.Web.RenderMode.Server : null
+                            __o = (global::Microsoft.AspNetCore.Components.IComponentRenderMode)(null);
 
 #line default
 #line hidden
 #nullable disable
-            ;
-            __builder.AddComponentRenderMode(__renderMode);
-            __builder.CloseComponent();
+            __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
+            }
+            ));
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+__o = typeof(global::Test.TestComponent);
+
+#line default
+#line hidden
+#nullable disable
         }
         #pragma warning restore 1998
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_With_Null/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_With_Null/TestComponent.ir.txt
@@ -1,0 +1,19 @@
+﻿Document - 
+    NamespaceDeclaration -  - Test
+        UsingDirective - (3:1,1 [20] ) - global::System
+        UsingDirective - (26:2,1 [40] ) - global::System.Collections.Generic
+        UsingDirective - (69:3,1 [25] ) - global::System.Linq
+        UsingDirective - (97:4,1 [36] ) - global::System.Threading.Tasks
+        UsingDirective - (136:5,1 [45] ) - global::Microsoft.AspNetCore.Components
+        ClassDeclaration -  - public partial - TestComponent - global::Microsoft.AspNetCore.Components.ComponentBase - 
+            DesignTimeDirective - 
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
+                IntermediateToken -  - CSharp - private static object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
+            MethodDeclaration -  - protected override - void - BuildRenderTree
+                Component - (0:0,0 [36] x:\dir\subdir\Test\TestComponent.cshtml) - TestComponent
+                    RenderMode - (28:0,28 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+                        LazyIntermediateToken - (28:0,28 [4] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - null

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_With_Null/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_With_Null/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (28:0,28 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|null|
+Generated Location: (998:24,97 [4] )
+|null|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_With_Null_Nullable_Disabled/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_With_Null_Nullable_Disabled/TestComponent.codegen.cs
@@ -10,21 +10,35 @@ namespace Test
     using global::Microsoft.AspNetCore.Components;
     public partial class TestComponent : global::Microsoft.AspNetCore.Components.ComponentBase
     {
+        #pragma warning disable 219
+        private void __RazorDirectiveTokenHelpers__() {
+        }
+        #pragma warning restore 219
+        #pragma warning disable 0414
+        private static object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
-            __builder.OpenComponent<global::Test.TestComponent>(0);
-            global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode = 
+            __o = (global::Microsoft.AspNetCore.Components.IComponentRenderMode)(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                            true ? Microsoft.AspNetCore.Components.Web.RenderMode.Server : null
+                            null
 
 #line default
 #line hidden
 #nullable disable
-            ;
-            __builder.AddComponentRenderMode(__renderMode);
-            __builder.CloseComponent();
+            );
+            __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
+            }
+            ));
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+__o = typeof(global::Test.TestComponent);
+
+#line default
+#line hidden
+#nullable disable
         }
         #pragma warning restore 1998
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_With_Null_Nullable_Disabled/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_With_Null_Nullable_Disabled/TestComponent.ir.txt
@@ -1,0 +1,19 @@
+﻿Document - 
+    NamespaceDeclaration -  - Test
+        UsingDirective - (3:1,1 [20] ) - global::System
+        UsingDirective - (26:2,1 [40] ) - global::System.Collections.Generic
+        UsingDirective - (69:3,1 [25] ) - global::System.Linq
+        UsingDirective - (97:4,1 [36] ) - global::System.Threading.Tasks
+        UsingDirective - (136:5,1 [45] ) - global::Microsoft.AspNetCore.Components
+        ClassDeclaration -  - public partial - TestComponent - global::Microsoft.AspNetCore.Components.ComponentBase - 
+            DesignTimeDirective - 
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
+                IntermediateToken -  - CSharp - private static object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
+            MethodDeclaration -  - protected override - void - BuildRenderTree
+                Component - (0:0,0 [36] x:\dir\subdir\Test\TestComponent.cshtml) - TestComponent
+                    RenderMode - (28:0,28 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+                        LazyIntermediateToken - (28:0,28 [4] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - null

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_With_Null_Nullable_Disabled/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_With_Null_Nullable_Disabled/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (28:0,28 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|null|
+Generated Location: (1012:25,28 [4] )
+|null|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_With_Null_Nullable_Enabled/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_With_Null_Nullable_Enabled/TestComponent.codegen.cs
@@ -10,21 +10,35 @@ namespace Test
     using global::Microsoft.AspNetCore.Components;
     public partial class TestComponent : global::Microsoft.AspNetCore.Components.ComponentBase
     {
+        #pragma warning disable 219
+        private void __RazorDirectiveTokenHelpers__() {
+        }
+        #pragma warning restore 219
+        #pragma warning disable 0414
+        private static object __o = null;
+        #pragma warning restore 0414
         #pragma warning disable 1998
         protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
-            __builder.OpenComponent<global::Test.TestComponent>(0);
-            global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode = 
+            __o = (global::Microsoft.AspNetCore.Components.IComponentRenderMode)(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                            true ? Microsoft.AspNetCore.Components.Web.RenderMode.Server : null
+                            null
 
 #line default
 #line hidden
 #nullable disable
-            ;
-            __builder.AddComponentRenderMode(__renderMode);
-            __builder.CloseComponent();
+            );
+            __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
+            }
+            ));
+#nullable restore
+#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+__o = typeof(global::Test.TestComponent);
+
+#line default
+#line hidden
+#nullable disable
         }
         #pragma warning restore 1998
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_With_Null_Nullable_Enabled/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_With_Null_Nullable_Enabled/TestComponent.ir.txt
@@ -1,0 +1,19 @@
+﻿Document - 
+    NamespaceDeclaration -  - Test
+        UsingDirective - (3:1,1 [20] ) - global::System
+        UsingDirective - (26:2,1 [40] ) - global::System.Collections.Generic
+        UsingDirective - (69:3,1 [25] ) - global::System.Linq
+        UsingDirective - (97:4,1 [36] ) - global::System.Threading.Tasks
+        UsingDirective - (136:5,1 [45] ) - global::Microsoft.AspNetCore.Components
+        ClassDeclaration -  - public partial - TestComponent - global::Microsoft.AspNetCore.Components.ComponentBase - 
+            DesignTimeDirective - 
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
+                IntermediateToken -  - CSharp - private static object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
+            MethodDeclaration -  - protected override - void - BuildRenderTree
+                Component - (0:0,0 [36] x:\dir\subdir\Test\TestComponent.cshtml) - TestComponent
+                    RenderMode - (28:0,28 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+                        LazyIntermediateToken - (28:0,28 [4] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - null

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_With_Null_Nullable_Enabled/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_With_Null_Nullable_Enabled/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (28:0,28 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|null|
+Generated Location: (1012:25,28 [4] )
+|null|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_With_Nullable_Receiver/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_With_Nullable_Receiver/TestComponent.codegen.cs
@@ -22,19 +22,18 @@ namespace Test
         {
             __o = (global::Microsoft.AspNetCore.Components.IComponentRenderMode)(
 #nullable restore
-#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                            Microsoft.AspNetCore.Components.Web.RenderMode.Server
+#line 10 "x:\dir\subdir\Test\TestComponent.cshtml"
+                            Container.RenderMode
 
 #line default
 #line hidden
 #nullable disable
             );
-            __o = "";
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
             ));
 #nullable restore
-#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
+#line 10 "x:\dir\subdir\Test\TestComponent.cshtml"
 __o = typeof(global::Test.TestComponent);
 
 #line default
@@ -42,6 +41,19 @@ __o = typeof(global::Test.TestComponent);
 #nullable disable
         }
         #pragma warning restore 1998
+#nullable restore
+#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
+ 
+    public class RenderModeContainer
+    {
+        public Microsoft.AspNetCore.Components.IComponentRenderMode RenderMode => Microsoft.AspNetCore.Components.Web.RenderMode.Server;
+    }
+
+    RenderModeContainer? Container => null;
+
+#line default
+#line hidden
+#nullable disable
     }
 }
 #pragma warning restore 1591

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_With_Nullable_Receiver/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_With_Nullable_Receiver/TestComponent.ir.txt
@@ -1,0 +1,23 @@
+﻿Document - 
+    NamespaceDeclaration -  - Test
+        UsingDirective - (3:1,1 [20] ) - global::System
+        UsingDirective - (26:2,1 [40] ) - global::System.Collections.Generic
+        UsingDirective - (69:3,1 [25] ) - global::System.Linq
+        UsingDirective - (97:4,1 [36] ) - global::System.Threading.Tasks
+        UsingDirective - (136:5,1 [45] ) - global::Microsoft.AspNetCore.Components
+        ClassDeclaration -  - public partial - TestComponent - global::Microsoft.AspNetCore.Components.ComponentBase - 
+            DesignTimeDirective - 
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning disable 0414
+            CSharpCode - 
+                IntermediateToken -  - CSharp - private static object __o = null;
+            CSharpCode - 
+                IntermediateToken -  - CSharp - #pragma warning restore 0414
+            MethodDeclaration -  - protected override - void - BuildRenderTree
+                HtmlContent - (248:8,1 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+                    LazyIntermediateToken - (248:8,1 [2] x:\dir\subdir\Test\TestComponent.cshtml) - Html - \n
+                Component - (250:9,0 [55] x:\dir\subdir\Test\TestComponent.cshtml) - TestComponent
+                    RenderMode - (278:9,28 [23] x:\dir\subdir\Test\TestComponent.cshtml)
+                        LazyIntermediateToken - (280:9,30 [20] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Container.RenderMode
+            CSharpCode - (8:1,1 [239] x:\dir\subdir\Test\TestComponent.cshtml)
+                LazyIntermediateToken - (8:1,1 [239] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public class RenderModeContainer\n    {\n        public Microsoft.AspNetCore.Components.IComponentRenderMode RenderMode => Microsoft.AspNetCore.Components.Web.RenderMode.Server;\n    }\n\n    RenderModeContainer? Container => null;\n

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_With_Nullable_Receiver/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_With_Nullable_Receiver/TestComponent.mappings.txt
@@ -1,0 +1,24 @@
+﻿Source Location: (280:9,30 [20] x:\dir\subdir\Test\TestComponent.cshtml)
+|Container.RenderMode|
+Generated Location: (1013:25,28 [20] )
+|Container.RenderMode|
+
+Source Location: (8:1,1 [239] x:\dir\subdir\Test\TestComponent.cshtml)
+|
+    public class RenderModeContainer
+    {
+        public Microsoft.AspNetCore.Components.IComponentRenderMode RenderMode => Microsoft.AspNetCore.Components.Web.RenderMode.Server;
+    }
+
+    RenderModeContainer? Container => null;
+|
+Generated Location: (1548:45,1 [239] )
+|
+    public class RenderModeContainer
+    {
+        public Microsoft.AspNetCore.Components.IComponentRenderMode RenderMode => Microsoft.AspNetCore.Components.Web.RenderMode.Server;
+    }
+
+    RenderModeContainer? Container => null;
+|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_With_Ternary/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_With_Ternary/TestComponent.codegen.cs
@@ -20,13 +20,15 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
+            __o = (global::Microsoft.AspNetCore.Components.IComponentRenderMode)(
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                            __o = (global::Microsoft.AspNetCore.Components.IComponentRenderMode)(true ? Microsoft.AspNetCore.Components.Web.RenderMode.Server : null);
+                            true ? Microsoft.AspNetCore.Components.Web.RenderMode.Server : null
 
 #line default
 #line hidden
 #nullable disable
+            );
             __builder.AddAttribute(-1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
             }
             ));

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_With_Ternary/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/RenderMode_With_Ternary/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 ﻿Source Location: (30:0,30 [67] x:\dir\subdir\Test\TestComponent.cshtml)
 |true ? Microsoft.AspNetCore.Components.Web.RenderMode.Server : null|
-Generated Location: (998:24,97 [67] )
+Generated Location: (1012:25,28 [67] )
 |true ? Microsoft.AspNetCore.Components.Web.RenderMode.Server : null|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Duplicate_RenderMode/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Duplicate_RenderMode/TestComponent.codegen.cs
@@ -14,13 +14,15 @@ namespace Test
         protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
             __builder.OpenComponent<global::Test.TestComponent>(0);
+            global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode = 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                            global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode = Microsoft.AspNetCore.Components.Web.RenderMode.Server;
+                            Microsoft.AspNetCore.Components.Web.RenderMode.Server
 
 #line default
 #line hidden
 #nullable disable
+            ;
             __builder.AddComponentParameter(1, "@rendermode", "Value2");
             __builder.AddComponentRenderMode(__renderMode);
             __builder.CloseComponent();

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Duplicate_RenderMode/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Duplicate_RenderMode/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 ﻿Source Location: (28:0,28 [53] x:\dir\subdir\Test\TestComponent.cshtml)
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
-Generated Location: (813:18,104 [53] )
+Generated Location: (827:19,28 [53] )
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_Attribute_With_Existing_Attributes/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_Attribute_With_Existing_Attributes/TestComponent.codegen.cs
@@ -15,13 +15,15 @@ namespace Test
         {
             __builder.OpenComponent<global::Test.TestComponent>(0);
             __builder.AddComponentParameter(1, "P2", "abc");
+            global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode = 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                                     global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode = Microsoft.AspNetCore.Components.Web.RenderMode.Server;
+                                     Microsoft.AspNetCore.Components.Web.RenderMode.Server
 
 #line default
 #line hidden
 #nullable disable
+            ;
             __builder.AddComponentParameter(2, "P1", "def");
             __builder.AddComponentRenderMode(__renderMode);
             __builder.CloseComponent();

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_Attribute_With_Existing_Attributes/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_Attribute_With_Existing_Attributes/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 ﻿Source Location: (37:0,37 [53] x:\dir\subdir\Test\TestComponent.cshtml)
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
-Generated Location: (884:19,113 [53] )
+Generated Location: (898:20,37 [53] )
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
 
 Source Location: (115:3,1 [94] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -9,7 +9,7 @@ Source Location: (115:3,1 [94] x:\dir\subdir\Test\TestComponent.cshtml)
 
     [Parameter]public string P2 {get; set;}
 |
-Generated Location: (1274:31,1 [94] )
+Generated Location: (1302:33,1 [94] )
 |
     [Parameter]public string P1 {get; set;}
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_Attribute_With_Expression/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_Attribute_With_Expression/TestComponent.codegen.cs
@@ -14,13 +14,15 @@ namespace Test
         protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
             __builder.OpenComponent<global::Test.TestComponent>(0);
+            global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode = 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                            global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode = new MyRenderMode() { Extra = "Hello" };
+                            new MyRenderMode() { Extra = "Hello" }
 
 #line default
 #line hidden
 #nullable disable
+            ;
             __builder.AddComponentRenderMode(__renderMode);
             __builder.CloseComponent();
         }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_Attribute_With_Expression/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_Attribute_With_Expression/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 ﻿Source Location: (30:0,30 [38] x:\dir\subdir\Test\TestComponent.cshtml)
 |new MyRenderMode() { Extra = "Hello" }|
-Generated Location: (813:18,104 [38] )
+Generated Location: (827:19,28 [38] )
 |new MyRenderMode() { Extra = "Hello" }|
 
 Source Location: (83:2,1 [135] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -10,7 +10,7 @@ Source Location: (83:2,1 [135] x:\dir\subdir\Test\TestComponent.cshtml)
         public string Extra {get;set;}
     }
 |
-Generated Location: (1126:29,1 [135] )
+Generated Location: (1154:31,1 [135] )
 |
     class MyRenderMode : Microsoft.AspNetCore.Components.IComponentRenderMode
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_Attribute_With_SimpleIdentifier/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_Attribute_With_SimpleIdentifier/TestComponent.codegen.cs
@@ -14,13 +14,15 @@ namespace Test
         protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
             __builder.OpenComponent<global::Test.TestComponent>(0);
+            global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode = 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                            global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode = Microsoft.AspNetCore.Components.Web.RenderMode.Server;
+                            Microsoft.AspNetCore.Components.Web.RenderMode.Server
 
 #line default
 #line hidden
 #nullable disable
+            ;
             __builder.AddComponentRenderMode(__renderMode);
             __builder.CloseComponent();
         }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_Attribute_With_SimpleIdentifier/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_Attribute_With_SimpleIdentifier/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 ﻿Source Location: (28:0,28 [53] x:\dir\subdir\Test\TestComponent.cshtml)
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
-Generated Location: (813:18,104 [53] )
+Generated Location: (827:19,28 [53] )
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_Child_Components/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_Child_Components/TestComponent.codegen.cs
@@ -14,31 +14,37 @@ namespace Test
         protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
             __builder.OpenComponent<global::Test.TestComponent>(0);
+            global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode = 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                            global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode = Microsoft.AspNetCore.Components.Web.RenderMode.Server;
+                            Microsoft.AspNetCore.Components.Web.RenderMode.Server
 
 #line default
 #line hidden
 #nullable disable
+            ;
             __builder.AddAttribute(1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
                 __builder2.OpenComponent<global::Test.TestComponent>(2);
+                global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode2_0 = 
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
-                                global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode2_0 = Microsoft.AspNetCore.Components.Web.RenderMode.Server;
+                                Microsoft.AspNetCore.Components.Web.RenderMode.Server
 
 #line default
 #line hidden
 #nullable disable
+                ;
                 __builder2.AddAttribute(3, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder3) => {
                     __builder3.OpenComponent<global::Test.TestComponent>(4);
+                    global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode3_0 = 
 #nullable restore
 #line 3 "x:\dir\subdir\Test\TestComponent.cshtml"
-                                    global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode3_0 = Microsoft.AspNetCore.Components.Web.RenderMode.Server;
+                                    Microsoft.AspNetCore.Components.Web.RenderMode.Server
 
 #line default
 #line hidden
 #nullable disable
+                    ;
                     __builder3.AddComponentRenderMode(__renderMode3_0);
                     __builder3.CloseComponent();
                 }
@@ -47,33 +53,39 @@ namespace Test
                 __builder2.CloseComponent();
                 __builder2.AddMarkupContent(5, "\r\n ");
                 __builder2.OpenComponent<global::Test.TestComponent>(6);
+                global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode2_1 = 
 #nullable restore
 #line 5 "x:\dir\subdir\Test\TestComponent.cshtml"
-                             global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode2_1 = Microsoft.AspNetCore.Components.Web.RenderMode.Server;
+                             Microsoft.AspNetCore.Components.Web.RenderMode.Server
 
 #line default
 #line hidden
 #nullable disable
+                ;
                 __builder2.AddAttribute(7, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder3) => {
                     __builder3.OpenComponent<global::Test.TestComponent>(8);
+                    global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode3_0 = 
 #nullable restore
 #line 6 "x:\dir\subdir\Test\TestComponent.cshtml"
-                                    global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode3_0 = Microsoft.AspNetCore.Components.Web.RenderMode.Server;
+                                    Microsoft.AspNetCore.Components.Web.RenderMode.Server
 
 #line default
 #line hidden
 #nullable disable
+                    ;
                     __builder3.AddComponentRenderMode(__renderMode3_0);
                     __builder3.CloseComponent();
                     __builder3.AddMarkupContent(9, "\r\n        ");
                     __builder3.OpenComponent<global::Test.TestComponent>(10);
+                    global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode3_1 = 
 #nullable restore
 #line 7 "x:\dir\subdir\Test\TestComponent.cshtml"
-                                    global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode3_1 = Microsoft.AspNetCore.Components.Web.RenderMode.Server;
+                                    Microsoft.AspNetCore.Components.Web.RenderMode.Server
 
 #line default
 #line hidden
 #nullable disable
+                    ;
                     __builder3.AddComponentRenderMode(__renderMode3_1);
                     __builder3.CloseComponent();
                 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_Child_Components/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_Child_Components/TestComponent.mappings.txt
@@ -1,31 +1,31 @@
 ﻿Source Location: (28:0,28 [53] x:\dir\subdir\Test\TestComponent.cshtml)
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
-Generated Location: (813:18,104 [53] )
+Generated Location: (827:19,28 [53] )
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
 
 Source Location: (117:1,32 [53] x:\dir\subdir\Test\TestComponent.cshtml)
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
-Generated Location: (1304:27,111 [53] )
+Generated Location: (1350:30,32 [53] )
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
 
 Source Location: (210:2,36 [53] x:\dir\subdir\Test\TestComponent.cshtml)
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
-Generated Location: (1808:36,115 [53] )
+Generated Location: (1894:41,36 [53] )
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
 
 Source Location: (320:4,29 [53] x:\dir\subdir\Test\TestComponent.cshtml)
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
-Generated Location: (2502:51,108 [53] )
+Generated Location: (2628:58,29 [53] )
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
 
 Source Location: (413:5,36 [53] x:\dir\subdir\Test\TestComponent.cshtml)
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
-Generated Location: (3006:60,115 [53] )
+Generated Location: (3172:69,36 [53] )
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
 
 Source Location: (508:6,36 [53] x:\dir\subdir\Test\TestComponent.cshtml)
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
-Generated Location: (3568:71,115 [53] )
+Generated Location: (3778:82,36 [53] )
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
 
 Source Location: (617:11,1 [73] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -33,7 +33,7 @@ Source Location: (617:11,1 [73] x:\dir\subdir\Test\TestComponent.cshtml)
     [Parameter]
     public RenderFragment ChildContent { get; set; }
 |
-Generated Location: (4207:90,1 [73] )
+Generated Location: (4439:102,1 [73] )
 |
     [Parameter]
     public RenderFragment ChildContent { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_Multiple_Components/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_Multiple_Components/TestComponent.codegen.cs
@@ -14,24 +14,28 @@ namespace Test
         protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
             __builder.OpenComponent<global::Test.TestComponent>(0);
+            global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode = 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                            global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode = Microsoft.AspNetCore.Components.Web.RenderMode.Server;
+                            Microsoft.AspNetCore.Components.Web.RenderMode.Server
 
 #line default
 #line hidden
 #nullable disable
+            ;
             __builder.AddComponentRenderMode(__renderMode);
             __builder.CloseComponent();
             __builder.AddMarkupContent(1, "\r\n");
             __builder.OpenComponent<global::Test.TestComponent>(2);
+            global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode1_1 = 
 #nullable restore
 #line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
-                            global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode1_1 = Microsoft.AspNetCore.Components.Web.RenderMode.Server;
+                            Microsoft.AspNetCore.Components.Web.RenderMode.Server
 
 #line default
 #line hidden
 #nullable disable
+            ;
             __builder.AddComponentRenderMode(__renderMode1_1);
             __builder.CloseComponent();
         }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_Multiple_Components/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_Multiple_Components/TestComponent.mappings.txt
@@ -1,10 +1,10 @@
 ﻿Source Location: (28:0,28 [53] x:\dir\subdir\Test\TestComponent.cshtml)
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
-Generated Location: (813:18,104 [53] )
+Generated Location: (827:19,28 [53] )
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
 
 Source Location: (115:1,28 [53] x:\dir\subdir\Test\TestComponent.cshtml)
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
-Generated Location: (1319:29,107 [53] )
+Generated Location: (1361:32,28 [53] )
 |Microsoft.AspNetCore.Components.Web.RenderMode.Server|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_With_Null_Nullable_Disabled/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_With_Null_Nullable_Disabled/TestComponent.codegen.cs
@@ -17,7 +17,7 @@ namespace Test
             global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode = 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                            true ? Microsoft.AspNetCore.Components.Web.RenderMode.Server : null
+                            null
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_With_Null_Nullable_Disabled/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_With_Null_Nullable_Disabled/TestComponent.ir.txt
@@ -1,0 +1,12 @@
+﻿Document - 
+    NamespaceDeclaration -  - Test
+        UsingDirective - (3:1,1 [22] ) - global::System
+        UsingDirective - (26:2,1 [42] ) - global::System.Collections.Generic
+        UsingDirective - (69:3,1 [27] ) - global::System.Linq
+        UsingDirective - (97:4,1 [38] ) - global::System.Threading.Tasks
+        UsingDirective - (136:5,1 [47] ) - global::Microsoft.AspNetCore.Components
+        ClassDeclaration -  - public partial - TestComponent - global::Microsoft.AspNetCore.Components.ComponentBase - 
+            MethodDeclaration -  - protected override - void - BuildRenderTree
+                Component - (0:0,0 [36] x:\dir\subdir\Test\TestComponent.cshtml) - TestComponent
+                    RenderMode - (28:0,28 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+                        LazyIntermediateToken - (28:0,28 [4] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - null

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_With_Null_Nullable_Disabled/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_With_Null_Nullable_Disabled/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (28:0,28 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|null|
+Generated Location: (827:19,28 [4] )
+|null|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_With_Null_Nullable_Enabled/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_With_Null_Nullable_Enabled/TestComponent.codegen.cs
@@ -17,7 +17,7 @@ namespace Test
             global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode = 
 #nullable restore
 #line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                            true ? Microsoft.AspNetCore.Components.Web.RenderMode.Server : null
+                            null
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_With_Null_Nullable_Enabled/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_With_Null_Nullable_Enabled/TestComponent.ir.txt
@@ -1,0 +1,12 @@
+﻿Document - 
+    NamespaceDeclaration -  - Test
+        UsingDirective - (3:1,1 [22] ) - global::System
+        UsingDirective - (26:2,1 [42] ) - global::System.Collections.Generic
+        UsingDirective - (69:3,1 [27] ) - global::System.Linq
+        UsingDirective - (97:4,1 [38] ) - global::System.Threading.Tasks
+        UsingDirective - (136:5,1 [47] ) - global::Microsoft.AspNetCore.Components
+        ClassDeclaration -  - public partial - TestComponent - global::Microsoft.AspNetCore.Components.ComponentBase - 
+            MethodDeclaration -  - protected override - void - BuildRenderTree
+                Component - (0:0,0 [36] x:\dir\subdir\Test\TestComponent.cshtml) - TestComponent
+                    RenderMode - (28:0,28 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+                        LazyIntermediateToken - (28:0,28 [4] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - null

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_With_Null_Nullable_Enabled/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_With_Null_Nullable_Enabled/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (28:0,28 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|null|
+Generated Location: (827:19,28 [4] )
+|null|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_With_Nullable_Receiver/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_With_Nullable_Receiver/TestComponent.codegen.cs
@@ -16,8 +16,8 @@ namespace Test
             __builder.OpenComponent<global::Test.TestComponent>(0);
             global::Microsoft.AspNetCore.Components.IComponentRenderMode __renderMode = 
 #nullable restore
-#line 1 "x:\dir\subdir\Test\TestComponent.cshtml"
-                            true ? Microsoft.AspNetCore.Components.Web.RenderMode.Server : null
+#line 10 "x:\dir\subdir\Test\TestComponent.cshtml"
+                            Container.RenderMode
 
 #line default
 #line hidden
@@ -27,6 +27,19 @@ namespace Test
             __builder.CloseComponent();
         }
         #pragma warning restore 1998
+#nullable restore
+#line 2 "x:\dir\subdir\Test\TestComponent.cshtml"
+ 
+    public class RenderModeContainer
+    {
+        public Microsoft.AspNetCore.Components.IComponentRenderMode RenderMode => Microsoft.AspNetCore.Components.Web.RenderMode.Server;
+    }
+
+    RenderModeContainer? Container => null;
+
+#line default
+#line hidden
+#nullable disable
     }
 }
 #pragma warning restore 1591

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_With_Nullable_Receiver/TestComponent.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_With_Nullable_Receiver/TestComponent.ir.txt
@@ -1,0 +1,14 @@
+﻿Document - 
+    NamespaceDeclaration -  - Test
+        UsingDirective - (3:1,1 [22] ) - global::System
+        UsingDirective - (26:2,1 [42] ) - global::System.Collections.Generic
+        UsingDirective - (69:3,1 [27] ) - global::System.Linq
+        UsingDirective - (97:4,1 [38] ) - global::System.Threading.Tasks
+        UsingDirective - (136:5,1 [47] ) - global::Microsoft.AspNetCore.Components
+        ClassDeclaration -  - public partial - TestComponent - global::Microsoft.AspNetCore.Components.ComponentBase - 
+            MethodDeclaration -  - protected override - void - BuildRenderTree
+                Component - (250:9,0 [55] x:\dir\subdir\Test\TestComponent.cshtml) - TestComponent
+                    RenderMode - (278:9,28 [23] x:\dir\subdir\Test\TestComponent.cshtml)
+                        LazyIntermediateToken - (280:9,30 [20] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - Container.RenderMode
+            CSharpCode - (8:1,1 [239] x:\dir\subdir\Test\TestComponent.cshtml)
+                LazyIntermediateToken - (8:1,1 [239] x:\dir\subdir\Test\TestComponent.cshtml) - CSharp - \n    public class RenderModeContainer\n    {\n        public Microsoft.AspNetCore.Components.IComponentRenderMode RenderMode => Microsoft.AspNetCore.Components.Web.RenderMode.Server;\n    }\n\n    RenderModeContainer? Container => null;\n

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_With_Nullable_Receiver/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_With_Nullable_Receiver/TestComponent.mappings.txt
@@ -1,0 +1,24 @@
+﻿Source Location: (280:9,30 [20] x:\dir\subdir\Test\TestComponent.cshtml)
+|Container.RenderMode|
+Generated Location: (828:19,28 [20] )
+|Container.RenderMode|
+
+Source Location: (8:1,1 [239] x:\dir\subdir\Test\TestComponent.cshtml)
+|
+    public class RenderModeContainer
+    {
+        public Microsoft.AspNetCore.Components.IComponentRenderMode RenderMode => Microsoft.AspNetCore.Components.Web.RenderMode.Server;
+    }
+
+    RenderModeContainer? Container => null;
+|
+Generated Location: (1137:31,1 [239] )
+|
+    public class RenderModeContainer
+    {
+        public Microsoft.AspNetCore.Components.IComponentRenderMode RenderMode => Microsoft.AspNetCore.Components.Web.RenderMode.Server;
+    }
+
+    RenderModeContainer? Container => null;
+|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_With_Ternary/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_With_Ternary/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 ﻿Source Location: (30:0,30 [67] x:\dir\subdir\Test\TestComponent.cshtml)
 |true ? Microsoft.AspNetCore.Components.Web.RenderMode.Server : null|
-Generated Location: (813:18,104 [67] )
+Generated Location: (827:19,28 [67] )
 |true ? Microsoft.AspNetCore.Components.Web.RenderMode.Server : null|
 

--- a/src/Compiler/test/Microsoft.AspNetCore.Razor.Test.Common/ErrorCode.cs
+++ b/src/Compiler/test/Microsoft.AspNetCore.Razor.Test.Common/ErrorCode.cs
@@ -16,5 +16,6 @@ public enum ErrorCode
     WRN_UnreferencedFieldAssg = 414,
     ERR_BadArgType = 1503,
     WRN_AsyncLacksAwaits = 1998,
+    WRN_NullReferenceReceiver = 8602,
     WRN_UninitializedNonNullableField = 8618,
 }

--- a/src/Compiler/test/Microsoft.AspNetCore.Razor.Test.ComponentShim/Microsoft.AspNetCore.Components.netstandard2.0.cs
+++ b/src/Compiler/test/Microsoft.AspNetCore.Razor.Test.ComponentShim/Microsoft.AspNetCore.Components.netstandard2.0.cs
@@ -465,7 +465,9 @@ namespace Microsoft.AspNetCore.Components.Rendering
         public void OpenElement(int sequence, string elementName) { }
         public void OpenRegion(int sequence) { }
         public void SetKey(object value) { }
-        public void AddComponentRenderMode(IComponentRenderMode renderMode) { }
+#nullable enable
+        public void AddComponentRenderMode(IComponentRenderMode? renderMode) { }
+#nullable restore
         public void SetUpdatesAttributeName(string updatesAttributeName) { }
         void System.IDisposable.Dispose() { }
     }


### PR DESCRIPTION
Changes code gen to only emit only the user expression portion of the render mode into a `#nullable restore` context.
