### PR TITLE
Fix parent tag calculation for attribute hovers

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperServiceTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperServiceTestBase.cs
@@ -59,6 +59,12 @@ public abstract class TagHelperServiceTestBase : LanguageServerTestBase
             rule.ParentTag = "test1";
         });
         builder1WithRequiredParent.SetMetadata(TypeName("Test1TagHelper.SomeChild"));
+        builder1WithRequiredParent.BindAttribute(attribute =>
+        {
+            attribute.Name = "attribute";
+            attribute.SetMetadata(PropertyName("Attribute"));
+            attribute.TypeName = typeof(string).FullName;
+        });
 
         var builder2 = TagHelperDescriptorBuilder.Create("Test2TagHelper", "TestAssembly");
         builder2.TagMatchingRule(rule => rule.TagName = "test2");


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/9397

The parent calculation for attributes was wrong, but without tag helper rules, the calculation had no effect, so the bug didn't show up anywhere.