### PR TITLE
Reduce noisy errors when viewing git diff on VS code

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/UriExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/UriExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Net;
+using Microsoft.AspNetCore.Razor.Utilities;
 
 namespace Microsoft.CodeAnalysis.Razor;
 
@@ -22,6 +23,27 @@ internal static class UriExtensions
         }
 
         // Absolute paths are usually encoded.
-        return uri.AbsolutePath.Contains("%") ? WebUtility.UrlDecode(uri.AbsolutePath) : uri.AbsolutePath;
+        var absolutePath = uri.AbsolutePath.Contains("%") ? WebUtility.UrlDecode(uri.AbsolutePath) : uri.AbsolutePath;
+
+        if (uri.Scheme.ToLower() == "git")
+        {
+            // return a normalized path when we want to add to a fake git directory path (hacky fix for https://github.com/dotnet/razor/issues/9365)
+            return AddToFakeGitDirectoryAtRoot(absolutePath);
+        }
+
+        return absolutePath;
+    }
+
+    private static string AddToFakeGitDirectoryAtRoot(string decodedAbsolutePath)
+    {
+        var normalizedPath = FilePathNormalizer.Normalize(decodedAbsolutePath);
+        var firstSeparatorIndex = normalizedPath.IndexOf('/');
+        if (firstSeparatorIndex < 0)
+        {
+            // no-op
+            return decodedAbsolutePath;
+        }
+
+        return normalizedPath[..(firstSeparatorIndex + 1)] + "_git_" + normalizedPath[firstSeparatorIndex..];
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/UriExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/UriExtensions.cs
@@ -25,7 +25,7 @@ internal static class UriExtensions
         // Absolute paths are usually encoded.
         var absolutePath = uri.AbsolutePath.Contains("%") ? WebUtility.UrlDecode(uri.AbsolutePath) : uri.AbsolutePath;
 
-        if (uri.Scheme.ToLower() == "git")
+        if (string.Equals(uri.Scheme, "git", StringComparison.OrdinalIgnoreCase))
         {
             // return a normalized path when we want to add to a fake git directory path (hacky fix for https://github.com/dotnet/razor/issues/9365)
             return AddToFakeGitDirectoryAtRoot(absolutePath);
@@ -44,6 +44,6 @@ internal static class UriExtensions
             return decodedAbsolutePath;
         }
 
-        return normalizedPath[..(firstSeparatorIndex + 1)] + "_git_" + normalizedPath[firstSeparatorIndex..];
+        return normalizedPath.Insert(firstSeparatorIndex + 1, "_git_/");
     }
 }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/UriExtensionsTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/UriExtensionsTest.cs
@@ -71,7 +71,7 @@ public class UriExtensionsTest : TestBase
         Assert.Equal(expected, path);
     }
 
-    [OSSkipConditionFact(new[] { "OSX", "Linux" })]
+    [OSSkipConditionTheory(new[] { "OSX", "Linux" })]
     [InlineData(@"file:///c:/path/to/dir/Index.cshtml", @"c:/path/to/dir/Index.cshtml")]
     [InlineData(@"file:///c:\path/to\dir/Index.cshtml", @"c:/path/to/dir/Index.cshtml")]
     [InlineData(@"file:///C:\path\to\dir\Index.cshtml", @"C:/path/to/dir/Index.cshtml")]

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/UriExtensionsTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/UriExtensionsTest.cs
@@ -93,4 +93,17 @@ public class UriExtensionsTest : TestBase
         // Assert
         Assert.Equal(@"\\some\path\to\file path.cshtml", path);
     }
+
+    [Fact, WorkItem("https://github.com/dotnet/razor/issues/9365")]
+    public void GetAbsoluteAndUNCPath_HasGitScheme_ReturnsANormalizedFakeGitFilePath()
+    {
+        // Arrange
+        var uri = new Uri("git:/c%3A/myFolder/Index.cshtml?%7B%22path%22%3A%22c%3A%5C%5CmyFolder%5C%5CIndex.cshtml%22%2C%22ref%22%3A%22~%22%7D");
+
+        // Act
+        var path = uri.GetAbsoluteOrUNCPath();
+
+        // Assert
+        Assert.Equal("c:/_git_/myFolder/Index.cshtml", path);
+    }
 }


### PR DESCRIPTION
﻿### Summary of the changes

- Fixes noisy errors generated when viewing git diff of cshtml/razor files on VS code.
This is a hacky workaround. Would be good to follow this up with a proper fix.


- The language server project was returning a wrong file path for URIs with git scheme
- e.g. this could happen when opening git diff on VS code

- With this hacky fix, we make up a fake git folder to provide for these file paths
- This makes sure the returned file path for the left hand side of the git diff view, would not collide with existing file paths (original file path for the right hand side)

Fixes #9365

