### PR TITLE
Cache tag helpers per assembly reference

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/src/ViewComponentTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/src/ViewComponentTagHelperDescriptorProvider.cs
@@ -49,7 +49,7 @@ public sealed class ViewComponentTagHelperDescriptorProvider : RazorEngineFeatur
         ViewComponentTagHelperDescriptorFactory factory,
         INamedTypeSymbol vcAttribute,
         INamedTypeSymbol nonVCAttribute)
-        : TagHelperCollector<ViewComponentTagHelperDescriptorProvider>(compilation, targetSymbol: null)
+        : TagHelperCollector<Collector>(compilation, targetSymbol: null)
     {
         private readonly ViewComponentTagHelperDescriptorFactory _factory = factory;
         private readonly INamedTypeSymbol _vcAttribute = vcAttribute;

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/src/ViewComponentTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/src/ViewComponentTagHelperDescriptorProvider.cs
@@ -41,7 +41,7 @@ public sealed class ViewComponentTagHelperDescriptorProvider : RazorEngineFeatur
         var factory = new ViewComponentTagHelperDescriptorFactory(compilation);
         var collector = new Collector(compilation, factory, vcAttribute, nonVCAttribute);
 
-        collector.Collect(context.Results);
+        collector.Collect(context);
     }
 
     private class Collector(

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/src/ViewComponentTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/src/ViewComponentTagHelperDescriptorProvider.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor;
 
@@ -37,37 +38,39 @@ public sealed class ViewComponentTagHelperDescriptorProvider : RazorEngineFeatur
             return;
         }
 
-        var types = new List<INamedTypeSymbol>();
-        var visitor = new ViewComponentTypeVisitor(vcAttribute, nonVCAttribute, types);
+        var factory = new ViewComponentTagHelperDescriptorFactory(compilation);
+        var collector = new Collector(compilation, factory, vcAttribute, nonVCAttribute);
 
-        // We always visit the global namespace.
-        visitor.Visit(compilation.Assembly.GlobalNamespace);
+        collector.Collect(context.Results);
+    }
 
-        foreach (var reference in compilation.References)
+    private class Collector(
+        Compilation compilation,
+        ViewComponentTagHelperDescriptorFactory factory,
+        INamedTypeSymbol vcAttribute,
+        INamedTypeSymbol nonVCAttribute)
+        : TagHelperCollector<ViewComponentTagHelperDescriptorProvider>(compilation, targetSymbol: null)
+    {
+        private readonly ViewComponentTagHelperDescriptorFactory _factory = factory;
+        private readonly INamedTypeSymbol _vcAttribute = vcAttribute;
+        private readonly INamedTypeSymbol _nonVCAttribute = nonVCAttribute;
+
+        protected override void Collect(ISymbol symbol, ICollection<TagHelperDescriptor> results)
         {
-            if (compilation.GetAssemblyOrModuleSymbol(reference) is IAssemblySymbol assembly)
+            using var _ = ListPool<INamedTypeSymbol>.GetPooledObject(out var types);
+            var visitor = new ViewComponentTypeVisitor(_vcAttribute, _nonVCAttribute, types);
+
+            visitor.Visit(symbol);
+
+            foreach (var type in types)
             {
-                if (IsTagHelperAssembly(assembly))
+                var descriptor = _factory.CreateDescriptor(type);
+
+                if (descriptor != null)
                 {
-                    visitor.Visit(assembly.GlobalNamespace);
+                    results.Add(descriptor);
                 }
             }
         }
-
-        var factory = new ViewComponentTagHelperDescriptorFactory(compilation);
-        for (var i = 0; i < types.Count; i++)
-        {
-            var descriptor = factory.CreateDescriptor(types[i]);
-
-            if (descriptor != null)
-            {
-                context.Results.Add(descriptor);
-            }
-        }
-    }
-
-    private bool IsTagHelperAssembly(IAssemblySymbol assembly)
-    {
-        return assembly.Name != null && !assembly.Name.StartsWith("System.", StringComparison.Ordinal);
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/src/ViewComponentTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/src/ViewComponentTagHelperDescriptorProvider.cs
@@ -49,7 +49,7 @@ public sealed class ViewComponentTagHelperDescriptorProvider : RazorEngineFeatur
         ViewComponentTagHelperDescriptorFactory factory,
         INamedTypeSymbol vcAttribute,
         INamedTypeSymbol nonVCAttribute)
-        : TagHelperCollector<ViewComponentTagHelperDescriptorProvider>(compilation, targetSymbol: null)
+        : TagHelperCollector<Collector>(compilation, targetSymbol: null)
     {
         private readonly ViewComponentTagHelperDescriptorFactory _factory = factory;
         private readonly INamedTypeSymbol _vcAttribute = vcAttribute;

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/src/ViewComponentTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/src/ViewComponentTagHelperDescriptorProvider.cs
@@ -41,7 +41,7 @@ public sealed class ViewComponentTagHelperDescriptorProvider : RazorEngineFeatur
         var factory = new ViewComponentTagHelperDescriptorFactory(compilation);
         var collector = new Collector(compilation, factory, vcAttribute, nonVCAttribute);
 
-        collector.Collect(context.Results);
+        collector.Collect(context);
     }
 
     private class Collector(

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/src/ViewComponentTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/src/ViewComponentTagHelperDescriptorProvider.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor;
 
@@ -37,37 +38,39 @@ public sealed class ViewComponentTagHelperDescriptorProvider : RazorEngineFeatur
             return;
         }
 
-        var types = new List<INamedTypeSymbol>();
-        var visitor = new ViewComponentTypeVisitor(vcAttribute, nonVCAttribute, types);
+        var factory = new ViewComponentTagHelperDescriptorFactory(compilation);
+        var collector = new Collector(compilation, factory, vcAttribute, nonVCAttribute);
 
-        // We always visit the global namespace.
-        visitor.Visit(compilation.Assembly.GlobalNamespace);
+        collector.Collect(context.Results);
+    }
 
-        foreach (var reference in compilation.References)
+    private class Collector(
+        Compilation compilation,
+        ViewComponentTagHelperDescriptorFactory factory,
+        INamedTypeSymbol vcAttribute,
+        INamedTypeSymbol nonVCAttribute)
+        : TagHelperCollector<ViewComponentTagHelperDescriptorProvider>(compilation, targetSymbol: null)
+    {
+        private readonly ViewComponentTagHelperDescriptorFactory _factory = factory;
+        private readonly INamedTypeSymbol _vcAttribute = vcAttribute;
+        private readonly INamedTypeSymbol _nonVCAttribute = nonVCAttribute;
+
+        protected override void Collect(ISymbol symbol, ICollection<TagHelperDescriptor> results)
         {
-            if (compilation.GetAssemblyOrModuleSymbol(reference) is IAssemblySymbol assembly)
+            using var _ = ListPool<INamedTypeSymbol>.GetPooledObject(out var types);
+            var visitor = new ViewComponentTypeVisitor(_vcAttribute, _nonVCAttribute, types);
+
+            visitor.Visit(symbol);
+
+            foreach (var type in types)
             {
-                if (IsTagHelperAssembly(assembly))
+                var descriptor = _factory.CreateDescriptor(type);
+
+                if (descriptor != null)
                 {
-                    visitor.Visit(assembly.GlobalNamespace);
+                    results.Add(descriptor);
                 }
             }
         }
-
-        var factory = new ViewComponentTagHelperDescriptorFactory(compilation);
-        for (var i = 0; i < types.Count; i++)
-        {
-            var descriptor = factory.CreateDescriptor(types[i]);
-
-            if (descriptor != null)
-            {
-                context.Results.Add(descriptor);
-            }
-        }
-    }
-
-    private bool IsTagHelperAssembly(IAssemblySymbol assembly)
-    {
-        return assembly.Name != null && !assembly.Name.StartsWith("System.", StringComparison.Ordinal);
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/src/ViewComponentTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/src/ViewComponentTagHelperDescriptorProvider.cs
@@ -49,7 +49,7 @@ public sealed class ViewComponentTagHelperDescriptorProvider : RazorEngineFeatur
         ViewComponentTagHelperDescriptorFactory factory,
         INamedTypeSymbol vcAttribute,
         INamedTypeSymbol nonVCAttribute)
-        : TagHelperCollector<ViewComponentTagHelperDescriptorProvider>(compilation, targetSymbol: null)
+        : TagHelperCollector<Collector>(compilation, targetSymbol: null)
     {
         private readonly ViewComponentTagHelperDescriptorFactory _factory = factory;
         private readonly INamedTypeSymbol _vcAttribute = vcAttribute;

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/src/ViewComponentTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/src/ViewComponentTagHelperDescriptorProvider.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor;
 
@@ -37,43 +38,39 @@ public sealed class ViewComponentTagHelperDescriptorProvider : RazorEngineFeatur
             return;
         }
 
-        var types = new List<INamedTypeSymbol>();
-        var visitor = new ViewComponentTypeVisitor(vcAttribute, nonVCAttribute, types);
+        var factory = new ViewComponentTagHelperDescriptorFactory(compilation);
+        var collector = new Collector(compilation, factory, vcAttribute, nonVCAttribute);
 
-        var targetSymbol = context.Items.GetTargetSymbol();
-        if (targetSymbol is not null)
+        collector.Collect(context.Results);
+    }
+
+    private class Collector(
+        Compilation compilation,
+        ViewComponentTagHelperDescriptorFactory factory,
+        INamedTypeSymbol vcAttribute,
+        INamedTypeSymbol nonVCAttribute)
+        : TagHelperCollector<ViewComponentTagHelperDescriptorProvider>(compilation, targetSymbol: null)
+    {
+        private readonly ViewComponentTagHelperDescriptorFactory _factory = factory;
+        private readonly INamedTypeSymbol _vcAttribute = vcAttribute;
+        private readonly INamedTypeSymbol _nonVCAttribute = nonVCAttribute;
+
+        protected override void Collect(ISymbol symbol, ICollection<TagHelperDescriptor> results)
         {
-            visitor.Visit(targetSymbol);
-        }
-        else
-        {
-            visitor.Visit(compilation.Assembly.GlobalNamespace);
-            foreach (var reference in compilation.References)
+            using var _ = ListPool<INamedTypeSymbol>.GetPooledObject(out var types);
+            var visitor = new ViewComponentTypeVisitor(_vcAttribute, _nonVCAttribute, types);
+
+            visitor.Visit(symbol);
+
+            foreach (var type in types)
             {
-                if (compilation.GetAssemblyOrModuleSymbol(reference) is IAssemblySymbol assembly)
+                var descriptor = _factory.CreateDescriptor(type);
+
+                if (descriptor != null)
                 {
-                    if (IsTagHelperAssembly(assembly))
-                    {
-                        visitor.Visit(assembly.GlobalNamespace);
-                    }
+                    results.Add(descriptor);
                 }
             }
         }
-
-        var factory = new ViewComponentTagHelperDescriptorFactory(compilation);
-        for (var i = 0; i < types.Count; i++)
-        {
-            var descriptor = factory.CreateDescriptor(types[i]);
-
-            if (descriptor != null)
-            {
-                context.Results.Add(descriptor);
-            }
-        }
-    }
-
-    internal static bool IsTagHelperAssembly(IAssemblySymbol assembly)
-    {
-        return assembly.Name != null && !assembly.Name.StartsWith("System.", StringComparison.Ordinal);
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/src/ViewComponentTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/src/ViewComponentTagHelperDescriptorProvider.cs
@@ -41,7 +41,7 @@ public sealed class ViewComponentTagHelperDescriptorProvider : RazorEngineFeatur
         var factory = new ViewComponentTagHelperDescriptorFactory(compilation);
         var collector = new Collector(compilation, factory, vcAttribute, nonVCAttribute);
 
-        collector.Collect(context.Results);
+        collector.Collect(context);
     }
 
     private class Collector(

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/src/ViewComponentTypeVisitor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/src/ViewComponentTypeVisitor.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 
 namespace Microsoft.AspNetCore.Mvc.Razor.Extensions;
@@ -28,10 +27,7 @@ internal class ViewComponentTypeVisitor : SymbolVisitor
 
     public override void VisitAssembly(IAssemblySymbol symbol)
     {
-        if (ViewComponentTagHelperDescriptorProvider.IsTagHelperAssembly(symbol))
-        {
-            Visit(symbol.GlobalNamespace);
-        }
+        Visit(symbol.GlobalNamespace);
     }
 
     public override void VisitNamedType(INamedTypeSymbol symbol)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/ITagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/ITagHelperDescriptorProvider.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 namespace Microsoft.AspNetCore.Razor.Language;
 
 public interface ITagHelperDescriptorProvider : IRazorEngineFeature

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/PublicAPI.Shipped.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/PublicAPI.Shipped.txt
@@ -388,7 +388,6 @@
 ~Microsoft.AspNetCore.Razor.Language.IRazorProjectEngineFeature.ProjectEngine.get -> Microsoft.AspNetCore.Razor.Language.RazorProjectEngine
 ~Microsoft.AspNetCore.Razor.Language.IRazorProjectEngineFeature.ProjectEngine.set -> void
 ~Microsoft.AspNetCore.Razor.Language.IRazorTargetExtensionFeature.TargetExtensions.get -> System.Collections.Generic.ICollection<Microsoft.AspNetCore.Razor.Language.CodeGeneration.ICodeTargetExtension>
-~Microsoft.AspNetCore.Razor.Language.ITagHelperDescriptorProvider.Execute(Microsoft.AspNetCore.Razor.Language.TagHelperDescriptorProviderContext context) -> void
 ~Microsoft.AspNetCore.Razor.Language.ITagHelperFeature.GetDescriptors() -> System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Razor.Language.TagHelperDescriptor>
 ~Microsoft.AspNetCore.Razor.Language.ItemCollection.Add(object key, object value) -> void
 ~Microsoft.AspNetCore.Razor.Language.ItemCollection.Add(System.Collections.Generic.KeyValuePair<object, object> item) -> void
@@ -1191,8 +1190,6 @@ Microsoft.AspNetCore.Razor.Language.IRazorParsingPhase
 Microsoft.AspNetCore.Razor.Language.IRazorProjectEngineFeature
 Microsoft.AspNetCore.Razor.Language.IRazorTagHelperBinderPhase
 Microsoft.AspNetCore.Razor.Language.IRazorTargetExtensionFeature
-Microsoft.AspNetCore.Razor.Language.ITagHelperDescriptorProvider
-Microsoft.AspNetCore.Razor.Language.ITagHelperDescriptorProvider.Order.get -> int
 Microsoft.AspNetCore.Razor.Language.ITagHelperFeature
 Microsoft.AspNetCore.Razor.Language.ItemCollection
 Microsoft.AspNetCore.Razor.Language.ItemCollection.Clear() -> void

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/PublicAPI.Unshipped.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/PublicAPI.Unshipped.txt
@@ -180,7 +180,7 @@ Microsoft.AspNetCore.Razor.Language.RequiredAttributeDescriptorBuilder.ValueComp
 Microsoft.AspNetCore.Razor.Language.SourceLocation.SourceLocation() -> void
 Microsoft.AspNetCore.Razor.Language.SourceSpan.SourceSpan() -> void
 Microsoft.AspNetCore.Razor.Language.TagHelperCollector<T>
-Microsoft.AspNetCore.Razor.Language.TagHelperCollector<T>.Collect(System.Collections.Generic.ICollection<Microsoft.AspNetCore.Razor.Language.TagHelperDescriptor!>! results) -> void
+Microsoft.AspNetCore.Razor.Language.TagHelperCollector<T>.Collect(Microsoft.AspNetCore.Razor.Language.TagHelperDescriptorProviderContext! context) -> void
 Microsoft.AspNetCore.Razor.Language.TagHelperCollector<T>.TagHelperCollector(Microsoft.CodeAnalysis.Compilation! compilation, Microsoft.CodeAnalysis.ISymbol? targetSymbol) -> void
 Microsoft.AspNetCore.Razor.Language.TagHelperDescriptor
 Microsoft.AspNetCore.Razor.Language.TagHelperDescriptor.AllowedChildTags.get -> System.Collections.Immutable.ImmutableArray<Microsoft.AspNetCore.Razor.Language.AllowedChildTagDescriptor!>
@@ -267,8 +267,6 @@ override sealed Microsoft.AspNetCore.Razor.Language.MetadataCollection.Equals(ob
 override sealed Microsoft.AspNetCore.Razor.Language.MetadataCollection.GetHashCode() -> int
 override sealed Microsoft.AspNetCore.Razor.Language.TagHelperObject<T>.Equals(object? obj) -> bool
 override sealed Microsoft.AspNetCore.Razor.Language.TagHelperObject<T>.GetHashCode() -> int
-readonly Microsoft.AspNetCore.Razor.Language.TagHelperCollector<T>.Compilation -> Microsoft.CodeAnalysis.Compilation!
-readonly Microsoft.AspNetCore.Razor.Language.TagHelperCollector<T>.TargetSymbol -> Microsoft.CodeAnalysis.ISymbol?
 static Microsoft.AspNetCore.Razor.Language.CommonMetadata.PropertyName(string! value) -> System.Collections.Generic.KeyValuePair<string!, string?>
 static Microsoft.AspNetCore.Razor.Language.CommonMetadata.TypeName(string! value) -> System.Collections.Generic.KeyValuePair<string!, string?>
 static Microsoft.AspNetCore.Razor.Language.MetadataCollection.Create(params System.Collections.Generic.KeyValuePair<string!, string?>[]! pairs) -> Microsoft.AspNetCore.Razor.Language.MetadataCollection!

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/PublicAPI.Unshipped.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/PublicAPI.Unshipped.txt
@@ -16,6 +16,7 @@ abstract Microsoft.AspNetCore.Razor.Language.MetadataCollection.Keys.get -> Syst
 abstract Microsoft.AspNetCore.Razor.Language.MetadataCollection.this[string! key].get -> string?
 abstract Microsoft.AspNetCore.Razor.Language.MetadataCollection.TryGetValue(string! key, out string? value) -> bool
 abstract Microsoft.AspNetCore.Razor.Language.MetadataCollection.Values.get -> System.Collections.Generic.IEnumerable<string?>!
+abstract Microsoft.AspNetCore.Razor.Language.TagHelperCollector<T>.Collect(Microsoft.CodeAnalysis.ISymbol! symbol, System.Collections.Generic.ICollection<Microsoft.AspNetCore.Razor.Language.TagHelperDescriptor!>! results) -> void
 Microsoft.AspNetCore.Razor.Language.AllowedChildTagDescriptor
 Microsoft.AspNetCore.Razor.Language.AllowedChildTagDescriptor.DisplayName.get -> string!
 Microsoft.AspNetCore.Razor.Language.AllowedChildTagDescriptor.Name.get -> string!
@@ -178,6 +179,9 @@ Microsoft.AspNetCore.Razor.Language.RequiredAttributeDescriptorBuilder.ValueComp
 Microsoft.AspNetCore.Razor.Language.RequiredAttributeDescriptorBuilder.ValueComparisonMode.set -> void
 Microsoft.AspNetCore.Razor.Language.SourceLocation.SourceLocation() -> void
 Microsoft.AspNetCore.Razor.Language.SourceSpan.SourceSpan() -> void
+Microsoft.AspNetCore.Razor.Language.TagHelperCollector<T>
+Microsoft.AspNetCore.Razor.Language.TagHelperCollector<T>.Collect(System.Collections.Generic.ICollection<Microsoft.AspNetCore.Razor.Language.TagHelperDescriptor!>! results) -> void
+Microsoft.AspNetCore.Razor.Language.TagHelperCollector<T>.TagHelperCollector(Microsoft.CodeAnalysis.Compilation! compilation, Microsoft.CodeAnalysis.ISymbol? targetSymbol) -> void
 Microsoft.AspNetCore.Razor.Language.TagHelperDescriptor
 Microsoft.AspNetCore.Razor.Language.TagHelperDescriptor.AllowedChildTags.get -> System.Collections.Immutable.ImmutableArray<Microsoft.AspNetCore.Razor.Language.AllowedChildTagDescriptor!>
 Microsoft.AspNetCore.Razor.Language.TagHelperDescriptor.AssemblyName.get -> string!
@@ -263,6 +267,8 @@ override sealed Microsoft.AspNetCore.Razor.Language.MetadataCollection.Equals(ob
 override sealed Microsoft.AspNetCore.Razor.Language.MetadataCollection.GetHashCode() -> int
 override sealed Microsoft.AspNetCore.Razor.Language.TagHelperObject<T>.Equals(object? obj) -> bool
 override sealed Microsoft.AspNetCore.Razor.Language.TagHelperObject<T>.GetHashCode() -> int
+readonly Microsoft.AspNetCore.Razor.Language.TagHelperCollector<T>.Compilation -> Microsoft.CodeAnalysis.Compilation!
+readonly Microsoft.AspNetCore.Razor.Language.TagHelperCollector<T>.TargetSymbol -> Microsoft.CodeAnalysis.ISymbol?
 static Microsoft.AspNetCore.Razor.Language.CommonMetadata.PropertyName(string! value) -> System.Collections.Generic.KeyValuePair<string!, string?>
 static Microsoft.AspNetCore.Razor.Language.CommonMetadata.TypeName(string! value) -> System.Collections.Generic.KeyValuePair<string!, string?>
 static Microsoft.AspNetCore.Razor.Language.MetadataCollection.Create(params System.Collections.Generic.KeyValuePair<string!, string?>[]! pairs) -> Microsoft.AspNetCore.Razor.Language.MetadataCollection!

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/PublicAPI.Unshipped.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/PublicAPI.Unshipped.txt
@@ -123,6 +123,9 @@ Microsoft.AspNetCore.Razor.Language.Intermediate.TypeParameter.ConstraintsSource
 Microsoft.AspNetCore.Razor.Language.Intermediate.TypeParameter.ConstraintsSource.init -> void
 Microsoft.AspNetCore.Razor.Language.Intermediate.TypeParameter.ParameterNameSource.get -> Microsoft.AspNetCore.Razor.Language.SourceSpan?
 Microsoft.AspNetCore.Razor.Language.Intermediate.TypeParameter.ParameterNameSource.init -> void
+Microsoft.AspNetCore.Razor.Language.ITagHelperDescriptorProvider
+Microsoft.AspNetCore.Razor.Language.ITagHelperDescriptorProvider.Execute(Microsoft.AspNetCore.Razor.Language.TagHelperDescriptorProviderContext! context) -> void
+Microsoft.AspNetCore.Razor.Language.ITagHelperDescriptorProvider.Order.get -> int
 Microsoft.AspNetCore.Razor.Language.MetadataCollection
 Microsoft.AspNetCore.Razor.Language.MetadataCollection.Contains(string! key, string? value) -> bool
 Microsoft.AspNetCore.Razor.Language.MetadataCollection.Enumerator

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperCollector.Cache.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperCollector.Cache.cs
@@ -1,0 +1,56 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.AspNetCore.Razor.Language;
+
+public abstract partial class TagHelperCollector<T>
+    where T : ITagHelperDescriptorProvider
+{
+    private class Cache
+    {
+        private const int IncludeDocumentation = 1 << 0;
+        private const int ExcludeHidden = 1 << 1;
+
+        // The cache needs to be large enough to handle all combinations of options.
+        private const int CacheSize = (IncludeDocumentation | ExcludeHidden) + 1;
+
+        private readonly TagHelperDescriptor[]?[] _tagHelpers = new TagHelperDescriptor[CacheSize][];
+
+        public bool TryGet(bool includeDocumentation, bool excludeHidden, [NotNullWhen(true)] out TagHelperDescriptor[]? tagHelpers)
+        {
+            var index = CalculateIndex(includeDocumentation, excludeHidden);
+
+            tagHelpers = _tagHelpers[index];
+            return tagHelpers is not null;
+        }
+
+        public void Add(TagHelperDescriptor[] tagHelpers, bool includeDocumentation, bool excludeHidden)
+        {
+            var index = CalculateIndex(includeDocumentation, excludeHidden);
+
+            Debug.Assert(_tagHelpers[index] is null);
+
+            _tagHelpers[index] = tagHelpers;
+        }
+
+        private static int CalculateIndex(bool includeDocumentation, bool excludeHidden)
+        {
+            var index = 0;
+
+            if (includeDocumentation)
+            {
+                index |= IncludeDocumentation;
+            }
+
+            if (excludeHidden)
+            {
+                index |= ExcludeHidden;
+            }
+
+            return index;
+        }
+    }
+}

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperCollector.Cache.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperCollector.Cache.cs
@@ -7,7 +7,7 @@ using System.Threading;
 namespace Microsoft.AspNetCore.Razor.Language;
 
 public abstract partial class TagHelperCollector<T>
-    where T : ITagHelperDescriptorProvider
+    where T : TagHelperCollector<T>
 {
     private class Cache
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperCollector.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperCollector.cs
@@ -8,8 +8,10 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.AspNetCore.Razor.Language;
 
-internal abstract class TagHelperCollector
+internal abstract class TagHelperCollector<T>
+    where T : ITagHelperDescriptorProvider
 {
+    // This type is generic to ensure that each descendent gets its own instance of this field.
     private static readonly ConditionalWeakTable<IAssemblySymbol, TagHelperDescriptor[]> s_perAssemblyTagHelperCache = new();
 
     private readonly Compilation _compilation;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperCollector.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperCollector.cs
@@ -1,0 +1,67 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Razor.PooledObjects;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.AspNetCore.Razor.Language;
+
+internal abstract class TagHelperCollector
+{
+    private static readonly ConditionalWeakTable<IAssemblySymbol, TagHelperDescriptor[]> s_perAssemblyTagHelperCache = new();
+
+    private readonly Compilation _compilation;
+    private readonly ISymbol? _targetSymbol;
+
+    protected TagHelperCollector(Compilation compilation, ISymbol? targetSymbol)
+    {
+        _compilation = compilation;
+        _targetSymbol = targetSymbol;
+    }
+
+    protected abstract void Collect(ISymbol symbol, ICollection<TagHelperDescriptor> results);
+
+    public void Collect(ICollection<TagHelperDescriptor> results)
+    {
+        if (_targetSymbol is not null)
+        {
+            Collect(_targetSymbol, results);
+        }
+        else
+        {
+            Collect(_compilation.Assembly.GlobalNamespace, results);
+
+            foreach (var reference in _compilation.References)
+            {
+                if (_compilation.GetAssemblyOrModuleSymbol(reference) is IAssemblySymbol assembly)
+                {
+                    TagHelperDescriptor[] tagHelpers;
+
+                    lock (s_perAssemblyTagHelperCache)
+                    {
+                        // Check to see if we already have tag helpers cached for this assembly
+                        // and use them cached versions if we do. Roslyn shares PE assembly symbols
+                        // across compilations, so this ensures that we don't produce new tag helpers
+                        // for the same assemblies over and over again.
+                        if (!s_perAssemblyTagHelperCache.TryGetValue(assembly, out tagHelpers))
+                        {
+                            using var _ = ListPool<TagHelperDescriptor>.GetPooledObject(out var referenceTagHelpers);
+                            Collect(assembly.GlobalNamespace, referenceTagHelpers);
+
+                            tagHelpers = referenceTagHelpers.ToArrayOrEmpty();
+
+                            s_perAssemblyTagHelperCache.Add(assembly, tagHelpers);
+                        }
+                    }
+
+                    foreach (var tagHelper in tagHelpers)
+                    {
+                        results.Add(tagHelper);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperCollector.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperCollector.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Microsoft.AspNetCore.Razor.Language;
 
-internal abstract class TagHelperCollector<T>
+public abstract class TagHelperCollector<T>
     where T : ITagHelperDescriptorProvider
 {
     // This type is generic to ensure that each descendent gets its own instance of this field.

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperCollector.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperCollector.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis;
 namespace Microsoft.AspNetCore.Razor.Language;
 
 public abstract partial class TagHelperCollector<T>
-    where T : ITagHelperDescriptorProvider
+    where T : TagHelperCollector<T>
 {
     // This type is generic to ensure that each descendent gets its own instance of this field.
     private static readonly ConditionalWeakTable<IAssemblySymbol, Cache> s_perAssemblyCaches = new();

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperCollector.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperCollector.cs
@@ -14,30 +14,30 @@ internal abstract class TagHelperCollector<T>
     // This type is generic to ensure that each descendent gets its own instance of this field.
     private static readonly ConditionalWeakTable<IAssemblySymbol, TagHelperDescriptor[]> s_perAssemblyTagHelperCache = new();
 
-    private readonly Compilation _compilation;
-    private readonly ISymbol? _targetSymbol;
+    protected readonly Compilation Compilation;
+    protected readonly ISymbol? TargetSymbol;
 
     protected TagHelperCollector(Compilation compilation, ISymbol? targetSymbol)
     {
-        _compilation = compilation;
-        _targetSymbol = targetSymbol;
+        Compilation = compilation;
+        TargetSymbol = targetSymbol;
     }
 
     protected abstract void Collect(ISymbol symbol, ICollection<TagHelperDescriptor> results);
 
     public void Collect(ICollection<TagHelperDescriptor> results)
     {
-        if (_targetSymbol is not null)
+        if (TargetSymbol is not null)
         {
-            Collect(_targetSymbol, results);
+            Collect(TargetSymbol, results);
         }
         else
         {
-            Collect(_compilation.Assembly.GlobalNamespace, results);
+            Collect(Compilation.Assembly.GlobalNamespace, results);
 
-            foreach (var reference in _compilation.References)
+            foreach (var reference in Compilation.References)
             {
-                if (_compilation.GetAssemblyOrModuleSymbol(reference) is IAssemblySymbol assembly)
+                if (Compilation.GetAssemblyOrModuleSymbol(reference) is IAssemblySymbol assembly)
                 {
                     TagHelperDescriptor[] tagHelpers;
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/BindTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/BindTagHelperDescriptorProvider.cs
@@ -125,8 +125,9 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
             return;
         }
 
-        var collector = new Collector(compilation, targetSymbol, bindElementAttribute, bindInputElementAttribute);
-        collector.Collect(context.Results);
+        var collector = new Collector(
+            compilation, targetSymbol, bindElementAttribute, bindInputElementAttribute);
+        collector.Collect(context);
     }
 
     private static TagHelperDescriptor GetOrCreateFallbackBindTagHelper()

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/BindTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/BindTagHelperDescriptorProvider.cs
@@ -240,7 +240,7 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
 
     private class Collector(
         Compilation compilation, ISymbol targetSymbol, INamedTypeSymbol bindElementAttribute, INamedTypeSymbol bindInputElementAttribute)
-        : TagHelperCollector<BindTagHelperDescriptorProvider>(compilation, targetSymbol)
+        : TagHelperCollector<Collector>(compilation, targetSymbol)
     {
         protected override void Collect(ISymbol symbol, ICollection<TagHelperDescriptor> results)
         {

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/BindTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/BindTagHelperDescriptorProvider.cs
@@ -238,10 +238,7 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
     }
 
     private class Collector(
-        Compilation compilation,
-        ISymbol targetSymbol,
-        INamedTypeSymbol bindElementAttribute,
-        INamedTypeSymbol bindInputElementAttribute)
+        Compilation compilation, ISymbol targetSymbol, INamedTypeSymbol bindElementAttribute, INamedTypeSymbol bindInputElementAttribute)
         : TagHelperCollector<BindTagHelperDescriptorProvider>(compilation, targetSymbol)
     {
         protected override void Collect(ISymbol symbol, ICollection<TagHelperDescriptor> results)
@@ -749,12 +746,7 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
 
             public override void VisitAssembly(IAssemblySymbol symbol)
             {
-                // This as a simple yet high-value optimization that excludes the vast majority of
-                // assemblies that (by definition) can't contain a component.
-                if (symbol.Name != null && !symbol.Name.StartsWith("System.", StringComparison.Ordinal))
-                {
-                    Visit(symbol.GlobalNamespace);
-                }
+                Visit(symbol.GlobalNamespace);
             }
         }
     }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/BindTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/BindTagHelperDescriptorProvider.cs
@@ -5,8 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
@@ -68,7 +66,7 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
         //  2.  We also support cases like '@bind-value="@FirstName"' where we will generate the 'value'
         //      attribute and another attribute based for a changed handler based on the metadata.
         //
-        //     These mappings are provided by attributes that tell us what attributes, suffixes, and
+        //      These mappings are provided by attributes that tell us what attributes, suffixes, and
         //      elements to map.
         //
         //  3.  When given an attribute like '@bind="@FirstName"' we will generate a value and change
@@ -118,22 +116,17 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
         // Tag Helper definition for case #1. This is the most general case.
         context.Results.Add(GetOrCreateFallbackBindTagHelper());
 
-        // For case #2 & #3 we have a whole bunch of attribute entries on BindMethods that we can use
-        // to data-drive the definitions of these tag helpers.
-        var elementBindData = GetElementBindData(compilation);
+        var bindElementAttribute = compilation.GetTypeByMetadataName(ComponentsApi.BindElementAttribute.FullTypeName);
+        var bindInputElementAttribute = compilation.GetTypeByMetadataName(ComponentsApi.BindInputElementAttribute.FullTypeName);
 
-        // Case #2 & #3
-        foreach (var tagHelper in CreateElementBindTagHelpers(elementBindData))
+        if (bindElementAttribute == null || bindInputElementAttribute == null)
         {
-            context.Results.Add(tagHelper);
+            // This won't likely happen, but just in case.
+            return;
         }
 
-        // For case #4 we look at the tag helpers that were already created corresponding to components
-        // and pattern match on properties.
-        foreach (var tagHelper in CreateComponentBindTagHelpers(context.Results))
-        {
-            context.Results.Add(tagHelper);
-        }
+        var collector = new Collector(compilation, targetSymbol, bindElementAttribute, bindInputElementAttribute);
+        collector.Collect(context.Results);
     }
 
     private static TagHelperDescriptor GetOrCreateFallbackBindTagHelper()
@@ -244,171 +237,166 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
         }
     }
 
-    private static ImmutableArray<ElementBindData> GetElementBindData(Compilation compilation)
+    private class Collector(
+        Compilation compilation,
+        ISymbol targetSymbol,
+        INamedTypeSymbol bindElementAttribute,
+        INamedTypeSymbol bindInputElementAttribute)
+        : TagHelperCollector<BindTagHelperDescriptorProvider>(compilation, targetSymbol)
     {
-        var bindElement = compilation.GetTypeByMetadataName(ComponentsApi.BindElementAttribute.FullTypeName);
-        var bindInputElement = compilation.GetTypeByMetadataName(ComponentsApi.BindInputElementAttribute.FullTypeName);
-
-        if (bindElement == null || bindInputElement == null)
+        protected override void Collect(ISymbol symbol, ICollection<TagHelperDescriptor> results)
         {
-            // This won't likely happen, but just in case.
-            return ImmutableArray<ElementBindData>.Empty;
-        }
+            using var _ = ListPool<INamedTypeSymbol>.GetPooledObject(out var types);
+            var visitor = new BindElementDataVisitor(types);
 
-        using var _ = ListPool<INamedTypeSymbol>.GetPooledObject(out var types);
-        var visitor = new BindElementDataVisitor(types);
+            visitor.Visit(symbol);
 
-        // Visit the primary output of this compilation, as well as all references.
-        visitor.Visit(compilation.Assembly);
-
-        foreach (var reference in compilation.References)
-        {
-            // We ignore .netmodules here - there really isn't a case where they are used by user code
-            // even though the Roslyn APIs all support them.
-            if (compilation.GetAssemblyOrModuleSymbol(reference) is IAssemblySymbol assembly)
+            foreach (var type in types)
             {
-                visitor.Visit(assembly);
+                // Create helper to delay computing display names for this type when we need them.
+                var displayNames = new DisplayNameHelper(type);
+
+                // Not handling duplicates here for now since we're the primary ones extending this.
+                // If we see users adding to the set of 'bind' constructs we will want to add deduplication
+                // and potentially diagnostics.
+                foreach (var attribute in type.GetAttributes())
+                {
+                    var constructorArguments = attribute.ConstructorArguments;
+
+                    TagHelperDescriptor tagHelper = null;
+
+                    // For case #2 & #3 we have a whole bunch of attribute entries on BindMethods that we can use
+                    // to data-drive the definitions of these tag helpers.
+
+                    // We need to check the constructor argument length here, because this can show up as 0
+                    // if the language service fails to initialize. This is an invalid case, so skip it.
+                    if (constructorArguments.Length == 4 && SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, bindElementAttribute))
+                    {
+                        var (typeName, namespaceName) = displayNames.GetNames();
+
+                        tagHelper = CreateElementBindTagHelper(
+                            typeName,
+                            namespaceName,
+                            typeNameIdentifier: type.Name,
+                            element: (string)constructorArguments[0].Value,
+                            typeAttribute: null,
+                            suffix: (string)constructorArguments[1].Value,
+                            valueAttribute: (string)constructorArguments[2].Value,
+                            changeAttribute: (string)constructorArguments[3].Value);
+                    }
+                    else if (constructorArguments.Length == 4 && SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, bindInputElementAttribute))
+                    {
+                        var (typeName, namespaceName) = displayNames.GetNames();
+
+                        tagHelper = CreateElementBindTagHelper(
+                            typeName,
+                            namespaceName,
+                            typeNameIdentifier: type.Name,
+                            element: "input",
+                            typeAttribute: (string)constructorArguments[0].Value,
+                            suffix: (string)constructorArguments[1].Value,
+                            valueAttribute: (string)constructorArguments[2].Value,
+                            changeAttribute: (string)constructorArguments[3].Value);
+                    }
+                    else if (constructorArguments.Length == 6 && SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, bindInputElementAttribute))
+                    {
+                        var (typeName, namespaceName) = displayNames.GetNames();
+
+                        tagHelper = CreateElementBindTagHelper(
+                            typeName,
+                            namespaceName,
+                            typeNameIdentifier: type.Name,
+                            element: "input",
+                            typeAttribute: (string)constructorArguments[0].Value,
+                            suffix: (string)constructorArguments[1].Value,
+                            valueAttribute: (string)constructorArguments[2].Value,
+                            changeAttribute: (string)constructorArguments[3].Value,
+                            isInvariantCulture: (bool)constructorArguments[4].Value,
+                            format: (string)constructorArguments[5].Value);
+                    }
+
+                    results.Add(tagHelper);
+                }
+            }
+
+            // For case #4 we look at the tag helpers that were already created corresponding to components
+            // and pattern match on properties.
+            using var componentBindTagHelpers = new PooledArrayBuilder<TagHelperDescriptor>(capacity: results.Count);
+
+            foreach (var tagHelper in results)
+            {
+                AddComponentBindTagHelpers(tagHelper, ref componentBindTagHelpers.AsRef());
+            }
+
+            foreach (var tagHelper in componentBindTagHelpers)
+            {
+                results.Add(tagHelper);
             }
         }
 
-        using var results = new PooledArrayBuilder<ElementBindData>();
-
-        foreach (var type in types)
+        /// <summary>
+        ///  Helper to avoid computing various type-based names until necessary.
+        /// </summary>
+        private ref struct DisplayNameHelper(INamedTypeSymbol type)
         {
-            // Create helper to delay computing display names for this type when we need them.
-            var displayNames = new DisplayNameHelper(type);
+            private readonly INamedTypeSymbol _type = type;
+            private (string Type, string Namespace)? _names;
 
-            // Not handling duplicates here for now since we're the primary ones extending this.
-            // If we see users adding to the set of 'bind' constructs we will want to add deduplication
-            // and potentially diagnostics.
-            foreach (var attribute in type.GetAttributes())
-            {
-                var constructorArguments = attribute.ConstructorArguments;
-
-                // We need to check the constructor argument length here, because this can show up as 0
-                // if the language service fails to initialize. This is an invalid case, so skip it.
-                if (constructorArguments.Length == 4 && SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, bindElement))
-                {
-                    var (assemblyName, typeName, namespaceName) = displayNames.GetNames();
-
-                    results.Add(new ElementBindData(
-                        assemblyName,
-                        typeName,
-                        namespaceName,
-                        type.Name,
-                        (string)constructorArguments[0].Value,
-                        null,
-                        (string)constructorArguments[1].Value,
-                        (string)constructorArguments[2].Value,
-                        (string)constructorArguments[3].Value));
-                }
-                else if (constructorArguments.Length == 4 && SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, bindInputElement))
-                {
-                    var (assemblyName, typeName, namespaceName) = displayNames.GetNames();
-
-                    results.Add(new ElementBindData(
-                        assemblyName,
-                        typeName,
-                        namespaceName,
-                        type.Name,
-                        "input",
-                        (string)constructorArguments[0].Value,
-                        (string)constructorArguments[1].Value,
-                        (string)constructorArguments[2].Value,
-                        (string)constructorArguments[3].Value));
-                }
-                else if (constructorArguments.Length == 6 && SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, bindInputElement))
-                {
-                    var (assemblyName, typeName, namespaceName) = displayNames.GetNames();
-
-                    results.Add(new ElementBindData(
-                        assemblyName,
-                        typeName,
-                        namespaceName,
-                        type.Name,
-                        "input",
-                        (string)constructorArguments[0].Value,
-                        (string)constructorArguments[1].Value,
-                        (string)constructorArguments[2].Value,
-                        (string)constructorArguments[3].Value,
-                        (bool)constructorArguments[4].Value,
-                        (string)constructorArguments[5].Value));
-                }
-            }
+            public (string Type, string Namespace) GetNames()
+                => _names ??= (_type.ToDisplayString(), _type.ContainingNamespace.ToDisplayString());
         }
 
-        return results.DrainToImmutable();
-    }
-
-    /// <summary>
-    ///  Helper to avoid computing various type-based names until necessary.
-    /// </summary>
-    private ref struct DisplayNameHelper
-    {
-        private readonly INamedTypeSymbol _type;
-        private (string Assembly, string Type, string Namespace)? _names;
-
-        public DisplayNameHelper(INamedTypeSymbol type)
-        {
-            _type = type;
-        }
-
-        public (string Assembly, string Type, string Namespace) GetNames()
-        {
-            _names ??= (_type.ContainingAssembly.Name, _type.ToDisplayString(), _type.ContainingNamespace.ToDisplayString());
-
-            return _names.GetValueOrDefault();
-        }
-    }
-
-    private static ImmutableArray<TagHelperDescriptor> CreateElementBindTagHelpers(ImmutableArray<ElementBindData> data)
-    {
-        using var results = new PooledArrayBuilder<TagHelperDescriptor>();
-
-        foreach (var entry in data)
+        private static TagHelperDescriptor CreateElementBindTagHelper(
+            string typeName,
+            string typeNamespace,
+            string typeNameIdentifier,
+            string element,
+            string typeAttribute,
+            string suffix,
+            string valueAttribute,
+            string changeAttribute,
+            bool isInvariantCulture = false,
+            string format = null)
         {
             string name, attributeName, formatName, formatAttributeName, eventName;
 
-            if (entry.Suffix is { } suffix)
+            if (suffix is { } s)
             {
-                name = "Bind_" + suffix;
-                attributeName = "@bind-" + suffix;
-                formatName = "Format_" + suffix;
-                formatAttributeName = "format-" + suffix;
-                eventName = "Event_" + suffix;
+                name = "Bind_" + s;
+                attributeName = "@bind-" + s;
+                formatName = "Format_" + s;
+                formatAttributeName = "format-" + s;
+                eventName = "Event_" + s;
             }
             else
             {
                 name = "Bind";
                 attributeName = "@bind";
 
-                suffix = entry.ValueAttribute;
+                suffix = valueAttribute;
                 formatName = "Format_" + suffix;
                 formatAttributeName = "format-" + suffix;
                 eventName = "Event_" + suffix;
             }
-
             using var _ = TagHelperDescriptorBuilder.GetPooledInstance(
                 ComponentMetadata.Bind.TagHelperKind, name, ComponentsApi.AssemblyName,
                 out var builder);
-
             using var metadata = builder.GetMetadataBuilder(ComponentMetadata.Bind.RuntimeName);
-
             builder.CaseSensitive = true;
             builder.SetDocumentation(
                 DocumentationDescriptor.From(
                     DocumentationId.BindTagHelper_Element,
-                    entry.ValueAttribute,
-                    entry.ChangeAttribute));
+                    valueAttribute,
+                    changeAttribute));
 
             metadata.Add(SpecialKind(ComponentMetadata.Bind.TagHelperKind));
             metadata.Add(MakeTrue(TagHelperMetadata.Common.ClassifyAttributesOnly));
-            metadata.Add(ComponentMetadata.Bind.ValueAttribute, entry.ValueAttribute);
-            metadata.Add(ComponentMetadata.Bind.ChangeAttribute, entry.ChangeAttribute);
-            metadata.Add(ComponentMetadata.Bind.IsInvariantCulture, entry.IsInvariantCulture ? bool.TrueString : bool.FalseString);
-            metadata.Add(ComponentMetadata.Bind.Format, entry.Format);
+            metadata.Add(ComponentMetadata.Bind.ValueAttribute, valueAttribute);
+            metadata.Add(ComponentMetadata.Bind.ChangeAttribute, changeAttribute);
+            metadata.Add(ComponentMetadata.Bind.IsInvariantCulture, isInvariantCulture ? bool.TrueString : bool.FalseString);
+            metadata.Add(ComponentMetadata.Bind.Format, format);
 
-            if (entry.TypeAttribute != null)
+            if (typeAttribute != null)
             {
                 // For entries that map to the <input /> element, we need to be able to know
                 // the difference between <input /> and <input type="text" .../> for which we
@@ -419,25 +407,25 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                 //
                 // Therefore we use this metadata to know which one is more specific when two
                 // tag helpers match.
-                metadata.Add(ComponentMetadata.Bind.TypeAttribute, entry.TypeAttribute);
+                metadata.Add(ComponentMetadata.Bind.TypeAttribute, typeAttribute);
             }
 
-            metadata.Add(TypeName(entry.TypeName));
-            metadata.Add(TypeNamespace(entry.TypeNamespace));
-            metadata.Add(TypeNameIdentifier(entry.TypeNameIdentifier));
+            metadata.Add(TypeName(typeName));
+            metadata.Add(TypeNamespace(typeNamespace));
+            metadata.Add(TypeNameIdentifier(typeNameIdentifier));
 
             builder.SetMetadata(metadata.Build());
 
             builder.TagMatchingRule(rule =>
             {
-                rule.TagName = entry.Element;
-                if (entry.TypeAttribute != null)
+                rule.TagName = element;
+                if (typeAttribute != null)
                 {
                     rule.Attribute(a =>
                     {
                         a.Name = "type";
                         a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
-                        a.Value = entry.TypeAttribute;
+                        a.Value = typeAttribute;
                         a.ValueComparisonMode = RequiredAttributeDescriptor.ValueComparisonMode.FullMatch;
                     });
                 }
@@ -452,14 +440,14 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
 
             builder.TagMatchingRule(rule =>
             {
-                rule.TagName = entry.Element;
-                if (entry.TypeAttribute != null)
+                rule.TagName = element;
+                if (typeAttribute != null)
                 {
                     rule.Attribute(a =>
                     {
                         a.Name = "type";
                         a.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.FullMatch;
-                        a.Value = entry.TypeAttribute;
+                        a.Value = typeAttribute;
                         a.ValueComparisonMode = RequiredAttributeDescriptor.ValueComparisonMode.FullMatch;
                     });
                 }
@@ -484,8 +472,8 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                 a.SetDocumentation(
                     DocumentationDescriptor.From(
                         DocumentationId.BindTagHelper_Element,
-                        entry.ValueAttribute,
-                        entry.ChangeAttribute));
+                        valueAttribute,
+                        changeAttribute));
 
                 a.Name = attributeName;
                 a.TypeName = typeof(object).FullName;
@@ -568,21 +556,14 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
                 attribute.SetMetadata(PropertyName(formatName));
             });
 
-            results.Add(builder.Build());
+            return builder.Build();
         }
 
-        return results.DrainToImmutable();
-    }
-
-    private static ImmutableArray<TagHelperDescriptor> CreateComponentBindTagHelpers(ICollection<TagHelperDescriptor> tagHelpers)
-    {
-        using var results = new PooledArrayBuilder<TagHelperDescriptor>();
-
-        foreach (var tagHelper in tagHelpers)
+        private static void AddComponentBindTagHelpers(TagHelperDescriptor tagHelper, ref PooledArrayBuilder<TagHelperDescriptor> results)
         {
             if (!tagHelper.IsComponentTagHelper)
             {
-                continue;
+                return;
             }
 
             // We want to create a 'bind' tag helper everywhere we see a pair of properties like `Foo`, `FooChanged`
@@ -745,61 +726,35 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
             }
         }
 
-        return results.DrainToImmutable();
-    }
-
-    [DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(),nq}}")]
-    private readonly record struct ElementBindData(
-        string Assembly,
-        string TypeName,
-        string TypeNamespace,
-        string TypeNameIdentifier,
-        string Element,
-        string TypeAttribute,
-        string Suffix,
-        string ValueAttribute,
-        string ChangeAttribute,
-        bool IsInvariantCulture = false,
-        string Format = null)
-    {
-        private string GetDebuggerDisplay()
+        private class BindElementDataVisitor(List<INamedTypeSymbol> results) : SymbolVisitor
         {
-            return $"Element: {Element} - Suffix: {Suffix ?? "(none)"} - Type: {TypeAttribute} Value: {ValueAttribute} Change: {ChangeAttribute}";
-        }
-    }
+            private readonly List<INamedTypeSymbol> _results = results;
 
-    private class BindElementDataVisitor : SymbolVisitor
-    {
-        private readonly List<INamedTypeSymbol> _results;
-
-        public BindElementDataVisitor(List<INamedTypeSymbol> results)
-        {
-            _results = results;
-        }
-
-        public override void VisitNamedType(INamedTypeSymbol symbol)
-        {
-            if (symbol.Name == "BindAttributes" && symbol.DeclaredAccessibility == Accessibility.Public)
+            public override void VisitNamedType(INamedTypeSymbol symbol)
             {
-                _results.Add(symbol);
+                if (symbol.DeclaredAccessibility == Accessibility.Public &&
+                    symbol.Name == "BindAttributes")
+                {
+                    _results.Add(symbol);
+                }
             }
-        }
 
-        public override void VisitNamespace(INamespaceSymbol symbol)
-        {
-            foreach (var member in symbol.GetMembers())
+            public override void VisitNamespace(INamespaceSymbol symbol)
             {
-                Visit(member);
+                foreach (var member in symbol.GetMembers())
+                {
+                    Visit(member);
+                }
             }
-        }
 
-        public override void VisitAssembly(IAssemblySymbol symbol)
-        {
-            // This as a simple yet high-value optimization that excludes the vast majority of
-            // assemblies that (by definition) can't contain a component.
-            if (symbol.Name != null && !symbol.Name.StartsWith("System.", StringComparison.Ordinal))
+            public override void VisitAssembly(IAssemblySymbol symbol)
             {
-                Visit(symbol.GlobalNamespace);
+                // This as a simple yet high-value optimization that excludes the vast majority of
+                // assemblies that (by definition) can't contain a component.
+                if (symbol.Name != null && !symbol.Name.StartsWith("System.", StringComparison.Ordinal))
+                {
+                    Visit(symbol.GlobalNamespace);
+                }
             }
         }
     }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentTagHelperDescriptorProvider.cs
@@ -44,7 +44,7 @@ internal partial class ComponentTagHelperDescriptorProvider : RazorEngineFeature
         var targetSymbol = context.Items.GetTargetSymbol();
 
         var collector = new Collector(compilation, targetSymbol);
-        collector.Collect(context.Results);
+        collector.Collect(context);
     }
 
     private sealed class Collector(Compilation compilation, ISymbol targetSymbol)

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentTagHelperDescriptorProvider.cs
@@ -47,7 +47,8 @@ internal partial class ComponentTagHelperDescriptorProvider : RazorEngineFeature
         collector.Collect(context.Results);
     }
 
-    private sealed class Collector(Compilation compilation, ISymbol targetSymbol) : TagHelperCollector(compilation, targetSymbol)
+    private sealed class Collector(Compilation compilation, ISymbol targetSymbol)
+        : TagHelperCollector<ComponentTagHelperDescriptorProvider>(compilation, targetSymbol)
     {
         protected override void Collect(ISymbol symbol, ICollection<TagHelperDescriptor> results)
         {

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentTagHelperDescriptorProvider.cs
@@ -745,12 +745,7 @@ internal partial class ComponentTagHelperDescriptorProvider : RazorEngineFeature
 
             public override void VisitAssembly(IAssemblySymbol symbol)
             {
-                // This as a simple yet high-value optimization that excludes the vast majority of
-                // assemblies that (by definition) can't contain a component.
-                if (symbol.Name != null && !symbol.Name.StartsWith("System.", StringComparison.Ordinal))
-                {
-                    Visit(symbol.GlobalNamespace);
-                }
+                Visit(symbol.GlobalNamespace);
             }
         }
     }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentTagHelperDescriptorProvider.cs
@@ -48,7 +48,7 @@ internal partial class ComponentTagHelperDescriptorProvider : RazorEngineFeature
     }
 
     private sealed class Collector(Compilation compilation, ISymbol targetSymbol)
-        : TagHelperCollector<ComponentTagHelperDescriptorProvider>(compilation, targetSymbol)
+        : TagHelperCollector<Collector>(compilation, targetSymbol)
     {
         protected override void Collect(ISymbol symbol, ICollection<TagHelperDescriptor> results)
         {

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/ComponentTagHelperDescriptorProvider.cs
@@ -8,19 +8,16 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Runtime.CompilerServices;
-using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Components;
+using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using static Microsoft.AspNetCore.Razor.Language.CommonMetadata;
 
 namespace Microsoft.CodeAnalysis.Razor;
 
-internal class ComponentTagHelperDescriptorProvider : RazorEngineFeatureBase, ITagHelperDescriptorProvider
+internal partial class ComponentTagHelperDescriptorProvider : RazorEngineFeatureBase, ITagHelperDescriptorProvider
 {
-    private static readonly ConditionalWeakTable<IAssemblySymbol, TagHelperDescriptor[]> s_perAssemblyTagHelperCache = new();
-
     private static readonly SymbolDisplayFormat GloballyQualifiedFullNameTypeDisplayFormat =
         SymbolDisplayFormat.FullyQualifiedFormat
             .WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Included)
@@ -45,746 +42,714 @@ internal class ComponentTagHelperDescriptorProvider : RazorEngineFeatureBase, IT
         }
 
         var targetSymbol = context.Items.GetTargetSymbol();
-        if (targetSymbol is not null)
-        {
-            CollectTagHelpers(targetSymbol, context.Results);
-        }
-        else
-        {
-            CollectTagHelpers(compilation.Assembly.GlobalNamespace, context.Results);
 
-            foreach (var reference in compilation.References)
-            {
-                if (compilation.GetAssemblyOrModuleSymbol(reference) is IAssemblySymbol assembly)
-                {
-                    TagHelperDescriptor[] tagHelpers;
-
-                    lock (s_perAssemblyTagHelperCache)
-                    {
-                        // Check to see if we already have tag helpers cached for this assembly
-                        // and use them cached versions if we do. Roslyn shares PE assembly symbols
-                        // across compilations, so this ensures that we don't produce new tag helpers
-                        // for the same assemblies over and over again.
-                        if (!s_perAssemblyTagHelperCache.TryGetValue(assembly, out tagHelpers))
-                        {
-                            using var _ = ListPool<TagHelperDescriptor>.GetPooledObject(out var referenceTagHelpers);
-                            CollectTagHelpers(assembly.GlobalNamespace, referenceTagHelpers);
-
-                            tagHelpers = referenceTagHelpers.ToArrayOrEmpty();
-
-                            s_perAssemblyTagHelperCache.Add(assembly, tagHelpers);
-                        }
-                    }
-
-                    foreach (var tagHelper in tagHelpers)
-                    {
-                        context.Results.Add(tagHelper);
-                    }
-                }
-            }
-        }
+        var collector = new Collector(compilation, targetSymbol);
+        collector.Collect(context.Results);
     }
 
-    private static void CollectTagHelpers(ISymbol symbol, ICollection<TagHelperDescriptor> results)
+    private sealed class Collector(Compilation compilation, ISymbol targetSymbol) : TagHelperCollector(compilation, targetSymbol)
     {
-        using var _ = ListPool<INamedTypeSymbol>.GetPooledObject(out var types);
-        var visitor = new ComponentTypeVisitor(types);
-
-        visitor.Visit(symbol);
-
-        foreach (var type in types)
+        protected override void Collect(ISymbol symbol, ICollection<TagHelperDescriptor> results)
         {
-            // Components have very simple matching rules.
-            // 1. The type name (short) matches the tag name.
-            // 2. The fully qualified name matches the tag name.
+            using var _ = ListPool<INamedTypeSymbol>.GetPooledObject(out var types);
+            var visitor = new ComponentTypeVisitor(types);
 
-            // First, compute the relevant properties for this type so that we
-            // don't need to compute them twice.
-            var properties = GetProperties(type);
+            visitor.Visit(symbol);
 
-            var shortNameMatchingDescriptor = CreateShortNameMatchingDescriptor(type, properties);
-            results.Add(shortNameMatchingDescriptor);
-
-            var fullyQualifiedNameMatchingDescriptor = CreateFullyQualifiedNameMatchingDescriptor(type, properties);
-            results.Add(fullyQualifiedNameMatchingDescriptor);
-
-            foreach (var childContent in shortNameMatchingDescriptor.GetChildContentProperties())
+            foreach (var type in types)
             {
-                // Synthesize a separate tag helper for each child content property that's declared.
-                results.Add(CreateChildContentDescriptor(shortNameMatchingDescriptor, childContent));
-                results.Add(CreateChildContentDescriptor(fullyQualifiedNameMatchingDescriptor, childContent));
-            }
-        }
-    }
+                // Components have very simple matching rules.
+                // 1. The type name (short) matches the tag name.
+                // 2. The fully qualified name matches the tag name.
 
-    private static TagHelperDescriptor CreateShortNameMatchingDescriptor(
-        INamedTypeSymbol type,
-        ImmutableArray<(IPropertySymbol property, PropertyKind kind)> properties)
-        => CreateNameMatchingDescriptor(type, properties, fullyQualified: false);
+                // First, compute the relevant properties for this type so that we
+                // don't need to compute them twice.
+                var properties = GetProperties(type);
 
-    private static TagHelperDescriptor CreateFullyQualifiedNameMatchingDescriptor(
-        INamedTypeSymbol type,
-        ImmutableArray<(IPropertySymbol property, PropertyKind kind)> properties)
-        => CreateNameMatchingDescriptor(type, properties, fullyQualified: true);
+                var shortNameMatchingDescriptor = CreateShortNameMatchingDescriptor(type, properties);
+                results.Add(shortNameMatchingDescriptor);
 
-    private static TagHelperDescriptor CreateNameMatchingDescriptor(
-        INamedTypeSymbol type,
-        ImmutableArray<(IPropertySymbol property, PropertyKind kind)> properties,
-        bool fullyQualified)
-    {
-        var typeName = type.ToDisplayString(SymbolExtensions.FullNameTypeDisplayFormat);
-        var assemblyName = type.ContainingAssembly.Identity.Name;
+                var fullyQualifiedNameMatchingDescriptor = CreateFullyQualifiedNameMatchingDescriptor(type, properties);
+                results.Add(fullyQualifiedNameMatchingDescriptor);
 
-        using var _ = TagHelperDescriptorBuilder.GetPooledInstance(
-            ComponentMetadata.Component.TagHelperKind, typeName, assemblyName, out var builder);
-
-        // This opts out this 'component' tag helper for any processing that's specific to the default
-        // Razor ITagHelper runtime.
-        using var metadata = builder.GetMetadataBuilder(ComponentMetadata.Component.RuntimeName);
-
-        metadata.Add(TypeName(typeName));
-        metadata.Add(TypeNamespace(type.ContainingNamespace.ToDisplayString(SymbolExtensions.FullNameTypeDisplayFormat)));
-        metadata.Add(TypeNameIdentifier(type.Name));
-
-        builder.CaseSensitive = true;
-
-        if (fullyQualified)
-        {
-            var containingNamespace = type.ContainingNamespace.ToDisplayString();
-            var fullName = $"{containingNamespace}.{type.Name}";
-
-            builder.TagMatchingRule(r =>
-            {
-                r.TagName = fullName;
-            });
-
-            metadata.Add(ComponentMetadata.Component.NameMatchKey, ComponentMetadata.Component.FullyQualifiedNameMatch);
-        }
-        else
-        {
-            builder.TagMatchingRule(r =>
-            {
-                r.TagName = type.Name;
-            });
-        }
-
-        if (type.IsGenericType)
-        {
-            metadata.Add(MakeTrue(ComponentMetadata.Component.GenericTypedKey));
-
-            using var cascadeGenericTypeAttributes = new PooledHashSet<string>(StringHashSetPool.Ordinal);
-
-            foreach (var attribute in type.GetAttributes())
-            {
-                if (attribute.AttributeClass.HasFullName(ComponentsApi.CascadingTypeParameterAttribute.MetadataName) &&
-                    attribute.ConstructorArguments.FirstOrDefault() is { Value: string value })
+                foreach (var childContent in shortNameMatchingDescriptor.GetChildContentProperties())
                 {
-                    cascadeGenericTypeAttributes.Add(value);
-                }
-            }
-
-            foreach (var typeArgument in type.TypeArguments)
-            {
-                if (typeArgument is ITypeParameterSymbol typeParameter)
-                {
-                    var cascade = cascadeGenericTypeAttributes.Contains(typeParameter.Name);
-                    CreateTypeParameterProperty(builder, typeParameter, cascade);
+                    // Synthesize a separate tag helper for each child content property that's declared.
+                    results.Add(CreateChildContentDescriptor(shortNameMatchingDescriptor, childContent));
+                    results.Add(CreateChildContentDescriptor(fullyQualifiedNameMatchingDescriptor, childContent));
                 }
             }
         }
 
-        if (HasRenderModeDirective(type))
-        {
-            metadata.Add(MakeTrue(ComponentMetadata.Component.HasRenderModeDirectiveKey));
-        }
+        private static TagHelperDescriptor CreateShortNameMatchingDescriptor(
+            INamedTypeSymbol type,
+            ImmutableArray<(IPropertySymbol property, PropertyKind kind)> properties)
+            => CreateNameMatchingDescriptor(type, properties, fullyQualified: false);
 
-        var xml = type.GetDocumentationCommentXml();
-        if (!string.IsNullOrEmpty(xml))
-        {
-            builder.SetDocumentation(xml);
-        }
+        private static TagHelperDescriptor CreateFullyQualifiedNameMatchingDescriptor(
+            INamedTypeSymbol type,
+            ImmutableArray<(IPropertySymbol property, PropertyKind kind)> properties)
+            => CreateNameMatchingDescriptor(type, properties, fullyQualified: true);
 
-        foreach (var (property, kind) in properties)
+        private static TagHelperDescriptor CreateNameMatchingDescriptor(
+            INamedTypeSymbol type,
+            ImmutableArray<(IPropertySymbol property, PropertyKind kind)> properties,
+            bool fullyQualified)
         {
-            if (kind == PropertyKind.Ignored)
+            var typeName = type.ToDisplayString(SymbolExtensions.FullNameTypeDisplayFormat);
+            var assemblyName = type.ContainingAssembly.Identity.Name;
+
+            using var _ = TagHelperDescriptorBuilder.GetPooledInstance(
+                ComponentMetadata.Component.TagHelperKind, typeName, assemblyName, out var builder);
+
+            // This opts out this 'component' tag helper for any processing that's specific to the default
+            // Razor ITagHelper runtime.
+            using var metadata = builder.GetMetadataBuilder(ComponentMetadata.Component.RuntimeName);
+
+            metadata.Add(TypeName(typeName));
+            metadata.Add(TypeNamespace(type.ContainingNamespace.ToDisplayString(SymbolExtensions.FullNameTypeDisplayFormat)));
+            metadata.Add(TypeNameIdentifier(type.Name));
+
+            builder.CaseSensitive = true;
+
+            if (fullyQualified)
             {
-                continue;
+                var containingNamespace = type.ContainingNamespace.ToDisplayString();
+                var fullName = $"{containingNamespace}.{type.Name}";
+
+                builder.TagMatchingRule(r =>
+                {
+                    r.TagName = fullName;
+                });
+
+                metadata.Add(ComponentMetadata.Component.NameMatchKey, ComponentMetadata.Component.FullyQualifiedNameMatch);
+            }
+            else
+            {
+                builder.TagMatchingRule(r =>
+                {
+                    r.TagName = type.Name;
+                });
             }
 
-            CreateProperty(builder, property, kind);
-        }
-
-        if (builder.BoundAttributes.Any(static a => a.IsParameterizedChildContentProperty()) &&
-            !builder.BoundAttributes.Any(static a => string.Equals(a.Name, ComponentMetadata.ChildContent.ParameterAttributeName, StringComparison.OrdinalIgnoreCase)))
-        {
-            // If we have any parameterized child content parameters, synthesize a 'Context' parameter to be
-            // able to set the variable name (for all child content). If the developer defined a 'Context' parameter
-            // already, then theirs wins.
-            CreateContextParameter(builder, childContentName: null);
-        }
-
-        builder.SetMetadata(metadata.Build());
-
-        return builder.Build();
-    }
-
-    private static void CreateProperty(TagHelperDescriptorBuilder builder, IPropertySymbol property, PropertyKind kind)
-    {
-        builder.BindAttribute(pb =>
-        {
-            using var metadata = new MetadataBuilder();
-
-            pb.Name = property.Name;
-            pb.TypeName = property.Type.ToDisplayString(SymbolExtensions.FullNameTypeDisplayFormat);
-            pb.IsEditorRequired = property.GetAttributes().Any(
-                static a => a.AttributeClass.HasFullName("Microsoft.AspNetCore.Components.EditorRequiredAttribute"));
-
-            metadata.Add(PropertyName(property.Name));
-            metadata.Add(GloballyQualifiedTypeName(property.Type.ToDisplayString(GloballyQualifiedFullNameTypeDisplayFormat)));
-
-            if (kind == PropertyKind.Enum)
-            {
-                pb.IsEnum = true;
-            }
-
-            if (kind == PropertyKind.ChildContent)
-            {
-                metadata.Add(MakeTrue(ComponentMetadata.Component.ChildContentKey));
-            }
-
-            if (kind == PropertyKind.EventCallback)
-            {
-                metadata.Add(MakeTrue(ComponentMetadata.Component.EventCallbackKey));
-            }
-
-            if (kind == PropertyKind.Delegate)
-            {
-                metadata.Add(MakeTrue(ComponentMetadata.Component.DelegateSignatureKey));
-                metadata.Add(ComponentMetadata.Component.DelegateWithAwaitableResultKey, IsAwaitable(property));
-            }
-
-            if (HasTypeParameter(property.Type))
+            if (type.IsGenericType)
             {
                 metadata.Add(MakeTrue(ComponentMetadata.Component.GenericTypedKey));
-            }
 
-            if (property.SetMethod.IsInitOnly)
-            {
-                metadata.Add(MakeTrue(ComponentMetadata.Component.InitOnlyProperty));
-            }
+                using var cascadeGenericTypeAttributes = new PooledHashSet<string>(StringHashSetPool.Ordinal);
 
-            pb.SetMetadata(metadata.Build());
-
-            var xml = property.GetDocumentationCommentXml();
-            if (!string.IsNullOrEmpty(xml))
-            {
-                pb.SetDocumentation(xml);
-            }
-        });
-
-        static bool HasTypeParameter(ITypeSymbol type)
-        {
-            if (type is ITypeParameterSymbol)
-            {
-                return true;
-            }
-
-            // We need to check for cases like:
-            // [Parameter] public List<T> MyProperty { get; set; }
-            // AND
-            // [Parameter] public List<string> MyProperty { get; set; }
-            //
-            // We need to inspect the type arguments to tell the difference between a property that
-            // uses the containing class' type parameter(s) and a vanilla usage of generic types like
-            // List<> and Dictionary<,>
-            //
-            // Since we need to handle cases like RenderFragment<List<T>>, this check must be recursive.
-            if (type is INamedTypeSymbol namedType && namedType.IsGenericType)
-            {
-                foreach (var typeArgument in namedType.TypeArguments)
+                foreach (var attribute in type.GetAttributes())
                 {
-                    if (HasTypeParameter(typeArgument))
+                    if (attribute.AttributeClass.HasFullName(ComponentsApi.CascadingTypeParameterAttribute.MetadataName) &&
+                        attribute.ConstructorArguments.FirstOrDefault() is { Value: string value })
                     {
-                        return true;
+                        cascadeGenericTypeAttributes.Add(value);
                     }
                 }
 
-                // Another case to handle - if the type being inspected is a nested type
-                // inside a generic containing class. The common usage for this would be a case
-                // where a generic templated component defines a 'context' nested class.
-                if (namedType.ContainingType != null && HasTypeParameter(namedType.ContainingType))
+                foreach (var typeArgument in type.TypeArguments)
+                {
+                    if (typeArgument is ITypeParameterSymbol typeParameter)
+                    {
+                        var cascade = cascadeGenericTypeAttributes.Contains(typeParameter.Name);
+                        CreateTypeParameterProperty(builder, typeParameter, cascade);
+                    }
+                }
+            }
+
+            if (HasRenderModeDirective(type))
+            {
+                metadata.Add(MakeTrue(ComponentMetadata.Component.HasRenderModeDirectiveKey));
+            }
+
+            var xml = type.GetDocumentationCommentXml();
+            if (!string.IsNullOrEmpty(xml))
+            {
+                builder.SetDocumentation(xml);
+            }
+
+            foreach (var (property, kind) in properties)
+            {
+                if (kind == PropertyKind.Ignored)
+                {
+                    continue;
+                }
+
+                CreateProperty(builder, property, kind);
+            }
+
+            if (builder.BoundAttributes.Any(static a => a.IsParameterizedChildContentProperty()) &&
+                !builder.BoundAttributes.Any(static a => string.Equals(a.Name, ComponentMetadata.ChildContent.ParameterAttributeName, StringComparison.OrdinalIgnoreCase)))
+            {
+                // If we have any parameterized child content parameters, synthesize a 'Context' parameter to be
+                // able to set the variable name (for all child content). If the developer defined a 'Context' parameter
+                // already, then theirs wins.
+                CreateContextParameter(builder, childContentName: null);
+            }
+
+            builder.SetMetadata(metadata.Build());
+
+            return builder.Build();
+        }
+
+        private static void CreateProperty(TagHelperDescriptorBuilder builder, IPropertySymbol property, PropertyKind kind)
+        {
+            builder.BindAttribute(pb =>
+            {
+                using var metadata = new MetadataBuilder();
+
+                pb.Name = property.Name;
+                pb.TypeName = property.Type.ToDisplayString(SymbolExtensions.FullNameTypeDisplayFormat);
+                pb.IsEditorRequired = property.GetAttributes().Any(
+                    static a => a.AttributeClass.HasFullName("Microsoft.AspNetCore.Components.EditorRequiredAttribute"));
+
+                metadata.Add(PropertyName(property.Name));
+                metadata.Add(GloballyQualifiedTypeName(property.Type.ToDisplayString(GloballyQualifiedFullNameTypeDisplayFormat)));
+
+                if (kind == PropertyKind.Enum)
+                {
+                    pb.IsEnum = true;
+                }
+
+                if (kind == PropertyKind.ChildContent)
+                {
+                    metadata.Add(MakeTrue(ComponentMetadata.Component.ChildContentKey));
+                }
+
+                if (kind == PropertyKind.EventCallback)
+                {
+                    metadata.Add(MakeTrue(ComponentMetadata.Component.EventCallbackKey));
+                }
+
+                if (kind == PropertyKind.Delegate)
+                {
+                    metadata.Add(MakeTrue(ComponentMetadata.Component.DelegateSignatureKey));
+                    metadata.Add(ComponentMetadata.Component.DelegateWithAwaitableResultKey, IsAwaitable(property));
+                }
+
+                if (HasTypeParameter(property.Type))
+                {
+                    metadata.Add(MakeTrue(ComponentMetadata.Component.GenericTypedKey));
+                }
+
+                if (property.SetMethod.IsInitOnly)
+                {
+                    metadata.Add(MakeTrue(ComponentMetadata.Component.InitOnlyProperty));
+                }
+
+                pb.SetMetadata(metadata.Build());
+
+                var xml = property.GetDocumentationCommentXml();
+                if (!string.IsNullOrEmpty(xml))
+                {
+                    pb.SetDocumentation(xml);
+                }
+            });
+
+            static bool HasTypeParameter(ITypeSymbol type)
+            {
+                if (type is ITypeParameterSymbol)
                 {
                     return true;
                 }
-            }
-            // Also check for cases like:
-            // [Parameter] public T[] MyProperty { get; set; }
-            else if (type is IArrayTypeSymbol array && HasTypeParameter(array.ElementType))
-            {
-                return true;
-            }
 
-            return false;
-        }
-    }
-
-    private static string IsAwaitable(IPropertySymbol prop)
-    {
-        var methodSymbol = ((INamedTypeSymbol)prop.Type).DelegateInvokeMethod;
-        if (methodSymbol.ReturnsVoid)
-        {
-            return bool.FalseString;
-        }
-        else
-        {
-            var members = methodSymbol.ReturnType.GetMembers();
-            foreach (var candidate in members)
-            {
-                if (candidate is not IMethodSymbol method || !string.Equals(candidate.Name, "GetAwaiter", StringComparison.Ordinal))
+                // We need to check for cases like:
+                // [Parameter] public List<T> MyProperty { get; set; }
+                // AND
+                // [Parameter] public List<string> MyProperty { get; set; }
+                //
+                // We need to inspect the type arguments to tell the difference between a property that
+                // uses the containing class' type parameter(s) and a vanilla usage of generic types like
+                // List<> and Dictionary<,>
+                //
+                // Since we need to handle cases like RenderFragment<List<T>>, this check must be recursive.
+                if (type is INamedTypeSymbol namedType && namedType.IsGenericType)
                 {
-                    continue;
-                }
-
-                if (!VerifyGetAwaiter(method))
-                {
-                    continue;
-                }
-
-                return bool.TrueString;
-            }
-
-            return methodSymbol.IsAsync ? bool.TrueString : bool.FalseString;
-
-            static bool VerifyGetAwaiter(IMethodSymbol getAwaiter)
-            {
-                var returnType = getAwaiter.ReturnType;
-                if (returnType == null)
-                {
-                    return false;
-                }
-
-
-                var foundIsCompleted = false;
-                var foundOnCompleted = false;
-                var foundGetResult = false;
-
-                foreach (var member in returnType.GetMembers())
-                {
-                    if (!foundIsCompleted &&
-                        member is IPropertySymbol property &&
-                        IsProperty_IsCompleted(property))
+                    foreach (var typeArgument in namedType.TypeArguments)
                     {
-                        foundIsCompleted = true;
-                    }
-
-                    if (!(foundOnCompleted && foundGetResult) && member is IMethodSymbol method)
-                    {
-                        if (IsMethod_OnCompleted(method))
+                        if (HasTypeParameter(typeArgument))
                         {
-                            foundOnCompleted = true;
-                        }
-                        else if (IsMethod_GetResult(method))
-                        {
-                            foundGetResult = true;
+                            return true;
                         }
                     }
 
-                    if (foundIsCompleted && foundOnCompleted && foundGetResult)
+                    // Another case to handle - if the type being inspected is a nested type
+                    // inside a generic containing class. The common usage for this would be a case
+                    // where a generic templated component defines a 'context' nested class.
+                    if (namedType.ContainingType != null && HasTypeParameter(namedType.ContainingType))
                     {
                         return true;
                     }
                 }
+                // Also check for cases like:
+                // [Parameter] public T[] MyProperty { get; set; }
+                else if (type is IArrayTypeSymbol array && HasTypeParameter(array.ElementType))
+                {
+                    return true;
+                }
 
                 return false;
+            }
+        }
 
-                static bool IsProperty_IsCompleted(IPropertySymbol property)
+        private static string IsAwaitable(IPropertySymbol prop)
+        {
+            var methodSymbol = ((INamedTypeSymbol)prop.Type).DelegateInvokeMethod;
+            if (methodSymbol.ReturnsVoid)
+            {
+                return bool.FalseString;
+            }
+            else
+            {
+                var members = methodSymbol.ReturnType.GetMembers();
+                foreach (var candidate in members)
                 {
-                    return property is
+                    if (candidate is not IMethodSymbol method || !string.Equals(candidate.Name, "GetAwaiter", StringComparison.Ordinal))
                     {
-                        Name: WellKnownMemberNames.IsCompleted,
-                        Type.SpecialType: SpecialType.System_Boolean,
-                        GetMethod: not null
-                    };
-                }
-
-                static bool IsMethod_OnCompleted(IMethodSymbol method)
-                {
-                    return method is
-                    {
-                        Name: WellKnownMemberNames.OnCompleted,
-                        ReturnsVoid: true,
-                        Parameters: [{ Type.TypeKind: TypeKind.Delegate }]
-                    };
-                }
-
-                static bool IsMethod_GetResult(IMethodSymbol method)
-                {
-                    return method is
-                    {
-                        Name: WellKnownMemberNames.GetResult,
-                        Parameters: []
-                    };
-                }
-            }
-        }
-    }
-
-    private static void CreateTypeParameterProperty(TagHelperDescriptorBuilder builder, ITypeParameterSymbol typeParameter, bool cascade)
-    {
-        builder.BindAttribute(pb =>
-        {
-            pb.DisplayName = typeParameter.Name;
-            pb.Name = typeParameter.Name;
-            pb.TypeName = typeof(Type).FullName;
-
-            using var _ = ListPool<KeyValuePair<string, string>>.GetPooledObject(out var metadataPairs);
-            metadataPairs.Add(PropertyName(typeParameter.Name));
-            metadataPairs.Add(MakeTrue(ComponentMetadata.Component.TypeParameterKey));
-            metadataPairs.Add(new(ComponentMetadata.Component.TypeParameterIsCascadingKey, cascade.ToString()));
-
-            // Type constraints (like "Image" or "Foo") are stored independently of
-            // things like constructor constraints and not null constraints in the
-            // type parameter so we create a single string representation of all the constraints
-            // here.
-            using var constraints = new PooledList<string>();
-
-            // CS0449: The 'class', 'struct', 'unmanaged', 'notnull', and 'default' constraints
-            // cannot be combined or duplicated, and must be specified first in the constraints list.
-            if (typeParameter.HasReferenceTypeConstraint)
-            {
-                constraints.Add("class");
-            }
-
-            if (typeParameter.HasNotNullConstraint)
-            {
-                constraints.Add("notnull");
-            }
-
-            if (typeParameter.HasUnmanagedTypeConstraint)
-            {
-                constraints.Add("unmanaged");
-            }
-            else if (typeParameter.HasValueTypeConstraint)
-            {
-                // `HasValueTypeConstraint` is also true when `unmanaged` constraint is present.
-                constraints.Add("struct");
-            }
-
-            foreach (var constraintType in typeParameter.ConstraintTypes)
-            {
-                constraints.Add(constraintType.ToDisplayString(GloballyQualifiedFullNameTypeDisplayFormat));
-            }
-
-            // CS0401: The new() constraint must be the last constraint specified.
-            if (typeParameter.HasConstructorConstraint)
-            {
-                constraints.Add("new()");
-            }
-
-            if (TryGetWhereClauseText(typeParameter, constraints, out var whereClauseText))
-            {
-                metadataPairs.Add(new(ComponentMetadata.Component.TypeParameterConstraintsKey, whereClauseText));
-            }
-
-            pb.SetMetadata(MetadataCollection.Create(metadataPairs));
-
-            pb.SetDocumentation(
-                DocumentationDescriptor.From(
-                    DocumentationId.ComponentTypeParameter,
-                    typeParameter.Name,
-                    builder.Name));
-        });
-
-        static bool TryGetWhereClauseText(ITypeParameterSymbol typeParameter, PooledList<string> constraints, [NotNullWhen(true)] out string constraintsText)
-        {
-            if (constraints.Count == 0)
-            {
-                constraintsText = null;
-                return false;
-            }
-
-            using var _ = StringBuilderPool.GetPooledObject(out var builder);
-
-            builder.Append("where ");
-            builder.Append(typeParameter.Name);
-            builder.Append(" : ");
-
-            var addComma = false;
-
-            foreach (var item in constraints)
-            {
-                if (addComma)
-                {
-                    builder.Append(", ");
-                }
-                else
-                {
-                    addComma = true;
-                }
-
-                builder.Append(item);
-            }
-
-            constraintsText = builder.ToString();
-            return true;
-        }
-    }
-
-    private static TagHelperDescriptor CreateChildContentDescriptor(TagHelperDescriptor component, BoundAttributeDescriptor attribute)
-    {
-        var typeName = component.GetTypeName() + "." + attribute.Name;
-        var assemblyName = component.AssemblyName;
-
-        using var _ = TagHelperDescriptorBuilder.GetPooledInstance(
-            ComponentMetadata.ChildContent.TagHelperKind, typeName, assemblyName,
-            out var builder);
-
-        // This opts out this 'component' tag helper for any processing that's specific to the default
-        // Razor ITagHelper runtime.
-        using var metadata = builder.GetMetadataBuilder(ComponentMetadata.ChildContent.RuntimeName);
-
-        metadata.Add(TypeName(typeName));
-        metadata.Add(TypeNamespace(component.GetTypeNamespace()));
-        metadata.Add(TypeNameIdentifier(component.GetTypeNameIdentifier()));
-
-        builder.CaseSensitive = true;
-
-        // Opt out of processing as a component. We'll process this specially as part of the component's body.
-        metadata.Add(SpecialKind(ComponentMetadata.ChildContent.TagHelperKind));
-
-        var xml = attribute.Documentation;
-        if (!string.IsNullOrEmpty(xml))
-        {
-            builder.SetDocumentation(xml);
-        }
-
-        // Child content matches the property name, but only as a direct child of the component.
-        builder.TagMatchingRule(r =>
-        {
-            r.TagName = attribute.Name;
-            r.ParentTag = component.TagMatchingRules[0].TagName;
-        });
-
-        if (attribute.IsParameterizedChildContentProperty())
-        {
-            // For child content attributes with a parameter, synthesize an attribute that allows you to name
-            // the parameter.
-            CreateContextParameter(builder, attribute.Name);
-        }
-
-        if (component.IsComponentFullyQualifiedNameMatch)
-        {
-            metadata.Add(ComponentMetadata.Component.NameMatchKey, ComponentMetadata.Component.FullyQualifiedNameMatch);
-        }
-
-        builder.SetMetadata(metadata.Build());
-
-        var descriptor = builder.Build();
-
-        return descriptor;
-    }
-
-    private static void CreateContextParameter(TagHelperDescriptorBuilder builder, string childContentName)
-    {
-        builder.BindAttribute(b =>
-        {
-            b.Name = ComponentMetadata.ChildContent.ParameterAttributeName;
-            b.TypeName = typeof(string).FullName;
-            b.SetMetadata(
-                MakeTrue(ComponentMetadata.Component.ChildContentParameterNameKey),
-                PropertyName(b.Name));
-
-            var documentation = childContentName == null
-                ? DocumentationDescriptor.ChildContentParameterName_TopLevel
-                : DocumentationDescriptor.From(DocumentationId.ChildContentParameterName, childContentName);
-
-            b.SetDocumentation(documentation);
-        });
-    }
-
-    // Does a walk up the inheritance chain to determine the set of parameters by using
-    // a dictionary keyed on property name.
-    //
-    // We consider parameters to be defined by properties satisfying all of the following:
-    // - are public
-    // - are visible (not shadowed)
-    // - have the [Parameter] attribute
-    // - have a setter, even if private
-    // - are not indexers
-    private static ImmutableArray<(IPropertySymbol property, PropertyKind kind)> GetProperties(INamedTypeSymbol type)
-    {
-        using var names = new PooledHashSet<string>(StringHashSetPool.Ordinal);
-        using var results = new PooledArrayBuilder<(IPropertySymbol, PropertyKind)>();
-
-        do
-        {
-            if (type.HasFullName(ComponentsApi.ComponentBase.MetadataName))
-            {
-                // The ComponentBase base class doesn't have any [Parameter].
-                // Bail out now to avoid walking through its many members, plus the members
-                // of the System.Object base class.
-                break;
-            }
-
-            foreach (var member in type.GetMembers())
-            {
-                if (member is not IPropertySymbol property)
-                {
-                    // Not a property
-                    continue;
-                }
-
-                if (names.Contains(property.Name))
-                {
-                    // Not visible
-                    continue;
-                }
-
-                var kind = PropertyKind.Default;
-                if (property.DeclaredAccessibility != Accessibility.Public)
-                {
-                    // Not public
-                    kind = PropertyKind.Ignored;
-                }
-
-                if (property.Parameters.Length != 0)
-                {
-                    // Indexer
-                    kind = PropertyKind.Ignored;
-                }
-
-                if (property.SetMethod == null)
-                {
-                    // No setter
-                    kind = PropertyKind.Ignored;
-                }
-                else if (property.SetMethod.DeclaredAccessibility != Accessibility.Public)
-                {
-                    // No public setter
-                    kind = PropertyKind.Ignored;
-                }
-
-                if (property.IsStatic)
-                {
-                    kind = PropertyKind.Ignored;
-                }
-
-                if (!property.GetAttributes().Any(static a => a.AttributeClass.HasFullName(ComponentsApi.ParameterAttribute.MetadataName)))
-                {
-                    if (property.IsOverride)
-                    {
-                        // This property does not contain [Parameter] attribute but it was overridden. Don't ignore it for now.
-                        // We can ignore it if the base class does not contains a [Parameter] as well.
                         continue;
                     }
 
-                    // Does not have [Parameter]
-                    kind = PropertyKind.Ignored;
-                }
-
-                if (kind == PropertyKind.Default)
-                {
-                    kind = property switch
+                    if (!VerifyGetAwaiter(method))
                     {
-                        var p when IsEnum(p) => PropertyKind.Enum,
-                        var p when IsRenderFragment(p) => PropertyKind.ChildContent,
-                        var p when IsEventCallback(p) => PropertyKind.EventCallback,
-                        var p when IsDelegate(p) => PropertyKind.Delegate,
-                        _ => PropertyKind.Default
-                    };
+                        continue;
+                    }
+
+                    return bool.TrueString;
                 }
 
-                names.Add(property.Name);
-                results.Add((property, kind));
-            }
+                return methodSymbol.IsAsync ? bool.TrueString : bool.FalseString;
 
-            type = type.BaseType;
-        }
-        while (type != null);
-
-        return results.DrainToImmutable();
-
-        static bool IsEnum(IPropertySymbol property)
-        {
-            return property.Type.TypeKind == TypeKind.Enum;
-        }
-
-        static bool IsRenderFragment(IPropertySymbol property)
-        {
-            return property.Type.HasFullName(ComponentsApi.RenderFragment.MetadataName) ||
-                  (property.Type is INamedTypeSymbol { IsGenericType: true } namedType &&
-                   namedType.ConstructedFrom.HasFullName(ComponentsApi.RenderFragmentOfT.DisplayName));
-        }
-
-        static bool IsEventCallback(IPropertySymbol property)
-        {
-            return property.Type.HasFullName(ComponentsApi.EventCallback.MetadataName) ||
-                  (property.Type is INamedTypeSymbol { IsGenericType: true } namedType &&
-                   namedType.ConstructedFrom.HasFullName(ComponentsApi.EventCallbackOfT.DisplayName));
-        }
-
-        static bool IsDelegate(IPropertySymbol property)
-        {
-            return property.Type.TypeKind == TypeKind.Delegate;
-        }
-    }
-
-    private static bool HasRenderModeDirective(INamedTypeSymbol type)
-    {
-        var attributes = type.GetAttributes();
-        foreach (var attribute in attributes)
-        {
-            var attributeClass = attribute.AttributeClass;
-            while (attributeClass is not null)
-            {
-                if (attributeClass.HasFullName(ComponentsApi.RenderModeAttribute.FullTypeName))
+                static bool VerifyGetAwaiter(IMethodSymbol getAwaiter)
                 {
-                    return true;
+                    var returnType = getAwaiter.ReturnType;
+                    if (returnType == null)
+                    {
+                        return false;
+                    }
+
+
+                    var foundIsCompleted = false;
+                    var foundOnCompleted = false;
+                    var foundGetResult = false;
+
+                    foreach (var member in returnType.GetMembers())
+                    {
+                        if (!foundIsCompleted &&
+                            member is IPropertySymbol property &&
+                            IsProperty_IsCompleted(property))
+                        {
+                            foundIsCompleted = true;
+                        }
+
+                        if (!(foundOnCompleted && foundGetResult) && member is IMethodSymbol method)
+                        {
+                            if (IsMethod_OnCompleted(method))
+                            {
+                                foundOnCompleted = true;
+                            }
+                            else if (IsMethod_GetResult(method))
+                            {
+                                foundGetResult = true;
+                            }
+                        }
+
+                        if (foundIsCompleted && foundOnCompleted && foundGetResult)
+                        {
+                            return true;
+                        }
+                    }
+
+                    return false;
+
+                    static bool IsProperty_IsCompleted(IPropertySymbol property)
+                    {
+                        return property is
+                        {
+                            Name: WellKnownMemberNames.IsCompleted,
+                            Type.SpecialType: SpecialType.System_Boolean,
+                            GetMethod: not null
+                        };
+                    }
+
+                    static bool IsMethod_OnCompleted(IMethodSymbol method)
+                    {
+                        return method is
+                        {
+                            Name: WellKnownMemberNames.OnCompleted,
+                            ReturnsVoid: true,
+                            Parameters: [{ Type.TypeKind: TypeKind.Delegate }]
+                        };
+                    }
+
+                    static bool IsMethod_GetResult(IMethodSymbol method)
+                    {
+                        return method is
+                        {
+                            Name: WellKnownMemberNames.GetResult,
+                            Parameters: []
+                        };
+                    }
+                }
+            }
+        }
+
+        private static void CreateTypeParameterProperty(TagHelperDescriptorBuilder builder, ITypeParameterSymbol typeParameter, bool cascade)
+        {
+            builder.BindAttribute(pb =>
+            {
+                pb.DisplayName = typeParameter.Name;
+                pb.Name = typeParameter.Name;
+                pb.TypeName = typeof(Type).FullName;
+
+                using var _ = ListPool<KeyValuePair<string, string>>.GetPooledObject(out var metadataPairs);
+                metadataPairs.Add(PropertyName(typeParameter.Name));
+                metadataPairs.Add(MakeTrue(ComponentMetadata.Component.TypeParameterKey));
+                metadataPairs.Add(new(ComponentMetadata.Component.TypeParameterIsCascadingKey, cascade.ToString()));
+
+                // Type constraints (like "Image" or "Foo") are stored independently of
+                // things like constructor constraints and not null constraints in the
+                // type parameter so we create a single string representation of all the constraints
+                // here.
+                using var constraints = new PooledList<string>();
+
+                // CS0449: The 'class', 'struct', 'unmanaged', 'notnull', and 'default' constraints
+                // cannot be combined or duplicated, and must be specified first in the constraints list.
+                if (typeParameter.HasReferenceTypeConstraint)
+                {
+                    constraints.Add("class");
                 }
 
-                attributeClass = attributeClass.BaseType;
+                if (typeParameter.HasNotNullConstraint)
+                {
+                    constraints.Add("notnull");
+                }
+
+                if (typeParameter.HasUnmanagedTypeConstraint)
+                {
+                    constraints.Add("unmanaged");
+                }
+                else if (typeParameter.HasValueTypeConstraint)
+                {
+                    // `HasValueTypeConstraint` is also true when `unmanaged` constraint is present.
+                    constraints.Add("struct");
+                }
+
+                foreach (var constraintType in typeParameter.ConstraintTypes)
+                {
+                    constraints.Add(constraintType.ToDisplayString(GloballyQualifiedFullNameTypeDisplayFormat));
+                }
+
+                // CS0401: The new() constraint must be the last constraint specified.
+                if (typeParameter.HasConstructorConstraint)
+                {
+                    constraints.Add("new()");
+                }
+
+                if (TryGetWhereClauseText(typeParameter, constraints, out var whereClauseText))
+                {
+                    metadataPairs.Add(new(ComponentMetadata.Component.TypeParameterConstraintsKey, whereClauseText));
+                }
+
+                pb.SetMetadata(MetadataCollection.Create(metadataPairs));
+
+                pb.SetDocumentation(
+                    DocumentationDescriptor.From(
+                        DocumentationId.ComponentTypeParameter,
+                        typeParameter.Name,
+                        builder.Name));
+            });
+
+            static bool TryGetWhereClauseText(ITypeParameterSymbol typeParameter, PooledList<string> constraints, [NotNullWhen(true)] out string constraintsText)
+            {
+                if (constraints.Count == 0)
+                {
+                    constraintsText = null;
+                    return false;
+                }
+
+                using var _ = StringBuilderPool.GetPooledObject(out var builder);
+
+                builder.Append("where ");
+                builder.Append(typeParameter.Name);
+                builder.Append(" : ");
+
+                var addComma = false;
+
+                foreach (var item in constraints)
+                {
+                    if (addComma)
+                    {
+                        builder.Append(", ");
+                    }
+                    else
+                    {
+                        addComma = true;
+                    }
+
+                    builder.Append(item);
+                }
+
+                constraintsText = builder.ToString();
+                return true;
             }
         }
-        return false;
-    }
 
-    private enum PropertyKind
-    {
-        Ignored,
-        Default,
-        Enum,
-        ChildContent,
-        Delegate,
-        EventCallback,
-    }
-
-    private class ComponentTypeVisitor(List<INamedTypeSymbol> results) : SymbolVisitor
-    {
-        private readonly List<INamedTypeSymbol> _results = results;
-
-        public override void VisitNamedType(INamedTypeSymbol symbol)
+        private static TagHelperDescriptor CreateChildContentDescriptor(TagHelperDescriptor component, BoundAttributeDescriptor attribute)
         {
-            if (ComponentDetectionConventions.IsComponent(symbol, ComponentsApi.IComponent.MetadataName))
+            var typeName = component.GetTypeName() + "." + attribute.Name;
+            var assemblyName = component.AssemblyName;
+
+            using var _ = TagHelperDescriptorBuilder.GetPooledInstance(
+                ComponentMetadata.ChildContent.TagHelperKind, typeName, assemblyName,
+                out var builder);
+
+            // This opts out this 'component' tag helper for any processing that's specific to the default
+            // Razor ITagHelper runtime.
+            using var metadata = builder.GetMetadataBuilder(ComponentMetadata.ChildContent.RuntimeName);
+
+            metadata.Add(TypeName(typeName));
+            metadata.Add(TypeNamespace(component.GetTypeNamespace()));
+            metadata.Add(TypeNameIdentifier(component.GetTypeNameIdentifier()));
+
+            builder.CaseSensitive = true;
+
+            // Opt out of processing as a component. We'll process this specially as part of the component's body.
+            metadata.Add(SpecialKind(ComponentMetadata.ChildContent.TagHelperKind));
+
+            var xml = attribute.Documentation;
+            if (!string.IsNullOrEmpty(xml))
             {
-                _results.Add(symbol);
+                builder.SetDocumentation(xml);
+            }
+
+            // Child content matches the property name, but only as a direct child of the component.
+            builder.TagMatchingRule(r =>
+            {
+                r.TagName = attribute.Name;
+                r.ParentTag = component.TagMatchingRules[0].TagName;
+            });
+
+            if (attribute.IsParameterizedChildContentProperty())
+            {
+                // For child content attributes with a parameter, synthesize an attribute that allows you to name
+                // the parameter.
+                CreateContextParameter(builder, attribute.Name);
+            }
+
+            if (component.IsComponentFullyQualifiedNameMatch)
+            {
+                metadata.Add(ComponentMetadata.Component.NameMatchKey, ComponentMetadata.Component.FullyQualifiedNameMatch);
+            }
+
+            builder.SetMetadata(metadata.Build());
+
+            var descriptor = builder.Build();
+
+            return descriptor;
+        }
+
+        private static void CreateContextParameter(TagHelperDescriptorBuilder builder, string childContentName)
+        {
+            builder.BindAttribute(b =>
+            {
+                b.Name = ComponentMetadata.ChildContent.ParameterAttributeName;
+                b.TypeName = typeof(string).FullName;
+                b.SetMetadata(
+                    MakeTrue(ComponentMetadata.Component.ChildContentParameterNameKey),
+                    PropertyName(b.Name));
+
+                var documentation = childContentName == null
+                    ? DocumentationDescriptor.ChildContentParameterName_TopLevel
+                    : DocumentationDescriptor.From(DocumentationId.ChildContentParameterName, childContentName);
+
+                b.SetDocumentation(documentation);
+            });
+        }
+
+        // Does a walk up the inheritance chain to determine the set of parameters by using
+        // a dictionary keyed on property name.
+        //
+        // We consider parameters to be defined by properties satisfying all of the following:
+        // - are public
+        // - are visible (not shadowed)
+        // - have the [Parameter] attribute
+        // - have a setter, even if private
+        // - are not indexers
+        private static ImmutableArray<(IPropertySymbol property, PropertyKind kind)> GetProperties(INamedTypeSymbol type)
+        {
+            using var names = new PooledHashSet<string>(StringHashSetPool.Ordinal);
+            using var results = new PooledArrayBuilder<(IPropertySymbol, PropertyKind)>();
+
+            do
+            {
+                if (type.HasFullName(ComponentsApi.ComponentBase.MetadataName))
+                {
+                    // The ComponentBase base class doesn't have any [Parameter].
+                    // Bail out now to avoid walking through its many members, plus the members
+                    // of the System.Object base class.
+                    break;
+                }
+
+                foreach (var member in type.GetMembers())
+                {
+                    if (member is not IPropertySymbol property)
+                    {
+                        // Not a property
+                        continue;
+                    }
+
+                    if (names.Contains(property.Name))
+                    {
+                        // Not visible
+                        continue;
+                    }
+
+                    var kind = PropertyKind.Default;
+                    if (property.DeclaredAccessibility != Accessibility.Public)
+                    {
+                        // Not public
+                        kind = PropertyKind.Ignored;
+                    }
+
+                    if (property.Parameters.Length != 0)
+                    {
+                        // Indexer
+                        kind = PropertyKind.Ignored;
+                    }
+
+                    if (property.SetMethod == null)
+                    {
+                        // No setter
+                        kind = PropertyKind.Ignored;
+                    }
+                    else if (property.SetMethod.DeclaredAccessibility != Accessibility.Public)
+                    {
+                        // No public setter
+                        kind = PropertyKind.Ignored;
+                    }
+
+                    if (property.IsStatic)
+                    {
+                        kind = PropertyKind.Ignored;
+                    }
+
+                    if (!property.GetAttributes().Any(static a => a.AttributeClass.HasFullName(ComponentsApi.ParameterAttribute.MetadataName)))
+                    {
+                        if (property.IsOverride)
+                        {
+                            // This property does not contain [Parameter] attribute but it was overridden. Don't ignore it for now.
+                            // We can ignore it if the base class does not contains a [Parameter] as well.
+                            continue;
+                        }
+
+                        // Does not have [Parameter]
+                        kind = PropertyKind.Ignored;
+                    }
+
+                    if (kind == PropertyKind.Default)
+                    {
+                        kind = property switch
+                        {
+                            var p when IsEnum(p) => PropertyKind.Enum,
+                            var p when IsRenderFragment(p) => PropertyKind.ChildContent,
+                            var p when IsEventCallback(p) => PropertyKind.EventCallback,
+                            var p when IsDelegate(p) => PropertyKind.Delegate,
+                            _ => PropertyKind.Default
+                        };
+                    }
+
+                    names.Add(property.Name);
+                    results.Add((property, kind));
+                }
+
+                type = type.BaseType;
+            }
+            while (type != null);
+
+            return results.DrainToImmutable();
+
+            static bool IsEnum(IPropertySymbol property)
+            {
+                return property.Type.TypeKind == TypeKind.Enum;
+            }
+
+            static bool IsRenderFragment(IPropertySymbol property)
+            {
+                return property.Type.HasFullName(ComponentsApi.RenderFragment.MetadataName) ||
+                      (property.Type is INamedTypeSymbol { IsGenericType: true } namedType &&
+                       namedType.ConstructedFrom.HasFullName(ComponentsApi.RenderFragmentOfT.DisplayName));
+            }
+
+            static bool IsEventCallback(IPropertySymbol property)
+            {
+                return property.Type.HasFullName(ComponentsApi.EventCallback.MetadataName) ||
+                      (property.Type is INamedTypeSymbol { IsGenericType: true } namedType &&
+                       namedType.ConstructedFrom.HasFullName(ComponentsApi.EventCallbackOfT.DisplayName));
+            }
+
+            static bool IsDelegate(IPropertySymbol property)
+            {
+                return property.Type.TypeKind == TypeKind.Delegate;
             }
         }
 
-        public override void VisitNamespace(INamespaceSymbol symbol)
+        private static bool HasRenderModeDirective(INamedTypeSymbol type)
         {
-            foreach (var member in symbol.GetMembers())
+            var attributes = type.GetAttributes();
+            foreach (var attribute in attributes)
             {
-                Visit(member);
+                var attributeClass = attribute.AttributeClass;
+                while (attributeClass is not null)
+                {
+                    if (attributeClass.HasFullName(ComponentsApi.RenderModeAttribute.FullTypeName))
+                    {
+                        return true;
+                    }
+
+                    attributeClass = attributeClass.BaseType;
+                }
             }
+            return false;
         }
 
-        public override void VisitAssembly(IAssemblySymbol symbol)
+        private enum PropertyKind
         {
-            // This as a simple yet high-value optimization that excludes the vast majority of
-            // assemblies that (by definition) can't contain a component.
-            if (symbol.Name != null && !symbol.Name.StartsWith("System.", StringComparison.Ordinal))
+            Ignored,
+            Default,
+            Enum,
+            ChildContent,
+            Delegate,
+            EventCallback,
+        }
+
+        private class ComponentTypeVisitor(List<INamedTypeSymbol> results) : SymbolVisitor
+        {
+            private readonly List<INamedTypeSymbol> _results = results;
+
+            public override void VisitNamedType(INamedTypeSymbol symbol)
             {
-                Visit(symbol.GlobalNamespace);
+                if (ComponentDetectionConventions.IsComponent(symbol, ComponentsApi.IComponent.MetadataName))
+                {
+                    _results.Add(symbol);
+                }
+            }
+
+            public override void VisitNamespace(INamespaceSymbol symbol)
+            {
+                foreach (var member in symbol.GetMembers())
+                {
+                    Visit(member);
+                }
+            }
+
+            public override void VisitAssembly(IAssemblySymbol symbol)
+            {
+                // This as a simple yet high-value optimization that excludes the vast majority of
+                // assemblies that (by definition) can't contain a component.
+                if (symbol.Name != null && !symbol.Name.StartsWith("System.", StringComparison.Ordinal))
+                {
+                    Visit(symbol.GlobalNamespace);
+                }
             }
         }
     }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/DefaultTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/DefaultTagHelperDescriptorProvider.cs
@@ -38,7 +38,7 @@ public sealed class DefaultTagHelperDescriptorProvider : RazorEngineFeatureBase,
         var targetSymbol = context.Items.GetTargetSymbol();
         var factory = new DefaultTagHelperDescriptorFactory(compilation, context.IncludeDocumentation, context.ExcludeHidden);
         var collector = new Collector(compilation, targetSymbol, factory, tagHelperTypeSymbol);
-        collector.Collect(context.Results);
+        collector.Collect(context);
     }
 
     private class Collector(

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/DefaultTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/DefaultTagHelperDescriptorProvider.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 
@@ -27,52 +28,42 @@ public sealed class DefaultTagHelperDescriptorProvider : RazorEngineFeatureBase,
             return;
         }
 
-        var iTagHelper = compilation.GetTypeByMetadataName(TagHelperTypes.ITagHelper);
-        if (iTagHelper == null || iTagHelper.TypeKind == TypeKind.Error)
+        var tagHelperTypeSymbol = compilation.GetTypeByMetadataName(TagHelperTypes.ITagHelper);
+        if (tagHelperTypeSymbol == null || tagHelperTypeSymbol.TypeKind == TypeKind.Error)
         {
             // Could not find attributes we care about in the compilation. Nothing to do.
             return;
         }
 
-        using var _ = ListPool<INamedTypeSymbol>.GetPooledObject(out var types);
-        var visitor = new TagHelperTypeVisitor(iTagHelper, types);
-
         var targetSymbol = context.Items.GetTargetSymbol();
-        if (targetSymbol is not null)
-        {
-            visitor.Visit(targetSymbol);
-        }
-        else
-        {
-            visitor.Visit(compilation.Assembly.GlobalNamespace);
+        var factory = new DefaultTagHelperDescriptorFactory(compilation, context.IncludeDocumentation, context.ExcludeHidden);
+        var collector = new Collector(compilation, targetSymbol, factory, tagHelperTypeSymbol);
+        collector.Collect(context.Results);
+    }
 
-            foreach (var reference in compilation.References)
+    private class Collector(
+        Compilation compilation, ISymbol targetSymbol, DefaultTagHelperDescriptorFactory factory, INamedTypeSymbol tagHelperTypeSymbol)
+        : TagHelperCollector<DefaultTagHelperDescriptorProvider>(compilation, targetSymbol)
+    {
+        private readonly DefaultTagHelperDescriptorFactory _factory = factory;
+        private readonly INamedTypeSymbol _tagHelperTypeSymbol = tagHelperTypeSymbol;
+
+        protected override void Collect(ISymbol symbol, ICollection<TagHelperDescriptor> results)
+        {
+            using var _ = ListPool<INamedTypeSymbol>.GetPooledObject(out var types);
+            var visitor = new TagHelperTypeVisitor(_tagHelperTypeSymbol, types);
+
+            visitor.Visit(symbol);
+
+            foreach (var type in types)
             {
-                if (compilation.GetAssemblyOrModuleSymbol(reference) is IAssemblySymbol assembly)
+                var descriptor = _factory.CreateDescriptor(type);
+
+                if (descriptor != null)
                 {
-                    if (IsTagHelperAssembly(assembly))
-                    {
-                        visitor.Visit(assembly.GlobalNamespace);
-                    }
+                    results.Add(descriptor);
                 }
             }
         }
-
-        var factory = new DefaultTagHelperDescriptorFactory(compilation, context.IncludeDocumentation, context.ExcludeHidden);
-
-        foreach (var type in types)
-        {
-            var descriptor = factory.CreateDescriptor(type);
-
-            if (descriptor != null)
-            {
-                context.Results.Add(descriptor);
-            }
-        }
-    }
-
-    private static bool IsTagHelperAssembly(IAssemblySymbol assembly)
-    {
-        return assembly.Name != null && !assembly.Name.StartsWith("System.", StringComparison.Ordinal);
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/DefaultTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/DefaultTagHelperDescriptorProvider.cs
@@ -43,7 +43,7 @@ public sealed class DefaultTagHelperDescriptorProvider : RazorEngineFeatureBase,
 
     private class Collector(
         Compilation compilation, ISymbol targetSymbol, DefaultTagHelperDescriptorFactory factory, INamedTypeSymbol tagHelperTypeSymbol)
-        : TagHelperCollector<DefaultTagHelperDescriptorProvider>(compilation, targetSymbol)
+        : TagHelperCollector<Collector>(compilation, targetSymbol)
     {
         private readonly DefaultTagHelperDescriptorFactory _factory = factory;
         private readonly INamedTypeSymbol _tagHelperTypeSymbol = tagHelperTypeSymbol;

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/EventHandlerTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/EventHandlerTagHelperDescriptorProvider.cs
@@ -44,7 +44,7 @@ internal class EventHandlerTagHelperDescriptorProvider : ITagHelperDescriptorPro
     }
 
     private class Collector(Compilation compilation, ISymbol targetSymbol, INamedTypeSymbol eventHandlerAttribute)
-        : TagHelperCollector<EventHandlerTagHelperDescriptorProvider>(compilation, targetSymbol)
+        : TagHelperCollector<Collector>(compilation, targetSymbol)
     {
         private readonly INamedTypeSymbol _eventHandlerAttribute = eventHandlerAttribute;
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/EventHandlerTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/EventHandlerTagHelperDescriptorProvider.cs
@@ -40,7 +40,7 @@ internal class EventHandlerTagHelperDescriptorProvider : ITagHelperDescriptorPro
         var targetSymbol = context.Items.GetTargetSymbol();
 
         var collector = new Collector(compilation, targetSymbol, eventHandlerAttribute);
-        collector.Collect(context.Results);
+        collector.Collect(context);
     }
 
     private class Collector(Compilation compilation, ISymbol targetSymbol, INamedTypeSymbol eventHandlerAttribute)

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/EventHandlerTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/EventHandlerTagHelperDescriptorProvider.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.PooledObjects;
@@ -38,111 +37,90 @@ internal class EventHandlerTagHelperDescriptorProvider : ITagHelperDescriptorPro
             return;
         }
 
-        var eventHandlerData = GetEventHandlerData(context, compilation, eventHandlerAttribute);
-
-        foreach (var tagHelper in CreateEventHandlerTagHelpers(eventHandlerData))
-        {
-            context.Results.Add(tagHelper);
-        }
-    }
-
-    private static ImmutableArray<EventHandlerData> GetEventHandlerData(TagHelperDescriptorProviderContext context, Compilation compilation, INamedTypeSymbol eventHandlerAttribute)
-    {
-        using var _ = ListPool<INamedTypeSymbol>.GetPooledObject(out var types);
-        var visitor = new EventHandlerDataVisitor(types);
-
         var targetSymbol = context.Items.GetTargetSymbol();
-        if (targetSymbol is not null)
+
+        var collector = new Collector(compilation, targetSymbol, eventHandlerAttribute);
+        collector.Collect(context.Results);
+    }
+
+    private class Collector(Compilation compilation, ISymbol targetSymbol, INamedTypeSymbol eventHandlerAttribute)
+        : TagHelperCollector<EventHandlerTagHelperDescriptorProvider>(compilation, targetSymbol)
+    {
+        private readonly INamedTypeSymbol _eventHandlerAttribute = eventHandlerAttribute;
+
+        protected override void Collect(ISymbol symbol, ICollection<TagHelperDescriptor> results)
         {
-            visitor.Visit(targetSymbol);
-        }
-        else
-        {
-            visitor.Visit(compilation.Assembly.GlobalNamespace);
-            foreach (var reference in compilation.References)
+            using var _ = ListPool<INamedTypeSymbol>.GetPooledObject(out var types);
+            var visitor = new EventHandlerDataVisitor(types);
+
+            visitor.Visit(symbol);
+
+            foreach (var type in types)
             {
-                if (compilation.GetAssemblyOrModuleSymbol(reference) is IAssemblySymbol assembly)
+                // Create helper to delay computing display names for this type when we need them.
+                var displayNames = new DisplayNameHelper(type);
+
+                // Not handling duplicates here for now since we're the primary ones extending this.
+                // If we see users adding to the set of event handler constructs we will want to add deduplication
+                // and potentially diagnostics.
+                foreach (var attribute in type.GetAttributes())
                 {
-                    visitor.Visit(assembly.GlobalNamespace);
-                }
-            }
-        }
-
-        using var results = new PooledArrayBuilder<EventHandlerData>();
-
-        foreach (var type in types)
-        {
-            // Create helper to delay computing display names for this type when we need them.
-            var displayNames = new DisplayNameHelper(type);
-
-            // Not handling duplicates here for now since we're the primary ones extending this.
-            // If we see users adding to the set of event handler constructs we will want to add deduplication
-            // and potentially diagnostics.
-            foreach (var attribute in type.GetAttributes())
-            {
-                if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, eventHandlerAttribute))
-                {
-                    var enablePreventDefault = false;
-                    var enableStopPropagation = false;
-                    if (attribute.ConstructorArguments.Length == 4)
+                    if (SymbolEqualityComparer.Default.Equals(attribute.AttributeClass, _eventHandlerAttribute))
                     {
-                        enablePreventDefault = (bool)attribute.ConstructorArguments[2].Value;
-                        enableStopPropagation = (bool)attribute.ConstructorArguments[3].Value;
+                        var enablePreventDefault = false;
+                        var enableStopPropagation = false;
+                        if (attribute.ConstructorArguments.Length == 4)
+                        {
+                            enablePreventDefault = (bool)attribute.ConstructorArguments[2].Value;
+                            enableStopPropagation = (bool)attribute.ConstructorArguments[3].Value;
+                        }
+
+                        var (typeName, namespaceName) = displayNames.GetNames();
+                        var constructorArguments = attribute.ConstructorArguments;
+
+                        results.Add(CreateTagHelper(
+                            typeName,
+                            namespaceName,
+                            type.Name,
+                            (string)constructorArguments[0].Value,
+                            (INamedTypeSymbol)constructorArguments[1].Value,
+                            enablePreventDefault,
+                            enableStopPropagation));
                     }
-
-                    var (assemblyName, typeName, namespaceName) = displayNames.GetNames();
-                    var constructorArguments = attribute.ConstructorArguments;
-
-                    results.Add(new EventHandlerData(
-                        assemblyName,
-                        typeName,
-                        namespaceName,
-                        type.Name,
-                        (string)constructorArguments[0].Value,
-                        (INamedTypeSymbol)constructorArguments[1].Value,
-                        enablePreventDefault,
-                        enableStopPropagation));
                 }
             }
         }
 
-        return results.DrainToImmutable();
-    }
-
-    /// <summary>
-    ///  Helper to avoid computing various type-based names until necessary.
-    /// </summary>
-    private ref struct DisplayNameHelper
-    {
-        private readonly INamedTypeSymbol _type;
-        private (string Assembly, string Type, string Namespace)? _names;
-
-        public DisplayNameHelper(INamedTypeSymbol type)
+        /// <summary>
+        ///  Helper to avoid computing various type-based names until necessary.
+        /// </summary>
+        private ref struct DisplayNameHelper(INamedTypeSymbol type)
         {
-            _type = type;
+            private readonly INamedTypeSymbol _type = type;
+            private (string Type, string Namespace)? _names;
+
+            public (string Type, string Namespace) GetNames()
+            {
+                _names ??= (_type.ToDisplayString(), _type.ContainingNamespace.ToDisplayString());
+
+                return _names.GetValueOrDefault();
+            }
         }
 
-        public (string Assembly, string Type, string Namespace) GetNames()
+        private static TagHelperDescriptor CreateTagHelper(
+            string typeName,
+            string typeNamespace,
+            string typeNameIdentifier,
+            string attribute,
+            INamedTypeSymbol eventArgsType,
+            bool enablePreventDefault,
+            bool enableStopPropagation)
         {
-            _names ??= (_type.ContainingAssembly.Name, _type.ToDisplayString(), _type.ContainingNamespace.ToDisplayString());
-
-            return _names.GetValueOrDefault();
-        }
-    }
-
-    private static ImmutableArray<TagHelperDescriptor> CreateEventHandlerTagHelpers(ImmutableArray<EventHandlerData> data)
-    {
-        using var results = new PooledArrayBuilder<TagHelperDescriptor>();
-
-        foreach (var entry in data)
-        {
-            var attributeName = "@" + entry.Attribute;
-            var eventArgType = entry.EventArgsType.ToDisplayString();
-
-            using var _ = TagHelperDescriptorBuilder.GetPooledInstance(
-                ComponentMetadata.EventHandler.TagHelperKind, entry.Attribute, ComponentsApi.AssemblyName,
+            var attributeName = "@" + attribute;
+            var eventArgType = eventArgsType.ToDisplayString();
+            _ = TagHelperDescriptorBuilder.GetPooledInstance(
+                ComponentMetadata.EventHandler.TagHelperKind, attribute, ComponentsApi.AssemblyName,
                 out var builder);
-
             builder.CaseSensitive = true;
             builder.SetDocumentation(
                 DocumentationDescriptor.From(
@@ -155,9 +133,9 @@ internal class EventHandlerTagHelperDescriptorProvider : ITagHelperDescriptorPro
                 new(ComponentMetadata.EventHandler.EventArgsType, eventArgType),
                 MakeTrue(TagHelperMetadata.Common.ClassifyAttributesOnly),
                 RuntimeName(ComponentMetadata.EventHandler.RuntimeName),
-                TypeName(entry.TypeName),
-                TypeNamespace(entry.TypeNamespace),
-                TypeNameIdentifier(entry.TypeNameIdentifier));
+                TypeName(typeName),
+                TypeNamespace(typeNamespace),
+                TypeNameIdentifier(typeNameIdentifier));
 
             builder.TagMatchingRule(rule =>
             {
@@ -171,7 +149,7 @@ internal class EventHandlerTagHelperDescriptorProvider : ITagHelperDescriptorPro
                 });
             });
 
-            if (entry.EnablePreventDefault)
+            if (enablePreventDefault)
             {
                 builder.TagMatchingRule(rule =>
                 {
@@ -186,7 +164,7 @@ internal class EventHandlerTagHelperDescriptorProvider : ITagHelperDescriptorPro
                 });
             }
 
-            if (entry.EnableStopPropagation)
+            if (enableStopPropagation)
             {
                 builder.TagMatchingRule(rule =>
                 {
@@ -219,9 +197,9 @@ internal class EventHandlerTagHelperDescriptorProvider : ITagHelperDescriptorPro
                     // logic that we don't want to interfere with.
                     IsWeaklyTyped,
                     IsDirectiveAttribute,
-                    PropertyName(entry.Attribute));
+                    PropertyName(attribute));
 
-                if (entry.EnablePreventDefault)
+                if (enablePreventDefault)
                 {
                     a.BindAttributeParameter(parameter =>
                     {
@@ -236,7 +214,7 @@ internal class EventHandlerTagHelperDescriptorProvider : ITagHelperDescriptorPro
                     });
                 }
 
-                if (entry.EnableStopPropagation)
+                if (enableStopPropagation)
                 {
                     a.BindAttributeParameter(parameter =>
                     {
@@ -252,54 +230,38 @@ internal class EventHandlerTagHelperDescriptorProvider : ITagHelperDescriptorPro
                 }
             });
 
-            results.Add(builder.Build());
+            return builder.Build();
         }
 
-        return results.DrainToImmutable();
-    }
-
-    private readonly record struct EventHandlerData(
-        string Assembly,
-        string TypeName,
-        string TypeNamespace,
-        string TypeNameIdentifier,
-        string Attribute,
-        INamedTypeSymbol EventArgsType,
-        bool EnablePreventDefault,
-        bool EnableStopPropagation);
-
-    private class EventHandlerDataVisitor : SymbolVisitor
-    {
-        private readonly List<INamedTypeSymbol> _results;
-
-        public EventHandlerDataVisitor(List<INamedTypeSymbol> results)
+        private class EventHandlerDataVisitor(List<INamedTypeSymbol> results) : SymbolVisitor
         {
-            _results = results;
-        }
+            private readonly List<INamedTypeSymbol> _results = results;
 
-        public override void VisitNamedType(INamedTypeSymbol symbol)
-        {
-            if (symbol.Name == "EventHandlers" && symbol.DeclaredAccessibility == Accessibility.Public)
+            public override void VisitNamedType(INamedTypeSymbol symbol)
             {
-                _results.Add(symbol);
+                if (symbol.DeclaredAccessibility == Accessibility.Public &&
+                    symbol.Name == "EventHandlers")
+                {
+                    _results.Add(symbol);
+                }
             }
-        }
 
-        public override void VisitNamespace(INamespaceSymbol symbol)
-        {
-            foreach (var member in symbol.GetMembers())
+            public override void VisitNamespace(INamespaceSymbol symbol)
             {
-                Visit(member);
+                foreach (var member in symbol.GetMembers())
+                {
+                    Visit(member);
+                }
             }
-        }
 
-        public override void VisitAssembly(IAssemblySymbol symbol)
-        {
-            // This as a simple yet high-value optimization that excludes the vast majority of
-            // assemblies that (by definition) can't contain a component.
-            if (symbol.Name != null && !symbol.Name.StartsWith("System.", StringComparison.Ordinal))
+            public override void VisitAssembly(IAssemblySymbol symbol)
             {
-                Visit(symbol.GlobalNamespace);
+                // This as a simple yet high-value optimization that excludes the vast majority of
+                // assemblies that (by definition) can't contain a component.
+                if (symbol.Name != null && !symbol.Name.StartsWith("System.", StringComparison.Ordinal))
+                {
+                    Visit(symbol.GlobalNamespace);
+                }
             }
         }
     }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/EventHandlerTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/EventHandlerTagHelperDescriptorProvider.cs
@@ -256,12 +256,7 @@ internal class EventHandlerTagHelperDescriptorProvider : ITagHelperDescriptorPro
 
             public override void VisitAssembly(IAssemblySymbol symbol)
             {
-                // This as a simple yet high-value optimization that excludes the vast majority of
-                // assemblies that (by definition) can't contain a component.
-                if (symbol.Name != null && !symbol.Name.StartsWith("System.", StringComparison.Ordinal))
-                {
-                    Visit(symbol.GlobalNamespace);
-                }
+                Visit(symbol.GlobalNamespace);
             }
         }
     }


### PR DESCRIPTION
Fixes #8336
Fixes #8609

Roslyn shares the same assembly symbol instances across compilations when they refer to the same underlying assembly. Using this information, we can cache `TagHelperDescriptors` per assembly using a `ConditionalWeakTable` when computing tag helpers for compilation references, which saves tons of allocation and CPU-bound work. during tag helper and component discovery.

I've introduced an abstract base type, `TagHelperCollector`, to perform the general algorithm of collecting tag helpers from a target symbol, or a compilation and its references. Next, I updated each `ITagHelperDescriptorProvider` that produces tag helpers from a compilation's references to use a `TagHelperCollector` descendant to perform the work.