### PR TITLE
Fix some snippets

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Endpoints/Completion.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Endpoints/Completion.cs
@@ -302,6 +302,14 @@ internal partial class RazorCustomMessageTarget
 
     private void AddSnippetCompletions(RazorLanguageKind languageKind, ref PooledArrayBuilder<CompletionItem> builder)
     {
+        // Temporary fix: snippets are broken in CSharp. We're investigating
+        // but this is very disruptive. This quick fix unblocks things.
+        // TODO: Add an option to enable this. 
+        if (languageKind != RazorLanguageKind.Html)
+        {
+            return;
+        }
+
         var snippets = _snippetCache.GetSnippets(ConvertLanguageKind(languageKind));
         if (snippets.IsDefaultOrEmpty)
         {
@@ -316,7 +324,8 @@ internal partial class RazorCustomMessageTarget
                 InsertTextFormat = InsertTextFormat.Snippet,
                 InsertText = s.Shortcut,
                 Data = s.CompletionData,
-                Kind = CompletionItemKind.Snippet
+                Kind = CompletionItemKind.Snippet,
+                CommitCharacters = []
             }));
     }
 


### PR DESCRIPTION
Fixes #9409

1. Fix so space is no longer a commit character for completions. This can lead to very poor typing experience.
2. Disable snippets for csharp while we look into issues with it breaking all csharp completion

![0bdaab09-52e6-4e59-8e3e-fa86b180ef37](https://github.com/dotnet/razor/assets/475144/2ae30dbf-cf62-4f2d-a75f-04dda2fa88ab)
