### PR TITLE
Don't assume everything is a snippet

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Snippets/SnippetInfo.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Snippets/SnippetInfo.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Snippets/SnippetInfo.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Snippets/SnippetInfo.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.VisualStudio.Editor.Razor.Snippets;
@@ -39,13 +41,16 @@ internal record SnippetInfo
         => _parsedXmlSnippet.Value;
 }
 
-internal record SnippetCompletionData(string Path)
+internal record SnippetCompletionData([property: JsonProperty(SnippetCompletionData.PropertyName)] string Path)
 {
+    private const string PropertyName = "__razor_snippet_path";
+
     internal static bool TryParse(object? data, [NotNullWhen(true)] out SnippetCompletionData? snippetCompletionData)
     {
         snippetCompletionData = data as SnippetCompletionData;
 
-        if (data is JObject jObject)
+        if (data is JObject jObject &&
+            jObject.Property(PropertyName) is not null)
         {
             try
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Endpoints/Completion.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Endpoints/Completion.cs
@@ -151,7 +151,7 @@ internal partial class RazorCustomMessageTarget
                     Items = builder.ToArray(),
                 };
             }
-            
+
             return completionList;
         }
         finally
@@ -232,9 +232,10 @@ internal partial class RazorCustomMessageTarget
     public async Task<CompletionItem?> ProvideResolvedCompletionItemAsync(DelegatedCompletionItemResolveParams request, CancellationToken cancellationToken)
     {
         // Check if we're completing a snippet item that we provided
-        if (SnippetCompletionData.TryParse(request.CompletionItem.Data, out var snippetCompletionData))
+        if (SnippetCompletionData.TryParse(request.CompletionItem.Data, out var snippetCompletionData) &&
+            _snippetCache.TryResolveSnippetString(snippetCompletionData) is { } snippetInsertText)
         {
-            request.CompletionItem.InsertText = _snippetCache.TryResolveSnippetString(snippetCompletionData);
+            request.CompletionItem.InsertText = snippetInsertText;
             return request.CompletionItem;
         }
 


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1899533 and the override completion part of https://github.com/dotnet/razor/issues/9409

We were incorrectly thinking everything was a snippet, and setting its `InsertText` to the snippet context, which would then be null. This not only prevented us calling delegated servers for completion resolve, which caused the override completion part of https://github.com/dotnet/razor/issues/9409, but also meant that the client fell back to using the `LabelText` to commit the completion item. This means the Html servers retrigger functionality was broken, since it was just retriggering on the same content over and over.