### PR TITLE
Return an incomplete list if the delegated server doesn't respond

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Endpoints/Completion.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Endpoints/Completion.cs
@@ -148,6 +148,11 @@ internal partial class RazorCustomMessageTarget
             {
                 completionList = new VSInternalCompletionList()
                 {
+                    // If we don't get a response from the delegated server, we have to make sure to return an incomplete completion
+                    // list. When a user is typing quickly, the delegated request from the first keystroke will fail to synchronize,
+                    // so if we return a "complete" list then the query won't re-query us for completion once the typing stops/slows
+                    // so we'd only ever return Razor completion items.
+                    IsIncomplete = true,
                     Items = builder.ToArray(),
                 };
             }


### PR DESCRIPTION
Take 2 on https://github.com/dotnet/razor/pull/9380 now that completion doesn't return null when the delegated server does.