### PR TITLE
Don't map to ranges that are invalid

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDocumentMappingServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDocumentMappingServiceTest.cs
@@ -397,6 +397,47 @@ public class RazorDocumentMappingServiceTest : TestBase
     }
 
     [Fact]
+    public void TryMapToHostDocumentRange_Inferred_OutOfOrderMappings_DoesntThrow()
+    {
+        // Real world repo is something like:
+        // 
+        // <Component1>
+        //    @if (true)
+        //    {
+        //        <Component2 att="val"
+        //                    onclick="() => thing()""    <-- note double quotes
+        //                    att2="val" />
+        //    }
+        // </Component1>
+        //
+        // Ends up with an unterminated string in the generated code, and a "missing }" diagnostic
+        // that has some very strange mappings!
+
+        // Arrange
+        var service = new RazorDocumentMappingService(_filePathService, new TestDocumentContextFactory(), LoggerFactory);
+        var codeDoc = CreateCodeDocumentWithCSharpProjection(
+            "@{ var abc = @<unclosed></unclosed>",
+            " var abc =  (__builder) => { }",
+            new SourceMapping[] { new(new(30, 1), new (2, 1)), new(new(28, 2), new(30, 2)), });
+        var projectedRange = new LinePositionSpan(new LinePosition(0, 25), new LinePosition(0, 25));
+
+        // Act
+        var result = service.TryMapToHostDocumentRange(
+            codeDoc.GetCSharpDocument(),
+            projectedRange,
+            MappingBehavior.Inferred,
+            out var originalRange);
+
+        // Assert
+        // We're really just happy this doesn't throw an exception. The behaviour is to map to the end of the file
+        Assert.True(result);
+        Assert.Equal(0, originalRange.Start.Line);
+        Assert.Equal(31, originalRange.Start.Character);
+        Assert.Equal(0, originalRange.End.Line);
+        Assert.Equal(35, originalRange.End.Character);
+    }
+
+    [Fact]
     public void TryMapToGeneratedDocumentPosition_NotMatchingAnyMapping()
     {
         // Arrange


### PR DESCRIPTION
Fixes https://prism.vsdata.io/failure/?query=c%3A*LinePositionSpan*%20fe%3A*razor*&eventType=fault&failureType=hits&failureHash=0aca18a1-1f14-3647-5fc8-d18f8edea02f&showFG=false

This code used to use VS protocol types, which did no validation, which means we were returning bad data to other services/components, and letting them deal with it. By switching to Roslyn data types, which do validate, the bad data has surfaced to us, so this not only prevents us throwing exceptions, but also prevents us returning bad mappings.

~No tests yet, because I can't repro it, and the one CAB we have so far can't be loaded on my machine, so a repro is still pending. Putting this up because its the end of my day, and to make sure our tests all pass.~
Found a repro, and wrote a very crappy test.