### PR TITLE
Replace explicit richCodeNavigationEnvironment in azure-pipelines-richnav.yml

### DIFF
--- a/azure-pipelines-richnav.yml
+++ b/azure-pipelines-richnav.yml
@@ -27,7 +27,6 @@ stages:
       helixRepo: dotnet/razor-tooling
       helixType: build.product/
       enableRichCodeNavigation: true
-      richCodeNavigationEnvironment: 'production'
       richCodeNavigationLanguage: 'csharp,typescript'
       jobs:
       - job: Windows


### PR DESCRIPTION
This is managed by the arcade defaults, we should be using the "internal" environment as requested by the RichNav team.

/cc @jjonescz 
