### PR TITLE
BindTagHelperDescriptorProvider should search the compilation

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/BindTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/BindTagHelperDescriptorProvider.cs
@@ -127,7 +127,7 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
 
         // We want to walk the compilation and its references, not the target symbol.
         var collector = new Collector(
-            compilation, targetSymbol: null, bindElementAttribute, bindInputElementAttribute);
+            compilation, bindElementAttribute, bindInputElementAttribute);
         collector.Collect(context);
     }
 
@@ -240,8 +240,8 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
     }
 
     private class Collector(
-        Compilation compilation, ISymbol targetSymbol, INamedTypeSymbol bindElementAttribute, INamedTypeSymbol bindInputElementAttribute)
-        : TagHelperCollector<Collector>(compilation, targetSymbol)
+        Compilation compilation, INamedTypeSymbol bindElementAttribute, INamedTypeSymbol bindInputElementAttribute)
+        : TagHelperCollector<Collector>(compilation, targetSymbol: null)
     {
         protected override void Collect(ISymbol symbol, ICollection<TagHelperDescriptor> results)
         {

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/src/BindTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/src/BindTagHelperDescriptorProvider.cs
@@ -125,8 +125,9 @@ internal class BindTagHelperDescriptorProvider : ITagHelperDescriptorProvider
             return;
         }
 
+        // We want to walk the compilation and its references, not the target symbol.
         var collector = new Collector(
-            compilation, targetSymbol, bindElementAttribute, bindInputElementAttribute);
+            compilation, targetSymbol: null, bindElementAttribute, bindInputElementAttribute);
         collector.Collect(context);
     }
 


### PR DESCRIPTION
The change to cache tag helpers per assembly led to a bug introduced in the BindTagHelperDescriptorProvider. It *should* visit the compilation's assembly and all of its references. However, while refactoring, I had passed in a different target symbol which ended up overriding the compilation search.

I'll be adding a unit test before this PR goes in. This bug wasn't caught by out tests. Instead, it was caught by the ASP.NET Blazor tests, so we need coverage here.