### PR TITLE
Display component availability in completion and hover

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace/RazorProjectInfoSerializer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace/RazorProjectInfoSerializer.cs
@@ -94,6 +94,7 @@ internal static class RazorProjectInfoSerializer
             filePath: project.FilePath!,
             configuration: configuration,
             rootNamespace: defaultNamespace,
+            displayName: project.Name,
             projectWorkspaceState: projectWorkspaceState,
             documents: documents);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LegacyRazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LegacyRazorCompletionEndpoint.cs
@@ -102,7 +102,8 @@ internal class LegacyRazorCompletionEndpoint : IVSCompletionEndpoint
         var completionCapability = _clientCapabilities?.TextDocument?.Completion as VSInternalCompletionSetting;
 
         // The completion items are cached and can be retrieved via this result id to enable the "resolve" completion functionality.
-        var resultId = _completionListCache.Add(completionList, razorCompletionItems);
+        var razorResolveContext = new RazorCompletionResolveContext(documentContext.FilePath, razorCompletionItems);
+        var resultId = _completionListCache.Add(completionList, razorResolveContext);
         completionList.SetResultId(resultId, completionCapability);
 
         return completionList;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LegacyRazorCompletionResolveEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LegacyRazorCompletionResolveEndpoint.cs
@@ -92,14 +92,14 @@ internal class LegacyRazorCompletionResolveEndpoint : IVSCompletionResolveEndpoi
             return Task.FromResult(completionItem);
         }
 
-        if (cachedCompletionItems.Context is not IReadOnlyList<RazorCompletionItem> razorCompletionItems)
+        if (cachedCompletionItems.Context is not RazorCompletionResolveContext razorCompletionResolveContext)
         {
             // Can't recognize the original request context, bail.
             return Task.FromResult(completionItem);
         }
 
         var labelQuery = completionItem.Label;
-        var associatedRazorCompletion = razorCompletionItems.FirstOrDefault(completion => string.Equals(labelQuery, completion.DisplayText, StringComparison.Ordinal));
+        var associatedRazorCompletion = razorCompletionResolveContext.CompletionItems.FirstOrDefault(completion => string.Equals(labelQuery, completion.DisplayText, StringComparison.Ordinal));
         if (associatedRazorCompletion is null)
         {
             _logger.LogError("Could not find an associated razor completion item. This should never happen since we were able to look up the cached completion list.");
@@ -166,11 +166,11 @@ internal class LegacyRazorCompletionResolveEndpoint : IVSCompletionResolveEndpoi
 
                 if (useDescriptionProperty)
                 {
-                    _vsLspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, out tagHelperClassifiedTextTooltip);
+                    _vsLspTagHelperTooltipFactory.TryCreateTooltip(razorCompletionResolveContext.FilePath, descriptionInfo, out tagHelperClassifiedTextTooltip);
                 }
                 else
                 {
-                    _lspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, _documentationKind, out tagHelperMarkupTooltip);
+                    _lspTagHelperTooltipFactory.TryCreateTooltip(razorCompletionResolveContext.FilePath, descriptionInfo, _documentationKind, out tagHelperMarkupTooltip);
                 }
 
                 break;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LegacyRazorCompletionResolveEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LegacyRazorCompletionResolveEndpoint.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionItemResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionItemResolver.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -34,13 +33,13 @@ internal class RazorCompletionItemResolver : CompletionItemResolver
         VSInternalClientCapabilities? clientCapabilities,
         CancellationToken cancellationToken)
     {
-        if (originalRequestContext is not IReadOnlyList<RazorCompletionItem> razorCompletionItems)
+        if (originalRequestContext is not RazorCompletionResolveContext razorCompletionResolveContext)
         {
             // Can't recognize the original request context, bail.
             return Task.FromResult<VSInternalCompletionItem?>(null);
         }
 
-        var associatedRazorCompletion = razorCompletionItems.FirstOrDefault(completion => string.Equals(completion.DisplayText, completionItem.Label, StringComparison.Ordinal));
+        var associatedRazorCompletion = razorCompletionResolveContext.CompletionItems.FirstOrDefault(completion => string.Equals(completion.DisplayText, completionItem.Label, StringComparison.Ordinal));
         if (associatedRazorCompletion is null)
         {
             return Task.FromResult<VSInternalCompletionItem?>(null);
@@ -107,11 +106,11 @@ internal class RazorCompletionItemResolver : CompletionItemResolver
 
                 if (useDescriptionProperty)
                 {
-                    _vsLspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, out tagHelperClassifiedTextTooltip);
+                    _vsLspTagHelperTooltipFactory.TryCreateTooltip(razorCompletionResolveContext.FilePath, descriptionInfo, out tagHelperClassifiedTextTooltip);
                 }
                 else
                 {
-                    _lspTagHelperTooltipFactory.TryCreateTooltip(descriptionInfo, documentationKind, out tagHelperMarkupTooltip);
+                    _lspTagHelperTooltipFactory.TryCreateTooltip(razorCompletionResolveContext.FilePath, descriptionInfo, documentationKind, out tagHelperMarkupTooltip);
                 }
 
                 break;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionListProvider.cs
@@ -88,7 +88,8 @@ internal class RazorCompletionListProvider
         var completionCapability = clientCapabilities?.TextDocument?.Completion as VSInternalCompletionSetting;
 
         // The completion list is cached and can be retrieved via this result id to enable the resolve completion functionality.
-        var resultId = _completionListCache.Add(completionList, razorCompletionItems);
+        var razorResolveContext = new RazorCompletionResolveContext(documentContext.FilePath, razorCompletionItems);
+        var resultId = _completionListCache.Add(completionList, razorResolveContext);
         completionList.SetResultId(resultId, completionCapability);
 
         return completionList;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionResolveContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionResolveContext.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Razor.Completion;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion;
+
+internal record RazorCompletionResolveContext(string FilePath, ImmutableArray<RazorCompletionItem> CompletionItems);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/HoverEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/HoverEndpoint.cs
@@ -80,7 +80,7 @@ internal sealed class HoverEndpoint : AbstractRazorDelegatingEndpoint<TextDocume
         }
 
         var location = new SourceLocation(positionInfo.HostDocumentIndex, request.Position.Line, request.Position.Character);
-        return _hoverInfoService.GetHoverInfo(codeDocument, location, _clientCapabilities!);
+        return _hoverInfoService.GetHoverInfo(documentContext.FilePath, codeDocument, location, _clientCapabilities!);
     }
 
     protected override async Task<VSInternalHover?> HandleDelegatedResponseAsync(VSInternalHover? response, TextDocumentPositionParams originalRequest, RazorRequestContext requestContext, DocumentPositionInfo positionInfo, CancellationToken cancellationToken)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/HoverInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/HoverInfoService.cs
@@ -59,7 +59,7 @@ internal sealed class HoverInfoService : IHoverInfoService
         _htmlFactsService = htmlFactsService;
     }
 
-    public VSInternalHover? GetHoverInfo(RazorCodeDocument codeDocument, SourceLocation location, VSInternalClientCapabilities clientCapabilities)
+    public VSInternalHover? GetHoverInfo(string documentFilePath, RazorCodeDocument codeDocument, SourceLocation location, VSInternalClientCapabilities clientCapabilities)
     {
         if (codeDocument is null)
         {
@@ -117,7 +117,7 @@ internal sealed class HoverInfoService : IHoverInfoService
 
                 var range = containingTagNameToken.GetRange(codeDocument.Source);
 
-                var result = ElementInfoToHover(binding.Descriptors, range, clientCapabilities);
+                var result = ElementInfoToHover(documentFilePath, binding.Descriptors, range, clientCapabilities);
                 return result;
             }
         }
@@ -246,13 +246,13 @@ internal sealed class HoverInfoService : IHoverInfoService
         }
     }
 
-    private VSInternalHover? ElementInfoToHover(IEnumerable<TagHelperDescriptor> descriptors, Range range, VSInternalClientCapabilities clientCapabilities)
+    private VSInternalHover? ElementInfoToHover(string documentFilePath, IEnumerable<TagHelperDescriptor> descriptors, Range range, VSInternalClientCapabilities clientCapabilities)
     {
         var descriptionInfos = descriptors.SelectAsArray(BoundElementDescriptionInfo.From);
         var elementDescriptionInfo = new AggregateBoundElementDescription(descriptionInfos);
 
         var isVSClient = clientCapabilities.SupportsVisualStudioExtensions;
-        if (isVSClient && _vsLspTagHelperTooltipFactory.TryCreateTooltip(elementDescriptionInfo, out ContainerElement? classifiedTextElement))
+        if (isVSClient && _vsLspTagHelperTooltipFactory.TryCreateTooltip(documentFilePath, elementDescriptionInfo, out ContainerElement? classifiedTextElement))
         {
             var vsHover = new VSInternalHover
             {
@@ -267,7 +267,7 @@ internal sealed class HoverInfoService : IHoverInfoService
         {
             var hoverContentFormat = GetHoverContentFormat(clientCapabilities);
 
-            if (!_lspTagHelperTooltipFactory.TryCreateTooltip(elementDescriptionInfo, hoverContentFormat, out var vsMarkupContent))
+            if (!_lspTagHelperTooltipFactory.TryCreateTooltip(documentFilePath, elementDescriptionInfo, hoverContentFormat, out var vsMarkupContent))
             {
                 return null;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/IHoverInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/IHoverInfoService.cs
@@ -8,5 +8,5 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover;
 
 internal interface IHoverInfoService
 {
-    VSInternalHover? GetHoverInfo(RazorCodeDocument codeDocument, SourceLocation location, VSInternalClientCapabilities clientCapabilities);
+    VSInternalHover? GetHoverInfo(string documentFilePath, RazorCodeDocument codeDocument, SourceLocation location, VSInternalClientCapabilities clientCapabilities);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
@@ -124,7 +125,7 @@ internal class ProjectConfigurationStateSynchronizer : IProjectConfigurationFile
             var intermediateOutputPath = Path.GetDirectoryName(configurationFilePath).AssumeNotNull();
             var rootNamespace = projectInfo.RootNamespace;
 
-            var projectKey = _projectService.AddProject(projectFilePath, intermediateOutputPath, projectInfo.Configuration, rootNamespace);
+            var projectKey = _projectService.AddProject(projectFilePath, intermediateOutputPath, projectInfo.Configuration, rootNamespace, projectInfo.DisplayName);
             _configurationToProjectMap[configurationFilePath] = projectKey;
 
             _logger.LogInformation("Project configuration file added for project '{0}': '{1}'", projectFilePath, configurationFilePath);
@@ -147,6 +148,7 @@ internal class ProjectConfigurationStateSynchronizer : IProjectConfigurationFile
                 projectKey,
                 projectInfo.Configuration,
                 projectInfo.RootNamespace,
+                projectInfo.DisplayName,
                 projectWorkspaceState,
                 documents);
         }
@@ -181,8 +183,9 @@ internal class ProjectConfigurationStateSynchronizer : IProjectConfigurationFile
                 projectKey,
                 configuration: null,
                 rootNamespace: null,
+                displayName: "",
                 ProjectWorkspaceState.Default,
-                Array.Empty<DocumentSnapshotHandle>());
+                ImmutableArray<DocumentSnapshotHandle>.Empty);
         }
     }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/DefaultRazorProjectService.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -244,12 +244,12 @@ internal class DefaultRazorProjectService : RazorProjectService
         }
     }
 
-    public override ProjectKey AddProject(string filePath, string intermediateOutputPath, RazorConfiguration? configuration, string? rootNamespace)
+    public override ProjectKey AddProject(string filePath, string intermediateOutputPath, RazorConfiguration? configuration, string? rootNamespace, string displayName)
     {
         _projectSnapshotManagerDispatcher.AssertDispatcherThread();
 
         var normalizedPath = FilePathNormalizer.Normalize(filePath);
-        var hostProject = new HostProject(normalizedPath, intermediateOutputPath, configuration ?? FallbackRazorConfiguration.Latest, rootNamespace);
+        var hostProject = new HostProject(normalizedPath, intermediateOutputPath, configuration ?? FallbackRazorConfiguration.Latest, rootNamespace, displayName);
         // ProjectAdded will no-op if the project already exists
         _projectSnapshotManagerAccessor.Instance.ProjectAdded(hostProject);
 
@@ -264,8 +264,9 @@ internal class DefaultRazorProjectService : RazorProjectService
         ProjectKey projectKey,
         RazorConfiguration? configuration,
         string? rootNamespace,
+        string displayName,
         ProjectWorkspaceState projectWorkspaceState,
-        IReadOnlyList<DocumentSnapshotHandle> documents)
+        ImmutableArray<DocumentSnapshotHandle> documents)
     {
         _projectSnapshotManagerDispatcher.AssertDispatcherThread();
 
@@ -314,13 +315,13 @@ internal class DefaultRazorProjectService : RazorProjectService
             _logger.LogInformation("Updating project '{key}''s root namespace to '{rootNamespace}'.", project.Key, rootNamespace);
         }
 
-        var hostProject = new HostProject(project.FilePath, project.IntermediateOutputPath, configuration, rootNamespace);
+        var hostProject = new HostProject(project.FilePath, project.IntermediateOutputPath, configuration, rootNamespace, displayName);
         _projectSnapshotManagerAccessor.Instance.ProjectConfigurationChanged(hostProject);
     }
 
-    private void UpdateProjectDocuments(IReadOnlyList<DocumentSnapshotHandle> documents, ProjectKey projectKey)
+    private void UpdateProjectDocuments(ImmutableArray<DocumentSnapshotHandle> documents, ProjectKey projectKey)
     {
-        _logger.LogDebug("UpdateProjectDocuments for {projectKey} with {documentCount} documents.", projectKey, documents.Count);
+        _logger.LogDebug("UpdateProjectDocuments for {projectKey} with {documentCount} documents.", projectKey, documents.Length);
 
         var project = (ProjectSnapshot)_projectSnapshotManagerAccessor.Instance.GetLoadedProject(projectKey);
         var currentHostProject = project.HostProject;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
+using System.Collections.Immutable;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Serialization;
@@ -22,12 +22,13 @@ internal abstract class RazorProjectService
 
     public abstract void UpdateDocument(string filePath, SourceText sourceText, int version);
 
-    public abstract ProjectKey AddProject(string filePath, string intermediateOutputPath, RazorConfiguration? configuration, string? rootNamespace);
+    public abstract ProjectKey AddProject(string filePath, string intermediateOutputPath, RazorConfiguration? configuration, string? rootNamespace, string displayName);
 
     public abstract void UpdateProject(
         ProjectKey projectKey,
         RazorConfiguration? configuration,
         string? rootNamespace,
+        string displayName,
         ProjectWorkspaceState projectWorkspaceState,
-        IReadOnlyList<DocumentSnapshotHandle> documents);
+        ImmutableArray<DocumentSnapshotHandle> documents);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/SnapshotResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/SnapshotResolver.cs
@@ -29,7 +29,7 @@ internal class SnapshotResolver : ISnapshotResolver
 
         var miscellaneousProjectPath = Path.Combine(TempDirectory.Instance.DirectoryPath, "__MISC_RAZOR_PROJECT__");
         var normalizedPath = FilePathNormalizer.Normalize(miscellaneousProjectPath);
-        MiscellaneousHostProject = new HostProject(normalizedPath, normalizedPath, FallbackRazorConfiguration.Latest, rootNamespace: null);
+        MiscellaneousHostProject = new HostProject(normalizedPath, normalizedPath, FallbackRazorConfiguration.Latest, rootNamespace: null, "Miscellaneous Files");
     }
 
     /// <inheritdoc/>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/SR.resx
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/SR.resx
@@ -144,6 +144,9 @@
   <data name="Language_Services_Missing_Service" xml:space="preserve">
     <value>Razor language services not configured properly, missing language service '{0}'.</value>
   </data>
+  <data name="Not_Available_In" xml:space="preserve">
+    <value>Not available in</value>
+  </data>
   <data name="PositionIndex_Outside_Range" xml:space="preserve">
     <value>Line '{0}' outside of the {1} range of '{2}' was queried. The document may not be up to date.</value>
   </data>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.cs.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.cs.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Služby jazyka Razor nejsou správně nakonfigurované, chybí služba jazyka {0}.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Not_Available_In">
+        <source>Not available in</source>
+        <target state="new">Not available in</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PositionIndex_Outside_Range">
         <source>Line '{0}' outside of the {1} range of '{2}' was queried. The document may not be up to date.</source>
         <target state="translated">Proběhl dotaz na řádek {0} mimo rozsah {1} {2}. Dokument nemusí být aktuální.</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.de.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.de.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Razor-Sprachdienste sind nicht ordnungsgemäß konfiguriert, der Sprachdienst "{0}" fehlt.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Not_Available_In">
+        <source>Not available in</source>
+        <target state="new">Not available in</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PositionIndex_Outside_Range">
         <source>Line '{0}' outside of the {1} range of '{2}' was queried. The document may not be up to date.</source>
         <target state="translated">Die Zeile "{0}" außerhalb des {1} Bereichs von "{2}" wurde abgefragt. Das Dokument ist möglicherweise nicht auf dem neuesten Stand.</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.es.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.es.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Los servicios de lenguaje Razor no están configurados correctamente; falta el servicio de idioma "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="Not_Available_In">
+        <source>Not available in</source>
+        <target state="new">Not available in</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PositionIndex_Outside_Range">
         <source>Line '{0}' outside of the {1} range of '{2}' was queried. The document may not be up to date.</source>
         <target state="translated">La línea '{0}' se consultó fuera del {1} rango de '{2}'. Es posible que el documento no esté actualizado.</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.fr.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.fr.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Les services de langage Razor ne sont pas configurés correctement, le service de langage «{0}» manquant.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Not_Available_In">
+        <source>Not available in</source>
+        <target state="new">Not available in</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PositionIndex_Outside_Range">
         <source>Line '{0}' outside of the {1} range of '{2}' was queried. The document may not be up to date.</source>
         <target state="translated">La ligne «{0}» en dehors de la plage{1} de «{2}» a été interrogée. Le document n’est peut-être pas à jour.</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.it.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.it.xlf
@@ -47,6 +47,11 @@
         <target state="translated">I servizi di linguaggio Razor non sono configurati correttamente. Manca il servizio di linguaggio '{0}'.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Not_Available_In">
+        <source>Not available in</source>
+        <target state="new">Not available in</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PositionIndex_Outside_Range">
         <source>Line '{0}' outside of the {1} range of '{2}' was queried. The document may not be up to date.</source>
         <target state="translated">È stata eseguita una query sulla riga '{0}' non compresa nell'intervallo {1} di '{2}'. Il documento potrebbe non essere aggiornato.</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.ja.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.ja.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Razor 言語サービスが正しく構成されていません。言語サービス '{0}' がありません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Not_Available_In">
+        <source>Not available in</source>
+        <target state="new">Not available in</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PositionIndex_Outside_Range">
         <source>Line '{0}' outside of the {1} range of '{2}' was queried. The document may not be up to date.</source>
         <target state="translated">'{2}' の {1} 範囲外の行 '{0}' がクエリされました。ドキュメントが最新ではない可能性があります。</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.ko.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.ko.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Razor 언어 서비스가 제대로 구성되지 않았습니다. 언어 서비스 '{0}'이(가) 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Not_Available_In">
+        <source>Not available in</source>
+        <target state="new">Not available in</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PositionIndex_Outside_Range">
         <source>Line '{0}' outside of the {1} range of '{2}' was queried. The document may not be up to date.</source>
         <target state="translated">'{2}'의 {1} 범위를 벗어나는 줄 '{0}'을(를) 쿼리했습니다. 문서가 최신이 아닐 수 있습니다.</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.pl.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.pl.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Usługi języka dla składni Razor nie zostały prawidłowo skonfigurowane — brak usługi językowej "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="Not_Available_In">
+        <source>Not available in</source>
+        <target state="new">Not available in</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PositionIndex_Outside_Range">
         <source>Line '{0}' outside of the {1} range of '{2}' was queried. The document may not be up to date.</source>
         <target state="translated">Wykonano zapytanie wiersza "{0}" poza zakresem {1} "{2}". Dokument może być nieaktualny.</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.pt-BR.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.pt-BR.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Serviços de Linguagem Razor não configurados corretamente, serviço de linguagem '{0}' ausente.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Not_Available_In">
+        <source>Not available in</source>
+        <target state="new">Not available in</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PositionIndex_Outside_Range">
         <source>Line '{0}' outside of the {1} range of '{2}' was queried. The document may not be up to date.</source>
         <target state="translated">A linha '{0}' fora do intervalo {1} de '{2}' foi consultada. O documento pode não estar atualizado.</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.ru.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.ru.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Языковые службы Razor настроены неправильно, отсутствует языковая служба "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="Not_Available_In">
+        <source>Not available in</source>
+        <target state="new">Not available in</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PositionIndex_Outside_Range">
         <source>Line '{0}' outside of the {1} range of '{2}' was queried. The document may not be up to date.</source>
         <target state="translated">Запрошена строка "{0}" за пределами диапазона {1} "{2}". Возможно, документ не обновлен.</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.tr.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.tr.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Razor dil hizmetleri düzgün yapılandırılmadı, '{0}' dil hizmeti eksik.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Not_Available_In">
+        <source>Not available in</source>
+        <target state="new">Not available in</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PositionIndex_Outside_Range">
         <source>Line '{0}' outside of the {1} range of '{2}' was queried. The document may not be up to date.</source>
         <target state="translated">{1} / '{2}' aralığının dışındaki '{0}' satırı sorgulandı. Belge güncel olmayabilir.</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.zh-Hans.xlf
@@ -47,6 +47,11 @@
         <target state="translated">Razor 语言服务未正确配置，缺少语言服务 "{0}"。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Not_Available_In">
+        <source>Not available in</source>
+        <target state="new">Not available in</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PositionIndex_Outside_Range">
         <source>Line '{0}' outside of the {1} range of '{2}' was queried. The document may not be up to date.</source>
         <target state="translated">查询了 "{0}" 的 {1} 范围外的行 "{2}"。文档可能不是最新的。</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.zh-Hant.xlf
@@ -47,6 +47,11 @@
         <target state="translated">未正確設定 Razor 語言服務，遺漏語言服務 '{0}'。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Not_Available_In">
+        <source>Not available in</source>
+        <target state="new">Not available in</target>
+        <note />
+      </trans-unit>
       <trans-unit id="PositionIndex_Outside_Range">
         <source>Line '{0}' outside of the {1} range of '{2}' was queried. The document may not be up to date.</source>
         <target state="translated">已查詢 '{2}' 之 {1} 範圍以外的行 '{0}'。文件可能不是最新狀態。</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultLSPTagHelperTooltipFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultLSPTagHelperTooltipFactory.cs
@@ -5,15 +5,17 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
+using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.Razor.Tooltip;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip;
 
-internal class DefaultLSPTagHelperTooltipFactory : LSPTagHelperTooltipFactory
+internal class DefaultLSPTagHelperTooltipFactory(ISnapshotResolver snapshotResolver) : LSPTagHelperTooltipFactory(snapshotResolver)
 {
     public override bool TryCreateTooltip(
+        string documentFilePath,
         AggregateBoundElementDescription elementDescriptionInfo,
         MarkupKind markupKind,
         [NotNullWhen(true)] out MarkupContent? tooltipContent)
@@ -63,6 +65,15 @@ internal class DefaultLSPTagHelperTooltipFactory : LSPTagHelperTooltipFactory
             descriptionBuilder.AppendLine();
             var finalSummaryContent = CleanSummaryContent(summaryContent);
             descriptionBuilder.Append(finalSummaryContent);
+
+            var availability = GetProjectAvailability(documentFilePath, tagHelperType);
+            if (availability is not null)
+            {
+                descriptionBuilder.AppendLine();
+                descriptionBuilder.AppendLine();
+                descriptionBuilder.Append("⚠️ Not available in: ");
+                descriptionBuilder.AppendLine(availability);
+            }
         }
 
         tooltipContent = new MarkupContent

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultLSPTagHelperTooltipFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultLSPTagHelperTooltipFactory.cs
@@ -56,23 +56,19 @@ internal class DefaultLSPTagHelperTooltipFactory(ISnapshotResolver snapshotResol
             StartOrEndBold(descriptionBuilder, markupKind);
 
             var documentation = descriptionInfo.Documentation;
-            if (!TryExtractSummary(documentation, out var summaryContent))
+            if (TryExtractSummary(documentation, out var summaryContent))
             {
-                continue;
+                descriptionBuilder.AppendLine();
+                descriptionBuilder.AppendLine();
+                var finalSummaryContent = CleanSummaryContent(summaryContent);
+                descriptionBuilder.Append(finalSummaryContent);
             }
-
-            descriptionBuilder.AppendLine();
-            descriptionBuilder.AppendLine();
-            var finalSummaryContent = CleanSummaryContent(summaryContent);
-            descriptionBuilder.Append(finalSummaryContent);
 
             var availability = GetProjectAvailability(documentFilePath, tagHelperType);
             if (availability is not null)
             {
                 descriptionBuilder.AppendLine();
-                descriptionBuilder.AppendLine();
-                descriptionBuilder.Append("⚠️ Not available in: ");
-                descriptionBuilder.AppendLine(availability);
+                descriptionBuilder.Append(availability);
             }
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultVSLSPTagHelperTooltipFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultVSLSPTagHelperTooltipFactory.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
+using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.Razor.Tooltip;
 using Microsoft.VisualStudio.Core.Imaging;
@@ -14,7 +15,7 @@ using Microsoft.VisualStudio.Text.Adornments;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip;
 
-internal class DefaultVSLSPTagHelperTooltipFactory : VSLSPTagHelperTooltipFactory
+internal class DefaultVSLSPTagHelperTooltipFactory(ISnapshotResolver snapshotResolver) : VSLSPTagHelperTooltipFactory(snapshotResolver)
 {
     private static readonly Guid s_imageCatalogGuid = new("{ae27a6b0-e345-4288-96df-5eaf394ee369}");
 
@@ -50,14 +51,14 @@ internal class DefaultVSLSPTagHelperTooltipFactory : VSLSPTagHelperTooltipFactor
     private static readonly ClassifiedTextRun s_newLine = new(VSPredefinedClassificationTypeNames.WhiteSpace, Environment.NewLine);
     private static readonly ClassifiedTextRun s_nullableType = new(VSPredefinedClassificationTypeNames.Punctuation, "?");
 
-    public override bool TryCreateTooltip(AggregateBoundElementDescription elementDescriptionInfo, [NotNullWhen(true)] out ContainerElement? tooltipContent)
+    public override bool TryCreateTooltip(string documentFilePath, AggregateBoundElementDescription elementDescriptionInfo, [NotNullWhen(true)] out ContainerElement? tooltipContent)
     {
         if (elementDescriptionInfo is null)
         {
             throw new ArgumentNullException(nameof(elementDescriptionInfo));
         }
 
-        if (!TryClassifyElement(elementDescriptionInfo, out var descriptionClassifications))
+        if (!TryClassifyElement(documentFilePath, elementDescriptionInfo, out var descriptionClassifications))
         {
             tooltipContent = null;
             return false;
@@ -86,14 +87,14 @@ internal class DefaultVSLSPTagHelperTooltipFactory : VSLSPTagHelperTooltipFactor
 
     // TO-DO: This method can be removed once LSP's VSCompletionItem supports returning ContainerElements for
     // its Description property, tracked by https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1319274.
-    public override bool TryCreateTooltip(AggregateBoundElementDescription elementDescriptionInfo, [NotNullWhen(true)] out ClassifiedTextElement? tooltipContent)
+    public override bool TryCreateTooltip(string documentFilePath, AggregateBoundElementDescription elementDescriptionInfo, [NotNullWhen(true)] out ClassifiedTextElement? tooltipContent)
     {
         if (elementDescriptionInfo is null)
         {
             throw new ArgumentNullException(nameof(elementDescriptionInfo));
         }
 
-        if (!TryClassifyElement(elementDescriptionInfo, out var descriptionClassifications))
+        if (!TryClassifyElement(documentFilePath, elementDescriptionInfo, out var descriptionClassifications))
         {
             tooltipContent = null;
             return false;
@@ -122,7 +123,7 @@ internal class DefaultVSLSPTagHelperTooltipFactory : VSLSPTagHelperTooltipFactor
         return true;
     }
 
-    private static bool TryClassifyElement(AggregateBoundElementDescription elementInfo, out ImmutableArray<DescriptionClassification> classifications)
+    private bool TryClassifyElement(string documentFilePath, AggregateBoundElementDescription elementInfo, out ImmutableArray<DescriptionClassification> classifications)
     {
         var associatedTagHelperInfos = elementInfo.DescriptionInfos;
         if (associatedTagHelperInfos.Length == 0)
@@ -148,12 +149,28 @@ internal class DefaultVSLSPTagHelperTooltipFactory : VSLSPTagHelperTooltipFactor
             var documentationRuns = new List<ClassifiedTextRun>();
             TryClassifySummary(documentationRuns, descriptionInfo.Documentation);
 
-            // 3. Combine type + summary information
+            // 3. Project availability
+            AddProjectAvailabilityInfo(documentFilePath, descriptionInfo.TagHelperTypeName, documentationRuns);
+
+            // 4. Combine type + summary information
             descriptions.Add(new DescriptionClassification(typeRuns, documentationRuns));
         }
 
         classifications = descriptions.DrainToImmutable();
         return true;
+    }
+
+    private void AddProjectAvailabilityInfo(string documentFilePath, string tagHelperTypeName, List<ClassifiedTextRun> documentationRuns)
+    {
+        var availability = GetProjectAvailability(documentFilePath, tagHelperTypeName);
+
+        if (availability is not null)
+        {
+            documentationRuns.Add(new ClassifiedTextRun(VSPredefinedClassificationTypeNames.Text, $"""
+
+                ⚠️ Not available in: {availability}
+                """));
+        }
     }
 
     private static bool TryClassifyAttribute(AggregateBoundAttributeDescription attributeInfo, out ImmutableArray<DescriptionClassification> classifications)
@@ -405,7 +422,6 @@ internal class DefaultVSLSPTagHelperTooltipFactory : VSLSPTagHelperTooltipFactor
         {
             if (currentTextRun.Length != 0)
             {
-
                 runs.Add(new ClassifiedTextRun(VSPredefinedClassificationTypeNames.Text, currentTextRun.ToString()));
                 currentTextRun.Clear();
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultVSLSPTagHelperTooltipFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultVSLSPTagHelperTooltipFactory.cs
@@ -166,10 +166,7 @@ internal class DefaultVSLSPTagHelperTooltipFactory(ISnapshotResolver snapshotRes
 
         if (availability is not null)
         {
-            documentationRuns.Add(new ClassifiedTextRun(VSPredefinedClassificationTypeNames.Text, $"""
-
-                ⚠️ Not available in: {availability}
-                """));
+            documentationRuns.Add(new ClassifiedTextRun(VSPredefinedClassificationTypeNames.Text, availability));
         }
     }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/LSPTagHelperTooltipFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/LSPTagHelperTooltipFactory.cs
@@ -2,14 +2,15 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Tooltip;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip;
 
-internal abstract class LSPTagHelperTooltipFactory : TagHelperTooltipFactoryBase
+internal abstract class LSPTagHelperTooltipFactory(ISnapshotResolver snapshotResolver) : TagHelperTooltipFactoryBase(snapshotResolver)
 {
-    public abstract bool TryCreateTooltip(AggregateBoundElementDescription elementDescriptionInfo, MarkupKind markupKind, [NotNullWhen(true)] out MarkupContent? tooltipContent);
+    public abstract bool TryCreateTooltip(string documentFilePath, AggregateBoundElementDescription elementDescriptionInfo, MarkupKind markupKind, [NotNullWhen(true)] out MarkupContent? tooltipContent);
 
     public abstract bool TryCreateTooltip(AggregateBoundAttributeDescription attributeDescriptionInfo, MarkupKind markupKind, [NotNullWhen(true)] out MarkupContent? tooltipContent);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/TagHelperTooltipFactoryBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/TagHelperTooltipFactoryBase.cs
@@ -60,7 +60,10 @@ internal abstract class TagHelperTooltipFactoryBase
             return null;
         }
 
-        return string.Join(", ", availability);
+        return $"""
+
+                ⚠️ {SR.Not_Available_In}: {string.Join(", ", availability)}
+                """;
     }
 
     // Internal for testing

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/VSLSPTagHelperTooltipFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/VSLSPTagHelperTooltipFactory.cs
@@ -2,18 +2,19 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Tooltip;
 using Microsoft.VisualStudio.Text.Adornments;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Tooltip;
 
-internal abstract class VSLSPTagHelperTooltipFactory : TagHelperTooltipFactoryBase
+internal abstract class VSLSPTagHelperTooltipFactory(ISnapshotResolver snapshotResolver) : TagHelperTooltipFactoryBase(snapshotResolver)
 {
-    public abstract bool TryCreateTooltip(AggregateBoundElementDescription elementDescriptionInfo, [NotNullWhen(true)] out ContainerElement? tooltipContent);
+    public abstract bool TryCreateTooltip(string documentFilePath, AggregateBoundElementDescription elementDescriptionInfo, [NotNullWhen(true)] out ContainerElement? tooltipContent);
 
     public abstract bool TryCreateTooltip(AggregateBoundAttributeDescription attributeDescriptionInfo, [NotNullWhen(true)] out ContainerElement? tooltipContent);
 
-    public abstract bool TryCreateTooltip(AggregateBoundElementDescription elementDescriptionInfo, [NotNullWhen(true)] out ClassifiedTextElement? tooltipContent);
+    public abstract bool TryCreateTooltip(string documentFilePath, AggregateBoundElementDescription elementDescriptionInfo, [NotNullWhen(true)] out ClassifiedTextElement? tooltipContent);
 
     public abstract bool TryCreateTooltip(AggregateBoundAttributeDescription attributeDescriptionInfo, [NotNullWhen(true)] out ClassifiedTextElement? tooltipContent);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/ProjectSystem/RazorProjectInfo.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/ProjectSystem/RazorProjectInfo.cs
@@ -23,6 +23,7 @@ internal sealed class RazorProjectInfo
     public string FilePath { get; }
     public RazorConfiguration? Configuration { get; }
     public string? RootNamespace { get; }
+    public string DisplayName { get; }
     public ProjectWorkspaceState? ProjectWorkspaceState { get; }
     public ImmutableArray<DocumentSnapshotHandle> Documents { get; }
 
@@ -31,6 +32,7 @@ internal sealed class RazorProjectInfo
         string filePath,
         RazorConfiguration? configuration,
         string? rootNamespace,
+        string displayName,
         ProjectWorkspaceState? projectWorkspaceState,
         ImmutableArray<DocumentSnapshotHandle> documents)
     {
@@ -38,6 +40,7 @@ internal sealed class RazorProjectInfo
         FilePath = filePath;
         Configuration = configuration;
         RootNamespace = rootNamespace;
+        DisplayName = displayName;
         ProjectWorkspaceState = projectWorkspaceState;
         Documents = documents.NullToEmpty();
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/Json/ObjectReaders.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/Json/ObjectReaders.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Utilities;
@@ -346,7 +347,9 @@ internal static partial class ObjectReaders
         var rootNamespace = reader.ReadString(nameof(RazorProjectInfo.RootNamespace));
         var documents = reader.ReadImmutableArray(nameof(RazorProjectInfo.Documents), static r => r.ReadNonNullObject(ReadDocumentSnapshotHandleFromProperties));
 
-        return new RazorProjectInfo(serializedFilePath, filePath, configuration, rootNamespace, projectWorkspaceState, documents);
+        var displayName = Path.GetFileNameWithoutExtension(filePath);
+
+        return new RazorProjectInfo(serializedFilePath, filePath, configuration, rootNamespace, displayName, projectWorkspaceState, documents);
     }
 
     public static Checksum ReadChecksum(JsonDataReader reader)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/RazorProjectInfoFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/RazorProjectInfoFormatter.cs
@@ -32,9 +32,10 @@ internal sealed class RazorProjectInfoFormatter : TopLevelFormatter<RazorProject
         var configuration = reader.DeserializeOrNull<RazorConfiguration>(options);
         var projectWorkspaceState = reader.DeserializeOrNull<ProjectWorkspaceState>(options);
         var rootNamespace = CachedStringFormatter.Instance.Deserialize(ref reader, options);
+        var displayName = CachedStringFormatter.Instance.Deserialize(ref reader, options).AssumeNotNull();
         var documents = reader.Deserialize<ImmutableArray<DocumentSnapshotHandle>>(options);
 
-        return new RazorProjectInfo(serializedFilePath, filePath, configuration, rootNamespace, projectWorkspaceState, documents);
+        return new RazorProjectInfo(serializedFilePath, filePath, configuration, rootNamespace, displayName, projectWorkspaceState, documents);
     }
 
     public override void Serialize(ref MessagePackWriter writer, RazorProjectInfo value, SerializerCachingOptions options)
@@ -47,6 +48,7 @@ internal sealed class RazorProjectInfoFormatter : TopLevelFormatter<RazorProject
         writer.Serialize(value.Configuration, options);
         writer.Serialize(value.ProjectWorkspaceState, options);
         CachedStringFormatter.Instance.Serialize(ref writer, value.RootNamespace, options);
+        CachedStringFormatter.Instance.Serialize(ref writer, value.DisplayName, options);
         writer.Serialize(value.Documents, options);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/SerializationFormat.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/SerializationFormat.cs
@@ -9,5 +9,5 @@ internal static class SerializationFormat
     // or any of the types that compose it changes. This includes: RazorConfiguration,
     // ProjectWorkspaceState, TagHelperDescriptor, and DocumentSnapshotHandle.
     // NOTE: If this version is changed, a coordinated insertion is required between Roslyn and Razor for the C# extension.
-    public const int Version = 2;
+    public const int Version = 3;
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/HostProject.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/HostProject.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using Microsoft.AspNetCore.Razor.Language;
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -14,7 +15,7 @@ internal class HostProject
         IntermediateOutputPath = intermediateOutputPath ?? throw new ArgumentNullException(nameof(intermediateOutputPath));
         Configuration = razorConfiguration ?? throw new ArgumentNullException(nameof(razorConfiguration));
         RootNamespace = rootNamespace;
-        DisplayName = displayName;
+        DisplayName = displayName ?? Path.GetFileNameWithoutExtension(projectFilePath);
 
         Key = ProjectKey.From(this);
     }
@@ -36,8 +37,7 @@ internal class HostProject
     public string? RootNamespace { get; }
 
     /// <summary>
-    /// An extra user-friendly string to show in the VS navigation bar to help the user. We expect this to only be set in VS,
-    /// and to be usually set to the target framework name (eg "net6.0")
+    /// An extra user-friendly string to show in the VS navigation bar to help the user, of the form "{ProjectFileName} ({Flavor})"
     /// </summary>
-    public string? DisplayName { get; }
+    public string DisplayName { get; }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshot.cs
@@ -27,6 +27,7 @@ internal interface IProjectSnapshot
     string IntermediateOutputPath { get; }
 
     string? RootNamespace { get; }
+    string DisplayName { get; }
     VersionStamp Version { get; }
     LanguageVersion CSharpLanguageVersion { get; }
     ImmutableArray<TagHelperDescriptor> TagHelpers { get; }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshotExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshotExtensions.cs
@@ -29,6 +29,7 @@ internal static class IProjectSnapshotExtensions
             filePath: project.FilePath,
             configuration: project.Configuration,
             rootNamespace: project.RootNamespace,
+            displayName: project.DisplayName,
             projectWorkspaceState: project.ProjectWorkspaceState,
             documents: documents.DrainToImmutable());
     }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshot.cs
@@ -40,6 +40,8 @@ internal class ProjectSnapshot : IProjectSnapshot
 
     public string? RootNamespace => State.HostProject.RootNamespace;
 
+    public string DisplayName => State.HostProject.DisplayName;
+
     public LanguageVersion CSharpLanguageVersion => State.CSharpLanguageVersion;
 
     public HostProject HostProject => State.HostProject;

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/EphemeralProjectSnapshot.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/EphemeralProjectSnapshot.cs
@@ -35,6 +35,7 @@ internal class EphemeralProjectSnapshot : IProjectSnapshot
         _services = services;
         FilePath = projectPath;
         IntermediateOutputPath = Path.Combine(Path.GetDirectoryName(FilePath) ?? FilePath, "obj");
+        DisplayName = Path.GetFileNameWithoutExtension(projectPath);
 
         _projectEngine = new Lazy<RazorProjectEngine>(CreateProjectEngine);
 
@@ -52,6 +53,8 @@ internal class EphemeralProjectSnapshot : IProjectSnapshot
     public string IntermediateOutputPath { get; }
 
     public string? RootNamespace { get; }
+
+    public string DisplayName { get; }
 
     public VersionStamp Version => VersionStamp.Default;
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Endpoints/ProjectContexts.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Endpoints/ProjectContexts.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
@@ -35,14 +34,11 @@ internal partial class RazorCustomMessageTarget
             if (project is ProjectSnapshot snapshot &&
                 project.GetDocument(documentFilePath) is not null)
             {
-                var projectFileName = Path.GetFileNameWithoutExtension(snapshot.HostProject.FilePath);
                 projectContexts.Add(new VSProjectContext
                 {
                     Id = project.Key.Id,
                     Kind = VSProjectKind.CSharp,
-                    Label = snapshot.HostProject.DisplayName is { Length: > 0 } displayName
-                        ? $"{projectFileName} ({displayName})"
-                        : projectFileName
+                    Label = snapshot.HostProject.DisplayName
                 });
             }
         }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
@@ -83,7 +83,12 @@ internal class DefaultWindowsRazorProjectHost : WindowsRazorProjectHostBase
 
             await UpdateAsync(() =>
             {
-                var hostProject = new HostProject(CommonServices.UnconfiguredProject.FullPath, intermediatePath, configuration, rootNamespace, displayName: sliceDimensions);
+                var projectFileName = Path.GetFileNameWithoutExtension(CommonServices.UnconfiguredProject.FullPath);
+                var displayName = sliceDimensions is { Length: > 0 }
+                    ? $"{projectFileName} ({sliceDimensions})"
+                    : projectFileName;
+
+                var hostProject = new HostProject(CommonServices.UnconfiguredProject.FullPath, intermediatePath, configuration, rootNamespace, displayName);
 
                 if (_languageServerFeatureOptions is not null)
                 {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
@@ -132,7 +132,12 @@ internal class FallbackWindowsRazorProjectHost : WindowsRazorProjectHostBase
         await UpdateAsync(() =>
         {
             var configuration = FallbackRazorConfiguration.SelectConfiguration(version);
-            var hostProject = new HostProject(CommonServices.UnconfiguredProject.FullPath, intermediatePath, configuration, rootNamespace: null, displayName: sliceDimensions);
+            var projectFileName = Path.GetFileNameWithoutExtension(CommonServices.UnconfiguredProject.FullPath);
+            var displayName = sliceDimensions is { Length: > 0 }
+                ? $"{projectFileName} ({sliceDimensions})"
+                : projectFileName;
+
+            var hostProject = new HostProject(CommonServices.UnconfiguredProject.FullPath, intermediatePath, configuration, rootNamespace: null, displayName);
 
             if (_languageServerFeatureOptions is not null)
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
@@ -259,7 +259,7 @@ internal abstract class WindowsRazorProjectHostBase : OnceInitializedOnceDispose
                 {
                     UninitializeProjectUnsafe(projectKey);
 
-                    var hostProject = new HostProject(newProjectFilePath, current.IntermediateOutputPath, current.Configuration, current.RootNamespace);
+                    var hostProject = new HostProject(newProjectFilePath, current.IntermediateOutputPath, current.Configuration, current.RootNamespace, current.DisplayName);
                     UpdateProjectUnsafe(hostProject);
 
                     // This should no-op in the common case, just putting it here for insurance.

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestProjectSnapshot.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test.Common/TestProjectSnapshot.cs
@@ -27,7 +27,8 @@ internal class TestProjectSnapshot : ProjectSnapshot
         string intermediateOutputPath,
         string[] documentFilePaths,
         RazorConfiguration configuration,
-        ProjectWorkspaceState? projectWorkspaceState)
+        ProjectWorkspaceState? projectWorkspaceState,
+        string? displayName = null)
     {
         var workspaceServices = new List<IWorkspaceService>()
         {
@@ -38,7 +39,7 @@ internal class TestProjectSnapshot : ProjectSnapshot
 
         var hostServices = TestServices.Create(workspaceServices, languageServices);
         using var workspace = TestWorkspace.Create(hostServices);
-        var hostProject = new HostProject(filePath, intermediateOutputPath, configuration, "TestRootNamespace");
+        var hostProject = new HostProject(filePath, intermediateOutputPath, configuration, "TestRootNamespace", displayName);
         var state = ProjectState.Create(workspace.Services, hostProject);
         foreach (var documentFilePath in documentFilePaths)
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultLSPTagHelperTooltipFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultLSPTagHelperTooltipFactoryTest.cs
@@ -64,11 +64,12 @@ World", cleanedSummary);
     public void TryCreateTooltip_Markup_NoAssociatedTagHelperDescriptions_ReturnsFalse()
     {
         // Arrange
-        var descriptionFactory = new DefaultLSPTagHelperTooltipFactory();
+        var snapshotResolver = new TestSnapshotResolver();
+        var descriptionFactory = new DefaultLSPTagHelperTooltipFactory(snapshotResolver);
         var elementDescription = AggregateBoundElementDescription.Empty;
 
         // Act
-        var result = descriptionFactory.TryCreateTooltip(elementDescription, MarkupKind.Markdown,  out var markdown);
+        var result = descriptionFactory.TryCreateTooltip("file.razor", elementDescription, MarkupKind.Markdown, out var markdown);
 
         // Assert
         Assert.False(result);
@@ -79,14 +80,15 @@ World", cleanedSummary);
     public void TryCreateTooltip_Markup_Element_SingleAssociatedTagHelper_ReturnsTrue()
     {
         // Arrange
-        var descriptionFactory = new DefaultLSPTagHelperTooltipFactory();
+        var snapshotResolver = new TestSnapshotResolver();
+        var descriptionFactory = new DefaultLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedTagHelperInfos = new[]
         {
             new BoundElementDescriptionInfo("Microsoft.AspNetCore.SomeTagHelper", "<summary>Uses <see cref=\"T:System.Collections.List{System.String}\" />s</summary>"),
         };
         var elementDescription = new AggregateBoundElementDescription(associatedTagHelperInfos.ToImmutableArray());
         // Act
-        var result = descriptionFactory.TryCreateTooltip(elementDescription, MarkupKind.Markdown, out var markdown);
+        var result = descriptionFactory.TryCreateTooltip("file.razor", elementDescription, MarkupKind.Markdown, out var markdown);
 
         // Assert
         Assert.True(result);
@@ -100,7 +102,8 @@ Uses `List<System.String>`s", markdown.Value);
     public void TryCreateTooltip_Markup_Element_PlainText_NoBold()
     {
         // Arrange
-        var descriptionFactory = new DefaultLSPTagHelperTooltipFactory();
+        var snapshotResolver = new TestSnapshotResolver();
+        var descriptionFactory = new DefaultLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedTagHelperInfos = new[]
         {
             new BoundElementDescriptionInfo("Microsoft.AspNetCore.SomeTagHelper", "<summary>Uses <see cref=\"T:System.Collections.List{System.String}\" />s</summary>"),
@@ -108,7 +111,7 @@ Uses `List<System.String>`s", markdown.Value);
         var elementDescription = new AggregateBoundElementDescription(associatedTagHelperInfos.ToImmutableArray());
 
         // Act
-        var result = descriptionFactory.TryCreateTooltip(elementDescription, MarkupKind.PlainText, out var markdown);
+        var result = descriptionFactory.TryCreateTooltip("file.razor", elementDescription, MarkupKind.PlainText, out var markdown);
 
         // Assert
         Assert.True(result, "TryCreateTooltip should have succeeded");
@@ -122,7 +125,8 @@ Uses `List<System.String>`s", markdown.Value);
     public void TryCreateTooltip_Markup_Attribute_PlainText_NoBold()
     {
         // Arrange
-        var descriptionFactory = new DefaultLSPTagHelperTooltipFactory();
+        var snapshotResolver = new TestSnapshotResolver();
+        var descriptionFactory = new DefaultLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedAttributeDescriptions = new[]
         {
             new BoundAttributeDescriptionInfo(
@@ -148,7 +152,8 @@ Uses `List<System.String>`s", markdown.Value);
     public void TryCreateTooltip_Markup_Element_MultipleAssociatedTagHelpers_ReturnsTrue()
     {
         // Arrange
-        var descriptionFactory = new DefaultLSPTagHelperTooltipFactory();
+        var snapshotResolver = new TestSnapshotResolver();
+        var descriptionFactory = new DefaultLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedTagHelperInfos = new[]
         {
             new BoundElementDescriptionInfo("Microsoft.AspNetCore.SomeTagHelper", "<summary>\nUses <see cref=\"T:System.Collections.List{System.String}\" />s\n</summary>"),
@@ -157,7 +162,7 @@ Uses `List<System.String>`s", markdown.Value);
         var elementDescription = new AggregateBoundElementDescription(associatedTagHelperInfos.ToImmutableArray());
 
         // Act
-        var result = descriptionFactory.TryCreateTooltip(elementDescription, MarkupKind.Markdown, out var markdown);
+        var result = descriptionFactory.TryCreateTooltip("file.razor", elementDescription, MarkupKind.Markdown, out var markdown);
 
         // Assert
         Assert.True(result);
@@ -175,7 +180,8 @@ Also uses `List<System.String>`s", markdown.Value);
     public void TryCreateTooltip_Markup_Attribute_SingleAssociatedAttribute_ReturnsTrue()
     {
         // Arrange
-        var descriptionFactory = new DefaultLSPTagHelperTooltipFactory();
+        var snapshotResolver = new TestSnapshotResolver();
+        var descriptionFactory = new DefaultLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedAttributeDescriptions = new[]
         {
             new BoundAttributeDescriptionInfo(
@@ -201,7 +207,8 @@ Uses `List<System.String>`s", markdown.Value);
     public void TryCreateTooltip_Markup_Attribute_MultipleAssociatedAttributes_ReturnsTrue()
     {
         // Arrange
-        var descriptionFactory = new DefaultLSPTagHelperTooltipFactory();
+        var snapshotResolver = new TestSnapshotResolver();
+        var descriptionFactory = new DefaultLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedAttributeDescriptions = new[]
         {
             new BoundAttributeDescriptionInfo(

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultVSLSPTagHelperTooltipFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultVSLSPTagHelperTooltipFactoryTest.cs
@@ -165,11 +165,12 @@ End summary description.";
     public void TryCreateTooltip_ClassifiedTextElement_NoAssociatedTagHelperDescriptions_ReturnsFalse()
     {
         // Arrange
-        var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory();
+        var snapshotResolver = new TestSnapshotResolver();
+        var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var elementDescription = AggregateBoundElementDescription.Empty;
 
         // Act
-        var result = descriptionFactory.TryCreateTooltip(elementDescription, out ClassifiedTextElement classifiedTextElement);
+        var result = descriptionFactory.TryCreateTooltip("file.razor", elementDescription, out ClassifiedTextElement classifiedTextElement);
 
         // Assert
         Assert.False(result);
@@ -180,7 +181,8 @@ End summary description.";
     public void TryCreateTooltip_ClassifiedTextElement_Element_SingleAssociatedTagHelper_ReturnsTrue_NestedTypes()
     {
         // Arrange
-        var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory();
+        var snapshotResolver = new TestSnapshotResolver();
+        var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedTagHelperInfos = new[]
         {
             new BoundElementDescriptionInfo(
@@ -190,7 +192,7 @@ End summary description.";
         var elementDescription = new AggregateBoundElementDescription(associatedTagHelperInfos.ToImmutableArray());
 
         // Act
-        var result = descriptionFactory.TryCreateTooltip(elementDescription, out ClassifiedTextElement classifiedTextElement);
+        var result = descriptionFactory.TryCreateTooltip("file.razor", elementDescription, out ClassifiedTextElement classifiedTextElement);
 
         // Assert
         Assert.True(result);
@@ -220,7 +222,8 @@ End summary description.";
     public void TryCreateTooltip_ClassifiedTextElement_Element_NamespaceContainsTypeName_ReturnsTrue()
     {
         // Arrange
-        var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory();
+        var snapshotResolver = new TestSnapshotResolver();
+        var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedTagHelperInfos = new[]
         {
             new BoundElementDescriptionInfo(
@@ -230,7 +233,7 @@ End summary description.";
         var elementDescription = new AggregateBoundElementDescription(associatedTagHelperInfos.ToImmutableArray());
 
         // Act
-        var result = descriptionFactory.TryCreateTooltip(elementDescription, out ClassifiedTextElement classifiedTextElement);
+        var result = descriptionFactory.TryCreateTooltip("file.razor", elementDescription, out ClassifiedTextElement classifiedTextElement);
 
         // Assert
         Assert.True(result);
@@ -259,7 +262,8 @@ End summary description.";
     public void TryCreateTooltip_ClassifiedTextElement_Element_MultipleAssociatedTagHelpers_ReturnsTrue()
     {
         // Arrange
-        var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory();
+        var snapshotResolver = new TestSnapshotResolver();
+        var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedTagHelperInfos = new[]
         {
             new BoundElementDescriptionInfo("Microsoft.AspNetCore.SomeTagHelper", "<summary>\nUses <see cref=\"T:System.Collections.List{System.String}\" />s\n</summary>"),
@@ -268,7 +272,7 @@ End summary description.";
         var elementDescription = new AggregateBoundElementDescription(associatedTagHelperInfos.ToImmutableArray());
 
         // Act
-        var result = descriptionFactory.TryCreateTooltip(elementDescription, out ClassifiedTextElement classifiedTextElement);
+        var result = descriptionFactory.TryCreateTooltip("file.razor", elementDescription, out ClassifiedTextElement classifiedTextElement);
 
         // Assert
         Assert.True(result);
@@ -312,7 +316,8 @@ End summary description.";
     public void TryCreateTooltip_ClassifiedTextElement_NoAssociatedAttributeDescriptions_ReturnsFalse()
     {
         // Arrange
-        var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory();
+        var snapshotResolver = new TestSnapshotResolver();
+        var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var elementDescription = AggregateBoundAttributeDescription.Empty;
 
         // Act
@@ -327,7 +332,8 @@ End summary description.";
     public void TryCreateTooltip_ClassifiedTextElement_Attribute_SingleAssociatedAttribute_ReturnsTrue_NestedTypes()
     {
         // Arrange
-        var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory();
+        var snapshotResolver = new TestSnapshotResolver();
+        var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedAttributeDescriptions = new[]
         {
             new BoundAttributeDescriptionInfo(
@@ -375,7 +381,8 @@ End summary description.";
     public void TryCreateTooltip_ClassifiedTextElement_Attribute_MultipleAssociatedAttributes_ReturnsTrue()
     {
         // Arrange
-        var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory();
+        var snapshotResolver = new TestSnapshotResolver();
+        var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedAttributeDescriptions = new[]
         {
             new BoundAttributeDescriptionInfo(
@@ -449,11 +456,12 @@ End summary description.";
     public void TryCreateTooltip_ContainerElement_NoAssociatedTagHelperDescriptions_ReturnsFalse()
     {
         // Arrange
-        var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory();
+        var snapshotResolver = new TestSnapshotResolver();
+        var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var elementDescription = AggregateBoundElementDescription.Empty;
 
         // Act
-        var result = descriptionFactory.TryCreateTooltip(elementDescription, out ContainerElement containerElement);
+        var result = descriptionFactory.TryCreateTooltip("file.razor", elementDescription, out ContainerElement containerElement);
 
         // Assert
         Assert.False(result);
@@ -464,7 +472,8 @@ End summary description.";
     public void TryCreateTooltip_ContainerElement_Attribute_MultipleAssociatedTagHelpers_ReturnsTrue()
     {
         // Arrange
-        var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory();
+        var snapshotResolver = new TestSnapshotResolver();
+        var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedTagHelperInfos = new[]
         {
             new BoundElementDescriptionInfo("Microsoft.AspNetCore.SomeTagHelper", "<summary>\nUses <see cref=\"T:System.Collections.List{System.String}\" />s\n</summary>"),
@@ -473,7 +482,7 @@ End summary description.";
         var elementDescription = new AggregateBoundElementDescription(associatedTagHelperInfos.ToImmutableArray());
 
         // Act
-        var result = descriptionFactory.TryCreateTooltip(elementDescription, out ContainerElement container);
+        var result = descriptionFactory.TryCreateTooltip("file.razor", elementDescription, out ContainerElement container);
 
         // Assert
         Assert.True(result);
@@ -547,7 +556,8 @@ End summary description.";
     public void TryCreateTooltip_ContainerElement_NoAssociatedAttributeDescriptions_ReturnsFalse()
     {
         // Arrange
-        var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory();
+        var snapshotResolver = new TestSnapshotResolver();
+        var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var elementDescription = AggregateBoundAttributeDescription.Empty;
 
         // Act
@@ -562,7 +572,8 @@ End summary description.";
     public void TryCreateTooltip_ContainerElement_Attribute_MultipleAssociatedAttributes_ReturnsTrue()
     {
         // Arrange
-        var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory();
+        var snapshotResolver = new TestSnapshotResolver();
+        var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedAttributeDescriptions = new[]
         {
             new BoundAttributeDescriptionInfo(

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionItemResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionItemResolverTest.cs
@@ -30,8 +30,9 @@ public class RazorCompletionItemResolverTest : LanguageServerTestBase
     public RazorCompletionItemResolverTest(ITestOutputHelper testOutput)
         : base(testOutput)
     {
-        _lspTagHelperTooltipFactory = new DefaultLSPTagHelperTooltipFactory();
-        _vsLspTagHelperTooltipFactory = new DefaultVSLSPTagHelperTooltipFactory();
+        var snapshotResolver = new TestSnapshotResolver();
+        _lspTagHelperTooltipFactory = new DefaultLSPTagHelperTooltipFactory(snapshotResolver);
+        _vsLspTagHelperTooltipFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         _completionCapability = new VSInternalCompletionSetting()
         {
             CompletionItem = new CompletionItemSetting()
@@ -75,7 +76,7 @@ public class RazorCompletionItemResolverTest : LanguageServerTestBase
 
         // Act
         var resolvedCompletionItem = await resolver.ResolveAsync(
-            completionItem, completionList, new[] { razorCompletionItem }, _defaultClientCapability, DisposalToken);
+            completionItem, completionList, CreateCompletionResolveContext(razorCompletionItem), _defaultClientCapability, DisposalToken);
 
         // Assert
         Assert.NotNull(resolvedCompletionItem.Documentation);
@@ -93,7 +94,7 @@ public class RazorCompletionItemResolverTest : LanguageServerTestBase
 
         // Act
         var resolvedCompletionItem = await resolver.ResolveAsync(
-            completionItem, completionList, new[] { razorCompletionItem }, _defaultClientCapability, DisposalToken);
+            completionItem, completionList, CreateCompletionResolveContext(razorCompletionItem), _defaultClientCapability, DisposalToken);
 
         // Assert
         Assert.NotNull(resolvedCompletionItem.Documentation);
@@ -111,7 +112,7 @@ public class RazorCompletionItemResolverTest : LanguageServerTestBase
 
         // Act
         var resolvedCompletionItem = await resolver.ResolveAsync(
-            completionItem, completionList, new[] { razorCompletionItem }, _defaultClientCapability, DisposalToken);
+            completionItem, completionList, CreateCompletionResolveContext(razorCompletionItem), _defaultClientCapability, DisposalToken);
 
         // Assert
         Assert.NotNull(resolvedCompletionItem.Documentation);
@@ -129,7 +130,7 @@ public class RazorCompletionItemResolverTest : LanguageServerTestBase
 
         // Act
         var resolvedCompletionItem = await resolver.ResolveAsync(
-            completionItem, completionList, new[] { razorCompletionItem }, _defaultClientCapability, DisposalToken);
+            completionItem, completionList, CreateCompletionResolveContext(razorCompletionItem), _defaultClientCapability, DisposalToken);
 
         // Assert
         Assert.NotNull(resolvedCompletionItem.Documentation);
@@ -147,7 +148,7 @@ public class RazorCompletionItemResolverTest : LanguageServerTestBase
 
         // Act
         var resolvedCompletionItem = await resolver.ResolveAsync(
-            completionItem, completionList, new[] { razorCompletionItem }, _defaultClientCapability, DisposalToken);
+            completionItem, completionList, CreateCompletionResolveContext(razorCompletionItem), _defaultClientCapability, DisposalToken);
 
         // Assert
         Assert.NotNull(resolvedCompletionItem.Documentation);
@@ -165,7 +166,7 @@ public class RazorCompletionItemResolverTest : LanguageServerTestBase
 
         // Act
         var resolvedCompletionItem = await resolver.ResolveAsync(
-            completionItem, completionList, new[] { razorCompletionItem }, _defaultClientCapability, DisposalToken);
+            completionItem, completionList, CreateCompletionResolveContext(razorCompletionItem), _defaultClientCapability, DisposalToken);
 
         // Assert
         Assert.NotNull(resolvedCompletionItem.Documentation);
@@ -183,7 +184,7 @@ public class RazorCompletionItemResolverTest : LanguageServerTestBase
 
         // Act
         var resolvedCompletionItem = await resolver.ResolveAsync(
-            completionItem, completionList, new[] { razorCompletionItem }, _vsClientCapability, DisposalToken);
+            completionItem, completionList, CreateCompletionResolveContext(razorCompletionItem), _vsClientCapability, DisposalToken);
 
         // Assert
         Assert.NotNull(resolvedCompletionItem.Description);
@@ -201,7 +202,7 @@ public class RazorCompletionItemResolverTest : LanguageServerTestBase
 
         // Act
         var resolvedCompletionItem = await resolver.ResolveAsync(
-            completionItem, completionList, new[] { razorCompletionItem }, _vsClientCapability, DisposalToken);
+            completionItem, completionList, CreateCompletionResolveContext(razorCompletionItem), _vsClientCapability, DisposalToken);
 
         // Assert
         Assert.NotNull(resolvedCompletionItem.Description);
@@ -219,7 +220,7 @@ public class RazorCompletionItemResolverTest : LanguageServerTestBase
 
         // Act
         var resolvedCompletionItem = await resolver.ResolveAsync(
-            completionItem, completionList, new[] { razorCompletionItem }, _vsClientCapability, DisposalToken);
+            completionItem, completionList, CreateCompletionResolveContext(razorCompletionItem), _vsClientCapability, DisposalToken);
 
         // Assert
         Assert.NotNull(resolvedCompletionItem.Description);
@@ -237,7 +238,7 @@ public class RazorCompletionItemResolverTest : LanguageServerTestBase
 
         // Act
         var resolvedCompletionItem = await resolver.ResolveAsync(
-            completionItem, completionList, new[] { razorCompletionItem }, _vsClientCapability, DisposalToken);
+            completionItem, completionList, CreateCompletionResolveContext(razorCompletionItem), _vsClientCapability, DisposalToken);
 
         // Assert
         Assert.NotNull(resolvedCompletionItem.Description);
@@ -261,4 +262,7 @@ public class RazorCompletionItemResolverTest : LanguageServerTestBase
 
     private VSInternalCompletionList CreateLSPCompletionList(params RazorCompletionItem[] razorCompletionItems)
         => RazorCompletionListProvider.CreateLSPCompletionList(razorCompletionItems.ToImmutableArray(), _defaultClientCapability);
+
+    private RazorCompletionResolveContext CreateCompletionResolveContext(RazorCompletionItem razorCompletionItem)
+        => new RazorCompletionResolveContext("file.razor", ImmutableArray<RazorCompletionItem>.Empty.Add(razorCompletionItem));
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperTooltipFactoryBaseTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperTooltipFactoryBaseTest.cs
@@ -420,14 +420,16 @@ There is no xml, but I got you this < and the >.
             @"C:\path\to\obj\1",
             documentFilePaths: new[] { razorFilePath },
             RazorConfiguration.Default,
-            projectWorkspaceState);
+            projectWorkspaceState,
+            displayName: "project1");
 
         var project2 = TestProjectSnapshot.Create(
            @"C:\path\to\project.csproj",
            @"C:\path\to\obj\2",
            documentFilePaths: new[] { razorFilePath },
            RazorConfiguration.Default,
-           projectWorkspaceState: null);
+           projectWorkspaceState: null,
+            displayName: "project2");
 
         var snapshotResolver = new TestSnapshotResolver(razorFilePath, project1, project2);
         var service = new TestTagHelperToolTipFactory(snapshotResolver);
@@ -436,7 +438,8 @@ There is no xml, but I got you this < and the >.
 
         AssertEx.EqualOrDiff("""
 
-            ⚠️ Not available in: C:\path\to\obj\2
+            ⚠️ Not available in:
+                project2
             """, availability);
     }
 
@@ -449,14 +452,16 @@ There is no xml, but I got you this < and the >.
             @"C:\path\to\obj\1",
             documentFilePaths: new[] { razorFilePath },
             RazorConfiguration.Default,
-            projectWorkspaceState: null);
+            projectWorkspaceState: null,
+            displayName: "project1");
 
         var project2 = TestProjectSnapshot.Create(
            @"C:\path\to\project.csproj",
            @"C:\path\to\obj\2",
            documentFilePaths: new[] { razorFilePath },
            RazorConfiguration.Default,
-           projectWorkspaceState: null);
+           projectWorkspaceState: null,
+           displayName: "project2");
 
         var snapshotResolver = new TestSnapshotResolver(razorFilePath, project1, project2);
         var service = new TestTagHelperToolTipFactory(snapshotResolver);
@@ -465,7 +470,9 @@ There is no xml, but I got you this < and the >.
 
         AssertEx.EqualOrDiff("""
 
-            ⚠️ Not available in: C:\path\to\obj\1, C:\path\to\obj\2
+            ⚠️ Not available in:
+                project1
+                project2
             """, availability);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperTooltipFactoryBaseTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperTooltipFactoryBaseTest.cs
@@ -3,10 +3,18 @@
 
 #nullable disable
 
+using System.Collections.Immutable;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Components;
+using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.AspNetCore.Razor.LanguageServer.Tooltip;
+using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common;
+using Roslyn.Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
+using static Microsoft.AspNetCore.Razor.Language.CommonMetadata;
+using TestBase = Microsoft.AspNetCore.Razor.Test.Common.TestBase;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Completion;
 
@@ -330,4 +338,138 @@ There is no xml, but I got you this < and the >.
         Assert.True(result);
         Assert.Equal("There is no xml, but I got you this < and the >.", summary);
     }
+
+    [Fact]
+    public void GetAvailableProjects_NoProjects_ReturnsNull()
+    {
+        var snapshotResolver = new TestSnapshotResolver();
+        var service = new TestTagHelperToolTipFactory(snapshotResolver);
+
+        var availability = service.GetProjectAvailability("file.razor", "MyTagHelper");
+
+        Assert.Null(availability);
+    }
+
+    [Fact]
+    public void GetAvailableProjects_OneProject_ReturnsNull()
+    {
+        var builder = TagHelperDescriptorBuilder.Create(ComponentMetadata.Component.TagHelperKind, "TestTagHelper", "TestAssembly");
+        builder.TagMatchingRule(rule => rule.TagName = "Test");
+        var tagHelperTypeName = "TestNamespace.TestTagHelper";
+        builder.Metadata(TypeName(tagHelperTypeName));
+        var tagHelpers = ImmutableArray.Create(builder.Build());
+        var projectWorkspaceState = new ProjectWorkspaceState(tagHelpers, CodeAnalysis.CSharp.LanguageVersion.Default);
+
+        var razorFilePath = @"C:\path\to\file.razor";
+        var project = TestProjectSnapshot.Create(@"C:\path\to\project.csproj", documentFilePaths: new[] { razorFilePath }, projectWorkspaceState);
+
+        var snapshotResolver = new TestSnapshotResolver(razorFilePath, project);
+        var service = new TestTagHelperToolTipFactory(snapshotResolver);
+
+        var availability = service.GetProjectAvailability(razorFilePath, tagHelperTypeName);
+
+        Assert.Null(availability);
+    }
+
+    [Fact]
+    public void GetAvailableProjects_AvailableInAllProjects_ReturnsNull()
+    {
+        var builder = TagHelperDescriptorBuilder.Create(ComponentMetadata.Component.TagHelperKind, "TestTagHelper", "TestAssembly");
+        builder.TagMatchingRule(rule => rule.TagName = "Test");
+        var tagHelperTypeName = "TestNamespace.TestTagHelper";
+        builder.Metadata(TypeName(tagHelperTypeName));
+        var tagHelpers = ImmutableArray.Create(builder.Build());
+        var projectWorkspaceState = new ProjectWorkspaceState(tagHelpers, CodeAnalysis.CSharp.LanguageVersion.Default);
+
+        var razorFilePath = @"C:\path\to\file.razor";
+        var project1 = TestProjectSnapshot.Create(
+            @"C:\path\to\project.csproj",
+            @"C:\path\to\obj\1",
+            documentFilePaths: new[] { razorFilePath },
+            RazorConfiguration.Default,
+            projectWorkspaceState);
+
+        var project2 = TestProjectSnapshot.Create(
+           @"C:\path\to\project.csproj",
+           @"C:\path\to\obj\2",
+           documentFilePaths: new[] { razorFilePath },
+           RazorConfiguration.Default,
+           projectWorkspaceState);
+
+        var snapshotResolver = new TestSnapshotResolver(razorFilePath, project1, project2);
+        var service = new TestTagHelperToolTipFactory(snapshotResolver);
+
+        var availability = service.GetProjectAvailability(razorFilePath, tagHelperTypeName);
+
+        Assert.Null(availability);
+    }
+
+    [Fact]
+    public void GetAvailableProjects_NotAvailableInAllProjects_ReturnsText()
+    {
+        var builder = TagHelperDescriptorBuilder.Create(ComponentMetadata.Component.TagHelperKind, "TestTagHelper", "TestAssembly");
+        builder.TagMatchingRule(rule => rule.TagName = "Test");
+        var tagHelperTypeName = "TestNamespace.TestTagHelper";
+        builder.Metadata(TypeName(tagHelperTypeName));
+        var tagHelpers = ImmutableArray.Create(builder.Build());
+        var projectWorkspaceState = new ProjectWorkspaceState(tagHelpers, CodeAnalysis.CSharp.LanguageVersion.Default);
+
+        var razorFilePath = @"C:\path\to\file.razor";
+        var project1 = TestProjectSnapshot.Create(
+            @"C:\path\to\project.csproj",
+            @"C:\path\to\obj\1",
+            documentFilePaths: new[] { razorFilePath },
+            RazorConfiguration.Default,
+            projectWorkspaceState);
+
+        var project2 = TestProjectSnapshot.Create(
+           @"C:\path\to\project.csproj",
+           @"C:\path\to\obj\2",
+           documentFilePaths: new[] { razorFilePath },
+           RazorConfiguration.Default,
+           projectWorkspaceState: null);
+
+        var snapshotResolver = new TestSnapshotResolver(razorFilePath, project1, project2);
+        var service = new TestTagHelperToolTipFactory(snapshotResolver);
+
+        var availability = service.GetProjectAvailability(razorFilePath, tagHelperTypeName);
+
+        AssertEx.EqualOrDiff("""
+
+            ⚠️ Not available in: C:\path\to\obj\2
+            """, availability);
+    }
+
+    [Fact]
+    public void GetAvailableProjects_NotAvailableInAnyProject_ReturnsText()
+    {
+        var razorFilePath = @"C:\path\to\file.razor";
+        var project1 = TestProjectSnapshot.Create(
+            @"C:\path\to\project.csproj",
+            @"C:\path\to\obj\1",
+            documentFilePaths: new[] { razorFilePath },
+            RazorConfiguration.Default,
+            projectWorkspaceState: null);
+
+        var project2 = TestProjectSnapshot.Create(
+           @"C:\path\to\project.csproj",
+           @"C:\path\to\obj\2",
+           documentFilePaths: new[] { razorFilePath },
+           RazorConfiguration.Default,
+           projectWorkspaceState: null);
+
+        var snapshotResolver = new TestSnapshotResolver(razorFilePath, project1, project2);
+        var service = new TestTagHelperToolTipFactory(snapshotResolver);
+
+        var availability = service.GetProjectAvailability(razorFilePath, "MyTagHelper");
+
+        AssertEx.EqualOrDiff("""
+
+            ⚠️ Not available in: C:\path\to\obj\1, C:\path\to\obj\2
+            """, availability);
+    }
+}
+
+file class TestTagHelperToolTipFactory(ISnapshotResolver snapshotResolver) : TagHelperTooltipFactoryBase(snapshotResolver)
+{
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorProjectServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorProjectServiceTest.cs
@@ -27,15 +27,8 @@ using Xunit.Sdk;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
-public class DefaultRazorProjectServiceTest : LanguageServerTestBase
+public class DefaultRazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageServerTestBase(testOutput)
 {
-    private readonly ImmutableArray<DocumentSnapshotHandle> _emptyDocuments = ImmutableArray<DocumentSnapshotHandle>.Empty;
-
-    public DefaultRazorProjectServiceTest(ITestOutputHelper testOutput)
-        : base(testOutput)
-    {
-    }
-
     [Fact]
     public void UpdateProject_UpdatesProjectWorkspaceState()
     {
@@ -47,7 +40,7 @@ public class DefaultRazorProjectServiceTest : LanguageServerTestBase
         var projectWorkspaceState = new ProjectWorkspaceState(ImmutableArray<TagHelperDescriptor>.Empty, LanguageVersion.LatestMajor);
 
         // Act
-        projectService.UpdateProject(hostProject.Key, hostProject.Configuration, hostProject.RootNamespace, hostProject.DisplayName, projectWorkspaceState, _emptyDocuments);
+        projectService.UpdateProject(hostProject.Key, hostProject.Configuration, hostProject.RootNamespace, hostProject.DisplayName, projectWorkspaceState, ImmutableArray<DocumentSnapshotHandle>.Empty);
 
         // Assert
         var project = projectManager.GetLoadedProject(hostProject.Key);
@@ -228,7 +221,7 @@ public class DefaultRazorProjectServiceTest : LanguageServerTestBase
         var projectService = CreateProjectService(new TestSnapshotResolver(), projectSnapshotManager.Object);
 
         // Act
-        projectService.UpdateProject(ownerProject.Key, ownerProject.Configuration, expectedRootNamespace, ownerProject.DisplayName, ProjectWorkspaceState.Default, _emptyDocuments);
+        projectService.UpdateProject(ownerProject.Key, ownerProject.Configuration, expectedRootNamespace, ownerProject.DisplayName, ProjectWorkspaceState.Default, ImmutableArray<DocumentSnapshotHandle>.Empty);
 
         // Assert
         projectSnapshotManager.VerifyAll();
@@ -249,7 +242,7 @@ public class DefaultRazorProjectServiceTest : LanguageServerTestBase
         var projectService = CreateProjectService(new TestSnapshotResolver(), projectSnapshotManager.Object);
 
         // Act & Assert
-        projectService.UpdateProject(ownerProject.Key, ownerProject.Configuration, "TestRootNamespace", displayName: "", ProjectWorkspaceState.Default, _emptyDocuments);
+        projectService.UpdateProject(ownerProject.Key, ownerProject.Configuration, "TestRootNamespace", displayName: "", ProjectWorkspaceState.Default, ImmutableArray<DocumentSnapshotHandle>.Empty);
     }
 
     [Fact]
@@ -271,7 +264,7 @@ public class DefaultRazorProjectServiceTest : LanguageServerTestBase
         var projectService = CreateProjectService(new TestSnapshotResolver(), projectSnapshotManager.Object);
 
         // Act
-        projectService.UpdateProject(ownerProject.Key, configuration: null, "TestRootNamespace", displayName: "", ProjectWorkspaceState.Default, _emptyDocuments);
+        projectService.UpdateProject(ownerProject.Key, configuration: null, "TestRootNamespace", displayName: "", ProjectWorkspaceState.Default, ImmutableArray<DocumentSnapshotHandle>.Empty);
 
         // Assert
         projectSnapshotManager.VerifyAll();
@@ -296,7 +289,7 @@ public class DefaultRazorProjectServiceTest : LanguageServerTestBase
         var projectService = CreateProjectService(new TestSnapshotResolver(), projectSnapshotManager.Object);
 
         // Act
-        projectService.UpdateProject(ownerProject.Key, FallbackRazorConfiguration.MVC_1_1, "TestRootNamespace", displayName: "", ProjectWorkspaceState.Default, _emptyDocuments);
+        projectService.UpdateProject(ownerProject.Key, FallbackRazorConfiguration.MVC_1_1, "TestRootNamespace", displayName: "", ProjectWorkspaceState.Default, ImmutableArray<DocumentSnapshotHandle>.Empty);
 
         // Assert
         projectSnapshotManager.VerifyAll();
@@ -315,7 +308,7 @@ public class DefaultRazorProjectServiceTest : LanguageServerTestBase
         var projectService = CreateProjectService(new TestSnapshotResolver(), projectSnapshotManager.Object);
 
         // Act & Assert
-        projectService.UpdateProject(projectKey, FallbackRazorConfiguration.MVC_1_1, "TestRootNamespace", displayName: "", ProjectWorkspaceState.Default, _emptyDocuments);
+        projectService.UpdateProject(projectKey, FallbackRazorConfiguration.MVC_1_1, "TestRootNamespace", displayName: "", ProjectWorkspaceState.Default, ImmutableArray<DocumentSnapshotHandle>.Empty);
     }
 
     [Fact]

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorProjectServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorProjectServiceTest.cs
@@ -29,12 +29,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
 public class DefaultRazorProjectServiceTest : LanguageServerTestBase
 {
-    private readonly IReadOnlyList<DocumentSnapshotHandle> _emptyDocuments;
+    private readonly ImmutableArray<DocumentSnapshotHandle> _emptyDocuments = ImmutableArray<DocumentSnapshotHandle>.Empty;
 
     public DefaultRazorProjectServiceTest(ITestOutputHelper testOutput)
         : base(testOutput)
     {
-        _emptyDocuments = Array.Empty<DocumentSnapshotHandle>();
     }
 
     [Fact]
@@ -48,7 +47,7 @@ public class DefaultRazorProjectServiceTest : LanguageServerTestBase
         var projectWorkspaceState = new ProjectWorkspaceState(ImmutableArray<TagHelperDescriptor>.Empty, LanguageVersion.LatestMajor);
 
         // Act
-        projectService.UpdateProject(hostProject.Key, hostProject.Configuration, hostProject.RootNamespace, projectWorkspaceState, _emptyDocuments);
+        projectService.UpdateProject(hostProject.Key, hostProject.Configuration, hostProject.RootNamespace, hostProject.DisplayName, projectWorkspaceState, _emptyDocuments);
 
         // Assert
         var project = projectManager.GetLoadedProject(hostProject.Key);
@@ -68,7 +67,7 @@ public class DefaultRazorProjectServiceTest : LanguageServerTestBase
         var newDocument = new DocumentSnapshotHandle("file.cshtml", "file.cshtml", FileKinds.Component);
 
         // Act
-        projectService.UpdateProject(hostProject.Key, hostProject.Configuration, hostProject.RootNamespace, ProjectWorkspaceState.Default, new[] { newDocument });
+        projectService.UpdateProject(hostProject.Key, hostProject.Configuration, hostProject.RootNamespace, hostProject.DisplayName, ProjectWorkspaceState.Default, ImmutableArray.Create(newDocument));
 
         // Assert
         var project = projectManager.GetLoadedProject(hostProject.Key);
@@ -91,7 +90,7 @@ public class DefaultRazorProjectServiceTest : LanguageServerTestBase
         var newDocument = new DocumentSnapshotHandle("C:/path/to/file2.cshtml", "file2.cshtml", FileKinds.Legacy);
 
         // Act
-        projectService.UpdateProject(hostProject.Key, hostProject.Configuration, hostProject.RootNamespace, ProjectWorkspaceState.Default, new[] { oldDocument, newDocument });
+        projectService.UpdateProject(hostProject.Key, hostProject.Configuration, hostProject.RootNamespace, hostProject.DisplayName, ProjectWorkspaceState.Default, ImmutableArray.CreateRange([oldDocument, newDocument]));
 
         // Assert
         var project = projectManager.GetLoadedProject(hostProject.Key);
@@ -122,7 +121,7 @@ public class DefaultRazorProjectServiceTest : LanguageServerTestBase
         var addedDocument = new DocumentSnapshotHandle("C:/path/to/file.cshtml", "file.cshtml", FileKinds.Legacy);
 
         // Act
-        projectService.UpdateProject(hostProject.Key, hostProject.Configuration, hostProject.RootNamespace, ProjectWorkspaceState.Default, new[] { addedDocument });
+        projectService.UpdateProject(hostProject.Key, hostProject.Configuration, hostProject.RootNamespace, hostProject.DisplayName, ProjectWorkspaceState.Default, ImmutableArray.Create(addedDocument));
 
         // Assert
         project = projectManager.GetLoadedProject(hostProject.Key);
@@ -155,7 +154,7 @@ public class DefaultRazorProjectServiceTest : LanguageServerTestBase
         var newDocument = new DocumentSnapshotHandle("C:/path/to/file2.cshtml", "file2.cshtml", FileKinds.Legacy);
 
         // Act
-        projectService.UpdateProject(hostProject.Key, hostProject.Configuration, hostProject.RootNamespace, ProjectWorkspaceState.Default, new[] { newDocument });
+        projectService.UpdateProject(hostProject.Key, hostProject.Configuration, hostProject.RootNamespace, hostProject.DisplayName, ProjectWorkspaceState.Default, ImmutableArray.Create(newDocument));
 
         // Assert
         project = projectManager.GetLoadedProject(hostProject.Key);
@@ -188,7 +187,7 @@ public class DefaultRazorProjectServiceTest : LanguageServerTestBase
         };
 
         // Act & Assert
-        projectService.UpdateProject(hostProject.Key, hostProject.Configuration, hostProject.RootNamespace, ProjectWorkspaceState.Default, new[] { newDocument });
+        projectService.UpdateProject(hostProject.Key, hostProject.Configuration, hostProject.RootNamespace, hostProject.DisplayName, ProjectWorkspaceState.Default, ImmutableArray.Create(newDocument));
     }
 
     [Fact]
@@ -204,7 +203,7 @@ public class DefaultRazorProjectServiceTest : LanguageServerTestBase
         var newDocument = new DocumentSnapshotHandle(legacyDocument.FilePath, legacyDocument.TargetPath, FileKinds.Component);
 
         // Act
-        projectService.UpdateProject(hostProject.Key, hostProject.Configuration, hostProject.RootNamespace, ProjectWorkspaceState.Default, new[] { newDocument });
+        projectService.UpdateProject(hostProject.Key, hostProject.Configuration, hostProject.RootNamespace, hostProject.DisplayName, ProjectWorkspaceState.Default, ImmutableArray.Create(newDocument));
 
         // Assert
         var project = projectManager.GetLoadedProject(hostProject.Key);
@@ -229,7 +228,7 @@ public class DefaultRazorProjectServiceTest : LanguageServerTestBase
         var projectService = CreateProjectService(new TestSnapshotResolver(), projectSnapshotManager.Object);
 
         // Act
-        projectService.UpdateProject(ownerProject.Key, ownerProject.Configuration, expectedRootNamespace, ProjectWorkspaceState.Default, _emptyDocuments);
+        projectService.UpdateProject(ownerProject.Key, ownerProject.Configuration, expectedRootNamespace, ownerProject.DisplayName, ProjectWorkspaceState.Default, _emptyDocuments);
 
         // Assert
         projectSnapshotManager.VerifyAll();
@@ -250,7 +249,7 @@ public class DefaultRazorProjectServiceTest : LanguageServerTestBase
         var projectService = CreateProjectService(new TestSnapshotResolver(), projectSnapshotManager.Object);
 
         // Act & Assert
-        projectService.UpdateProject(ownerProject.Key, ownerProject.Configuration, "TestRootNamespace", ProjectWorkspaceState.Default, _emptyDocuments);
+        projectService.UpdateProject(ownerProject.Key, ownerProject.Configuration, "TestRootNamespace", displayName: "", ProjectWorkspaceState.Default, _emptyDocuments);
     }
 
     [Fact]
@@ -272,7 +271,7 @@ public class DefaultRazorProjectServiceTest : LanguageServerTestBase
         var projectService = CreateProjectService(new TestSnapshotResolver(), projectSnapshotManager.Object);
 
         // Act
-        projectService.UpdateProject(ownerProject.Key, configuration: null, "TestRootNamespace", ProjectWorkspaceState.Default, _emptyDocuments);
+        projectService.UpdateProject(ownerProject.Key, configuration: null, "TestRootNamespace", displayName: "", ProjectWorkspaceState.Default, _emptyDocuments);
 
         // Assert
         projectSnapshotManager.VerifyAll();
@@ -297,7 +296,7 @@ public class DefaultRazorProjectServiceTest : LanguageServerTestBase
         var projectService = CreateProjectService(new TestSnapshotResolver(), projectSnapshotManager.Object);
 
         // Act
-        projectService.UpdateProject(ownerProject.Key, FallbackRazorConfiguration.MVC_1_1, "TestRootNamespace", ProjectWorkspaceState.Default, _emptyDocuments);
+        projectService.UpdateProject(ownerProject.Key, FallbackRazorConfiguration.MVC_1_1, "TestRootNamespace", displayName: "", ProjectWorkspaceState.Default, _emptyDocuments);
 
         // Assert
         projectSnapshotManager.VerifyAll();
@@ -316,7 +315,7 @@ public class DefaultRazorProjectServiceTest : LanguageServerTestBase
         var projectService = CreateProjectService(new TestSnapshotResolver(), projectSnapshotManager.Object);
 
         // Act & Assert
-        projectService.UpdateProject(projectKey, FallbackRazorConfiguration.MVC_1_1, "TestRootNamespace", ProjectWorkspaceState.Default, _emptyDocuments);
+        projectService.UpdateProject(projectKey, FallbackRazorConfiguration.MVC_1_1, "TestRootNamespace", displayName: "", ProjectWorkspaceState.Default, _emptyDocuments);
     }
 
     [Fact]
@@ -979,7 +978,7 @@ public class DefaultRazorProjectServiceTest : LanguageServerTestBase
         var projectService = CreateProjectService(projectResolver, projectSnapshotManager.Object);
 
         // Act
-        projectService.AddProject(projectFilePath, "C:/path/to/obj", configuration: null, rootNamespace: null);
+        projectService.AddProject(projectFilePath, "C:/path/to/obj", configuration: null, rootNamespace: null, displayName: "");
 
         // Assert
         projectSnapshotManager.VerifyAll();
@@ -1006,7 +1005,7 @@ public class DefaultRazorProjectServiceTest : LanguageServerTestBase
         var projectService = CreateProjectService(projectResolver, projectSnapshotManager.Object);
 
         // Act
-        projectService.AddProject(projectFilePath, "C:/path/to/obj", configuration, "My.Root.Namespace");
+        projectService.AddProject(projectFilePath, "C:/path/to/obj", configuration, "My.Root.Namespace", displayName: "");
 
         // Assert
         projectSnapshotManager.VerifyAll();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverInfoServiceTest.cs
@@ -76,7 +76,7 @@ public class HoverInfoServiceTest : TagHelperServiceTestBase
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = service.GetHoverInfo(codeDocument, location, CreateMarkDownCapabilities());
+        var hover = service.GetHoverInfo("file.cshtml", codeDocument, location, CreateMarkDownCapabilities());
 
         // Assert
         Assert.Contains("**Test1TagHelper**", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
@@ -105,7 +105,7 @@ public class HoverInfoServiceTest : TagHelperServiceTestBase
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = service.GetHoverInfo(codeDocument, location, CreateMarkDownCapabilities());
+        var hover = service.GetHoverInfo("file.cshtml", codeDocument, location, CreateMarkDownCapabilities());
 
         // Assert
         Assert.Contains("**SomeChild**", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
@@ -134,7 +134,7 @@ public class HoverInfoServiceTest : TagHelperServiceTestBase
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = service.GetHoverInfo(codeDocument, location, CreateMarkDownCapabilities());
+        var hover = service.GetHoverInfo("file.cshtml", codeDocument, location, CreateMarkDownCapabilities());
 
         // Assert
         Assert.Contains("**Attribute**", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
@@ -157,7 +157,7 @@ public class HoverInfoServiceTest : TagHelperServiceTestBase
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = service.GetHoverInfo(codeDocument, location, CreateMarkDownCapabilities());
+        var hover = service.GetHoverInfo("file.cshtml", codeDocument, location, CreateMarkDownCapabilities());
 
         // Assert
         Assert.Contains("**Test1TagHelper**", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
@@ -184,7 +184,7 @@ public class HoverInfoServiceTest : TagHelperServiceTestBase
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = service.GetHoverInfo(codeDocument, location, CreateMarkDownCapabilities());
+        var hover = service.GetHoverInfo("file.cshtml", codeDocument, location, CreateMarkDownCapabilities());
 
         // Assert
         Assert.Contains("**BoolVal**", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
@@ -213,7 +213,7 @@ public class HoverInfoServiceTest : TagHelperServiceTestBase
         var location = new SourceLocation(edgeLocation, 0, edgeLocation);
 
         // Act
-        var hover = service.GetHoverInfo(codeDocument, location, CreateMarkDownCapabilities());
+        var hover = service.GetHoverInfo("file.cshtml", codeDocument, location, CreateMarkDownCapabilities());
 
         // Assert
         Assert.Contains("**BoolVal**", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
@@ -241,7 +241,7 @@ public class HoverInfoServiceTest : TagHelperServiceTestBase
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = service.GetHoverInfo(codeDocument, location, CreateMarkDownCapabilities());
+        var hover = service.GetHoverInfo("file.cshtml", codeDocument, location, CreateMarkDownCapabilities());
 
         // Assert
         Assert.Null(hover);
@@ -262,7 +262,7 @@ public class HoverInfoServiceTest : TagHelperServiceTestBase
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = service.GetHoverInfo(codeDocument, location, CreateMarkDownCapabilities());
+        var hover = service.GetHoverInfo("file.cshtml", codeDocument, location, CreateMarkDownCapabilities());
 
         // Assert
         Assert.Null(hover);
@@ -283,7 +283,7 @@ public class HoverInfoServiceTest : TagHelperServiceTestBase
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = service.GetHoverInfo(codeDocument, location, CreateMarkDownCapabilities());
+        var hover = service.GetHoverInfo("file.cshtml", codeDocument, location, CreateMarkDownCapabilities());
 
         // Assert
         Assert.Null(hover);
@@ -304,7 +304,7 @@ public class HoverInfoServiceTest : TagHelperServiceTestBase
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = service.GetHoverInfo(codeDocument, location, CreateMarkDownCapabilities());
+        var hover = service.GetHoverInfo("file.cshtml", codeDocument, location, CreateMarkDownCapabilities());
 
         // Assert
         Assert.Contains("**BoolVal**", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
@@ -336,7 +336,7 @@ public class HoverInfoServiceTest : TagHelperServiceTestBase
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = service.GetHoverInfo(codeDocument, location, CreateMarkDownCapabilities());
+        var hover = service.GetHoverInfo("file.cshtml", codeDocument, location, CreateMarkDownCapabilities());
 
         // Assert
         Assert.NotNull(hover);
@@ -364,7 +364,7 @@ public class HoverInfoServiceTest : TagHelperServiceTestBase
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = service.GetHoverInfo(codeDocument, location, CreateMarkDownCapabilities());
+        var hover = service.GetHoverInfo("file.cshtml", codeDocument, location, CreateMarkDownCapabilities());
 
         // Assert
         Assert.Contains("**Test1TagHelper**", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
@@ -391,7 +391,7 @@ public class HoverInfoServiceTest : TagHelperServiceTestBase
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = service.GetHoverInfo(codeDocument, location, CreateMarkDownCapabilities());
+        var hover = service.GetHoverInfo("file.cshtml", codeDocument, location, CreateMarkDownCapabilities());
 
         // Assert
         Assert.Contains("**BoolVal**", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
@@ -419,7 +419,7 @@ public class HoverInfoServiceTest : TagHelperServiceTestBase
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = service.GetHoverInfo(codeDocument, location, CreateMarkDownCapabilities());
+        var hover = service.GetHoverInfo("file.cshtml", codeDocument, location, CreateMarkDownCapabilities());
 
         // Assert
         Assert.Null(hover);
@@ -441,7 +441,7 @@ public class HoverInfoServiceTest : TagHelperServiceTestBase
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = service.GetHoverInfo(codeDocument, location, CreatePlainTextCapabilities());
+        var hover = service.GetHoverInfo("file.cshtml", codeDocument, location, CreatePlainTextCapabilities());
 
         // Assert
         Assert.Contains("Test1TagHelper", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
@@ -470,7 +470,7 @@ public class HoverInfoServiceTest : TagHelperServiceTestBase
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = service.GetHoverInfo(codeDocument, location, CreatePlainTextCapabilities());
+        var hover = service.GetHoverInfo("file.cshtml", codeDocument, location, CreatePlainTextCapabilities());
 
         // Assert
         Assert.Contains("Test1TagHelper", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
@@ -499,7 +499,7 @@ public class HoverInfoServiceTest : TagHelperServiceTestBase
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = service.GetHoverInfo(codeDocument, location, CreatePlainTextCapabilities());
+        var hover = service.GetHoverInfo("file.cshtml", codeDocument, location, CreatePlainTextCapabilities());
 
         // Assert
         Assert.Contains("BoolVal", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
@@ -529,7 +529,7 @@ public class HoverInfoServiceTest : TagHelperServiceTestBase
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = service.GetHoverInfo(codeDocument, location, CreatePlainTextCapabilities());
+        var hover = service.GetHoverInfo("file.cshtml", codeDocument, location, CreatePlainTextCapabilities());
 
         // Assert
         Assert.Null(hover);
@@ -551,7 +551,7 @@ public class HoverInfoServiceTest : TagHelperServiceTestBase
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = service.GetHoverInfo(codeDocument, location, CreatePlainTextCapabilities());
+        var hover = service.GetHoverInfo("file.cshtml", codeDocument, location, CreatePlainTextCapabilities());
 
         // Assert
         Assert.Null(hover);
@@ -574,7 +574,7 @@ public class HoverInfoServiceTest : TagHelperServiceTestBase
         clientCapabilities.SupportsVisualStudioExtensions = true;
 
         // Act
-        var vsHover = service.GetHoverInfo(codeDocument, location, clientCapabilities);
+        var vsHover = service.GetHoverInfo("file.cshtml", codeDocument, location, clientCapabilities);
 
         // Assert
         Assert.False(vsHover.Contents.Value.TryGetFourth(out var _));
@@ -617,7 +617,7 @@ public class HoverInfoServiceTest : TagHelperServiceTestBase
         clientCapabilities.SupportsVisualStudioExtensions = true;
 
         // Act
-        var vsHover = service.GetHoverInfo(codeDocument, location, clientCapabilities);
+        var vsHover = service.GetHoverInfo("file.cshtml", codeDocument, location, clientCapabilities);
 
         // Assert
         Assert.False(vsHover.Contents.Value.TryGetFourth(out var _));
@@ -904,8 +904,9 @@ public class HoverInfoServiceTest : TagHelperServiceTestBase
 
     private HoverInfoService GetHoverInfoService()
     {
-        var lspTagHelperTooltipFactory = new DefaultLSPTagHelperTooltipFactory();
-        var vsLspTagHelperTooltipFactory = new DefaultVSLSPTagHelperTooltipFactory();
+        var snapshotResolver = new TestSnapshotResolver();
+        var lspTagHelperTooltipFactory = new DefaultLSPTagHelperTooltipFactory(snapshotResolver);
+        var vsLspTagHelperTooltipFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         return new HoverInfoService(TagHelperFactsService, lspTagHelperTooltipFactory, vsLspTagHelperTooltipFactory, HtmlFactsService);
     }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationFileChangeEventArgsTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationFileChangeEventArgsTest.cs
@@ -27,6 +27,7 @@ public class ProjectConfigurationFileChangeEventArgsTest(ITestOutputHelper testO
                 "c:/path/to/project.csproj",
                 configuration: null,
                 rootNamespace: null,
+                displayName: "project",
                 projectWorkspaceState: null,
                 documents: ImmutableArray<DocumentSnapshotHandle>.Empty));
 
@@ -54,6 +55,7 @@ public class ProjectConfigurationFileChangeEventArgsTest(ITestOutputHelper testO
             "c:/path/to/project.csproj",
             configuration: null,
             rootNamespace: null,
+            displayName: "project",
             projectWorkspaceState: null,
             documents: ImmutableArray<DocumentSnapshotHandle>.Empty);
 
@@ -84,6 +86,7 @@ public class ProjectConfigurationFileChangeEventArgsTest(ITestOutputHelper testO
             "c:/path/to/project.csproj",
             configuration: null,
             rootNamespace: null,
+            displayName: "project",
             projectWorkspaceState: null,
             documents: ImmutableArray<DocumentSnapshotHandle>.Empty);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationStateSynchronizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationStateSynchronizerTest.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Threading.Tasks;
@@ -54,19 +53,21 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
             "path/to/project.csproj",
             RazorConfiguration.Default,
             rootNamespace: "TestRootNamespace",
+            displayName: "project",
             new ProjectWorkspaceState(ImmutableArray<TagHelperDescriptor>.Empty, LanguageVersion.CSharp5),
             ImmutableArray<DocumentSnapshotHandle>.Empty);
         var intermediateOutputPath = Path.GetDirectoryName(projectInfo.SerializedFilePath);
         var projectKey = TestProjectKey.Create(intermediateOutputPath);
         var projectService = new Mock<RazorProjectService>(MockBehavior.Strict);
         projectService
-            .Setup(x => x.AddProject(projectInfo.FilePath, @"path\to\obj", projectInfo.Configuration, projectInfo.RootNamespace))
+            .Setup(x => x.AddProject(projectInfo.FilePath, @"path\to\obj", projectInfo.Configuration, projectInfo.RootNamespace, projectInfo.DisplayName))
             .Returns(projectKey);
         projectService
             .Setup(x => x.UpdateProject(
                 projectKey,
                 projectInfo.Configuration,
                 projectInfo.RootNamespace,
+                projectInfo.DisplayName,
                 projectInfo.ProjectWorkspaceState,
                 projectInfo.Documents)).Verifiable();
         projectService
@@ -74,6 +75,7 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
                  projectKey,
                  null,
                  null,
+                 "",
                  ProjectWorkspaceState.Default,
                  ImmutableArray<DocumentSnapshotHandle>.Empty)).Verifiable();
         var synchronizer = GetSynchronizer(projectService.Object);
@@ -137,16 +139,18 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
             "path/to/project.csproj",
             RazorConfiguration.Default,
             rootNamespace: "TestRootNamespace",
+            displayName: "project",
             new ProjectWorkspaceState(ImmutableArray<TagHelperDescriptor>.Empty, LanguageVersion.CSharp5),
             ImmutableArray<DocumentSnapshotHandle>.Empty);
         var projectKey = TestProjectKey.Create(Path.GetDirectoryName(projectInfo.SerializedFilePath));
         var projectService = new Mock<RazorProjectService>(MockBehavior.Strict);
-        projectService.Setup(service => service.AddProject(projectInfo.FilePath, @"path\to\obj", projectInfo.Configuration, projectInfo.RootNamespace))
+        projectService.Setup(service => service.AddProject(projectInfo.FilePath, @"path\to\obj", projectInfo.Configuration, projectInfo.RootNamespace, projectInfo.DisplayName))
             .Returns(projectKey);
         projectService.Setup(service => service.UpdateProject(
             projectKey,
             projectInfo.Configuration,
             projectInfo.RootNamespace,
+            projectInfo.DisplayName,
             projectInfo.ProjectWorkspaceState,
             projectInfo.Documents)).Verifiable();
         var synchronizer = GetSynchronizer(projectService.Object);
@@ -174,24 +178,27 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
             "path/to/project.csproj",
             RazorConfiguration.Default,
             rootNamespace: "TestRootNamespace",
+            displayName: "project",
             new ProjectWorkspaceState(ImmutableArray<TagHelperDescriptor>.Empty, LanguageVersion.CSharp5),
             ImmutableArray<DocumentSnapshotHandle>.Empty);
         var projectKey = TestProjectKey.Create(Path.GetDirectoryName(projectInfo.SerializedFilePath));
         var projectService = new Mock<RazorProjectService>(MockBehavior.Strict);
-        projectService.Setup(service => service.AddProject(projectInfo.FilePath, @"path\to\obj", projectInfo.Configuration, projectInfo.RootNamespace))
+        projectService.Setup(service => service.AddProject(projectInfo.FilePath, @"path\to\obj", projectInfo.Configuration, projectInfo.RootNamespace, projectInfo.DisplayName))
             .Returns(projectKey);
         projectService.Setup(service => service.UpdateProject(
             projectKey,
             projectInfo.Configuration,
             projectInfo.RootNamespace,
+            projectInfo.DisplayName,
             projectInfo.ProjectWorkspaceState,
             projectInfo.Documents)).Verifiable();
         projectService.Setup(service => service.UpdateProject(
              projectKey,
              null,
              null,
+             "",
              ProjectWorkspaceState.Default,
-             Array.Empty<DocumentSnapshotHandle>())).Verifiable();
+             ImmutableArray<DocumentSnapshotHandle>.Empty)).Verifiable();
         var synchronizer = GetSynchronizer(projectService.Object);
         var deserializer = CreateDeserializer(projectInfo);
         var addArgs = new ProjectConfigurationFileChangeEventArgs("/path/to/obj/project.razor.bin", RazorFileChangeKind.Added, deserializer);
@@ -228,16 +235,18 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
             "path/to/project.csproj",
             RazorConfiguration.Default,
             rootNamespace: "TestRootNamespace",
+            displayName: "project",
             new ProjectWorkspaceState(ImmutableArray<TagHelperDescriptor>.Empty, LanguageVersion.CSharp5),
             ImmutableArray<DocumentSnapshotHandle>.Empty);
         var projectKey = TestProjectKey.Create(Path.GetDirectoryName(initialProjectInfo.SerializedFilePath));
         var projectService = new Mock<RazorProjectService>(MockBehavior.Strict);
-        projectService.Setup(service => service.AddProject(initialProjectInfo.FilePath, @"path\to\obj", initialProjectInfo.Configuration, initialProjectInfo.RootNamespace))
+        projectService.Setup(service => service.AddProject(initialProjectInfo.FilePath, @"path\to\obj", initialProjectInfo.Configuration, initialProjectInfo.RootNamespace, initialProjectInfo.DisplayName))
             .Returns(projectKey);
         projectService.Setup(service => service.UpdateProject(
             projectKey,
             initialProjectInfo.Configuration,
             initialProjectInfo.RootNamespace,
+            initialProjectInfo.DisplayName,
             initialProjectInfo.ProjectWorkspaceState,
             initialProjectInfo.Documents)).Verifiable();
         var changedProjectInfo = new RazorProjectInfo(
@@ -248,12 +257,14 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
                 "TestConfiguration",
                 Array.Empty<RazorExtension>()),
             rootNamespace: "TestRootNamespace2",
+            displayName: "project",
             new ProjectWorkspaceState(ImmutableArray<TagHelperDescriptor>.Empty, LanguageVersion.CSharp6),
             ImmutableArray<DocumentSnapshotHandle>.Empty);
         projectService.Setup(service => service.UpdateProject(
             projectKey,
             changedProjectInfo.Configuration,
             changedProjectInfo.RootNamespace,
+            changedProjectInfo.DisplayName,
             changedProjectInfo.ProjectWorkspaceState,
             changedProjectInfo.Documents)).Verifiable();
         var synchronizer = GetSynchronizer(projectService.Object);
@@ -291,16 +302,18 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
             "path/to/project.csproj",
             RazorConfiguration.Default,
             rootNamespace: "TestRootNamespace",
+            displayName: "project",
             new ProjectWorkspaceState(ImmutableArray<TagHelperDescriptor>.Empty, LanguageVersion.CSharp5),
             ImmutableArray<DocumentSnapshotHandle>.Empty);
         var projectKey = TestProjectKey.Create(Path.GetDirectoryName(initialProjectInfo.SerializedFilePath));
         var projectService = new Mock<RazorProjectService>(MockBehavior.Strict);
-        projectService.Setup(service => service.AddProject(initialProjectInfo.FilePath, @"path\to\obj", initialProjectInfo.Configuration, initialProjectInfo.RootNamespace))
+        projectService.Setup(service => service.AddProject(initialProjectInfo.FilePath, @"path\to\obj", initialProjectInfo.Configuration, initialProjectInfo.RootNamespace, initialProjectInfo.DisplayName))
             .Returns(projectKey);
         projectService.Setup(service => service.UpdateProject(
             projectKey,
             initialProjectInfo.Configuration,
             initialProjectInfo.RootNamespace,
+            initialProjectInfo.DisplayName,
             initialProjectInfo.ProjectWorkspaceState,
             initialProjectInfo.Documents)).Verifiable();
         var changedProjectInfo = new RazorProjectInfo(
@@ -311,6 +324,7 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
                 "TestConfiguration",
                 Array.Empty<RazorExtension>()),
             rootNamespace: "TestRootNamespace2",
+            displayName: "project",
             new ProjectWorkspaceState(ImmutableArray<TagHelperDescriptor>.Empty, LanguageVersion.CSharp6),
             ImmutableArray<DocumentSnapshotHandle>.Empty);
 
@@ -319,8 +333,9 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
              projectKey,
              null,
              null,
+             "",
              ProjectWorkspaceState.Default,
-             Array.Empty<DocumentSnapshotHandle>())).Verifiable();
+             ImmutableArray<DocumentSnapshotHandle>.Empty)).Verifiable();
         var synchronizer = GetSynchronizer(projectService.Object);
         var addDeserializer = CreateDeserializer(initialProjectInfo);
         var addArgs = new ProjectConfigurationFileChangeEventArgs("/path/to/obj/project.razor.bin", RazorFileChangeKind.Added, addDeserializer);
@@ -391,18 +406,20 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
             "path/to/project.csproj",
             RazorConfiguration.Default,
             rootNamespace: "TestRootNamespace",
+            displayName: "project",
             new ProjectWorkspaceState(ImmutableArray<TagHelperDescriptor>.Empty, LanguageVersion.CSharp5),
             ImmutableArray<DocumentSnapshotHandle>.Empty);
         var projectKey = TestProjectKey.Create(Path.GetDirectoryName(projectInfo.SerializedFilePath));
         var projectService = new Mock<RazorProjectService>(MockBehavior.Strict);
-        projectService.Setup(service => service.AddProject(projectInfo.FilePath, @"path\to\obj", projectInfo.Configuration, projectInfo.RootNamespace))
+        projectService.Setup(service => service.AddProject(projectInfo.FilePath, @"path\to\obj", projectInfo.Configuration, projectInfo.RootNamespace, projectInfo.DisplayName))
             .Returns(projectKey);
         projectService.Setup(p => p.UpdateProject(
             projectKey,
             It.IsAny<RazorConfiguration>(),
             It.IsAny<string>(),
+            It.IsAny<string>(),
             It.IsAny<ProjectWorkspaceState>(),
-            It.IsAny<IReadOnlyList<DocumentSnapshotHandle>>()));
+            It.IsAny<ImmutableArray<DocumentSnapshotHandle>>()));
 
         var synchronizer = GetSynchronizer(projectService.Object);
         var changedDeserializer = CreateDeserializer(projectInfo);
@@ -424,8 +441,9 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
             projectKey,
             It.IsAny<RazorConfiguration>(),
             It.IsAny<string>(),
+            It.IsAny<string>(),
             It.IsAny<ProjectWorkspaceState>(),
-            It.IsAny<IReadOnlyList<DocumentSnapshotHandle>>()), Times.Once);
+            It.IsAny<ImmutableArray<DocumentSnapshotHandle>>()), Times.Once);
 
         projectService.VerifyAll();
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestSnapshotResolver.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestSnapshotResolver.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer;
+
+internal class TestSnapshotResolver : ISnapshotResolver
+{
+    private readonly IProjectSnapshot _miscProject = TestProjectSnapshot.Create(@"C:\temp\miscellaneous\project.csproj");
+
+    public IEnumerable<IProjectSnapshot> FindPotentialProjects(string documentFilePath)
+    {
+        yield break;
+    }
+
+    public IProjectSnapshot GetMiscellaneousProject()
+    {
+        return _miscProject;
+    }
+
+    public bool TryResolveDocumentInAnyProject(string documentFilePath, [NotNullWhen(true)] out IDocumentSnapshot? documentSnapshot)
+    {
+        documentSnapshot = null;
+        return false;
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestSnapshotResolver.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestSnapshotResolver.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
@@ -12,10 +13,27 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer;
 internal class TestSnapshotResolver : ISnapshotResolver
 {
     private readonly IProjectSnapshot _miscProject = TestProjectSnapshot.Create(@"C:\temp\miscellaneous\project.csproj");
+    private readonly string? _filePath;
+    private readonly IProjectSnapshot[]? _projects;
+
+    public TestSnapshotResolver()
+    {
+    }
+
+    public TestSnapshotResolver(string filePath, params IProjectSnapshot[] projects)
+    {
+        _filePath = filePath;
+        _projects = projects;
+    }
 
     public IEnumerable<IProjectSnapshot> FindPotentialProjects(string documentFilePath)
     {
-        yield break;
+        if (documentFilePath == _filePath)
+        {
+            return _projects.AssumeNotNull();
+        }
+
+        return Array.Empty<IProjectSnapshot>();
     }
 
     public IProjectSnapshot GetMiscellaneousProject()

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/SerializationTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/SerializationTest.cs
@@ -44,6 +44,7 @@ public class SerializationTest : TestBase
             "/path/to/project.csproj",
             _configuration,
             rootNamespace: "TestProject",
+            displayName: "project",
             _projectWorkspaceState,
             ImmutableArray<DocumentSnapshotHandle>.Empty);
 
@@ -76,6 +77,7 @@ public class SerializationTest : TestBase
             "/path/to/project.csproj",
             _configuration,
             rootNamespace: "TestProject",
+            displayName: "project",
             _projectWorkspaceState,
             ImmutableArray<DocumentSnapshotHandle>.Empty);
 
@@ -110,6 +112,7 @@ public class SerializationTest : TestBase
             "/path/to/project.csproj",
             _configuration,
             rootNamespace: "TestProject",
+            displayName: "project",
             _projectWorkspaceState,
             ImmutableArray.Create(legacyDocument, componentDocument));
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/8879

The PR is larger than you'd expect because I had to plumb the display name, previously only used in the ProjectContext endpoint, all the way through our project system and `project.razor.bin` file