### PR TITLE
Port SyntaxNavigator from Roslyn

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/HtmlMarkupParser.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/HtmlMarkupParser.cs
@@ -2172,7 +2172,7 @@ internal class HtmlMarkupParser : TokenizerBackedParser<HtmlTokenizer>
 
         // Find the last token of this node and return its immediate non-list parent.
         var red = node.CreateRed();
-        var last = red.GetLastTerminal();
+        Syntax.SyntaxNode last = red.GetLastToken();
         if (last == null)
         {
             return null;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/SyntaxNavigator.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/SyntaxNavigator.cs
@@ -1,0 +1,295 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Microsoft.AspNetCore.Razor.PooledObjects;
+
+namespace Microsoft.AspNetCore.Razor.Language.Syntax;
+
+internal static class SyntaxNavigator
+{
+    private static Func<SyntaxToken, bool> GetPredicateFunction(bool includeZeroWidth)
+    {
+        return includeZeroWidth ? SyntaxToken.Any : SyntaxToken.NonZeroWidth;
+    }
+
+    private static bool Matches(Func<SyntaxToken, bool>? predicate, SyntaxToken token)
+    {
+        return predicate == null || ReferenceEquals(predicate, SyntaxToken.Any) || predicate(token);
+    }
+
+    internal static SyntaxToken? GetFirstToken(SyntaxNode current, bool includeZeroWidth)
+    {
+        return GetFirstToken(current, GetPredicateFunction(includeZeroWidth));
+    }
+
+    internal static SyntaxToken? GetLastToken(SyntaxNode current, bool includeZeroWidth)
+    {
+        return GetLastToken(current, GetPredicateFunction(includeZeroWidth));
+    }
+
+    internal static SyntaxToken? GetPreviousToken(in SyntaxToken current, bool includeZeroWidth)
+    {
+        return GetPreviousToken(current, GetPredicateFunction(includeZeroWidth));
+    }
+
+    internal static SyntaxToken? GetNextToken(SyntaxToken current, bool includeZeroWidth)
+    {
+        return GetNextToken(current, GetPredicateFunction(includeZeroWidth));
+    }
+
+    internal static SyntaxToken? GetFirstToken(SyntaxNode current, Func<SyntaxToken, bool>? predicate)
+    {
+        using var stack = new PooledArrayBuilder<ChildSyntaxList.Enumerator>();
+        stack.Push(current.ChildNodes().GetEnumerator());
+
+        while (stack.Count > 0)
+        {
+            var en = stack.Pop();
+            if (en.MoveNext())
+            {
+                var child = en.Current;
+
+                if (child.IsToken)
+                {
+                    var token = GetFirstToken((SyntaxToken)child, predicate);
+                    if (token != null)
+                    {
+                        return token;
+                    }
+                }
+
+                // push this enumerator back, not done yet
+                stack.Push(en);
+
+                if (!child.IsToken)
+                {
+                    stack.Push(child.ChildNodes().GetEnumerator());
+                }
+            }
+        }
+
+        return null;
+    }
+
+    internal static SyntaxToken? GetLastToken(SyntaxNode current, Func<SyntaxToken, bool> predicate)
+    {
+        using var stack = new PooledArrayBuilder<ChildSyntaxList.Reversed.Enumerator>();
+        stack.Push(current.ChildNodes().Reverse().GetEnumerator());
+
+        while (stack.Count > 0)
+        {
+            var en = stack.Pop();
+
+            if (en.MoveNext())
+            {
+                var child = en.Current;
+
+                if (child.IsToken)
+                {
+                    var token = GetLastToken((SyntaxToken)child, predicate);
+                    if (token != null)
+                    {
+                        return token;
+                    }
+                }
+
+                // push this enumerator back, not done yet
+                stack.Push(en);
+
+                if (!child.IsToken)
+                {
+                    stack.Push(child.ChildNodes().Reverse().GetEnumerator());
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static SyntaxToken? GetFirstToken(SyntaxToken token, Func<SyntaxToken, bool>? predicate)
+    {
+        if (Matches(predicate, token))
+        {
+            return token;
+        }
+
+        return null;
+    }
+
+    private static SyntaxToken? GetLastToken(SyntaxToken token, Func<SyntaxToken, bool> predicate)
+    {
+        if (Matches(predicate, token))
+        {
+            return token;
+        }
+
+        return null;
+    }
+
+    internal static SyntaxToken? GetNextToken(SyntaxNode node, Func<SyntaxToken, bool>? predicate)
+    {
+        while (node.Parent != null)
+        {
+            // walk forward in parent's child list until we find ourselves and then return the
+            // next token
+            var returnNext = false;
+            foreach (var child in node.Parent.ChildNodes())
+            {
+                if (returnNext)
+                {
+                    if (child.IsToken)
+                    {
+                        var token = GetFirstToken((SyntaxToken)child, predicate);
+                        if (token != null)
+                        {
+                            return token;
+                        }
+                    }
+                    else
+                    {
+                        var token = GetFirstToken(child, predicate);
+                        if (token != null)
+                        {
+                            return token;
+                        }
+                    }
+                }
+                else if (child == node)
+                {
+                    returnNext = true;
+                }
+            }
+
+            // didn't find the next token in my parent's children, look up the tree
+            node = node.Parent;
+        }
+
+        return null;
+    }
+
+    internal static SyntaxToken? GetPreviousToken(
+        SyntaxNode node,
+        Func<SyntaxToken, bool> predicate)
+    {
+        while (node.Parent != null)
+        {
+            // walk forward in parent's child list until we find ourselves and then return the
+            // previous token
+            var returnPrevious = false;
+            foreach (var child in node.Parent.ChildNodes().Reverse())
+            {
+                if (returnPrevious)
+                {
+                    if (child.IsToken)
+                    {
+                        var token = GetLastToken((SyntaxToken)child, predicate);
+                        if (token != null)
+                        {
+                            return token;
+                        }
+                    }
+                    else
+                    {
+                        var token = GetLastToken(child, predicate);
+                        if (token != null)
+                        {
+                            return token;
+                        }
+                    }
+                }
+                else if (child == node)
+                {
+                    returnPrevious = true;
+                }
+            }
+
+            // didn't find the previous token in my parent's children, look up the tree
+            node = node.Parent;
+        }
+
+        return null;
+    }
+
+    internal static SyntaxToken? GetNextToken(SyntaxToken current, Func<SyntaxToken, bool>? predicate)
+    {
+        if (current.Parent != null)
+        {
+            // walk forward in parent's child list until we find ourself
+            // and then return the next token
+            var returnNext = false;
+            foreach (var child in current.Parent.ChildNodes())
+            {
+                if (returnNext)
+                {
+                    if (child.IsToken)
+                    {
+                        var token = GetFirstToken((SyntaxToken)child, predicate);
+                        if (token != null)
+                        {
+                            return token;
+                        }
+                    }
+                    else
+                    {
+                        var token = GetFirstToken(child, predicate);
+                        if (token != null)
+                        {
+                            return token;
+                        }
+                    }
+                }
+                else if (child == current)
+                {
+                    returnNext = true;
+                }
+            }
+
+            // otherwise get next token from the parent's parent, and so on
+            return GetNextToken(current.Parent, predicate);
+        }
+
+        return null;
+    }
+
+    internal static SyntaxToken? GetPreviousToken(SyntaxToken current, Func<SyntaxToken, bool> predicate)
+    {
+        if (current.Parent != null)
+        {
+            // walk forward in parent's child list until we find ourself
+            // and then return the next token
+            var returnPrevious = false;
+            foreach (var child in current.Parent.ChildNodes().Reverse())
+            {
+                if (returnPrevious)
+                {
+                    if (child.IsToken)
+                    {
+                        var token = GetLastToken((SyntaxToken)child, predicate);
+                        if (token != null)
+                        {
+                            return token;
+                        }
+                    }
+                    else
+                    {
+                        var token = GetLastToken(child, predicate);
+                        if (token != null)
+                        {
+                            return token;
+                        }
+                    }
+                }
+                else if (child == current)
+                {
+                    returnPrevious = true;
+                }
+            }
+
+            // otherwise get next token from the parent's parent, and so on
+            return GetPreviousToken(current.Parent, predicate);
+        }
+
+        return null;
+    }
+}

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/SyntaxNavigator.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/SyntaxNavigator.cs
@@ -28,7 +28,7 @@ internal static class SyntaxNavigator
         return GetLastToken(current, GetPredicateFunction(includeZeroWidth));
     }
 
-    internal static SyntaxToken? GetPreviousToken(in SyntaxToken current, bool includeZeroWidth)
+    internal static SyntaxToken? GetPreviousToken(SyntaxToken current, bool includeZeroWidth)
     {
         return GetPreviousToken(current, GetPredicateFunction(includeZeroWidth));
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/SyntaxNode.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/SyntaxNode.cs
@@ -463,7 +463,7 @@ internal abstract partial class SyntaxNode
                 foundToken = originalFoundToken;
                 do
                 {
-                    foundToken = SyntaxNavigator.GetPreviousToken(foundToken, includeZeroWidth: true);
+                    foundToken = foundToken.GetPreviousToken(includeZeroWidth: true);
                     if (foundToken is null or { Kind: SyntaxKind.NewLine })
                     {
                         return false;
@@ -485,7 +485,7 @@ internal abstract partial class SyntaxNode
                 var currentToken = originalFoundToken;
                 do
                 {
-                    currentToken = SyntaxNavigator.GetNextToken(currentToken, includeZeroWidth: true);
+                    currentToken = currentToken.GetNextToken(includeZeroWidth: true);
 
                     if (currentToken is null || currentToken.Span.End > this.Span.End)
                     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/SyntaxNode.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/SyntaxNode.cs
@@ -224,11 +224,6 @@ internal abstract partial class SyntaxNode
         return lastToken != null ? lastToken.GetTrailingTrivia() : default(SyntaxTriviaList);
     }
 
-    internal SyntaxToken GetFirstToken()
-    {
-        return ((SyntaxToken)GetFirstTerminal());
-    }
-
     internal SyntaxList<SyntaxToken> GetTokens()
     {
         var tokens = SyntaxListBuilder<SyntaxToken>.Create();
@@ -258,59 +253,22 @@ internal abstract partial class SyntaxNode
         }
     }
 
-    internal SyntaxToken GetLastToken()
+    /// <summary>
+    /// Gets the first token of the tree rooted by this node. Skips zero-width tokens.
+    /// </summary>
+    /// <returns>The first token or <c>default(SyntaxToken)</c> if it doesn't exist.</returns>
+    public SyntaxToken GetFirstToken(bool includeZeroWidth = false)
     {
-        return ((SyntaxToken)GetLastTerminal());
+        return SyntaxNavigator.GetFirstToken(this, includeZeroWidth);
     }
 
-    public SyntaxNode GetFirstTerminal()
+    /// <summary>
+    /// Gets the last token of the tree rooted by this node. Skips zero-width tokens.
+    /// </summary>
+    /// <returns>The last token or <c>default(SyntaxToken)</c> if it doesn't exist.</returns>
+    public SyntaxToken GetLastToken(bool includeZeroWidth = false)
     {
-        var node = this;
-
-        do
-        {
-            var foundChild = false;
-            for (int i = 0, n = node.SlotCount; i < n; i++)
-            {
-                var child = node.GetNodeSlot(i);
-                if (child != null)
-                {
-                    node = child;
-                    foundChild = true;
-                    break;
-                }
-            }
-
-            if (!foundChild)
-            {
-                return null;
-            }
-        }
-        while (node.SlotCount != 0);
-
-        return node == this ? this : node;
-    }
-
-    public SyntaxNode GetLastTerminal()
-    {
-        var node = this;
-
-        do
-        {
-            SyntaxNode lastChild = null;
-            for (var i = node.SlotCount - 1; i >= 0; i--)
-            {
-                var child = node.GetNodeSlot(i);
-                if (child != null && child.FullWidth > 0)
-                {
-                    lastChild = child;
-                    break;
-                }
-            }
-            node = lastChild;
-        } while (node?.SlotCount > 0);
-
-        return node;
+        return SyntaxNavigator.GetLastToken(this, includeZeroWidth);
     }
 
     /// <summary>

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/SyntaxToken.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/SyntaxToken.cs
@@ -5,14 +5,15 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using Microsoft.AspNetCore.Razor.Language.Legacy;
 
 namespace Microsoft.AspNetCore.Razor.Language.Syntax;
 
 internal class SyntaxToken : RazorSyntaxNode
 {
+    internal static readonly Func<SyntaxToken, bool> NonZeroWidth = t => t.Width > 0;
+    internal static readonly Func<SyntaxToken, bool> Any = t => true;
+
     internal SyntaxToken(GreenNode green, SyntaxNode parent, int position)
         : base(green, parent, position)
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/SyntaxToken.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/SyntaxToken.cs
@@ -100,6 +100,24 @@ internal class SyntaxToken : RazorSyntaxNode
         return new SyntaxTriviaList(trailing.CreateRed(this, trailingPosition), trailingPosition, index);
     }
 
+    /// <summary>
+    /// Gets the token that follows this token in the syntax tree.
+    /// </summary>
+    /// <returns>The token that follows this token in the syntax tree.</returns>
+    public SyntaxToken GetNextToken(bool includeZeroWidth = false)
+    {
+        return SyntaxNavigator.GetNextToken(this, includeZeroWidth);
+    }
+
+    /// <summary>
+    /// Gets the token that precedes this token in the syntax tree.
+    /// </summary>
+    /// <returns>The previous token that precedes this token in the syntax tree.</returns>
+    public SyntaxToken GetPreviousToken(bool includeZeroWidth = false)
+    {
+        return SyntaxNavigator.GetPreviousToken(this, includeZeroWidth);
+    }
+
     public override string ToString()
     {
         return Content;

--- a/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/Language/SyntaxTreeVerifier.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/Language/SyntaxTreeVerifier.cs
@@ -7,6 +7,7 @@ using System;
 using System.Text;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.AspNetCore.Razor.PooledObjects;
 using Xunit;
 using Xunit.Sdk;
 
@@ -17,7 +18,7 @@ internal class SyntaxTreeVerifier
 {
     public static void Verify(RazorSyntaxTree syntaxTree, bool ensureFullFidelity = true)
     {
-        var verifier = new Verifier(syntaxTree.Source);
+        using var verifier = new Verifier(syntaxTree.Source);
         verifier.Visit(syntaxTree.Root);
 
         if (ensureFullFidelity)
@@ -66,12 +67,87 @@ $@"Could not locate Syntax Node owner at position '{i}':
                 }
             }
         }
+
+        // Verify that NextToken/PreviousToken/FirstToken/LastToken work correctly
+        ref readonly var tokens = ref verifier.AllTokens;
+
+        if (tokens.Count == 0)
+        {
+            Assert.Fail("No tokens found in the syntax tree. There should at least be an EOF token.");
+        }
+
+        var root = syntaxTree.Root;
+        var lastToken = root.GetLastToken(includeZeroWidth: true);
+        var firstToken = root.GetFirstToken(includeZeroWidth: true);
+        Assert.Equal(SyntaxKind.EndOfFile, lastToken.Kind);
+        Assert.Null(lastToken.GetNextToken(includeZeroWidth: true));
+        Assert.Null(lastToken.GetNextToken(includeZeroWidth: false));
+        Assert.Null(firstToken.GetPreviousToken(includeZeroWidth: true));
+        Assert.Null(firstToken.GetPreviousToken(includeZeroWidth: false));
+
+        Assert.Same(tokens[0], firstToken);
+        Assert.Same(tokens[^1], lastToken);
+
+        if (tokens.Count == 1)
+        {
+            Assert.Same(lastToken, firstToken);
+            Assert.Null(lastToken.GetPreviousToken(includeZeroWidth: true));
+            Assert.Null(lastToken.GetPreviousToken(includeZeroWidth: false));
+            return;
+        }
+
+        for (var i = 1; i < (tokens.Count - 1); i++)
+        {
+            var previousTokenIndex = i - 1;
+            var previous = tokens[previousTokenIndex];
+            var current = tokens[i];
+            Assert.Same(previous.GetNextToken(includeZeroWidth: true), current);
+            Assert.Same(current.GetPreviousToken(includeZeroWidth: true), previous);
+            validateNonZeroWidth(previous.GetNextToken(includeZeroWidth: false), previousTokenIndex, countUp: true, in tokens);
+            validateNonZeroWidth(previous.GetPreviousToken(includeZeroWidth: false), previousTokenIndex, countUp: false, in tokens);
+        }
+
+        validateNonZeroWidth(lastToken.GetPreviousToken(includeZeroWidth: false), tokens.Count - 1, countUp: false, in tokens);
+
+        void validateNonZeroWidth(SyntaxToken foundNonZeroWidthToken, int originalTokenIndex, bool countUp, in PooledArrayBuilder<SyntaxToken> tokens)
+        {
+            var (targetIndex, increment) = countUp ? (tokens.Count, 1) : (-1, -1);
+            if (foundNonZeroWidthToken == null)
+            {
+                for (var i = originalTokenIndex + increment; i != targetIndex; i += increment)
+                {
+                    Assert.Equal(0, tokens[i].Width);
+                }
+
+                return;
+            }
+
+            Assert.NotEqual(0, foundNonZeroWidthToken.Width);
+
+            for (var i = originalTokenIndex + increment; i != targetIndex; i += increment)
+            {
+                var token = tokens[i];
+
+                if (token.Width == 0)
+                {
+                    continue;
+                }
+
+                Assert.Same(foundNonZeroWidthToken, token);
+                return;
+            }
+
+            Assert.Fail("Did not find the non-zero width token in the list of tokens.");
+        }
     }
 
-    private class Verifier : SyntaxWalker
+    private class Verifier : SyntaxWalker, IDisposable
     {
         private readonly RazorSourceDocument _source;
         private SourceLocation _currentLocation;
+#pragma warning disable CA1805
+        internal PooledArrayBuilder<SyntaxToken> AllTokens = new();
+#pragma warning restore CA1805
 
         public Verifier(RazorSourceDocument source)
         {
@@ -81,18 +157,27 @@ $@"Could not locate Syntax Node owner at position '{i}':
 
         public override void VisitToken(SyntaxToken token)
         {
-            if (token != null && !token.IsMissing && token.Kind != SyntaxKind.Marker)
+            if (token != null)
             {
-                var start = token.GetSourceLocation(_source);
-                if (!start.Equals(_currentLocation))
+                AllTokens.Add(token);
+                if (!token.IsMissing && token.Kind != SyntaxKind.Marker)
                 {
-                    throw new InvalidOperationException($"Token starting at {start} should start at {_currentLocation} - {token} ");
-                }
+                    var start = token.GetSourceLocation(_source);
+                    if (!start.Equals(_currentLocation))
+                    {
+                        throw new InvalidOperationException($"Token starting at {start} should start at {_currentLocation} - {token} ");
+                    }
 
-                _currentLocation = SourceLocationTracker.Advance(_currentLocation, token.Content);
+                    _currentLocation = SourceLocationTracker.Advance(_currentLocation, token.Content);
+                }
             }
 
             base.VisitToken(token);
+        }
+
+        public void Dispose()
+        {
+            AllTokens.Dispose();
         }
     }
 }


### PR DESCRIPTION
Port over SyntaxNavigator from Roslyn. I've also rewritten FindToken to utilize this, instead of the hand-built system I did previously. In lieu of specific tests, I've instead added a hook to the common `SyntaxValidator` type, that collects all `SyntaxTokens` in a tree and validates the new APIs on them to ensure that we get correct results.
