### PR TITLE
Don't generate code for closed files that are part of fallback projects

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/FallbackHostProject.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/FallbackHostProject.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Razor.Language;
+
+namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+internal class FallbackHostProject : HostProject
+{
+    public FallbackHostProject(string projectFilePath, string intermediateOutputPath, RazorConfiguration razorConfiguration, string rootNamespace, string displayName)
+        : base(projectFilePath, intermediateOutputPath, razorConfiguration, rootNamespace, displayName)
+    {
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/FallbackProjectManager.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/FallbackProjectManager.cs
@@ -82,7 +82,12 @@ internal sealed class FallbackProjectManager
         }
 
         var rootNamespace = project.DefaultNamespace ?? "ASP";
-        var hostProject = new HostProject(project.FilePath, intermediateOutputPath, FallbackRazorConfiguration.Latest, rootNamespace, project.Name);
+
+        // We create this as a fallback project so that other parts of the system can reason about them - eg we don't do code
+        // generation for closed files for documents in these projects. If these projects become "real", either because capabilities
+        // change or simply a timing difference between Roslyn and our CPS components, the HostProject instance associated with
+        // the project will be updated, and it will no longer be a fallback project.
+        var hostProject = new FallbackHostProject(project.FilePath, intermediateOutputPath, FallbackRazorConfiguration.Latest, rootNamespace, project.Name);
 
         _projectSnapshotManagerAccessor.Instance.ProjectAdded(hostProject);
 

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/BackgroundDocumentGenerator.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/BackgroundDocumentGenerator.cs
@@ -134,6 +134,12 @@ internal class BackgroundDocumentGenerator : IProjectSnapshotChangeTrigger
             throw new ArgumentNullException(nameof(document));
         }
 
+        if (project is ProjectSnapshot { HostProject: FallbackHostProject })
+        {
+            // We don't support closed file code generation for fallback projects
+            return;
+        }
+
         _dispatcher.AssertDispatcherThread();
 
         lock (Work)


### PR DESCRIPTION
Fixes a regression from https://github.com/dotnet/razor/pull/9486