### PR TITLE
Warn for unrecognized components with attribute tag helpers

### DIFF
--- a/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGeneratorComponentTests.cs
+++ b/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGeneratorComponentTests.cs
@@ -743,8 +743,13 @@ public sealed class RazorSourceGeneratorComponentTests : RazorSourceGeneratorTes
         // Assert
         result.Diagnostics.Verify(
             Diagnostic("RZ10012").WithLocation(1, 1),
+            Diagnostic("RZ10012").WithLocation(2, 1),
+            Diagnostic("RZ10012").WithLocation(3, 1),
             Diagnostic("RZ10012").WithLocation(4, 1),
+            Diagnostic("RZ10012").WithLocation(5, 1),
+            Diagnostic("RZ10012").WithLocation(6, 1),
             Diagnostic("RZ10022").WithLocation(6, 16), // Attribute '@formname' can only be applied to 'form' elements.
+            Diagnostic("RZ10012").WithLocation(7, 1),
             Diagnostic("RZ10023").WithLocation(7, 18)); // Attribute '@rendermode' is only valid when used on a component.
         Assert.Single(result.GeneratedSources);
     }


### PR DESCRIPTION
Previously, the warning `RZ10012: Found markup element with unexpected name 'NonExistingComponent'. If this is intended to be a component, add a @using directive for its namespace.` was reported only for `MarkupElementSyntax` nodes which is fine for elements like `<X />`. But elements like `<X @key="null" />` are rewritten into `MarkupTagHelperElementSyntax` nodes because there are tag helpers registered for things like `@key`, `@ref`, etc. So this PR adds the reporting also to tag helper elements if they match by attribute (components have also tag helpers which match by tag name - and we obviously don't want to report this warning for them).

Fixes https://github.com/dotnet/razor/issues/9381.