### PR TITLE
Remove LocateOwner from Razor Tooling Tests

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
@@ -67,7 +67,7 @@ internal class TagHelperCompletionProvider : IRazorCompletionItemProvider
             _ => owner.Parent
         };
 
-        if (_htmlFactsService.TryGetElementInfo(owner, out var containingTagNameToken, out var attributes, out _) &&
+        if (_htmlFactsService.TryGetElementInfo(owner, out var containingTagNameToken, out var attributes, closingForwardSlashOrCloseAngleToken: out _) &&
             containingTagNameToken.Span.IntersectsWith(context.AbsoluteIndex))
         {
             // Trying to complete the element type

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
@@ -63,17 +63,14 @@ internal class TagHelperCompletionProvider : IRazorCompletionItemProvider
             // This provider is trying to find the nearest Start or End tag. Most of the time, that's a level up, but if the index the user is typing at
             // is a token of a start or end tag directly, we already have the node we want.
             MarkupStartTagSyntax or MarkupEndTagSyntax or MarkupTagHelperStartTagSyntax or MarkupTagHelperEndTagSyntax => owner,
-            // When overtyping a self closing tag completion happens on "<c$$ />" and the owner is a "misc attribute content"
-            // so we have to navigate back up to the start tag to provide completion. Need to be careful though as we don't
-            // want element completions for <c $$ /> even though the parent node is the same
-            { Parent: MarkupMiscAttributeContentSyntax { Parent: MarkupStartTagSyntax startTag } } when context.AbsoluteIndex == startTag.Name.Span.End => startTag,
             // Either the parent is a context we can handle, or it's not and we shouldn't show completions.
             _ => owner.Parent
         };
 
-        if (_htmlFactsService.TryGetElementInfo(owner, out var containingTagNameToken, out var attributes) &&
+        if (_htmlFactsService.TryGetElementInfo(owner, out var containingTagNameToken, out var attributes, out _) &&
             containingTagNameToken.Span.IntersectsWith(context.AbsoluteIndex))
         {
+            // Trying to complete the element type
             var stringifiedAttributes = _tagHelperFactsService.StringifyAttributes(attributes);
             var containingElement = owner.Parent;
             var elementCompletions = GetElementCompletions(containingElement, containingTagNameToken.Content, stringifiedAttributes, context);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/HoverInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/HoverInfoService.cs
@@ -93,7 +93,7 @@ internal sealed class HoverInfoService : IHoverInfoService
         // only check nodes that are at a different location in the file.
         var ownerStart = owner.SpanStart;
 
-        if (_htmlFactsService.TryGetElementInfo(owner, out var containingTagNameToken, out var attributes, out _) &&
+        if (_htmlFactsService.TryGetElementInfo(owner, out var containingTagNameToken, out var attributes, closingForwardSlashOrCloseAngleToken: out _) &&
             containingTagNameToken.Span.IntersectsWith(location.AbsoluteIndex))
         {
             // Hovering over HTML tag name

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/HoverInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/HoverInfoService.cs
@@ -93,7 +93,7 @@ internal sealed class HoverInfoService : IHoverInfoService
         // only check nodes that are at a different location in the file.
         var ownerStart = owner.SpanStart;
 
-        if (_htmlFactsService.TryGetElementInfo(owner, out var containingTagNameToken, out var attributes) &&
+        if (_htmlFactsService.TryGetElementInfo(owner, out var containingTagNameToken, out var attributes, out _) &&
             containingTagNameToken.Span.IntersectsWith(location.AbsoluteIndex))
         {
             // Hovering over HTML tag name

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
@@ -184,9 +184,7 @@ internal class DirectiveCompletionItemProvider : IRazorCompletionItemProvider
     // Internal for testing
     internal static bool IsDirectiveCompletableToken(AspNetCore.Razor.Language.Syntax.SyntaxToken token)
     {
-        return token.Kind == SyntaxKind.Identifier ||
-            // Marker symbol
-            token.Kind == SyntaxKind.Marker ||
-            token.Kind == SyntaxKind.Keyword;
+        return token is { Kind: SyntaxKind.Identifier or SyntaxKind.Marker or SyntaxKind.Keyword }
+                     or { Kind: SyntaxKind.Transition, Parent.Kind: SyntaxKind.CSharpTransition };
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/MarkupTransitionCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/MarkupTransitionCompletionItemProvider.cs
@@ -74,7 +74,7 @@ internal class MarkupTransitionCompletionItemProvider : IRazorCompletionItemProv
 
         // Also helps filter out edge cases like `< te` and `< te=""`
         // (see comment in AtMarkupTransitionCompletionPoint)
-        if (!_htmlFactsService.TryGetElementInfo(owner, out var containingTagNameToken, out _, out _) ||
+        if (!_htmlFactsService.TryGetElementInfo(owner, out var containingTagNameToken, out _, closingForwardSlashOrCloseAngleToken: out _) ||
             !containingTagNameToken.Span.IntersectsWith(context.AbsoluteIndex))
         {
             return ImmutableArray<RazorCompletionItem>.Empty;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/MarkupTransitionCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/MarkupTransitionCompletionItemProvider.cs
@@ -58,16 +58,23 @@ internal class MarkupTransitionCompletionItemProvider : IRazorCompletionItemProv
             return ImmutableArray<RazorCompletionItem>.Empty;
         }
 
+        // If we're at the edge of a razor code block, FindInnermostNode will have returned that edge. However,
+        // the cursor, from the user's perspective, may still be on a markup element, so we want to walk back
+        // one token.
+        if (owner is RazorMetaCodeSyntax { SpanStart: var spanStart, MetaCode: [var metaCodeToken, ..] } && spanStart == context.AbsoluteIndex)
+        {
+            var previousToken = metaCodeToken.GetPreviousToken();
+            owner = previousToken.Parent;
+        }
+
         if (!AtMarkupTransitionCompletionPoint(owner))
         {
             return ImmutableArray<RazorCompletionItem>.Empty;
         }
 
-        var parent = owner.Parent;
-
         // Also helps filter out edge cases like `< te` and `< te=""`
         // (see comment in AtMarkupTransitionCompletionPoint)
-        if (!_htmlFactsService.TryGetElementInfo(parent, out var containingTagNameToken, out _) ||
+        if (!_htmlFactsService.TryGetElementInfo(owner, out var containingTagNameToken, out _, out _) ||
             !containingTagNameToken.Span.IntersectsWith(context.AbsoluteIndex))
         {
             return ImmutableArray<RazorCompletionItem>.Empty;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionFactsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionFactsService.cs
@@ -82,9 +82,9 @@ internal class RazorCompletionFactsService : IRazorCompletionFactsService
 
         // We also want to walk back for cases like <a hr|/>, which do not involve whitespace at all. For this case, we want
         // to see if we're on the closing slash or angle bracket of a start or end tag
-        if (htmlFactsService.TryGetElementInfo(originalNode, containingTagNameToken: out _, attributeNodes: out _, lastTokenInsideBody: out var lastTokenInsideBody)
-            && lastTokenInsideBody.SpanStart == requestIndex
-            && lastTokenInsideBody.GetPreviousToken() is { } previousToken2)
+        if (htmlFactsService.TryGetElementInfo(originalNode, containingTagNameToken: out _, attributeNodes: out _, closingForwardSlashOrCloseAngleToken: out var closingForwardSlashOrCloseAngleToken)
+            && closingForwardSlashOrCloseAngleToken.SpanStart == requestIndex
+            && closingForwardSlashOrCloseAngleToken.GetPreviousToken() is { } previousToken2)
         {
             Debug.Assert(previousToken2.Span.End == requestIndex);
             return previousToken2.Parent;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultHtmlFactsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultHtmlFactsService.cs
@@ -10,34 +10,34 @@ namespace Microsoft.VisualStudio.Editor.Razor;
 
 internal class DefaultHtmlFactsService : HtmlFactsService
 {
-    public override bool TryGetElementInfo(SyntaxNode element, out SyntaxToken containingTagNameToken, out SyntaxList<RazorSyntaxNode> attributeNodes, out SyntaxToken lastTokenInsideBody)
+    public override bool TryGetElementInfo(SyntaxNode element, out SyntaxToken containingTagNameToken, out SyntaxList<RazorSyntaxNode> attributeNodes, out SyntaxToken closingForwardSlashOrCloseAngleToken)
     {
         switch (element)
         {
             case MarkupStartTagSyntax startTag:
                 containingTagNameToken = startTag.Name;
                 attributeNodes = startTag.Attributes;
-                lastTokenInsideBody = startTag.ForwardSlash ?? startTag.CloseAngle;
+                closingForwardSlashOrCloseAngleToken = startTag.ForwardSlash ?? startTag.CloseAngle;
                 return true;
             case MarkupEndTagSyntax { Parent: MarkupElementSyntax parent } endTag:
                 containingTagNameToken = endTag.Name;
                 attributeNodes = parent.StartTag?.Attributes ?? new SyntaxList<RazorSyntaxNode>();
-                lastTokenInsideBody = endTag.ForwardSlash ?? endTag.CloseAngle;
+                closingForwardSlashOrCloseAngleToken = endTag.ForwardSlash ?? endTag.CloseAngle;
                 return true;
             case MarkupTagHelperStartTagSyntax startTagHelper:
                 containingTagNameToken = startTagHelper.Name;
                 attributeNodes = startTagHelper.Attributes;
-                lastTokenInsideBody = startTagHelper.ForwardSlash ?? startTagHelper.CloseAngle;
+                closingForwardSlashOrCloseAngleToken = startTagHelper.ForwardSlash ?? startTagHelper.CloseAngle;
                 return true;
             case MarkupTagHelperEndTagSyntax { Parent: MarkupTagHelperElementSyntax parent } endTagHelper:
                 containingTagNameToken = endTagHelper.Name;
                 attributeNodes = parent.StartTag?.Attributes ?? new SyntaxList<RazorSyntaxNode>();
-                lastTokenInsideBody = endTagHelper.ForwardSlash ?? endTagHelper.CloseAngle;
+                closingForwardSlashOrCloseAngleToken = endTagHelper.ForwardSlash ?? endTagHelper.CloseAngle;
                 return true;
             default:
                 containingTagNameToken = null;
                 attributeNodes = default;
-                lastTokenInsideBody = null;
+                closingForwardSlashOrCloseAngleToken = null;
                 return false;
         }
     }
@@ -50,7 +50,7 @@ internal class DefaultHtmlFactsService : HtmlFactsService
         out TextSpan? selectedAttributeNameLocation,
         out SyntaxList<RazorSyntaxNode> attributeNodes)
     {
-        if (!TryGetElementInfo(attribute.Parent, out containingTagNameToken, out attributeNodes, out _))
+        if (!TryGetElementInfo(attribute.Parent, out containingTagNameToken, out attributeNodes, closingForwardSlashOrCloseAngleToken: out _))
         {
             containingTagNameToken = null;
             prefixLocation = null;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/HtmlFactsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/HtmlFactsService.cs
@@ -137,7 +137,7 @@ internal abstract class HtmlFactsService
         "wbr",
     };
 
-    public abstract bool TryGetElementInfo(SyntaxNode element, out SyntaxToken containingTagNameToken, out SyntaxList<RazorSyntaxNode> attributeNodes);
+    public abstract bool TryGetElementInfo(SyntaxNode element, out SyntaxToken containingTagNameToken, out SyntaxList<RazorSyntaxNode> attributeNodes, out SyntaxToken lastTokenInsideBody);
 
     public abstract bool TryGetAttributeInfo(
         SyntaxNode attribute,

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/HtmlFactsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/HtmlFactsService.cs
@@ -137,7 +137,7 @@ internal abstract class HtmlFactsService
         "wbr",
     };
 
-    public abstract bool TryGetElementInfo(SyntaxNode element, out SyntaxToken containingTagNameToken, out SyntaxList<RazorSyntaxNode> attributeNodes, out SyntaxToken lastTokenInsideBody);
+    public abstract bool TryGetElementInfo(SyntaxNode element, out SyntaxToken containingTagNameToken, out SyntaxList<RazorSyntaxNode> attributeNodes, out SyntaxToken closingForwardSlashOrCloseAngleToken);
 
     public abstract bool TryGetAttributeInfo(
         SyntaxNode attribute,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/CompletionListProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/CompletionListProviderTest.cs
@@ -106,7 +106,7 @@ public class CompletionListProviderTest : LanguageServerTestBase
             VSInternalCompletionList completionList,
             IEnumerable<string> triggerCharacters,
             ILoggerFactory loggerFactory)
-            : base(null, null, loggerFactory)
+            : base(completionFactsService: null, htmlFactsService: null, completionListCache: null, loggerFactory)
         {
             _completionList = completionList;
             TriggerCharacters = triggerCharacters.ToImmutableHashSet();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionListProvierTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionListProvierTest.cs
@@ -26,6 +26,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion;
 public class RazorCompletionListProvierTest : LanguageServerTestBase
 {
     private readonly IRazorCompletionFactsService _completionFactsService;
+    private readonly HtmlFactsService _htmlFactsService;
     private readonly CompletionListCache _completionListCache;
     private readonly VSInternalClientCapabilities _clientCapabilities;
     private readonly VSInternalCompletionContext _defaultCompletionContext;
@@ -34,6 +35,7 @@ public class RazorCompletionListProvierTest : LanguageServerTestBase
         : base(testOutput)
     {     
         _completionFactsService = new RazorCompletionFactsService(GetCompletionProviders());
+        _htmlFactsService = new DefaultHtmlFactsService();
         _completionListCache = new CompletionListCache();
         _clientCapabilities = new VSInternalClientCapabilities()
         {
@@ -359,7 +361,7 @@ public class RazorCompletionListProvierTest : LanguageServerTestBase
         var documentPath = "C:/path/to/document.cshtml";
         var codeDocument = CreateCodeDocument("@");
         var documentContext = TestDocumentContext.From(documentPath, codeDocument, hostDocumentVersion: 0);
-        var provider = new RazorCompletionListProvider(_completionFactsService, _completionListCache, LoggerFactory);
+        var provider = new RazorCompletionListProvider(_completionFactsService, _htmlFactsService, _completionListCache, LoggerFactory);
 
         // Act
         var completionList = await provider.GetCompletionListAsync(
@@ -390,7 +392,7 @@ public class RazorCompletionListProvierTest : LanguageServerTestBase
             TriggerKind = CompletionTriggerKind.TriggerForIncompleteCompletions,
             InvokeKind = VSInternalCompletionInvokeKind.Deletion,
         };
-        var provider = new RazorCompletionListProvider(_completionFactsService, _completionListCache, LoggerFactory);
+        var provider = new RazorCompletionListProvider(_completionFactsService, _htmlFactsService, _completionListCache, LoggerFactory);
 
         // Act
         var completionList = await provider.GetCompletionListAsync(
@@ -418,7 +420,7 @@ public class RazorCompletionListProvierTest : LanguageServerTestBase
         var codeDocument = CreateCodeDocument("@in");
         codeDocument.SetTagHelperContext(tagHelperContext);
         var documentContext = TestDocumentContext.From(documentPath, codeDocument, hostDocumentVersion: 0);
-        var provider = new RazorCompletionListProvider(_completionFactsService, _completionListCache, LoggerFactory);
+        var provider = new RazorCompletionListProvider(_completionFactsService, _htmlFactsService, _completionListCache, LoggerFactory);
         var completionContext = new VSInternalCompletionContext()
         {
             TriggerKind = CompletionTriggerKind.TriggerForIncompleteCompletions,
@@ -452,7 +454,7 @@ public class RazorCompletionListProvierTest : LanguageServerTestBase
         var codeDocument = CreateCodeDocument("@inje");
         codeDocument.SetTagHelperContext(tagHelperContext);
         var documentContext = TestDocumentContext.From(documentPath, codeDocument, hostDocumentVersion: 0);
-        var provider = new RazorCompletionListProvider(_completionFactsService, _completionListCache, LoggerFactory);
+        var provider = new RazorCompletionListProvider(_completionFactsService, _htmlFactsService, _completionListCache, LoggerFactory);
         var completionContext = new VSInternalCompletionContext()
         {
             TriggerKind = CompletionTriggerKind.TriggerCharacter,
@@ -480,7 +482,7 @@ public class RazorCompletionListProvierTest : LanguageServerTestBase
         var codeDocument = CreateCodeDocument("@inje");
         codeDocument.SetTagHelperContext(tagHelperContext);
         var documentContext = TestDocumentContext.From(documentPath, codeDocument, hostDocumentVersion: 0);
-        var provider = new RazorCompletionListProvider(_completionFactsService, _completionListCache, LoggerFactory);
+        var provider = new RazorCompletionListProvider(_completionFactsService, _htmlFactsService, _completionListCache, LoggerFactory);
         var completionContext = new VSInternalCompletionContext()
         {
             TriggerKind = CompletionTriggerKind.TriggerForIncompleteCompletions,
@@ -515,7 +517,7 @@ public class RazorCompletionListProvierTest : LanguageServerTestBase
         var codeDocument = CreateCodeDocument("<");
         codeDocument.SetTagHelperContext(tagHelperContext);
         var documentContext = TestDocumentContext.From(documentPath, codeDocument, hostDocumentVersion: 0);
-        var provider = new RazorCompletionListProvider(_completionFactsService, _completionListCache, LoggerFactory);
+        var provider = new RazorCompletionListProvider(_completionFactsService, _htmlFactsService, _completionListCache, LoggerFactory);
 
         // Act
         var completionList = await provider.GetCompletionListAsync(
@@ -545,7 +547,7 @@ public class RazorCompletionListProvierTest : LanguageServerTestBase
         var codeDocument = CreateCodeDocument("<test  ");
         codeDocument.SetTagHelperContext(tagHelperContext);
         var documentContext = TestDocumentContext.From(documentPath, codeDocument, hostDocumentVersion: 0);
-        var provider = new RazorCompletionListProvider(_completionFactsService, _completionListCache, LoggerFactory);
+        var provider = new RazorCompletionListProvider(_completionFactsService, _htmlFactsService, _completionListCache, LoggerFactory);
 
         // Act
         var completionList = await provider.GetCompletionListAsync(
@@ -580,7 +582,7 @@ public class RazorCompletionListProvierTest : LanguageServerTestBase
         await optionsMonitor.UpdateAsync(optionsMonitor.CurrentValue with { AutoInsertAttributeQuotes = false }, DisposalToken);
 
         var completionFactsService = new RazorCompletionFactsService(GetCompletionProviders(optionsMonitor));
-        var provider = new RazorCompletionListProvider(completionFactsService, _completionListCache, LoggerFactory);
+        var provider = new RazorCompletionListProvider(completionFactsService, _htmlFactsService, _completionListCache, LoggerFactory);
 
         // Act
         var completionList = await provider.GetCompletionListAsync(

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
@@ -8,10 +8,10 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.Completion;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.VisualStudio.Editor.Razor;
 using Xunit;
@@ -898,8 +898,8 @@ public class TagHelperCompletionProviderTest : TagHelperServiceTestBase
         var syntaxTree = codeDocument.GetSyntaxTree();
         var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
 
-        var queryableChange = new SourceChange(position, length: 0, newText: string.Empty);
-        var owner = syntaxTree.Root.LocateOwner(queryableChange);
+        var owner = syntaxTree.Root.FindInnermostNode(position, includeWhitespace: true, walkMarkersBack: true);
+        owner = RazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, position, new DefaultHtmlFactsService());
         return new RazorCompletionContext(position, owner, syntaxTree, tagHelperDocumentContext, Options: options);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TagHelperFactsServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TagHelperFactsServiceTest.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.LanguageServer.Completion;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Xunit;
 using Xunit.Abstractions;
 using static Microsoft.AspNetCore.Razor.Language.CommonMetadata;
@@ -23,9 +24,7 @@ public class TagHelperFactsServiceTest(ITestOutputHelper testOutput) : TagHelper
         // Arrange
         var codeDocument = CreateComponentDocument($"<TestElement @test='abc' />", DefaultTagHelpers);
         var syntaxTree = codeDocument.GetSyntaxTree();
-        var sourceSpan = new SourceSpan(3, 0);
-        var sourceChangeLocation = new SourceChange(sourceSpan, string.Empty);
-        var startTag = (MarkupTagHelperStartTagSyntax)syntaxTree.Root.LocateOwner(sourceChangeLocation).Parent;
+        var startTag = (MarkupTagHelperStartTagSyntax)syntaxTree.Root.FindInnermostNode(3);
 
         // Act
         var attributes = TagHelperFactsService.StringifyAttributes(startTag.Attributes);
@@ -46,9 +45,7 @@ public class TagHelperFactsServiceTest(ITestOutputHelper testOutput) : TagHelper
         // Arrange
         var codeDocument = CreateComponentDocument($"<TestElement @test:something='abc' />", DefaultTagHelpers);
         var syntaxTree = codeDocument.GetSyntaxTree();
-        var sourceSpan = new SourceSpan(3, 0);
-        var sourceChangeLocation = new SourceChange(sourceSpan, string.Empty);
-        var startTag = (MarkupTagHelperStartTagSyntax)syntaxTree.Root.LocateOwner(sourceChangeLocation).Parent;
+        var startTag = (MarkupTagHelperStartTagSyntax)syntaxTree.Root.FindInnermostNode(3);
 
         // Act
         var attributes = TagHelperFactsService.StringifyAttributes(startTag.Attributes);
@@ -69,9 +66,7 @@ public class TagHelperFactsServiceTest(ITestOutputHelper testOutput) : TagHelper
         // Arrange
         var codeDocument = CreateComponentDocument($"<TestElement @minimized />", DefaultTagHelpers);
         var syntaxTree = codeDocument.GetSyntaxTree();
-        var sourceSpan = new SourceSpan(3, 0);
-        var sourceChangeLocation = new SourceChange(sourceSpan, string.Empty);
-        var startTag = (MarkupTagHelperStartTagSyntax)syntaxTree.Root.LocateOwner(sourceChangeLocation).Parent;
+        var startTag = (MarkupTagHelperStartTagSyntax)syntaxTree.Root.FindInnermostNode(3);
 
         // Act
         var attributes = TagHelperFactsService.StringifyAttributes(startTag.Attributes);
@@ -92,9 +87,7 @@ public class TagHelperFactsServiceTest(ITestOutputHelper testOutput) : TagHelper
         // Arrange
         var codeDocument = CreateComponentDocument($"<TestElement @minimized:something />", DefaultTagHelpers);
         var syntaxTree = codeDocument.GetSyntaxTree();
-        var sourceSpan = new SourceSpan(3, 0);
-        var sourceChangeLocation = new SourceChange(sourceSpan, string.Empty);
-        var startTag = (MarkupTagHelperStartTagSyntax)syntaxTree.Root.LocateOwner(sourceChangeLocation).Parent;
+        var startTag = (MarkupTagHelperStartTagSyntax)syntaxTree.Root.FindInnermostNode(3);
 
         // Act
         var attributes = TagHelperFactsService.StringifyAttributes(startTag.Attributes);
@@ -124,9 +117,7 @@ public class TagHelperFactsServiceTest(ITestOutputHelper testOutput) : TagHelper
         tagHelper.SetMetadata(TypeName("WithBoundAttribute"));
         var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test bound='true' />", isRazorFile: false, tagHelper.Build());
         var syntaxTree = codeDocument.GetSyntaxTree();
-        var sourceSpan = new SourceSpan(30 + Environment.NewLine.Length, 0);
-        var sourceChangeLocation = new SourceChange(sourceSpan, string.Empty);
-        var startTag = (MarkupTagHelperStartTagSyntax)syntaxTree.Root.LocateOwner(sourceChangeLocation).Parent;
+        var startTag = (MarkupTagHelperStartTagSyntax)syntaxTree.Root.FindInnermostNode(30 + Environment.NewLine.Length);
 
         // Act
         var attributes = TagHelperFactsService.StringifyAttributes(startTag.Attributes);
@@ -156,9 +147,7 @@ public class TagHelperFactsServiceTest(ITestOutputHelper testOutput) : TagHelper
         tagHelper.SetMetadata(TypeName("WithBoundAttribute"));
         var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test bound />", isRazorFile: false, tagHelper.Build());
         var syntaxTree = codeDocument.GetSyntaxTree();
-        var sourceSpan = new SourceSpan(30 + Environment.NewLine.Length, 0);
-        var sourceChangeLocation = new SourceChange(sourceSpan, string.Empty);
-        var startTag = (MarkupTagHelperStartTagSyntax)syntaxTree.Root.LocateOwner(sourceChangeLocation).Parent;
+        var startTag = (MarkupTagHelperStartTagSyntax)syntaxTree.Root.FindInnermostNode(30 + Environment.NewLine.Length);
 
         // Act
         var attributes = TagHelperFactsService.StringifyAttributes(startTag.Attributes);
@@ -179,9 +168,7 @@ public class TagHelperFactsServiceTest(ITestOutputHelper testOutput) : TagHelper
         // Arrange
         var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<input unbound='hello world' />", isRazorFile: false, DefaultTagHelpers);
         var syntaxTree = codeDocument.GetSyntaxTree();
-        var sourceSpan = new SourceSpan(30 + Environment.NewLine.Length, 0);
-        var sourceChangeLocation = new SourceChange(sourceSpan, string.Empty);
-        var startTag = (MarkupStartTagSyntax)syntaxTree.Root.LocateOwner(sourceChangeLocation).Parent;
+        var startTag = (MarkupStartTagSyntax)syntaxTree.Root.FindInnermostNode(30 + Environment.NewLine.Length);
 
         // Act
         var attributes = TagHelperFactsService.StringifyAttributes(startTag.Attributes);
@@ -202,9 +189,7 @@ public class TagHelperFactsServiceTest(ITestOutputHelper testOutput) : TagHelper
         // Arrange
         var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<input unbound />", isRazorFile: false, DefaultTagHelpers);
         var syntaxTree = codeDocument.GetSyntaxTree();
-        var sourceSpan = new SourceSpan(30 + Environment.NewLine.Length, 0);
-        var sourceChangeLocation = new SourceChange(sourceSpan, string.Empty);
-        var startTag = (MarkupStartTagSyntax)syntaxTree.Root.LocateOwner(sourceChangeLocation).Parent;
+        var startTag = (MarkupStartTagSyntax)syntaxTree.Root.FindInnermostNode(30 + Environment.NewLine.Length);
 
         // Act
         var attributes = TagHelperFactsService.StringifyAttributes(startTag.Attributes);
@@ -225,9 +210,7 @@ public class TagHelperFactsServiceTest(ITestOutputHelper testOutput) : TagHelper
         // Arrange
         var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<input unbound @DateTime.Now />", isRazorFile: false, DefaultTagHelpers);
         var syntaxTree = codeDocument.GetSyntaxTree();
-        var sourceSpan = new SourceSpan(30 + Environment.NewLine.Length, 0);
-        var sourceChangeLocation = new SourceChange(sourceSpan, string.Empty);
-        var startTag = (MarkupStartTagSyntax)syntaxTree.Root.LocateOwner(sourceChangeLocation).Parent;
+        var startTag = (MarkupStartTagSyntax)syntaxTree.Root.FindInnermostNode(30 + Environment.NewLine.Length);
 
         // Act
         var attributes = TagHelperFactsService.StringifyAttributes(startTag.Attributes);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderBaseTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderBaseTest.cs
@@ -5,8 +5,9 @@
 
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.IntegrationTests;
-using Microsoft.AspNetCore.Razor.Language.Legacy;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Editor.Razor;
 using Xunit;
 using Xunit.Abstractions;
 using RazorSyntaxNode = Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxNode;
@@ -162,7 +163,7 @@ public class DirectiveAttributeCompletionItemProviderBaseTest : RazorToolingInte
         var node = GetNodeAt("<p class='hello @DateTime.Now'>", 2);
 
         // Act
-        var result = DirectiveAttributeCompletionItemProviderBase.TryGetElementInfo(node.Parent, out var tagName, out var attributes);
+        var result = DirectiveAttributeCompletionItemProviderBase.TryGetElementInfo(node, out var tagName, out var attributes);
 
         // Assert
         Assert.True(result);
@@ -181,7 +182,7 @@ public class DirectiveAttributeCompletionItemProviderBaseTest : RazorToolingInte
 }", 2);
 
         // Act
-        var result = DirectiveAttributeCompletionItemProviderBase.TryGetElementInfo(node.Parent, out var tagName, out var attributes);
+        var result = DirectiveAttributeCompletionItemProviderBase.TryGetElementInfo(node, out var tagName, out var attributes);
 
         // Assert
         Assert.True(result);
@@ -196,7 +197,7 @@ public class DirectiveAttributeCompletionItemProviderBaseTest : RazorToolingInte
         var node = GetNodeAt("<p>", 2);
 
         // Act
-        var result = DirectiveAttributeCompletionItemProviderBase.TryGetElementInfo(node.Parent, out _, out var attributes);
+        var result = DirectiveAttributeCompletionItemProviderBase.TryGetElementInfo(node, out _, out var attributes);
 
         // Assert
         Assert.True(result);
@@ -210,7 +211,7 @@ public class DirectiveAttributeCompletionItemProviderBaseTest : RazorToolingInte
         var node = GetNodeAt("<p class='hello @DateTime.Now'>", 2);
 
         // Act
-        var result = DirectiveAttributeCompletionItemProviderBase.TryGetElementInfo(node.Parent, out _, out var attributes);
+        var result = DirectiveAttributeCompletionItemProviderBase.TryGetElementInfo(node, out _, out var attributes);
 
         // Assert
         Assert.True(result);
@@ -228,7 +229,7 @@ public class DirectiveAttributeCompletionItemProviderBaseTest : RazorToolingInte
 }", 2);
 
         // Act
-        var result = DirectiveAttributeCompletionItemProviderBase.TryGetElementInfo(node.Parent, out _, out var attributes);
+        var result = DirectiveAttributeCompletionItemProviderBase.TryGetElementInfo(node, out _, out var attributes);
 
         // Assert
         Assert.True(result);
@@ -239,8 +240,8 @@ public class DirectiveAttributeCompletionItemProviderBaseTest : RazorToolingInte
     {
         var result = CompileToCSharp(content, throwOnFailure: false);
         var syntaxTree = result.CodeDocument.GetSyntaxTree();
-        var change = new SourceChange(new SourceSpan(index, 0), string.Empty);
-        var owner = syntaxTree.Root.LocateOwner(change);
+        var owner = syntaxTree.Root.FindInnermostNode(index, includeWhitespace: true, walkMarkersBack: true);
+        owner = RazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, index, new DefaultHtmlFactsService());
 
         return owner;
     }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.IntegrationTests;
-using Microsoft.AspNetCore.Razor.Language.Legacy;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.VisualStudio.Editor.Razor;
 using Xunit;
 using Xunit.Abstractions;
@@ -43,19 +43,6 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
     {
         var result = CompileToCSharp(content, throwOnFailure: false);
         return result.CodeDocument;
-    }
-
-    [Fact]
-    public void GetCompletionItems_LocationHasNoOwner_ReturnsEmptyCollection()
-    {
-        // Arrange
-        var context = CreateRazorCompletionContext(absoluteIndex: 30, "<input @  />");
-
-        // Act
-        var completions = _provider.GetCompletionItems(context);
-
-        // Assert
-        Assert.Empty(completions);
     }
 
     [Fact]
@@ -303,8 +290,8 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
         var syntaxTree = codeDocument.GetSyntaxTree();
         var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
 
-        var queryableChange = new SourceChange(absoluteIndex, length: 0, newText: string.Empty);
-        var owner = syntaxTree.Root.LocateOwner(queryableChange);
+        var owner = syntaxTree.Root.FindInnermostNode(absoluteIndex, includeWhitespace: true, walkMarkersBack: true);
+        owner = RazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, absoluteIndex, new DefaultHtmlFactsService());
         return new RazorCompletionContext(absoluteIndex, owner, syntaxTree, tagHelperDocumentContext);
     }
 }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeParameterCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeParameterCompletionItemProviderTest.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.IntegrationTests;
-using Microsoft.AspNetCore.Razor.Language.Legacy;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.VisualStudio.Editor.Razor;
 using Xunit;
 using Xunit.Abstractions;
@@ -42,19 +42,6 @@ public class DirectiveAttributeParameterCompletionItemProviderTest : RazorToolin
     {
         var result = CompileToCSharp(content, throwOnFailure: false);
         return result.CodeDocument;
-    }
-
-    [Fact]
-    public void GetCompletionItems_LocationHasNoOwner_ReturnsEmptyCollection()
-    {
-        // Arrange
-        var context = CreateRazorCompletionContext(absoluteIndex: 30, "<input @  />");
-
-        // Act
-        var completions = _provider.GetCompletionItems(context);
-
-        // Assert
-        Assert.Empty(completions);
     }
 
     [Fact]
@@ -196,8 +183,8 @@ public class DirectiveAttributeParameterCompletionItemProviderTest : RazorToolin
         var syntaxTree = codeDocument.GetSyntaxTree();
         var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
 
-        var queryableChange = new SourceChange(absoluteIndex, length: 0, newText: string.Empty);
-        var owner = syntaxTree.Root.LocateOwner(queryableChange);
+        var owner = syntaxTree.Root.FindInnermostNode(absoluteIndex);
+        owner = RazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, absoluteIndex, new DefaultHtmlFactsService());
         return new RazorCompletionContext(absoluteIndex, owner, syntaxTree, tagHelperDocumentContext);
     }
 }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
@@ -10,6 +10,8 @@ using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
+using Microsoft.VisualStudio.Editor.Razor;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -226,20 +228,6 @@ public class DirectiveCompletionItemProviderTest : ToolingTestBase
     }
 
     [Fact]
-    public void ShouldProvideCompletions_ReturnsFalseIfNoOwner()
-    {
-        // Arrange
-        var syntaxTree = CreateSyntaxTree("@");
-        var context = CreateRazorCompletionContext(absoluteIndex: 2, syntaxTree);
-
-        // Act
-        var result = DirectiveCompletionItemProvider.ShouldProvideCompletions(context);
-
-        // Assert
-        Assert.False(result);
-    }
-
-    [Fact]
     public void ShouldProvideCompletions_ReturnsFalseWhenOwnerIsNotExpression()
     {
         // Arrange
@@ -448,8 +436,8 @@ public class DirectiveCompletionItemProviderTest : ToolingTestBase
     private static RazorCompletionContext CreateRazorCompletionContext(int absoluteIndex, RazorSyntaxTree syntaxTree, CompletionReason reason = CompletionReason.Invoked)
     {
         var tagHelperDocumentContext = TagHelperDocumentContext.Create(prefix: string.Empty, Array.Empty<TagHelperDescriptor>());
-        var queryableChange = new SourceChange(absoluteIndex, length: 0, newText: string.Empty);
-        var owner = syntaxTree.Root.LocateOwner(queryableChange);
+        var owner = syntaxTree.Root.FindInnermostNode(absoluteIndex);
+        owner = RazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, absoluteIndex, new DefaultHtmlFactsService());
         return new RazorCompletionContext(absoluteIndex, owner, syntaxTree, tagHelperDocumentContext, reason);
     }
 
@@ -471,7 +459,6 @@ public class DirectiveCompletionItemProviderTest : ToolingTestBase
             Assert.Equal(item.InsertText, directive.Directive);
             Assert.Equal(directive.Description, completionDescription.Description);
         }
-
 
         Assert.Equal(item.CommitCharacters, commitCharacters ?? DirectiveCompletionItemProvider.SingleLineDirectiveCommitCharacters);
     }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/MarkupTransitionCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/MarkupTransitionCompletionItemProviderTest.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.VisualStudio.Editor.Razor;
 using Xunit;
 using Xunit.Abstractions;
@@ -336,8 +337,8 @@ public class MarkupTransitionCompletionItemProviderTest : ToolingTestBase
     {
         var tagHelperDocumentContext = TagHelperDocumentContext.Create(prefix: string.Empty, Array.Empty<TagHelperDescriptor>());
 
-        var queryableChange = new SourceChange(absoluteIndex, length: 0, newText: string.Empty);
-        var owner = syntaxTree.Root.LocateOwner(queryableChange);
+        var owner = syntaxTree.Root.FindInnermostNode(absoluteIndex, includeWhitespace: true, walkMarkersBack: true);
+        owner = RazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, absoluteIndex, new DefaultHtmlFactsService());
         return new RazorCompletionContext(absoluteIndex, owner, syntaxTree, tagHelperDocumentContext);
     }
 


### PR DESCRIPTION
This required adjusting some implementation logic that would have been broken by https://github.com/dotnet/razor/pull/9455, but weren't caught by the tests directly on the main completion provider. We should consider moving these tests to more functional-style implementation, where we test the whole provider pipeline, to avoid potential future bugs here.

With this PR, we've removed all LocateOwner product usages outside the legacy tooling! A followup PR will mark `LocateOwner` as `Obsolete` and suppress the specific areas that it's allowed to be used.