### PR TITLE
Deduplicate slashes during path normalization

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/FilePathNormalizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/FilePathNormalizerTest.cs
@@ -37,7 +37,7 @@ public class FilePathNormalizerTest(ITestOutputHelper testOutput) : ToolingTestB
     }
 
     [Fact]
-    public void NormalizeDirectory_DedupesForwardSlashes()
+    public void NormalizeDirectory_DedupesBackSlashes()
     {
         // Arrange
         var directory = "C:\\path\\to\\\\directory\\";

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/FilePathNormalizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/FilePathNormalizerTest.cs
@@ -50,7 +50,7 @@ public class FilePathNormalizerTest(ITestOutputHelper testOutput) : ToolingTestB
     }
 
     [Fact]
-    public void NormalizeDirectory_DedupesBackSlashes()
+    public void NormalizeDirectory_DedupesForwardSlashes()
     {
         // Arrange
         var directory = "C:/path/to//directory/";

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/FilePathNormalizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/FilePathNormalizerTest.cs
@@ -40,7 +40,7 @@ public class FilePathNormalizerTest(ITestOutputHelper testOutput) : ToolingTestB
     public void NormalizeDirectory_DedupesBackSlashes()
     {
         // Arrange
-        var directory = "C:\\path\\to\\\\directory\\";
+        var directory = @"C:\path\to\\directory\";
 
         // Act
         var normalized = FilePathNormalizer.NormalizeDirectory(directory);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/FilePathNormalizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/FilePathNormalizerTest.cs
@@ -37,6 +37,45 @@ public class FilePathNormalizerTest(ITestOutputHelper testOutput) : ToolingTestB
     }
 
     [Fact]
+    public void NormalizeDirectory_DedupesForwardSlashes()
+    {
+        // Arrange
+        var directory = "C:\\path\\to\\\\directory\\";
+
+        // Act
+        var normalized = FilePathNormalizer.NormalizeDirectory(directory);
+
+        // Assert
+        Assert.Equal("C:/path/to/directory/", normalized);
+    }
+
+    [Fact]
+    public void NormalizeDirectory_DedupesBackSlashes()
+    {
+        // Arrange
+        var directory = "C:/path/to//directory/";
+
+        // Act
+        var normalized = FilePathNormalizer.NormalizeDirectory(directory);
+
+        // Assert
+        Assert.Equal("C:/path/to/directory/", normalized);
+    }
+
+    [Fact]
+    public void NormalizeDirectory_DedupesMismatchedSlashes()
+    {
+        // Arrange
+        var directory = "C:\\path\\to\\/directory\\";
+
+        // Act
+        var normalized = FilePathNormalizer.NormalizeDirectory(directory);
+
+        // Assert
+        Assert.Equal("C:/path/to/directory/", normalized);
+    }
+
+    [Fact]
     public void NormalizeDirectory_EndsWithSlash()
     {
         // Arrange


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/9527

The way we handle paths wasn't fixing two slashes in a row to be one slash, which isn't fundamentally a problem, but Roslyn does, and it meant that we were not correctly matching Razor projects to Roslyn projects. We now match Roslyns path normalization logic: https://github.com/dotnet/roslyn/blob/main/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs#L146