### PR TITLE
Fix telemetry (again!)

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/TelemetryScope.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/TelemetryScope.cs
@@ -93,7 +93,7 @@ internal sealed class TelemetryScope : IDisposable
 
     public static TelemetryScope Create(ITelemetryReporter reporter, string name, Severity severity, Property property1, Property property2, Property property3)
     {
-        var array = new Property[3];
+        var array = new Property[4];
         array[0] = property1;
         array[1] = property2;
         array[2] = property3;


### PR DESCRIPTION
When reducing allocations in our telemetry, I inadvertently created one array to be too small, resulting in our correlation ID being overwritten for telemetry with three properties.

Many thanks to @maryamariyan for spotting this bug!