### PR TITLE
Mark LocateOwner obsolete

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/LegacySyntaxNodeExtensions.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/LegacySyntaxNodeExtensions.cs
@@ -140,6 +140,7 @@ internal static partial class LegacySyntaxNodeExtensions
         return node.WithAnnotations(newAnnotationsArray);
     }
 
+    [Obsolete("Use FindToken or FindInnermostNode instead", error: false)]
     public static SyntaxNode? LocateOwner(this SyntaxNode node, SourceChange change)
     {
         if (node is null)

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/BraceSmartIndenter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/BraceSmartIndenter.cs
@@ -260,7 +260,9 @@ internal class BraceSmartIndenter : IDisposable
         // @{ |}
 
         var change = new SourceChange(changePosition, 0, string.Empty);
+#pragma warning disable CS0618 // Type or member is obsolete, BraceSmartIndenter is only used in legacy scenarios
         var owner = syntaxTree.Root.LocateOwner(change);
+#pragma warning restore CS0618 // Type or member is obsolete
 
         if (IsUnlinkedSpan(owner))
         {

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/RazorIndentationFacts.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/RazorIndentationFacts.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
@@ -33,6 +34,7 @@ internal static class RazorIndentationFacts
         int indentSize,
         int tabSize)
     {
+        Debug.Assert(syntaxTreeSnapshot.TextBuffer.IsLegacyCoreRazorBuffer());
         if (syntaxTree is null)
         {
             throw new ArgumentNullException(nameof(syntaxTree));
@@ -60,7 +62,9 @@ internal static class RazorIndentationFacts
 
         var previousLineEndIndex = GetPreviousLineEndIndex(syntaxTreeSnapshot, line);
         var simulatedChange = new SourceChange(previousLineEndIndex, 0, string.Empty);
+#pragma warning disable CS0618 // Type or member is obsolete, RazorIndentationFacts is only used in legacy scenarios
         var owner = syntaxTree.Root.LocateOwner(simulatedChange);
+#pragma warning restore CS0618 // Type or member is obsolete
         if (owner is null || owner.IsCodeSpanKind())
         {
             // Example,

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/RazorSyntaxTreePartialParser.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/RazorSyntaxTreePartialParser.cs
@@ -71,7 +71,9 @@ internal class RazorSyntaxTreePartialParser
         }
 
         // Locate the span responsible for this change
+#pragma warning disable CS0618 // Type or member is obsolete, RazorSyntaxTreePartialParser is only used in legacy scenarios
         _lastChangeOwner = ModifiedSyntaxTreeRoot.LocateOwner(change);
+#pragma warning restore CS0618 // Type or member is obsolete
 
         if (_lastResultProvisional)
         {

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/BraceSmartIndenterTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/BraceSmartIndenterTest.cs
@@ -549,7 +549,9 @@ public class BraceSmartIndenterTest : BraceSmartIndenterTestBase
     private static SyntaxNode ExtractSpan(int spanLocation, string content)
     {
         var syntaxTree = GetSyntaxTree(content);
+#pragma warning disable CS0618 // Type or member is obsolete
         var span = syntaxTree.Root.LocateOwner(new SourceChange(new SourceSpan(spanLocation, 0), string.Empty));
+#pragma warning restore CS0618 // Type or member is obsolete
         return span;
     }
 

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/BraceSmartIndenterTestBase.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/BraceSmartIndenterTestBase.cs
@@ -2,19 +2,17 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using Microsoft.VisualStudio.Test;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Operations;
-using Microsoft.VisualStudio.Utilities;
 using Moq;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.VisualStudio.Editor.Razor;
 
-public class BraceSmartIndenterTestBase(ITestOutputHelper testOutput) : ProjectSnapshotManagerDispatcherTestBase(testOutput)
+public partial class BraceSmartIndenterTestBase(ITestOutputHelper testOutput) : ProjectSnapshotManagerDispatcherTestBase(testOutput)
 {
     private protected static VisualStudioDocumentTracker CreateDocumentTracker(Func<ITextBuffer> bufferAccessor, ITextView focusedTextView)
     {
@@ -84,19 +82,5 @@ public class BraceSmartIndenterTestBase(ITestOutputHelper testOutput) : ProjectS
         var mock = new Mock<ITextBuffer>(MockBehavior.Strict);
         mock.SetupGet(a => a.ContentType).Returns(new LegacyCoreContentType());
         return mock.Object;
-    }
-
-    protected class LegacyCoreContentType : IContentType
-    {
-        public string TypeName => throw new NotImplementedException();
-
-        public string DisplayName => throw new NotImplementedException();
-
-        public IEnumerable<IContentType> BaseTypes => throw new NotImplementedException();
-
-        public bool IsOfType(string type)
-        {
-            return type == RazorConstants.LegacyCoreContentType;
-        }
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultRazorIndentationFactsServiceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultRazorIndentationFactsServiceTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.VisualStudio.Test;
 using Microsoft.VisualStudio.Text;
 using Xunit;
 using Xunit.Abstractions;
@@ -174,6 +175,7 @@ public class DefaultRazorIndentationFactsServiceTest(ITestOutputHelper testOutpu
     </div>
 </div>
 ");
+        var textBuffer = new TestTextBuffer(source, new LegacyCoreContentType());
         var syntaxTree = GetSyntaxTree(new StringTextSnapshot("something else"));
 
         // Act
@@ -195,6 +197,7 @@ public class DefaultRazorIndentationFactsServiceTest(ITestOutputHelper testOutpu
         var source = new StringTextSnapshot($@"
 @{{
 ");
+        var textBuffer = new TestTextBuffer(source, new LegacyCoreContentType());
         var syntaxTree = GetSyntaxTree(source);
 
         // Act
@@ -217,6 +220,7 @@ public class DefaultRazorIndentationFactsServiceTest(ITestOutputHelper testOutpu
         var source = new StringTextSnapshot($@"
 @custom
 ");
+        var textBuffer = new TestTextBuffer(source, new LegacyCoreContentType());
         var syntaxTree = GetSyntaxTree(source, new[] { customDirective });
 
         // Act
@@ -238,6 +242,7 @@ public class DefaultRazorIndentationFactsServiceTest(ITestOutputHelper testOutpu
         var source = new StringTextSnapshot($@"@{{
     <div>
 ");
+        var textBuffer = new TestTextBuffer(source, new LegacyCoreContentType());
         var syntaxTree = GetSyntaxTree(source);
 
         // Act
@@ -261,6 +266,7 @@ public class DefaultRazorIndentationFactsServiceTest(ITestOutputHelper testOutpu
 {{
     <div>
 }}");
+        var textBuffer = new TestTextBuffer(source, new LegacyCoreContentType());
         var syntaxTree = GetSyntaxTree(source, new[] { customDirective });
 
         // Act
@@ -286,6 +292,7 @@ public class DefaultRazorIndentationFactsServiceTest(ITestOutputHelper testOutpu
     }}
 </div>
 ");
+        var textBuffer = new TestTextBuffer(source, new LegacyCoreContentType());
         var syntaxTree = GetSyntaxTree(source);
 
         // Act
@@ -311,6 +318,8 @@ public class DefaultRazorIndentationFactsServiceTest(ITestOutputHelper testOutpu
         <div>
     }}
 }}");
+
+        var textBuffer = new TestTextBuffer(source, new LegacyCoreContentType());
         var syntaxTree = GetSyntaxTree(source, new[] { customDirective });
 
         // Act

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/LegacyCoreContentType.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/LegacyCoreContentType.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.Utilities;
+
+namespace Microsoft.VisualStudio.Editor.Razor;
+
+public class LegacyCoreContentType : IContentType
+{
+    public string TypeName => throw new NotImplementedException();
+
+    public string DisplayName => throw new NotImplementedException();
+
+    public IEnumerable<IContentType> BaseTypes => throw new NotImplementedException();
+
+    public bool IsOfType(string type)
+    {
+        return type == RazorConstants.LegacyCoreContentType;
+    }
+}

--- a/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/Language/SyntaxTreeVerifier.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/Language/SyntaxTreeVerifier.cs
@@ -40,7 +40,9 @@ internal class SyntaxTreeVerifier
             {
                 var span = new SourceSpan(i, 0);
                 var location = new SourceChange(span, string.Empty);
+#pragma warning disable CS0618 // Type or member is obsolete, will be removed in an upcoming change
                 var owner = syntaxTree.Root.LocateOwner(location);
+#pragma warning restore CS0618 // Type or member is obsolete
 
                 if (owner == null)
                 {


### PR DESCRIPTION
There are no more product usages in the LSP codepaths, so we are marking this obsolete in preparation for disabling SpanEditHandlers in non-legacy scenarios.
