### PR TITLE
Script for starting VS Code using correct dotnet

### DIFF
--- a/startcode.cmd
+++ b/startcode.cmd
@@ -1,0 +1,4 @@
+@echo off
+setlocal
+
+powershell -ExecutionPolicy ByPass -NoProfile -Command "& '%~dp0startcode.ps1'" %*

--- a/startcode.ps1
+++ b/startcode.ps1
@@ -1,0 +1,12 @@
+﻿
+# In the case the .dotnet folder exists, need to assume it's possibly where the
+# dotnet sdk listed by global.json exists. Rather than parsing out global.json,
+# checking for matches in that directory (non-trivial), just put it first on the
+# path, enable mulit-level lookup and start code.
+$dotnetPath = Join-Path (Get-Location) ".dotnet"
+if (Test-Path $dotnetPath) {
+  $env:DOTNET_MULTILEVEL_LOOKUP=1
+  $env:PATH="$dotnetPath;$env:PATH"
+}
+
+code .


### PR DESCRIPTION
This adds startcode.cmd/ps1 scripts which are similar in nature to startvs variants. Most notably it effectively puts the `.dotnet` directory into consideration for searching for the appropriate .NET SDK for global.json.

