### PR TITLE
Obsolete ClassifiedSpanInternal.AcceptedCharacters

### DIFF
--- a/Razor.Slim.slnf
+++ b/Razor.Slim.slnf
@@ -12,6 +12,7 @@
       "src\\Compiler\\Microsoft.AspNetCore.Mvc.Razor.Extensions\\test\\Microsoft.AspNetCore.Mvc.Razor.Extensions.Test.csproj",
       "src\\Compiler\\Microsoft.AspNetCore.Razor.Language\\src\\Microsoft.CodeAnalysis.Razor.Compiler.Language.csproj",
       "src\\Compiler\\Microsoft.AspNetCore.Razor.Language\\test\\Microsoft.AspNetCore.Razor.Language.Test.csproj",
+      "src\\Compiler\\Microsoft.AspNetCore.Razor.Language\\legacyTest\\Microsoft.AspNetCore.Razor.Language.Legacy.Test.csproj",
       "src\\Compiler\\Microsoft.CodeAnalysis.Razor\\src\\Microsoft.CodeAnalysis.Razor.Compiler.CSharp.csproj",
       "src\\Compiler\\Microsoft.CodeAnalysis.Razor\\test\\Microsoft.CodeAnalysis.Razor.Test.csproj",
       "src\\Compiler\\Microsoft.NET.Sdk.Razor.SourceGenerators.Transport\\Microsoft.NET.Sdk.Razor.SourceGenerators.Transport.csproj",

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/ClassifiedSpanInternal.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/ClassifiedSpanInternal.cs
@@ -3,6 +3,8 @@
 
 #nullable disable
 
+using System;
+
 namespace Microsoft.AspNetCore.Razor.Language.Legacy;
 
 internal struct ClassifiedSpanInternal
@@ -13,9 +15,12 @@ internal struct ClassifiedSpanInternal
         BlockSpan = blockSpan;
         SpanKind = spanKind;
         BlockKind = blockKind;
+#pragma warning disable CS0618 // Type or member is obsolete
         AcceptedCharacters = acceptedCharacters;
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 
+    [Obsolete("This property is deprecated. Do not use it.", error: false)]
     public AcceptedCharactersInternal AcceptedCharacters { get; }
 
     public BlockKindInternal BlockKind { get; }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.LegacyEditor/RazorWrapperFactory.CodeDocumentWrapper.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.LegacyEditor/RazorWrapperFactory.CodeDocumentWrapper.cs
@@ -27,7 +27,9 @@ internal static partial class RazorWrapperFactory
                     ConvertSourceSpan(item.BlockSpan),
                     (SpanKind)item.SpanKind,
                     (BlockKind)item.BlockKind,
+#pragma warning disable CS0618 // Type or member is obsolete
                     (AcceptedCharacters)item.AcceptedCharacters));
+#pragma warning restore CS0618 // Type or member is obsolete
             }
 
             return builder.DrainToImmutable();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorDocumentMappingService.cs
@@ -498,10 +498,11 @@ internal sealed class RazorDocumentMappingService : IRazorDocumentMappingService
                     {
                         // We're at an edge.
 
-                        if (span.Length > 0 &&
-                            classifiedSpan.AcceptedCharacters == AcceptedCharactersInternal.None)
+                        if (classifiedSpan.SpanKind is SpanKindInternal.MetaCode or SpanKindInternal.Transition)
                         {
-                            // Non-marker spans do not own the edges after it
+                            // If we're on an edge of a transition of some kind (MetaCode representing an open or closing piece of syntax such as <|,
+                            // and Transition representing an explicit transition to/from razor syntax, such as @|), prefer to classify to the span
+                            // to the right to better represent where the user clicks
                             continue;
                         }
 

--- a/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/Language/Legacy/ClassifiedSpan/ClassifiedSpanWriter.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/Language/Legacy/ClassifiedSpan/ClassifiedSpanWriter.cs
@@ -29,7 +29,9 @@ internal class ClassifiedSpanWriter(TextWriter writer, RazorSyntaxTree syntaxTre
         Write($"{span.SpanKind} span at {span.Span}");
         if (validateSpanEditHandlers)
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             Write($" (Accepts:{span.AcceptedCharacters})");
+#pragma warning restore CS0618 // Type or member is obsolete
         }
         WriteSeparator();
         Write($"Parent: {span.BlockKind} block at {span.BlockSpan}");


### PR DESCRIPTION
This property is calculated through use of SpanEditHandlers, so it needs to go. As part of this, I had to update the tooling `RazorDocumentMappingService` to not rely on this property. Luckily, once I understood what the original code was looking for, there was an obvious, more straightforward way to get that information.

@dotnet/razor-compiler and @dotnet/razor-tooling for review.