### PR TITLE
Fire telemetry when a document is opened that is tracked by a fallback project

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshot.cs
@@ -34,6 +34,8 @@ internal class ProjectSnapshot : IProjectSnapshot
 
     public IEnumerable<string> DocumentFilePaths => State.Documents.Keys;
 
+    public int DocumentCount => State.Documents.Count;
+
     public string FilePath => State.HostProject.FilePath;
 
     public string IntermediateOutputPath => State.HostProject.IntermediateOutputPath;


### PR DESCRIPTION
We now have support for fallback projects, which is great, but we don't know how many people actually _use_ the files in these projects.