### PR TITLE
Use raw string literals for readability

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/test/InjectTargetExtensionTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/test/InjectTargetExtensionTest.cs
@@ -30,9 +30,11 @@ public class InjectTargetExtensionTest
         target.WriteInjectProperty(context, node);
 
         // Assert
-        Assert.Equal(
-            "[global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]" + Environment.NewLine +
-            "public PropertyType PropertyName { get; private set; }" + Environment.NewLine,
+        Assert.Equal("""
+            [global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]
+            public PropertyType PropertyName { get; private set; }
+
+            """,
             context.CodeWriter.GenerateCode());
     }
 
@@ -58,14 +60,18 @@ public class InjectTargetExtensionTest
         target.WriteInjectProperty(context, node);
 
         // Assert
-        Assert.Equal(Environment.NewLine +
-            "#nullable restore" + Environment.NewLine +
-            "#line 2 \"test-path\"" + Environment.NewLine +
-            "[global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]" + Environment.NewLine +
-            "public PropertyType<ModelType> PropertyName { get; private set; }" + Environment.NewLine + Environment.NewLine +
-            "#line default" + Environment.NewLine +
-            "#line hidden" + Environment.NewLine +
-            "#nullable disable" + Environment.NewLine,
+        Assert.Equal("""
+
+            #nullable restore
+            #line 2 "test-path"
+            [global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]
+            public PropertyType<ModelType> PropertyName { get; private set; }
+
+            #line default
+            #line hidden
+            #nullable disable
+
+            """,
             context.CodeWriter.GenerateCode());
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/test/IntegrationTests/CodeGenerationIntegrationTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version1_X/test/IntegrationTests/CodeGenerationIntegrationTest.cs
@@ -157,14 +157,14 @@ public class MyModel
     public void Sections_DesignTime()
     {
         // Arrange
-        AddCSharpSyntaxTree($@"
+        AddCSharpSyntaxTree($$"""
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 
-public class InputTestTagHelper : {typeof(TagHelper).FullName}
-{{
-    public ModelExpression For {{ get; set; }}
-}}
-");
+public class InputTestTagHelper : {{typeof(TagHelper).FullName}}
+{
+    public ModelExpression For { get; set; }
+}
+""");
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -320,14 +320,14 @@ public class ThisShouldBeGenerated
     public void ModelExpressionTagHelper_DesignTime()
     {
         // Arrange
-        AddCSharpSyntaxTree($@"
+        AddCSharpSyntaxTree($$"""
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 
-public class InputTestTagHelper : {typeof(TagHelper).FullName}
-{{
-    public ModelExpression For {{ get; set; }}
-}}
-");
+public class InputTestTagHelper : {{typeof(TagHelper).FullName}}
+{
+    public ModelExpression For { get; set; }
+}
+""");
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -344,21 +344,21 @@ public class InputTestTagHelper : {typeof(TagHelper).FullName}
     public void ViewComponentTagHelper_DesignTime()
     {
         // Arrange
-        AddCSharpSyntaxTree($@"
+        AddCSharpSyntaxTree($$"""
 public class TestViewComponent
-{{
+{
     public string Invoke(string firstName)
-    {{
+    {
         return firstName;
-    }}
-}}
+    }
+}
 
-[{typeof(HtmlTargetElementAttribute).FullName}]
-public class AllTagHelper : {typeof(TagHelper).FullName}
-{{
-    public string Bar {{ get; set; }}
-}}
-");
+[{{typeof(HtmlTargetElementAttribute).FullName}}]
+public class AllTagHelper : {{typeof(TagHelper).FullName}}
+{
+    public string Bar { get; set; }
+}
+""");
 
         var projectItem = CreateProjectItemFromFile();
 

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/InjectTargetExtensionTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/InjectTargetExtensionTest.cs
@@ -28,9 +28,11 @@ public class InjectTargetExtensionTest
         target.WriteInjectProperty(context, node);
 
         // Assert
-        Assert.Equal(
-            "[global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]" + Environment.NewLine +
-            "public PropertyType PropertyName { get; private set; }" + Environment.NewLine,
+        Assert.Equal("""
+            [global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]
+            public PropertyType PropertyName { get; private set; }
+
+            """,
             context.CodeWriter.GenerateCode());
     }
 
@@ -56,14 +58,18 @@ public class InjectTargetExtensionTest
         target.WriteInjectProperty(context, node);
 
         // Assert
-        Assert.Equal(Environment.NewLine +
-            "#nullable restore" + Environment.NewLine +
-            "#line 2 \"test-path\"" + Environment.NewLine +
-            "[global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]" + Environment.NewLine +
-            "public PropertyType<ModelType> PropertyName { get; private set; }" + Environment.NewLine + Environment.NewLine +
-            "#line default" + Environment.NewLine +
-            "#line hidden" + Environment.NewLine +
-            "#nullable disable" + Environment.NewLine,
+        Assert.Equal("""
+
+            #nullable restore
+            #line 2 "test-path"
+            [global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]
+            public PropertyType<ModelType> PropertyName { get; private set; }
+
+            #line default
+            #line hidden
+            #nullable disable
+
+            """,
             context.CodeWriter.GenerateCode());
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/IntegrationTests/CodeGenerationIntegrationTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/IntegrationTests/CodeGenerationIntegrationTest.cs
@@ -189,14 +189,14 @@ public class MyModel
     public void Sections_Runtime()
     {
         // Arrange
-        AddCSharpSyntaxTree($@"
+        AddCSharpSyntaxTree($$"""
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 
-public class InputTestTagHelper : {typeof(TagHelper).FullName}
-{{
-    public ModelExpression For {{ get; set; }}
-}}
-");
+public class InputTestTagHelper : {{typeof(TagHelper).FullName}}
+{
+    public ModelExpression For { get; set; }
+}
+""");
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -323,14 +323,14 @@ public class MyService<TModel>
     public void ModelExpressionTagHelper_Runtime()
     {
         // Arrange
-        AddCSharpSyntaxTree($@"
+        AddCSharpSyntaxTree($$"""
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 
-public class InputTestTagHelper : {typeof(TagHelper).FullName}
-{{
-    public ModelExpression For {{ get; set; }}
-}}
-");
+public class InputTestTagHelper : {{typeof(TagHelper).FullName}}
+{
+    public ModelExpression For { get; set; }
+}
+""");
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -346,12 +346,12 @@ public class InputTestTagHelper : {typeof(TagHelper).FullName}
     public void RazorPages_Runtime()
     {
         // Arrange
-        AddCSharpSyntaxTree($@"
-public class DivTagHelper : {typeof(TagHelper).FullName}
-{{
+        AddCSharpSyntaxTree($$"""
+public class DivTagHelper : {{typeof(TagHelper).FullName}}
+{
 
-}}
-");
+}
+""");
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -381,12 +381,12 @@ public class DivTagHelper : {typeof(TagHelper).FullName}
     public void RazorPagesWithoutModel_Runtime()
     {
         // Arrange
-        AddCSharpSyntaxTree($@"
-public class DivTagHelper : {typeof(TagHelper).FullName}
-{{
+        AddCSharpSyntaxTree($$"""
+public class DivTagHelper : {{typeof(TagHelper).FullName}}
+{
 
-}}
-");
+}
+""");
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -430,21 +430,21 @@ public class DivTagHelper : {typeof(TagHelper).FullName}
     public void ViewComponentTagHelper_Runtime()
     {
         // Arrange
-        AddCSharpSyntaxTree($@"
+        AddCSharpSyntaxTree($$"""
 public class TestViewComponent
-{{
+{
     public string Invoke(string firstName)
-    {{
+    {
         return firstName;
-    }}
-}}
+    }
+}
 
-[{typeof(HtmlTargetElementAttribute).FullName}]
-public class AllTagHelper : {typeof(TagHelper).FullName}
-{{
-    public string Bar {{ get; set; }}
-}}
-");
+[{{typeof(HtmlTargetElementAttribute).FullName}}]
+public class AllTagHelper : {{typeof(TagHelper).FullName}}
+{
+    public string Bar { get; set; }
+}
+""");
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -639,14 +639,14 @@ public class MyModel
     public void Sections_DesignTime()
     {
         // Arrange
-        AddCSharpSyntaxTree($@"
+        AddCSharpSyntaxTree($$"""
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 
-public class InputTestTagHelper : {typeof(TagHelper).FullName}
-{{
-    public ModelExpression For {{ get; set; }}
-}}
-");
+public class InputTestTagHelper : {{typeof(TagHelper).FullName}}
+{
+    public ModelExpression For { get; set; }
+}
+""");
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -802,14 +802,14 @@ public class ThisShouldBeGenerated
     public void ModelExpressionTagHelper_DesignTime()
     {
         // Arrange
-        AddCSharpSyntaxTree($@"
+        AddCSharpSyntaxTree($$"""
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 
-public class InputTestTagHelper : {typeof(TagHelper).FullName}
-{{
-    public ModelExpression For {{ get; set; }}
-}}
-");
+public class InputTestTagHelper : {{typeof(TagHelper).FullName}}
+{
+    public ModelExpression For { get; set; }
+}
+""");
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -826,12 +826,12 @@ public class InputTestTagHelper : {typeof(TagHelper).FullName}
     public void RazorPages_DesignTime()
     {
         // Arrange
-        AddCSharpSyntaxTree($@"
-public class DivTagHelper : {typeof(TagHelper).FullName}
-{{
+        AddCSharpSyntaxTree($$"""
+public class DivTagHelper : {{typeof(TagHelper).FullName}}
+{
 
-}}
-");
+}
+""");
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -863,12 +863,12 @@ public class DivTagHelper : {typeof(TagHelper).FullName}
     public void RazorPagesWithoutModel_DesignTime()
     {
         // Arrange
-        AddCSharpSyntaxTree($@"
-public class DivTagHelper : {typeof(TagHelper).FullName}
-{{
+        AddCSharpSyntaxTree($$"""
+public class DivTagHelper : {{typeof(TagHelper).FullName}}
+{
 
-}}
-");
+}
+""");
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -915,21 +915,21 @@ public class DivTagHelper : {typeof(TagHelper).FullName}
     public void ViewComponentTagHelper_DesignTime()
     {
         // Arrange
-        AddCSharpSyntaxTree($@"
+        AddCSharpSyntaxTree($$"""
 public class TestViewComponent
-{{
+{
     public string Invoke(string firstName)
-    {{
+    {
         return firstName;
-    }}
-}}
+    }
+}
 
-[{typeof(HtmlTargetElementAttribute).FullName}]
-public class AllTagHelper : {typeof(TagHelper).FullName}
-{{
-    public string Bar {{ get; set; }}
-}}
-");
+[{{typeof(HtmlTargetElementAttribute).FullName}}]
+public class AllTagHelper : {{typeof(TagHelper).FullName}}
+{
+    public string Bar { get; set; }
+}
+""");
 
         var projectItem = CreateProjectItemFromFile();
 

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/RazorPageDocumentClassifierPassTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/RazorPageDocumentClassifierPassTest.cs
@@ -64,9 +64,12 @@ public class RazorPageDocumentClassifierPassTest : RazorProjectEngineTestBase
             endCharacterIndex: 0);
 
         var expectedDiagnostic = RazorExtensionsDiagnosticFactory.CreatePageDirective_MustExistAtTheTopOfFile(sourceSpan);
-        var content = Environment.NewLine +
-"@somethingelse" + Environment.NewLine +
-"@page" + Environment.NewLine;
+        var content = """
+            
+            @somethingelse
+            @page
+            
+            """;
         var codeDocument = RazorCodeDocument.Create(RazorSourceDocument.Create(content, "Test.cshtml"));
 
         var engine = CreateProjectEngine().Engine;

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/InjectTargetExtensionTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/InjectTargetExtensionTest.cs
@@ -30,11 +30,13 @@ public class InjectTargetExtensionTest
         target.WriteInjectProperty(context, node);
 
         // Assert
-        Assert.Equal(
-            "#nullable restore" + Environment.NewLine +
-            "[global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]" + Environment.NewLine +
-            "public PropertyType PropertyName { get; private set; } = default!;" + Environment.NewLine +
-            "#nullable disable" + Environment.NewLine,
+        Assert.Equal("""
+            #nullable restore
+            [global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]
+            public PropertyType PropertyName { get; private set; } = default!;
+            #nullable disable
+
+            """,
             context.CodeWriter.GenerateCode());
     }
 
@@ -60,16 +62,20 @@ public class InjectTargetExtensionTest
         target.WriteInjectProperty(context, node);
 
         // Assert
-        Assert.Equal(Environment.NewLine +
-            "#nullable restore" + Environment.NewLine +
-            "#line 2 \"test-path\"" + Environment.NewLine +
-            "#nullable restore" + Environment.NewLine +
-            "[global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]" + Environment.NewLine +
-            "public PropertyType<ModelType> PropertyName { get; private set; } = default!;" + Environment.NewLine +
-            "#nullable disable" + Environment.NewLine + Environment.NewLine +
-            "#line default" + Environment.NewLine +
-            "#line hidden" + Environment.NewLine +
-            "#nullable disable" + Environment.NewLine,
+        Assert.Equal("""
+
+            #nullable restore
+            #line 2 "test-path"
+            #nullable restore
+            [global::Microsoft.AspNetCore.Mvc.Razor.Internal.RazorInjectAttribute]
+            public PropertyType<ModelType> PropertyName { get; private set; } = default!;
+            #nullable disable
+
+            #line default
+            #line hidden
+            #nullable disable
+
+            """,
             context.CodeWriter.GenerateCode());
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/IntegrationTests/CodeGenerationIntegrationTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/IntegrationTests/CodeGenerationIntegrationTest.cs
@@ -72,11 +72,13 @@ public class CodeGenerationIntegrationTest : IntegrationTestBase
     public void IncompleteDirectives_Runtime()
     {
         // Arrange
-        AddCSharpSyntaxTree(@"
-public class MyService<TModel>
-{
-    public string Html { get; set; }
-}");
+        AddCSharpSyntaxTree("""
+
+            public class MyService<TModel>
+            {
+                public string Html { get; set; }
+            }
+            """);
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -96,22 +98,24 @@ public class MyService<TModel>
     public void InheritsViewModel_Runtime()
     {
         // Arrange
-        AddCSharpSyntaxTree(@"
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc.Razor;
+        AddCSharpSyntaxTree("""
 
-public class MyBasePageForViews<TModel> : RazorPage
-{
-    public override Task ExecuteAsync()
-    {
-        throw new System.NotImplementedException();
-    }
-}
-public class MyModel
-{
+            using System.Threading.Tasks;
+            using Microsoft.AspNetCore.Mvc.Razor;
 
-}
-");
+            public class MyBasePageForViews<TModel> : RazorPage
+            {
+                public override Task ExecuteAsync()
+                {
+                    throw new System.NotImplementedException();
+                }
+            }
+            public class MyModel
+            {
+
+            }
+
+            """);
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -128,22 +132,24 @@ public class MyModel
     public void InheritsWithViewImports_Runtime()
     {
         // Arrange
-        AddCSharpSyntaxTree(@"
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc.RazorPages;
+        AddCSharpSyntaxTree("""
 
-public abstract class MyPageModel<T> : Page
-{
-    public override Task ExecuteAsync()
-    {
-        throw new System.NotImplementedException();
-    }
-}
+            using System.Threading.Tasks;
+            using Microsoft.AspNetCore.Mvc.RazorPages;
 
-public class MyModel
-{
+            public abstract class MyPageModel<T> : Page
+            {
+                public override Task ExecuteAsync()
+                {
+                    throw new System.NotImplementedException();
+                }
+            }
 
-}");
+            public class MyModel
+            {
+
+            }
+            """);
         AddProjectItemFromText(@"@inherits MyPageModel<TModel>");
 
         var projectItem = CreateProjectItemFromFile();
@@ -162,9 +168,11 @@ public class MyModel
     {
         // Arrange
         var projectItem = CreateProjectItemFromFile();
-        AddProjectItemFromText(@"
-@using System
-@attribute [Serializable]");
+        AddProjectItemFromText("""
+
+            @using System
+            @attribute [Serializable]
+            """);
 
         // Act
         var compiled = CompileToAssembly(projectItem, designTime: false, throwOnFailure: false);
@@ -231,13 +239,14 @@ public class MyModel
     {
         // Arrange
         AddCSharpSyntaxTree($$"""
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
 
-public class InputTestTagHelper : {{typeof(TagHelper).FullName}}
-{
-    public ModelExpression For { get; set; }
-}
-""");
+            using Microsoft.AspNetCore.Mvc.ViewFeatures;
+
+            public class InputTestTagHelper : {{typeof(TagHelper).FullName}}
+            {
+                public ModelExpression For { get; set; }
+            }
+            """);
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -269,12 +278,14 @@ public class InputTestTagHelper : {{typeof(TagHelper).FullName}}
     public void Inject_Runtime()
     {
         // Arrange
-        AddCSharpSyntaxTree(@"
-public class MyApp
-{
-    public string MyProperty { get; set; }
-}
-");
+        AddCSharpSyntaxTree("""
+
+            public class MyApp
+            {
+                public string MyProperty { get; set; }
+            }
+
+            """);
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -291,21 +302,23 @@ public class MyApp
     public void InjectWithModel_Runtime()
     {
         // Arrange
-        AddCSharpSyntaxTree(@"
-public class MyModel
-{
+        AddCSharpSyntaxTree("""
 
-}
+            public class MyModel
+            {
 
-public class MyService<TModel>
-{
-    public string Html { get; set; }
-}
+            }
 
-public class MyApp
-{
-    public string MyProperty { get; set; }
-}");
+            public class MyService<TModel>
+            {
+                public string Html { get; set; }
+            }
+
+            public class MyApp
+            {
+                public string MyProperty { get; set; }
+            }
+            """);
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -322,22 +335,24 @@ public class MyApp
     public void InjectWithSemicolon_Runtime()
     {
         // Arrange
-        AddCSharpSyntaxTree(@"
-public class MyModel
-{
+        AddCSharpSyntaxTree("""
 
-}
+            public class MyModel
+            {
 
-public class MyApp
-{
-    public string MyProperty { get; set; }
-}
+            }
 
-public class MyService<TModel>
-{
-    public string Html { get; set; }
-}
-");
+            public class MyApp
+            {
+                public string MyProperty { get; set; }
+            }
+
+            public class MyService<TModel>
+            {
+                public string Html { get; set; }
+            }
+
+            """);
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -371,13 +386,13 @@ public class MyService<TModel>
     {
         // Arrange
         AddCSharpSyntaxTree($$"""
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
+            using Microsoft.AspNetCore.Mvc.ViewFeatures;
 
-public class InputTestTagHelper : {{typeof(TagHelper).FullName}}
-{
-    public ModelExpression For { get; set; }
-}
-""");
+            public class InputTestTagHelper : {{typeof(TagHelper).FullName}}
+            {
+                public ModelExpression For { get; set; }
+            }
+            """);
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -395,11 +410,11 @@ public class InputTestTagHelper : {{typeof(TagHelper).FullName}}
     {
         // Arrange
         AddCSharpSyntaxTree($$"""
-public class DivTagHelper : {{typeof(TagHelper).FullName}}
-{
+            public class DivTagHelper : {{typeof(TagHelper).FullName}}
+            {
 
-}
-""");
+            }
+            """);
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -432,11 +447,11 @@ public class DivTagHelper : {{typeof(TagHelper).FullName}}
     {
         // Arrange
         AddCSharpSyntaxTree($$"""
-public class DivTagHelper : {{typeof(TagHelper).FullName}}
-{
+            public class DivTagHelper : {{typeof(TagHelper).FullName}}
+            {
 
-}
-""");
+            }
+            """);
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -484,20 +499,20 @@ public class DivTagHelper : {{typeof(TagHelper).FullName}}
     {
         // Arrange
         AddCSharpSyntaxTree($$"""
-public class TestViewComponent
-{
-    public string Invoke(string firstName)
-    {
-        return firstName;
-    }
-}
+            public class TestViewComponent
+            {
+                public string Invoke(string firstName)
+                {
+                    return firstName;
+                }
+            }
 
-[{{typeof(HtmlTargetElementAttribute).FullName}}]
-public class AllTagHelper : {{typeof(TagHelper).FullName}}
-{
-    public string Bar { get; set; }
-}
-""");
+            [{{typeof(HtmlTargetElementAttribute).FullName}}]
+            public class AllTagHelper : {{typeof(TagHelper).FullName}}
+            {
+                public string Bar { get; set; }
+            }
+            """);
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -515,37 +530,37 @@ public class AllTagHelper : {{typeof(TagHelper).FullName}}
     {
         // Arrange
         AddCSharpSyntaxTree($$"""
-using System;
+            using System;
 
-public class OptionalTestViewComponent
-{
-    public string Invoke(bool showSecret = false)
-    {
-        return showSecret ? ""what a secret"" : ""not a secret"";
-    }
-}
-public class OptionalTestWithParamViewComponent
-{
-    public string Invoke(string secret, bool showSecret = false)
-    {
-        var isSecret = showSecret ? ""what a secret"" : ""not a secret"";
-        return isSecret + "" : "" + secret;
-    }
-}
-public class OptionalWithMultipleTypesViewComponent
-{
-    public string Invoke(
-        int age = 42,
-        double favoriteDecimal = 12.3,
-        char favoriteLetter = 'b',
-        DateTime? birthDate = null,
-        string anotherOne = null)
-    {
-        birthDate = new DateTime(1979, 8, 23);
-        return age + "" : "" + favoriteDecimal + "" : "" + favoriteLetter + "" : "" + birthDate + "" : "" + anotherOne;
-    }
-}
-""");
+            public class OptionalTestViewComponent
+            {
+                public string Invoke(bool showSecret = false)
+                {
+                    return showSecret ? "what a secret" : "not a secret";
+                }
+            }
+            public class OptionalTestWithParamViewComponent
+            {
+                public string Invoke(string secret, bool showSecret = false)
+                {
+                    var isSecret = showSecret ? "what a secret" : "not a secret";
+                    return isSecret + "" : "" + secret;
+                }
+            }
+            public class OptionalWithMultipleTypesViewComponent
+            {
+                public string Invoke(
+                    int age = 42,
+                    double favoriteDecimal = 12.3,
+                    char favoriteLetter = 'b',
+                    DateTime? birthDate = null,
+                    string anotherOne = null)
+                {
+                    birthDate = new DateTime(1979, 8, 23);
+                    return age + " : " + favoriteDecimal + " : " + favoriteLetter + " : " + birthDate + " : " + anotherOne;
+                }
+            }
+            """);
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -581,34 +596,36 @@ public class OptionalWithMultipleTypesViewComponent
     {
         // Arrange
         AddCSharpSyntaxTree($$"""
-[{{typeof(HtmlTargetElementAttribute).FullName}}({{"\"all\""}})]
-public class AllTagHelper : {{typeof(TagHelper).FullName}}
-{
-    public string Bar { get; set; }
-}
+            [{{typeof(HtmlTargetElementAttribute).FullName}}({{"all"}})]
+            public class AllTagHelper : {{typeof(TagHelper).FullName}}
+            {
+                public string Bar { get; set; }
+            }
 
-[{{typeof(HtmlTargetElementAttribute).FullName}}({{"\"form\""}})]
-public class FormTagHelper : {{typeof(TagHelper).FullName}}
-{
-}
-""");
+            [{{typeof(HtmlTargetElementAttribute).FullName}}({{"form"}})]
+            public class FormTagHelper : {{typeof(TagHelper).FullName}}
+            {
+            }
+            """);
 
         // Act
         // This test case attempts to use all syntaxes that might interact with auto-generated attributes
-        var generated = CompileToCSharp(@"@page
-@addTagHelper *, AppCode
-@{
-    ViewData[""Title""] = ""Home page"";
-}
-<div class=""text-center"">
-    <h1 class=""display-4"">Welcome</h1>
-    <p>Learn about<a href= ""https://docs.microsoft.com/aspnet/core"" > building Web apps with ASP.NET Core</a>.</p>
-</div>
-<all Bar=""Foo""></all>
-<form asp-route=""register"" method=""post"">
-  <input name=""regular input"" />
-</form>
-", cssScope: "TestCssScope");
+        var generated = CompileToCSharp("""
+            @page
+            @addTagHelper *, AppCode
+            @{
+                ViewData["Title"] = "Home page";
+            }
+            <div class="text-center">
+                <h1 class="display-4">Welcome</h1>
+                <p>Learn about<a href= "https://docs.microsoft.com/aspnet/core" > building Web apps with ASP.NET Core</a>.</p>
+            </div>
+            <all Bar="Foo"></all>
+            <form asp-route="register" method="post">
+              <input name="regular input" />
+            </form>
+
+            """, cssScope: "TestCssScope");
 
         // Assert
         var intermediate = generated.CodeDocument.GetDocumentIntermediateNode();
@@ -623,33 +640,35 @@ public class FormTagHelper : {{typeof(TagHelper).FullName}}
     {
         // Arrange
         AddCSharpSyntaxTree($$"""
-[{{typeof(HtmlTargetElementAttribute).FullName}}({{"\"all\""}})]
-public class AllTagHelper : {{typeof(TagHelper).FullName}}
-{
-    public string Bar { get; set; }
-}
+            [{{typeof(HtmlTargetElementAttribute).FullName}}({{"\"all"}})]
+            public class AllTagHelper : {{typeof(TagHelper).FullName}}
+            {
+                public string Bar { get; set; }
+            }
 
-[{{typeof(HtmlTargetElementAttribute).FullName}}({{"\"form\""}})]
-public class FormTagHelper : {{typeof(TagHelper).FullName}}
-{
-}
-""");
+            [{{typeof(HtmlTargetElementAttribute).FullName}}({{"form"}})]
+            public class FormTagHelper : {{typeof(TagHelper).FullName}}
+            {
+            }
+            """);
 
         // Act
         // This test case attempts to use all syntaxes that might interact with auto-generated attributes
-        var generated = CompileToCSharp(@"@addTagHelper *, AppCode
-@{
-    ViewData[""Title""] = ""Home page"";
-}
-<div class=""text-center"">
-    <h1 class=""display-4"">Welcome</h1>
-    <p>Learn about<a href= ""https://docs.microsoft.com/aspnet/core"" > building Web apps with ASP.NET Core</a>.</p>
-</div>
-<all Bar=""Foo""></all>
-<form asp-route=""register"" method=""post"">
-  <input name=""regular input"" />
-</form>
-", cssScope: "TestCssScope");
+        var generated = CompileToCSharp("""
+            @addTagHelper *, AppCode
+            @{
+                ViewData["Title"] = "Home page";
+            }
+            <div class="text-center">
+                <h1 class="display-4">Welcome</h1>
+                <p>Learn about<a href= "https://docs.microsoft.com/aspnet/core" > building Web apps with ASP.NET Core</a>.</p>
+            </div>
+            <all Bar="Foo"></all>
+            <form asp-route="register" method="post">
+              <input name="regular input" />
+            </form>
+
+            """, cssScope: "TestCssScope");
 
         // Assert
         var intermediate = generated.CodeDocument.GetDocumentIntermediateNode();
@@ -664,32 +683,34 @@ public class FormTagHelper : {{typeof(TagHelper).FullName}}
     {
         // Arrange
         AddCSharpSyntaxTree($$"""
-[{{typeof(HtmlTargetElementAttribute).FullName}}({{"\"all\""}})]
-public class AllTagHelper : {{typeof(TagHelper).FullName}}
-{
-    public string Bar { get; set; }
-}
-[{{typeof(HtmlTargetElementAttribute).FullName}}({{"\"form\""}})]
-public class FormTagHelper : {{typeof(TagHelper).FullName}}
-{
-}
-""");
+            [{{typeof(HtmlTargetElementAttribute).FullName}}({{"all"}})]
+            public class AllTagHelper : {{typeof(TagHelper).FullName}}
+            {
+                public string Bar { get; set; }
+            }
+            [{{typeof(HtmlTargetElementAttribute).FullName}}({{"form"}})]
+            public class FormTagHelper : {{typeof(TagHelper).FullName}}
+            {
+            }
+            """);
 
         // Act
         // This test case attempts to use all syntaxes that might interact with auto-generated attributes
-        var generated = CompileToCSharp(@"
-<!DOCTYPE html>
-<html lang=""en"">
-<head>
-    <meta charset=""utf-8"" />
-    <meta name=""viewport"" content=""width=device-width, initial-scale=1.0"" />
-    <title>@ViewData[""Title""] - Test layout component</title>
-</head>
-<body>
-    <p>This is a body.</p>
-</body>
-</html>
-", cssScope: "TestCssScope");
+        var generated = CompileToCSharp("""
+
+            <!DOCTYPE html>
+            <html lang="en">
+            <head>
+                <meta charset="utf-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                <title>@ViewData["Title"] - Test layout component</title>
+            </head>
+            <body>
+                <p>This is a body.</p>
+            </body>
+            </html>
+
+            """, cssScope: "TestCssScope");
 
         // Assert
         var intermediate = generated.CodeDocument.GetDocumentIntermediateNode();
@@ -705,25 +726,29 @@ public class FormTagHelper : {{typeof(TagHelper).FullName}}
         // Arrange
         BaseCompilation = BaseCompilation.WithOptions(BaseCompilation.Options.WithNullableContextOptions(NullableContextOptions.Enable));
 
-        AddCSharpSyntaxTree(@"
-namespace TestNamespace;
+        AddCSharpSyntaxTree("""
 
-public class TestModel
-{
-    public string Name { get; set; } = string.Empty;
+            namespace TestNamespace;
 
-    public string? Address { get; set; }
-}");
+            public class TestModel
+            {
+                public string Name { get; set; } = string.Empty;
+
+                public string? Address { get; set; }
+            }
+            """);
 
         // Act
         // This test case attempts to use all syntaxes that might interact with auto-generated attributes
-        var generated = CompileToCSharp(@"
-@using TestNamespace
-@model TestModel
+        var generated = CompileToCSharp("""
 
-<h1>@Model.Name</h1>
+            @using TestNamespace
+            @model TestModel
 
-<h2>@Model.Address</h2>");
+            <h1>@Model.Name</h1>
+
+            <h2>@Model.Address</h2>
+            """);
 
         // Assert
         var intermediate = generated.CodeDocument.GetDocumentIntermediateNode();
@@ -739,25 +764,29 @@ public class TestModel
         // Arrange
         BaseCompilation = BaseCompilation.WithOptions(BaseCompilation.Options.WithNullableContextOptions(NullableContextOptions.Enable));
 
-        AddCSharpSyntaxTree(@"
-namespace TestNamespace;
+        AddCSharpSyntaxTree("""
 
-public class TestModel
-{
-    public string Name { get; set; } = string.Empty;
+            namespace TestNamespace;
 
-    public string? Address { get; set; }
-}");
+            public class TestModel
+            {
+                public string Name { get; set; } = string.Empty;
+
+                public string? Address { get; set; }
+            }
+            """);
 
         // Act
         // This test case attempts to use all syntaxes that might interact with auto-generated attributes
-        var generated = CompileToCSharp(@"
-@using TestNamespace
-@model TestModel?
+        var generated = CompileToCSharp("""
 
-<h1>@Model?.Name</h1>
+            @using TestNamespace
+            @model TestModel?
 
-<h2>@Model?.Address</h2>");
+            <h1>@Model?.Name</h1>
+
+            <h2>@Model?.Address</h2>
+            """);
 
         // Assert
         var intermediate = generated.CodeDocument.GetDocumentIntermediateNode();
@@ -773,25 +802,29 @@ public class TestModel
         // Arrange
         BaseCompilation = BaseCompilation.WithOptions(BaseCompilation.Options.WithNullableContextOptions(NullableContextOptions.Disable));
 
-        AddCSharpSyntaxTree(@"
-namespace TestNamespace;
+        AddCSharpSyntaxTree("""
 
-public class TestModel
-{
-    public string Name { get; set; } = string.Empty;
+            namespace TestNamespace;
 
-    public string Address { get; set; }
-}");
+            public class TestModel
+            {
+                public string Name { get; set; } = string.Empty;
+
+                public string Address { get; set; }
+            }
+            """);
 
         // Act
         // This test case attempts to use all syntaxes that might interact with auto-generated attributes
-        var generated = CompileToCSharp(@"
-@using TestNamespace
-@model TestModel?
+        var generated = CompileToCSharp("""
 
-<h1>@Model?.Name</h1>
+            @using TestNamespace
+            @model TestModel?
 
-<h2>@Model?.Address</h2>");
+            <h1>@Model?.Name</h1>
+
+            <h2>@Model?.Address</h2>
+            """);
 
         // Assert
         var intermediate = generated.CodeDocument.GetDocumentIntermediateNode();
@@ -809,28 +842,32 @@ public class TestModel
         // Arrange
         BaseCompilation = BaseCompilation.WithOptions(BaseCompilation.Options.WithNullableContextOptions(NullableContextOptions.Enable));
 
-        AddCSharpSyntaxTree(@"
-namespace TestNamespace;
-using Microsoft.AspNetCore.Mvc.Razor;
+        AddCSharpSyntaxTree("""
 
-public abstract class MyBasePage<TModel> : RazorPage<TModel> where TModel : class? {}
+            namespace TestNamespace;
+            using Microsoft.AspNetCore.Mvc.Razor;
 
-public class TestModel
-{
-    public string Name { get; set; } = string.Empty;
+            public abstract class MyBasePage<TModel> : RazorPage<TModel> where TModel : class? {}
 
-    public string? Address { get; set; }
-}");
+            public class TestModel
+            {
+                public string Name { get; set; } = string.Empty;
+
+                public string? Address { get; set; }
+            }
+            """);
 
         // Act
         // This test case attempts to use all syntaxes that might interact with auto-generated attributes
-        var generated = CompileToCSharp(@"
-@using TestNamespace
-@inherits MyBasePage<TestModel?>
+        var generated = CompileToCSharp("""
 
-<h1>@Model?.Name</h1>
+            @using TestNamespace
+            @inherits MyBasePage<TestModel?>
 
-<h2>@Model?.Address</h2>");
+            <h1>@Model?.Name</h1>
+
+            <h2>@Model?.Address</h2>
+            """);
 
         // Assert
         var intermediate = generated.CodeDocument.GetDocumentIntermediateNode();
@@ -887,11 +924,13 @@ public class TestModel
     public void IncompleteDirectives_DesignTime()
     {
         // Arrange
-        AddCSharpSyntaxTree(@"
-public class MyService<TModel>
-{
-    public string Html { get; set; }
-}");
+        AddCSharpSyntaxTree("""
+
+            public class MyService<TModel>
+            {
+                public string Html { get; set; }
+            }
+            """);
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -913,22 +952,24 @@ public class MyService<TModel>
     public void InheritsViewModel_DesignTime()
     {
         // Arrange
-        AddCSharpSyntaxTree(@"
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc.Razor;
+        AddCSharpSyntaxTree("""
 
-public class MyBasePageForViews<TModel> : RazorPage
-{
-    public override Task ExecuteAsync()
-    {
-        throw new System.NotImplementedException();
-    }
-}
-public class MyModel
-{
+            using System.Threading.Tasks;
+            using Microsoft.AspNetCore.Mvc.Razor;
 
-}
-");
+            public class MyBasePageForViews<TModel> : RazorPage
+            {
+                public override Task ExecuteAsync()
+                {
+                    throw new System.NotImplementedException();
+                }
+            }
+            public class MyModel
+            {
+
+            }
+
+            """);
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -947,22 +988,24 @@ public class MyModel
     public void InheritsWithViewImports_DesignTime()
     {
         // Arrange
-        AddCSharpSyntaxTree(@"
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc.RazorPages;
+        AddCSharpSyntaxTree("""
 
-public abstract class MyPageModel<T> : Page
-{
-    public override Task ExecuteAsync()
-    {
-        throw new System.NotImplementedException();
-    }
-}
+            using System.Threading.Tasks;
+            using Microsoft.AspNetCore.Mvc.RazorPages;
 
-public class MyModel
-{
+            public abstract class MyPageModel<T> : Page
+            {
+                public override Task ExecuteAsync()
+                {
+                    throw new System.NotImplementedException();
+                }
+            }
 
-}");
+            public class MyModel
+            {
+
+            }
+            """);
 
         AddProjectItemFromText(@"@inherits MyPageModel<TModel>");
 
@@ -984,9 +1027,11 @@ public class MyModel
     {
         // Arrange
         var projectItem = CreateProjectItemFromFile();
-        AddProjectItemFromText(@"
-@using System
-@attribute [Serializable]");
+        AddProjectItemFromText("""
+
+            @using System
+            @attribute [Serializable]
+            """);
 
         // Act
         var compiled = CompileToAssembly(projectItem, designTime: true, throwOnFailure: false);
@@ -1061,13 +1106,13 @@ public class MyModel
     {
         // Arrange
         AddCSharpSyntaxTree($$"""
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
+            using Microsoft.AspNetCore.Mvc.ViewFeatures;
 
-public class InputTestTagHelper : {{typeof(TagHelper).FullName}}
-{
-    public ModelExpression For { get; set; }
-}
-""");
+            public class InputTestTagHelper : {{typeof(TagHelper).FullName}}
+            {
+                public ModelExpression For { get; set; }
+            }
+            """);
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -1103,12 +1148,14 @@ public class InputTestTagHelper : {{typeof(TagHelper).FullName}}
     public void Inject_DesignTime()
     {
         // Arrange
-        AddCSharpSyntaxTree(@"
-public class MyApp
-{
-    public string MyProperty { get; set; }
-}
-");
+        AddCSharpSyntaxTree("""
+
+            public class MyApp
+            {
+                public string MyProperty { get; set; }
+            }
+
+            """);
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -1127,21 +1174,23 @@ public class MyApp
     public void InjectWithModel_DesignTime()
     {
         // Arrange
-        AddCSharpSyntaxTree(@"
-public class MyModel
-{
+        AddCSharpSyntaxTree("""
 
-}
+            public class MyModel
+            {
 
-public class MyService<TModel>
-{
-    public string Html { get; set; }
-}
+            }
 
-public class MyApp
-{
-    public string MyProperty { get; set; }
-}");
+            public class MyService<TModel>
+            {
+                public string Html { get; set; }
+            }
+
+            public class MyApp
+            {
+                public string MyProperty { get; set; }
+            }
+            """);
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -1160,22 +1209,24 @@ public class MyApp
     public void InjectWithSemicolon_DesignTime()
     {
         // Arrange
-        AddCSharpSyntaxTree(@"
-public class MyModel
-{
+        AddCSharpSyntaxTree("""
 
-}
+            public class MyModel
+            {
 
-public class MyApp
-{
-    public string MyProperty { get; set; }
-}
+            }
 
-public class MyService<TModel>
-{
-    public string Html { get; set; }
-}
-");
+            public class MyApp
+            {
+                public string MyProperty { get; set; }
+            }
+
+            public class MyService<TModel>
+            {
+                public string Html { get; set; }
+            }
+
+            """);
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -1211,11 +1262,13 @@ public class MyService<TModel>
     public void MultipleModels_DesignTime()
     {
         // Arrange
-        AddCSharpSyntaxTree(@"
-public class ThisShouldBeGenerated
-{
+        AddCSharpSyntaxTree("""
 
-}");
+            public class ThisShouldBeGenerated
+            {
+
+            }
+            """);
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -1238,13 +1291,13 @@ public class ThisShouldBeGenerated
     {
         // Arrange
         AddCSharpSyntaxTree($$"""
-using Microsoft.AspNetCore.Mvc.ViewFeatures;
+            using Microsoft.AspNetCore.Mvc.ViewFeatures;
 
-public class InputTestTagHelper : {{typeof(TagHelper).FullName}}
-{
-    public ModelExpression For { get; set; }
-}
-""");
+            public class InputTestTagHelper : {{typeof(TagHelper).FullName}}
+            {
+                public ModelExpression For { get; set; }
+            }
+            """);
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -1264,11 +1317,11 @@ public class InputTestTagHelper : {{typeof(TagHelper).FullName}}
     {
         // Arrange
         AddCSharpSyntaxTree($$"""
-public class DivTagHelper : {{typeof(TagHelper).FullName}}
-{
+            public class DivTagHelper : {{typeof(TagHelper).FullName}}
+            {
 
-}
-""");
+            }
+            """);
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -1305,11 +1358,11 @@ public class DivTagHelper : {{typeof(TagHelper).FullName}}
     {
         // Arrange
         AddCSharpSyntaxTree($$"""
-public class DivTagHelper : {{typeof(TagHelper).FullName}}
-{
+            public class DivTagHelper : {{typeof(TagHelper).FullName}}
+            {
 
-}
-""");
+            }
+            """);
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -1363,20 +1416,20 @@ public class DivTagHelper : {{typeof(TagHelper).FullName}}
     {
         // Arrange
         AddCSharpSyntaxTree($$"""
-public class TestViewComponent
-{
-    public string Invoke(string firstName)
-    {
-        return firstName;
-    }
-}
+            public class TestViewComponent
+            {
+                public string Invoke(string firstName)
+                {
+                    return firstName;
+                }
+            }
 
-[{{typeof(HtmlTargetElementAttribute).FullName}}]
-public class AllTagHelper : {{typeof(TagHelper).FullName}}
-{
-    public string Bar { get; set; }
-}
-""");
+            [{{typeof(HtmlTargetElementAttribute).FullName}}]
+            public class AllTagHelper : {{typeof(TagHelper).FullName}}
+            {
+                public string Bar { get; set; }
+            }
+            """);
 
         var projectItem = CreateProjectItemFromFile();
 

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/IntegrationTests/CodeGenerationIntegrationTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/IntegrationTests/CodeGenerationIntegrationTest.cs
@@ -230,14 +230,14 @@ public class MyModel
     public void Sections_Runtime()
     {
         // Arrange
-        AddCSharpSyntaxTree($@"
+        AddCSharpSyntaxTree($$"""
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 
-public class InputTestTagHelper : {typeof(TagHelper).FullName}
-{{
-    public ModelExpression For {{ get; set; }}
-}}
-");
+public class InputTestTagHelper : {{typeof(TagHelper).FullName}}
+{
+    public ModelExpression For { get; set; }
+}
+""");
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -370,14 +370,14 @@ public class MyService<TModel>
     public void ModelExpressionTagHelper_Runtime()
     {
         // Arrange
-        AddCSharpSyntaxTree($@"
+        AddCSharpSyntaxTree($$"""
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 
-public class InputTestTagHelper : {typeof(TagHelper).FullName}
-{{
-    public ModelExpression For {{ get; set; }}
-}}
-");
+public class InputTestTagHelper : {{typeof(TagHelper).FullName}}
+{
+    public ModelExpression For { get; set; }
+}
+""");
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -394,12 +394,12 @@ public class InputTestTagHelper : {typeof(TagHelper).FullName}
     public void RazorPages_Runtime()
     {
         // Arrange
-        AddCSharpSyntaxTree($@"
-public class DivTagHelper : {typeof(TagHelper).FullName}
-{{
+        AddCSharpSyntaxTree($$"""
+public class DivTagHelper : {{typeof(TagHelper).FullName}}
+{
 
-}}
-");
+}
+""");
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -431,12 +431,12 @@ public class DivTagHelper : {typeof(TagHelper).FullName}
     public void RazorPagesWithoutModel_Runtime()
     {
         // Arrange
-        AddCSharpSyntaxTree($@"
-public class DivTagHelper : {typeof(TagHelper).FullName}
-{{
+        AddCSharpSyntaxTree($$"""
+public class DivTagHelper : {{typeof(TagHelper).FullName}}
+{
 
-}}
-");
+}
+""");
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -483,21 +483,21 @@ public class DivTagHelper : {typeof(TagHelper).FullName}
     public void ViewComponentTagHelper_Runtime()
     {
         // Arrange
-        AddCSharpSyntaxTree($@"
+        AddCSharpSyntaxTree($$"""
 public class TestViewComponent
-{{
+{
     public string Invoke(string firstName)
-    {{
+    {
         return firstName;
-    }}
-}}
+    }
+}
 
-[{typeof(HtmlTargetElementAttribute).FullName}]
-public class AllTagHelper : {typeof(TagHelper).FullName}
-{{
-    public string Bar {{ get; set; }}
-}}
-");
+[{{typeof(HtmlTargetElementAttribute).FullName}}]
+public class AllTagHelper : {{typeof(TagHelper).FullName}}
+{
+    public string Bar { get; set; }
+}
+""");
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -514,38 +514,38 @@ public class AllTagHelper : {typeof(TagHelper).FullName}
     public void ViewComponentTagHelperOptionalParam_Runtime()
     {
         // Arrange
-        AddCSharpSyntaxTree($@"
+        AddCSharpSyntaxTree($$"""
 using System;
 
 public class OptionalTestViewComponent
-{{
+{
     public string Invoke(bool showSecret = false)
-    {{
+    {
         return showSecret ? ""what a secret"" : ""not a secret"";
-    }}
-}}
+    }
+}
 public class OptionalTestWithParamViewComponent
-{{
+{
     public string Invoke(string secret, bool showSecret = false)
-    {{
+    {
         var isSecret = showSecret ? ""what a secret"" : ""not a secret"";
         return isSecret + "" : "" + secret;
-    }}
-}}
+    }
+}
 public class OptionalWithMultipleTypesViewComponent
-{{
+{
     public string Invoke(
         int age = 42,
         double favoriteDecimal = 12.3,
         char favoriteLetter = 'b',
         DateTime? birthDate = null,
         string anotherOne = null)
-    {{
+    {
         birthDate = new DateTime(1979, 8, 23);
         return age + "" : "" + favoriteDecimal + "" : "" + favoriteLetter + "" : "" + birthDate + "" : "" + anotherOne;
-    }}
-}}
-");
+    }
+}
+""");
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -580,18 +580,18 @@ public class OptionalWithMultipleTypesViewComponent
     public void RazorPage_WithCssScope()
     {
         // Arrange
-        AddCSharpSyntaxTree($@"
-[{typeof(HtmlTargetElementAttribute).FullName}({"\"all\""})]
-public class AllTagHelper : {typeof(TagHelper).FullName}
-{{
-    public string Bar {{ get; set; }}
-}}
+        AddCSharpSyntaxTree($$"""
+[{{typeof(HtmlTargetElementAttribute).FullName}}({{"\"all\""}})]
+public class AllTagHelper : {{typeof(TagHelper).FullName}}
+{
+    public string Bar { get; set; }
+}
 
-[{typeof(HtmlTargetElementAttribute).FullName}({"\"form\""})]
-public class FormTagHelper : {typeof(TagHelper).FullName}
-{{
-}}
-");
+[{{typeof(HtmlTargetElementAttribute).FullName}}({{"\"form\""}})]
+public class FormTagHelper : {{typeof(TagHelper).FullName}}
+{
+}
+""");
 
         // Act
         // This test case attempts to use all syntaxes that might interact with auto-generated attributes
@@ -622,18 +622,18 @@ public class FormTagHelper : {typeof(TagHelper).FullName}
     public void RazorView_WithCssScope()
     {
         // Arrange
-        AddCSharpSyntaxTree($@"
-[{typeof(HtmlTargetElementAttribute).FullName}({"\"all\""})]
-public class AllTagHelper : {typeof(TagHelper).FullName}
-{{
-    public string Bar {{ get; set; }}
-}}
+        AddCSharpSyntaxTree($$"""
+[{{typeof(HtmlTargetElementAttribute).FullName}}({{"\"all\""}})]
+public class AllTagHelper : {{typeof(TagHelper).FullName}}
+{
+    public string Bar { get; set; }
+}
 
-[{typeof(HtmlTargetElementAttribute).FullName}({"\"form\""})]
-public class FormTagHelper : {typeof(TagHelper).FullName}
-{{
-}}
-");
+[{{typeof(HtmlTargetElementAttribute).FullName}}({{"\"form\""}})]
+public class FormTagHelper : {{typeof(TagHelper).FullName}}
+{
+}
+""");
 
         // Act
         // This test case attempts to use all syntaxes that might interact with auto-generated attributes
@@ -663,17 +663,17 @@ public class FormTagHelper : {typeof(TagHelper).FullName}
     public void RazorView_Layout_WithCssScope()
     {
         // Arrange
-        AddCSharpSyntaxTree($@"
-[{typeof(HtmlTargetElementAttribute).FullName}({"\"all\""})]
-public class AllTagHelper : {typeof(TagHelper).FullName}
-{{
-    public string Bar {{ get; set; }}
-}}
-[{typeof(HtmlTargetElementAttribute).FullName}({"\"form\""})]
-public class FormTagHelper : {typeof(TagHelper).FullName}
-{{
-}}
-");
+        AddCSharpSyntaxTree($$"""
+[{{typeof(HtmlTargetElementAttribute).FullName}}({{"\"all\""}})]
+public class AllTagHelper : {{typeof(TagHelper).FullName}}
+{
+    public string Bar { get; set; }
+}
+[{{typeof(HtmlTargetElementAttribute).FullName}}({{"\"form\""}})]
+public class FormTagHelper : {{typeof(TagHelper).FullName}}
+{
+}
+""");
 
         // Act
         // This test case attempts to use all syntaxes that might interact with auto-generated attributes
@@ -1060,14 +1060,14 @@ public class MyModel
     public void Sections_DesignTime()
     {
         // Arrange
-        AddCSharpSyntaxTree($@"
+        AddCSharpSyntaxTree($$"""
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 
-public class InputTestTagHelper : {typeof(TagHelper).FullName}
-{{
-    public ModelExpression For {{ get; set; }}
-}}
-");
+public class InputTestTagHelper : {{typeof(TagHelper).FullName}}
+{
+    public ModelExpression For { get; set; }
+}
+""");
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -1237,14 +1237,14 @@ public class ThisShouldBeGenerated
     public void ModelExpressionTagHelper_DesignTime()
     {
         // Arrange
-        AddCSharpSyntaxTree($@"
+        AddCSharpSyntaxTree($$"""
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 
-public class InputTestTagHelper : {typeof(TagHelper).FullName}
-{{
-    public ModelExpression For {{ get; set; }}
-}}
-");
+public class InputTestTagHelper : {{typeof(TagHelper).FullName}}
+{
+    public ModelExpression For { get; set; }
+}
+""");
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -1263,12 +1263,12 @@ public class InputTestTagHelper : {typeof(TagHelper).FullName}
     public void RazorPages_DesignTime()
     {
         // Arrange
-        AddCSharpSyntaxTree($@"
-public class DivTagHelper : {typeof(TagHelper).FullName}
-{{
+        AddCSharpSyntaxTree($$"""
+public class DivTagHelper : {{typeof(TagHelper).FullName}}
+{
 
-}}
-");
+}
+""");
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -1304,12 +1304,12 @@ public class DivTagHelper : {typeof(TagHelper).FullName}
     public void RazorPagesWithoutModel_DesignTime()
     {
         // Arrange
-        AddCSharpSyntaxTree($@"
-public class DivTagHelper : {typeof(TagHelper).FullName}
-{{
+        AddCSharpSyntaxTree($$"""
+public class DivTagHelper : {{typeof(TagHelper).FullName}}
+{
 
-}}
-");
+}
+""");
 
         var projectItem = CreateProjectItemFromFile();
 
@@ -1362,21 +1362,21 @@ public class DivTagHelper : {typeof(TagHelper).FullName}
     public void ViewComponentTagHelper_DesignTime()
     {
         // Arrange
-        AddCSharpSyntaxTree($@"
+        AddCSharpSyntaxTree($$"""
 public class TestViewComponent
-{{
+{
     public string Invoke(string firstName)
-    {{
+    {
         return firstName;
-    }}
-}}
+    }
+}
 
-[{typeof(HtmlTargetElementAttribute).FullName}]
-public class AllTagHelper : {typeof(TagHelper).FullName}
-{{
-    public string Bar {{ get; set; }}
-}}
-");
+[{{typeof(HtmlTargetElementAttribute).FullName}}]
+public class AllTagHelper : {{typeof(TagHelper).FullName}}
+{
+    public string Bar { get; set; }
+}
+""");
 
         var projectItem = CreateProjectItemFromFile();
 

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/IntegrationTests/CodeGenerationIntegrationTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/IntegrationTests/CodeGenerationIntegrationTest.cs
@@ -544,7 +544,7 @@ public class CodeGenerationIntegrationTest : IntegrationTestBase
                 public string Invoke(string secret, bool showSecret = false)
                 {
                     var isSecret = showSecret ? "what a secret" : "not a secret";
-                    return isSecret + "" : "" + secret;
+                    return isSecret + " : " + secret;
                 }
             }
             public class OptionalWithMultipleTypesViewComponent
@@ -596,13 +596,13 @@ public class CodeGenerationIntegrationTest : IntegrationTestBase
     {
         // Arrange
         AddCSharpSyntaxTree($$"""
-            [{{typeof(HtmlTargetElementAttribute).FullName}}({{"all"}})]
+            [{{typeof(HtmlTargetElementAttribute).FullName}}("all")]
             public class AllTagHelper : {{typeof(TagHelper).FullName}}
             {
                 public string Bar { get; set; }
             }
 
-            [{{typeof(HtmlTargetElementAttribute).FullName}}({{"form"}})]
+            [{{typeof(HtmlTargetElementAttribute).FullName}}("form")]
             public class FormTagHelper : {{typeof(TagHelper).FullName}}
             {
             }
@@ -640,13 +640,13 @@ public class CodeGenerationIntegrationTest : IntegrationTestBase
     {
         // Arrange
         AddCSharpSyntaxTree($$"""
-            [{{typeof(HtmlTargetElementAttribute).FullName}}({{"\"all"}})]
+            [{{typeof(HtmlTargetElementAttribute).FullName}}("all")]
             public class AllTagHelper : {{typeof(TagHelper).FullName}}
             {
                 public string Bar { get; set; }
             }
 
-            [{{typeof(HtmlTargetElementAttribute).FullName}}({{"form"}})]
+            [{{typeof(HtmlTargetElementAttribute).FullName}}("form")]
             public class FormTagHelper : {{typeof(TagHelper).FullName}}
             {
             }
@@ -683,12 +683,12 @@ public class CodeGenerationIntegrationTest : IntegrationTestBase
     {
         // Arrange
         AddCSharpSyntaxTree($$"""
-            [{{typeof(HtmlTargetElementAttribute).FullName}}({{"all"}})]
+            [{{typeof(HtmlTargetElementAttribute).FullName}}("all")]
             public class AllTagHelper : {{typeof(TagHelper).FullName}}
             {
                 public string Bar { get; set; }
             }
-            [{{typeof(HtmlTargetElementAttribute).FullName}}({{"form"}})]
+            [{{typeof(HtmlTargetElementAttribute).FullName}}("form")]
             public class FormTagHelper : {{typeof(TagHelper).FullName}}
             {
             }

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/RazorPageDocumentClassifierPassTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/RazorPageDocumentClassifierPassTest.cs
@@ -64,9 +64,12 @@ public class RazorPageDocumentClassifierPassTest : RazorProjectEngineTestBase
             endCharacterIndex: 0);
 
         var expectedDiagnostic = RazorExtensionsDiagnosticFactory.CreatePageDirective_MustExistAtTheTopOfFile(sourceSpan);
-        var content = Environment.NewLine +
-"@somethingelse" + Environment.NewLine +
-"@page" + Environment.NewLine;
+        var content = """
+            
+            @somethingelse
+            @page
+            
+            """;
         var codeDocument = RazorCodeDocument.Create(RazorSourceDocument.Create(content, "Test.cshtml"));
 
         var engine = CreateRuntimeEngine();

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpAutoCompleteTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpAutoCompleteTest.cs
@@ -35,19 +35,28 @@ public class CSharpAutoCompleteTest() : ParserTestBase(layer: TestProject.Layer.
     public void FunctionsDirectiveAutoCompleteAtStartOfFile()
     {
         // Arrange, Act & Assert
-        ParseDocumentTest("@functions{" + Environment.NewLine + "foo", new[] { FunctionsDirective.Directive });
+        ParseDocumentTest("""
+            @functions{
+            foo
+            """, new[] { FunctionsDirective.Directive });
     }
 
     [Fact]
     public void SectionDirectiveAutoCompleteAtStartOfFile()
     {
         // Arrange, Act & Assert
-        ParseDocumentTest("@section Header {" + Environment.NewLine + "<p>Foo</p>", new[] { SectionDirective.Directive });
+        ParseDocumentTest("""
+            @section Header {
+            <p>Foo</p>
+            """, new[] { SectionDirective.Directive });
     }
 
     [Fact]
     public void VerbatimBlockAutoCompleteAtStartOfFile()
     {
-        ParseDocumentTest("@{" + Environment.NewLine + "<p></p>");
+        ParseDocumentTest("""
+            @{
+            <p></p>
+            """);
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpBlockTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpBlockTest.cs
@@ -44,7 +44,7 @@ public class CSharpBlockTest() : ParserTestBase(layer: TestProject.Layer.Compile
     {
         ParseDocumentTest(
 @"@{
-    void Foo()
+    void Foo() 
     {
         var time = DateTime.Now
         <strong>Hello the time is @time</strong>

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpBlockTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpBlockTest.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -568,8 +568,9 @@ catch(bar) { baz(); }");
     public void SupportsTryStatementWithMultipleCatchClause()
     {
         ParseDocumentTest(
-            "@try { var foo = new { } } catch(Foo Bar Baz) { var foo = new { } } catch(Foo Bar Baz) " +
-            "{ var foo = new { } } catch(Foo Bar Baz) { var foo = new { } }");
+"""
+            @try { var foo = new { } } catch(Foo Bar Baz) { var foo = new { } } catch(Foo Bar Baz) { var foo = new { } } catch(Foo Bar Baz) { var foo = new { } }
+            """);
     }
 
     [Fact]
@@ -582,8 +583,9 @@ catch(bar) { baz(); }");
     public void SupportsMarkupWithinAdditionalCatchClauses()
     {
         RunSimpleWrappedMarkupTest(
-            prefix: "@try { var foo = new { } } catch(Foo Bar Baz) { var foo = new { } } catch(Foo Bar Baz) " +
-            "{ var foo = new { } } catch(Foo Bar Baz) {",
+            prefix: """
+            @try { var foo = new { } } catch(Foo Bar Baz) { var foo = new { } } catch(Foo Bar Baz) { var foo = new { } } catch(Foo Bar Baz) {
+            """,
             markup: " <p>Foo</p> ",
             suffix: "}");
     }
@@ -664,16 +666,18 @@ catch(bar) { baz(); }");
     public void ParsersCanNestRecursively()
     {
         // Arrange
-        ParseDocumentTest("@foreach(var c in db.Categories) {" + Environment.NewLine
-                     + "            <div>" + Environment.NewLine
-                     + "                <h1>@c.Name</h1>" + Environment.NewLine
-                     + "                <ul>" + Environment.NewLine
-                     + "                    @foreach(var p in c.Products) {" + Environment.NewLine
-                     + "                        <li><a href=\"@Html.ActionUrl(\"Products\", \"Detail\", new { id = p.Id })\">@p.Name</a></li>" + Environment.NewLine
-                     + "                    }" + Environment.NewLine
-                     + "                </ul>" + Environment.NewLine
-                     + "            </div>" + Environment.NewLine
-                     + "        }");
+        ParseDocumentTest("""
+            @foreach(var c in db.Categories) {
+                        <div>
+                            <h1>@c.Name</h1>
+                            <ul>
+                                @foreach(var p in c.Products) {
+                                    <li><a href="@Html.ActionUrl("Products", "Detail", new { id = p.Id })">@p.Name</a></li>
+                                }
+                            </ul>
+                        </div>
+                    }
+            """);
     }
 
     [Fact]

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpBlockTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpBlockTest.cs
@@ -432,7 +432,10 @@ while(true);");
     [Fact]
     public void CapturesNewlineAfterUsing()
     {
-        ParseDocumentTest($"@using Foo{Environment.NewLine}");
+        ParseDocumentTest($"""
+            @using Foo
+            
+            """);
     }
 
     [Fact]

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpBlockTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpBlockTest.cs
@@ -434,7 +434,7 @@ while(true);");
     {
         ParseDocumentTest($"""
             @using Foo
-            
+
             """);
     }
 
@@ -570,8 +570,7 @@ catch(bar) { baz(); }");
     [Fact]
     public void SupportsTryStatementWithMultipleCatchClause()
     {
-        ParseDocumentTest(
-"""
+        ParseDocumentTest("""
             @try { var foo = new { } } catch(Foo Bar Baz) { var foo = new { } } catch(Foo Bar Baz) { var foo = new { } } catch(Foo Bar Baz) { var foo = new { } }
             """);
     }
@@ -585,8 +584,7 @@ catch(bar) { baz(); }");
     [Fact]
     public void SupportsMarkupWithinAdditionalCatchClauses()
     {
-        RunSimpleWrappedMarkupTest(
-            prefix: """
+        RunSimpleWrappedMarkupTest(prefix: """
             @try { var foo = new { } } catch(Foo Bar Baz) { var foo = new { } } catch(Foo Bar Baz) { var foo = new { } } catch(Foo Bar Baz) {
             """,
             markup: " <p>Foo</p> ",

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpBlockTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpBlockTest.cs
@@ -44,7 +44,7 @@ public class CSharpBlockTest() : ParserTestBase(layer: TestProject.Layer.Compile
     {
         ParseDocumentTest(
 @"@{
-    void Foo() 
+    void Foo()
     {
         var time = DateTime.Now
         <strong>Hello the time is @time</strong>

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpErrorTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpErrorTest.cs
@@ -33,8 +33,11 @@ public class CSharpErrorTest() : ParserTestBase(layer: TestProject.Layer.Compile
     public void CapturesWhitespaceToEOLInInvalidUsingStmtAndTreatsAsFileCode()
     {
         // ParseBlockCapturesWhitespaceToEndOfLineInInvalidUsingStatementAndTreatsAsFileCode
-        ParseDocumentTest(
-            "@using          " + Environment.NewLine + Environment.NewLine);
+        ParseDocumentTest("""
+            @using
+
+
+            """);
     }
 
     [Fact]
@@ -52,23 +55,30 @@ public class CSharpErrorTest() : ParserTestBase(layer: TestProject.Layer.Compile
     [Fact]
     public void MethodProducesErrorIfNewlineFollowsTransition()
     {
-        ParseDocumentTest("@" + Environment.NewLine);
+        ParseDocumentTest("""
+            @
+
+            """);
     }
 
     [Fact]
     public void MethodProducesErrorIfWhitespaceBetweenTransitionAndBlockStartInEmbeddedExpr()
     {
         // ParseBlockMethodProducesErrorIfWhitespaceBetweenTransitionAndBlockStartInEmbeddedExpression
-        ParseDocumentTest("@{" + Environment.NewLine
-                     + "    @   {}" + Environment.NewLine
-                     + "}");
+        ParseDocumentTest("""
+            @{
+                @   {}
+            }
+            """);
     }
 
     [Fact]
     public void MethodProducesErrorIfEOFAfterTransitionInEmbeddedExpression()
     {
-        ParseDocumentTest("@{" + Environment.NewLine
-                     + "    @");
+        ParseDocumentTest("""
+            @{
+                @
+            """);
     }
 
     [Fact]
@@ -81,25 +91,32 @@ public class CSharpErrorTest() : ParserTestBase(layer: TestProject.Layer.Compile
     public void ShouldReportErrorAndTerminateAtEOFIfIfParenInExplicitExprUnclosed()
     {
         // ParseBlockShouldReportErrorAndTerminateAtEOFIfIfParenInExplicitExpressionUnclosed
-        ParseDocumentTest("@(foo bar" + Environment.NewLine
-                     + "baz");
+        ParseDocumentTest("""
+            @(foo bar
+            baz
+            """);
     }
 
     [Fact]
     public void ShouldReportErrorAndTerminateAtMarkupIfIfParenInExplicitExprUnclosed()
     {
         // ParseBlockShouldReportErrorAndTerminateAtMarkupIfIfParenInExplicitExpressionUnclosed
-        ParseDocumentTest("@(foo bar" + Environment.NewLine
-                     + "<html>" + Environment.NewLine
-                     + "baz" + Environment.NewLine
-                     + "</html");
+        ParseDocumentTest("""
+            @(foo bar
+            <html>
+            baz
+            </html
+            """);
     }
 
     [Fact]
     public void CorrectlyHandlesInCorrectTransitionsIfImplicitExpressionParensUnclosed()
     {
-        ParseDocumentTest("@Href(" + Environment.NewLine
-                     + "<h1>@Html.Foo(Bar);</h1>" + Environment.NewLine);
+        ParseDocumentTest("""
+            @Href(
+            <h1>@Html.Foo(Bar);</h1>
+
+            """);
     }
 
     [Fact]
@@ -107,9 +124,11 @@ public class CSharpErrorTest() : ParserTestBase(layer: TestProject.Layer.Compile
     public void ShouldReportErrorAndTerminateAtEOFIfParenInImplicitExprUnclosed()
     {
         // ParseBlockShouldReportErrorAndTerminateAtEOFIfParenInImplicitExpressionUnclosed
-        ParseDocumentTest("@Foo(Bar(Baz)" + Environment.NewLine
-                        + "Biz" + Environment.NewLine
-                        + "Boz");
+        ParseDocumentTest("""
+            @Foo(Bar(Baz)
+            Biz
+            Boz
+            """);
     }
 
     [Fact]
@@ -117,11 +136,13 @@ public class CSharpErrorTest() : ParserTestBase(layer: TestProject.Layer.Compile
     public void ShouldReportErrorAndTerminateAtMarkupIfParenInImplicitExpressionUnclosed()
     {
         // ParseBlockShouldReportErrorAndTerminateAtMarkupIfParenInImplicitExpressionUnclosed
-        ParseDocumentTest("@Foo(Bar(Baz)" + Environment.NewLine
-                        + "Biz" + Environment.NewLine
-                        + "<html>" + Environment.NewLine
-                        + "Boz" + Environment.NewLine
-                        + "</html>");
+        ParseDocumentTest("""
+            @Foo(Bar(Baz)
+            Biz
+            <html>
+            Boz
+            </html>
+            """);
     }
 
     [Fact]
@@ -129,9 +150,11 @@ public class CSharpErrorTest() : ParserTestBase(layer: TestProject.Layer.Compile
     public void ShouldReportErrorAndTerminateAtEOFIfBracketInImplicitExpressionUnclosed()
     {
         // ParseBlockShouldReportErrorAndTerminateAtEOFIfBracketInImplicitExpressionUnclosed
-        ParseDocumentTest("@Foo[Bar[Baz]" + Environment.NewLine
-                     + "Biz" + Environment.NewLine
-                     + "Boz");
+        ParseDocumentTest("""
+            @Foo[Bar[Baz]
+            Biz
+            Boz
+            """);
     }
 
     [Fact]
@@ -139,11 +162,13 @@ public class CSharpErrorTest() : ParserTestBase(layer: TestProject.Layer.Compile
     public void ShouldReportErrorAndTerminateAtMarkupIfBracketInImplicitExprUnclosed()
     {
         // ParseBlockShouldReportErrorAndTerminateAtMarkupIfBracketInImplicitExpressionUnclosed
-        ParseDocumentTest("@Foo[Bar[Baz]" + Environment.NewLine
-                     + "Biz" + Environment.NewLine
-                     + "<b>" + Environment.NewLine
-                     + "Boz" + Environment.NewLine
-                     + "</b>");
+        ParseDocumentTest("""
+            @Foo[Bar[Baz]
+            Biz
+            <b>
+            Boz
+            </b>
+            """);
     }
 
     // Simple EOF handling errors:
@@ -260,45 +285,57 @@ public class CSharpErrorTest() : ParserTestBase(layer: TestProject.Layer.Compile
     [Fact]
     public void TerminatesIfBlockAtEOLWhenRecoveringFromMissingCloseParen()
     {
-        ParseDocumentTest("@if(foo bar" + Environment.NewLine
-                     + "baz");
+        ParseDocumentTest("""
+            @if(foo bar
+            baz
+            """);
     }
 
     [Fact]
     public void TerminatesForeachBlockAtEOLWhenRecoveringFromMissingCloseParen()
     {
-        ParseDocumentTest("@foreach(foo bar" + Environment.NewLine
-                     + "baz");
+        ParseDocumentTest("""
+            @foreach(foo bar
+            baz
+            """);
     }
 
     [Fact]
     public void TerminatesWhileClauseInDoStmtAtEOLWhenRecoveringFromMissingCloseParen()
     {
-        ParseDocumentTest("@do { } while(foo bar" + Environment.NewLine
-                     + "baz");
+        ParseDocumentTest("""
+            @do { } while(foo bar
+            baz
+            """);
     }
 
     [Fact]
     public void TerminatesUsingBlockAtEOLWhenRecoveringFromMissingCloseParen()
     {
-        ParseDocumentTest("@using(foo bar" + Environment.NewLine
-                     + "baz");
+        ParseDocumentTest("""
+            @using(foo bar
+            baz
+            """);
     }
 
     [Fact]
     public void ResumesIfStatementAfterOpenParen()
     {
-        ParseDocumentTest("@if(" + Environment.NewLine
-                     + "else { <p>Foo</p> }");
+        ParseDocumentTest("""
+            @if(
+            else { <p>Foo</p> }
+            """);
     }
 
     [Fact]
     public void TerminatesNormalCSharpStringsAtEOLIfEndQuoteMissing()
     {
-        ParseDocumentTest("@if(foo) {" + Environment.NewLine
-                          + "    var p = \"foo bar baz" + Environment.NewLine
-                          + ";" + Environment.NewLine
-                          + "}");
+        ParseDocumentTest("""
+            @if(foo) {
+                var p = "foo bar baz
+            ;
+            }
+            """);
     }
 
     [Fact]
@@ -310,20 +347,24 @@ public class CSharpErrorTest() : ParserTestBase(layer: TestProject.Layer.Compile
     [Fact]
     public void TerminatesVerbatimStringAtEndOfFile()
     {
-        ParseDocumentTest("@if(foo) { var foo = @\"blah " + Environment.NewLine
-                          + "blah; " + Environment.NewLine
-                          + "<p>Foo</p>" + Environment.NewLine
-                          + "blah " + Environment.NewLine
-                          + "blah");
+        ParseDocumentTest("""
+            @if(foo) { var foo = @"blah
+            blah;
+            <p>Foo</p>
+            blah
+            blah
+            """);
     }
 
     [Fact]
     public void CorrectlyParsesMarkupIncorrectyAssumedToBeWithinAStatement()
     {
-        ParseDocumentTest("@if(foo) {" + Environment.NewLine
-                     + "    var foo = \"foo bar baz" + Environment.NewLine
-                     + "    <p>Foo is @foo</p>" + Environment.NewLine
-                     + "}");
+        ParseDocumentTest("""
+            @if(foo) {
+                var foo = "foo bar baz
+                <p>Foo is @foo</p>
+            }
+            """);
     }
 
     [Fact]

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpErrorTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpErrorTest.cs
@@ -34,7 +34,7 @@ public class CSharpErrorTest() : ParserTestBase(layer: TestProject.Layer.Compile
     {
         // ParseBlockCapturesWhitespaceToEndOfLineInInvalidUsingStatementAndTreatsAsFileCode
         ParseDocumentTest("""
-            @using
+            @using          
 
 
             """);
@@ -348,10 +348,10 @@ public class CSharpErrorTest() : ParserTestBase(layer: TestProject.Layer.Compile
     public void TerminatesVerbatimStringAtEndOfFile()
     {
         ParseDocumentTest("""
-            @if(foo) { var foo = @"blah
-            blah;
+            @if(foo) { var foo = @"blah 
+            blah; 
             <p>Foo</p>
-            blah
+            blah 
             blah
             """);
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpExplicitExpressionTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpExplicitExpressionTest.cs
@@ -44,11 +44,13 @@ public class CSharpExplicitExpressionTest() : ParserTestBase(layer: TestProject.
     [Fact]
     public void ShouldAcceptMultiLineVerbatimStrings()
     {
-        ParseDocumentTest(@"@(@""" + Environment.NewLine
-                     + @"Foo" + Environment.NewLine
-                     + @"Bar" + Environment.NewLine
-                     + @"Baz" + Environment.NewLine
-                     + @""")");
+        ParseDocumentTest("""
+            @(@"
+            Foo
+            Bar
+            Baz
+            ")
+            """);
     }
 
     [Fact]

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpRazorCommentsTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpRazorCommentsTest.cs
@@ -94,7 +94,7 @@ This is a comment
     {
         ParseDocumentTest("""
             <p>
-              @**@
+              @**@  
             @**@
             </p>
             """);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpRazorCommentsTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpRazorCommentsTest.cs
@@ -25,8 +25,11 @@ public class CSharpRazorCommentsTest() : ParserTestBase(layer: TestProject.Layer
     [Fact]
     public void RazorCommentInImplicitExpressionMethodCall()
     {
-        ParseDocumentTest("@foo(" + Environment.NewLine
-                        + "@**@" + Environment.NewLine);
+        ParseDocumentTest("""
+            @foo(
+            @**@
+            
+            """);
     }
 
     [Fact]
@@ -50,10 +53,12 @@ This is a comment
     [Fact]
     public void RazorCommentInVerbatimBlock()
     {
-        ParseDocumentTest("@{" + Environment.NewLine
-                        + "    <text" + Environment.NewLine
-                        + "    @**@" + Environment.NewLine
-                        + "}");
+        ParseDocumentTest("""
+            @{
+                <text
+                @**@
+            }
+            """);
     }
 
     [Fact]
@@ -78,58 +83,71 @@ This is a comment
     public void RazorCommentInMarkup()
     {
         ParseDocumentTest(
-            "<p>" + Environment.NewLine
-            + "@**@" + Environment.NewLine
-            + "</p>");
+"""
+            <p>
+            @**@
+            </p>
+            """);
     }
 
     [Fact]
     public void MultipleRazorCommentInMarkup()
     {
         ParseDocumentTest(
-            "<p>" + Environment.NewLine
-            + "  @**@  " + Environment.NewLine
-            + "@**@" + Environment.NewLine
-            + "</p>");
+"""
+            <p>
+              @**@  
+            @**@
+            </p>
+            """);
     }
 
     [Fact]
     public void MultipleRazorCommentsInSameLineInMarkup()
     {
         ParseDocumentTest(
-            "<p>" + Environment.NewLine
-            + "@**@  @**@" + Environment.NewLine
-            + "</p>");
+"""
+            <p>
+            @**@  @**@
+            </p>
+            """);
     }
 
     [Fact]
     public void RazorCommentsSurroundingMarkup()
     {
         ParseDocumentTest(
-            "<p>" + Environment.NewLine
-            + "@* hello *@ content @* world *@" + Environment.NewLine
-            + "</p>");
+"""
+            <p>
+            @* hello *@ content @* world *@
+            </p>
+            """);
     }
 
     [Fact]
     public void RazorCommentBetweenCodeBlockAndMarkup()
     {
         ParseDocumentTest(
-            "@{ }" + Environment.NewLine +
-            "@* Hello World *@" + Environment.NewLine +
-            "<div>Foo</div>"
-        );
+"""
+            @{ }
+            @* Hello World *@
+            <div>Foo</div>
+            """        );
     }
 
     [Fact]
     public void RazorCommentWithExtraNewLineInMarkup()
     {
         ParseDocumentTest(
-            "<p>" + Environment.NewLine + Environment.NewLine
-            + "@* content *@" + Environment.NewLine
-            + "@*" + Environment.NewLine
-            + "content" + Environment.NewLine
-            + "*@" + Environment.NewLine + Environment.NewLine
-            + "</p>");
+"""
+            <p>
+            
+            @* content *@
+            @*
+            content
+            *@
+            
+            </p>
+            """);
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpRazorCommentsTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpRazorCommentsTest.cs
@@ -28,7 +28,7 @@ public class CSharpRazorCommentsTest() : ParserTestBase(layer: TestProject.Layer
         ParseDocumentTest("""
             @foo(
             @**@
-            
+
             """);
     }
 
@@ -82,8 +82,7 @@ This is a comment
     [Fact]
     public void RazorCommentInMarkup()
     {
-        ParseDocumentTest(
-"""
+        ParseDocumentTest("""
             <p>
             @**@
             </p>
@@ -93,10 +92,9 @@ This is a comment
     [Fact]
     public void MultipleRazorCommentInMarkup()
     {
-        ParseDocumentTest(
-"""
+        ParseDocumentTest("""
             <p>
-              @**@  
+              @**@
             @**@
             </p>
             """);
@@ -105,8 +103,7 @@ This is a comment
     [Fact]
     public void MultipleRazorCommentsInSameLineInMarkup()
     {
-        ParseDocumentTest(
-"""
+        ParseDocumentTest("""
             <p>
             @**@  @**@
             </p>
@@ -116,8 +113,7 @@ This is a comment
     [Fact]
     public void RazorCommentsSurroundingMarkup()
     {
-        ParseDocumentTest(
-"""
+        ParseDocumentTest("""
             <p>
             @* hello *@ content @* world *@
             </p>
@@ -127,8 +123,7 @@ This is a comment
     [Fact]
     public void RazorCommentBetweenCodeBlockAndMarkup()
     {
-        ParseDocumentTest(
-"""
+        ParseDocumentTest("""
             @{ }
             @* Hello World *@
             <div>Foo</div>
@@ -138,15 +133,14 @@ This is a comment
     [Fact]
     public void RazorCommentWithExtraNewLineInMarkup()
     {
-        ParseDocumentTest(
-"""
+        ParseDocumentTest("""
             <p>
-            
+
             @* content *@
             @*
             content
             *@
-            
+
             </p>
             """);
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpSectionTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpSectionTest.cs
@@ -26,8 +26,8 @@ public class CSharpSectionTest() : ParserTestBase(layer: TestProject.Layer.Compi
     public void CapturesWhitespaceToEndOfLineInSectionStatementMissingOpenBrace()
     {
         ParseDocumentTest("""
-            @section Foo
-
+            @section Foo         
+                
             """,
             new[] { SectionDirective.Directive });
     }
@@ -36,8 +36,8 @@ public class CSharpSectionTest() : ParserTestBase(layer: TestProject.Layer.Compi
     public void CapturesWhitespaceToEndOfLineInSectionStatementMissingName()
     {
         ParseDocumentTest("""
-            @section
-
+            @section         
+                
             """,
             new[] { SectionDirective.Directive });
     }
@@ -167,7 +167,7 @@ public class CSharpSectionTest() : ParserTestBase(layer: TestProject.Layer.Compi
     {
         // ParseSectionBlockReportsErrorAndAcceptsWhitespaceToEndOfLineIfSectionNotFollowedByOpenBrace
         ParseDocumentTest("""
-            @section foo
+            @section foo      
 
             """,
             new[] { SectionDirective.Directive });
@@ -177,7 +177,7 @@ public class CSharpSectionTest() : ParserTestBase(layer: TestProject.Layer.Compi
     public void AcceptsOpenBraceMultipleLinesBelowSectionName()
     {
         ParseDocumentTest("""
-            @section foo
+            @section foo      
 
 
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpSectionTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpSectionTest.cs
@@ -15,24 +15,30 @@ public class CSharpSectionTest() : ParserTestBase(layer: TestProject.Layer.Compi
     [Fact]
     public void CapturesNewlineImmediatelyFollowing()
     {
-        ParseDocumentTest(
-            "@section" + Environment.NewLine,
+        ParseDocumentTest("""
+            @section
+
+            """,
             new[] { SectionDirective.Directive });
     }
 
     [Fact]
     public void CapturesWhitespaceToEndOfLineInSectionStatementMissingOpenBrace()
     {
-        ParseDocumentTest(
-            "@section Foo         " + Environment.NewLine + "    ",
+        ParseDocumentTest("""
+            @section Foo
+
+            """,
             new[] { SectionDirective.Directive });
     }
 
     [Fact]
     public void CapturesWhitespaceToEndOfLineInSectionStatementMissingName()
     {
-        ParseDocumentTest(
-            "@section         " + Environment.NewLine + "    ",
+        ParseDocumentTest("""
+            @section
+
+            """,
             new[] { SectionDirective.Directive });
     }
 
@@ -160,25 +166,27 @@ public class CSharpSectionTest() : ParserTestBase(layer: TestProject.Layer.Compi
     public void ReportsErrorAndAcceptsWhitespaceToEOLIfSectionNotFollowedByOpenBrace()
     {
         // ParseSectionBlockReportsErrorAndAcceptsWhitespaceToEndOfLineIfSectionNotFollowedByOpenBrace
-        ParseDocumentTest(
-            "@section foo      " + Environment.NewLine,
+        ParseDocumentTest("""
+            @section foo
+
+            """,
             new[] { SectionDirective.Directive });
     }
 
     [Fact]
     public void AcceptsOpenBraceMultipleLinesBelowSectionName()
     {
-        ParseDocumentTest(
-            "@section foo      "
-            + Environment.NewLine
-            + Environment.NewLine
-            + Environment.NewLine
-            + Environment.NewLine
-            + Environment.NewLine
-            + Environment.NewLine
-            + "{" + Environment.NewLine
-            + "<p>Foo</p>" + Environment.NewLine
-            + "}",
+        ParseDocumentTest("""
+            @section foo
+
+
+
+
+
+            {
+            <p>Foo</p>
+            }
+            """,
             new[] { SectionDirective.Directive });
     }
 
@@ -217,11 +225,12 @@ public class CSharpSectionTest() : ParserTestBase(layer: TestProject.Layer.Compi
     [Fact]
     public void SectionIsCorrectlyTerminatedWhenCloseBraceImmediatelyFollowsCodeBlock()
     {
-        ParseDocumentTest(
-            "@section Foo {" + Environment.NewLine
-            + "@if(true) {" + Environment.NewLine
-            + "}" + Environment.NewLine
-            + "}",
+        ParseDocumentTest("""
+            @section Foo {
+            @if(true) {
+            }
+            }
+            """,
             new[] { SectionDirective.Directive });
     }
 
@@ -229,10 +238,11 @@ public class CSharpSectionTest() : ParserTestBase(layer: TestProject.Layer.Compi
     public void SectionCorrectlyTerminatedWhenCloseBraceFollowsCodeBlockNoWhitespace()
     {
         // SectionIsCorrectlyTerminatedWhenCloseBraceImmediatelyFollowsCodeBlockNoWhitespace
-        ParseDocumentTest(
-            "@section Foo {" + Environment.NewLine
-            + "@if(true) {" + Environment.NewLine
-            + "}}",
+        ParseDocumentTest("""
+            @section Foo {
+            @if(true) {
+            }}
+            """,
             new[] { SectionDirective.Directive });
     }
 
@@ -265,8 +275,11 @@ public class CSharpSectionTest() : ParserTestBase(layer: TestProject.Layer.Compi
     [Fact]
     public void CommentRecoversFromUnclosedTag()
     {
-        ParseDocumentTest(
-            "@section s {" + Environment.NewLine + "<a" + Environment.NewLine + "<!--  > \" '-->}",
+        ParseDocumentTest("""
+            @section s {
+            <a
+            <!--  > " '-->}
+            """,
             new[] { SectionDirective.Directive });
     }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpSpecialBlockTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpSpecialBlockTest.cs
@@ -42,10 +42,11 @@ public class CSharpSpecialBlockTest() : ParserTestBase(layer: TestProject.Layer.
     [Fact]
     public void ParseBlockTerminatesSingleLineCommentAtEndOfLine()
     {
-        ParseDocumentTest(
-"@if(!false) {" + Environment.NewLine +
-"    // Foo" + Environment.NewLine +
-"\t<p>A real tag!</p>" + Environment.NewLine +
-"}");
+        ParseDocumentTest("""
+            @if(!false) {
+                // Foo
+            	<p>A real tag!</p>
+            }
+            """);
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpTemplateTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpTemplateTest.cs
@@ -13,13 +13,19 @@ public class CSharpTemplateTest() : ParserTestBase(layer: TestProject.Layer.Comp
     [Fact]
     public void HandlesSingleLineTemplate()
     {
-        ParseDocumentTest("@{ var foo = @: bar" + Environment.NewLine + "; }");
+        ParseDocumentTest("""
+            @{ var foo = @: bar
+            ; }
+            """);
     }
 
     [Fact]
     public void HandlesSingleLineImmediatelyFollowingStatementChar()
     {
-        ParseDocumentTest("@{i@: bar" + Environment.NewLine + "}");
+        ParseDocumentTest("""
+            @{i@: bar
+            }
+            """);
     }
 
     [Fact]

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpToMarkupSwitchTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpToMarkupSwitchTest.cs
@@ -25,69 +25,83 @@ public class CSharpToMarkupSwitchTest() : ParserTestBase(layer: TestProject.Laye
     [Fact]
     public void GivesSpacesToCodeOnAtColonTemplateTransitionInDesignTimeMode()
     {
-        ParseDocumentTest("@Foo(    " + Environment.NewLine
-                     + "@:<p>Foo</p>    " + Environment.NewLine
-                     + ")", designTime: true);
+        ParseDocumentTest("""
+            @Foo(    
+            @:<p>Foo</p>    
+            )
+            """, designTime: true);
     }
 
     [Fact]
     public void GivesSpacesToCodeOnTagTransitionInDesignTimeMode()
     {
-        ParseDocumentTest("@{" + Environment.NewLine
-                     + "    <p>Foo</p>    " + Environment.NewLine
-                     + "}", designTime: true);
+        ParseDocumentTest("""
+            @{
+                <p>Foo</p>    
+            }
+            """, designTime: true);
     }
 
     [Fact]
     public void GivesSpacesToCodeOnInvalidAtTagTransitionInDesignTimeMode()
     {
-        ParseDocumentTest("@{" + Environment.NewLine
-                     + "    @<p>Foo</p>    " + Environment.NewLine
-                     + "}", designTime: true);
+        ParseDocumentTest("""
+            @{
+                @<p>Foo</p>    
+            }
+            """, designTime: true);
     }
 
     [Fact]
     public void GivesSpacesToCodeOnAtColonTransitionInDesignTimeMode()
     {
-        ParseDocumentTest("@{" + Environment.NewLine
-                     + "    @:<p>Foo</p>    " + Environment.NewLine
-                     + "}", designTime: true);
+        ParseDocumentTest("""
+            @{
+                @:<p>Foo</p>    
+            }
+            """, designTime: true);
     }
 
     [Fact]
     public void ShouldSupportSingleLineMarkupContainingStatementBlock()
     {
-        ParseDocumentTest("@Repeat(10," + Environment.NewLine
-                     + "    @: @{}" + Environment.NewLine
-                     + ")");
+        ParseDocumentTest("""
+            @Repeat(10,
+                @: @{}
+            )
+            """);
     }
 
     [Fact]
     public void ShouldSupportMarkupWithoutPreceedingWhitespace()
     {
-        ParseDocumentTest("@foreach(var file in files){" + Environment.NewLine
-                     + Environment.NewLine
-                     + Environment.NewLine
-                     + "@:Baz" + Environment.NewLine
-                     + "<br/>" + Environment.NewLine
-                     + "<a>Foo</a>" + Environment.NewLine
-                     + "@:Bar" + Environment.NewLine
-                     + "}");
+        ParseDocumentTest("""
+            @foreach(var file in files){
+            
+            
+            @:Baz
+            <br/>
+            <a>Foo</a>
+            @:Bar
+            }
+            """);
     }
 
     [Fact]
     public void GivesAllWhitespaceOnSameLineWithTrailingNewLineToMarkupExclPreceedingNewline()
     {
         // ParseBlockGivesAllWhitespaceOnSameLineExcludingPreceedingNewlineButIncludingTrailingNewLineToMarkup
-        ParseDocumentTest("@if(foo) {" + Environment.NewLine
-                     + "    var foo = \"After this statement there are 10 spaces\";          " + Environment.NewLine
-                     + "    <p>" + Environment.NewLine
-                     + "        Foo" + Environment.NewLine
-                     + "        @bar" + Environment.NewLine
-                     + "    </p>" + Environment.NewLine
-                     + "    @:Hello!" + Environment.NewLine
-                     + "    var biz = boz;" + Environment.NewLine
-                     + "}");
+        ParseDocumentTest("""
+            @if(foo) {
+                var foo = "After this statement there are 10 spaces";          
+                <p>
+                    Foo
+                    @bar
+                </p>
+                @:Hello!
+                var biz = boz;
+            }
+            """);
     }
 
     [Fact]
@@ -106,42 +120,46 @@ public class CSharpToMarkupSwitchTest() : ParserTestBase(layer: TestProject.Laye
     public void SupportsMarkupInCaseAndDefaultBranchesOfSwitch()
     {
         // Arrange
-        ParseDocumentTest("@switch(foo) {" + Environment.NewLine
-                     + "    case 0:" + Environment.NewLine
-                     + "        <p>Foo</p>" + Environment.NewLine
-                     + "        break;" + Environment.NewLine
-                     + "    case 1:" + Environment.NewLine
-                     + "        <p>Bar</p>" + Environment.NewLine
-                     + "        return;" + Environment.NewLine
-                     + "    case 2:" + Environment.NewLine
-                     + "        {" + Environment.NewLine
-                     + "            <p>Baz</p>" + Environment.NewLine
-                     + "            <p>Boz</p>" + Environment.NewLine
-                     + "        }" + Environment.NewLine
-                     + "    default:" + Environment.NewLine
-                     + "        <p>Biz</p>" + Environment.NewLine
-                     + "}");
+        ParseDocumentTest("""
+            @switch(foo) {
+                case 0:
+                    <p>Foo</p>
+                    break;
+                case 1:
+                    <p>Bar</p>
+                    return;
+                case 2:
+                    {
+                        <p>Baz</p>
+                        <p>Boz</p>
+                    }
+                default:
+                    <p>Biz</p>
+            }
+            """);
     }
 
     [Fact]
     public void SupportsMarkupInCaseAndDefaultBranchesOfSwitchInCodeBlock()
     {
         // Arrange
-        ParseDocumentTest("@{ switch(foo) {" + Environment.NewLine
-                     + "    case 0:" + Environment.NewLine
-                     + "        <p>Foo</p>" + Environment.NewLine
-                     + "        break;" + Environment.NewLine
-                     + "    case 1:" + Environment.NewLine
-                     + "        <p>Bar</p>" + Environment.NewLine
-                     + "        return;" + Environment.NewLine
-                     + "    case 2:" + Environment.NewLine
-                     + "        {" + Environment.NewLine
-                     + "            <p>Baz</p>" + Environment.NewLine
-                     + "            <p>Boz</p>" + Environment.NewLine
-                     + "        }" + Environment.NewLine
-                     + "    default:" + Environment.NewLine
-                     + "        <p>Biz</p>" + Environment.NewLine
-                     + "} }");
+        ParseDocumentTest("""
+            @{ switch(foo) {
+                case 0:
+                    <p>Foo</p>
+                    break;
+                case 1:
+                    <p>Bar</p>
+                    return;
+                case 2:
+                    {
+                        <p>Baz</p>
+                        <p>Boz</p>
+                    }
+                default:
+                    <p>Biz</p>
+            } }
+            """);
     }
 
     [Fact]
@@ -160,16 +178,20 @@ public class CSharpToMarkupSwitchTest() : ParserTestBase(layer: TestProject.Laye
     public void ParsesMarkupStatementOnSwitchCharacterFollowedByColon()
     {
         // Arrange
-        ParseDocumentTest("@if(foo) { @:Bar" + Environment.NewLine
-                     + "} zoop");
+        ParseDocumentTest("""
+            @if(foo) { @:Bar
+            } zoop
+            """);
     }
 
     [Fact]
     public void ParsesMarkupStatementOnSwitchCharacterFollowedByDoubleColon()
     {
         // Arrange
-        ParseDocumentTest("@if(foo) { @::Sometext" + Environment.NewLine
-                     + "}");
+        ParseDocumentTest("""
+            @if(foo) { @::Sometext
+            }
+            """);
     }
 
 
@@ -177,16 +199,20 @@ public class CSharpToMarkupSwitchTest() : ParserTestBase(layer: TestProject.Laye
     public void ParsesMarkupStatementOnSwitchCharacterFollowedByTripleColon()
     {
         // Arrange
-        ParseDocumentTest("@if(foo) { @:::Sometext" + Environment.NewLine
-                     + "}");
+        ParseDocumentTest("""
+            @if(foo) { @:::Sometext
+            }
+            """);
     }
 
     [Fact]
     public void ParsesMarkupStatementOnSwitchCharacterFollowedByColonInCodeBlock()
     {
         // Arrange
-        ParseDocumentTest("@{ if(foo) { @:Bar" + Environment.NewLine
-                     + "} } zoop");
+        ParseDocumentTest("""
+            @{ if(foo) { @:Bar
+            } } zoop
+            """);
     }
 
     [Fact]
@@ -204,16 +230,18 @@ public class CSharpToMarkupSwitchTest() : ParserTestBase(layer: TestProject.Laye
     [Fact]
     public void SupportsAllKindsOfImplicitMarkupInCodeBlock()
     {
-        ParseDocumentTest("@{" + Environment.NewLine
-                     + "    if(true) {" + Environment.NewLine
-                     + "        @:Single Line Markup" + Environment.NewLine
-                     + "    }" + Environment.NewLine
-                     + "    foreach (var p in Enumerable.Range(1, 10)) {" + Environment.NewLine
-                     + "        <text>The number is @p</text>" + Environment.NewLine
-                     + "    }" + Environment.NewLine
-                     + "    if(!false) {" + Environment.NewLine
-                     + "        <p>A real tag!</p>" + Environment.NewLine
-                     + "    }" + Environment.NewLine
-                     + "}");
+        ParseDocumentTest("""
+            @{
+                if(true) {
+                    @:Single Line Markup
+                }
+                foreach (var p in Enumerable.Range(1, 10)) {
+                    <text>The number is @p</text>
+                }
+                if(!false) {
+                    <p>A real tag!</p>
+                }
+            }
+            """);
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpVerbatimBlockTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpVerbatimBlockTest.cs
@@ -31,18 +31,28 @@ public class CSharpVerbatimBlockTest() : ParserTestBase(layer: TestProject.Layer
     [Fact]
     public void InnerImplicitExprWithOnlySingleAtAcceptsSingleSpaceOrNewlineAtDesignTime()
     {
-        ParseDocumentTest("@{" + Environment.NewLine + "    @" + Environment.NewLine + "}", designTime: true);
+        ParseDocumentTest("""
+            @{
+                @
+            }
+            """, designTime: true);
     }
 
     [Fact]
     public void InnerImplicitExprDoesNotAcceptTrailingNewlineInRunTimeMode()
     {
-        ParseDocumentTest("@{@foo." + Environment.NewLine + "}");
+        ParseDocumentTest("""
+            @{@foo.
+            }
+            """);
     }
 
     [Fact]
     public void InnerImplicitExprAcceptsTrailingNewlineInDesignTimeMode()
     {
-        ParseDocumentTest("@{@foo." + Environment.NewLine + "}", designTime: true);
+        ParseDocumentTest("""
+            @{@foo.
+            }
+            """, designTime: true);
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpWhitespaceHandlingTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/CSharpWhitespaceHandlingTest.cs
@@ -13,6 +13,9 @@ public class CSharpWhitespaceHandlingTest() : ParserTestBase(layer: TestProject.
     [Fact]
     public void StmtBlockDoesNotAcceptTrailingNewlineIfTheyAreSignificantToAncestor()
     {
-        ParseDocumentTest("@{@: @if (true) { }" + Environment.NewLine + "}");
+        ParseDocumentTest("""
+            @{@: @if (true) { }
+            }
+            """);
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/HtmlAttributeTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/HtmlAttributeTest.cs
@@ -14,126 +14,174 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
     public void SymbolBoundAttributes_BeforeEqualWhitespace1()
     {
         var attributeName = "[item]";
-        ParseDocumentTest($"@{{<a {attributeName}{Environment.NewLine}='Foo'\t{attributeName}={Environment.NewLine}'Bar' />}}");
+        ParseDocumentTest($$"""
+            @{<a {{attributeName}}
+            ='Foo'\t{{attributeName}}=
+            'Bar' />}
+            """);
     }
 
     [Fact]
     public void SymbolBoundAttributes_BeforeEqualWhitespace2()
     {
         var attributeName = "[(item,";
-        ParseDocumentTest($"@{{<a {attributeName}{Environment.NewLine}='Foo'\t{attributeName}={Environment.NewLine}'Bar' />}}");
+        ParseDocumentTest($$"""
+            @{<a {{attributeName}}
+            ='Foo'\t{{attributeName}}=
+            'Bar' />}
+            """);
     }
 
     [Fact]
     public void SymbolBoundAttributes_BeforeEqualWhitespace3()
     {
         var attributeName = "(click)";
-        ParseDocumentTest($"@{{<a {attributeName}{Environment.NewLine}='Foo'\t{attributeName}={Environment.NewLine}'Bar' />}}");
+        ParseDocumentTest($$"""
+            @{<a {{attributeName}}
+            ='Foo'\t{{attributeName}}=
+            'Bar' />}
+            """);
     }
 
     [Fact]
     public void SymbolBoundAttributes_BeforeEqualWhitespace4()
     {
         var attributeName = "(^click)";
-        ParseDocumentTest($"@{{<a {attributeName}{Environment.NewLine}='Foo'\t{attributeName}={Environment.NewLine}'Bar' />}}");
+        ParseDocumentTest($$"""
+            @{<a {{attributeName}}
+            ='Foo'\t{{attributeName}}=
+            'Bar' />}
+            """);
     }
 
     [Fact]
     public void SymbolBoundAttributes_BeforeEqualWhitespace5()
     {
         var attributeName = "*something";
-        ParseDocumentTest($"@{{<a {attributeName}{Environment.NewLine}='Foo'\t{attributeName}={Environment.NewLine}'Bar' />}}");
+        ParseDocumentTest($$"""
+            @{<a {{attributeName}}
+            ='Foo'\t{{attributeName}}=
+            'Bar' />}
+            """);
     }
 
     [Fact]
     public void SymbolBoundAttributes_BeforeEqualWhitespace6()
     {
         var attributeName = "#local";
-        ParseDocumentTest($"@{{<a {attributeName}{Environment.NewLine}='Foo'\t{attributeName}={Environment.NewLine}'Bar' />}}");
+        ParseDocumentTest($$"""
+            @{<a {{attributeName}}
+            ='Foo'\t{{attributeName}}=
+            'Bar' />}
+            """);
     }
 
     [Fact]
     public void SymbolBoundAttributes_Whitespace1()
     {
         var attributeName = "[item]";
-        ParseDocumentTest($"@{{<a {Environment.NewLine}  {attributeName}='Foo'\t{Environment.NewLine}{attributeName}='Bar' />}}");
+        ParseDocumentTest($$"""
+            @{<a 
+              {{attributeName}}='Foo'\t
+            {{attributeName}}='Bar' />}
+            """);
     }
 
     [Fact]
     public void SymbolBoundAttributes_Whitespace2()
     {
         var attributeName = "[(item,";
-        ParseDocumentTest($"@{{<a {Environment.NewLine}  {attributeName}='Foo'\t{Environment.NewLine}{attributeName}='Bar' />}}");
+        ParseDocumentTest($$"""
+            @{<a 
+              {{attributeName}}='Foo'\t
+            {{attributeName}}='Bar' />}
+            """);
     }
 
     [Fact]
     public void SymbolBoundAttributes_Whitespace3()
     {
         var attributeName = "(click)";
-        ParseDocumentTest($"@{{<a {Environment.NewLine}  {attributeName}='Foo'\t{Environment.NewLine}{attributeName}='Bar' />}}");
+        ParseDocumentTest($$"""
+            @{<a 
+              {{attributeName}}='Foo'\t
+            {{attributeName}}='Bar' />}
+            """);
     }
 
     [Fact]
     public void SymbolBoundAttributes_Whitespace4()
     {
         var attributeName = "(^click)";
-        ParseDocumentTest($"@{{<a {Environment.NewLine}  {attributeName}='Foo'\t{Environment.NewLine}{attributeName}='Bar' />}}");
+        ParseDocumentTest($$"""
+            @{<a 
+              {{attributeName}}='Foo'\t
+            {{attributeName}}='Bar' />}
+            """);
     }
 
     [Fact]
     public void SymbolBoundAttributes_Whitespace5()
     {
         var attributeName = "*something";
-        ParseDocumentTest($"@{{<a {Environment.NewLine}  {attributeName}='Foo'\t{Environment.NewLine}{attributeName}='Bar' />}}");
+        ParseDocumentTest($$"""
+            @{<a 
+              {{attributeName}}='Foo'\t
+            {{attributeName}}='Bar' />}
+            """);
     }
 
     [Fact]
     public void SymbolBoundAttributes_Whitespace6()
     {
         var attributeName = "#local";
-        ParseDocumentTest($"@{{<a {Environment.NewLine}  {attributeName}='Foo'\t{Environment.NewLine}{attributeName}='Bar' />}}");
+        ParseDocumentTest($$"""
+            @{<a 
+              {{attributeName}}='Foo'\t
+            {{attributeName}}='Bar' />}
+            """);
     }
 
     [Fact]
     public void SymbolBoundAttributes1()
     {
         var attributeName = "[item]";
-        ParseDocumentTest($"@{{<a {attributeName}='Foo' />}}");
+        ParseDocumentTest($$"""@{<a {{attributeName}}='Foo' />}""");
     }
 
     [Fact]
     public void SymbolBoundAttributes2()
     {
         var attributeName = "[(item,";
-        ParseDocumentTest($"@{{<a {attributeName}='Foo' />}}");
+        ParseDocumentTest($$"""@{<a {{attributeName}}='Foo' />}""");
     }
 
     [Fact]
     public void SymbolBoundAttributes3()
     {
         var attributeName = "(click)";
-        ParseDocumentTest($"@{{<a {attributeName}='Foo' />}}");
+        ParseDocumentTest($$"""@{<a {{attributeName}}='Foo' />}""");
     }
 
     [Fact]
     public void SymbolBoundAttributes4()
     {
         var attributeName = "(^click)";
-        ParseDocumentTest($"@{{<a {attributeName}='Foo' />}}");
+        ParseDocumentTest($$"""@{<a {{attributeName}}='Foo' />}""");
     }
 
     [Fact]
     public void SymbolBoundAttributes5()
     {
         var attributeName = "*something";
-        ParseDocumentTest($"@{{<a {attributeName}='Foo' />}}");
+        ParseDocumentTest($$"""@{<a {{attributeName}}='Foo' />}""");
     }
 
     [Fact]
     public void SymbolBoundAttributes6()
     {
         var attributeName = "#local";
-        ParseDocumentTest($"@{{<a {attributeName}='Foo' />}}");
+        ParseDocumentTest($$"""@{<a {{attributeName}}='Foo' />}""");
     }
 
     [Fact]

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/HtmlAttributeTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/HtmlAttributeTest.cs
@@ -16,7 +16,7 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
         var attributeName = "[item]";
         ParseDocumentTest($$"""
             @{<a {{attributeName}}
-            ='Foo'\t{{attributeName}}=
+            ='Foo'	{{attributeName}}=
             'Bar' />}
             """);
     }
@@ -27,7 +27,7 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
         var attributeName = "[(item,";
         ParseDocumentTest($$"""
             @{<a {{attributeName}}
-            ='Foo'\t{{attributeName}}=
+            ='Foo'	{{attributeName}}=
             'Bar' />}
             """);
     }
@@ -38,7 +38,7 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
         var attributeName = "(click)";
         ParseDocumentTest($$"""
             @{<a {{attributeName}}
-            ='Foo'\t{{attributeName}}=
+            ='Foo'	{{attributeName}}=
             'Bar' />}
             """);
     }
@@ -49,7 +49,7 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
         var attributeName = "(^click)";
         ParseDocumentTest($$"""
             @{<a {{attributeName}}
-            ='Foo'\t{{attributeName}}=
+            ='Foo'	{{attributeName}}=
             'Bar' />}
             """);
     }
@@ -60,7 +60,7 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
         var attributeName = "*something";
         ParseDocumentTest($$"""
             @{<a {{attributeName}}
-            ='Foo'\t{{attributeName}}=
+            ='Foo'	{{attributeName}}=
             'Bar' />}
             """);
     }
@@ -71,7 +71,7 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
         var attributeName = "#local";
         ParseDocumentTest($$"""
             @{<a {{attributeName}}
-            ='Foo'\t{{attributeName}}=
+            ='Foo'	{{attributeName}}=
             'Bar' />}
             """);
     }
@@ -81,8 +81,8 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
     {
         var attributeName = "[item]";
         ParseDocumentTest($$"""
-            @{<a 
-              {{attributeName}}='Foo'\t
+            @{<a
+              {{attributeName}}='Foo'
             {{attributeName}}='Bar' />}
             """);
     }
@@ -92,8 +92,8 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
     {
         var attributeName = "[(item,";
         ParseDocumentTest($$"""
-            @{<a 
-              {{attributeName}}='Foo'\t
+            @{<a
+              {{attributeName}}='Foo'
             {{attributeName}}='Bar' />}
             """);
     }
@@ -103,8 +103,8 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
     {
         var attributeName = "(click)";
         ParseDocumentTest($$"""
-            @{<a 
-              {{attributeName}}='Foo'\t
+            @{<a
+              {{attributeName}}='Foo'
             {{attributeName}}='Bar' />}
             """);
     }
@@ -114,8 +114,8 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
     {
         var attributeName = "(^click)";
         ParseDocumentTest($$"""
-            @{<a 
-              {{attributeName}}='Foo'\t
+            @{<a
+              {{attributeName}}='Foo'
             {{attributeName}}='Bar' />}
             """);
     }
@@ -125,8 +125,8 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
     {
         var attributeName = "*something";
         ParseDocumentTest($$"""
-            @{<a 
-              {{attributeName}}='Foo'\t
+            @{<a
+              {{attributeName}}='Foo'
             {{attributeName}}='Bar' />}
             """);
     }
@@ -136,8 +136,8 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
     {
         var attributeName = "#local";
         ParseDocumentTest($$"""
-            @{<a 
-              {{attributeName}}='Foo'\t
+            @{<a
+              {{attributeName}}='Foo'
             {{attributeName}}='Bar' />}
             """);
     }
@@ -146,7 +146,9 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
     public void SymbolBoundAttributes1()
     {
         var attributeName = "[item]";
-        ParseDocumentTest($$"""@{<a {{attributeName}}='Foo' />}""");
+        ParseDocumentTest($$"""
+            @{<a {{attributeName}}='Foo' />}
+            """);
     }
 
     [Fact]
@@ -181,7 +183,9 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
     public void SymbolBoundAttributes6()
     {
         var attributeName = "#local";
-        ParseDocumentTest($$"""@{<a {{attributeName}}='Foo' />}""");
+        ParseDocumentTest($$"""
+            @{<a {{attributeName}}='Foo' />}
+            """);
     }
 
     [Fact]

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/HtmlAttributeTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/HtmlAttributeTest.cs
@@ -81,8 +81,8 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
     {
         var attributeName = "[item]";
         ParseDocumentTest($$"""
-            @{<a
-              {{attributeName}}='Foo'
+            @{<a 
+              {{attributeName}}='Foo'	
             {{attributeName}}='Bar' />}
             """);
     }
@@ -92,8 +92,8 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
     {
         var attributeName = "[(item,";
         ParseDocumentTest($$"""
-            @{<a
-              {{attributeName}}='Foo'
+            @{<a 
+              {{attributeName}}='Foo'	
             {{attributeName}}='Bar' />}
             """);
     }
@@ -103,8 +103,8 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
     {
         var attributeName = "(click)";
         ParseDocumentTest($$"""
-            @{<a
-              {{attributeName}}='Foo'
+            @{<a 
+              {{attributeName}}='Foo'	
             {{attributeName}}='Bar' />}
             """);
     }
@@ -114,8 +114,8 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
     {
         var attributeName = "(^click)";
         ParseDocumentTest($$"""
-            @{<a
-              {{attributeName}}='Foo'
+            @{<a 
+              {{attributeName}}='Foo'	
             {{attributeName}}='Bar' />}
             """);
     }
@@ -125,8 +125,8 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
     {
         var attributeName = "*something";
         ParseDocumentTest($$"""
-            @{<a
-              {{attributeName}}='Foo'
+            @{<a 
+              {{attributeName}}='Foo'	
             {{attributeName}}='Bar' />}
             """);
     }
@@ -136,8 +136,8 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
     {
         var attributeName = "#local";
         ParseDocumentTest($$"""
-            @{<a
-              {{attributeName}}='Foo'
+            @{<a 
+              {{attributeName}}='Foo'	
             {{attributeName}}='Bar' />}
             """);
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/HtmlBlockTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/HtmlBlockTest.cs
@@ -22,24 +22,30 @@ public class HtmlBlockTest() : ParserTestBase(layer: TestProject.Layer.Compiler,
     [Fact]
     public void HandlesOpenAngleAtEof()
     {
-        ParseDocumentTest("@{" + Environment.NewLine
-                        + "<");
+        ParseDocumentTest("""
+            @{
+            <
+            """);
     }
 
     [Fact]
     public void HandlesOpenAngleWithProperTagFollowingIt()
     {
-        ParseDocumentTest("@{" + Environment.NewLine
-                        + "<" + Environment.NewLine
-                        + "</html>",
+        ParseDocumentTest("""
+            @{
+            <
+            </html>
+            """,
                         designTime: true);
     }
 
     [Fact]
     public void TagWithoutCloseAngleDoesNotTerminateBlock()
     {
-        ParseDocumentTest("@{<                      " + Environment.NewLine
-                     + "   ");
+        ParseDocumentTest("""
+            @{<                      
+               
+            """);
     }
 
     [Fact]
@@ -51,8 +57,10 @@ public class HtmlBlockTest() : ParserTestBase(layer: TestProject.Layer.Compiler,
     [Fact]
     public void ReadsToEndOfLineIfFirstCharacterAfterTransitionIsColon()
     {
-        ParseDocumentTest("@{@:<li>Foo Bar Baz" + Environment.NewLine
-                     + "bork}");
+        ParseDocumentTest("""
+            @{@:<li>Foo Bar Baz
+            bork}
+            """);
     }
 
     [Fact]

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/HtmlDocumentTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/HtmlDocumentTest.cs
@@ -52,9 +52,11 @@ public class HtmlDocumentTest() : ParserTestBase(layer: TestProject.Layer.Compil
     [Fact]
     public void WithinSectionDoesNotCreateDocumentLevelSpan()
     {
-        ParseDocumentTest("@section Foo {" + Environment.NewLine
-                        + "    <html></html>" + Environment.NewLine
-                        + "}",
+        ParseDocumentTest("""
+            @section Foo {
+                <html></html>
+            }
+            """,
             new[] { SectionDirective.Directive, });
     }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/HtmlToCodeSwitchTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/HtmlToCodeSwitchTest.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -40,8 +40,10 @@ public class HtmlToCodeSwitchTest() : ParserTestBase(layer: TestProject.Layer.Co
     public void ParsesCodeWithinSingleLineMarkup()
     {
         // TODO: Fix at a later date, HTML should be a tag block.
-        ParseDocumentTest("@{@:<li>Foo @Bar Baz" + Environment.NewLine
-                     + "bork}");
+        ParseDocumentTest("""
+            @{@:<li>Foo @Bar Baz
+            bork}
+            """);
     }
 
     [Fact]
@@ -83,44 +85,52 @@ public class HtmlToCodeSwitchTest() : ParserTestBase(layer: TestProject.Layer.Co
     [Fact]
     public void GivesWhitespacePreceedingToCodeIfThereIsNoMarkupOnThatLine()
     {
-        ParseDocumentTest("@{   <ul>" + Environment.NewLine
-                     + "    @foreach(var p in Products) {" + Environment.NewLine
-                     + "        <li>Product: @p.Name</li>" + Environment.NewLine
-                     + "    }" + Environment.NewLine
-                     + "    </ul>}");
+        ParseDocumentTest("""
+            @{   <ul>
+                @foreach(var p in Products) {
+                    <li>Product: @p.Name</li>
+                }
+                </ul>}
+            """);
     }
 
     [Fact]
     public void ParseDocumentGivesWhitespacePreceedingToCodeIfThereIsNoMarkupOnThatLine()
     {
-        ParseDocumentTest("   <ul>" + Environment.NewLine
-                        + "    @foreach(var p in Products) {" + Environment.NewLine
-                        + "        <li>Product: @p.Name</li>" + Environment.NewLine
-                        + "    }" + Environment.NewLine
-                        + "    </ul>");
+        ParseDocumentTest("""
+               <ul>
+                @foreach(var p in Products) {
+                    <li>Product: @p.Name</li>
+                }
+                </ul>
+            """);
     }
 
     [Fact]
     public void SectionContextGivesWhitespacePreceedingToCodeIfThereIsNoMarkupOnThatLine()
     {
-        ParseDocumentTest("@{@section foo {" + Environment.NewLine
-                        + "    <ul>" + Environment.NewLine
-                        + "        @foreach(var p in Products) {" + Environment.NewLine
-                        + "            <li>Product: @p.Name</li>" + Environment.NewLine
-                        + "        }" + Environment.NewLine
-                        + "    </ul>" + Environment.NewLine
-                        + "}}",
+        ParseDocumentTest("""
+            @{@section foo {
+                <ul>
+                    @foreach(var p in Products) {
+                        <li>Product: @p.Name</li>
+                    }
+                </ul>
+            }}
+            """,
             new[] { SectionDirective.Directive, });
     }
 
     [Fact]
     public void CSharpCodeParserDoesNotAcceptLeadingOrTrailingWhitespaceInDesignMode()
     {
-        ParseDocumentTest("@{   <ul>" + Environment.NewLine
-                     + "    @foreach(var p in Products) {" + Environment.NewLine
-                     + "        <li>Product: @p.Name</li>" + Environment.NewLine
-                     + "    }" + Environment.NewLine
-                     + "    </ul>}",
+        ParseDocumentTest("""
+            @{   <ul>
+                @foreach(var p in Products) {
+                    <li>Product: @p.Name</li>
+                }
+                </ul>}
+            """,
             designTime: true);
     }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/RazorDirectivesTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/RazorDirectivesTest.cs
@@ -805,24 +805,28 @@ public class RazorDirectivesTest() : ParserTestBase(layer: TestProject.Layer.Com
     [Fact]
     public void TypeParam_WithSemicolon()
     {
-        ParseDocumentTest(@$"@typeparam TItem;
+        ParseDocumentTest($$"""
+@typeparam TItem;
 <ul>
 </ul>
-@code {{
+@code {
     // something
-}}",
+}
+""",
             new[] { ComponentConstrainedTypeParamDirective.Directive });
     }
 
     [Fact]
     public void TypeParam_WithoutSemicolon()
     {
-        ParseDocumentTest(@$"@typeparam TItem
+        ParseDocumentTest($$"""
+@typeparam TItem
 <ul>
 </ul>
-@code {{
+@code {
     // something
-}}",
+}
+""",
             new[] { ComponentConstrainedTypeParamDirective.Directive });
     }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/RazorDirectivesTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/RazorDirectivesTest.cs
@@ -166,8 +166,10 @@ public class RazorDirectivesTest() : ParserTestBase(layer: TestProject.Layer.Com
             b => b.AddNamespaceToken());
 
         // Act & Assert
-        ParseDocumentTest(
-            "@custom System." + Environment.NewLine,
+        ParseDocumentTest("""
+            @custom System.
+
+            """,
             new[] { descriptor });
     }
 
@@ -181,8 +183,10 @@ public class RazorDirectivesTest() : ParserTestBase(layer: TestProject.Layer.Com
             b => b.AddNamespaceToken());
 
         // Act & Assert
-        ParseDocumentTest(
-            "@custom System<" + Environment.NewLine,
+        ParseDocumentTest("""
+            @custom System<
+
+            """,
             new[] { descriptor });
     }
 
@@ -196,7 +200,10 @@ public class RazorDirectivesTest() : ParserTestBase(layer: TestProject.Layer.Com
             b => b.AddTypeToken());
 
         // Act & Assert
-        ParseDocumentTest(Environment.NewLine + "  @custom System.Text.Encoding.ASCIIEncoding",
+        ParseDocumentTest("""
+
+              @custom System.Text.Encoding.ASCIIEncoding
+            """,
             new[] { descriptor });
     }
 
@@ -204,14 +211,20 @@ public class RazorDirectivesTest() : ParserTestBase(layer: TestProject.Layer.Com
     public void BuiltInDirectiveDoesNotErorrIfNotAtStartOfLineBecauseOfWhitespace()
     {
         // Act & Assert
-        ParseDocumentTest(Environment.NewLine + "  @addTagHelper \"*, Foo\"");
+        ParseDocumentTest("""
+
+              @addTagHelper "*, Foo"
+            """);
     }
 
     [Fact]
     public void BuiltInDirectiveErrorsIfNotAtStartOfLine()
     {
         // Act & Assert
-        ParseDocumentTest("{  @addTagHelper \"*, Foo\"" + Environment.NewLine + "}");
+        ParseDocumentTest("""
+            {  @addTagHelper "*, Foo"
+            }
+            """);
     }
 
     [Fact]
@@ -225,7 +238,10 @@ public class RazorDirectivesTest() : ParserTestBase(layer: TestProject.Layer.Com
 
         // Act & Assert
         ParseDocumentTest(
-            "{  @custom System.Text.Encoding.ASCIIEncoding" + Environment.NewLine + "}",
+"""
+            {  @custom System.Text.Encoding.ASCIIEncoding
+            }
+            """,
             new[] { descriptor });
     }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/TagHelperBlockRewriterTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/TagHelperBlockRewriterTest.cs
@@ -1193,7 +1193,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = $"<input data-required='{dateTimeNowString}' />";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         RunParseTreeRewriterTest(document, "input");
@@ -1206,7 +1206,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = "<input data-required='value' />";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         RunParseTreeRewriterTest(document, "input");
@@ -1220,7 +1220,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = $"<input data-required='prefix {dateTimeNowString}' />";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         RunParseTreeRewriterTest(document, "input");
@@ -1234,7 +1234,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = $"<input data-required='{dateTimeNowString} suffix' />";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         RunParseTreeRewriterTest(document, "input");
@@ -1248,7 +1248,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = $"<input data-required='prefix {dateTimeNowString} suffix' />";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         RunParseTreeRewriterTest(document, "input");
@@ -1262,7 +1262,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = $"<input pre-attribute data-required='prefix {dateTimeNowString} suffix' post-attribute />";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         RunParseTreeRewriterTest(document, "input");
@@ -1276,7 +1276,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = $"<input data-required='{dateTimeNowString} middle {dateTimeNowString}' />";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         RunParseTreeRewriterTest(document, "input");
@@ -1681,7 +1681,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = "<input unbound-required />";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -1694,7 +1694,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = "<p bound-string></p>";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -1707,7 +1707,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = "<input bound-required-string />";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -1720,7 +1720,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = "<input bound-required-int />";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -1733,7 +1733,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = "<p bound-int></p>";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -1746,7 +1746,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = "<input int-dictionary/>";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -1759,7 +1759,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = "<input string-dictionary />";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -1772,7 +1772,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = "<input int-prefix- />";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -1785,7 +1785,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = "<input string-prefix-/>";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -1798,7 +1798,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = "<input int-prefix-value/>";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -1811,7 +1811,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = "<input string-prefix-value />";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -1824,7 +1824,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = "<input int-prefix-value='' />";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -1837,7 +1837,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = "<input string-prefix-value=''/>";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -1850,7 +1850,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = "<input int-prefix-value='3'/>";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -1863,7 +1863,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = "<input string-prefix-value='some string' />";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -1876,7 +1876,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = "<input unbound-required bound-required-string />";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -1889,7 +1889,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = "<p bound-int bound-string></p>";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -1902,7 +1902,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = "<input bound-required-int unbound-required bound-required-string />";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -1915,7 +1915,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = "<p bound-int bound-string bound-string></p>";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -1928,7 +1928,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = "<input unbound-required class='btn' />";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -1941,7 +1941,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = "<p bound-string class='btn'></p>";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -1954,7 +1954,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = "<input class='btn' unbound-required />";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -1967,7 +1967,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = "<p class='btn' bound-string></p>";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -1980,7 +1980,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = "<input bound-required-string class='btn' />";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -1993,7 +1993,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = "<input class='btn' bound-required-string />";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -2006,7 +2006,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = "<input bound-required-int class='btn' />";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -2019,7 +2019,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = "<p bound-int class='btn'></p>";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -2032,7 +2032,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = "<input class='btn' bound-required-int />";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -2045,7 +2045,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = "<p class='btn' bound-int></p>";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -2059,7 +2059,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = $"<input class='{expressionString}' bound-required-int />";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -2073,7 +2073,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = $"<p class='{expressionString}' bound-int></p>";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -2087,7 +2087,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = $"<input    bound-required-int class='{expressionString}'   bound-required-string class='{expressionString}'  unbound-required  />";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);
@@ -2101,7 +2101,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         var document = $"<p    bound-int class='{expressionString}'   bound-string class='{expressionString}'  bound-string></p>";
 
         // Wrap in a CSharp block
-        document = $"@{{{document}}}";
+        document = $$"""@{{{document}}}""";
 
         // Act & Assert
         EvaluateData(MinimizedAttribute_Descriptors, document);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/TagHelperParseTreeRewriterTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/TagHelperParseTreeRewriterTest.cs
@@ -432,8 +432,16 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     public void CanHandleInvalidChildrenWithWhitespace()
     {
         // Arrange
-        var documentContent = $"<p>{Environment.NewLine}    <strong>{Environment.NewLine}        Hello" +
-            $"{Environment.NewLine}    </strong>{Environment.NewLine}</p>";
+        var documentContent = $"""
+            <p>
+                <strong>
+                    Hello
+            """+
+$"""
+            
+                </strong>
+            </p>
+            """;
         var descriptors = new TagHelperDescriptor[]
         {
                 TagHelperDescriptorBuilder.Create("PTagHelper", "SomeAssembly")
@@ -541,7 +549,11 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     public void UnderstandsAllowedChildren2()
     {
         // Arrange
-        var documentContent = $"<p>{Environment.NewLine}<br />{Environment.NewLine}</p>";
+        var documentContent = $"""
+            <p>
+            <br />
+            </p>
+            """;
         var descriptors = TagHelperParseTreeRewriterTest.GetAllowedChildrenTagHelperDescriptors(new[] { "br" });
 
         // Act & Assert

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/TagHelperParseTreeRewriterTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/TagHelperParseTreeRewriterTest.cs
@@ -436,9 +436,6 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
             <p>
                 <strong>
                     Hello
-            """+
-$"""
-            
                 </strong>
             </p>
             """;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/CodeGeneration/CSharpCodeWriterTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/CodeGeneration/CSharpCodeWriterTest.cs
@@ -309,7 +309,10 @@ public class CSharpCodeWriterTest
 
         // Assert
         var output = writer.GenerateCode();
-        Assert.Equal("private global::System.String _myString;" + Environment.NewLine, output);
+        Assert.Equal("""
+            private global::System.String _myString;
+
+            """, output);
     }
 
     [Fact]
@@ -323,7 +326,10 @@ public class CSharpCodeWriterTest
 
         // Assert
         var output = writer.GenerateCode();
-        Assert.Equal("private readonly static global::System.String _myString;" + Environment.NewLine, output);
+        Assert.Equal("""
+            private readonly static global::System.String _myString;
+
+            """, output);
     }
 
     [Fact]
@@ -341,12 +347,14 @@ public class CSharpCodeWriterTest
 
         // Assert
         var output = writer.GenerateCode();
-        Assert.Equal(
-            "#pragma warning disable 0001" + Environment.NewLine +
-            "#pragma warning disable 0002" + Environment.NewLine +
-            "private readonly static global::System.String _myString;" + Environment.NewLine +
-            "#pragma warning restore 0002" + Environment.NewLine +
-            "#pragma warning restore 0001" + Environment.NewLine,
+        Assert.Equal("""
+            #pragma warning disable 0001
+            #pragma warning disable 0002
+            private readonly static global::System.String _myString;
+            #pragma warning restore 0002
+            #pragma warning restore 0001
+
+            """,
             output);
     }
 
@@ -361,7 +369,10 @@ public class CSharpCodeWriterTest
 
         // Assert
         var output = writer.GenerateCode();
-        Assert.Equal("public global::System.String MyString { get; set; }" + Environment.NewLine, output);
+        Assert.Equal("""
+            public global::System.String MyString { get; set; }
+
+            """, output);
     }
 
     [Fact]
@@ -375,7 +386,10 @@ public class CSharpCodeWriterTest
 
         // Assert
         var output = writer.GenerateCode();
-        Assert.Equal("public static global::System.String MyString { get; set; }" + Environment.NewLine, output);
+        Assert.Equal("""
+            public static global::System.String MyString { get; set; }
+
+            """, output);
     }
 
     [Fact]
@@ -396,7 +410,12 @@ public class CSharpCodeWriterTest
 
         // Assert
         var output = writer.GenerateCode();
-        Assert.Equal("class C" + Environment.NewLine + "{" + Environment.NewLine + "\tint f;" + Environment.NewLine, output);
+        Assert.Equal("""
+            class C
+            {
+            	int f;
+
+            """, output);
     }
 
     [Fact]
@@ -417,6 +436,11 @@ public class CSharpCodeWriterTest
 
         // Assert
         var output = writer.GenerateCode();
-        Assert.Equal("class C" + Environment.NewLine + "{" + Environment.NewLine + "    int f;" + Environment.NewLine, output);
+        Assert.Equal("""
+            class C
+            {
+                int f;
+
+            """, output);
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/DirectiveRemovalOptimizationPassTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/DirectiveRemovalOptimizationPassTest.cs
@@ -48,7 +48,10 @@ public class DirectiveRemovalOptimizationPassTest
     public void Execute_MultipleCustomDirectives_RemovesDirectiveNodesFromDocument()
     {
         // Arrange
-        var content = "@custom \"Hello\"" + Environment.NewLine + "@custom \"World\"";
+        var content = """
+            @custom "Hello"
+            @custom "World"
+            """;
         var sourceDocument = TestRazorSourceDocument.Create(content);
         var codeDocument = RazorCodeDocument.Create(sourceDocument);
         var defaultEngine = RazorProjectEngine.Create(b =>

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/HtmlNodeOptimizationPassTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/HtmlNodeOptimizationPassTest.cs
@@ -17,7 +17,10 @@ public class HtmlNodeOptimizationPassTest
     public void Execute_RewritesWhitespace()
     {
         // Assert
-        var content = Environment.NewLine + "    @true";
+        var content = """
+            
+                @true
+            """;
         var sourceDocument = TestRazorSourceDocument.Create(content);
         var originalTree = RazorSyntaxTree.Parse(sourceDocument);
         var pass = new HtmlNodeOptimizationPass();

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentBindIntegrationTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentBindIntegrationTest.cs
@@ -43,10 +43,11 @@ namespace Test
         // Assert
         var diagnostic = Assert.Single(result.Diagnostics);
         Assert.Equal("RZ9989", diagnostic.Id);
-        Assert.Equal(
-            "The attribute '@bind-value' was matched by multiple bind attributes. Duplicates:" + Environment.NewLine +
-            "Test.BindAttributes" + Environment.NewLine +
-            "Test.BindAttributes",
+        Assert.Equal("""
+            The attribute '@bind-value' was matched by multiple bind attributes. Duplicates:
+            Test.BindAttributes
+            Test.BindAttributes
+            """,
             diagnostic.GetMessage(CultureInfo.CurrentCulture));
     }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentChildContentIntegrationTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentChildContentIntegrationTest.cs
@@ -111,9 +111,9 @@ Some Content
         // Assert
         var diagnostic = Assert.Single(generated.Diagnostics);
         Assert.Same(ComponentDiagnosticFactory.ChildContentMixedWithExplicitChildContent.Id, diagnostic.Id);
-        Assert.Equal(
-            "Unrecognized child content inside component 'RenderChildContent'. The component 'RenderChildContent' accepts " +
-            "child content through the following top-level items: 'ChildContent'.",
+        Assert.Equal("""
+            Unrecognized child content inside component 'RenderChildContent'. The component 'RenderChildContent' accepts child content through the following top-level items: 'ChildContent'.
+            """,
             diagnostic.GetMessage(CultureInfo.CurrentCulture));
     }
 
@@ -237,9 +237,9 @@ Some Content
         // Assert
         var diagnostic = Assert.Single(generated.Diagnostics);
         Assert.Same(ComponentDiagnosticFactory.ChildContentRepeatedParameterName.Id, diagnostic.Id);
-        Assert.Equal(
-            "The child content element 'ChildContent' of component 'RenderChildContentString' uses the same parameter name ('context') as enclosing child content " +
-            "element 'ChildContent' of component 'RenderChildContentString'. Specify the parameter name like: '<ChildContent Context=\"another_name\"> to resolve the ambiguity",
+        Assert.Equal("""
+            The child content element 'ChildContent' of component 'RenderChildContentString' uses the same parameter name ('context') as enclosing child content element 'ChildContent' of component 'RenderChildContentString'. Specify the parameter name like: '<ChildContent Context="another_name"> to resolve the ambiguity
+            """,
             diagnostic.GetMessage(CultureInfo.CurrentCulture));
     }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentDeclarationIntegrationTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentDeclarationIntegrationTest.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentDiagnosticRazorIntegrationTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentDiagnosticRazorIntegrationTest.cs
@@ -74,16 +74,18 @@ namespace Test
             item =>
             {
                 Assert.Equal("RZ9978", item.Id);
-                Assert.Equal("The directives @addTagHelper, @removeTagHelper and @tagHelperPrefix are not valid in a component document. " +
-            "Use '@using <namespace>' directive instead.", item.GetMessage(CultureInfo.CurrentCulture));
+                Assert.Equal("""
+            The directives @addTagHelper, @removeTagHelper and @tagHelperPrefix are not valid in a component document. Use '@using <namespace>' directive instead.
+            """, item.GetMessage(CultureInfo.CurrentCulture));
                 Assert.Equal(0, item.Span.LineIndex);
                 Assert.Equal(0, item.Span.CharacterIndex);
             },
             item =>
             {
                 Assert.Equal("RZ9978", item.Id);
-                Assert.Equal("The directives @addTagHelper, @removeTagHelper and @tagHelperPrefix are not valid in a component document. " +
-            "Use '@using <namespace>' directive instead.", item.GetMessage(CultureInfo.CurrentCulture));
+                Assert.Equal("""
+            The directives @addTagHelper, @removeTagHelper and @tagHelperPrefix are not valid in a component document. Use '@using <namespace>' directive instead.
+            """, item.GetMessage(CultureInfo.CurrentCulture));
                 Assert.Equal(1, item.Span.LineIndex);
                 Assert.Equal(0, item.Span.CharacterIndex);
             });

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentGenericTypeIntegrationTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentGenericTypeIntegrationTest.cs
@@ -95,9 +95,9 @@ namespace Test
         // Assert
         var diagnostic = Assert.Single(generated.Diagnostics);
         Assert.Same(ComponentDiagnosticFactory.GenericComponentTypeInferenceUnderspecified.Id, diagnostic.Id);
-        Assert.Equal(
-            "The type of component 'GenericContext' cannot be inferred based on the values provided. Consider " +
-            "specifying the type arguments directly using the following attributes: 'TItem'.",
+        Assert.Equal("""
+            The type of component 'GenericContext' cannot be inferred based on the values provided. Consider specifying the type arguments directly using the following attributes: 'TItem'.
+            """,
             diagnostic.GetMessage(CultureInfo.CurrentCulture));
     }
 
@@ -114,9 +114,9 @@ namespace Test
         // Assert
         var diagnostic = Assert.Single(generated.Diagnostics);
         Assert.Same(ComponentDiagnosticFactory.GenericComponentMissingTypeArgument.Id, diagnostic.Id);
-        Assert.Equal(
-            "The component 'MultipleGenericParameter' is missing required type arguments. " +
-            "Specify the missing types using the attributes: 'TItem2', 'TItem3'.",
+        Assert.Equal("""
+            The component 'MultipleGenericParameter' is missing required type arguments. Specify the missing types using the attributes: 'TItem2', 'TItem3'.
+            """,
             diagnostic.GetMessage(CultureInfo.CurrentCulture));
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpAutoCompleteTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpAutoCompleteTest.cs
@@ -35,19 +35,28 @@ public class CSharpAutoCompleteTest() : ParserTestBase(layer: TestProject.Layer.
     public void FunctionsDirectiveAutoCompleteAtStartOfFile()
     {
         // Arrange, Act & Assert
-        ParseDocumentTest("@functions{" + Environment.NewLine + "foo", new[] { FunctionsDirective.Directive });
+        ParseDocumentTest("""
+            @functions{
+            foo
+            """, new[] { FunctionsDirective.Directive });
     }
 
     [Fact]
     public void SectionDirectiveAutoCompleteAtStartOfFile()
     {
         // Arrange, Act & Assert
-        ParseDocumentTest("@section Header {" + Environment.NewLine + "<p>Foo</p>", new[] { SectionDirective.Directive });
+        ParseDocumentTest("""
+            @section Header {
+            <p>Foo</p>
+            """, new[] { SectionDirective.Directive });
     }
 
     [Fact]
     public void VerbatimBlockAutoCompleteAtStartOfFile()
     {
-        ParseDocumentTest("@{" + Environment.NewLine + "<p></p>");
+        ParseDocumentTest("""
+            @{
+            <p></p>
+            """);
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpBlockTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpBlockTest.cs
@@ -44,7 +44,7 @@ public class CSharpBlockTest() : ParserTestBase(layer: TestProject.Layer.Compile
     {
         ParseDocumentTest(
 @"@{
-    void Foo()
+    void Foo() 
     {
         var time = DateTime.Now
         <strong>Hello the time is @time</strong>

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpBlockTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpBlockTest.cs
@@ -432,7 +432,10 @@ while(true);");
     [Fact]
     public void CapturesNewlineAfterUsing()
     {
-        ParseDocumentTest($"@using Foo{Environment.NewLine}");
+        ParseDocumentTest($"""
+            @using Foo
+            
+            """);
     }
 
     [Fact]

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpBlockTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpBlockTest.cs
@@ -44,7 +44,7 @@ public class CSharpBlockTest() : ParserTestBase(layer: TestProject.Layer.Compile
     {
         ParseDocumentTest(
 @"@{
-    void Foo() 
+    void Foo()
     {
         var time = DateTime.Now
         <strong>Hello the time is @time</strong>
@@ -434,7 +434,7 @@ while(true);");
     {
         ParseDocumentTest($"""
             @using Foo
-            
+
             """);
     }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpBlockTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpBlockTest.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -44,7 +44,7 @@ public class CSharpBlockTest() : ParserTestBase(layer: TestProject.Layer.Compile
     {
         ParseDocumentTest(
 @"@{
-    void Foo() 
+    void Foo()
     {
         var time = DateTime.Now
         <strong>Hello the time is @time</strong>
@@ -567,9 +567,9 @@ catch(bar) { baz(); }");
     [Fact]
     public void SupportsTryStatementWithMultipleCatchClause()
     {
-        ParseDocumentTest(
-            "@try { var foo = new { } } catch(Foo Bar Baz) { var foo = new { } } catch(Foo Bar Baz) " +
-            "{ var foo = new { } } catch(Foo Bar Baz) { var foo = new { } }");
+        ParseDocumentTest("""
+            @try { var foo = new { } } catch(Foo Bar Baz) { var foo = new { } } catch(Foo Bar Baz) { var foo = new { } } catch(Foo Bar Baz) { var foo = new { } }
+            """);
     }
 
     [Fact]
@@ -581,9 +581,9 @@ catch(bar) { baz(); }");
     [Fact]
     public void SupportsMarkupWithinAdditionalCatchClauses()
     {
-        RunSimpleWrappedMarkupTest(
-            prefix: "@try { var foo = new { } } catch(Foo Bar Baz) { var foo = new { } } catch(Foo Bar Baz) " +
-            "{ var foo = new { } } catch(Foo Bar Baz) {",
+        RunSimpleWrappedMarkupTest(prefix: """
+            @try { var foo = new { } } catch(Foo Bar Baz) { var foo = new { } } catch(Foo Bar Baz) { var foo = new { } } catch(Foo Bar Baz) {
+            """,
             markup: " <p>Foo</p> ",
             suffix: "}");
     }
@@ -664,16 +664,18 @@ catch(bar) { baz(); }");
     public void ParsersCanNestRecursively()
     {
         // Arrange
-        ParseDocumentTest("@foreach(var c in db.Categories) {" + Environment.NewLine
-                     + "            <div>" + Environment.NewLine
-                     + "                <h1>@c.Name</h1>" + Environment.NewLine
-                     + "                <ul>" + Environment.NewLine
-                     + "                    @foreach(var p in c.Products) {" + Environment.NewLine
-                     + "                        <li><a href=\"@Html.ActionUrl(\"Products\", \"Detail\", new { id = p.Id })\">@p.Name</a></li>" + Environment.NewLine
-                     + "                    }" + Environment.NewLine
-                     + "                </ul>" + Environment.NewLine
-                     + "            </div>" + Environment.NewLine
-                     + "        }");
+        ParseDocumentTest("""
+            @foreach(var c in db.Categories) {
+                        <div>
+                            <h1>@c.Name</h1>
+                            <ul>
+                                @foreach(var p in c.Products) {
+                                    <li><a href="@Html.ActionUrl("Products", "Detail", new { id = p.Id })">@p.Name</a></li>
+                                }
+                            </ul>
+                        </div>
+                    }
+            """);
     }
 
     [Fact]

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpCodeParserTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpCodeParserTest.cs
@@ -44,11 +44,17 @@ public class CSharpCodeParserTest
                         }
                     },
                     {
-                        "th" + Environment.NewLine,
+                        """
+                        th
+
+                        """,
                         directiveLocation,
                         new[]
                         {
-                            InvalidPrefixError(2 + Environment.NewLine.Length, Environment.NewLine[0], "th" + Environment.NewLine),
+                            InvalidPrefixError(2 + Environment.NewLine.Length, Environment.NewLine[0], """
+                            th
+
+                            """),
                         }
                     },
                     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpErrorTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpErrorTest.cs
@@ -33,8 +33,11 @@ public class CSharpErrorTest() : ParserTestBase(layer: TestProject.Layer.Compile
     public void CapturesWhitespaceToEOLInInvalidUsingStmtAndTreatsAsFileCode()
     {
         // ParseBlockCapturesWhitespaceToEndOfLineInInvalidUsingStatementAndTreatsAsFileCode
-        ParseDocumentTest(
-            "@using          " + Environment.NewLine + Environment.NewLine);
+        ParseDocumentTest("""
+            @using
+
+
+            """);
     }
 
     [Fact]
@@ -52,23 +55,30 @@ public class CSharpErrorTest() : ParserTestBase(layer: TestProject.Layer.Compile
     [Fact]
     public void MethodProducesErrorIfNewlineFollowsTransition()
     {
-        ParseDocumentTest("@" + Environment.NewLine);
+        ParseDocumentTest("""
+            @
+
+            """);
     }
 
     [Fact]
     public void MethodProducesErrorIfWhitespaceBetweenTransitionAndBlockStartInEmbeddedExpr()
     {
         // ParseBlockMethodProducesErrorIfWhitespaceBetweenTransitionAndBlockStartInEmbeddedExpression
-        ParseDocumentTest("@{" + Environment.NewLine
-                     + "    @   {}" + Environment.NewLine
-                     + "}");
+        ParseDocumentTest("""
+            @{
+                @   {}
+            }
+            """);
     }
 
     [Fact]
     public void MethodProducesErrorIfEOFAfterTransitionInEmbeddedExpression()
     {
-        ParseDocumentTest("@{" + Environment.NewLine
-                     + "    @");
+        ParseDocumentTest("""
+            @{
+                @
+            """);
     }
 
     [Fact]
@@ -81,25 +91,32 @@ public class CSharpErrorTest() : ParserTestBase(layer: TestProject.Layer.Compile
     public void ShouldReportErrorAndTerminateAtEOFIfIfParenInExplicitExprUnclosed()
     {
         // ParseBlockShouldReportErrorAndTerminateAtEOFIfIfParenInExplicitExpressionUnclosed
-        ParseDocumentTest("@(foo bar" + Environment.NewLine
-                     + "baz");
+        ParseDocumentTest("""
+            @(foo bar
+            baz
+            """);
     }
 
     [Fact]
     public void ShouldReportErrorAndTerminateAtMarkupIfIfParenInExplicitExprUnclosed()
     {
         // ParseBlockShouldReportErrorAndTerminateAtMarkupIfIfParenInExplicitExpressionUnclosed
-        ParseDocumentTest("@(foo bar" + Environment.NewLine
-                     + "<html>" + Environment.NewLine
-                     + "baz" + Environment.NewLine
-                     + "</html");
+        ParseDocumentTest("""
+            @(foo bar
+            <html>
+            baz
+            </html
+            """);
     }
 
     [Fact]
     public void CorrectlyHandlesInCorrectTransitionsIfImplicitExpressionParensUnclosed()
     {
-        ParseDocumentTest("@Href(" + Environment.NewLine
-                     + "<h1>@Html.Foo(Bar);</h1>" + Environment.NewLine);
+        ParseDocumentTest("""
+            @Href(
+            <h1>@Html.Foo(Bar);</h1>
+
+            """);
     }
 
     [Fact]
@@ -107,9 +124,11 @@ public class CSharpErrorTest() : ParserTestBase(layer: TestProject.Layer.Compile
     public void ShouldReportErrorAndTerminateAtEOFIfParenInImplicitExprUnclosed()
     {
         // ParseBlockShouldReportErrorAndTerminateAtEOFIfParenInImplicitExpressionUnclosed
-        ParseDocumentTest("@Foo(Bar(Baz)" + Environment.NewLine
-                        + "Biz" + Environment.NewLine
-                        + "Boz");
+        ParseDocumentTest("""
+            @Foo(Bar(Baz)
+            Biz
+            Boz
+            """);
     }
 
     [Fact]
@@ -117,11 +136,13 @@ public class CSharpErrorTest() : ParserTestBase(layer: TestProject.Layer.Compile
     public void ShouldReportErrorAndTerminateAtMarkupIfParenInImplicitExpressionUnclosed()
     {
         // ParseBlockShouldReportErrorAndTerminateAtMarkupIfParenInImplicitExpressionUnclosed
-        ParseDocumentTest("@Foo(Bar(Baz)" + Environment.NewLine
-                        + "Biz" + Environment.NewLine
-                        + "<html>" + Environment.NewLine
-                        + "Boz" + Environment.NewLine
-                        + "</html>");
+        ParseDocumentTest("""
+            @Foo(Bar(Baz)
+            Biz
+            <html>
+            Boz
+            </html>
+            """);
     }
 
     [Fact]
@@ -129,9 +150,11 @@ public class CSharpErrorTest() : ParserTestBase(layer: TestProject.Layer.Compile
     public void ShouldReportErrorAndTerminateAtEOFIfBracketInImplicitExpressionUnclosed()
     {
         // ParseBlockShouldReportErrorAndTerminateAtEOFIfBracketInImplicitExpressionUnclosed
-        ParseDocumentTest("@Foo[Bar[Baz]" + Environment.NewLine
-                     + "Biz" + Environment.NewLine
-                     + "Boz");
+        ParseDocumentTest("""
+            @Foo[Bar[Baz]
+            Biz
+            Boz
+            """);
     }
 
     [Fact]
@@ -139,11 +162,13 @@ public class CSharpErrorTest() : ParserTestBase(layer: TestProject.Layer.Compile
     public void ShouldReportErrorAndTerminateAtMarkupIfBracketInImplicitExprUnclosed()
     {
         // ParseBlockShouldReportErrorAndTerminateAtMarkupIfBracketInImplicitExpressionUnclosed
-        ParseDocumentTest("@Foo[Bar[Baz]" + Environment.NewLine
-                     + "Biz" + Environment.NewLine
-                     + "<b>" + Environment.NewLine
-                     + "Boz" + Environment.NewLine
-                     + "</b>");
+        ParseDocumentTest("""
+            @Foo[Bar[Baz]
+            Biz
+            <b>
+            Boz
+            </b>
+            """);
     }
 
     // Simple EOF handling errors:
@@ -260,45 +285,57 @@ public class CSharpErrorTest() : ParserTestBase(layer: TestProject.Layer.Compile
     [Fact]
     public void TerminatesIfBlockAtEOLWhenRecoveringFromMissingCloseParen()
     {
-        ParseDocumentTest("@if(foo bar" + Environment.NewLine
-                     + "baz");
+        ParseDocumentTest("""
+            @if(foo bar
+            baz
+            """);
     }
 
     [Fact]
     public void TerminatesForeachBlockAtEOLWhenRecoveringFromMissingCloseParen()
     {
-        ParseDocumentTest("@foreach(foo bar" + Environment.NewLine
-                     + "baz");
+        ParseDocumentTest("""
+            @foreach(foo bar
+            baz
+            """);
     }
 
     [Fact]
     public void TerminatesWhileClauseInDoStmtAtEOLWhenRecoveringFromMissingCloseParen()
     {
-        ParseDocumentTest("@do { } while(foo bar" + Environment.NewLine
-                     + "baz");
+        ParseDocumentTest("""
+            @do { } while(foo bar
+            baz
+            """);
     }
 
     [Fact]
     public void TerminatesUsingBlockAtEOLWhenRecoveringFromMissingCloseParen()
     {
-        ParseDocumentTest("@using(foo bar" + Environment.NewLine
-                     + "baz");
+        ParseDocumentTest("""
+            @using(foo bar
+            baz
+            """);
     }
 
     [Fact]
     public void ResumesIfStatementAfterOpenParen()
     {
-        ParseDocumentTest("@if(" + Environment.NewLine
-                     + "else { <p>Foo</p> }");
+        ParseDocumentTest("""
+            @if(
+            else { <p>Foo</p> }
+            """);
     }
 
     [Fact]
     public void TerminatesNormalCSharpStringsAtEOLIfEndQuoteMissing()
     {
-        ParseDocumentTest("@if(foo) {" + Environment.NewLine
-                          + "    var p = \"foo bar baz" + Environment.NewLine
-                          + ";" + Environment.NewLine
-                          + "}");
+        ParseDocumentTest("""
+            @if(foo) {
+                var p = "foo bar baz
+            ;
+            }
+            """);
     }
 
     [Fact]
@@ -310,20 +347,24 @@ public class CSharpErrorTest() : ParserTestBase(layer: TestProject.Layer.Compile
     [Fact]
     public void TerminatesVerbatimStringAtEndOfFile()
     {
-        ParseDocumentTest("@if(foo) { var foo = @\"blah " + Environment.NewLine
-                          + "blah; " + Environment.NewLine
-                          + "<p>Foo</p>" + Environment.NewLine
-                          + "blah " + Environment.NewLine
-                          + "blah");
+        ParseDocumentTest("""
+            @if(foo) { var foo = @"blah
+            blah;
+            <p>Foo</p>
+            blah
+            blah
+            """);
     }
 
     [Fact]
     public void CorrectlyParsesMarkupIncorrectyAssumedToBeWithinAStatement()
     {
-        ParseDocumentTest("@if(foo) {" + Environment.NewLine
-                     + "    var foo = \"foo bar baz" + Environment.NewLine
-                     + "    <p>Foo is @foo</p>" + Environment.NewLine
-                     + "}");
+        ParseDocumentTest("""
+            @if(foo) {
+                var foo = "foo bar baz
+                <p>Foo is @foo</p>
+            }
+            """);
     }
 
     [Fact]

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpErrorTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpErrorTest.cs
@@ -34,7 +34,7 @@ public class CSharpErrorTest() : ParserTestBase(layer: TestProject.Layer.Compile
     {
         // ParseBlockCapturesWhitespaceToEndOfLineInInvalidUsingStatementAndTreatsAsFileCode
         ParseDocumentTest("""
-            @using
+            @using          
 
 
             """);
@@ -348,10 +348,10 @@ public class CSharpErrorTest() : ParserTestBase(layer: TestProject.Layer.Compile
     public void TerminatesVerbatimStringAtEndOfFile()
     {
         ParseDocumentTest("""
-            @if(foo) { var foo = @"blah
-            blah;
+            @if(foo) { var foo = @"blah 
+            blah; 
             <p>Foo</p>
-            blah
+            blah 
             blah
             """);
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpExplicitExpressionTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpExplicitExpressionTest.cs
@@ -44,11 +44,13 @@ public class CSharpExplicitExpressionTest() : ParserTestBase(layer: TestProject.
     [Fact]
     public void ShouldAcceptMultiLineVerbatimStrings()
     {
-        ParseDocumentTest(@"@(@""" + Environment.NewLine
-                     + @"Foo" + Environment.NewLine
-                     + @"Bar" + Environment.NewLine
-                     + @"Baz" + Environment.NewLine
-                     + @""")");
+        ParseDocumentTest("""
+            @(@"
+            Foo
+            Bar
+            Baz
+            ")
+            """);
     }
 
     [Fact]

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpRazorCommentsTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpRazorCommentsTest.cs
@@ -94,7 +94,7 @@ This is a comment
     {
         ParseDocumentTest("""
             <p>
-              @**@
+              @**@  
             @**@
             </p>
             """);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpRazorCommentsTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpRazorCommentsTest.cs
@@ -25,8 +25,11 @@ public class CSharpRazorCommentsTest() : ParserTestBase(layer: TestProject.Layer
     [Fact]
     public void RazorCommentInImplicitExpressionMethodCall()
     {
-        ParseDocumentTest("@foo(" + Environment.NewLine
-                        + "@**@" + Environment.NewLine);
+        ParseDocumentTest("""
+            @foo(
+            @**@
+
+            """);
     }
 
     [Fact]
@@ -50,10 +53,12 @@ This is a comment
     [Fact]
     public void RazorCommentInVerbatimBlock()
     {
-        ParseDocumentTest("@{" + Environment.NewLine
-                        + "    <text" + Environment.NewLine
-                        + "    @**@" + Environment.NewLine
-                        + "}");
+        ParseDocumentTest("""
+            @{
+                <text
+                @**@
+            }
+            """);
     }
 
     [Fact]
@@ -77,59 +82,66 @@ This is a comment
     [Fact]
     public void RazorCommentInMarkup()
     {
-        ParseDocumentTest(
-            "<p>" + Environment.NewLine
-            + "@**@" + Environment.NewLine
-            + "</p>");
+        ParseDocumentTest("""
+            <p>
+            @**@
+            </p>
+            """);
     }
 
     [Fact]
     public void MultipleRazorCommentInMarkup()
     {
-        ParseDocumentTest(
-            "<p>" + Environment.NewLine
-            + "  @**@  " + Environment.NewLine
-            + "@**@" + Environment.NewLine
-            + "</p>");
+        ParseDocumentTest("""
+            <p>
+              @**@
+            @**@
+            </p>
+            """);
     }
 
     [Fact]
     public void MultipleRazorCommentsInSameLineInMarkup()
     {
-        ParseDocumentTest(
-            "<p>" + Environment.NewLine
-            + "@**@  @**@" + Environment.NewLine
-            + "</p>");
+        ParseDocumentTest("""
+            <p>
+            @**@  @**@
+            </p>
+            """);
     }
 
     [Fact]
     public void RazorCommentsSurroundingMarkup()
     {
-        ParseDocumentTest(
-            "<p>" + Environment.NewLine
-            + "@* hello *@ content @* world *@" + Environment.NewLine
-            + "</p>");
+        ParseDocumentTest("""
+            <p>
+            @* hello *@ content @* world *@
+            </p>
+            """);
     }
 
     [Fact]
     public void RazorCommentBetweenCodeBlockAndMarkup()
     {
-        ParseDocumentTest(
-            "@{ }" + Environment.NewLine +
-            "@* Hello World *@" + Environment.NewLine +
-            "<div>Foo</div>"
-        );
+        ParseDocumentTest("""
+            @{ }
+            @* Hello World *@
+            <div>Foo</div>
+            """        );
     }
 
     [Fact]
     public void RazorCommentWithExtraNewLineInMarkup()
     {
-        ParseDocumentTest(
-            "<p>" + Environment.NewLine + Environment.NewLine
-            + "@* content *@" + Environment.NewLine
-            + "@*" + Environment.NewLine
-            + "content" + Environment.NewLine
-            + "*@" + Environment.NewLine + Environment.NewLine
-            + "</p>");
+        ParseDocumentTest("""
+            <p>
+
+            @* content *@
+            @*
+            content
+            *@
+
+            </p>
+            """);
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpSectionTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpSectionTest.cs
@@ -26,8 +26,8 @@ public class CSharpSectionTest() : ParserTestBase(layer: TestProject.Layer.Compi
     public void CapturesWhitespaceToEndOfLineInSectionStatementMissingOpenBrace()
     {
         ParseDocumentTest("""
-            @section Foo
-
+            @section Foo         
+                
             """,
             new[] { SectionDirective.Directive });
     }
@@ -36,8 +36,8 @@ public class CSharpSectionTest() : ParserTestBase(layer: TestProject.Layer.Compi
     public void CapturesWhitespaceToEndOfLineInSectionStatementMissingName()
     {
         ParseDocumentTest("""
-            @section
-
+            @section         
+                
             """,
             new[] { SectionDirective.Directive });
     }
@@ -167,7 +167,7 @@ public class CSharpSectionTest() : ParserTestBase(layer: TestProject.Layer.Compi
     {
         // ParseSectionBlockReportsErrorAndAcceptsWhitespaceToEndOfLineIfSectionNotFollowedByOpenBrace
         ParseDocumentTest("""
-            @section foo
+            @section foo      
 
             """,
             new[] { SectionDirective.Directive });
@@ -177,7 +177,7 @@ public class CSharpSectionTest() : ParserTestBase(layer: TestProject.Layer.Compi
     public void AcceptsOpenBraceMultipleLinesBelowSectionName()
     {
         ParseDocumentTest("""
-            @section foo
+            @section foo      
 
 
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpSectionTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpSectionTest.cs
@@ -15,24 +15,30 @@ public class CSharpSectionTest() : ParserTestBase(layer: TestProject.Layer.Compi
     [Fact]
     public void CapturesNewlineImmediatelyFollowing()
     {
-        ParseDocumentTest(
-            "@section" + Environment.NewLine,
+        ParseDocumentTest("""
+            @section
+
+            """,
             new[] { SectionDirective.Directive });
     }
 
     [Fact]
     public void CapturesWhitespaceToEndOfLineInSectionStatementMissingOpenBrace()
     {
-        ParseDocumentTest(
-            "@section Foo         " + Environment.NewLine + "    ",
+        ParseDocumentTest("""
+            @section Foo
+
+            """,
             new[] { SectionDirective.Directive });
     }
 
     [Fact]
     public void CapturesWhitespaceToEndOfLineInSectionStatementMissingName()
     {
-        ParseDocumentTest(
-            "@section         " + Environment.NewLine + "    ",
+        ParseDocumentTest("""
+            @section
+
+            """,
             new[] { SectionDirective.Directive });
     }
 
@@ -160,25 +166,27 @@ public class CSharpSectionTest() : ParserTestBase(layer: TestProject.Layer.Compi
     public void ReportsErrorAndAcceptsWhitespaceToEOLIfSectionNotFollowedByOpenBrace()
     {
         // ParseSectionBlockReportsErrorAndAcceptsWhitespaceToEndOfLineIfSectionNotFollowedByOpenBrace
-        ParseDocumentTest(
-            "@section foo      " + Environment.NewLine,
+        ParseDocumentTest("""
+            @section foo
+
+            """,
             new[] { SectionDirective.Directive });
     }
 
     [Fact]
     public void AcceptsOpenBraceMultipleLinesBelowSectionName()
     {
-        ParseDocumentTest(
-            "@section foo      "
-            + Environment.NewLine
-            + Environment.NewLine
-            + Environment.NewLine
-            + Environment.NewLine
-            + Environment.NewLine
-            + Environment.NewLine
-            + "{" + Environment.NewLine
-            + "<p>Foo</p>" + Environment.NewLine
-            + "}",
+        ParseDocumentTest("""
+            @section foo
+
+
+
+
+
+            {
+            <p>Foo</p>
+            }
+            """,
             new[] { SectionDirective.Directive });
     }
 
@@ -217,11 +225,12 @@ public class CSharpSectionTest() : ParserTestBase(layer: TestProject.Layer.Compi
     [Fact]
     public void SectionIsCorrectlyTerminatedWhenCloseBraceImmediatelyFollowsCodeBlock()
     {
-        ParseDocumentTest(
-            "@section Foo {" + Environment.NewLine
-            + "@if(true) {" + Environment.NewLine
-            + "}" + Environment.NewLine
-            + "}",
+        ParseDocumentTest("""
+            @section Foo {
+            @if(true) {
+            }
+            }
+            """,
             new[] { SectionDirective.Directive });
     }
 
@@ -229,10 +238,11 @@ public class CSharpSectionTest() : ParserTestBase(layer: TestProject.Layer.Compi
     public void SectionCorrectlyTerminatedWhenCloseBraceFollowsCodeBlockNoWhitespace()
     {
         // SectionIsCorrectlyTerminatedWhenCloseBraceImmediatelyFollowsCodeBlockNoWhitespace
-        ParseDocumentTest(
-            "@section Foo {" + Environment.NewLine
-            + "@if(true) {" + Environment.NewLine
-            + "}}",
+        ParseDocumentTest("""
+            @section Foo {
+            @if(true) {
+            }}
+            """,
             new[] { SectionDirective.Directive });
     }
 
@@ -265,8 +275,11 @@ public class CSharpSectionTest() : ParserTestBase(layer: TestProject.Layer.Compi
     [Fact]
     public void CommentRecoversFromUnclosedTag()
     {
-        ParseDocumentTest(
-            "@section s {" + Environment.NewLine + "<a" + Environment.NewLine + "<!--  > \" '-->}",
+        ParseDocumentTest("""
+            @section s {
+            <a
+            <!--  > " '-->}
+            """,
             new[] { SectionDirective.Directive });
     }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpSpecialBlockTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpSpecialBlockTest.cs
@@ -42,10 +42,11 @@ public class CSharpSpecialBlockTest() : ParserTestBase(layer: TestProject.Layer.
     [Fact]
     public void ParseBlockTerminatesSingleLineCommentAtEndOfLine()
     {
-        ParseDocumentTest(
-"@if(!false) {" + Environment.NewLine +
-"    // Foo" + Environment.NewLine +
-"\t<p>A real tag!</p>" + Environment.NewLine +
-"}");
+        ParseDocumentTest("""
+            @if(!false) {
+                // Foo
+            	<p>A real tag!</p>
+            }
+            """);
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpTemplateTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpTemplateTest.cs
@@ -13,13 +13,19 @@ public class CSharpTemplateTest() : ParserTestBase(layer: TestProject.Layer.Comp
     [Fact]
     public void HandlesSingleLineTemplate()
     {
-        ParseDocumentTest("@{ var foo = @: bar" + Environment.NewLine + "; }");
+        ParseDocumentTest("""
+            @{ var foo = @: bar
+            ; }
+            """);
     }
 
     [Fact]
     public void HandlesSingleLineImmediatelyFollowingStatementChar()
     {
-        ParseDocumentTest("@{i@: bar" + Environment.NewLine + "}");
+        ParseDocumentTest("""
+            @{i@: bar
+            }
+            """);
     }
 
     [Fact]

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpToMarkupSwitchTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpToMarkupSwitchTest.cs
@@ -25,69 +25,83 @@ public class CSharpToMarkupSwitchTest() : ParserTestBase(layer: TestProject.Laye
     [Fact]
     public void GivesSpacesToCodeOnAtColonTemplateTransitionInDesignTimeMode()
     {
-        ParseDocumentTest("@Foo(    " + Environment.NewLine
-                     + "@:<p>Foo</p>    " + Environment.NewLine
-                     + ")", designTime: true);
+        ParseDocumentTest("""
+            @Foo(    
+            @:<p>Foo</p>    
+            )
+            """, designTime: true);
     }
 
     [Fact]
     public void GivesSpacesToCodeOnTagTransitionInDesignTimeMode()
     {
-        ParseDocumentTest("@{" + Environment.NewLine
-                     + "    <p>Foo</p>    " + Environment.NewLine
-                     + "}", designTime: true);
+        ParseDocumentTest("""
+            @{
+                <p>Foo</p>    
+            }
+            """, designTime: true);
     }
 
     [Fact]
     public void GivesSpacesToCodeOnInvalidAtTagTransitionInDesignTimeMode()
     {
-        ParseDocumentTest("@{" + Environment.NewLine
-                     + "    @<p>Foo</p>    " + Environment.NewLine
-                     + "}", designTime: true);
+        ParseDocumentTest("""
+            @{
+                @<p>Foo</p>    
+            }
+            """, designTime: true);
     }
 
     [Fact]
     public void GivesSpacesToCodeOnAtColonTransitionInDesignTimeMode()
     {
-        ParseDocumentTest("@{" + Environment.NewLine
-                     + "    @:<p>Foo</p>    " + Environment.NewLine
-                     + "}", designTime: true);
+        ParseDocumentTest("""
+            @{
+                @:<p>Foo</p>    
+            }
+            """, designTime: true);
     }
 
     [Fact]
     public void ShouldSupportSingleLineMarkupContainingStatementBlock()
     {
-        ParseDocumentTest("@Repeat(10," + Environment.NewLine
-                     + "    @: @{}" + Environment.NewLine
-                     + ")");
+        ParseDocumentTest("""
+            @Repeat(10,
+                @: @{}
+            )
+            """);
     }
 
     [Fact]
     public void ShouldSupportMarkupWithoutPreceedingWhitespace()
     {
-        ParseDocumentTest("@foreach(var file in files){" + Environment.NewLine
-                     + Environment.NewLine
-                     + Environment.NewLine
-                     + "@:Baz" + Environment.NewLine
-                     + "<br/>" + Environment.NewLine
-                     + "<a>Foo</a>" + Environment.NewLine
-                     + "@:Bar" + Environment.NewLine
-                     + "}");
+        ParseDocumentTest("""
+            @foreach(var file in files){
+            
+            
+            @:Baz
+            <br/>
+            <a>Foo</a>
+            @:Bar
+            }
+            """);
     }
 
     [Fact]
     public void GivesAllWhitespaceOnSameLineWithTrailingNewLineToMarkupExclPreceedingNewline()
     {
         // ParseBlockGivesAllWhitespaceOnSameLineExcludingPreceedingNewlineButIncludingTrailingNewLineToMarkup
-        ParseDocumentTest("@if(foo) {" + Environment.NewLine
-                     + "    var foo = \"After this statement there are 10 spaces\";          " + Environment.NewLine
-                     + "    <p>" + Environment.NewLine
-                     + "        Foo" + Environment.NewLine
-                     + "        @bar" + Environment.NewLine
-                     + "    </p>" + Environment.NewLine
-                     + "    @:Hello!" + Environment.NewLine
-                     + "    var biz = boz;" + Environment.NewLine
-                     + "}");
+        ParseDocumentTest("""
+            @if(foo) {
+                var foo = "After this statement there are 10 spaces";          
+                <p>
+                    Foo
+                    @bar
+                </p>
+                @:Hello!
+                var biz = boz;
+            }
+            """);
     }
 
     [Fact]
@@ -106,42 +120,46 @@ public class CSharpToMarkupSwitchTest() : ParserTestBase(layer: TestProject.Laye
     public void SupportsMarkupInCaseAndDefaultBranchesOfSwitch()
     {
         // Arrange
-        ParseDocumentTest("@switch(foo) {" + Environment.NewLine
-                     + "    case 0:" + Environment.NewLine
-                     + "        <p>Foo</p>" + Environment.NewLine
-                     + "        break;" + Environment.NewLine
-                     + "    case 1:" + Environment.NewLine
-                     + "        <p>Bar</p>" + Environment.NewLine
-                     + "        return;" + Environment.NewLine
-                     + "    case 2:" + Environment.NewLine
-                     + "        {" + Environment.NewLine
-                     + "            <p>Baz</p>" + Environment.NewLine
-                     + "            <p>Boz</p>" + Environment.NewLine
-                     + "        }" + Environment.NewLine
-                     + "    default:" + Environment.NewLine
-                     + "        <p>Biz</p>" + Environment.NewLine
-                     + "}");
+        ParseDocumentTest("""
+            @switch(foo) {
+                case 0:
+                    <p>Foo</p>
+                    break;
+                case 1:
+                    <p>Bar</p>
+                    return;
+                case 2:
+                    {
+                        <p>Baz</p>
+                        <p>Boz</p>
+                    }
+                default:
+                    <p>Biz</p>
+            }
+            """);
     }
 
     [Fact]
     public void SupportsMarkupInCaseAndDefaultBranchesOfSwitchInCodeBlock()
     {
         // Arrange
-        ParseDocumentTest("@{ switch(foo) {" + Environment.NewLine
-                     + "    case 0:" + Environment.NewLine
-                     + "        <p>Foo</p>" + Environment.NewLine
-                     + "        break;" + Environment.NewLine
-                     + "    case 1:" + Environment.NewLine
-                     + "        <p>Bar</p>" + Environment.NewLine
-                     + "        return;" + Environment.NewLine
-                     + "    case 2:" + Environment.NewLine
-                     + "        {" + Environment.NewLine
-                     + "            <p>Baz</p>" + Environment.NewLine
-                     + "            <p>Boz</p>" + Environment.NewLine
-                     + "        }" + Environment.NewLine
-                     + "    default:" + Environment.NewLine
-                     + "        <p>Biz</p>" + Environment.NewLine
-                     + "} }");
+        ParseDocumentTest("""
+            @{ switch(foo) {
+                case 0:
+                    <p>Foo</p>
+                    break;
+                case 1:
+                    <p>Bar</p>
+                    return;
+                case 2:
+                    {
+                        <p>Baz</p>
+                        <p>Boz</p>
+                    }
+                default:
+                    <p>Biz</p>
+            } }
+            """);
     }
 
     [Fact]
@@ -160,16 +178,20 @@ public class CSharpToMarkupSwitchTest() : ParserTestBase(layer: TestProject.Laye
     public void ParsesMarkupStatementOnSwitchCharacterFollowedByColon()
     {
         // Arrange
-        ParseDocumentTest("@if(foo) { @:Bar" + Environment.NewLine
-                     + "} zoop");
+        ParseDocumentTest("""
+            @if(foo) { @:Bar
+            } zoop
+            """);
     }
 
     [Fact]
     public void ParsesMarkupStatementOnSwitchCharacterFollowedByDoubleColon()
     {
         // Arrange
-        ParseDocumentTest("@if(foo) { @::Sometext" + Environment.NewLine
-                     + "}");
+        ParseDocumentTest("""
+            @if(foo) { @::Sometext
+            }
+            """);
     }
 
 
@@ -177,16 +199,20 @@ public class CSharpToMarkupSwitchTest() : ParserTestBase(layer: TestProject.Laye
     public void ParsesMarkupStatementOnSwitchCharacterFollowedByTripleColon()
     {
         // Arrange
-        ParseDocumentTest("@if(foo) { @:::Sometext" + Environment.NewLine
-                     + "}");
+        ParseDocumentTest("""
+            @if(foo) { @:::Sometext
+            }
+            """);
     }
 
     [Fact]
     public void ParsesMarkupStatementOnSwitchCharacterFollowedByColonInCodeBlock()
     {
         // Arrange
-        ParseDocumentTest("@{ if(foo) { @:Bar" + Environment.NewLine
-                     + "} } zoop");
+        ParseDocumentTest("""
+            @{ if(foo) { @:Bar
+            } } zoop
+            """);
     }
 
     [Fact]
@@ -204,16 +230,18 @@ public class CSharpToMarkupSwitchTest() : ParserTestBase(layer: TestProject.Laye
     [Fact]
     public void SupportsAllKindsOfImplicitMarkupInCodeBlock()
     {
-        ParseDocumentTest("@{" + Environment.NewLine
-                     + "    if(true) {" + Environment.NewLine
-                     + "        @:Single Line Markup" + Environment.NewLine
-                     + "    }" + Environment.NewLine
-                     + "    foreach (var p in Enumerable.Range(1, 10)) {" + Environment.NewLine
-                     + "        <text>The number is @p</text>" + Environment.NewLine
-                     + "    }" + Environment.NewLine
-                     + "    if(!false) {" + Environment.NewLine
-                     + "        <p>A real tag!</p>" + Environment.NewLine
-                     + "    }" + Environment.NewLine
-                     + "}");
+        ParseDocumentTest("""
+            @{
+                if(true) {
+                    @:Single Line Markup
+                }
+                foreach (var p in Enumerable.Range(1, 10)) {
+                    <text>The number is @p</text>
+                }
+                if(!false) {
+                    <p>A real tag!</p>
+                }
+            }
+            """);
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpTokenizerLiteralTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpTokenizerLiteralTest.cs
@@ -194,19 +194,13 @@ public class CSharpTokenizerLiteralTest : CSharpTokenizerTestBase
     [Fact]
     public void Character_Literal_Terminated_By_CRLF_Even_When_Last_Char_Is_Slash()
     {
-        TestTokenizer("""
-            'foo\
-            
-            """, SyntaxFactory.Token(SyntaxKind.CharacterLiteral, "'foo\\"), IgnoreRemaining);
+        TestTokenizer("'foo\\\r\n", SyntaxFactory.Token(SyntaxKind.CharacterLiteral, "'foo\\"), IgnoreRemaining);
     }
 
     [Fact]
     public void Character_Literal_Terminated_By_CRLF_Even_When_Last_Char_Is_Slash_And_Followed_By_Stuff()
     {
-        TestTokenizer($"""
-            'foo\\
-            flarg
-            """, SyntaxFactory.Token(SyntaxKind.CharacterLiteral, "'foo\\"), IgnoreRemaining);
+        TestTokenizer($"'foo\\\r\nflarg", SyntaxFactory.Token(SyntaxKind.CharacterLiteral, "'foo\\"), IgnoreRemaining);
     }
 
     [Fact]
@@ -254,19 +248,13 @@ public class CSharpTokenizerLiteralTest : CSharpTokenizerTestBase
     [Fact]
     public void String_Literal_Terminated_By_CRLF_Even_When_Last_Char_Is_Slash()
     {
-        TestTokenizer("""
-            "foo\
-            
-            """, SyntaxFactory.Token(SyntaxKind.StringLiteral, "\"foo\\"), IgnoreRemaining);
+        TestTokenizer("\"foo\\\r\n", SyntaxFactory.Token(SyntaxKind.StringLiteral, "\"foo\\"), IgnoreRemaining);
     }
 
     [Fact]
     public void String_Literal_Terminated_By_CRLF_Even_When_Last_Char_Is_Slash_And_Followed_By_Stuff()
     {
-        TestTokenizer($"""
-            \"foo\\
-            flarg
-            """, SyntaxFactory.Token(SyntaxKind.StringLiteral, "\"foo\\"), IgnoreRemaining);
+        TestTokenizer($"\"foo\\\r\nflarg", SyntaxFactory.Token(SyntaxKind.StringLiteral, "\"foo\\"), IgnoreRemaining);
     }
 
     [Fact]

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpTokenizerLiteralTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpTokenizerLiteralTest.cs
@@ -203,7 +203,10 @@ public class CSharpTokenizerLiteralTest : CSharpTokenizerTestBase
     [Fact]
     public void Character_Literal_Terminated_By_CRLF_Even_When_Last_Char_Is_Slash_And_Followed_By_Stuff()
     {
-        TestTokenizer($"'foo\\{Environment.NewLine}flarg", SyntaxFactory.Token(SyntaxKind.CharacterLiteral, "'foo\\"), IgnoreRemaining);
+        TestTokenizer($"""
+            'foo\\
+            flarg
+            """, SyntaxFactory.Token(SyntaxKind.CharacterLiteral, "'foo\\"), IgnoreRemaining);
     }
 
     [Fact]
@@ -260,7 +263,10 @@ public class CSharpTokenizerLiteralTest : CSharpTokenizerTestBase
     [Fact]
     public void String_Literal_Terminated_By_CRLF_Even_When_Last_Char_Is_Slash_And_Followed_By_Stuff()
     {
-        TestTokenizer($"\"foo\\{Environment.NewLine}flarg", SyntaxFactory.Token(SyntaxKind.StringLiteral, "\"foo\\"), IgnoreRemaining);
+        TestTokenizer($"""
+            \"foo\\
+            flarg
+            """, SyntaxFactory.Token(SyntaxKind.StringLiteral, "\"foo\\"), IgnoreRemaining);
     }
 
     [Fact]

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpTokenizerLiteralTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpTokenizerLiteralTest.cs
@@ -194,7 +194,10 @@ public class CSharpTokenizerLiteralTest : CSharpTokenizerTestBase
     [Fact]
     public void Character_Literal_Terminated_By_CRLF_Even_When_Last_Char_Is_Slash()
     {
-        TestTokenizer("'foo\\" + Environment.NewLine, SyntaxFactory.Token(SyntaxKind.CharacterLiteral, "'foo\\"), IgnoreRemaining);
+        TestTokenizer("""
+            'foo\
+            
+            """, SyntaxFactory.Token(SyntaxKind.CharacterLiteral, "'foo\\"), IgnoreRemaining);
     }
 
     [Fact]
@@ -248,7 +251,10 @@ public class CSharpTokenizerLiteralTest : CSharpTokenizerTestBase
     [Fact]
     public void String_Literal_Terminated_By_CRLF_Even_When_Last_Char_Is_Slash()
     {
-        TestTokenizer("\"foo\\" + Environment.NewLine, SyntaxFactory.Token(SyntaxKind.StringLiteral, "\"foo\\"), IgnoreRemaining);
+        TestTokenizer("""
+            "foo\
+            
+            """, SyntaxFactory.Token(SyntaxKind.StringLiteral, "\"foo\\"), IgnoreRemaining);
     }
 
     [Fact]

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpVerbatimBlockTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpVerbatimBlockTest.cs
@@ -31,18 +31,28 @@ public class CSharpVerbatimBlockTest() : ParserTestBase(layer: TestProject.Layer
     [Fact]
     public void InnerImplicitExprWithOnlySingleAtAcceptsSingleSpaceOrNewlineAtDesignTime()
     {
-        ParseDocumentTest("@{" + Environment.NewLine + "    @" + Environment.NewLine + "}", designTime: true);
+        ParseDocumentTest("""
+            @{
+                @
+            }
+            """, designTime: true);
     }
 
     [Fact]
     public void InnerImplicitExprDoesNotAcceptTrailingNewlineInRunTimeMode()
     {
-        ParseDocumentTest("@{@foo." + Environment.NewLine + "}");
+        ParseDocumentTest("""
+            @{@foo.
+            }
+            """);
     }
 
     [Fact]
     public void InnerImplicitExprAcceptsTrailingNewlineInDesignTimeMode()
     {
-        ParseDocumentTest("@{@foo." + Environment.NewLine + "}", designTime: true);
+        ParseDocumentTest("""
+            @{@foo.
+            }
+            """, designTime: true);
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpWhitespaceHandlingTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpWhitespaceHandlingTest.cs
@@ -13,6 +13,9 @@ public class CSharpWhitespaceHandlingTest() : ParserTestBase(layer: TestProject.
     [Fact]
     public void StmtBlockDoesNotAcceptTrailingNewlineIfTheyAreSignificantToAncestor()
     {
-        ParseDocumentTest("@{@: @if (true) { }" + Environment.NewLine + "}");
+        ParseDocumentTest("""
+            @{@: @if (true) { }
+            }
+            """);
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/HtmlAttributeTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/HtmlAttributeTest.cs
@@ -82,8 +82,8 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
     {
         var attributeName = "[item]";
         ParseDocumentTest($$"""
-            @{<a
-              {{attributeName}}='Foo'
+            @{<a 
+              {{attributeName}}='Foo'	
             {{attributeName}}='Bar' />}
             """);
     }
@@ -93,8 +93,8 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
     {
         var attributeName = "[(item,";
         ParseDocumentTest($$"""
-            @{<a
-              {{attributeName}}='Foo'
+            @{<a 
+              {{attributeName}}='Foo'	
             {{attributeName}}='Bar' />}
             """);
     }
@@ -104,8 +104,8 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
     {
         var attributeName = "(click)";
         ParseDocumentTest($$"""
-            @{<a
-              {{attributeName}}='Foo'
+            @{<a 
+              {{attributeName}}='Foo'	
             {{attributeName}}='Bar' />}
             """);
     }
@@ -115,8 +115,8 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
     {
         var attributeName = "(^click)";
         ParseDocumentTest($$"""
-            @{<a
-              {{attributeName}}='Foo'
+            @{<a 
+              {{attributeName}}='Foo'	
             {{attributeName}}='Bar' />}
             """);
     }
@@ -126,8 +126,8 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
     {
         var attributeName = "*something";
         ParseDocumentTest($$"""
-            @{<a
-              {{attributeName}}='Foo'
+            @{<a 
+              {{attributeName}}='Foo'	
             {{attributeName}}='Bar' />}
             """);
     }
@@ -137,8 +137,8 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
     {
         var attributeName = "#local";
         ParseDocumentTest($$"""
-            @{<a
-              {{attributeName}}='Foo'
+            @{<a 
+              {{attributeName}}='Foo'	
             {{attributeName}}='Bar' />}
             """);
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/HtmlAttributeTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/HtmlAttributeTest.cs
@@ -15,126 +15,174 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
     public void SymbolBoundAttributes_BeforeEqualWhitespace1()
     {
         var attributeName = "[item]";
-        ParseDocumentTest($"@{{<a {attributeName}{Environment.NewLine}='Foo'\t{attributeName}={Environment.NewLine}'Bar' />}}");
+        ParseDocumentTest($$"""
+            @{<a {{attributeName}}
+            ='Foo'\t{{attributeName}}=
+            'Bar' />}
+            """);
     }
 
     [Fact]
     public void SymbolBoundAttributes_BeforeEqualWhitespace2()
     {
         var attributeName = "[(item,";
-        ParseDocumentTest($"@{{<a {attributeName}{Environment.NewLine}='Foo'\t{attributeName}={Environment.NewLine}'Bar' />}}");
+        ParseDocumentTest($$"""
+            @{<a {{attributeName}}
+            ='Foo'\t{{attributeName}}=
+            'Bar' />}
+            """);
     }
 
     [Fact]
     public void SymbolBoundAttributes_BeforeEqualWhitespace3()
     {
         var attributeName = "(click)";
-        ParseDocumentTest($"@{{<a {attributeName}{Environment.NewLine}='Foo'\t{attributeName}={Environment.NewLine}'Bar' />}}");
+        ParseDocumentTest($$"""
+            @{<a {{attributeName}}
+            ='Foo'\t{{attributeName}}=
+            'Bar' />}
+            """);
     }
 
     [Fact]
     public void SymbolBoundAttributes_BeforeEqualWhitespace4()
     {
         var attributeName = "(^click)";
-        ParseDocumentTest($"@{{<a {attributeName}{Environment.NewLine}='Foo'\t{attributeName}={Environment.NewLine}'Bar' />}}");
+        ParseDocumentTest($$"""
+            @{<a {{attributeName}}
+            ='Foo'\t{{attributeName}}=
+            'Bar' />}
+            """);
     }
 
     [Fact]
     public void SymbolBoundAttributes_BeforeEqualWhitespace5()
     {
         var attributeName = "*something";
-        ParseDocumentTest($"@{{<a {attributeName}{Environment.NewLine}='Foo'\t{attributeName}={Environment.NewLine}'Bar' />}}");
+        ParseDocumentTest($$"""
+            @{<a {{attributeName}}
+            ='Foo'\t{{attributeName}}=
+            'Bar' />}
+            """);
     }
 
     [Fact]
     public void SymbolBoundAttributes_BeforeEqualWhitespace6()
     {
         var attributeName = "#local";
-        ParseDocumentTest($"@{{<a {attributeName}{Environment.NewLine}='Foo'\t{attributeName}={Environment.NewLine}'Bar' />}}");
+        ParseDocumentTest($$"""
+            @{<a {{attributeName}}
+            ='Foo'\t{{attributeName}}=
+            'Bar' />}
+            """);
     }
 
     [Fact]
     public void SymbolBoundAttributes_Whitespace1()
     {
         var attributeName = "[item]";
-        ParseDocumentTest($"@{{<a {Environment.NewLine}  {attributeName}='Foo'\t{Environment.NewLine}{attributeName}='Bar' />}}");
+        ParseDocumentTest($$"""
+            @{<a 
+              {{attributeName}}='Foo'\t
+            {{attributeName}}='Bar' />}
+            """);
     }
 
     [Fact]
     public void SymbolBoundAttributes_Whitespace2()
     {
         var attributeName = "[(item,";
-        ParseDocumentTest($"@{{<a {Environment.NewLine}  {attributeName}='Foo'\t{Environment.NewLine}{attributeName}='Bar' />}}");
+        ParseDocumentTest($$"""
+            @{<a 
+              {{attributeName}}='Foo'\t
+            {{attributeName}}='Bar' />}
+            """);
     }
 
     [Fact]
     public void SymbolBoundAttributes_Whitespace3()
     {
         var attributeName = "(click)";
-        ParseDocumentTest($"@{{<a {Environment.NewLine}  {attributeName}='Foo'\t{Environment.NewLine}{attributeName}='Bar' />}}");
+        ParseDocumentTest($$"""
+            @{<a 
+              {{attributeName}}='Foo'\t
+            {{attributeName}}='Bar' />}
+            """);
     }
 
     [Fact]
     public void SymbolBoundAttributes_Whitespace4()
     {
         var attributeName = "(^click)";
-        ParseDocumentTest($"@{{<a {Environment.NewLine}  {attributeName}='Foo'\t{Environment.NewLine}{attributeName}='Bar' />}}");
+        ParseDocumentTest($$"""
+            @{<a 
+              {{attributeName}}='Foo'\t
+            {{attributeName}}='Bar' />}
+            """);
     }
 
     [Fact]
     public void SymbolBoundAttributes_Whitespace5()
     {
         var attributeName = "*something";
-        ParseDocumentTest($"@{{<a {Environment.NewLine}  {attributeName}='Foo'\t{Environment.NewLine}{attributeName}='Bar' />}}");
+        ParseDocumentTest($$"""
+            @{<a 
+              {{attributeName}}='Foo'\t
+            {{attributeName}}='Bar' />}
+            """);
     }
 
     [Fact]
     public void SymbolBoundAttributes_Whitespace6()
     {
         var attributeName = "#local";
-        ParseDocumentTest($"@{{<a {Environment.NewLine}  {attributeName}='Foo'\t{Environment.NewLine}{attributeName}='Bar' />}}");
+        ParseDocumentTest($$"""
+            @{<a 
+              {{attributeName}}='Foo'\t
+            {{attributeName}}='Bar' />}
+            """);
     }
 
     [Fact]
     public void SymbolBoundAttributes1()
     {
         var attributeName = "[item]";
-        ParseDocumentTest($"@{{<a {attributeName}='Foo' />}}");
+        ParseDocumentTest($$"""@{<a {{attributeName}}='Foo' />}""");
     }
 
     [Fact]
     public void SymbolBoundAttributes2()
     {
         var attributeName = "[(item,";
-        ParseDocumentTest($"@{{<a {attributeName}='Foo' />}}");
+        ParseDocumentTest($$"""@{<a {{attributeName}}='Foo' />}""");
     }
 
     [Fact]
     public void SymbolBoundAttributes3()
     {
         var attributeName = "(click)";
-        ParseDocumentTest($"@{{<a {attributeName}='Foo' />}}");
+        ParseDocumentTest($$"""@{<a {{attributeName}}='Foo' />}""");
     }
 
     [Fact]
     public void SymbolBoundAttributes4()
     {
         var attributeName = "(^click)";
-        ParseDocumentTest($"@{{<a {attributeName}='Foo' />}}");
+        ParseDocumentTest($$"""@{<a {{attributeName}}='Foo' />}""");
     }
 
     [Fact]
     public void SymbolBoundAttributes5()
     {
         var attributeName = "*something";
-        ParseDocumentTest($"@{{<a {attributeName}='Foo' />}}");
+        ParseDocumentTest($$"""@{<a {{attributeName}}='Foo' />}""");
     }
 
     [Fact]
     public void SymbolBoundAttributes6()
     {
         var attributeName = "#local";
-        ParseDocumentTest($"@{{<a {attributeName}='Foo' />}}");
+        ParseDocumentTest($$"""@{<a {{attributeName}}='Foo' />}""");
     }
 
     [Fact]

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/HtmlAttributeTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/HtmlAttributeTest.cs
@@ -17,7 +17,7 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
         var attributeName = "[item]";
         ParseDocumentTest($$"""
             @{<a {{attributeName}}
-            ='Foo'\t{{attributeName}}=
+            ='Foo'	{{attributeName}}=
             'Bar' />}
             """);
     }
@@ -28,7 +28,7 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
         var attributeName = "[(item,";
         ParseDocumentTest($$"""
             @{<a {{attributeName}}
-            ='Foo'\t{{attributeName}}=
+            ='Foo'	{{attributeName}}=
             'Bar' />}
             """);
     }
@@ -39,7 +39,7 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
         var attributeName = "(click)";
         ParseDocumentTest($$"""
             @{<a {{attributeName}}
-            ='Foo'\t{{attributeName}}=
+            ='Foo'	{{attributeName}}=
             'Bar' />}
             """);
     }
@@ -50,7 +50,7 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
         var attributeName = "(^click)";
         ParseDocumentTest($$"""
             @{<a {{attributeName}}
-            ='Foo'\t{{attributeName}}=
+            ='Foo'	{{attributeName}}=
             'Bar' />}
             """);
     }
@@ -61,7 +61,7 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
         var attributeName = "*something";
         ParseDocumentTest($$"""
             @{<a {{attributeName}}
-            ='Foo'\t{{attributeName}}=
+            ='Foo'	{{attributeName}}=
             'Bar' />}
             """);
     }
@@ -72,7 +72,7 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
         var attributeName = "#local";
         ParseDocumentTest($$"""
             @{<a {{attributeName}}
-            ='Foo'\t{{attributeName}}=
+            ='Foo'	{{attributeName}}=
             'Bar' />}
             """);
     }
@@ -82,8 +82,8 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
     {
         var attributeName = "[item]";
         ParseDocumentTest($$"""
-            @{<a 
-              {{attributeName}}='Foo'\t
+            @{<a
+              {{attributeName}}='Foo'
             {{attributeName}}='Bar' />}
             """);
     }
@@ -93,8 +93,8 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
     {
         var attributeName = "[(item,";
         ParseDocumentTest($$"""
-            @{<a 
-              {{attributeName}}='Foo'\t
+            @{<a
+              {{attributeName}}='Foo'
             {{attributeName}}='Bar' />}
             """);
     }
@@ -104,8 +104,8 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
     {
         var attributeName = "(click)";
         ParseDocumentTest($$"""
-            @{<a 
-              {{attributeName}}='Foo'\t
+            @{<a
+              {{attributeName}}='Foo'
             {{attributeName}}='Bar' />}
             """);
     }
@@ -115,8 +115,8 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
     {
         var attributeName = "(^click)";
         ParseDocumentTest($$"""
-            @{<a 
-              {{attributeName}}='Foo'\t
+            @{<a
+              {{attributeName}}='Foo'
             {{attributeName}}='Bar' />}
             """);
     }
@@ -126,8 +126,8 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
     {
         var attributeName = "*something";
         ParseDocumentTest($$"""
-            @{<a 
-              {{attributeName}}='Foo'\t
+            @{<a
+              {{attributeName}}='Foo'
             {{attributeName}}='Bar' />}
             """);
     }
@@ -137,8 +137,8 @@ public class HtmlAttributeTest() : ParserTestBase(layer: TestProject.Layer.Compi
     {
         var attributeName = "#local";
         ParseDocumentTest($$"""
-            @{<a 
-              {{attributeName}}='Foo'\t
+            @{<a
+              {{attributeName}}='Foo'
             {{attributeName}}='Bar' />}
             """);
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/HtmlBlockTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/HtmlBlockTest.cs
@@ -22,24 +22,30 @@ public class HtmlBlockTest() : ParserTestBase(layer: TestProject.Layer.Compiler)
     [Fact]
     public void HandlesOpenAngleAtEof()
     {
-        ParseDocumentTest("@{" + Environment.NewLine
-                        + "<");
+        ParseDocumentTest("""
+            @{
+            <
+            """);
     }
 
     [Fact]
     public void HandlesOpenAngleWithProperTagFollowingIt()
     {
-        ParseDocumentTest("@{" + Environment.NewLine
-                        + "<" + Environment.NewLine
-                        + "</html>",
+        ParseDocumentTest("""
+            @{
+            <
+            </html>
+            """,
                         designTime: true);
     }
 
     [Fact]
     public void TagWithoutCloseAngleDoesNotTerminateBlock()
     {
-        ParseDocumentTest("@{<                      " + Environment.NewLine
-                     + "   ");
+        ParseDocumentTest("""
+            @{<                      
+               
+            """);
     }
 
     [Fact]
@@ -51,8 +57,10 @@ public class HtmlBlockTest() : ParserTestBase(layer: TestProject.Layer.Compiler)
     [Fact]
     public void ReadsToEndOfLineIfFirstCharacterAfterTransitionIsColon()
     {
-        ParseDocumentTest("@{@:<li>Foo Bar Baz" + Environment.NewLine
-                     + "bork}");
+        ParseDocumentTest("""
+            @{@:<li>Foo Bar Baz
+            bork}
+            """);
     }
 
     [Fact]

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/HtmlDocumentTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/HtmlDocumentTest.cs
@@ -52,9 +52,11 @@ public class HtmlDocumentTest() : ParserTestBase(layer: TestProject.Layer.Compil
     [Fact]
     public void WithinSectionDoesNotCreateDocumentLevelSpan()
     {
-        ParseDocumentTest("@section Foo {" + Environment.NewLine
-                        + "    <html></html>" + Environment.NewLine
-                        + "}",
+        ParseDocumentTest("""
+            @section Foo {
+                <html></html>
+            }
+            """,
             new[] { SectionDirective.Directive, });
     }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/HtmlToCodeSwitchTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/HtmlToCodeSwitchTest.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #nullable disable
@@ -40,8 +40,10 @@ public class HtmlToCodeSwitchTest() : ParserTestBase(layer: TestProject.Layer.Co
     public void ParsesCodeWithinSingleLineMarkup()
     {
         // TODO: Fix at a later date, HTML should be a tag block.
-        ParseDocumentTest("@{@:<li>Foo @Bar Baz" + Environment.NewLine
-                     + "bork}");
+        ParseDocumentTest("""
+            @{@:<li>Foo @Bar Baz
+            bork}
+            """);
     }
 
     [Fact]
@@ -83,44 +85,52 @@ public class HtmlToCodeSwitchTest() : ParserTestBase(layer: TestProject.Layer.Co
     [Fact]
     public void GivesWhitespacePreceedingToCodeIfThereIsNoMarkupOnThatLine()
     {
-        ParseDocumentTest("@{   <ul>" + Environment.NewLine
-                     + "    @foreach(var p in Products) {" + Environment.NewLine
-                     + "        <li>Product: @p.Name</li>" + Environment.NewLine
-                     + "    }" + Environment.NewLine
-                     + "    </ul>}");
+        ParseDocumentTest("""
+            @{   <ul>
+                @foreach(var p in Products) {
+                    <li>Product: @p.Name</li>
+                }
+                </ul>}
+            """);
     }
 
     [Fact]
     public void ParseDocumentGivesWhitespacePreceedingToCodeIfThereIsNoMarkupOnThatLine()
     {
-        ParseDocumentTest("   <ul>" + Environment.NewLine
-                        + "    @foreach(var p in Products) {" + Environment.NewLine
-                        + "        <li>Product: @p.Name</li>" + Environment.NewLine
-                        + "    }" + Environment.NewLine
-                        + "    </ul>");
+        ParseDocumentTest("""
+               <ul>
+                @foreach(var p in Products) {
+                    <li>Product: @p.Name</li>
+                }
+                </ul>
+            """);
     }
 
     [Fact]
     public void SectionContextGivesWhitespacePreceedingToCodeIfThereIsNoMarkupOnThatLine()
     {
-        ParseDocumentTest("@{@section foo {" + Environment.NewLine
-                        + "    <ul>" + Environment.NewLine
-                        + "        @foreach(var p in Products) {" + Environment.NewLine
-                        + "            <li>Product: @p.Name</li>" + Environment.NewLine
-                        + "        }" + Environment.NewLine
-                        + "    </ul>" + Environment.NewLine
-                        + "}}",
+        ParseDocumentTest("""
+            @{@section foo {
+                <ul>
+                    @foreach(var p in Products) {
+                        <li>Product: @p.Name</li>
+                    }
+                </ul>
+            }}
+            """,
             new[] { SectionDirective.Directive, });
     }
 
     [Fact]
     public void CSharpCodeParserDoesNotAcceptLeadingOrTrailingWhitespaceInDesignMode()
     {
-        ParseDocumentTest("@{   <ul>" + Environment.NewLine
-                     + "    @foreach(var p in Products) {" + Environment.NewLine
-                     + "        <li>Product: @p.Name</li>" + Environment.NewLine
-                     + "    }" + Environment.NewLine
-                     + "    </ul>}",
+        ParseDocumentTest("""
+            @{   <ul>
+                @foreach(var p in Products) {
+                    <li>Product: @p.Name</li>
+                }
+                </ul>}
+            """,
             designTime: true);
     }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/RazorDirectivesTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/RazorDirectivesTest.cs
@@ -804,24 +804,28 @@ public class RazorDirectivesTest() : ParserTestBase(layer: TestProject.Layer.Com
     [Fact]
     public void TypeParam_WithSemicolon()
     {
-        ParseDocumentTest(@$"@typeparam TItem;
+        ParseDocumentTest($$"""
+@typeparam TItem;
 <ul>
 </ul>
-@code {{
+@code {
     // something
-}}",
+}
+""",
             new[] { ComponentConstrainedTypeParamDirective.Directive });
     }
 
     [Fact]
     public void TypeParam_WithoutSemicolon()
     {
-        ParseDocumentTest(@$"@typeparam TItem
+        ParseDocumentTest($$"""
+@typeparam TItem
 <ul>
 </ul>
-@code {{
+@code {
     // something
-}}",
+}
+""",
             new[] { ComponentConstrainedTypeParamDirective.Directive });
     }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/RazorDirectivesTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/RazorDirectivesTest.cs
@@ -166,8 +166,10 @@ public class RazorDirectivesTest() : ParserTestBase(layer: TestProject.Layer.Com
             b => b.AddNamespaceToken());
 
         // Act & Assert
-        ParseDocumentTest(
-            "@custom System." + Environment.NewLine,
+        ParseDocumentTest("""
+            @custom System.
+
+            """,
             new[] { descriptor });
     }
 
@@ -181,8 +183,10 @@ public class RazorDirectivesTest() : ParserTestBase(layer: TestProject.Layer.Com
             b => b.AddNamespaceToken());
 
         // Act & Assert
-        ParseDocumentTest(
-            "@custom System<" + Environment.NewLine,
+        ParseDocumentTest("""
+            @custom System<
+
+            """,
             new[] { descriptor });
     }
 
@@ -196,7 +200,10 @@ public class RazorDirectivesTest() : ParserTestBase(layer: TestProject.Layer.Com
             b => b.AddTypeToken());
 
         // Act & Assert
-        ParseDocumentTest(Environment.NewLine + "  @custom System.Text.Encoding.ASCIIEncoding",
+        ParseDocumentTest("""
+
+              @custom System.Text.Encoding.ASCIIEncoding
+            """,
             new[] { descriptor });
     }
 
@@ -204,14 +211,20 @@ public class RazorDirectivesTest() : ParserTestBase(layer: TestProject.Layer.Com
     public void BuiltInDirectiveDoesNotErorrIfNotAtStartOfLineBecauseOfWhitespace()
     {
         // Act & Assert
-        ParseDocumentTest(Environment.NewLine + "  @addTagHelper \"*, Foo\"");
+        ParseDocumentTest("""
+
+              @addTagHelper "*, Foo"
+            """);
     }
 
     [Fact]
     public void BuiltInDirectiveErrorsIfNotAtStartOfLine()
     {
         // Act & Assert
-        ParseDocumentTest("{  @addTagHelper \"*, Foo\"" + Environment.NewLine + "}");
+        ParseDocumentTest("""
+            {  @addTagHelper "*, Foo"
+            }
+            """);
     }
 
     [Fact]
@@ -224,8 +237,10 @@ public class RazorDirectivesTest() : ParserTestBase(layer: TestProject.Layer.Com
             b => b.AddTypeToken());
 
         // Act & Assert
-        ParseDocumentTest(
-            "{  @custom System.Text.Encoding.ASCIIEncoding" + Environment.NewLine + "}",
+        ParseDocumentTest("""
+            {  @custom System.Text.Encoding.ASCIIEncoding
+            }
+            """,
             new[] { descriptor });
     }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/TagHelperParseTreeRewriterTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/TagHelperParseTreeRewriterTest.cs
@@ -432,8 +432,14 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     public void CanHandleInvalidChildrenWithWhitespace()
     {
         // Arrange
-        var documentContent = $"<p>{Environment.NewLine}    <strong>{Environment.NewLine}        Hello" +
-            $"{Environment.NewLine}    </strong>{Environment.NewLine}</p>";
+        var documentContent = """
+            <p>
+                <strong>
+                    Hello
+
+                </strong>
+            </p>
+            """;
         var descriptors = new TagHelperDescriptor[]
         {
                 TagHelperDescriptorBuilder.Create("PTagHelper", "SomeAssembly")
@@ -541,7 +547,11 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     public void UnderstandsAllowedChildren2()
     {
         // Arrange
-        var documentContent = $"<p>{Environment.NewLine}<br />{Environment.NewLine}</p>";
+        var documentContent = $"""
+            <p>
+            <br />
+            </p>
+            """;
         var descriptors = TagHelperParseTreeRewriterTest.GetAllowedChildrenTagHelperDescriptors(new[] { "br" });
 
         // Act & Assert

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/TagHelperParseTreeRewriterTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/TagHelperParseTreeRewriterTest.cs
@@ -436,7 +436,6 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
             <p>
                 <strong>
                     Hello
-
                 </strong>
             </p>
             """;

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/test/DefaultTagHelperDescriptorFactoryTest.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/test/DefaultTagHelperDescriptorFactoryTest.cs
@@ -1424,11 +1424,12 @@ public class DefaultTagHelperDescriptorFactoryTest
     {
         // Arrange
         name = name.Replace("\n", "\\n").Replace("\r", "\\r").Replace("\"", "\\\"");
-        var text = $@"
-        [{typeof(AspNetCore.Razor.TagHelpers.HtmlTargetElementAttribute).FullName}(""{name}"")]
-        public class DynamicTestTagHelper : {typeof(AspNetCore.Razor.TagHelpers.TagHelper).FullName}
-        {{
-        }}";
+        var text = $$"""
+        [{{typeof(AspNetCore.Razor.TagHelpers.HtmlTargetElementAttribute).FullName}}(""{{name}}"")]
+        public class DynamicTestTagHelper : {{typeof(AspNetCore.Razor.TagHelpers.TagHelper).FullName}}
+        {
+        }
+        """;
         var syntaxTree = CSharpSyntaxTree.ParseText(text);
         var compilation = TestCompilation.Create(_assembly, syntaxTree);
         var tagHelperType = compilation.GetTypeByMetadataName("DynamicTestTagHelper");
@@ -1603,12 +1604,13 @@ public class DefaultTagHelperDescriptorFactoryTest
     public void CreateDescriptor_WithValidAttributeName_HasNoErrors(string name)
     {
         // Arrange
-        var text = $@"
-            public class DynamicTestTagHelper : {typeof(AspNetCore.Razor.TagHelpers.TagHelper).FullName}
-            {{
-                [{typeof(AspNetCore.Razor.TagHelpers.HtmlAttributeNameAttribute).FullName}(""{name}"")]
-                public string SomeAttribute {{ get; set; }}
-            }}";
+        var text = $$"""
+            public class DynamicTestTagHelper : {{typeof(AspNetCore.Razor.TagHelpers.TagHelper).FullName}}
+            {
+                [{{typeof(AspNetCore.Razor.TagHelpers.HtmlAttributeNameAttribute).FullName}}(""{{name}}"")]
+                public string SomeAttribute { get; set; }
+            }
+            """;
         var syntaxTree = CSharpSyntaxTree.ParseText(text);
         var compilation = TestCompilation.Create(_assembly, syntaxTree);
         var tagHelperType = compilation.GetTypeByMetadataName("DynamicTestTagHelper");
@@ -1643,12 +1645,13 @@ public class DefaultTagHelperDescriptorFactoryTest
     public void CreateDescriptor_WithValidAttributePrefix_HasNoErrors(string prefix)
     {
         // Arrange
-        var text = $@"
-            public class DynamicTestTagHelper : {typeof(AspNetCore.Razor.TagHelpers.TagHelper).FullName}
-            {{
-                [{typeof(AspNetCore.Razor.TagHelpers.HtmlAttributeNameAttribute).FullName}({nameof(AspNetCore.Razor.TagHelpers.HtmlAttributeNameAttribute.DictionaryAttributePrefix)} = ""{prefix}"")]
-                public System.Collections.Generic.IDictionary<string, int> SomeAttribute {{ get; set; }}
-            }}";
+        var text = $$"""
+            public class DynamicTestTagHelper : {{typeof(AspNetCore.Razor.TagHelpers.TagHelper).FullName}}
+            {
+                [{{typeof(AspNetCore.Razor.TagHelpers.HtmlAttributeNameAttribute).FullName}}({{nameof(AspNetCore.Razor.TagHelpers.HtmlAttributeNameAttribute.DictionaryAttributePrefix)}} = ""{{prefix}}"")]
+                public System.Collections.Generic.IDictionary<string, int> SomeAttribute { get; set; }
+            }
+            """;
         var syntaxTree = CSharpSyntaxTree.ParseText(text);
         var compilation = TestCompilation.Create(_assembly, syntaxTree);
         var tagHelperType = compilation.GetTypeByMetadataName("DynamicTestTagHelper");
@@ -1686,12 +1689,13 @@ public class DefaultTagHelperDescriptorFactoryTest
     {
         // Arrange
         name = name.Replace("\n", "\\n").Replace("\r", "\\r").Replace("\"", "\\\"");
-        var text = $@"
-            public class DynamicTestTagHelper : {typeof(AspNetCore.Razor.TagHelpers.TagHelper).FullName}
-            {{
-                [{typeof(AspNetCore.Razor.TagHelpers.HtmlAttributeNameAttribute).FullName}(""{name}"")]
-                public string InvalidProperty {{ get; set; }}
-            }}";
+        var text = $$"""
+            public class DynamicTestTagHelper : {{typeof(AspNetCore.Razor.TagHelpers.TagHelper).FullName}}
+            {
+                [{{typeof(AspNetCore.Razor.TagHelpers.HtmlAttributeNameAttribute).FullName}}(""{{name}}"")]
+                public string InvalidProperty { get; set; }
+            }
+            """;
         var syntaxTree = CSharpSyntaxTree.ParseText(text);
         var compilation = TestCompilation.Create(_assembly, syntaxTree);
         var tagHelperType = compilation.GetTypeByMetadataName("DynamicTestTagHelper");
@@ -1732,12 +1736,13 @@ public class DefaultTagHelperDescriptorFactoryTest
     {
         // Arrange
         prefix = prefix.Replace("\n", "\\n").Replace("\r", "\\r").Replace("\"", "\\\"");
-        var text = $@"
-            public class DynamicTestTagHelper : {typeof(AspNetCore.Razor.TagHelpers.TagHelper).FullName}
-            {{
-                [{typeof(AspNetCore.Razor.TagHelpers.HtmlAttributeNameAttribute).FullName}({nameof(AspNetCore.Razor.TagHelpers.HtmlAttributeNameAttribute.DictionaryAttributePrefix)} = ""{prefix}"")]
-                public System.Collections.Generic.IDictionary<System.String, System.Int32> InvalidProperty {{ get; set; }}
-            }}";
+        var text = $$"""
+            public class DynamicTestTagHelper : {{typeof(AspNetCore.Razor.TagHelpers.TagHelper).FullName}}
+            {
+                [{{typeof(AspNetCore.Razor.TagHelpers.HtmlAttributeNameAttribute).FullName}}({{nameof(AspNetCore.Razor.TagHelpers.HtmlAttributeNameAttribute.DictionaryAttributePrefix)}} = ""{{prefix}}"")]
+                public System.Collections.Generic.IDictionary<System.String, System.Int32> InvalidProperty { get; set; }
+            }
+            """;
         var syntaxTree = CSharpSyntaxTree.ParseText(text);
         var compilation = TestCompilation.Create(_assembly, syntaxTree);
         var tagHelperType = compilation.GetTypeByMetadataName("DynamicTestTagHelper");
@@ -1775,11 +1780,12 @@ public class DefaultTagHelperDescriptorFactoryTest
     {
         // Arrange
         name = name.Replace("\n", "\\n").Replace("\r", "\\r").Replace("\"", "\\\"");
-        var text = $@"
-            [{typeof(AspNetCore.Razor.TagHelpers.RestrictChildrenAttribute).FullName}(""{name}"")]
-            public class DynamicTestTagHelper : {typeof(AspNetCore.Razor.TagHelpers.TagHelper).FullName}
-            {{
-            }}";
+        var text = $$"""
+            [{{typeof(AspNetCore.Razor.TagHelpers.RestrictChildrenAttribute).FullName}}(""{{name}}"")]
+            public class DynamicTestTagHelper : {{typeof(AspNetCore.Razor.TagHelpers.TagHelper).FullName}}
+            {
+            }
+            """;
         var syntaxTree = CSharpSyntaxTree.ParseText(text);
         var compilation = TestCompilation.Create(_assembly, syntaxTree);
         var tagHelperType = compilation.GetTypeByMetadataName("DynamicTestTagHelper");
@@ -1816,11 +1822,12 @@ public class DefaultTagHelperDescriptorFactoryTest
     {
         // Arrange
         name = name.Replace("\n", "\\n").Replace("\r", "\\r").Replace("\"", "\\\"");
-        var text = $@"
-            [{typeof(AspNetCore.Razor.TagHelpers.HtmlTargetElementAttribute).FullName}({nameof(AspNetCore.Razor.TagHelpers.HtmlTargetElementAttribute.ParentTag)} = ""{name}"")]
-            public class DynamicTestTagHelper : {typeof(AspNetCore.Razor.TagHelpers.TagHelper).FullName}
-            {{
-            }}";
+        var text = $$"""
+            [{{typeof(AspNetCore.Razor.TagHelpers.HtmlTargetElementAttribute).FullName}}({{nameof(AspNetCore.Razor.TagHelpers.HtmlTargetElementAttribute.ParentTag)}} = ""{{name}}"")]
+            public class DynamicTestTagHelper : {{typeof(AspNetCore.Razor.TagHelpers.TagHelper).FullName}}
+            {
+            }
+            """;
         var syntaxTree = CSharpSyntaxTree.ParseText(text);
         var compilation = TestCompilation.Create(_assembly, syntaxTree);
         var tagHelperType = compilation.GetTypeByMetadataName("DynamicTestTagHelper");

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/test/DefaultTagHelperDescriptorFactoryTest.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/test/DefaultTagHelperDescriptorFactoryTest.cs
@@ -1425,11 +1425,11 @@ public class DefaultTagHelperDescriptorFactoryTest
         // Arrange
         name = name.Replace("\n", "\\n").Replace("\r", "\\r").Replace("\"", "\\\"");
         var text = $$"""
-        [{{typeof(AspNetCore.Razor.TagHelpers.HtmlTargetElementAttribute).FullName}}(""{{name}}"")]
-        public class DynamicTestTagHelper : {{typeof(AspNetCore.Razor.TagHelpers.TagHelper).FullName}}
-        {
-        }
-        """;
+            [{{typeof(AspNetCore.Razor.TagHelpers.HtmlTargetElementAttribute).FullName}}("{{name}}")]
+            public class DynamicTestTagHelper : {{typeof(AspNetCore.Razor.TagHelpers.TagHelper).FullName}}
+            {
+            }
+            """;
         var syntaxTree = CSharpSyntaxTree.ParseText(text);
         var compilation = TestCompilation.Create(_assembly, syntaxTree);
         var tagHelperType = compilation.GetTypeByMetadataName("DynamicTestTagHelper");
@@ -1607,7 +1607,7 @@ public class DefaultTagHelperDescriptorFactoryTest
         var text = $$"""
             public class DynamicTestTagHelper : {{typeof(AspNetCore.Razor.TagHelpers.TagHelper).FullName}}
             {
-                [{{typeof(AspNetCore.Razor.TagHelpers.HtmlAttributeNameAttribute).FullName}}(""{{name}}"")]
+                [{{typeof(AspNetCore.Razor.TagHelpers.HtmlAttributeNameAttribute).FullName}}("{{name}}")]
                 public string SomeAttribute { get; set; }
             }
             """;
@@ -1648,7 +1648,7 @@ public class DefaultTagHelperDescriptorFactoryTest
         var text = $$"""
             public class DynamicTestTagHelper : {{typeof(AspNetCore.Razor.TagHelpers.TagHelper).FullName}}
             {
-                [{{typeof(AspNetCore.Razor.TagHelpers.HtmlAttributeNameAttribute).FullName}}({{nameof(AspNetCore.Razor.TagHelpers.HtmlAttributeNameAttribute.DictionaryAttributePrefix)}} = ""{{prefix}}"")]
+                [{{typeof(AspNetCore.Razor.TagHelpers.HtmlAttributeNameAttribute).FullName}}({{nameof(AspNetCore.Razor.TagHelpers.HtmlAttributeNameAttribute.DictionaryAttributePrefix)}} = "{{prefix}}")]
                 public System.Collections.Generic.IDictionary<string, int> SomeAttribute { get; set; }
             }
             """;
@@ -1692,7 +1692,7 @@ public class DefaultTagHelperDescriptorFactoryTest
         var text = $$"""
             public class DynamicTestTagHelper : {{typeof(AspNetCore.Razor.TagHelpers.TagHelper).FullName}}
             {
-                [{{typeof(AspNetCore.Razor.TagHelpers.HtmlAttributeNameAttribute).FullName}}(""{{name}}"")]
+                [{{typeof(AspNetCore.Razor.TagHelpers.HtmlAttributeNameAttribute).FullName}}("{{name}}")]
                 public string InvalidProperty { get; set; }
             }
             """;
@@ -1739,7 +1739,7 @@ public class DefaultTagHelperDescriptorFactoryTest
         var text = $$"""
             public class DynamicTestTagHelper : {{typeof(AspNetCore.Razor.TagHelpers.TagHelper).FullName}}
             {
-                [{{typeof(AspNetCore.Razor.TagHelpers.HtmlAttributeNameAttribute).FullName}}({{nameof(AspNetCore.Razor.TagHelpers.HtmlAttributeNameAttribute.DictionaryAttributePrefix)}} = ""{{prefix}}"")]
+                [{{typeof(AspNetCore.Razor.TagHelpers.HtmlAttributeNameAttribute).FullName}}({{nameof(AspNetCore.Razor.TagHelpers.HtmlAttributeNameAttribute.DictionaryAttributePrefix)}} = "{{prefix}}")]
                 public System.Collections.Generic.IDictionary<System.String, System.Int32> InvalidProperty { get; set; }
             }
             """;
@@ -1781,7 +1781,7 @@ public class DefaultTagHelperDescriptorFactoryTest
         // Arrange
         name = name.Replace("\n", "\\n").Replace("\r", "\\r").Replace("\"", "\\\"");
         var text = $$"""
-            [{{typeof(AspNetCore.Razor.TagHelpers.RestrictChildrenAttribute).FullName}}(""{{name}}"")]
+            [{{typeof(AspNetCore.Razor.TagHelpers.RestrictChildrenAttribute).FullName}}("{{name}}")]
             public class DynamicTestTagHelper : {{typeof(AspNetCore.Razor.TagHelpers.TagHelper).FullName}}
             {
             }
@@ -1823,7 +1823,7 @@ public class DefaultTagHelperDescriptorFactoryTest
         // Arrange
         name = name.Replace("\n", "\\n").Replace("\r", "\\r").Replace("\"", "\\\"");
         var text = $$"""
-            [{{typeof(AspNetCore.Razor.TagHelpers.HtmlTargetElementAttribute).FullName}}({{nameof(AspNetCore.Razor.TagHelpers.HtmlTargetElementAttribute.ParentTag)}} = ""{{name}}"")]
+            [{{typeof(AspNetCore.Razor.TagHelpers.HtmlTargetElementAttribute).FullName}}({{nameof(AspNetCore.Razor.TagHelpers.HtmlTargetElementAttribute.ParentTag)}} = "{{name}}")]
             public class DynamicTestTagHelper : {{typeof(AspNetCore.Razor.TagHelpers.TagHelper).FullName}}
             {
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeEndpoint.cs
@@ -24,7 +24,10 @@ internal class LinkedEditingRangeEndpoint : IRazorRequestHandler<LinkedEditingRa
     // This is loosely based off logic from the Razor compiler:
     // https://github.com/dotnet/aspnetcore/blob/9da42b9fab4c61fe46627ac0c6877905ec845d5a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/HtmlTokenizer.cs
     // Internal for testing only.
-    internal static readonly string WordPattern = @"!?[^ <>!\/\?\[\]=""\\@" + Environment.NewLine + "]+";
+    internal static readonly string WordPattern = $"""
+            !?[^ <>!\/\?\[\]="\\@
+            ]+
+            """;
 
     private readonly ILogger _logger;
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeEndpoint.cs
@@ -24,10 +24,7 @@ internal class LinkedEditingRangeEndpoint : IRazorRequestHandler<LinkedEditingRa
     // This is loosely based off logic from the Razor compiler:
     // https://github.com/dotnet/aspnetcore/blob/9da42b9fab4c61fe46627ac0c6877905ec845d5a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/HtmlTokenizer.cs
     // Internal for testing only.
-    internal static readonly string WordPattern = $"""
-            !?[^ <>!\/\?\[\]="\\@
-            ]+
-            """;
+    internal static readonly string WordPattern = @"!?[^ <>!\/\?\[\]=""\\@" + Environment.NewLine + "]+";
 
     private readonly ILogger _logger;
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/WorkspaceProjectStateChangeDetector.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/WorkspaceProjectStateChangeDetector.cs
@@ -315,8 +315,12 @@ internal class WorkspaceProjectStateChangeDetector : IProjectSnapshotChangeTrigg
         }
         catch (Exception ex)
         {
-            Debug.Fail("WorkspaceProjectStateChangeDetector.Workspace_WorkspaceChanged threw exception:" +
-                Environment.NewLine + ex.Message + Environment.NewLine + "Stack trace:" + Environment.NewLine + ex.StackTrace);
+            Debug.Fail($"""
+                WorkspaceProjectStateChangeDetector.Workspace_WorkspaceChanged threw exception:
+                {ex.Message}
+                Stack trace:
+                {ex.StackTrace}
+                """);
         }
     }
 

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParser.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioRazorParser.cs
@@ -174,8 +174,12 @@ internal class DefaultVisualStudioRazorParser : VisualStudioRazorParser, IDispos
         }
         catch (Exception ex)
         {
-            Debug.Fail("DefaultVisualStudioRazorParser.QueueReparse threw exception:" +
-                Environment.NewLine + ex.Message + Environment.NewLine + "Stack trace:" + Environment.NewLine + ex.StackTrace);
+            Debug.Fail($"""
+                DefaultVisualStudioRazorParser.QueueReparse threw exception:
+                {ex.Message}
+                Stack trace:
+                {ex.StackTrace}
+                """);
         }
     }
 
@@ -466,8 +470,12 @@ internal class DefaultVisualStudioRazorParser : VisualStudioRazorParser, IDispos
         }
         catch (Exception ex)
         {
-            Debug.Fail("DefaultVisualStudioRazorParser.OnResultsReady threw exception:" +
-                Environment.NewLine + ex.Message + Environment.NewLine + "Stack trace:" + Environment.NewLine + ex.StackTrace);
+            Debug.Fail($"""
+                DefaultVisualStudioRazorParser.OnResultsReady threw exception:
+                {ex.Message}
+                Stack trace:
+                {ex.StackTrace}
+                """);
         }
     }
 

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Documents/EditorDocumentManagerListener.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Documents/EditorDocumentManagerListener.cs
@@ -139,8 +139,12 @@ internal class EditorDocumentManagerListener : IPriorityProjectSnapshotChangeTri
         }
         catch (Exception ex)
         {
-            Debug.Fail("EditorDocumentManagerListener.ProjectManager_Changed threw exception:" +
-                Environment.NewLine + ex.Message + Environment.NewLine + "Stack trace:" + Environment.NewLine + ex.StackTrace);
+            Debug.Fail($"""
+                EditorDocumentManagerListener.ProjectManager_Changed threw exception:
+                {ex.Message}
+                Stack trace:
+                {ex.StackTrace}
+                """);
         }
     }
 
@@ -163,8 +167,12 @@ internal class EditorDocumentManagerListener : IPriorityProjectSnapshotChangeTri
         }
         catch (Exception ex)
         {
-            Debug.Fail("EditorDocumentManagerListener.Document_ChangedOnDisk threw exception:" +
-                Environment.NewLine + ex.Message + Environment.NewLine + "Stack trace:" + Environment.NewLine + ex.StackTrace);
+            Debug.Fail($"""
+                EditorDocumentManagerListener.Document_ChangedOnDisk threw exception:
+                {ex.Message}
+                Stack trace:
+                {ex.StackTrace}
+                """);
         }
     }
 
@@ -188,8 +196,12 @@ internal class EditorDocumentManagerListener : IPriorityProjectSnapshotChangeTri
         }
         catch (Exception ex)
         {
-            Debug.Fail("EditorDocumentManagerListener.Document_ChangedInEditor threw exception:" +
-                Environment.NewLine + ex.Message + Environment.NewLine + "Stack trace:" + Environment.NewLine + ex.StackTrace);
+            Debug.Fail($"""
+                EditorDocumentManagerListener.Document_ChangedInEditor threw exception:
+                {ex.Message}
+                Stack trace:
+                {ex.StackTrace}
+                """);
         }
     }
 
@@ -228,8 +240,12 @@ internal class EditorDocumentManagerListener : IPriorityProjectSnapshotChangeTri
         }
         catch (Exception ex)
         {
-            Debug.Fail("EditorDocumentManagerListener.Document_Opened threw exception:" +
-                Environment.NewLine + ex.Message + Environment.NewLine + "Stack trace:" + Environment.NewLine + ex.StackTrace);
+            Debug.Fail($"""
+                EditorDocumentManagerListener.Document_Opened threw exception:
+                {ex.Message}
+                Stack trace:
+                {ex.StackTrace}
+                """);
         }
     }
 
@@ -253,8 +269,12 @@ internal class EditorDocumentManagerListener : IPriorityProjectSnapshotChangeTri
         }
         catch (Exception ex)
         {
-            Debug.Fail("EditorDocumentManagerListener.Document_Closed threw exception:" +
-                Environment.NewLine + ex.Message + Environment.NewLine + "Stack trace:" + Environment.NewLine + ex.StackTrace);
+            Debug.Fail($"""
+                EditorDocumentManagerListener.Document_Closed threw exception:
+                {ex.Message}
+                Stack trace:
+                {ex.StackTrace}
+                """);
         }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/RazorTextViewConnectionListener.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/RazorTextViewConnectionListener.cs
@@ -64,8 +64,12 @@ internal class RazorTextViewConnectionListener : ITextViewConnectionListener
         }
         catch (Exception ex)
         {
-            Debug.Fail("RazorTextViewConnectionListener.SubjectBuffersConnected threw exception:" +
-                Environment.NewLine + ex.Message + Environment.NewLine + "Stack trace:" + Environment.NewLine + ex.StackTrace);
+            Debug.Fail($"""
+                RazorTextViewConnectionListener.SubjectBuffersConnected threw exception:
+                {ex.Message}
+                Stack trace:
+                {ex.StackTrace}
+                """);
         }
     }
 
@@ -94,8 +98,12 @@ internal class RazorTextViewConnectionListener : ITextViewConnectionListener
         }
         catch (Exception ex)
         {
-            Debug.Fail("RazorTextViewConnectionListener.SubjectBuffersDisconnected threw exception:" +
-                Environment.NewLine + ex.Message + Environment.NewLine + "Stack trace:" + Environment.NewLine + ex.StackTrace);
+            Debug.Fail($"""
+                RazorTextViewConnectionListener.SubjectBuffersDisconnected threw exception:
+                {ex.Message}
+                Stack trace:
+                {ex.StackTrace}
+                """);
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/AddUsingsCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/AddUsingsCodeActionResolverTest.cs
@@ -96,7 +96,10 @@ public class AddUsingsCodeActionResolverTest : LanguageServerTestBase
         Assert.Single(textDocumentEdit.Edits);
         var firstEdit = textDocumentEdit.Edits.First();
         Assert.Equal(0, firstEdit.Range.Start.Line);
-        Assert.Equal($"@using System{Environment.NewLine}", firstEdit.NewText);
+        Assert.Equal($"""
+            @using System
+            
+            """, firstEdit.NewText);
     }
 
     [Fact]
@@ -104,7 +107,10 @@ public class AddUsingsCodeActionResolverTest : LanguageServerTestBase
     {
         // Arrange
         var documentPath = new Uri("c:/Test.razor");
-        var contents = $"@page \"/\"{Environment.NewLine}";
+        var contents = $"""
+            @page \"/\"
+            
+            """;
         var codeDocument = CreateCodeDocument(contents);
 
         var resolver = new AddUsingsCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument));
@@ -127,7 +133,10 @@ public class AddUsingsCodeActionResolverTest : LanguageServerTestBase
         Assert.True(addUsingsChange.TryGetFirst(out var textDocumentEdit));
         var firstEdit = Assert.Single(textDocumentEdit.Edits);
         Assert.Equal(1, firstEdit.Range.Start.Line);
-        Assert.Equal($"@using System{Environment.NewLine}", firstEdit.NewText);
+        Assert.Equal($"""
+            @using System
+            
+            """, firstEdit.NewText);
     }
 
     [Fact]
@@ -135,7 +144,10 @@ public class AddUsingsCodeActionResolverTest : LanguageServerTestBase
     {
         // Arrange
         var documentPath = new Uri("c:/Test.cshtml");
-        var contents = $"@page{Environment.NewLine}@model IndexModel";
+        var contents = $"""
+            @page
+            @model IndexModel
+            """;
 
         var projectItem = new TestRazorProjectItem("c:/Test.cshtml", "c:/Test.cshtml", "Test.cshtml") { Content = contents };
         var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty, (builder) =>
@@ -166,7 +178,10 @@ public class AddUsingsCodeActionResolverTest : LanguageServerTestBase
         Assert.True(addUsingsChange.TryGetFirst(out var textDocumentEdit));
         var firstEdit = Assert.Single(textDocumentEdit.Edits);
         Assert.Equal(1, firstEdit.Range.Start.Line);
-        Assert.Equal($"@using System{Environment.NewLine}", firstEdit.NewText);
+        Assert.Equal($"""
+            @using System
+            
+            """, firstEdit.NewText);
     }
 
     [Fact]
@@ -174,7 +189,12 @@ public class AddUsingsCodeActionResolverTest : LanguageServerTestBase
     {
         // Arrange
         var documentPath = new Uri("c:/Test.razor");
-        var contents = $"<table>{Environment.NewLine}<tr>{Environment.NewLine}</tr>{Environment.NewLine}</table>";
+        var contents = $"""
+            <table>
+            <tr>
+            </tr>
+            </table>
+            """;
         var codeDocument = CreateCodeDocument(contents);
 
         var resolver = new AddUsingsCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument));
@@ -197,7 +217,10 @@ public class AddUsingsCodeActionResolverTest : LanguageServerTestBase
         Assert.True(addUsingsChange.TryGetFirst(out var textDocumentEdit));
         var firstEdit = Assert.Single(textDocumentEdit.Edits);
         Assert.Equal(0, firstEdit.Range.Start.Line);
-        Assert.Equal($"@using System{Environment.NewLine}", firstEdit.NewText);
+        Assert.Equal($"""
+            @using System
+            
+            """, firstEdit.NewText);
     }
 
     [Fact]
@@ -205,7 +228,10 @@ public class AddUsingsCodeActionResolverTest : LanguageServerTestBase
     {
         // Arrange
         var documentPath = new Uri("c:/Test.razor");
-        var contents = $"@namespace Testing{Environment.NewLine}";
+        var contents = $"""
+            @namespace Testing
+            
+            """;
         var codeDocument = CreateCodeDocument(contents);
 
         var resolver = new AddUsingsCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument));
@@ -228,7 +254,10 @@ public class AddUsingsCodeActionResolverTest : LanguageServerTestBase
         Assert.True(addUsingsChange.TryGetFirst(out var textDocumentEdit));
         var firstEdit = Assert.Single(textDocumentEdit.Edits);
         Assert.Equal(1, firstEdit.Range.Start.Line);
-        Assert.Equal($"@using System{Environment.NewLine}", firstEdit.NewText);
+        Assert.Equal($"""
+            @using System
+            
+            """, firstEdit.NewText);
     }
 
     [Fact]
@@ -236,7 +265,11 @@ public class AddUsingsCodeActionResolverTest : LanguageServerTestBase
     {
         // Arrange
         var documentPath = new Uri("c:/Test.razor");
-        var contents = $"@page \"/\"{Environment.NewLine}@namespace Testing{Environment.NewLine}";
+        var contents = $"""
+            @page \"/\"
+            @namespace Testing
+            
+            """;
         var codeDocument = CreateCodeDocument(contents);
 
         var resolver = new AddUsingsCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument));
@@ -259,7 +292,10 @@ public class AddUsingsCodeActionResolverTest : LanguageServerTestBase
         Assert.True(addUsingsChange.TryGetFirst(out var textDocumentEdit));
         var firstEdit = Assert.Single(textDocumentEdit.Edits);
         Assert.Equal(2, firstEdit.Range.Start.Line);
-        Assert.Equal($"@using System{Environment.NewLine}", firstEdit.NewText);
+        Assert.Equal($"""
+            @using System
+            
+            """, firstEdit.NewText);
     }
 
     [Fact]
@@ -290,7 +326,10 @@ public class AddUsingsCodeActionResolverTest : LanguageServerTestBase
         Assert.True(addUsingsChange.TryGetFirst(out var textDocumentEdit));
         var firstEdit = Assert.Single(textDocumentEdit.Edits);
         Assert.Equal(1, firstEdit.Range.Start.Line);
-        Assert.Equal($"@using System.Linq{Environment.NewLine}", firstEdit.NewText);
+        Assert.Equal($"""
+            @using System.Linq
+            
+            """, firstEdit.NewText);
     }
 
     [Fact]
@@ -298,7 +337,11 @@ public class AddUsingsCodeActionResolverTest : LanguageServerTestBase
     {
         // Arrange
         var documentPath = new Uri("c:/Test.razor");
-        var contents = $"@using System{Environment.NewLine}@using System.Linq{Environment.NewLine}";
+        var contents = $"""
+            @using System
+            @using System.Linq
+            
+            """;
         var codeDocument = CreateCodeDocument(contents);
 
         var resolver = new AddUsingsCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument));
@@ -321,7 +364,10 @@ public class AddUsingsCodeActionResolverTest : LanguageServerTestBase
         Assert.True(addUsingsChange.TryGetFirst(out var textDocumentEdit));
         var firstEdit = Assert.Single(textDocumentEdit.Edits);
         Assert.Equal(2, firstEdit.Range.Start.Line);
-        Assert.Equal($"@using Microsoft.AspNetCore.Razor.Language{Environment.NewLine}", firstEdit.NewText);
+        Assert.Equal($"""
+            @using Microsoft.AspNetCore.Razor.Language
+            
+            """, firstEdit.NewText);
     }
 
     private static RazorCodeDocument CreateCodeDocument(string text)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/AddUsingsCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/AddUsingsCodeActionResolverTest.cs
@@ -98,7 +98,7 @@ public class AddUsingsCodeActionResolverTest : LanguageServerTestBase
         Assert.Equal(0, firstEdit.Range.Start.Line);
         Assert.Equal($"""
             @using System
-            
+
             """, firstEdit.NewText);
     }
 
@@ -108,8 +108,8 @@ public class AddUsingsCodeActionResolverTest : LanguageServerTestBase
         // Arrange
         var documentPath = new Uri("c:/Test.razor");
         var contents = $"""
-            @page \"/\"
-            
+            @page "/"
+
             """;
         var codeDocument = CreateCodeDocument(contents);
 
@@ -135,7 +135,7 @@ public class AddUsingsCodeActionResolverTest : LanguageServerTestBase
         Assert.Equal(1, firstEdit.Range.Start.Line);
         Assert.Equal($"""
             @using System
-            
+
             """, firstEdit.NewText);
     }
 
@@ -180,7 +180,7 @@ public class AddUsingsCodeActionResolverTest : LanguageServerTestBase
         Assert.Equal(1, firstEdit.Range.Start.Line);
         Assert.Equal($"""
             @using System
-            
+
             """, firstEdit.NewText);
     }
 
@@ -219,7 +219,7 @@ public class AddUsingsCodeActionResolverTest : LanguageServerTestBase
         Assert.Equal(0, firstEdit.Range.Start.Line);
         Assert.Equal($"""
             @using System
-            
+
             """, firstEdit.NewText);
     }
 
@@ -230,7 +230,7 @@ public class AddUsingsCodeActionResolverTest : LanguageServerTestBase
         var documentPath = new Uri("c:/Test.razor");
         var contents = $"""
             @namespace Testing
-            
+
             """;
         var codeDocument = CreateCodeDocument(contents);
 
@@ -256,7 +256,7 @@ public class AddUsingsCodeActionResolverTest : LanguageServerTestBase
         Assert.Equal(1, firstEdit.Range.Start.Line);
         Assert.Equal($"""
             @using System
-            
+
             """, firstEdit.NewText);
     }
 
@@ -266,9 +266,9 @@ public class AddUsingsCodeActionResolverTest : LanguageServerTestBase
         // Arrange
         var documentPath = new Uri("c:/Test.razor");
         var contents = $"""
-            @page \"/\"
+            @page "/"
             @namespace Testing
-            
+
             """;
         var codeDocument = CreateCodeDocument(contents);
 
@@ -294,7 +294,7 @@ public class AddUsingsCodeActionResolverTest : LanguageServerTestBase
         Assert.Equal(2, firstEdit.Range.Start.Line);
         Assert.Equal($"""
             @using System
-            
+
             """, firstEdit.NewText);
     }
 
@@ -328,7 +328,7 @@ public class AddUsingsCodeActionResolverTest : LanguageServerTestBase
         Assert.Equal(1, firstEdit.Range.Start.Line);
         Assert.Equal($"""
             @using System.Linq
-            
+
             """, firstEdit.NewText);
     }
 
@@ -340,7 +340,7 @@ public class AddUsingsCodeActionResolverTest : LanguageServerTestBase
         var contents = $"""
             @using System
             @using System.Linq
-            
+
             """;
         var codeDocument = CreateCodeDocument(contents);
 
@@ -366,7 +366,7 @@ public class AddUsingsCodeActionResolverTest : LanguageServerTestBase
         Assert.Equal(2, firstEdit.Range.Start.Line);
         Assert.Equal($"""
             @using Microsoft.AspNetCore.Razor.Language
-            
+
             """, firstEdit.NewText);
     }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/CreateComponentCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/CreateComponentCodeActionResolverTest.cs
@@ -127,7 +127,7 @@ public class CreateComponentCodeActionResolverTest : LanguageServerTestBase
         // Arrange
         var documentPath = new Uri("c:/Test.razor");
         var contents = $"""
-            @page \"/test\"
+            @page "/test"
             @namespace Another.Namespace
             """;
         var codeDocument = CreateCodeDocument(contents);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/CreateComponentCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/CreateComponentCodeActionResolverTest.cs
@@ -126,7 +126,10 @@ public class CreateComponentCodeActionResolverTest : LanguageServerTestBase
     {
         // Arrange
         var documentPath = new Uri("c:/Test.razor");
-        var contents = $"@page \"/test\"{Environment.NewLine}@namespace Another.Namespace";
+        var contents = $"""
+            @page \"/test\"
+            @namespace Another.Namespace
+            """;
         var codeDocument = CreateCodeDocument(contents);
 
         var resolver = new CreateComponentCodeActionResolver(CreateDocumentContextFactory(documentPath, codeDocument), TestLanguageServerFeatureOptions.Instance);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
@@ -63,7 +63,10 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
     {
         // Arrange
         var documentPath = new Uri("c:\\Test.razor");
-        var contents = $"@page \"/test\"{Environment.NewLine}@code {{ private int x = 1; }}";
+        var contents = $$"""
+            @page \"/test\"
+            @code { private int x = 1; }
+            """;
         var codeDocument = CreateCodeDocument(contents);
         codeDocument.SetUnsupported();
 
@@ -82,7 +85,10 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
     {
         // Arrange
         var documentPath = new Uri("c:\\Test.razor");
-        var contents = $"@page \"/test\"{Environment.NewLine}@code {{ private int x = 1; }}";
+        var contents = $$"""
+            @page \"/test\"
+            @code { private int x = 1; }
+            """;
         var codeDocument = CreateCodeDocument(contents);
         codeDocument.SetFileKind(FileKinds.Legacy);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
@@ -64,7 +64,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
         // Arrange
         var documentPath = new Uri("c:\\Test.razor");
         var contents = $$"""
-            @page \"/test\"
+            @page "/test"
             @code { private int x = 1; }
             """;
         var codeDocument = CreateCodeDocument(contents);
@@ -86,7 +86,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
         // Arrange
         var documentPath = new Uri("c:\\Test.razor");
         var contents = $$"""
-            @page \"/test\"
+            @page "/test"
             @code { private int x = 1; }
             """;
         var codeDocument = CreateCodeDocument(contents);
@@ -151,7 +151,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
             using System.Linq;
             using System.Threading.Tasks;
             using Microsoft.AspNetCore.Components;
-            
+
             namespace test.Pages
             {
                 public partial class Test
@@ -213,7 +213,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
             using System.Linq;
             using System.Threading.Tasks;
             using Microsoft.AspNetCore.Components;
-            
+
             namespace test.Pages
             {
                 public partial class Test
@@ -283,7 +283,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
             using System.Linq;
             using System.Threading.Tasks;
             using Microsoft.AspNetCore.Components;
-            
+
             namespace test.Pages
             {
                 public partial class Test
@@ -363,7 +363,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
             using System.Linq;
             using System.Threading.Tasks;
             using Microsoft.AspNetCore.Components;
-            
+
             namespace test.Pages
             {
                 public partial class Test
@@ -445,7 +445,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
             using System.Linq;
             using System.Threading.Tasks;
             using Microsoft.AspNetCore.Components;
-            
+
             namespace test.Pages
             {
                 public partial class Test
@@ -515,7 +515,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
             using System.Linq;
             using System.Threading.Tasks;
             using Microsoft.AspNetCore.Components;
-            
+
             namespace test.Pages
             {
                 public partial class Test
@@ -578,7 +578,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
             using System.Threading.Tasks;
             using Microsoft.AspNetCore.Components;
             using System.Diagnostics;
-            
+
             namespace test.Pages
             {
                 public partial class Test
@@ -599,7 +599,7 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
             @page "/test"
 
             @code {
-            #region TestRegion 
+            #region TestRegion
                     private int x = 1;
             #endregion
             }
@@ -641,12 +641,12 @@ public class ExtractToCodeBehindCodeActionResolverTest : LanguageServerTestBase
             using System.Linq;
             using System.Threading.Tasks;
             using Microsoft.AspNetCore.Components;
-     
+
             namespace test.Pages
             {
                 public partial class Test
                 {
-                    #region TestRegion 
+                    #region TestRegion
                     private int x = 1;
                     #endregion
                 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultVSLSPTagHelperTooltipFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultVSLSPTagHelperTooltipFactoryTest.cs
@@ -86,7 +86,11 @@ public class DefaultVSLSPTagHelperTooltipFactoryTest(ITestOutputHelper testOutpu
         //
         //     World
         Assert.Collection(runs, run => AssertExpectedClassification(
-            run, "Hello" + Environment.NewLine + Environment.NewLine + "World", VSPredefinedClassificationTypeNames.Text));
+            run, """
+            Hello
+
+            World
+            """, VSPredefinedClassificationTypeNames.Text));
     }
 
     [Fact]
@@ -150,14 +154,13 @@ End summary description.";
         // Expected output:
         //     code: This is code and This is some other code.
         Assert.Collection(runs, run => AssertExpectedClassification(
-            run,
-            "Summary description:" +
-            Environment.NewLine +
-            Environment.NewLine +
-            "Paragraph text." +
-            Environment.NewLine +
-            Environment.NewLine +
-            "End summary description.",
+            run, """
+            Summary description:
+
+            Paragraph text.
+
+            End summary description.
+            """,
             VSPredefinedClassificationTypeNames.Text));
     }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DirectiveAttributeTransitionCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DirectiveAttributeTransitionCompletionItemProviderTest.cs
@@ -174,7 +174,10 @@ public class DirectiveAttributeTransitionCompletionItemProviderTest : ToolingTes
     public void GetCompletionItems_InbetweenSelfClosingEnd_ReturnsEmptyList()
     {
         // Arrange
-        var context = CreateContext(absoluteIndex: 8, "<input /" + Environment.NewLine);
+        var context = CreateContext(absoluteIndex: 8, """
+            <input /
+            
+            """);
 
         // Act
         var result = _provider.GetCompletionItems(context);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorTranslateDiagnosticsEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorTranslateDiagnosticsEndpointTest.cs
@@ -774,7 +774,10 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
     {
         // Arrange
         var documentPath = new Uri("C:/path/to/document.cshtml");
-        var addTagHelper = $"@addTagHelper *, TestAssembly{Environment.NewLine}";
+        var addTagHelper = $"""
+            @addTagHelper *, TestAssembly
+            
+            """;
         var codeDocument = CreateCodeDocument(
             $"{addTagHelper}<button></button>",
             ImmutableArray.Create(GetButtonTagHelperDescriptor().Build()));
@@ -803,7 +806,10 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
     {
         // Arrange
         var documentPath = new Uri("C:/path/to/document.cshtml");
-        var addTagHelper = $"@addTagHelper *, TestAssembly{Environment.NewLine}";
+        var addTagHelper = $"""
+            @addTagHelper *, TestAssembly
+            
+            """;
         var codeDocument = CreateCodeDocument(
             $"{addTagHelper}<button></button>",
             ImmutableArray.Create(GetButtonTagHelperDescriptor().Build()));
@@ -910,7 +916,10 @@ public class RazorTranslateDiagnosticsEndpointTest : LanguageServerTestBase
 
         var descriptor = GetButtonTagHelperDescriptor();
 
-        var addTagHelper = $"@addTagHelper *, TestAssembly{Environment.NewLine}";
+        var addTagHelper = $"""
+            @addTagHelper *, TestAssembly
+            
+            """;
         var codeDocument = CreateCodeDocumentWithCSharpProjection(
             $"{addTagHelper}<button onactivate=\"Send\" disabled=\"@(Something)\">Hi</button>",
             $"var __o = Send;var __o = Something;",

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentSynchronization/DocumentDidChangeEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentSynchronization/DocumentDidChangeEndpointTest.cs
@@ -86,7 +86,10 @@ public class DocumentDidChangeEndpointTest : LanguageServerTestBase
                     End = new Position(0, 1)
                 },
                 RangeLength = 4,
-                Text = "i!" + Environment.NewLine
+                Text = """
+                    i!
+
+                    """
             },
             // Hi!
             //

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/LinkedEditingRange/LinkedEditingRangeEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/LinkedEditingRange/LinkedEditingRangeEndpointTest.cs
@@ -44,7 +44,10 @@ public class LinkedEditingRangeEndpointTest : TagHelperServiceTestBase
     public async Task Handle_TagHelperStartTag_ReturnsCorrectRange()
     {
         // Arrange
-        var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1></test1>";
+        var txt = """
+            @addTagHelper *, TestAssembly
+            <test1></test1>
+            """;
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
         var uri = new Uri("file://path/test.razor");
         var documentContext = CreateDocumentContext(uri, codeDocument);
@@ -82,7 +85,10 @@ public class LinkedEditingRangeEndpointTest : TagHelperServiceTestBase
     public async Task Handle_TagHelperStartTag_ReturnsCorrectRange_EndSpan()
     {
         // Arrange
-        var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1></test1>";
+        var txt = """
+            @addTagHelper *, TestAssembly
+            <test1></test1>
+            """;
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
         var uri = new Uri("file://path/test.razor");
         var documentContext = CreateDocumentContext(uri, codeDocument);
@@ -120,7 +126,10 @@ public class LinkedEditingRangeEndpointTest : TagHelperServiceTestBase
     public async Task Handle_TagHelperEndTag_ReturnsCorrectRange()
     {
         // Arrange
-        var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1></test1>";
+        var txt = """
+            @addTagHelper *, TestAssembly
+            <test1></test1>
+            """;
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
         var uri = new Uri("file://path/test.razor");
         var documentContext = CreateDocumentContext(uri, codeDocument);
@@ -158,7 +167,10 @@ public class LinkedEditingRangeEndpointTest : TagHelperServiceTestBase
     public async Task Handle_NoTag_ReturnsNull()
     {
         // Arrange
-        var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1></test1>";
+        var txt = """
+            @addTagHelper *, TestAssembly
+            <test1></test1>
+            """;
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
         var uri = new Uri("file://path/test.razor");
         var documentContext = CreateDocumentContext(uri, codeDocument);
@@ -181,7 +193,10 @@ public class LinkedEditingRangeEndpointTest : TagHelperServiceTestBase
     public async Task Handle_SelfClosingTagHelper_ReturnsNull()
     {
         // Arrange
-        var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1 />";
+        var txt = """
+            @addTagHelper *, TestAssembly
+            <test1 />
+            """;
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
         var uri = new Uri("file://path/test.razor");
         var documentContext = CreateDocumentContext(uri, codeDocument);
@@ -204,7 +219,10 @@ public class LinkedEditingRangeEndpointTest : TagHelperServiceTestBase
     public async Task Handle_NestedTagHelperStartTags_ReturnsCorrectRange()
     {
         // Arrange
-        var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test1><test1></test1></test1>";
+        var txt = """
+            @addTagHelper *, TestAssembly
+            <test1><test1></test1></test1>
+            """;
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
         var uri = new Uri("file://path/test.razor");
         var documentContext = CreateDocumentContext(uri, codeDocument);
@@ -242,7 +260,10 @@ public class LinkedEditingRangeEndpointTest : TagHelperServiceTestBase
     public async Task Handle_HTMLStartTag_ReturnsCorrectRange()
     {
         // Arrange
-        var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<body></body>";
+        var txt = """
+            @addTagHelper *, TestAssembly
+            <body></body>
+            """;
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
         var uri = new Uri("file://path/test.razor");
         var documentContext = CreateDocumentContext(uri, codeDocument);
@@ -280,7 +301,10 @@ public class LinkedEditingRangeEndpointTest : TagHelperServiceTestBase
     public async Task Handle_HTMLEndTag_ReturnsCorrectRange()
     {
         // Arrange
-        var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<body></body>";
+        var txt = """
+            @addTagHelper *, TestAssembly
+            <body></body>
+            """;
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
         var uri = new Uri("file://path/test.razor");
         var documentContext = CreateDocumentContext(uri, codeDocument);
@@ -318,7 +342,10 @@ public class LinkedEditingRangeEndpointTest : TagHelperServiceTestBase
     public async Task Handle_SelfClosingHTMLTag_ReturnsNull()
     {
         // Arrange
-        var txt = $"@addTagHelper *, TestAssembly{Environment.NewLine}<body />";
+        var txt = """
+            @addTagHelper *, TestAssembly
+            <body />
+            """;
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
         var uri = new Uri("file://path/test.razor");
         var documentContext = CreateDocumentContext(uri, codeDocument);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/LinkedEditingRange/LinkedEditingRangeEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/LinkedEditingRange/LinkedEditingRangeEndpointTest.cs
@@ -349,7 +349,10 @@ public class LinkedEditingRangeEndpointTest : TagHelperServiceTestBase
         Assert.True(Regex.Match("Te/st", LinkedEditingRangeEndpoint.WordPattern).Length != 5);
         Assert.True(Regex.Match("Te\\st", LinkedEditingRangeEndpoint.WordPattern).Length != 5);
         Assert.True(Regex.Match("Te!st", LinkedEditingRangeEndpoint.WordPattern).Length != 5);
-        Assert.True(Regex.Match("Te" + Environment.NewLine + "st",
+        Assert.True(Regex.Match("""
+            Te
+            st
+            """,
             LinkedEditingRangeEndpoint.WordPattern).Length != 4 + Environment.NewLine.Length);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDocumentMappingServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorDocumentMappingServiceTest.cs
@@ -751,7 +751,10 @@ public class RazorDocumentMappingServiceTest : ToolingTestBase
         var descriptor = TagHelperDescriptorBuilder.Create("TestTagHelper", "TestAssembly");
         descriptor.TagMatchingRule(rule => rule.TagName = "test");
         descriptor.SetMetadata(TypeName("TestTagHelper"));
-        var text = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test>@Name</test>";
+        var text = """
+            @addTagHelper *, TestAssembly
+            <test>@Name</test>
+            """;
         var (classifiedSpans, tagHelperSpans) = GetClassifiedSpans(text, new[] { descriptor.Build() });
 
         // Act
@@ -768,7 +771,10 @@ public class RazorDocumentMappingServiceTest : ToolingTestBase
         var descriptor = TagHelperDescriptorBuilder.Create("TestTagHelper", "TestAssembly");
         descriptor.TagMatchingRule(rule => rule.TagName = "test");
         descriptor.SetMetadata(TypeName("TestTagHelper"));
-        var text = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test></test>@DateTime.Now";
+        var text = """
+            @addTagHelper *, TestAssembly
+            <test></test>@DateTime.Now
+            """;
         var (classifiedSpans, tagHelperSpans) = GetClassifiedSpans(text, new[] { descriptor.Build() });
 
         // Act
@@ -791,7 +797,10 @@ public class RazorDocumentMappingServiceTest : ToolingTestBase
             builder.SetMetadata(PropertyName("AspInt"));
         });
         descriptor.SetMetadata(TypeName("TestTagHelper"));
-        var text = $"@addTagHelper *, TestAssembly{Environment.NewLine}<test asp-int='123'></test>";
+        var text = """
+            @addTagHelper *, TestAssembly
+            <test asp-int='123'></test>
+            """;
         var (classifiedSpans, tagHelperSpans) = GetClassifiedSpans(text, new[] { descriptor.Build() });
 
         // Act
@@ -847,7 +856,10 @@ public class RazorDocumentMappingServiceTest : ToolingTestBase
     public void GetLanguageKindCore_GetsLastClassifiedSpanLanguageIfAtEndOfDocument()
     {
         // Arrange
-        var text = $"<strong>Something</strong>{Environment.NewLine}<App>";
+        var text = """
+            <strong>Something</strong>
+            <App>
+            """;
         var classifiedSpans = ImmutableArray.Create<ClassifiedSpanInternal>(
            new(new SourceSpan(0, 0),
                blockSpan: new SourceSpan(absoluteIndex: 0, lineIndex: 0, characterIndex: 0, length: text.Length),

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TagHelperFactsServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TagHelperFactsServiceTest.cs
@@ -115,7 +115,10 @@ public class TagHelperFactsServiceTest(ITestOutputHelper testOutput) : TagHelper
             attribute.TypeName = typeof(bool).FullName;
         });
         tagHelper.SetMetadata(TypeName("WithBoundAttribute"));
-        var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test bound='true' />", isRazorFile: false, tagHelper.Build());
+        var codeDocument = CreateCodeDocument("""
+            @addTagHelper *, TestAssembly
+            <test bound='true' />
+            """, isRazorFile: false, tagHelper.Build());
         var syntaxTree = codeDocument.GetSyntaxTree();
         var startTag = (MarkupTagHelperStartTagSyntax)syntaxTree.Root.FindInnermostNode(30 + Environment.NewLine.Length);
 
@@ -145,7 +148,10 @@ public class TagHelperFactsServiceTest(ITestOutputHelper testOutput) : TagHelper
             attribute.TypeName = typeof(bool).FullName;
         });
         tagHelper.SetMetadata(TypeName("WithBoundAttribute"));
-        var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<test bound />", isRazorFile: false, tagHelper.Build());
+        var codeDocument = CreateCodeDocument("""
+            @addTagHelper *, TestAssembly
+            <test bound />
+            """, isRazorFile: false, tagHelper.Build());
         var syntaxTree = codeDocument.GetSyntaxTree();
         var startTag = (MarkupTagHelperStartTagSyntax)syntaxTree.Root.FindInnermostNode(30 + Environment.NewLine.Length);
 
@@ -166,7 +172,10 @@ public class TagHelperFactsServiceTest(ITestOutputHelper testOutput) : TagHelper
     public void StringifyAttributes_UnboundAttribute()
     {
         // Arrange
-        var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<input unbound='hello world' />", isRazorFile: false, DefaultTagHelpers);
+        var codeDocument = CreateCodeDocument("""
+            @addTagHelper *, TestAssembly
+            <input unbound='hello world' />
+            """, isRazorFile: false, DefaultTagHelpers);
         var syntaxTree = codeDocument.GetSyntaxTree();
         var startTag = (MarkupStartTagSyntax)syntaxTree.Root.FindInnermostNode(30 + Environment.NewLine.Length);
 
@@ -187,7 +196,10 @@ public class TagHelperFactsServiceTest(ITestOutputHelper testOutput) : TagHelper
     public void StringifyAttributes_UnboundMinimizedAttribute()
     {
         // Arrange
-        var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<input unbound />", isRazorFile: false, DefaultTagHelpers);
+        var codeDocument = CreateCodeDocument("""
+            @addTagHelper *, TestAssembly
+            <input unbound />
+            """, isRazorFile: false, DefaultTagHelpers);
         var syntaxTree = codeDocument.GetSyntaxTree();
         var startTag = (MarkupStartTagSyntax)syntaxTree.Root.FindInnermostNode(30 + Environment.NewLine.Length);
 
@@ -208,7 +220,10 @@ public class TagHelperFactsServiceTest(ITestOutputHelper testOutput) : TagHelper
     public void StringifyAttributes_IgnoresMiscContent()
     {
         // Arrange
-        var codeDocument = CreateCodeDocument($"@addTagHelper *, TestAssembly{Environment.NewLine}<input unbound @DateTime.Now />", isRazorFile: false, DefaultTagHelpers);
+        var codeDocument = CreateCodeDocument("""
+            @addTagHelper *, TestAssembly
+            <input unbound @DateTime.Now />
+            """, isRazorFile: false, DefaultTagHelpers);
         var syntaxTree = codeDocument.GetSyntaxTree();
         var startTag = (MarkupStartTagSyntax)syntaxTree.Root.FindInnermostNode(30 + Environment.NewLine.Length);
 

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/BraceSmartIndenterTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/BraceSmartIndenterTest.cs
@@ -85,7 +85,10 @@ public class BraceSmartIndenterTest : BraceSmartIndenterTestBase
     public void ContainsInvalidContent_NewLineSpan_ReturnsFalse()
     {
         // Arrange
-        var span = ExtractSpan(2, "@{" + Environment.NewLine + "}");
+        var span = ExtractSpan(2, """
+            @{
+            }
+            """);
 
         // Act
         var result = BraceSmartIndenter.ContainsInvalidContent(span);
@@ -428,7 +431,10 @@ public class BraceSmartIndenterTest : BraceSmartIndenterTestBase
     public void TryCreateIndentationContext_ReturnsFalseIfNoFocusedTextView()
     {
         // Arrange
-        var snapshot = new StringTextSnapshot(Environment.NewLine + "Hello World");
+        var snapshot = new StringTextSnapshot("""
+            
+            Hello World
+            """);
         var syntaxTree = RazorSyntaxTree.Parse(TestRazorSourceDocument.Create(snapshot.Content));
         ITextBuffer textBuffer = null;
         var documentTracker = CreateDocumentTracker(() => textBuffer, focusedTextView: null);
@@ -465,7 +471,10 @@ public class BraceSmartIndenterTest : BraceSmartIndenterTestBase
     public void TryCreateIndentationContext_ReturnsFalseIfNewLineIsNotPrecededByOpenBrace_FileStart()
     {
         // Arrange
-        var initialSnapshot = new StringTextSnapshot(Environment.NewLine + "Hello World");
+        var initialSnapshot = new StringTextSnapshot("""
+            
+            Hello World
+            """);
         var syntaxTree = RazorSyntaxTree.Parse(TestRazorSourceDocument.Create(initialSnapshot.Content));
         ITextBuffer textBuffer = null;
         var focusedTextView = CreateFocusedTextView(() => textBuffer);
@@ -503,7 +512,10 @@ public class BraceSmartIndenterTest : BraceSmartIndenterTestBase
     public void TryCreateIndentationContext_ReturnsFalseIfNewLineIsNotFollowedByCloseBrace()
     {
         // Arrange
-        var initialSnapshot = new StringTextSnapshot("@{ " + Environment.NewLine + "World");
+        var initialSnapshot = new StringTextSnapshot("""
+            @{ 
+            World
+            """);
         var syntaxTree = RazorSyntaxTree.Parse(TestRazorSourceDocument.Create(initialSnapshot.Content));
         ITextBuffer textBuffer = null;
         var focusedTextView = CreateFocusedTextView(() => textBuffer);

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultRazorIndentationFactsServiceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultRazorIndentationFactsServiceTest.cs
@@ -194,9 +194,9 @@ public class DefaultRazorIndentationFactsServiceTest(ITestOutputHelper testOutpu
     public void GetDesiredIndentation_ReturnsNull_IfOwningSpanIsCode()
     {
         // Arrange
-        var source = new StringTextSnapshot($@"
-@{{
-");
+        var source = new StringTextSnapshot("""
+@{
+""");
         var textBuffer = new TestTextBuffer(source, new LegacyCoreContentType());
         var syntaxTree = GetSyntaxTree(source);
 
@@ -239,9 +239,10 @@ public class DefaultRazorIndentationFactsServiceTest(ITestOutputHelper testOutpu
     public void GetDesiredIndentation_ReturnsCorrectIndentation_ForMarkupWithinCodeBlock()
     {
         // Arrange
-        var source = new StringTextSnapshot($@"@{{
+        var source = new StringTextSnapshot("""
+@{
     <div>
-");
+""");
         var textBuffer = new TestTextBuffer(source, new LegacyCoreContentType());
         var syntaxTree = GetSyntaxTree(source);
 
@@ -262,10 +263,12 @@ public class DefaultRazorIndentationFactsServiceTest(ITestOutputHelper testOutpu
     {
         // Arrange
         var customDirective = DirectiveDescriptor.CreateRazorBlockDirective("custom");
-        var source = new StringTextSnapshot($@"@custom
-{{
+        var source = new StringTextSnapshot("""
+@custom
+{
     <div>
-}}");
+}
+""");
         var textBuffer = new TestTextBuffer(source, new LegacyCoreContentType());
         var syntaxTree = GetSyntaxTree(source, new[] { customDirective });
 
@@ -285,13 +288,13 @@ public class DefaultRazorIndentationFactsServiceTest(ITestOutputHelper testOutpu
     public void GetDesiredIndentation_ReturnsCorrectIndentation_ForNestedMarkupWithinCodeBlock()
     {
         // Arrange
-        var source = new StringTextSnapshot($@"
+        var source = new StringTextSnapshot("""
 <div>
-    @{{
+    @{
         <span>
-    }}
+    }
 </div>
-");
+""");
         var textBuffer = new TestTextBuffer(source, new LegacyCoreContentType());
         var syntaxTree = GetSyntaxTree(source);
 
@@ -312,12 +315,14 @@ public class DefaultRazorIndentationFactsServiceTest(ITestOutputHelper testOutpu
     {
         // Arrange
         var customDirective = DirectiveDescriptor.CreateRazorBlockDirective("custom");
-        var source = new StringTextSnapshot($@"@custom
-{{
-    @{{
+        var source = new StringTextSnapshot("""
+@custom
+{
+    @{
         <div>
-    }}
-}}");
+    }
+}
+""");
 
         var textBuffer = new TestTextBuffer(source, new LegacyCoreContentType());
         var syntaxTree = GetSyntaxTree(source, new[] { customDirective });

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultRazorIndentationFactsServiceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultRazorIndentationFactsServiceTest.cs
@@ -195,7 +195,9 @@ public class DefaultRazorIndentationFactsServiceTest(ITestOutputHelper testOutpu
     {
         // Arrange
         var source = new StringTextSnapshot("""
+
             @{
+
             """);
         var textBuffer = new TestTextBuffer(source, new LegacyCoreContentType());
         var syntaxTree = GetSyntaxTree(source);
@@ -242,6 +244,7 @@ public class DefaultRazorIndentationFactsServiceTest(ITestOutputHelper testOutpu
         var source = new StringTextSnapshot("""
             @{
                 <div>
+
             """);
         var textBuffer = new TestTextBuffer(source, new LegacyCoreContentType());
         var syntaxTree = GetSyntaxTree(source);

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultRazorIndentationFactsServiceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultRazorIndentationFactsServiceTest.cs
@@ -195,8 +195,8 @@ public class DefaultRazorIndentationFactsServiceTest(ITestOutputHelper testOutpu
     {
         // Arrange
         var source = new StringTextSnapshot("""
-@{
-""");
+            @{
+            """);
         var textBuffer = new TestTextBuffer(source, new LegacyCoreContentType());
         var syntaxTree = GetSyntaxTree(source);
 
@@ -240,9 +240,9 @@ public class DefaultRazorIndentationFactsServiceTest(ITestOutputHelper testOutpu
     {
         // Arrange
         var source = new StringTextSnapshot("""
-@{
-    <div>
-""");
+            @{
+                <div>
+            """);
         var textBuffer = new TestTextBuffer(source, new LegacyCoreContentType());
         var syntaxTree = GetSyntaxTree(source);
 
@@ -264,11 +264,11 @@ public class DefaultRazorIndentationFactsServiceTest(ITestOutputHelper testOutpu
         // Arrange
         var customDirective = DirectiveDescriptor.CreateRazorBlockDirective("custom");
         var source = new StringTextSnapshot("""
-@custom
-{
-    <div>
-}
-""");
+            @custom
+            {
+                <div>
+            }
+            """);
         var textBuffer = new TestTextBuffer(source, new LegacyCoreContentType());
         var syntaxTree = GetSyntaxTree(source, new[] { customDirective });
 
@@ -289,12 +289,12 @@ public class DefaultRazorIndentationFactsServiceTest(ITestOutputHelper testOutpu
     {
         // Arrange
         var source = new StringTextSnapshot("""
-<div>
-    @{
-        <span>
-    }
-</div>
-""");
+            <div>
+                @{
+                    <span>
+                }
+            </div>
+            """);
         var textBuffer = new TestTextBuffer(source, new LegacyCoreContentType());
         var syntaxTree = GetSyntaxTree(source);
 
@@ -316,13 +316,13 @@ public class DefaultRazorIndentationFactsServiceTest(ITestOutputHelper testOutpu
         // Arrange
         var customDirective = DirectiveDescriptor.CreateRazorBlockDirective("custom");
         var source = new StringTextSnapshot("""
-@custom
-{
-    @{
-        <div>
-    }
-}
-""");
+            @custom
+            {
+                @{
+                    <div>
+                }
+            }
+            """);
 
         var textBuffer = new TestTextBuffer(source, new LegacyCoreContentType());
         var syntaxTree = GetSyntaxTree(source, new[] { customDirective });

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultVisualStudioRazorParserIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultVisualStudioRazorParserIntegrationTest.cs
@@ -114,12 +114,16 @@ public class DefaultVisualStudioRazorParserIntegrationTest : ProjectSnapshotMana
     public async Task ImpExprAcceptsDCIInStmtBlkAfterIdentifiers()
     {
         // ImplicitExpressionAcceptsDotlessCommitInsertionsInStatementBlockAfterIdentifiers
-        var changed = new StringTextSnapshot("@{" + Environment.NewLine
-                                            + "    @DateTime." + Environment.NewLine
-                                            + "}");
-        var original = new StringTextSnapshot("@{" + Environment.NewLine
-                                        + "    @DateTime" + Environment.NewLine
-                                        + "}");
+        var changed = new StringTextSnapshot("""
+            @{
+                @DateTime.
+            }
+            """);
+        var original = new StringTextSnapshot("""
+            @{
+                @DateTime
+            }
+            """);
 
         var edit = new TestEdit(15 + Environment.NewLine.Length, 0, original, changed, ".");
         using (var manager = CreateParserManager(original))
@@ -138,17 +142,21 @@ public class DefaultVisualStudioRazorParserIntegrationTest : ProjectSnapshotMana
             ApplyAndVerifyPartialChange(edit, "DateTime.");
 
             original = changed;
-            changed = new StringTextSnapshot("@{" + Environment.NewLine
-                                            + "    @DateTime.." + Environment.NewLine
-                                            + "}");
+            changed = new StringTextSnapshot("""
+                @{
+                    @DateTime..
+                }
+                """);
             edit = new TestEdit(16 + Environment.NewLine.Length, 0, original, changed, ".");
 
             ApplyAndVerifyPartialChange(edit, "DateTime..");
 
             original = changed;
-            changed = new StringTextSnapshot("@{" + Environment.NewLine
-                                            + "    @DateTime.Now." + Environment.NewLine
-                                            + "}");
+            changed = new StringTextSnapshot("""
+                @{
+                    @DateTime.Now.
+                }
+                """);
             edit = new TestEdit(16 + Environment.NewLine.Length, 0, original, changed, "Now");
 
             ApplyAndVerifyPartialChange(edit, "DateTime.Now.");
@@ -159,12 +167,16 @@ public class DefaultVisualStudioRazorParserIntegrationTest : ProjectSnapshotMana
     public async Task ImpExprAcceptsDCIInStatementBlock()
     {
         // ImpExprAcceptsDotlessCommitInsertionsInStatementBlock
-        var changed = new StringTextSnapshot("@{" + Environment.NewLine
-                                                + "    @DateT." + Environment.NewLine
-                                                + "}");
-        var original = new StringTextSnapshot("@{" + Environment.NewLine
-                                        + "    @DateT" + Environment.NewLine
-                                        + "}");
+        var changed = new StringTextSnapshot("""
+            @{
+                @DateT.
+            }
+            """);
+        var original = new StringTextSnapshot("""
+            @{
+                @DateT
+            }
+            """);
 
         var edit = new TestEdit(12 + Environment.NewLine.Length, 0, original, changed, ".");
         using (var manager = CreateParserManager(original))
@@ -182,9 +194,11 @@ public class DefaultVisualStudioRazorParserIntegrationTest : ProjectSnapshotMana
             ApplyAndVerifyPartialChange(edit, "DateT.");
 
             original = changed;
-            changed = new StringTextSnapshot("@{" + Environment.NewLine
-                                            + "    @DateTime." + Environment.NewLine
-                                            + "}");
+            changed = new StringTextSnapshot("""
+                @{
+                    @DateTime.
+                }
+                """);
             edit = new TestEdit(12 + Environment.NewLine.Length, 0, original, changed, "ime");
 
             ApplyAndVerifyPartialChange(edit, "DateTime.");

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Debugging/DefaultRazorBreakpointResolverTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Debugging/DefaultRazorBreakpointResolverTest.cs
@@ -36,21 +36,21 @@ public class DefaultRazorBreakpointResolverTest : ToolingTestBase
         _csharpDocumentUri = new Uri(_documentUri.OriginalString + ".g.cs", UriKind.Absolute);
 
         var csharpTextSnapshot = new StringTextSnapshot($$"""
-public class SomeRazorFile
-{
-    {{ValidBreakpointCSharp}}
-    {{InvalidBreakpointCSharp}}
-}
-""");
+            public class SomeRazorFile
+            {
+                {{ValidBreakpointCSharp}}
+                {{InvalidBreakpointCSharp}}
+            }
+            """);
         _csharpTextBuffer = new TestTextBuffer(csharpTextSnapshot);
 
         var textBufferSnapshot = new StringTextSnapshot($$"""
-@code
-{
-    {{ValidBreakpointCSharp}}
-    {{InvalidBreakpointCSharp}}
-}
-""");
+            @code
+            {
+                {{ValidBreakpointCSharp}}
+                {{InvalidBreakpointCSharp}}
+            }
+            """);
         _hostTextbuffer = new TestTextBuffer(textBufferSnapshot);
     }
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Debugging/DefaultRazorBreakpointResolverTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Debugging/DefaultRazorBreakpointResolverTest.cs
@@ -35,21 +35,22 @@ public class DefaultRazorBreakpointResolverTest : ToolingTestBase
         _documentUri = new Uri("file://C:/path/to/file.razor", UriKind.Absolute);
         _csharpDocumentUri = new Uri(_documentUri.OriginalString + ".g.cs", UriKind.Absolute);
 
-        var csharpTextSnapshot = new StringTextSnapshot(
-$@"public class SomeRazorFile
-{{
-    {ValidBreakpointCSharp}
-    {InvalidBreakpointCSharp}
-}}");
+        var csharpTextSnapshot = new StringTextSnapshot($$"""
+public class SomeRazorFile
+{
+    {{ValidBreakpointCSharp}}
+    {{InvalidBreakpointCSharp}}
+}
+""");
         _csharpTextBuffer = new TestTextBuffer(csharpTextSnapshot);
 
-        var textBufferSnapshot = new StringTextSnapshot(@$"
+        var textBufferSnapshot = new StringTextSnapshot($$"""
 @code
-{{
-    {ValidBreakpointCSharp}
-    {InvalidBreakpointCSharp}
-}}
-");
+{
+    {{ValidBreakpointCSharp}}
+    {{InvalidBreakpointCSharp}}
+}
+""");
         _hostTextbuffer = new TestTextBuffer(textBufferSnapshot);
     }
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Debugging/DefaultRazorProximityExpressionResolverTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Debugging/DefaultRazorProximityExpressionResolverTest.cs
@@ -39,18 +39,17 @@ public class DefaultRazorProximityExpressionResolverTest : ToolingTestBase
 
         _validProximityExpressionRoot = "var abc = 123;";
         _invalidProximityExpressionRoot = "private int bar;";
-        var csharpTextSnapshot = new StringTextSnapshot(
-$$"""
-public class SomeRazorFile
-{
-    {{_invalidProximityExpressionRoot}}
+        var csharpTextSnapshot = new StringTextSnapshot($$"""
+            public class SomeRazorFile
+            {
+                {{_invalidProximityExpressionRoot}}
 
-    public void Render()
-    {
-        {{_validProximityExpressionRoot}}
-    }
-}
-""");
+                public void Render()
+                {
+                    {{_validProximityExpressionRoot}}
+                }
+            }
+            """);
         _csharpTextBuffer = new TestTextBuffer(csharpTextSnapshot);
 
         var textBufferSnapshot = new StringTextSnapshot($$"""@{{{_invalidProximityExpressionRoot}}} @code {{{_validProximityExpressionRoot}}}""");

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Debugging/DefaultRazorProximityExpressionResolverTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/Debugging/DefaultRazorProximityExpressionResolverTest.cs
@@ -40,19 +40,20 @@ public class DefaultRazorProximityExpressionResolverTest : ToolingTestBase
         _validProximityExpressionRoot = "var abc = 123;";
         _invalidProximityExpressionRoot = "private int bar;";
         var csharpTextSnapshot = new StringTextSnapshot(
-$@"public class SomeRazorFile
-{{
-    {_invalidProximityExpressionRoot}
+$$"""
+public class SomeRazorFile
+{
+    {{_invalidProximityExpressionRoot}}
 
     public void Render()
-    {{
-        {_validProximityExpressionRoot}
-    }}
-}}
-");
+    {
+        {{_validProximityExpressionRoot}}
+    }
+}
+""");
         _csharpTextBuffer = new TestTextBuffer(csharpTextSnapshot);
 
-        var textBufferSnapshot = new StringTextSnapshot($"@{{{_invalidProximityExpressionRoot}}} @code {{{_validProximityExpressionRoot}}}");
+        var textBufferSnapshot = new StringTextSnapshot($$"""@{{{_invalidProximityExpressionRoot}}} @code {{{_validProximityExpressionRoot}}}""");
         _hostTextbuffer = new TestTextBuffer(textBufferSnapshot);
     }
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/RazorLSPSpanMappingServiceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServerClient.Razor.Test/RazorLSPSpanMappingServiceTest.cs
@@ -26,8 +26,18 @@ public class RazorLSPSpanMappingServiceTest : ToolingTestBase
 {
     private readonly Uri _mockDocumentUri = new("C://project/path/document.razor");
 
-    private static readonly string s_mockGeneratedContent = $"Hello {Environment.NewLine} This is the source text in the generated C# file. {Environment.NewLine} This is some more sample text for demo purposes.";
-    private static readonly string s_mockRazorContent = $"Hello {Environment.NewLine} This is the {Environment.NewLine} source text {Environment.NewLine} in the generated C# file. {Environment.NewLine} This is some more sample text for demo purposes.";
+    private static readonly string s_mockGeneratedContent = """
+            Hello
+             This is the source text in the generated C# file.
+             This is some more sample text for demo purposes.
+            """;
+    private static readonly string s_mockRazorContent = """
+            Hello
+             This is the
+             source text
+             in the generated C# file.
+             This is some more sample text for demo purposes.
+            """;
 
     private readonly SourceText _sourceTextGenerated;
     private readonly SourceText _sourceTextRazor;

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectStateChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectStateChangeDetectorTest.cs
@@ -493,14 +493,13 @@ public class WorkspaceProjectStateChangeDetectorTest : WorkspaceTestBase
         await s_dispatcher.RunOnDispatcherThreadAsync(() => projectManager.ProjectAdded(_hostProjectOne), DisposalToken);
         workspaceStateGenerator.ClearQueue();
 
-        var sourceText = SourceText.From(
-$$"""
-public partial class TestComponent : {{ComponentsApi.IComponent.MetadataName}} {}
-namespace Microsoft.AspNetCore.Components
-{
-    public interface IComponent {}
-}
-""");
+        var sourceText = SourceText.From($$"""
+            public partial class TestComponent : {{ComponentsApi.IComponent.MetadataName}} {}
+            namespace Microsoft.AspNetCore.Components
+            {
+                public interface IComponent {}
+            }
+            """);
         var syntaxTreeRoot = await CSharpSyntaxTree.ParseText(sourceText).GetRootAsync();
         var solution = _solutionWithTwoProjects
             .WithDocumentText(_partialComponentClassDocumentId, sourceText)
@@ -589,10 +588,9 @@ namespace Microsoft.AspNetCore.Components
     public async Task IsPartialComponentClass_NoIComponent_ReturnsFalse()
     {
         // Arrange
-        var sourceText = SourceText.From(
-"""
-public partial class TestComponent{}
-""");
+        var sourceText = SourceText.From("""
+            public partial class TestComponent{}
+            """);
         var syntaxTreeRoot = await CSharpSyntaxTree.ParseText(sourceText).GetRootAsync();
         var solution = _solutionWithTwoProjects
             .WithDocumentText(_partialComponentClassDocumentId, sourceText)
@@ -614,14 +612,13 @@ public partial class TestComponent{}
     public async Task IsPartialComponentClass_InitializedDocument_ReturnsTrue()
     {
         // Arrange
-        var sourceText = SourceText.From(
-$$"""
-public partial class TestComponent : {{ComponentsApi.IComponent.MetadataName}} {}
-namespace Microsoft.AspNetCore.Components
-{
-    public interface IComponent {}
-}
-""");
+        var sourceText = SourceText.From($$"""
+            public partial class TestComponent : {{ComponentsApi.IComponent.MetadataName}} {}
+            namespace Microsoft.AspNetCore.Components
+            {
+                public interface IComponent {}
+            }
+            """);
         var syntaxTreeRoot = await CSharpSyntaxTree.ParseText(sourceText).GetRootAsync();
         var solution = _solutionWithTwoProjects
             .WithDocumentText(_partialComponentClassDocumentId, sourceText)
@@ -643,14 +640,13 @@ namespace Microsoft.AspNetCore.Components
     public void IsPartialComponentClass_Uninitialized_ReturnsFalse()
     {
         // Arrange
-        var sourceText = SourceText.From(
-$$"""
-public partial class TestComponent : {{ComponentsApi.IComponent.MetadataName}} {}
-namespace Microsoft.AspNetCore.Components
-{
-    public interface IComponent {}
-}
-""");
+        var sourceText = SourceText.From($$"""
+            public partial class TestComponent : {{ComponentsApi.IComponent.MetadataName}} {}
+            namespace Microsoft.AspNetCore.Components
+            {
+                public interface IComponent {}
+            }
+            """);
         var syntaxTreeRoot = CSharpSyntaxTree.ParseText(sourceText).GetRoot();
         var solution = _solutionWithTwoProjects
             .WithDocumentText(_partialComponentClassDocumentId, sourceText)
@@ -668,14 +664,13 @@ namespace Microsoft.AspNetCore.Components
     public async Task IsPartialComponentClass_UninitializedSemanticModel_ReturnsFalse()
     {
         // Arrange
-        var sourceText = SourceText.From(
-$$"""
-public partial class TestComponent : {{ComponentsApi.IComponent.MetadataName}} {}
-namespace Microsoft.AspNetCore.Components
-{
-    public interface IComponent {}
-}
-""");
+        var sourceText = SourceText.From($$"""
+            public partial class TestComponent : {{ComponentsApi.IComponent.MetadataName}} {}
+            namespace Microsoft.AspNetCore.Components
+            {
+                public interface IComponent {}
+            }
+            """);
         var syntaxTreeRoot = await CSharpSyntaxTree.ParseText(sourceText).GetRootAsync();
         var solution = _solutionWithTwoProjects
             .WithDocumentText(_partialComponentClassDocumentId, sourceText)
@@ -718,18 +713,17 @@ namespace Microsoft.AspNetCore.Components
     {
 
         // Arrange
-        var sourceText = SourceText.From(
-$$"""
-public partial class NonComponent1 {}
-public class NonComponent2 {}
-public partial class TestComponent : {{ComponentsApi.IComponent.MetadataName}} {}
-public partial class NonComponent3 {}
-public class NonComponent4 {}
-namespace Microsoft.AspNetCore.Components
-{
-    public interface IComponent {}
-}
-""");
+        var sourceText = SourceText.From($$"""
+            public partial class NonComponent1 {}
+            public class NonComponent2 {}
+            public partial class TestComponent : {{ComponentsApi.IComponent.MetadataName}} {}
+            public partial class NonComponent3 {}
+            public class NonComponent4 {}
+            namespace Microsoft.AspNetCore.Components
+            {
+                public interface IComponent {}
+            }
+            """);
         var syntaxTreeRoot = await CSharpSyntaxTree.ParseText(sourceText).GetRootAsync();
         var solution = _solutionWithTwoProjects
             .WithDocumentText(_partialComponentClassDocumentId, sourceText)
@@ -752,17 +746,16 @@ namespace Microsoft.AspNetCore.Components
     {
 
         // Arrange
-        var sourceText = SourceText.From(
-"""
-public partial class NonComponent1 {}
-public class NonComponent2 {}
-public partial class NonComponent3 {}
-public class NonComponent4 {}
-namespace Microsoft.AspNetCore.Components
-{
-    public interface IComponent {}
-}
-""");
+        var sourceText = SourceText.From("""
+            public partial class NonComponent1 {}
+            public class NonComponent2 {}
+            public partial class NonComponent3 {}
+            public class NonComponent4 {}
+            namespace Microsoft.AspNetCore.Components
+            {
+                public interface IComponent {}
+            }
+            """);
         var syntaxTreeRoot = await CSharpSyntaxTree.ParseText(sourceText).GetRootAsync();
         var solution = _solutionWithTwoProjects
             .WithDocumentText(_partialComponentClassDocumentId, sourceText)

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectStateChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectStateChangeDetectorTest.cs
@@ -494,13 +494,13 @@ public class WorkspaceProjectStateChangeDetectorTest : WorkspaceTestBase
         workspaceStateGenerator.ClearQueue();
 
         var sourceText = SourceText.From(
-$@"
-public partial class TestComponent : {ComponentsApi.IComponent.MetadataName} {{}}
+$$"""
+public partial class TestComponent : {{ComponentsApi.IComponent.MetadataName}} {}
 namespace Microsoft.AspNetCore.Components
-{{
-    public interface IComponent {{}}
-}}
-");
+{
+    public interface IComponent {}
+}
+""");
         var syntaxTreeRoot = await CSharpSyntaxTree.ParseText(sourceText).GetRootAsync();
         var solution = _solutionWithTwoProjects
             .WithDocumentText(_partialComponentClassDocumentId, sourceText)
@@ -590,9 +590,9 @@ namespace Microsoft.AspNetCore.Components
     {
         // Arrange
         var sourceText = SourceText.From(
-$@"
-public partial class TestComponent{{}}
-");
+"""
+public partial class TestComponent{}
+""");
         var syntaxTreeRoot = await CSharpSyntaxTree.ParseText(sourceText).GetRootAsync();
         var solution = _solutionWithTwoProjects
             .WithDocumentText(_partialComponentClassDocumentId, sourceText)
@@ -615,13 +615,13 @@ public partial class TestComponent{{}}
     {
         // Arrange
         var sourceText = SourceText.From(
-$@"
-public partial class TestComponent : {ComponentsApi.IComponent.MetadataName} {{}}
+$$"""
+public partial class TestComponent : {{ComponentsApi.IComponent.MetadataName}} {}
 namespace Microsoft.AspNetCore.Components
-{{
-    public interface IComponent {{}}
-}}
-");
+{
+    public interface IComponent {}
+}
+""");
         var syntaxTreeRoot = await CSharpSyntaxTree.ParseText(sourceText).GetRootAsync();
         var solution = _solutionWithTwoProjects
             .WithDocumentText(_partialComponentClassDocumentId, sourceText)
@@ -644,13 +644,13 @@ namespace Microsoft.AspNetCore.Components
     {
         // Arrange
         var sourceText = SourceText.From(
-$@"
-public partial class TestComponent : {ComponentsApi.IComponent.MetadataName} {{}}
+$$"""
+public partial class TestComponent : {{ComponentsApi.IComponent.MetadataName}} {}
 namespace Microsoft.AspNetCore.Components
-{{
-    public interface IComponent {{}}
-}}
-");
+{
+    public interface IComponent {}
+}
+""");
         var syntaxTreeRoot = CSharpSyntaxTree.ParseText(sourceText).GetRoot();
         var solution = _solutionWithTwoProjects
             .WithDocumentText(_partialComponentClassDocumentId, sourceText)
@@ -669,13 +669,13 @@ namespace Microsoft.AspNetCore.Components
     {
         // Arrange
         var sourceText = SourceText.From(
-$@"
-public partial class TestComponent : {ComponentsApi.IComponent.MetadataName} {{}}
+$$"""
+public partial class TestComponent : {{ComponentsApi.IComponent.MetadataName}} {}
 namespace Microsoft.AspNetCore.Components
-{{
-    public interface IComponent {{}}
-}}
-");
+{
+    public interface IComponent {}
+}
+""");
         var syntaxTreeRoot = await CSharpSyntaxTree.ParseText(sourceText).GetRootAsync();
         var solution = _solutionWithTwoProjects
             .WithDocumentText(_partialComponentClassDocumentId, sourceText)
@@ -719,17 +719,17 @@ namespace Microsoft.AspNetCore.Components
 
         // Arrange
         var sourceText = SourceText.From(
-$@"
-public partial class NonComponent1 {{}}
-public class NonComponent2 {{}}
-public partial class TestComponent : {ComponentsApi.IComponent.MetadataName} {{}}
-public partial class NonComponent3 {{}}
-public class NonComponent4 {{}}
+$$"""
+public partial class NonComponent1 {}
+public class NonComponent2 {}
+public partial class TestComponent : {{ComponentsApi.IComponent.MetadataName}} {}
+public partial class NonComponent3 {}
+public class NonComponent4 {}
 namespace Microsoft.AspNetCore.Components
-{{
-    public interface IComponent {{}}
-}}
-");
+{
+    public interface IComponent {}
+}
+""");
         var syntaxTreeRoot = await CSharpSyntaxTree.ParseText(sourceText).GetRootAsync();
         var solution = _solutionWithTwoProjects
             .WithDocumentText(_partialComponentClassDocumentId, sourceText)
@@ -753,16 +753,16 @@ namespace Microsoft.AspNetCore.Components
 
         // Arrange
         var sourceText = SourceText.From(
-$@"
-public partial class NonComponent1 {{}}
-public class NonComponent2 {{}}
-public partial class NonComponent3 {{}}
-public class NonComponent4 {{}}
+"""
+public partial class NonComponent1 {}
+public class NonComponent2 {}
+public partial class NonComponent3 {}
+public class NonComponent4 {}
 namespace Microsoft.AspNetCore.Components
-{{
-    public interface IComponent {{}}
-}}
-");
+{
+    public interface IComponent {}
+}
+""");
         var syntaxTreeRoot = await CSharpSyntaxTree.ParseText(sourceText).GetRootAsync();
         var solution = _solutionWithTwoProjects
             .WithDocumentText(_partialComponentClassDocumentId, sourceText)

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractIntegrationTest.cs
@@ -43,7 +43,10 @@ public abstract class AbstractIntegrationTest : AbstractIdeIntegrationTest
     public override void Dispose()
     {
         var fails = _traceListener?.Fails ?? Array.Empty<string>();
-        Assert.False(fails.Length > 0, $"Expected 0 Debug.Fail calls. Actual:{Environment.NewLine}{string.Join(Environment.NewLine, fails)}");
+        Assert.False(fails.Length > 0, $"""
+            Expected 0 Debug.Fail calls. Actual:
+            {string.Join(Environment.NewLine, fails)}
+            """);
 
         base.Dispose();
     }


### PR DESCRIPTION
Refactors a number of string, verbatim string, and interpolated string locations to use raw string literals where it will improve readability. This was mainly done programmatically with the Roslyn API, targeting a few specific patterns that we use (such as string + Environment.NewLine), and then going through each location and either making sure formatting still aligned, or reverting if it didn't improve readability in my eyes.