### PR TITLE
Fix issue with Checksum and long strings

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/ChecksumTests.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/ChecksumTests.cs
@@ -143,4 +143,19 @@ public class ChecksumTests(ITestOutputHelper testOutput) : ToolingTestBase(testO
             }
         }
     }
+
+    [Fact]
+    public void TestLargeString()
+    {
+        // Regression test for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1909377.
+
+        object? largeString = RazorTestResources.GetResourceText("FormattingTest.razor");
+
+        var builder = new Checksum.Builder();
+        builder.AppendData(largeString);
+
+        var result = builder.FreeAndGetChecksum();
+
+        Assert.NotNull(result);
+    }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Utilities/Checksum.Builder.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Utilities/Checksum.Builder.cs
@@ -148,7 +148,7 @@ internal sealed partial record Checksum
                 var index = 0;
                 while (index < stringBytes.Length)
                 {
-                    var remaining = stringBytes.Length;
+                    var remaining = stringBytes.Length - index;
                     var toCopy = Math.Min(remaining, buffer.Length);
 
                     stringBytes.Slice(index, toCopy).CopyTo(buffer);


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1909377

There is a logic error in Checksum.Builder that causes an ArgumentOutOfRangeException to be thrown on .NET Framework when a string larger than 4KB is appended.