### PR TITLE
Use message in the fault description

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Telemetry/TelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Telemetry/TelemetryReporter.cs
@@ -130,11 +130,16 @@ internal abstract class TelemetryReporter : ITelemetryReporter
 
             var faultEvent = new FaultEvent(
                 eventName: GetEventName("fault"),
-                description: GetExceptionDetails(exception),
+                description: (message is null ? string.Empty : message + ": ") + GetExceptionDetails(exception),
                 FaultSeverity.General,
                 exceptionObject: exception,
                 gatherEventDetails: faultUtility =>
                 {
+                    if (message is not null)
+                    {
+                        faultUtility.AddErrorInformation(message);
+                    }
+
                     foreach (var data in @params)
                     {
                         if (data is null)


### PR DESCRIPTION
Noticed this in my other PR, where I was manually reporting a fault and passing in a message, but the message was never used.

With this change it should show up in PRISM and in a CAB if we collect it.