### PR TITLE
Group code actions so Razor shows first

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/RazorCodeActionsTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/RazorCodeActionsTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -26,7 +27,11 @@ public class RazorCodeActionsTests(ITestOutputHelper testOutputHelper) : Abstrac
         var codeActions = await TestServices.Editor.InvokeCodeActionListAsync(ControlledHangMitigatingCancellationToken);
 
         // Assert
-        var codeActionSet = Assert.Single(codeActions);
+
+        // We expect two groups, one for Razor, one for Html
+        Assert.Equal(2, codeActions.Count());
+        // Razor should be first
+        var codeActionSet = codeActions.First();
         var usingString = $"@using {RazorProjectConstants.BlazorProjectName}.Shared";
         var codeAction = Assert.Single(codeActionSet.Actions, a => a.DisplayText.Equals(usingString));
 


### PR DESCRIPTION
Reported on Discord by @AdmiralSnyder. Looks like VS sorts code actions alphabetically, which means in the German locale, Html's "Remove <tag>" code action is first:

![image](https://github.com/dotnet/razor/assets/754264/70b06956-b6bd-412b-b714-308ba062afe8)

This is also trivially problematic in English just by having a namespace that makes things appear in an unexpected location:

![image](https://github.com/dotnet/razor/assets/754264/ce237fd6-cbd6-462c-b254-c9955867211c)

This PR means we group Razor code actions before Html code actions, which partially solves the issue:

![image](https://github.com/dotnet/razor/assets/754264/33301d3d-894f-4d88-b232-4e550afa61fd)

Following up with the editor team to see if there is a better solution. Maybe we should create more groups too, so our "Extract to component" code action is always after our "fully qualify" code actions?