### PR TITLE
Port FallbackProjectManager fix to main

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultRazorDynamicFileInfoProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DefaultRazorDynamicFileInfoProvider.cs
@@ -270,7 +270,13 @@ internal class DefaultRazorDynamicFileInfoProvider : RazorDynamicFileInfoProvide
             throw new ArgumentNullException(nameof(filePath));
         }
 
-        _fallbackProjectManager.DynamicFileRemoved(projectId, projectFilePath, filePath);
+        var projectKey = TryFindProjectKeyForProjectId(projectId);
+        if (projectKey is not { } razorProjectKey)
+        {
+            return Task.CompletedTask;
+        }
+
+        _fallbackProjectManager.DynamicFileRemoved(projectId, razorProjectKey, projectFilePath, filePath);
 
         // ---------------------------------------------------------- NOTE & CAUTION --------------------------------------------------------------
         //

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/FallbackProjectManager.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/FallbackProjectManager.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Immutable;
 using System.Composition;
 using System.IO;
+using Microsoft.AspNetCore.Razor.Telemetry;
+using Microsoft.AspNetCore.Razor.Utilities;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -16,55 +18,64 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 /// </summary>
 [Shared]
 [Export(typeof(FallbackProjectManager))]
-internal sealed class FallbackProjectManager
+[method: ImportingConstructor]
+internal sealed class FallbackProjectManager(
+    ProjectConfigurationFilePathStore projectConfigurationFilePathStore,
+    LanguageServerFeatureOptions languageServerFeatureOptions,
+    ProjectSnapshotManagerAccessor projectSnapshotManagerAccessor,
+    ITelemetryReporter telemetryReporter)
 {
-    private readonly ProjectConfigurationFilePathStore _projectConfigurationFilePathStore;
-    private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
-    private readonly ProjectSnapshotManagerAccessor _projectSnapshotManagerAccessor;
+    private readonly ProjectConfigurationFilePathStore _projectConfigurationFilePathStore = projectConfigurationFilePathStore;
+    private readonly LanguageServerFeatureOptions _languageServerFeatureOptions = languageServerFeatureOptions;
+    private readonly ProjectSnapshotManagerAccessor _projectSnapshotManagerAccessor = projectSnapshotManagerAccessor;
+    private readonly ITelemetryReporter _telemetryReporter = telemetryReporter;
 
     private ImmutableHashSet<ProjectId> _fallbackProjectIds = ImmutableHashSet<ProjectId>.Empty;
 
-    [ImportingConstructor]
-    public FallbackProjectManager(
-        ProjectConfigurationFilePathStore projectConfigurationFilePathStore,
-        LanguageServerFeatureOptions languageServerFeatureOptions,
-        ProjectSnapshotManagerAccessor projectSnapshotManagerAccessor)
-    {
-        _projectConfigurationFilePathStore = projectConfigurationFilePathStore;
-        _languageServerFeatureOptions = languageServerFeatureOptions;
-        _projectSnapshotManagerAccessor = projectSnapshotManagerAccessor;
-    }
-
     internal void DynamicFileAdded(ProjectId projectId, ProjectKey razorProjectKey, string projectFilePath, string filePath)
     {
-        var project = _projectSnapshotManagerAccessor.Instance.GetLoadedProject(razorProjectKey);
-        if (_fallbackProjectIds.Contains(projectId))
+        try
         {
-            // The project might have started as a fallback project, but it might have been upgraded by our getting CPS info
-            // about it. In that case, leave the CPS bits to do the work
-            if (project is ProjectSnapshot { HostProject: FallbackHostProject })
+            var project = _projectSnapshotManagerAccessor.Instance.GetLoadedProject(razorProjectKey);
+            if (_fallbackProjectIds.Contains(projectId))
             {
-                // If this is a fallback project, then Roslyn may not track documents in the project, so these dynamic file notifications
-                // are the only way to know about files in the project.
-                AddFallbackDocument(razorProjectKey, filePath, projectFilePath);
+                // The project might have started as a fallback project, but it might have been upgraded by our getting CPS info
+                // about it. In that case, leave the CPS bits to do the work
+                if (project is ProjectSnapshot { HostProject: FallbackHostProject })
+                {
+                    // If this is a fallback project, then Roslyn may not track documents in the project, so these dynamic file notifications
+                    // are the only way to know about files in the project.
+                    AddFallbackDocument(razorProjectKey, filePath, projectFilePath);
+                }
+            }
+            else if (project is null)
+            {
+                // We have been asked to provide dynamic file info, which means there is a .razor or .cshtml file in the project
+                // but for some reason our project system doesn't know about the project. In these cases (often when people don't
+                // use the Razor or Web SDK) we spin up a fallback experience for them
+                AddFallbackProject(projectId, filePath);
             }
         }
-        else if (project is null)
+        catch (Exception ex)
         {
-            // We have been asked to provide dynamic file info, which means there is a .razor or .cshtml file in the project
-            // but for some reason our project system doesn't know about the project. In these cases (often when people don't
-            // use the Razor or Web SDK) we spin up a fallback experience for them
-            AddFallbackProject(projectId, filePath);
+            _telemetryReporter.ReportFault(ex, "Error while trying to add fallback document to project");
         }
     }
 
     internal void DynamicFileRemoved(ProjectId projectId, string projectFilePath, string filePath)
     {
-        if (_fallbackProjectIds.Contains(projectId))
+        try
         {
-            // If this is a fallback project, then Roslyn may not track documents in the project, so these dynamic file notifications
-            // are the only way to know about files in the project.
-            RemoveFallbackDocument(projectId, filePath, projectFilePath);
+            if (_fallbackProjectIds.Contains(projectId))
+            {
+                // If this is a fallback project, then Roslyn may not track documents in the project, so these dynamic file notifications
+                // are the only way to know about files in the project.
+                RemoveFallbackDocument(projectId, filePath, projectFilePath);
+            }
+        }
+        catch (Exception ex)
+        {
+            _telemetryReporter.ReportFault(ex, "Error while trying to remove fallback document from project");
         }
     }
 
@@ -107,15 +118,27 @@ internal sealed class FallbackProjectManager
     private void AddFallbackDocument(ProjectKey projectKey, string filePath, string projectFilePath)
     {
         var hostDocument = CreateHostDocument(filePath, projectFilePath);
+        if (hostDocument is null)
+        {
+            return;
+        }
+
         var textLoader = new FileTextLoader(filePath, defaultEncoding: null);
         _projectSnapshotManagerAccessor.Instance.DocumentAdded(projectKey, hostDocument, textLoader);
     }
 
-    private static HostDocument CreateHostDocument(string filePath, string projectFilePath)
+    private static HostDocument? CreateHostDocument(string filePath, string projectFilePath)
     {
-        var targetPath = filePath.StartsWith(projectFilePath, FilePathComparison.Instance)
-            ? filePath[projectFilePath.Length..]
-            : filePath;
+        // The compiler only supports paths that are relative to the project root, so filter our files
+        // that don't match
+        var projectPath = FilePathNormalizer.GetNormalizedDirectoryName(projectFilePath);
+        var normalizedFilePath = FilePathNormalizer.Normalize(filePath);
+        if (!normalizedFilePath.StartsWith(projectPath, FilePathComparison.Instance))
+        {
+            return null;
+        }
+
+        var targetPath = filePath[projectPath.Length..];
         var hostDocument = new HostDocument(filePath, targetPath);
         return hostDocument;
     }
@@ -135,6 +158,11 @@ internal sealed class FallbackProjectManager
         }
 
         var hostDocument = CreateHostDocument(filePath, projectFilePath);
+        if (hostDocument is null)
+        {
+            return;
+        }
+
         _projectSnapshotManagerAccessor.Instance.DocumentRemoved(razorProjectKey, hostDocument);
     }
 

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/FallbackProjectManagerTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/FallbackProjectManagerTest.cs
@@ -48,7 +48,8 @@ public class FallbackProjectManagerTest : WorkspaceTestBase
 
         _fallbackProjectManger.DynamicFileAdded(projectId, hostProject.Key, SomeProject.FilePath, SomeProjectFile1.FilePath);
 
-        Assert.Empty(_fallbackProjectManger.GetTestAccessor().ProjectIds);
+        var project = Assert.Single(_projectSnapshotManager.GetProjects());
+        Assert.IsNotType<FallbackHostProject>(((ProjectSnapshot)project).HostProject);
     }
 
     [Fact]
@@ -62,9 +63,6 @@ public class FallbackProjectManagerTest : WorkspaceTestBase
         Workspace.TryApplyChanges(Workspace.CurrentSolution.AddProject(projectInfo));
 
         _fallbackProjectManger.DynamicFileAdded(projectId, SomeProject.Key, SomeProject.FilePath, SomeProjectFile1.FilePath);
-
-        var actualId = Assert.Single(_fallbackProjectManger.GetTestAccessor().ProjectIds);
-        Assert.Equal(projectId, actualId);
 
         var project = Assert.Single(_projectSnapshotManager.GetProjects());
         Assert.Equal("DisplayName", project.DisplayName);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/FallbackProjectManagerTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/FallbackProjectManagerTest.cs
@@ -5,6 +5,8 @@ using System.IO;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer;
+using Microsoft.AspNetCore.Razor.Telemetry;
+using Microsoft.AspNetCore.Razor.Utilities;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Moq;
 using Xunit;
@@ -30,7 +32,7 @@ public class FallbackProjectManagerTest : WorkspaceTestBase
 
         var projectSnapshotManagerAccessor = Mock.Of<ProjectSnapshotManagerAccessor>(a => a.Instance == _projectSnapshotManager, MockBehavior.Strict);
 
-        _fallbackProjectManger = new FallbackProjectManager(_projectConfigurationFilePathStore, languageServerFeatureOptions, projectSnapshotManagerAccessor);
+        _fallbackProjectManger = new FallbackProjectManager(_projectConfigurationFilePathStore, languageServerFeatureOptions, projectSnapshotManagerAccessor, NoOpTelemetryReporter.Instance);
     }
 
     [Fact]
@@ -72,6 +74,7 @@ public class FallbackProjectManagerTest : WorkspaceTestBase
 
         var documentFilePath = Assert.Single(project.DocumentFilePaths);
         Assert.Equal(SomeProjectFile1.FilePath, documentFilePath);
+        Assert.Equal(SomeProjectFile1.TargetPath, project.GetDocument(documentFilePath)!.TargetPath);
     }
 
     [Fact]
@@ -110,14 +113,44 @@ public class FallbackProjectManagerTest : WorkspaceTestBase
 
         _fallbackProjectManger.DynamicFileAdded(projectId, SomeProject.Key, SomeProject.FilePath, SomeProjectFile2.FilePath);
 
-        _fallbackProjectManger.DynamicFileAdded(projectId, SomeProject.Key, SomeProject.FilePath, SomeProjectComponentFile1.FilePath);
+        _fallbackProjectManger.DynamicFileAdded(projectId, SomeProject.Key, SomeProject.FilePath, SomeProjectNestedComponentFile3.FilePath);
 
         var project = Assert.Single(_projectSnapshotManager.GetProjects());
 
         Assert.Collection(project.DocumentFilePaths.OrderBy(f => f), // DocumentFilePaths comes from a dictionary, so no sort guarantee
             f => Assert.Equal(SomeProjectFile1.FilePath, f),
-            f => Assert.Equal(SomeProjectComponentFile1.FilePath, f),
-            f => Assert.Equal(SomeProjectFile2.FilePath, f));
+            f => Assert.Equal(SomeProjectFile2.FilePath, f),
+            f => Assert.Equal(SomeProjectNestedComponentFile3.FilePath, f));
+
+        Assert.Equal(SomeProjectFile1.TargetPath, project.GetDocument(SomeProjectFile1.FilePath)!.TargetPath);
+        Assert.Equal(SomeProjectFile2.TargetPath, project.GetDocument(SomeProjectFile2.FilePath)!.TargetPath);
+        // The test data is created with a "\" so when the test runs on linux, and direct string comparison wouldn't work
+        Assert.True(FilePathNormalizer.FilePathsEquivalent(SomeProjectNestedComponentFile3.TargetPath, project.GetDocument(SomeProjectNestedComponentFile3.FilePath)!.TargetPath));
+    }
+
+    [Fact]
+    public void DynamicFileAdded_TrackedProject_IgnoresDocumentFromOutsideCone()
+    {
+        var projectId = ProjectId.CreateNewId();
+        var projectInfo = ProjectInfo.Create(projectId, VersionStamp.Default, "DisplayName", "AssemblyName", LanguageNames.CSharp, filePath: SomeProject.FilePath)
+            .WithCompilationOutputInfo(new CompilationOutputInfo().WithAssemblyPath(Path.Combine(SomeProject.IntermediateOutputPath, "SomeProject.dll")))
+            .WithDefaultNamespace("RootNamespace");
+
+        Workspace.TryApplyChanges(Workspace.CurrentSolution.AddProject(projectInfo));
+
+        _fallbackProjectManger.DynamicFileAdded(projectId, SomeProject.Key, SomeProject.FilePath, SomeProjectFile1.FilePath);
+
+        // These two represent linked files, or shared project items
+        _fallbackProjectManger.DynamicFileAdded(projectId, SomeProject.Key, SomeProject.FilePath, AnotherProjectFile2.FilePath);
+
+        _fallbackProjectManger.DynamicFileAdded(projectId, SomeProject.Key, SomeProject.FilePath, AnotherProjectComponentFile1.FilePath);
+
+        var project = Assert.Single(_projectSnapshotManager.GetProjects());
+
+        Assert.Collection(project.DocumentFilePaths,
+            f => Assert.Equal(SomeProjectFile1.FilePath, f));
+
+        Assert.Equal(SomeProjectFile1.TargetPath, project.GetDocument(SomeProjectFile1.FilePath)!.TargetPath);
     }
 
     [Fact]

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Shared/TestProjectData.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Shared/TestProjectData.cs
@@ -28,14 +28,14 @@ internal static class TestProjectData
         SomeProjectFile1 = new HostDocument(Path.Combine(someProjectPath, "File1.cshtml"), "File1.cshtml", FileKinds.Legacy);
         SomeProjectFile2 = new HostDocument(Path.Combine(someProjectPath, "File2.cshtml"), "File2.cshtml", FileKinds.Legacy);
         SomeProjectImportFile = new HostDocument(Path.Combine(someProjectPath, "_Imports.cshtml"), "_Imports.cshtml", FileKinds.Legacy);
-        SomeProjectNestedFile3 = new HostDocument(Path.Combine(someProjectPath, "Nested", "File3.cshtml"), "Nested\\File1.cshtml", FileKinds.Legacy);
-        SomeProjectNestedFile4 = new HostDocument(Path.Combine(someProjectPath, "Nested", "File4.cshtml"), "Nested\\File2.cshtml", FileKinds.Legacy);
+        SomeProjectNestedFile3 = new HostDocument(Path.Combine(someProjectPath, "Nested", "File3.cshtml"), "Nested\\File3.cshtml", FileKinds.Legacy);
+        SomeProjectNestedFile4 = new HostDocument(Path.Combine(someProjectPath, "Nested", "File4.cshtml"), "Nested\\File4.cshtml", FileKinds.Legacy);
         SomeProjectNestedImportFile = new HostDocument(Path.Combine(someProjectPath, "Nested", "_Imports.cshtml"), "Nested\\_Imports.cshtml", FileKinds.Legacy);
         SomeProjectComponentFile1 = new HostDocument(Path.Combine(someProjectPath, "File1.razor"), "File1.razor", FileKinds.Component);
         SomeProjectComponentFile2 = new HostDocument(Path.Combine(someProjectPath, "File2.razor"), "File2.razor", FileKinds.Component);
         SomeProjectComponentImportFile1 = new HostDocument(Path.Combine(someProjectPath, "_Imports.razor"), "_Imports.razor", FileKinds.Component);
-        SomeProjectNestedComponentFile3 = new HostDocument(Path.Combine(someProjectPath, "Nested", "File3.razor"), "Nested\\File1.razor", FileKinds.Component);
-        SomeProjectNestedComponentFile4 = new HostDocument(Path.Combine(someProjectPath, "Nested", "File4.razor"), "Nested\\File2.razor", FileKinds.Component);
+        SomeProjectNestedComponentFile3 = new HostDocument(Path.Combine(someProjectPath, "Nested", "File3.razor"), "Nested\\File3.razor", FileKinds.Component);
+        SomeProjectNestedComponentFile4 = new HostDocument(Path.Combine(someProjectPath, "Nested", "File4.razor"), "Nested\\File4.razor", FileKinds.Component);
         SomeProjectCshtmlComponentFile5 = new HostDocument(Path.Combine(someProjectPath, "File5.cshtml"), "File5.cshtml", FileKinds.Component);
 
         var anotherProjectPath = Path.Combine(baseDirectory, "AnotherProject");

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultRazorDynamicFileInfoProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultRazorDynamicFileInfoProviderTest.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer;
+using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -57,7 +58,7 @@ public class DefaultRazorDynamicFileInfoProviderTest : WorkspaceTestBase
         var projectSnapshotManagerAccessor = Mock.Of<ProjectSnapshotManagerAccessor>(a => a.Instance == _projectSnapshotManager, MockBehavior.Strict);
 
         var projectConfigurationFilePathStore = Mock.Of<ProjectConfigurationFilePathStore>(MockBehavior.Strict);
-        var fallbackProjectManager = new FallbackProjectManager(projectConfigurationFilePathStore, languageServerFeatureOptions, projectSnapshotManagerAccessor);
+        var fallbackProjectManager = new FallbackProjectManager(projectConfigurationFilePathStore, languageServerFeatureOptions, projectSnapshotManagerAccessor, NoOpTelemetryReporter.Instance);
 
         _provider = new DefaultRazorDynamicFileInfoProvider(_documentServiceFactory, _editorFeatureDetector, filePathService, projectSnapshotManagerAccessor, fallbackProjectManager);
         _testAccessor = _provider.GetTestAccessor();


### PR DESCRIPTION
Porting https://github.com/dotnet/razor/pull/9582 to main, in case that one doesn't merge, and because there will be conflicts anyway.

Also took the liberty of removing the unnecessary HashSet.

Only https://github.com/dotnet/razor/pull/9589/commits/70179b3cab6826b266afb053e72c3c374ec6aa03 has not been reviewed in the other PR.