### PR TITLE
Tag Helper Discovery Telemetry

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/OOPTagHelperResolver.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/OOPTagHelperResolver.cs
@@ -25,14 +25,12 @@ internal class OOPTagHelperResolver : ITagHelperResolver
     private readonly ProjectSnapshotProjectEngineFactory _factory;
     private readonly IErrorReporter _errorReporter;
     private readonly Workspace _workspace;
-    private readonly ITelemetryReporter _telemetryReporter;
 
     public OOPTagHelperResolver(ProjectSnapshotProjectEngineFactory factory, IErrorReporter errorReporter, Workspace workspace, ITelemetryReporter telemetryReporter)
     {
         _factory = factory ?? throw new ArgumentNullException(nameof(factory));
         _errorReporter = errorReporter ?? throw new ArgumentNullException(nameof(errorReporter));
         _workspace = workspace ?? throw new ArgumentNullException(nameof(workspace));
-        _telemetryReporter = telemetryReporter ?? throw new ArgumentNullException(nameof(telemetryReporter));
 
         _innerResolver = new CompilationTagHelperResolver(telemetryReporter);
         _resultCache = new TagHelperResultCache();

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultProjectWorkspaceStateGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultProjectWorkspaceStateGeneratorTest.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
+using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Xunit;
@@ -58,7 +59,7 @@ public class DefaultProjectWorkspaceStateGeneratorTest : ProjectSnapshotManagerD
     public void Dispose_MakesUpdateNoop()
     {
         // Arrange
-        using (var stateGenerator = new DefaultProjectWorkspaceStateGenerator(Dispatcher))
+        using (var stateGenerator = new DefaultProjectWorkspaceStateGenerator(Dispatcher, NoOpTelemetryReporter.Instance))
         {
             stateGenerator.BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false);
 
@@ -75,7 +76,7 @@ public class DefaultProjectWorkspaceStateGeneratorTest : ProjectSnapshotManagerD
     public void Update_StartsUpdateTask()
     {
         // Arrange
-        using (var stateGenerator = new DefaultProjectWorkspaceStateGenerator(Dispatcher))
+        using (var stateGenerator = new DefaultProjectWorkspaceStateGenerator(Dispatcher, NoOpTelemetryReporter.Instance))
         {
             stateGenerator.BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false);
 
@@ -92,7 +93,7 @@ public class DefaultProjectWorkspaceStateGeneratorTest : ProjectSnapshotManagerD
     public void Update_SoftCancelsIncompleteTaskForSameProject()
     {
         // Arrange
-        using (var stateGenerator = new DefaultProjectWorkspaceStateGenerator(Dispatcher))
+        using (var stateGenerator = new DefaultProjectWorkspaceStateGenerator(Dispatcher, NoOpTelemetryReporter.Instance))
         {
             stateGenerator.BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false);
             stateGenerator.Update(_workspaceProject, _projectSnapshot, DisposalToken);
@@ -110,7 +111,7 @@ public class DefaultProjectWorkspaceStateGeneratorTest : ProjectSnapshotManagerD
     public async Task Update_NullWorkspaceProject_ClearsProjectWorkspaceState()
     {
         // Arrange
-        using (var stateGenerator = new DefaultProjectWorkspaceStateGenerator(Dispatcher))
+        using (var stateGenerator = new DefaultProjectWorkspaceStateGenerator(Dispatcher, NoOpTelemetryReporter.Instance))
         {
             stateGenerator.NotifyBackgroundWorkCompleted = new ManualResetEventSlim(initialState: false);
             var projectManager = new TestProjectSnapshotManager(_workspace, Dispatcher);
@@ -134,7 +135,7 @@ public class DefaultProjectWorkspaceStateGeneratorTest : ProjectSnapshotManagerD
     public async Task Update_ResolvesTagHelpersAndUpdatesWorkspaceState()
     {
         // Arrange
-        using (var stateGenerator = new DefaultProjectWorkspaceStateGenerator(Dispatcher))
+        using (var stateGenerator = new DefaultProjectWorkspaceStateGenerator(Dispatcher, NoOpTelemetryReporter.Instance))
         {
             stateGenerator.NotifyBackgroundWorkCompleted = new ManualResetEventSlim(initialState: false);
             var projectManager = new TestProjectSnapshotManager(_workspace, Dispatcher);


### PR DESCRIPTION
As discussed at various times, here is some telemetry to _maybe_ help us track down tag helper issues.

I'm no telemetry expert here, but my hope is with these queries we'll be able to find things like:

* Occurances of tag helper discovery never finishing (i've seen this on my machine, but maybe nowhere else?)
* Where tag helper discovery results in us losing tag helper information
* Sessions that never get a non-zero number of tag helpers
* How often we're trying to discover tag helpers in general (with/without any changes)

Please keep that in mind when reviewing. I don't know how to write the Kusto queries for those, I'm just assuming that I, or someone smarter than I, will be able to work it out later :)

Also removing some old telemetry which I don't think we've ever used, and looking at the data, I'm not sure what problem we thought we had that we were looking for, but we don't seem to have it. Either the response is instant, or the data is bad. Neither is useful.
<img width="127" alt="image" src="https://github.com/dotnet/razor/assets/754264/c99d78e1-b2ca-4474-a33e-9807288e9910">
