### PR TITLE
Fix reporting of incorrect `RazorLangVersion`

### DIFF
--- a/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators/IncrementalValueProviderExtensions.cs
+++ b/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators/IncrementalValueProviderExtensions.cs
@@ -28,8 +28,8 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
         {
             context.RegisterSourceOutput(source, (spc, source) =>
             {
-                var (sourceItem, diagnostic) = source;
-                if (sourceItem == null && diagnostic != null)
+                var (_, diagnostic) = source;
+                if (diagnostic != null)
                 {
                     spc.ReportDiagnostic(diagnostic);
                 }
@@ -42,8 +42,8 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
         {
             context.RegisterSourceOutput(source, (spc, source) =>
             {
-                var (sourceItem, diagnostic) = source;
-                if (sourceItem == null && diagnostic != null)
+                var (_, diagnostic) = source;
+                if (diagnostic != null)
                 {
                     spc.ReportDiagnostic(diagnostic);
                 }

--- a/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators/RazorSourceGenerator.RazorProviders.cs
+++ b/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators/RazorSourceGenerator.RazorProviders.cs
@@ -31,7 +31,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
             globalOptions.TryGetValue("build_property.SupportLocalizedComponentNames", out var supportLocalizedComponentNames);
             globalOptions.TryGetValue("build_property.GenerateRazorMetadataSourceChecksumAttributes", out var generateMetadataSourceChecksumAttributes);
 
-            var razorLanguageVersion = RazorLanguageVersion.Latest;
+            RazorLanguageVersion razorLanguageVersion;
             Diagnostic? diagnostic = null;
             if (!globalOptions.TryGetValue("build_property.RazorLangVersion", out var razorLanguageVersionString) ||
                 !RazorLanguageVersion.TryParse(razorLanguageVersionString, out razorLanguageVersion))
@@ -40,6 +40,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                     RazorDiagnostics.InvalidRazorLangVersionDescriptor,
                     Location.None,
                     razorLanguageVersionString);
+                razorLanguageVersion = RazorLanguageVersion.Latest;
             }
 
             var razorConfiguration = RazorConfiguration.Create(razorLanguageVersion, configurationName ?? "default", System.Linq.Enumerable.Empty<RazorExtension>(), true);

--- a/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGeneratorTests.cs
+++ b/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGeneratorTests.cs
@@ -2828,8 +2828,9 @@ namespace MyApp
             var result = RunGenerator(compilation!, ref driver);
 
             result.Diagnostics.Verify(
-                Diagnostic("CS8785").WithArguments("RazorSourceGenerator", "ArgumentNullException", "Value cannot be null. (Parameter 'languageVersion')").WithLocation(1, 1));
-            Assert.Empty(result.GeneratedSources);
+                // error RZ3600: Invalid value '{0}'' for RazorLangVersion. Valid values include 'Latest' or a valid version in range 1.0 to 8.0.
+                Diagnostic("RZ3600").WithArguments(langVersion).WithLocation(1, 1));
+            Assert.Single(result.GeneratedSources);
         }
     }
 }


### PR DESCRIPTION
Before:

```
warning CS8785: Generator 'RazorSourceGenerator' failed to generate source. It will not contribute to the output and compilation errors may occur as a result. Exception was of type 'ArgumentNullException' with message 'Value cannot be null. (Parameter 'languageVersion')'.
... more errors due to missing razor files
```

After:

```
error RZ3600: Invalid value '{0}'' for RazorLangVersion. Valid values include 'Latest' or a valid version in range 1.0 to 8.0.
```