### PR TITLE
Log when formatting operations are being abandoned

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RangeExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RangeExtensions.cs
@@ -130,4 +130,9 @@ internal static class RangeExtensions
 
         return result;
     }
+
+    public static string ToDisplayString(this Range range)
+    {
+        return $"({range.Start.Line}, {range.Start.Character})-({range.End.Line}, {range.End.Character})";
+    }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContentValidationPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContentValidationPass.cs
@@ -57,6 +57,21 @@ internal class FormattingContentValidationPass : FormattingPassBase
             // Looks like we removed some non-whitespace content as part of formatting. Oops.
             // Discard this formatting result.
 
+            _logger.LogWarning("{value}", SR.Format_operation_changed_nonwhitespace);
+
+            foreach (var edit in edits)
+            {
+                if (edit.NewText.Any(c => !char.IsWhiteSpace(c)))
+                {
+                    _logger.LogWarning("{value}", SR.FormatEdit_at_adds(edit.Range.ToDisplayString(), edit.NewText));
+                }
+                else if (text.GetSubText(edit.Range.ToTextSpan(text)) is { } subText &&
+                    subText.GetFirstNonWhitespaceOffset(span: null, out _) is not null)
+                {
+                    _logger.LogWarning("{value}", SR.FormatEdit_at_deletes(edit.Range.ToDisplayString(), subText.ToString()));
+                }
+            }
+
             if (DebugAssertsEnabled)
             {
                 Debug.Fail("A formatting result was rejected because it was going to change non-whitespace content in the document.");

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingDiagnosticValidationPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingDiagnosticValidationPass.cs
@@ -65,6 +65,23 @@ internal class FormattingDiagnosticValidationPass : FormattingPassBase
         // at all possible). Also worth noting the order has to be maintained in that case.
         if (!originalDiagnostics.SequenceEqual(changedDiagnostics, LocationIgnoringDiagnosticComparer.Instance))
         {
+            // Yes, these log messages look weird, but this is how structured logging works. The first parameter, the "template" is not
+            // supposed to change, or it causes lots of allocations. The second parameter is the "argument" which is supposed to change.
+            // In our case, we never use structured logging such that the argument name is important, so we just use the same one, and
+            // save some memory, and still log the expected values.
+            _logger.LogWarning("{value}", SR.Format_operation_changed_diagnostics);
+            _logger.LogWarning("{value}", SR.Diagnostics_before);
+            foreach (var diagnostic in originalDiagnostics)
+            {
+                _logger.LogWarning("{value}", diagnostic);
+            }
+
+            _logger.LogWarning("{value}", SR.Diagnostics_after);
+            foreach (var diagnostic in changedDiagnostics)
+            {
+                _logger.LogWarning("{value}", diagnostic);
+            }
+
             if (DebugAssertsEnabled)
             {
                 Debug.Fail("A formatting result was rejected because the formatted text produced different diagnostics compared to the original text.");

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/SR.resx
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/SR.resx
@@ -120,17 +120,38 @@
   <data name="Blazor_directive_attributes" xml:space="preserve">
     <value>Blazor directive attributes</value>
   </data>
+  <data name="Changes" xml:space="preserve">
+    <value>Changes:</value>
+  </data>
   <data name="Create_Component_FromTag_Title" xml:space="preserve">
     <value>Create component from tag</value>
   </data>
+  <data name="Diagnostics_after" xml:space="preserve">
+    <value>Diagnostics after:</value>
+  </data>
+  <data name="Diagnostics_before" xml:space="preserve">
+    <value>Diagnostics before:</value>
+  </data>
   <data name="Document_Not_Found" xml:space="preserve">
     <value>Document {0} was not found.</value>
+  </data>
+  <data name="Edit_at_adds" xml:space="preserve">
+    <value>Edit at {0} adds the non-whitespace content '{1}'.</value>
+  </data>
+  <data name="Edit_at_deletes" xml:space="preserve">
+    <value>Edit at {0} deletes the non-whitespace content '{1}'.</value>
   </data>
   <data name="ExtractTo_CodeBehind_Title" xml:space="preserve">
     <value>Extract block to code behind</value>
   </data>
   <data name="File_Externally_Modified" xml:space="preserve">
     <value>File was externally modified: {0}</value>
+  </data>
+  <data name="Format_operation_changed_diagnostics" xml:space="preserve">
+    <value>A format operation is being abandoned because it would introduce or remove one of more diagnostics.</value>
+  </data>
+  <data name="Format_operation_changed_nonwhitespace" xml:space="preserve">
+    <value>A format operation is being abandoned because it would add or delete non-whitespace content.</value>
   </data>
   <data name="Generate_Async_Event_Handler_Title" xml:space="preserve">
     <value>Generate Async Event Handler '{0}'</value>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.cs.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.cs.xlf
@@ -7,14 +7,39 @@
         <target state="translated">Atributy direktivy Blazor</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changes">
+        <source>Changes:</source>
+        <target state="new">Changes:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Create_Component_FromTag_Title">
         <source>Create component from tag</source>
         <target state="translated">Vytvořit komponentu ze značky</target>
         <note />
       </trans-unit>
+      <trans-unit id="Diagnostics_after">
+        <source>Diagnostics after:</source>
+        <target state="new">Diagnostics after:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Diagnostics_before">
+        <source>Diagnostics before:</source>
+        <target state="new">Diagnostics before:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Document_Not_Found">
         <source>Document {0} was not found.</source>
         <target state="translated">Dokument {0} nebyl nalezen.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Edit_at_adds">
+        <source>Edit at {0} adds the non-whitespace content '{1}'.</source>
+        <target state="new">Edit at {0} adds the non-whitespace content '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Edit_at_deletes">
+        <source>Edit at {0} deletes the non-whitespace content '{1}'.</source>
+        <target state="new">Edit at {0} deletes the non-whitespace content '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExtractTo_CodeBehind_Title">
@@ -25,6 +50,16 @@
       <trans-unit id="File_Externally_Modified">
         <source>File was externally modified: {0}</source>
         <target state="translated">Došlo k externí úpravě souboru: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_operation_changed_diagnostics">
+        <source>A format operation is being abandoned because it would introduce or remove one of more diagnostics.</source>
+        <target state="new">A format operation is being abandoned because it would introduce or remove one of more diagnostics.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_operation_changed_nonwhitespace">
+        <source>A format operation is being abandoned because it would add or delete non-whitespace content.</source>
+        <target state="new">A format operation is being abandoned because it would add or delete non-whitespace content.</target>
         <note />
       </trans-unit>
       <trans-unit id="Generate_Async_Event_Handler_Title">

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.de.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.de.xlf
@@ -7,14 +7,39 @@
         <target state="translated">Attribute für Blazor-Direktiven</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changes">
+        <source>Changes:</source>
+        <target state="new">Changes:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Create_Component_FromTag_Title">
         <source>Create component from tag</source>
         <target state="translated">Komponente aus Tag erstellen</target>
         <note />
       </trans-unit>
+      <trans-unit id="Diagnostics_after">
+        <source>Diagnostics after:</source>
+        <target state="new">Diagnostics after:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Diagnostics_before">
+        <source>Diagnostics before:</source>
+        <target state="new">Diagnostics before:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Document_Not_Found">
         <source>Document {0} was not found.</source>
         <target state="translated">Dokument „{0}“ wurde nicht gefunden.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Edit_at_adds">
+        <source>Edit at {0} adds the non-whitespace content '{1}'.</source>
+        <target state="new">Edit at {0} adds the non-whitespace content '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Edit_at_deletes">
+        <source>Edit at {0} deletes the non-whitespace content '{1}'.</source>
+        <target state="new">Edit at {0} deletes the non-whitespace content '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExtractTo_CodeBehind_Title">
@@ -25,6 +50,16 @@
       <trans-unit id="File_Externally_Modified">
         <source>File was externally modified: {0}</source>
         <target state="translated">Datei wurde extern modifiziert: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_operation_changed_diagnostics">
+        <source>A format operation is being abandoned because it would introduce or remove one of more diagnostics.</source>
+        <target state="new">A format operation is being abandoned because it would introduce or remove one of more diagnostics.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_operation_changed_nonwhitespace">
+        <source>A format operation is being abandoned because it would add or delete non-whitespace content.</source>
+        <target state="new">A format operation is being abandoned because it would add or delete non-whitespace content.</target>
         <note />
       </trans-unit>
       <trans-unit id="Generate_Async_Event_Handler_Title">

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.es.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.es.xlf
@@ -7,14 +7,39 @@
         <target state="translated">Atributos de directiva de Blazor</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changes">
+        <source>Changes:</source>
+        <target state="new">Changes:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Create_Component_FromTag_Title">
         <source>Create component from tag</source>
         <target state="translated">Crear un componente a partir de la etiqueta</target>
         <note />
       </trans-unit>
+      <trans-unit id="Diagnostics_after">
+        <source>Diagnostics after:</source>
+        <target state="new">Diagnostics after:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Diagnostics_before">
+        <source>Diagnostics before:</source>
+        <target state="new">Diagnostics before:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Document_Not_Found">
         <source>Document {0} was not found.</source>
         <target state="translated">No se encontró el documento {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Edit_at_adds">
+        <source>Edit at {0} adds the non-whitespace content '{1}'.</source>
+        <target state="new">Edit at {0} adds the non-whitespace content '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Edit_at_deletes">
+        <source>Edit at {0} deletes the non-whitespace content '{1}'.</source>
+        <target state="new">Edit at {0} deletes the non-whitespace content '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExtractTo_CodeBehind_Title">
@@ -25,6 +50,16 @@
       <trans-unit id="File_Externally_Modified">
         <source>File was externally modified: {0}</source>
         <target state="translated">El archivo se modificó externamente: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_operation_changed_diagnostics">
+        <source>A format operation is being abandoned because it would introduce or remove one of more diagnostics.</source>
+        <target state="new">A format operation is being abandoned because it would introduce or remove one of more diagnostics.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_operation_changed_nonwhitespace">
+        <source>A format operation is being abandoned because it would add or delete non-whitespace content.</source>
+        <target state="new">A format operation is being abandoned because it would add or delete non-whitespace content.</target>
         <note />
       </trans-unit>
       <trans-unit id="Generate_Async_Event_Handler_Title">

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.fr.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.fr.xlf
@@ -7,14 +7,39 @@
         <target state="translated">Attributs de directive Blazor</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changes">
+        <source>Changes:</source>
+        <target state="new">Changes:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Create_Component_FromTag_Title">
         <source>Create component from tag</source>
         <target state="translated">Créer un composant à partir de la balise</target>
         <note />
       </trans-unit>
+      <trans-unit id="Diagnostics_after">
+        <source>Diagnostics after:</source>
+        <target state="new">Diagnostics after:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Diagnostics_before">
+        <source>Diagnostics before:</source>
+        <target state="new">Diagnostics before:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Document_Not_Found">
         <source>Document {0} was not found.</source>
         <target state="translated">Le document {0} est introuvable.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Edit_at_adds">
+        <source>Edit at {0} adds the non-whitespace content '{1}'.</source>
+        <target state="new">Edit at {0} adds the non-whitespace content '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Edit_at_deletes">
+        <source>Edit at {0} deletes the non-whitespace content '{1}'.</source>
+        <target state="new">Edit at {0} deletes the non-whitespace content '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExtractTo_CodeBehind_Title">
@@ -25,6 +50,16 @@
       <trans-unit id="File_Externally_Modified">
         <source>File was externally modified: {0}</source>
         <target state="translated">Le fichier a été modifié en externe : {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_operation_changed_diagnostics">
+        <source>A format operation is being abandoned because it would introduce or remove one of more diagnostics.</source>
+        <target state="new">A format operation is being abandoned because it would introduce or remove one of more diagnostics.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_operation_changed_nonwhitespace">
+        <source>A format operation is being abandoned because it would add or delete non-whitespace content.</source>
+        <target state="new">A format operation is being abandoned because it would add or delete non-whitespace content.</target>
         <note />
       </trans-unit>
       <trans-unit id="Generate_Async_Event_Handler_Title">

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.it.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.it.xlf
@@ -7,14 +7,39 @@
         <target state="translated">Attributo per la direttiva Blazor</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changes">
+        <source>Changes:</source>
+        <target state="new">Changes:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Create_Component_FromTag_Title">
         <source>Create component from tag</source>
         <target state="translated">Crea componente da tag</target>
         <note />
       </trans-unit>
+      <trans-unit id="Diagnostics_after">
+        <source>Diagnostics after:</source>
+        <target state="new">Diagnostics after:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Diagnostics_before">
+        <source>Diagnostics before:</source>
+        <target state="new">Diagnostics before:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Document_Not_Found">
         <source>Document {0} was not found.</source>
         <target state="translated">Impossibile trovare il documento{0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Edit_at_adds">
+        <source>Edit at {0} adds the non-whitespace content '{1}'.</source>
+        <target state="new">Edit at {0} adds the non-whitespace content '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Edit_at_deletes">
+        <source>Edit at {0} deletes the non-whitespace content '{1}'.</source>
+        <target state="new">Edit at {0} deletes the non-whitespace content '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExtractTo_CodeBehind_Title">
@@ -25,6 +50,16 @@
       <trans-unit id="File_Externally_Modified">
         <source>File was externally modified: {0}</source>
         <target state="translated">Il file è stato modificato esternamente: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_operation_changed_diagnostics">
+        <source>A format operation is being abandoned because it would introduce or remove one of more diagnostics.</source>
+        <target state="new">A format operation is being abandoned because it would introduce or remove one of more diagnostics.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_operation_changed_nonwhitespace">
+        <source>A format operation is being abandoned because it would add or delete non-whitespace content.</source>
+        <target state="new">A format operation is being abandoned because it would add or delete non-whitespace content.</target>
         <note />
       </trans-unit>
       <trans-unit id="Generate_Async_Event_Handler_Title">

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.ja.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.ja.xlf
@@ -7,14 +7,39 @@
         <target state="translated">Blazor ディレクティブ属性</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changes">
+        <source>Changes:</source>
+        <target state="new">Changes:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Create_Component_FromTag_Title">
         <source>Create component from tag</source>
         <target state="translated">タグからコンポーネントを作成する</target>
         <note />
       </trans-unit>
+      <trans-unit id="Diagnostics_after">
+        <source>Diagnostics after:</source>
+        <target state="new">Diagnostics after:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Diagnostics_before">
+        <source>Diagnostics before:</source>
+        <target state="new">Diagnostics before:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Document_Not_Found">
         <source>Document {0} was not found.</source>
         <target state="translated">ドキュメント {0}が見つかりませんでした。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Edit_at_adds">
+        <source>Edit at {0} adds the non-whitespace content '{1}'.</source>
+        <target state="new">Edit at {0} adds the non-whitespace content '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Edit_at_deletes">
+        <source>Edit at {0} deletes the non-whitespace content '{1}'.</source>
+        <target state="new">Edit at {0} deletes the non-whitespace content '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExtractTo_CodeBehind_Title">
@@ -25,6 +50,16 @@
       <trans-unit id="File_Externally_Modified">
         <source>File was externally modified: {0}</source>
         <target state="translated">ファイルが外部で変更されました: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_operation_changed_diagnostics">
+        <source>A format operation is being abandoned because it would introduce or remove one of more diagnostics.</source>
+        <target state="new">A format operation is being abandoned because it would introduce or remove one of more diagnostics.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_operation_changed_nonwhitespace">
+        <source>A format operation is being abandoned because it would add or delete non-whitespace content.</source>
+        <target state="new">A format operation is being abandoned because it would add or delete non-whitespace content.</target>
         <note />
       </trans-unit>
       <trans-unit id="Generate_Async_Event_Handler_Title">

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.ko.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.ko.xlf
@@ -7,14 +7,39 @@
         <target state="translated">Blazor 지시문 특성</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changes">
+        <source>Changes:</source>
+        <target state="new">Changes:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Create_Component_FromTag_Title">
         <source>Create component from tag</source>
         <target state="translated">태그에서 구성 요소 만들기</target>
         <note />
       </trans-unit>
+      <trans-unit id="Diagnostics_after">
+        <source>Diagnostics after:</source>
+        <target state="new">Diagnostics after:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Diagnostics_before">
+        <source>Diagnostics before:</source>
+        <target state="new">Diagnostics before:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Document_Not_Found">
         <source>Document {0} was not found.</source>
         <target state="translated">문서 {0}을(를) 찾을 수 없습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Edit_at_adds">
+        <source>Edit at {0} adds the non-whitespace content '{1}'.</source>
+        <target state="new">Edit at {0} adds the non-whitespace content '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Edit_at_deletes">
+        <source>Edit at {0} deletes the non-whitespace content '{1}'.</source>
+        <target state="new">Edit at {0} deletes the non-whitespace content '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExtractTo_CodeBehind_Title">
@@ -25,6 +50,16 @@
       <trans-unit id="File_Externally_Modified">
         <source>File was externally modified: {0}</source>
         <target state="translated">{0}의 파일이 외부에서 수정되었습니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_operation_changed_diagnostics">
+        <source>A format operation is being abandoned because it would introduce or remove one of more diagnostics.</source>
+        <target state="new">A format operation is being abandoned because it would introduce or remove one of more diagnostics.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_operation_changed_nonwhitespace">
+        <source>A format operation is being abandoned because it would add or delete non-whitespace content.</source>
+        <target state="new">A format operation is being abandoned because it would add or delete non-whitespace content.</target>
         <note />
       </trans-unit>
       <trans-unit id="Generate_Async_Event_Handler_Title">

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.pl.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.pl.xlf
@@ -7,14 +7,39 @@
         <target state="translated">Atrybut dyrektywy Blazor</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changes">
+        <source>Changes:</source>
+        <target state="new">Changes:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Create_Component_FromTag_Title">
         <source>Create component from tag</source>
         <target state="translated">Utwórz składnik z tagu</target>
         <note />
       </trans-unit>
+      <trans-unit id="Diagnostics_after">
+        <source>Diagnostics after:</source>
+        <target state="new">Diagnostics after:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Diagnostics_before">
+        <source>Diagnostics before:</source>
+        <target state="new">Diagnostics before:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Document_Not_Found">
         <source>Document {0} was not found.</source>
         <target state="translated">Nie znaleziono {0} dokumentu.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Edit_at_adds">
+        <source>Edit at {0} adds the non-whitespace content '{1}'.</source>
+        <target state="new">Edit at {0} adds the non-whitespace content '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Edit_at_deletes">
+        <source>Edit at {0} deletes the non-whitespace content '{1}'.</source>
+        <target state="new">Edit at {0} deletes the non-whitespace content '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExtractTo_CodeBehind_Title">
@@ -25,6 +50,16 @@
       <trans-unit id="File_Externally_Modified">
         <source>File was externally modified: {0}</source>
         <target state="translated">Plik został zmodyfikowany na zewnątrz: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_operation_changed_diagnostics">
+        <source>A format operation is being abandoned because it would introduce or remove one of more diagnostics.</source>
+        <target state="new">A format operation is being abandoned because it would introduce or remove one of more diagnostics.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_operation_changed_nonwhitespace">
+        <source>A format operation is being abandoned because it would add or delete non-whitespace content.</source>
+        <target state="new">A format operation is being abandoned because it would add or delete non-whitespace content.</target>
         <note />
       </trans-unit>
       <trans-unit id="Generate_Async_Event_Handler_Title">

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.pt-BR.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.pt-BR.xlf
@@ -7,14 +7,39 @@
         <target state="translated">Atributos da diretiva Blazor</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changes">
+        <source>Changes:</source>
+        <target state="new">Changes:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Create_Component_FromTag_Title">
         <source>Create component from tag</source>
         <target state="translated">Criar componente a partir da marca</target>
         <note />
       </trans-unit>
+      <trans-unit id="Diagnostics_after">
+        <source>Diagnostics after:</source>
+        <target state="new">Diagnostics after:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Diagnostics_before">
+        <source>Diagnostics before:</source>
+        <target state="new">Diagnostics before:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Document_Not_Found">
         <source>Document {0} was not found.</source>
         <target state="translated">O documento {0} não foi encontrado.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Edit_at_adds">
+        <source>Edit at {0} adds the non-whitespace content '{1}'.</source>
+        <target state="new">Edit at {0} adds the non-whitespace content '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Edit_at_deletes">
+        <source>Edit at {0} deletes the non-whitespace content '{1}'.</source>
+        <target state="new">Edit at {0} deletes the non-whitespace content '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExtractTo_CodeBehind_Title">
@@ -25,6 +50,16 @@
       <trans-unit id="File_Externally_Modified">
         <source>File was externally modified: {0}</source>
         <target state="translated">O arquivo foi modificado externamente: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_operation_changed_diagnostics">
+        <source>A format operation is being abandoned because it would introduce or remove one of more diagnostics.</source>
+        <target state="new">A format operation is being abandoned because it would introduce or remove one of more diagnostics.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_operation_changed_nonwhitespace">
+        <source>A format operation is being abandoned because it would add or delete non-whitespace content.</source>
+        <target state="new">A format operation is being abandoned because it would add or delete non-whitespace content.</target>
         <note />
       </trans-unit>
       <trans-unit id="Generate_Async_Event_Handler_Title">

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.ru.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.ru.xlf
@@ -7,14 +7,39 @@
         <target state="translated">Атрибуты директивы Blazor</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changes">
+        <source>Changes:</source>
+        <target state="new">Changes:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Create_Component_FromTag_Title">
         <source>Create component from tag</source>
         <target state="translated">Создание компонента из тега</target>
         <note />
       </trans-unit>
+      <trans-unit id="Diagnostics_after">
+        <source>Diagnostics after:</source>
+        <target state="new">Diagnostics after:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Diagnostics_before">
+        <source>Diagnostics before:</source>
+        <target state="new">Diagnostics before:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Document_Not_Found">
         <source>Document {0} was not found.</source>
         <target state="translated">Документ {0} не найден.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Edit_at_adds">
+        <source>Edit at {0} adds the non-whitespace content '{1}'.</source>
+        <target state="new">Edit at {0} adds the non-whitespace content '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Edit_at_deletes">
+        <source>Edit at {0} deletes the non-whitespace content '{1}'.</source>
+        <target state="new">Edit at {0} deletes the non-whitespace content '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExtractTo_CodeBehind_Title">
@@ -25,6 +50,16 @@
       <trans-unit id="File_Externally_Modified">
         <source>File was externally modified: {0}</source>
         <target state="translated">Файл был изменен извне: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_operation_changed_diagnostics">
+        <source>A format operation is being abandoned because it would introduce or remove one of more diagnostics.</source>
+        <target state="new">A format operation is being abandoned because it would introduce or remove one of more diagnostics.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_operation_changed_nonwhitespace">
+        <source>A format operation is being abandoned because it would add or delete non-whitespace content.</source>
+        <target state="new">A format operation is being abandoned because it would add or delete non-whitespace content.</target>
         <note />
       </trans-unit>
       <trans-unit id="Generate_Async_Event_Handler_Title">

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.tr.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.tr.xlf
@@ -7,14 +7,39 @@
         <target state="translated">Blazor yönergesi öznitelikleri</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changes">
+        <source>Changes:</source>
+        <target state="new">Changes:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Create_Component_FromTag_Title">
         <source>Create component from tag</source>
         <target state="translated">Etiketten bileşen oluştur</target>
         <note />
       </trans-unit>
+      <trans-unit id="Diagnostics_after">
+        <source>Diagnostics after:</source>
+        <target state="new">Diagnostics after:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Diagnostics_before">
+        <source>Diagnostics before:</source>
+        <target state="new">Diagnostics before:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Document_Not_Found">
         <source>Document {0} was not found.</source>
         <target state="translated">Belge {0} bulunamadı.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Edit_at_adds">
+        <source>Edit at {0} adds the non-whitespace content '{1}'.</source>
+        <target state="new">Edit at {0} adds the non-whitespace content '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Edit_at_deletes">
+        <source>Edit at {0} deletes the non-whitespace content '{1}'.</source>
+        <target state="new">Edit at {0} deletes the non-whitespace content '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExtractTo_CodeBehind_Title">
@@ -25,6 +50,16 @@
       <trans-unit id="File_Externally_Modified">
         <source>File was externally modified: {0}</source>
         <target state="translated">Dosya dışarıdan değiştirildi: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_operation_changed_diagnostics">
+        <source>A format operation is being abandoned because it would introduce or remove one of more diagnostics.</source>
+        <target state="new">A format operation is being abandoned because it would introduce or remove one of more diagnostics.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_operation_changed_nonwhitespace">
+        <source>A format operation is being abandoned because it would add or delete non-whitespace content.</source>
+        <target state="new">A format operation is being abandoned because it would add or delete non-whitespace content.</target>
         <note />
       </trans-unit>
       <trans-unit id="Generate_Async_Event_Handler_Title">

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.zh-Hans.xlf
@@ -7,14 +7,39 @@
         <target state="translated">Blazor 指令特性</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changes">
+        <source>Changes:</source>
+        <target state="new">Changes:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Create_Component_FromTag_Title">
         <source>Create component from tag</source>
         <target state="translated">从标记创建组件</target>
         <note />
       </trans-unit>
+      <trans-unit id="Diagnostics_after">
+        <source>Diagnostics after:</source>
+        <target state="new">Diagnostics after:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Diagnostics_before">
+        <source>Diagnostics before:</source>
+        <target state="new">Diagnostics before:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Document_Not_Found">
         <source>Document {0} was not found.</source>
         <target state="translated">找不到文档 {0}。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Edit_at_adds">
+        <source>Edit at {0} adds the non-whitespace content '{1}'.</source>
+        <target state="new">Edit at {0} adds the non-whitespace content '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Edit_at_deletes">
+        <source>Edit at {0} deletes the non-whitespace content '{1}'.</source>
+        <target state="new">Edit at {0} deletes the non-whitespace content '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExtractTo_CodeBehind_Title">
@@ -25,6 +50,16 @@
       <trans-unit id="File_Externally_Modified">
         <source>File was externally modified: {0}</source>
         <target state="translated">已从外部修改了文件: {0}。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_operation_changed_diagnostics">
+        <source>A format operation is being abandoned because it would introduce or remove one of more diagnostics.</source>
+        <target state="new">A format operation is being abandoned because it would introduce or remove one of more diagnostics.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_operation_changed_nonwhitespace">
+        <source>A format operation is being abandoned because it would add or delete non-whitespace content.</source>
+        <target state="new">A format operation is being abandoned because it would add or delete non-whitespace content.</target>
         <note />
       </trans-unit>
       <trans-unit id="Generate_Async_Event_Handler_Title">

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.zh-Hant.xlf
@@ -7,14 +7,39 @@
         <target state="translated">Blazor 指示詞屬性</target>
         <note />
       </trans-unit>
+      <trans-unit id="Changes">
+        <source>Changes:</source>
+        <target state="new">Changes:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Create_Component_FromTag_Title">
         <source>Create component from tag</source>
         <target state="translated">從標籤建立元件</target>
         <note />
       </trans-unit>
+      <trans-unit id="Diagnostics_after">
+        <source>Diagnostics after:</source>
+        <target state="new">Diagnostics after:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Diagnostics_before">
+        <source>Diagnostics before:</source>
+        <target state="new">Diagnostics before:</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Document_Not_Found">
         <source>Document {0} was not found.</source>
         <target state="translated">找不到文件 {0}。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Edit_at_adds">
+        <source>Edit at {0} adds the non-whitespace content '{1}'.</source>
+        <target state="new">Edit at {0} adds the non-whitespace content '{1}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Edit_at_deletes">
+        <source>Edit at {0} deletes the non-whitespace content '{1}'.</source>
+        <target state="new">Edit at {0} deletes the non-whitespace content '{1}'.</target>
         <note />
       </trans-unit>
       <trans-unit id="ExtractTo_CodeBehind_Title">
@@ -25,6 +50,16 @@
       <trans-unit id="File_Externally_Modified">
         <source>File was externally modified: {0}</source>
         <target state="translated">已在外部修改檔案: {0}</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_operation_changed_diagnostics">
+        <source>A format operation is being abandoned because it would introduce or remove one of more diagnostics.</source>
+        <target state="new">A format operation is being abandoned because it would introduce or remove one of more diagnostics.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Format_operation_changed_nonwhitespace">
+        <source>A format operation is being abandoned because it would add or delete non-whitespace content.</source>
+        <target state="new">A format operation is being abandoned because it would add or delete non-whitespace content.</target>
         <note />
       </trans-unit>
       <trans-unit id="Generate_Async_Event_Handler_Title">


### PR DESCRIPTION
Fixes: https://github.com/dotnet/razor/issues/9616

Logs look like this:

```
A format operation is being abandoned because it would introduce or remove one of more diagnostics.
Diagnostics before:
Diagnostics after:
/path/to/document.razor(1,2): Error RZ1003: A space or line break was encountered after the "@" character.  Only valid identifiers, keywords, comments, "(" and "{" are valid at the start of a code block and they must occur immediately following "@" with no space in between.
```

and

```
A format operation is being abandoned because it would add or delete non-whitespace content.
Edit at (2, 0)-(3, 0) deletes the non-whitespace content 'public class Foo { }
'.
```

or mabye

```
A format operation is being abandoned because it would add or delete non-whitespace content.
Edit at (2, 0)-(3, 0) adds the non-whitespace content '   f '.
```
