### PR TITLE
Enable and implement "Auto list members" and "Parameter information" …

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCompletionBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCompletionBenchmark.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Completion;
 using Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
+using Microsoft.AspNetCore.Razor.Microbenchmarks.Serialization;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -43,7 +44,9 @@ public class RazorCompletionBenchmark : RazorLanguageServerBenchmarkBase
 
         var delegatedCompletionListProvider = new TestDelegatedCompletionListProvider(responseRewriters, documentMappingService, clientConnection, completionListCache);
         var completionListProvider = new CompletionListProvider(razorCompletionListProvider, delegatedCompletionListProvider);
-        CompletionEndpoint = new RazorCompletionEndpoint(completionListProvider, telemetryReporter: null);
+        var optionsMonitor = new BenchmarkOptionsMonitor<RazorLSPOptions>(RazorLSPOptions.Default);
+
+        CompletionEndpoint = new RazorCompletionEndpoint(completionListProvider, telemetryReporter: null, optionsMonitor);
 
         var clientCapabilities = new VSInternalClientCapabilities
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorConfigurationService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorConfigurationService.cs
@@ -167,6 +167,11 @@ internal class DefaultRazorConfigurationService : IConfigurationSyncService
                 settings = settings with { ClientSpaceSettings = ClientSpaceSettings.Default };
             }
 
+            if (settings.ClientCompletionSettings is null)
+            {
+                settings = settings with { ClientCompletionSettings = ClientCompletionSettings.Default };
+            }
+
             if (settings.AdvancedSettings is null)
             {
                 settings = settings with { AdvancedSettings = ClientAdvancedSettings.Default };

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLSPOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLSPOptions.cs
@@ -12,17 +12,39 @@ internal record RazorLSPOptions(
     bool AutoClosingTags,
     bool InsertSpaces,
     int TabSize,
+    bool AutoShowCompletion,
+    bool AutoListParams,
     bool FormatOnType,
     bool AutoInsertAttributeQuotes,
     bool ColorBackground,
     bool CommitElementsWithSpace)
 {
     public RazorLSPOptions(Trace trace, bool enableFormatting, bool autoClosingTags, bool commitElementsWithSpace, ClientSettings settings)
-        : this(trace, enableFormatting, autoClosingTags, !settings.ClientSpaceSettings.IndentWithTabs, settings.ClientSpaceSettings.IndentSize, settings.AdvancedSettings.FormatOnType, settings.AdvancedSettings.AutoInsertAttributeQuotes, settings.AdvancedSettings.ColorBackground, commitElementsWithSpace)
+        : this(trace,
+              enableFormatting,
+              autoClosingTags,
+              !settings.ClientSpaceSettings.IndentWithTabs,
+              settings.ClientSpaceSettings.IndentSize,
+              settings.ClientCompletionSettings.AutoShowCompletion,
+              settings.ClientCompletionSettings.AutoListParams,
+              settings.AdvancedSettings.FormatOnType,
+              settings.AdvancedSettings.AutoInsertAttributeQuotes,
+              settings.AdvancedSettings.ColorBackground,
+              commitElementsWithSpace)
     {
     }
 
-    public readonly static RazorLSPOptions Default = new(Trace: default, EnableFormatting: true, AutoClosingTags: true, InsertSpaces: true, TabSize: 4, FormatOnType: true, AutoInsertAttributeQuotes: true, ColorBackground: false, CommitElementsWithSpace: true);
+    public readonly static RazorLSPOptions Default = new(Trace: default,
+                                                         EnableFormatting: true,
+                                                         AutoClosingTags: true,
+                                                         AutoListParams:true,
+                                                         InsertSpaces: true,
+                                                         TabSize: 4,
+                                                         AutoShowCompletion: true,
+                                                         FormatOnType: true,
+                                                         AutoInsertAttributeQuotes: true,
+                                                         ColorBackground: false,
+                                                         CommitElementsWithSpace: true);
 
     public LogLevel MinLogLevel => GetLogLevelForTrace(Trace);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SignatureHelp/SignatureHelpEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SignatureHelp/SignatureHelpEndpoint.cs
@@ -47,7 +47,7 @@ internal sealed class SignatureHelpEndpoint : AbstractRazorDelegatingEndpoint<Si
         if (request.Context is not null && request.Context.TriggerKind != SignatureHelpTriggerKind.Invoked && !_optionsMonitor.CurrentValue.AutoListParams)
         {
             // Return nothing is "Parameter Information" option is disabled unless signature help is invoked explicitly via command as opposed to typing or content change
-            return Task.FromResult((IDelegatedParams?)null);
+            return Task.FromResult<IDelegatedParams?>(null);
         }
 
         var documentContext = requestContext.GetRequiredDocumentContext();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SignatureHelp/SignatureHelpEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SignatureHelp/SignatureHelpEndpoint.cs
@@ -16,21 +16,19 @@ using LS = Microsoft.VisualStudio.LanguageServer.Protocol;
 namespace Microsoft.AspNetCore.Razor.LanguageServer.SignatureHelp;
 
 [LanguageServerEndpoint(Methods.TextDocumentSignatureHelpName)]
-internal sealed class SignatureHelpEndpoint : AbstractRazorDelegatingEndpoint<SignatureHelpParams, LS.SignatureHelp?>, ICapabilitiesProvider
-{
-    private readonly IOptionsMonitor<RazorLSPOptions> _optionsMonitor;
-
-    public SignatureHelpEndpoint(
+internal sealed class SignatureHelpEndpoint(
         LanguageServerFeatureOptions languageServerFeatureOptions,
         IRazorDocumentMappingService documentMappingService,
         IClientConnection clientConnection,
         IOptionsMonitor<RazorLSPOptions> optionsMonitor,
         ILoggerFactory loggerProvider)
-        : base(languageServerFeatureOptions, documentMappingService, clientConnection, loggerProvider.CreateLogger<SignatureHelpEndpoint>())
-    {
-        _optionsMonitor = optionsMonitor;
-    }
-
+    : AbstractRazorDelegatingEndpoint<SignatureHelpParams, LS.SignatureHelp?>(
+        languageServerFeatureOptions,
+        documentMappingService,
+        clientConnection,
+        loggerProvider.CreateLogger<SignatureHelpEndpoint>()),
+    ICapabilitiesProvider
+{
     protected override string CustomMessageTarget => CustomMessageNames.RazorSignatureHelpEndpointName;
 
     public void ApplyCapabilities(VSInternalServerCapabilities serverCapabilities, VSInternalClientCapabilities clientCapabilities)
@@ -44,7 +42,7 @@ internal sealed class SignatureHelpEndpoint : AbstractRazorDelegatingEndpoint<Si
 
     protected override Task<IDelegatedParams?> CreateDelegatedParamsAsync(SignatureHelpParams request, RazorRequestContext requestContext, DocumentPositionInfo positionInfo, CancellationToken cancellationToken)
     {
-        if (request.Context is not null && request.Context.TriggerKind != SignatureHelpTriggerKind.Invoked && !_optionsMonitor.CurrentValue.AutoListParams)
+        if (request.Context is not null && request.Context.TriggerKind != SignatureHelpTriggerKind.Invoked && !optionsMonitor.CurrentValue.AutoListParams)
         {
             // Return nothing is "Parameter Information" option is disabled unless signature help is invoked explicitly via command as opposed to typing or content change
             return Task.FromResult<IDelegatedParams?>(null);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SignatureHelp/SignatureHelpEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SignatureHelp/SignatureHelpEndpoint.cs
@@ -44,7 +44,7 @@ internal sealed class SignatureHelpEndpoint(
     {
         if (request.Context is not null && request.Context.TriggerKind != SignatureHelpTriggerKind.Invoked && !optionsMonitor.CurrentValue.AutoListParams)
         {
-            // Return nothing is "Parameter Information" option is disabled unless signature help is invoked explicitly via command as opposed to typing or content change
+            // Return nothing if "Parameter Information" option is disabled unless signature help is invoked explicitly via command as opposed to typing or content change
             return Task.FromResult<IDelegatedParams?>(null);
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SignatureHelp/SignatureHelpEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SignatureHelp/SignatureHelpEndpoint.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using LS = Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -17,13 +18,17 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.SignatureHelp;
 [LanguageServerEndpoint(Methods.TextDocumentSignatureHelpName)]
 internal sealed class SignatureHelpEndpoint : AbstractRazorDelegatingEndpoint<SignatureHelpParams, LS.SignatureHelp?>, ICapabilitiesProvider
 {
+    private readonly IOptionsMonitor<RazorLSPOptions> _optionsMonitor;
+
     public SignatureHelpEndpoint(
         LanguageServerFeatureOptions languageServerFeatureOptions,
         IRazorDocumentMappingService documentMappingService,
         IClientConnection clientConnection,
+        IOptionsMonitor<RazorLSPOptions> optionsMonitor,
         ILoggerFactory loggerProvider)
         : base(languageServerFeatureOptions, documentMappingService, clientConnection, loggerProvider.CreateLogger<SignatureHelpEndpoint>())
     {
+        _optionsMonitor = optionsMonitor;
     }
 
     protected override string CustomMessageTarget => CustomMessageNames.RazorSignatureHelpEndpointName;
@@ -39,6 +44,12 @@ internal sealed class SignatureHelpEndpoint : AbstractRazorDelegatingEndpoint<Si
 
     protected override Task<IDelegatedParams?> CreateDelegatedParamsAsync(SignatureHelpParams request, RazorRequestContext requestContext, DocumentPositionInfo positionInfo, CancellationToken cancellationToken)
     {
+        if (request.Context is not null && request.Context.TriggerKind != SignatureHelpTriggerKind.Invoked && !_optionsMonitor.CurrentValue.AutoListParams)
+        {
+            // Return nothing is "Parameter Information" option is disabled unless signature help is invoked explicitly via command as opposed to typing or content change
+            return Task.FromResult((IDelegatedParams?)null);
+        }
+
         var documentContext = requestContext.GetRequiredDocumentContext();
         return Task.FromResult<IDelegatedParams?>(new DelegatedPositionParams(
                 documentContext.Identifier,

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Editor/ClientSettings.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Editor/ClientSettings.cs
@@ -12,10 +12,16 @@ namespace Microsoft.CodeAnalysis.Razor.Editor;
 /// settings back to the server.
 /// </summary>
 /// <param name="ClientSpaceSettings"></param>
+/// <param name="ClientCompletionSettings"></param>
 /// <param name="AdvancedSettings"></param>
-internal record ClientSettings(ClientSpaceSettings ClientSpaceSettings, ClientAdvancedSettings AdvancedSettings)
+internal record ClientSettings(ClientSpaceSettings ClientSpaceSettings, ClientCompletionSettings ClientCompletionSettings, ClientAdvancedSettings AdvancedSettings)
 {
-    public static readonly ClientSettings Default = new(ClientSpaceSettings.Default, ClientAdvancedSettings.Default);
+    public static readonly ClientSettings Default = new(ClientSpaceSettings.Default, ClientCompletionSettings.Default, ClientAdvancedSettings.Default);
+}
+
+internal sealed record ClientCompletionSettings(bool AutoShowCompletion, bool AutoListParams)
+{
+    public static readonly ClientCompletionSettings Default = new(AutoShowCompletion: true, AutoListParams: true);
 }
 
 internal sealed record ClientSpaceSettings(bool IndentWithTabs, int IndentSize)

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/ClientSettingsManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/ClientSettingsManager.cs
@@ -74,6 +74,19 @@ internal class ClientSettingsManager : EditorSettingsManager, IClientSettingsMan
         }
     }
 
+    public void Update(ClientCompletionSettings updatedSettings)
+    {
+        if (updatedSettings is null)
+        {
+            throw new ArgumentNullException(nameof(updatedSettings));
+        }
+
+        lock (_settingsUpdateLock)
+        {
+            UpdateSettings_NoLock(_settings with { ClientCompletionSettings = updatedSettings });
+        }
+    }
+
     public ClientSettings GetClientSettings() => _settings;
 
     public void Update(ClientAdvancedSettings advancedSettings)

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/IClientSettingsManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/IClientSettingsManager.cs
@@ -12,6 +12,8 @@ internal interface IClientSettingsManager
 
     void Update(ClientSpaceSettings updateSettings);
 
+    void Update(ClientCompletionSettings updateSettings);
+
     void Update(ClientAdvancedSettings updateSettings);
 
     ClientSettings GetClientSettings();

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorLSPTextViewConnectionListener.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorLSPTextViewConnectionListener.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Razor.Editor;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Editor.Razor;
+using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.OLE.Interop;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
@@ -218,11 +219,12 @@ internal class RazorLSPTextViewConnectionListener : ITextViewConnectionListener
 
         // Retrieve current space/tabs settings from from Tools->Options and update options in
         // the actual editor.
-        var settings = UpdateRazorEditorOptions(_textManager, optionsTracker);
+        (ClientSpaceSettings ClientSpaceSettings, ClientCompletionSettings ClientCompletionSettings) settings = UpdateRazorEditorOptions(_textManager, optionsTracker);
 
         // Keep track of accurate settings on the client side so we can easily retrieve the
         // options later when the server sends us a workspace/configuration request.
-        _editorSettingsManager.Update(settings);
+        _editorSettingsManager.Update(settings.ClientSpaceSettings);
+        _editorSettingsManager.Update(settings.ClientCompletionSettings);
     }
 
     private static void InitializeRazorTextViewOptions(IVsTextManager4 textManager, RazorEditorOptionsTracker optionsTracker)
@@ -252,6 +254,9 @@ internal class RazorLSPTextViewConnectionListener : ITextViewConnectionListener
         optionsTracker.ViewOptions.SetOptionValue(DefaultTextViewOptions.BraceCompletionEnabledOptionName, Convert.ToBoolean(langPrefs3[0].fBraceCompletion));
         optionsTracker.ViewOptions.SetOptionValue(DefaultTextViewOptions.CutOrCopyBlankLineIfNoSelectionName, Convert.ToBoolean(langPrefs3[0].fCutCopyBlanks));
 
+        // Completion options
+        optionsTracker.ViewOptions.SetOptionValue(DefaultLanguageOptions.ShowCompletionOnTypeCharName, Convert.ToBoolean(langPrefs3[0].fAutoListMembers));
+
         // Scroll bar options
         optionsTracker.ViewOptions.SetOptionValue(DefaultTextViewHostOptions.HorizontalScrollBarName, Convert.ToBoolean(langPrefs3[0].fShowHorizontalScrollBar));
         optionsTracker.ViewOptions.SetOptionValue(DefaultTextViewHostOptions.VerticalScrollBarName, Convert.ToBoolean(langPrefs3[0].fShowVerticalScrollBar));
@@ -265,7 +270,7 @@ internal class RazorLSPTextViewConnectionListener : ITextViewConnectionListener
         optionsTracker.ViewOptions.SetOptionValue(DefaultTextViewHostOptions.PreviewSizeOptionName, (int)langPrefs3[0].uOverviewWidth);
     }
 
-    private static ClientSpaceSettings UpdateRazorEditorOptions(IVsTextManager4 textManager, RazorEditorOptionsTracker optionsTracker)
+    private static (ClientSpaceSettings, ClientCompletionSettings) UpdateRazorEditorOptions(IVsTextManager4 textManager, RazorEditorOptionsTracker optionsTracker)
     {
         var insertSpaces = true;
         var tabSize = 4;
@@ -273,12 +278,16 @@ internal class RazorLSPTextViewConnectionListener : ITextViewConnectionListener
         var langPrefs3 = new LANGPREFERENCES3[] { new LANGPREFERENCES3() { guidLang = RazorVisualStudioWindowsConstants.RazorLanguageServiceGuid } };
         if (VSConstants.S_OK != textManager.GetUserPreferences4(null, langPrefs3, null))
         {
-            return new ClientSpaceSettings(IndentWithTabs: !insertSpaces, tabSize);
+            return (new ClientSpaceSettings(IndentWithTabs: !insertSpaces, tabSize), ClientCompletionSettings.Default);
         }
 
         // Tabs options
         insertSpaces = !Convert.ToBoolean(langPrefs3[0].fInsertTabs);
         tabSize = (int)langPrefs3[0].uTabSize;
+
+        // Completion options
+        var autoShowCompletion = Convert.ToBoolean(langPrefs3[0].fAutoListMembers);
+        var autoListParams = Convert.ToBoolean(langPrefs3[0].fAutoListParams);
 
         optionsTracker.ViewOptions.SetOptionValue(DefaultOptions.ConvertTabsToSpacesOptionId, insertSpaces);
         optionsTracker.ViewOptions.SetOptionValue(DefaultOptions.TabSizeOptionId, tabSize);
@@ -289,7 +298,7 @@ internal class RazorLSPTextViewConnectionListener : ITextViewConnectionListener
         optionsTracker.BufferOptions.SetOptionValue(DefaultOptions.ConvertTabsToSpacesOptionId, insertSpaces);
         optionsTracker.BufferOptions.SetOptionValue(DefaultOptions.TabSizeOptionId, tabSize);
 
-        return new ClientSpaceSettings(IndentWithTabs: !insertSpaces, tabSize);
+        return (new ClientSpaceSettings(IndentWithTabs: !insertSpaces, tabSize), new ClientCompletionSettings(autoShowCompletion, autoListParams));
     }
 
     private class RazorLSPTextViewFilter : IOleCommandTarget, IVsTextViewFilter

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
@@ -34,6 +34,7 @@
 [$RootKey$\Languages\Language Services\Razor]
 @="{4513FA64-5B72-4B58-9D4C-1D3C81996C2C}"
 "Package"="{13b72f58-279e-49e0-a56d-296be02f0805}"
+"ShowCompletion"=dword:00000001
 "ShowBraceCompletion"=dword:00000001
 "ShowSmartIndent"=dword:00000001
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndToEndTest.NetFx.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndToEndTest.NetFx.cs
@@ -716,6 +716,8 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : SingleServer
             AutoClosingTags: true,
             insertSpaces,
             tabSize,
+            AutoShowCompletion: true,
+            AutoListParams: true,
             FormatOnType: true,
             AutoInsertAttributeQuotes: true,
             ColorBackground: false,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Xunit;
@@ -19,7 +20,8 @@ public class RazorCompletionEndpointTest(ITestOutputHelper testOutput) : Languag
     {
         // Arrange
         var documentPath = "C:/path/to/document.cshtml";
-        var completionEndpoint = new RazorCompletionEndpoint(completionListProvider: null, telemetryReporter: null);
+        var optionsMonitor = GetOptionsMonitor();
+        var completionEndpoint = new RazorCompletionEndpoint(completionListProvider: null, telemetryReporter: null, optionsMonitor);
         var request = new CompletionParams()
         {
             TextDocument = new TextDocumentIdentifier()
@@ -36,5 +38,41 @@ public class RazorCompletionEndpointTest(ITestOutputHelper testOutput) : Languag
 
         // Assert
         Assert.Null(completionList);
+    }
+
+    [Fact]
+    public async Task Handle_AutoShowCompletionDisabled_NoCompletionItems()
+    {
+        // Arrange
+        var codeDocument = CreateCodeDocument();
+        var documentPath = "C:/path/to/document.cshtml";
+        var uri = new Uri(documentPath);
+        var documentContext = CreateDocumentContext(uri, codeDocument);
+        var optionsMonitor = GetOptionsMonitor(autoShowCompletion: false);
+        var completionEndpoint = new RazorCompletionEndpoint(completionListProvider: null, telemetryReporter: null, optionsMonitor);
+        var request = new CompletionParams()
+        {
+            TextDocument = new TextDocumentIdentifier()
+            {
+                Uri = uri
+            },
+            Position = new Position(0, 1),
+            Context = new VSInternalCompletionContext() { InvokeKind = VSInternalCompletionInvokeKind.Typing },
+        };
+        var requestContext = CreateRazorRequestContext(documentContext);
+
+        // Act
+        var completionList = await Task.Run(() => completionEndpoint.HandleRequestAsync(request, requestContext, default));
+
+        // Assert
+        Assert.Null(completionList);
+    }
+
+    private static RazorCodeDocument CreateCodeDocument()
+    {
+        return CreateCodeDocument("""
+
+            @{ }
+            """);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorConfigurationServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorConfigurationServiceTest.cs
@@ -21,7 +21,7 @@ public class DefaultRazorConfigurationServiceTest(ITestOutputHelper testOutput) 
     {
         // Arrange
         var expectedOptions = new RazorLSPOptions(
-            Trace.Messages, EnableFormatting: false, AutoClosingTags: false, InsertSpaces: true, TabSize: 4, FormatOnType: true, AutoInsertAttributeQuotes: true, ColorBackground: false, CommitElementsWithSpace: false);
+            Trace.Messages, EnableFormatting: false, AutoClosingTags: false, InsertSpaces: true, TabSize: 4, AutoShowCompletion: true, AutoListParams: true, FormatOnType: true, AutoInsertAttributeQuotes: true, ColorBackground: false, CommitElementsWithSpace: false);
         var razorJsonString =
             """
 
@@ -93,7 +93,7 @@ public class DefaultRazorConfigurationServiceTest(ITestOutputHelper testOutput) 
     {
         // Arrange - purposely choosing options opposite of default
         var expectedOptions = new RazorLSPOptions(
-            Trace.Verbose, EnableFormatting: false, AutoClosingTags: false, InsertSpaces: true, TabSize: 4, FormatOnType: true, AutoInsertAttributeQuotes: true, ColorBackground: false, CommitElementsWithSpace: false);
+            Trace.Verbose, EnableFormatting: false, AutoClosingTags: false, InsertSpaces: true, TabSize: 4, AutoShowCompletion: true, AutoListParams: true, FormatOnType: true, AutoInsertAttributeQuotes: true, ColorBackground: false, CommitElementsWithSpace: false);
         var razorJsonString = """
             {
               "trace": "Verbose",
@@ -130,7 +130,7 @@ public class DefaultRazorConfigurationServiceTest(ITestOutputHelper testOutput) 
     {
         // Arrange - purposely choosing options opposite of default
         var expectedOptions = new RazorLSPOptions(
-            Trace.Off, EnableFormatting: true, AutoClosingTags: false, InsertSpaces: false, TabSize: 8, FormatOnType: false, AutoInsertAttributeQuotes: false, ColorBackground: false, CommitElementsWithSpace: false);
+            Trace.Off, EnableFormatting: true, AutoClosingTags: false, InsertSpaces: false, TabSize: 8, AutoShowCompletion: true, AutoListParams: true, FormatOnType: false, AutoInsertAttributeQuotes: false, ColorBackground: false, CommitElementsWithSpace: false);
         var razorJsonString = """
             {
             }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLSPOptionsMonitorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLSPOptionsMonitorTest.cs
@@ -28,7 +28,7 @@ public class RazorLSPOptionsMonitorTest : ToolingTestBase
     public async Task UpdateAsync_Invokes_OnChangeRegistration()
     {
         // Arrange
-        var expectedOptions = new RazorLSPOptions(Trace.Messages, EnableFormatting: false, AutoClosingTags: true, InsertSpaces: true, TabSize: 4, FormatOnType: true, AutoInsertAttributeQuotes: true, ColorBackground: false, CommitElementsWithSpace: true);
+        var expectedOptions = new RazorLSPOptions(Trace.Messages, EnableFormatting: false, AutoClosingTags: true, InsertSpaces: true, TabSize: 4, AutoShowCompletion: true, AutoListParams: true, FormatOnType: true, AutoInsertAttributeQuotes: true, ColorBackground: false, CommitElementsWithSpace: true);
         var configService = Mock.Of<IConfigurationSyncService>(
             f => f.GetLatestOptionsAsync(DisposalToken) == Task.FromResult(expectedOptions),
             MockBehavior.Strict);
@@ -50,7 +50,7 @@ public class RazorLSPOptionsMonitorTest : ToolingTestBase
     public async Task UpdateAsync_DoesNotInvoke_OnChangeRegistration_AfterDispose()
     {
         // Arrange
-        var expectedOptions = new RazorLSPOptions(Trace.Messages, EnableFormatting: false, AutoClosingTags: true, InsertSpaces: true, TabSize: 4, FormatOnType: true, AutoInsertAttributeQuotes: true, ColorBackground: false, CommitElementsWithSpace: true);
+        var expectedOptions = new RazorLSPOptions(Trace.Messages, EnableFormatting: false, AutoClosingTags: true, InsertSpaces: true, TabSize: 4, AutoShowCompletion: true, AutoListParams: true, FormatOnType: true, AutoInsertAttributeQuotes: true, ColorBackground: false, CommitElementsWithSpace: true);
         var configService = Mock.Of<IConfigurationSyncService>(
             f => f.GetLatestOptionsAsync(DisposalToken) == Task.FromResult(expectedOptions),
             MockBehavior.Strict);
@@ -96,7 +96,7 @@ public class RazorLSPOptionsMonitorTest : ToolingTestBase
     public void InitializedOptionsAreCurrent()
     {
         // Arrange
-        var expectedOptions = new RazorLSPOptions(Trace.Messages, EnableFormatting: false, AutoClosingTags: true, InsertSpaces: true, TabSize: 4, FormatOnType: true, AutoInsertAttributeQuotes: true, ColorBackground: false, CommitElementsWithSpace: true);
+        var expectedOptions = new RazorLSPOptions(Trace.Messages, EnableFormatting: false, AutoClosingTags: true, InsertSpaces: true, TabSize: 4, AutoShowCompletion: true, AutoListParams: true, FormatOnType: true, AutoInsertAttributeQuotes: true, ColorBackground: false, CommitElementsWithSpace: true);
         var configService = Mock.Of<IConfigurationSyncService>(
             f => f.GetLatestOptionsAsync(DisposalToken) == Task.FromResult(expectedOptions),
             MockBehavior.Strict);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/LanguageServerTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/LanguageServerTestBase.cs
@@ -117,10 +117,10 @@ public abstract class LanguageServerTestBase : ToolingTestBase
         return new VersionedDocumentContext(uri, snapshot, projectContext: null, version: 0);
     }
 
-    internal static IOptionsMonitor<RazorLSPOptions> GetOptionsMonitor(bool enableFormatting = true, bool formatOnType = true, bool autoInsertAttributeQuotes = true, bool colorBackground = false, bool commitElementsWithSpace = true)
+    internal static IOptionsMonitor<RazorLSPOptions> GetOptionsMonitor(bool enableFormatting = true, bool autoShowCompletion = true, bool autoListParams = true, bool formatOnType = true, bool autoInsertAttributeQuotes = true, bool colorBackground = false, bool commitElementsWithSpace = true)
     {
         var monitor = new Mock<IOptionsMonitor<RazorLSPOptions>>(MockBehavior.Strict);
-        monitor.SetupGet(m => m.CurrentValue).Returns(new RazorLSPOptions(default, enableFormatting, true, InsertSpaces: true, TabSize: 4, formatOnType, autoInsertAttributeQuotes, colorBackground, commitElementsWithSpace));
+        monitor.SetupGet(m => m.CurrentValue).Returns(new RazorLSPOptions(default, enableFormatting, true, InsertSpaces: true, TabSize: 4, autoShowCompletion, autoListParams, formatOnType, autoInsertAttributeQuotes, colorBackground, commitElementsWithSpace));
         return monitor.Object;
     }
 

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultWorkspaceEditorSettingsTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultWorkspaceEditorSettingsTest.cs
@@ -22,7 +22,7 @@ public class DefaultWorkspaceEditorSettingsTest : ProjectSnapshotManagerDispatch
     public void InitialSettingsAreEditorSettingsManagerDefault()
     {
         // Arrange
-        var settings = new ClientSettings(new ClientSpaceSettings(true, 123), ClientAdvancedSettings.Default);
+        var settings = new ClientSettings(new ClientSpaceSettings(true, 123), ClientCompletionSettings.Default, ClientAdvancedSettings.Default);
         var editorSettingsManager = Mock.Of<IClientSettingsManager>(m => m.GetClientSettings() == settings, MockBehavior.Strict);
 
         // Act


### PR DESCRIPTION
We have several completion issues where we show too much information in the completion list. Ideally of course we should show relevant information only, but meanwhile this PR enables and implements options to disable completion if it starts getting in the way. It enables "Statement completion" section of Razor LSP language service and allows to disable "Auto list members" and "Parameter information". We didn't really need to disable parameter information that much but you can't leave that option disabled if you enable "Auto list members" option, so this PR implements both.

-

Fixes: #6620
