### PR TITLE
Add `global::` prefix to `System.Action`

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Intermediate/ReferenceCaptureIntermediateNode.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Intermediate/ReferenceCaptureIntermediateNode.cs
@@ -39,7 +39,7 @@ public sealed class ReferenceCaptureIntermediateNode : IntermediateNode
 
     public string FieldTypeName => IsComponentCapture ? ComponentCaptureTypeName : $"global::{ComponentsApi.ElementReference.FullTypeName}";
 
-    public string TypeName => $"System.Action<{FieldTypeName}>";
+    public string TypeName => $"global::System.Action<{FieldTypeName}>";
 
     public override void Accept(IntermediateNodeVisitor visitor)
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentCodeGenerationTestBase.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentCodeGenerationTestBase.cs
@@ -8339,6 +8339,23 @@ namespace Test
         CompileToAssembly(generated);
     }
 
+    [IntegrationTestFact, WorkItem("https://github.com/dotnet/razor/issues/9625")]
+    public void Component_WithRef_Generic_SystemInNamespace()
+    {
+        var generated = CompileToCSharp("""
+            @namespace X.Y.System.Z
+            @typeparam T
+
+            <TestComponent Param="Param" @ref="comp" />
+
+            @code {
+                private TestComponent<T?>? comp;
+                [Parameter] public T? Param { get; set; }
+            }
+            """, nullableEnable: true);
+        CompileToAssembly(generated);
+    }
+
     #endregion
 
     #region Templates

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithRef_Nullable_Generic/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/Component_WithRef_Nullable_Generic/TestComponent.codegen.cs
@@ -74,7 +74,7 @@ namespace __Blazor.Test.TestComponent
     #line hidden
     internal static class TypeInference
     {
-        public static global::Test.MyComponent<T> CreateMyComponent_0<T>(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder, int seq, int __seq0, T __arg0, int __seq1, System.Action<global::Test.MyComponent<T>> __arg1)
+        public static global::Test.MyComponent<T> CreateMyComponent_0<T>(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder, int seq, int __seq0, T __arg0, int __seq1, global::System.Action<global::Test.MyComponent<T>> __arg1)
         {
         __builder.OpenComponent<global::Test.MyComponent<T>>(seq);
         __builder.AddAttribute(__seq0, "MyParameter", (object)__arg0);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponent_WithComponentRef_TypeInference_CreatesDiagnostic/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/GenericComponent_WithComponentRef_TypeInference_CreatesDiagnostic/TestComponent.codegen.cs
@@ -74,7 +74,7 @@ namespace __Blazor.Test.TestComponent
     #line hidden
     internal static class TypeInference
     {
-        public static global::Test.MyComponent<TItem> CreateMyComponent_0<TItem>(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder, int seq, int __seq0, TItem __arg0, int __seq1, System.Action<global::Test.MyComponent<TItem>> __arg1)
+        public static global::Test.MyComponent<TItem> CreateMyComponent_0<TItem>(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder, int seq, int __seq0, TItem __arg0, int __seq1, global::System.Action<global::Test.MyComponent<TItem>> __arg1)
         {
         __builder.OpenComponent<global::Test.MyComponent<TItem>>(seq);
         __builder.AddAttribute(__seq0, "Item", (object)__arg0);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithRef_Nullable_Generic/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithRef_Nullable_Generic/TestComponent.codegen.cs
@@ -49,7 +49,7 @@ namespace __Blazor.Test.TestComponent
     #line hidden
     internal static class TypeInference
     {
-        public static void CreateMyComponent_0<T>(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder, int seq, int __seq0, T __arg0, int __seq1, System.Action<global::Test.MyComponent<T>> __arg1)
+        public static void CreateMyComponent_0<T>(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder, int seq, int __seq0, T __arg0, int __seq1, global::System.Action<global::Test.MyComponent<T>> __arg1)
         {
         __builder.OpenComponent<global::Test.MyComponent<T>>(seq);
         __builder.AddComponentParameter(__seq0, "MyParameter", __arg0);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithComponentRef_TypeInference_CreatesDiagnostic/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithComponentRef_TypeInference_CreatesDiagnostic/TestComponent.codegen.cs
@@ -49,7 +49,7 @@ namespace __Blazor.Test.TestComponent
     #line hidden
     internal static class TypeInference
     {
-        public static void CreateMyComponent_0<TItem>(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder, int seq, int __seq0, TItem __arg0, int __seq1, System.Action<global::Test.MyComponent<TItem>> __arg1)
+        public static void CreateMyComponent_0<TItem>(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder, int seq, int __seq0, TItem __arg0, int __seq1, global::System.Action<global::Test.MyComponent<TItem>> __arg1)
         {
         __builder.OpenComponent<global::Test.MyComponent<TItem>>(seq);
         __builder.AddComponentParameter(__seq0, "Item", __arg0);


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/9625.