### PR TITLE
Enable precise ranges by default

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
@@ -48,7 +48,7 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
         _usePreciseSemanticTokenRanges = new Lazy<bool>(() =>
         {
             var featureFlags = (IVsFeatureFlags)AsyncPackage.GetGlobalService(typeof(SVsFeatureFlags));
-            var usePreciseSemanticTokenRanges = featureFlags.IsFeatureEnabled(UsePreciseSemanticTokenRangesFeatureFlag, defaultValue: false);
+            var usePreciseSemanticTokenRanges = featureFlags.IsFeatureEnabled(UsePreciseSemanticTokenRangesFeatureFlag, defaultValue: true);
             return usePreciseSemanticTokenRanges;
         });
     }

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
@@ -57,7 +57,7 @@
 
 [$RootKey$\FeatureFlags\Razor\LSP\UsePreciseSemanticTokenRanges]
 "Description"="Use precise semantic token ranges when requesting semantic token information on razor files. Note: This is experimental, some actions may not apply correctly, or at all!"
-"Value"=dword:00000000
+"Value"=dword:00000001
 "Title"="Use precise semantic token ranges when requesting semantic token information on Razor files (requires restart)"
 "PreviewPaneChannels"="*"
 "VisibleToInternalUsersOnlyChannels"="*"


### PR DESCRIPTION
﻿### Summary of the changes

- Enable precise ranges by default to run a validation build for this.

Related to PR https://github.com/dotnet/razor/pull/9304