### PR TITLE
Ship release/dev17.9 to VS main until VS snap

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -51,7 +51,7 @@
         "Shipping",
         "NonShipping"
       ],
-      "vsBranch": "rel/d17.9",
+      "vsBranch": "main",
       "vsMajorVersion": 17,
       "insertionTitlePrefix": "[17.9P2]"
     }


### PR DESCRIPTION
We need to insert these release branch builds into main until VS snaps on Friday.

I'll try and update docs to more clearly indicate this step so that it's easier to get right in future.