### PR TITLE
Change pipelines to 'non-scouting'

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,10 +83,10 @@ stages:
           pool:
             ${{ if eq(variables['System.TeamProject'], 'public') }}:
               name: $(DncEngPublicBuildPool)
-              demands: ImageOverride -equals windows.vs2022preview.scout.amd64.open
+              demands: ImageOverride -equals windows.vs2022preview.amd64.open
             ${{ if ne(variables['System.TeamProject'], 'public') }}:
               name: $(DncEngInternalBuildPool)
-              demands: ImageOverride -equals windows.vs2022preview.scout.amd64
+              demands: ImageOverride -equals windows.vs2022preview.amd64
           steps:
           - task: NodeTool@0
             displayName: Install Node 10.x
@@ -131,10 +131,10 @@ stages:
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: $(DncEngPublicBuildPool)
-            demands: ImageOverride -equals windows.vs2022preview.scout.amd64.open
+            demands: ImageOverride -equals windows.vs2022preview.amd64.open
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.vs2022preview.scout.amd64
+            demands: ImageOverride -equals windows.vs2022preview.amd64
         strategy:
           matrix:
             ${{ if eq(variables['System.TeamProject'], 'public') }}:


### PR DESCRIPTION
Unblocks build by switching the images used for CI operations