### PR TITLE
Remove Microsoft.SourceBuild.Intermediate from prebuilt baseline

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -3,12 +3,10 @@
 
 <UsageData>
   <IgnorePatterns>
-    <UsagePattern IdentityGlob="Microsoft.SourceBuild.Intermediate.*/*" />
-
     <!-- Prebuilts showing in repo build only - ignoring. -->
     <UsagePattern IdentityGlob="Microsoft.Extensions.ObjectPool/6.0.0" />
 
-    <!-- 
+    <!--
       Ignoring the following prebuilts. NetPrevious targeting is needed in repo legs
       because the intermediate is used by multiple versions of dependent repos.
     -->


### PR DESCRIPTION
Prebuilt detection no longer detects Microsoft.SourceBuild.Intermediates as prebuilts due to https://github.com/dotnet/arcade/pull/13935. 

Addresses https://github.com/dotnet/source-build/issues/3010