### PR TITLE
Disable integration tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,6 +16,8 @@ variables:
   value: 'Verbose'
 - name: RAZOR_TRACE
   value: 'Verbose'
+- name: RunIntegrationTests
+  value: false
 - ${{ if ne(variables['System.TeamProject'], 'public') }}:
   - group: DotNetBuilds storage account read tokens
   - name: _InternalRuntimeDownloadArgs
@@ -237,7 +239,7 @@ stages:
             -integrationTest
           name: Run_Integration_Tests
           displayName: Run Integration Tests
-          condition: and(succeeded(), in(variables['Build.Reason'], 'PullRequest'))
+          condition: and(RunIntegrationTests, succeeded(), in(variables['Build.Reason'], 'PullRequest'))
 
         - powershell: ./eng/scripts/FinishDumpCollectionForHangingBuilds.ps1 artifacts/log/$(_BuildConfig)
           displayName: Finish background dump collection

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -239,7 +239,7 @@ stages:
             -integrationTest
           name: Run_Integration_Tests
           displayName: Run Integration Tests
-          condition: and(RunIntegrationTests, succeeded(), in(variables['Build.Reason'], 'PullRequest'))
+          condition: and(eq(variables['RunIntegrationTests'], true), succeeded(), in(variables['Build.Reason'], 'PullRequest'))
 
         - powershell: ./eng/scripts/FinishDumpCollectionForHangingBuilds.ps1 artifacts/log/$(_BuildConfig)
           displayName: Finish background dump collection


### PR DESCRIPTION
I think this should work, but I've no idea. Even the much touted Azure Pipelines extension in VS Code didn't seem to help.

Attn: @phil-allen-msft 