### PR TITLE
Fix stack overflow handling RemoteInvocationException

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Editor_NetFx/TestTelemetryReporter.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Editor_NetFx/TestTelemetryReporter.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.Telemetry;
 
 namespace Microsoft.VisualStudio.Editor.Razor.Test.Shared;
 
-internal class TestTelemetryReporter : TelemetryReporter
+internal class TestTelemetryReporter : VSTelemetryReporter
 {
     public List<TelemetryEvent> Events { get; } = [];
 

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TelemetryReporterTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TelemetryReporterTests.cs
@@ -248,8 +248,6 @@ public class TelemetryReporterTests
         var ae = new ApplicationException("expectedText");
         var rie = new RemoteInvocationException("a", 0, ae);
 
-
-        var p3Value = Guid.NewGuid();
         reporter.ReportFault(rie, rie.Message);
 
         Assert.Collection(reporter.Events,
@@ -257,13 +255,10 @@ public class TelemetryReporterTests
             {
                 Assert.Equal(TelemetrySeverity.High, e1.Severity);
                 Assert.Equal("dotnet/razor/fault", e1.Name);
-                if (e1 is not FaultEvent faultEvent1)
-                {
-                    // faultEvent doesn't expose any interesting properties,
-                    // like the ExceptionObject, or the resulting Description,
-                    // or really anything we would explicitly want to verify against.
-                    Assert.Fail("It should be a fault event");
-                }
+                // faultEvent doesn't expose any interesting properties,
+                // like the ExceptionObject, or the resulting Description,
+                // or really anything we would explicitly want to verify against.
+                Assert.IsType<FaultEvent>(e1);
             });
     }
 
@@ -274,7 +269,6 @@ public class TelemetryReporterTests
 
         var rie = new RemoteInvocationException("a", 0, errorData:null);
 
-        var p3Value = Guid.NewGuid();
         reporter.ReportFault(rie, rie.Message);
 
         Assert.Collection(reporter.Events,
@@ -282,13 +276,10 @@ public class TelemetryReporterTests
             {
                 Assert.Equal(TelemetrySeverity.High, e1.Severity);
                 Assert.Equal("dotnet/razor/fault", e1.Name);
-                if (e1 is not FaultEvent faultEvent1)
-                {
-                    // faultEvent doesn't expose any interesting properties,
-                    // like the ExceptionObject, or the resulting Description,
-                    // or really anything we would explicitly want to verify against.
-                    Assert.Fail("It should be a fault event");
-                }
+                // faultEvent doesn't expose any interesting properties,
+                // like the ExceptionObject, or the resulting Description,
+                // or really anything we would explicitly want to verify against.
+                Assert.IsType<FaultEvent>(e1);
             });
     }
 

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TelemetryReporterTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TelemetryReporterTests.cs
@@ -5,6 +5,7 @@ using System;
 using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.VisualStudio.Editor.Razor.Test.Shared;
 using Microsoft.VisualStudio.Telemetry;
+using StreamJsonRpc;
 using Xunit;
 
 namespace Microsoft.VisualStudio.Editor.Razor.Test;
@@ -236,6 +237,58 @@ public class TelemetryReporterTests
                 Assert.Equal(p3Value, p3.Value);
 
                 Assert.Equal(100, e1.Properties["dotnet.razor.p4"]);
+            });
+    }
+
+    [Fact]
+    public void HandleRIEWithInnerException()
+    {
+        var reporter = new TestTelemetryReporter();
+
+        var ae = new ApplicationException("expectedText");
+        var rie = new RemoteInvocationException("a", 0, ae);
+
+
+        var p3Value = Guid.NewGuid();
+        reporter.ReportFault(rie, rie.Message);
+
+        Assert.Collection(reporter.Events,
+            e1 =>
+            {
+                Assert.Equal(TelemetrySeverity.High, e1.Severity);
+                Assert.Equal("dotnet/razor/fault", e1.Name);
+                if (e1 is not FaultEvent faultEvent1)
+                {
+                    // faultEvent doesn't expose any interesting properties,
+                    // like the ExceptionObject, or the resulting Description,
+                    // or really anything we would explicitly want to verify against.
+                    Assert.Fail("It should be a fault event");
+                }
+            });
+    }
+
+    [Fact]
+    public void HandleRIEWithNoInnerException()
+    {
+        var reporter = new TestTelemetryReporter();
+
+        var rie = new RemoteInvocationException("a", 0, errorData:null);
+
+        var p3Value = Guid.NewGuid();
+        reporter.ReportFault(rie, rie.Message);
+
+        Assert.Collection(reporter.Events,
+            e1 =>
+            {
+                Assert.Equal(TelemetrySeverity.High, e1.Severity);
+                Assert.Equal("dotnet/razor/fault", e1.Name);
+                if (e1 is not FaultEvent faultEvent1)
+                {
+                    // faultEvent doesn't expose any interesting properties,
+                    // like the ExceptionObject, or the resulting Description,
+                    // or really anything we would explicitly want to verify against.
+                    Assert.Fail("It should be a fault event");
+                }
             });
     }
 


### PR DESCRIPTION
0) If TelemetryReporter.ReportFault were called with an RemoteInvocationException that had no InnerException, we would: 1) Pass it to HandleException
2) HandleException would see it is an RIE, pass it to ReportRemoteInvocationException. 3) ReportRemoteInvocationException would see it has no InnerException, and call HandleFault (return to step 0)

RESULT: Stack overflow.  By having ReportRemoteInvocationException effectively ask the quesiton: Does the ReportFault above me on the stack already have the Deserialized ErrorData?, it can break the stack overflow.

﻿### Summary of the changes

-

Fixes:
