### PR TITLE
Move data validity check to happen before the call that would throw if the data wasn't valid

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/TagHelperSemanticRangeVisitor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/TagHelperSemanticRangeVisitor.cs
@@ -604,8 +604,16 @@ internal sealed class TagHelperSemanticRangeVisitor : SyntaxWalker
 
         void AddRange(SemanticRange semanticRange)
         {
-            var linePositionSpan = semanticRange.AsLinePositionSpan();
-            if (linePositionSpan.Start == linePositionSpan.End)
+            // If the end is before the start, well that's no good!
+            if (semanticRange.EndLine < semanticRange.StartLine)
+            {
+                return;
+            }
+
+            // If the end is before the start, that's still no good, but I'm separating out this check
+            // to make it clear that it also checks for equality: No point classifying 0-length ranges.
+            if (semanticRange.EndLine == semanticRange.StartLine &&
+                semanticRange.EndCharacter <= semanticRange.StartCharacter)
             {
                 return;
             }


### PR DESCRIPTION
Fixes the only stack from https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1925926 that occurs in 17.9

When I converted semantic tokens to use value types, I either blindly converted this bit of code without thinking, or I was lazy and used the `LinePositionSpan` comparison method as a helper method, but either way it was silly as `LinePositionSpan` will throw on bad data. This would have previously been VS LSP types which didn't throw.