### PR TITLE
Offer to fully qualify component name even if case doesn't match

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/IStartTagSyntaxNode.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/IStartTagSyntaxNode.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.AspNetCore.Razor.Language.Syntax;
+
+internal interface IStartTagSyntaxNode
+{
+    SyntaxList<RazorSyntaxNode> Attributes { get; }
+    SyntaxToken Name { get; }
+    TextSpan Span { get; }
+    int SpanStart { get; }
+    SyntaxNode? Parent { get; }
+}

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/MarkupStartTagSyntax.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/MarkupStartTagSyntax.cs
@@ -1,11 +1,11 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 
 namespace Microsoft.AspNetCore.Razor.Language.Syntax;
 
-internal partial class MarkupStartTagSyntax
+internal partial class MarkupStartTagSyntax : IStartTagSyntaxNode
 {
     private SyntaxNode _lazyChildren;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/MarkupTagHelperStartTagSyntax.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/MarkupTagHelperStartTagSyntax.cs
@@ -1,9 +1,9 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 namespace Microsoft.AspNetCore.Razor.Language.Syntax;
 
-internal partial class MarkupTagHelperStartTagSyntax
+internal partial class MarkupTagHelperStartTagSyntax : IStartTagSyntaxNode
 {
     private SyntaxNode _lazyChildren;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperMatchingConventions.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperMatchingConventions.cs
@@ -25,7 +25,7 @@ internal static class TagHelperMatchingConventions
                SatisfiesAttributes(tagAttributes, rule);
     }
 
-    public static bool SatisfiesTagName(ReadOnlySpan<char> tagNameWithoutPrefix, TagMatchingRuleDescriptor rule)
+    public static bool SatisfiesTagName(ReadOnlySpan<char> tagNameWithoutPrefix, TagMatchingRuleDescriptor rule, StringComparison? comparisonOverride = null)
     {
         if (tagNameWithoutPrefix.IsEmpty)
         {
@@ -39,7 +39,7 @@ internal static class TagHelperMatchingConventions
         }
 
         if (rule.TagName is not (null or ElementCatchAllName) &&
-            !tagNameWithoutPrefix.Equals(rule.TagName.AsSpan(), rule.GetComparison()))
+            !tagNameWithoutPrefix.Equals(rule.TagName.AsSpan(), comparisonOverride ?? rule.GetComparison()))
         {
             return false;
         }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperMatchingConventions.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperMatchingConventions.cs
@@ -86,10 +86,10 @@ internal static class TagHelperMatchingConventions
     {
         return SatisfiesBoundAttributeName(name.AsSpan(), descriptor) ||
                SatisfiesBoundAttributeIndexer(name.AsSpan(), descriptor) ||
-               GetSatifyingBoundAttributeWithParameter(name, descriptor, descriptor.Parameters) is not null;
+               GetSatisfyingBoundAttributeWithParameter(name, descriptor, descriptor.Parameters) is not null;
     }
 
-    private static BoundAttributeParameterDescriptor? GetSatifyingBoundAttributeWithParameter(
+    private static BoundAttributeParameterDescriptor? GetSatisfyingBoundAttributeWithParameter(
         string name,
         BoundAttributeDescriptor descriptor,
         ImmutableArray<BoundAttributeParameterDescriptor> boundAttributeParameters)
@@ -190,7 +190,7 @@ internal static class TagHelperMatchingConventions
         // First, check if we have a bound attribute descriptor that matches the parameter if it exists.
         foreach (var attribute in descriptor.BoundAttributes)
         {
-            boundAttributeParameter = GetSatifyingBoundAttributeWithParameter(name, attribute, attribute.Parameters);
+            boundAttributeParameter = GetSatisfyingBoundAttributeWithParameter(name, attribute, attribute.Parameters);
 
             if (boundAttributeParameter != null)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/AddUsingsCodeActionProviderHelper.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/AddUsingsCodeActionProviderHelper.cs
@@ -45,7 +45,7 @@ internal static class AddUsingsCodeActionProviderHelper
             // This identifier will be eventually thrown away.
             Debug.Assert(codeDocument.Source.FilePath != null);
             var identifier = new OptionalVersionedTextDocumentIdentifier { Uri = new Uri(codeDocument.Source.FilePath, UriKind.Relative) };
-            var workspaceEdit = AddUsingsCodeActionResolver.CreateAddUsingWorkspaceEdit(usingStatement, codeDocument, codeDocumentIdentifier: identifier);
+            var workspaceEdit = AddUsingsCodeActionResolver.CreateAddUsingWorkspaceEdit(usingStatement, additionalEdit: null, codeDocument, codeDocumentIdentifier: identifier);
             edits.AddRange(workspaceEdit.DocumentChanges!.Value.First.First().Edits);
         }
 
@@ -84,7 +84,7 @@ internal static class AddUsingsCodeActionProviderHelper
         return namespaceName.ToString();
     }
 
-    internal static bool TryCreateAddUsingResolutionParams(string fullyQualifiedName, Uri uri, [NotNullWhen(true)] out string? @namespace, [NotNullWhen(true)] out RazorCodeActionResolutionParams? resolutionParams)
+    internal static bool TryCreateAddUsingResolutionParams(string fullyQualifiedName, Uri uri, TextDocumentEdit? additionalEdit, [NotNullWhen(true)] out string? @namespace, [NotNullWhen(true)] out RazorCodeActionResolutionParams? resolutionParams)
     {
         @namespace = GetNamespaceFromFQN(fullyQualifiedName);
         if (string.IsNullOrEmpty(@namespace))
@@ -97,7 +97,8 @@ internal static class AddUsingsCodeActionProviderHelper
         var actionParams = new AddUsingsCodeActionParams
         {
             Uri = uri,
-            Namespace = @namespace
+            Namespace = @namespace,
+            AdditionalEdit = additionalEdit
         };
 
         resolutionParams = new RazorCodeActionResolutionParams

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/TypeAccessibilityCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/TypeAccessibilityCodeActionProvider.cs
@@ -148,9 +148,9 @@ internal sealed class TypeAccessibilityCodeActionProvider : ICSharpCodeActionPro
                 var fqnCodeAction = CreateFQNCodeAction(context, diagnostic, codeAction, fqn);
                 typeAccessibilityCodeActions.Add(fqnCodeAction);
 
-                if (AddUsingsCodeActionProviderHelper.TryCreateAddUsingResolutionParams(fqn, context.Request.TextDocument.Uri, out var @namespace, out var resolutionParams))
+                if (AddUsingsCodeActionProviderHelper.TryCreateAddUsingResolutionParams(fqn, context.Request.TextDocument.Uri, additionalEdit: null, out var @namespace, out var resolutionParams))
                 {
-                    var addUsingCodeAction = RazorCodeActionFactory.CreateAddComponentUsing(@namespace, resolutionParams);
+                    var addUsingCodeAction = RazorCodeActionFactory.CreateAddComponentUsing(@namespace, newTagName: null, resolutionParams);
                     typeAccessibilityCodeActions.Add(addUsingCodeAction);
                 }
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/AddUsingsCodeActionParams.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/AddUsingsCodeActionParams.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
 
@@ -9,4 +10,5 @@ internal sealed class AddUsingsCodeActionParams
 {
     public required Uri Uri { get; set; }
     public required string Namespace { get; set; }
+    public TextDocumentEdit? AdditionalEdit { get; set; }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ComponentAccessibilityCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ComponentAccessibilityCodeActionProvider.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
@@ -47,7 +47,10 @@ internal sealed class ComponentAccessibilityCodeActionProvider : IRazorCodeActio
 
         // Find start tag. We allow this code action to work from anywhere in the start tag, which includes
         // embedded C#, so we just have to traverse up the tree to find a start tag if there is one.
-        var startTag = (MarkupStartTagSyntax?)node.FirstAncestorOrSelf<SyntaxNode>(n => n is MarkupStartTagSyntax);
+        // We also check for tag helper start tags here, because an invalid start tag with a valid tag helper
+        // anywhere in it  would otherwise not match. We rely on the IsTagUnknown method below, to ensure we
+        // only offer on actual potential component tags (because it checks for the compiler diagnostic)
+        var startTag = (IStartTagSyntaxNode?)node.FirstAncestorOrSelf<SyntaxNode>(n => n is MarkupStartTagSyntax or MarkupTagHelperStartTagSyntax);
         if (startTag is null)
         {
             return s_emptyResult;
@@ -81,7 +84,7 @@ internal sealed class ComponentAccessibilityCodeActionProvider : IRazorCodeActio
         return Task.FromResult<IReadOnlyList<RazorVSInternalCodeAction>?>(codeActions.ToArray());
     }
 
-    private static bool IsApplicableTag(MarkupStartTagSyntax startTag)
+    private static bool IsApplicableTag(IStartTagSyntaxNode startTag)
     {
         if (startTag.Name.FullWidth == 0)
         {
@@ -92,7 +95,7 @@ internal sealed class ComponentAccessibilityCodeActionProvider : IRazorCodeActio
         return true;
     }
 
-    private void AddCreateComponentFromTag(RazorCodeActionContext context, MarkupStartTagSyntax startTag, List<RazorVSInternalCodeAction> container)
+    private void AddCreateComponentFromTag(RazorCodeActionContext context, IStartTagSyntaxNode startTag, List<RazorVSInternalCodeAction> container)
     {
         if (context is null)
         {
@@ -133,7 +136,7 @@ internal sealed class ComponentAccessibilityCodeActionProvider : IRazorCodeActio
         container.Add(codeAction);
     }
 
-    private void AddComponentAccessFromTag(RazorCodeActionContext context, MarkupStartTagSyntax startTag, List<RazorVSInternalCodeAction> container)
+    private void AddComponentAccessFromTag(RazorCodeActionContext context, IStartTagSyntaxNode startTag, List<RazorVSInternalCodeAction> container)
     {
         var matching = FindMatchingTagHelpers(context, startTag);
 
@@ -149,8 +152,9 @@ internal sealed class ComponentAccessibilityCodeActionProvider : IRazorCodeActio
             // e.g. <Component /> -> <Component<T> />
             var fullyQualifiedName = DefaultRazorComponentSearchEngine.RemoveGenericContent(tagHelperPair._short.Name.AsMemory()).ToString();
 
-            // Insert @using
-            if (AddUsingsCodeActionProviderHelper.TryCreateAddUsingResolutionParams(fullyQualifiedName, context.Request.TextDocument.Uri, out var @namespace, out var resolutionParams))
+            // Insert @using, but only if the match was case sensitive
+            if (!tagHelperPair._caseInsensitiveMatch &&
+                AddUsingsCodeActionProviderHelper.TryCreateAddUsingResolutionParams(fullyQualifiedName, context.Request.TextDocument.Uri, out var @namespace, out var resolutionParams))
             {
                 var addUsingCodeAction = RazorCodeActionFactory.CreateAddComponentUsing(@namespace, resolutionParams);
                 container.Add(addUsingCodeAction);
@@ -163,7 +167,7 @@ internal sealed class ComponentAccessibilityCodeActionProvider : IRazorCodeActio
         }
     }
 
-    private List<TagHelperPair> FindMatchingTagHelpers(RazorCodeActionContext context, MarkupStartTagSyntax startTag)
+    private List<TagHelperPair> FindMatchingTagHelpers(RazorCodeActionContext context, IStartTagSyntaxNode startTag)
     {
         // Get all data necessary for matching
         var tagName = startTag.Name.Content;
@@ -184,9 +188,9 @@ internal sealed class ComponentAccessibilityCodeActionProvider : IRazorCodeActio
 
         foreach (var tagHelper in context.DocumentSnapshot.Project.TagHelpers)
         {
-            if (tagHelper.TagMatchingRules.All(rule => TagHelperMatchingConventions.SatisfiesRule(tagName.AsSpan(), parentTagName.AsSpan(), attributes, rule)))
+            if (SatisfiesRules(tagHelper.TagMatchingRules, tagName.AsSpan(), parentTagName.AsSpan(), attributes, out var caseInsensitiveMatch))
             {
-                matching.Add(tagHelper.Name, new TagHelperPair(@short: tagHelper));
+                matching.Add(tagHelper.Name, new TagHelperPair(@short: tagHelper, caseInsensitiveMatch));
             }
         }
 
@@ -205,7 +209,44 @@ internal sealed class ComponentAccessibilityCodeActionProvider : IRazorCodeActio
         return new List<TagHelperPair>(matching.Values);
     }
 
-    private static WorkspaceEdit CreateRenameTagEdit(RazorCodeActionContext context, MarkupStartTagSyntax startTag, string newTagName)
+    private bool SatisfiesRules(ImmutableArray<TagMatchingRuleDescriptor> tagMatchingRules, ReadOnlySpan<char> tagNameWithoutPrefix, ReadOnlySpan<char> parentTagNameWithoutPrefix, ImmutableArray<KeyValuePair<string, string>> tagAttributes, out bool caseInsensitiveMatch)
+    {
+        caseInsensitiveMatch = false;
+
+        foreach (var rule in tagMatchingRules)
+        {
+            // We have to match parent tag and attributes regardless, so check them first and exit early if there is a fail
+            if (!TagHelperMatchingConventions.SatisfiesParentTag(parentTagNameWithoutPrefix, rule) ||
+               !TagHelperMatchingConventions.SatisfiesAttributes(tagAttributes, rule))
+            {
+                return false;
+            }
+
+            // Tag helpers that target catch-all will come back as satisfying the rule, but we don't want to use them for the code action
+            // so we have to check that ourselves
+            if (rule.TagName is null or TagHelperMatchingConventions.ElementCatchAllName)
+            {
+                return false;
+            }
+            else if (TagHelperMatchingConventions.SatisfiesTagName(tagNameWithoutPrefix, rule))
+            {
+                // Nothing to do, just loop around to the next rule
+            }
+            else if (TagHelperMatchingConventions.SatisfiesTagName(tagNameWithoutPrefix, rule, StringComparison.OrdinalIgnoreCase))
+            {
+                // Because the code action will be fixing the casing of the tag, we don't need all the rules to be consistent.
+                caseInsensitiveMatch = true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static WorkspaceEdit CreateRenameTagEdit(RazorCodeActionContext context, IStartTagSyntaxNode startTag, string newTagName)
     {
         using var _ = ListPool<TextEdit>.GetPooledObject(out var textEdits);
         var codeDocumentIdentifier = new OptionalVersionedTextDocumentIdentifier() { Uri = context.Request.TextDocument.Uri };
@@ -243,7 +284,7 @@ internal sealed class ComponentAccessibilityCodeActionProvider : IRazorCodeActio
         };
     }
 
-    private static bool IsTagUnknown(MarkupStartTagSyntax startTag, RazorCodeActionContext context)
+    private static bool IsTagUnknown(IStartTagSyntaxNode startTag, RazorCodeActionContext context)
     {
         foreach (var diagnostic in context.CodeDocument.GetCSharpDocument().Diagnostics)
         {
@@ -264,13 +305,14 @@ internal sealed class ComponentAccessibilityCodeActionProvider : IRazorCodeActio
 
     private class TagHelperPair
     {
-        public TagHelperDescriptor _short;
+        public readonly TagHelperDescriptor _short;
+        public readonly bool _caseInsensitiveMatch;
         public TagHelperDescriptor? _fullyQualified = null;
 
-        public TagHelperPair(TagHelperDescriptor @short, TagHelperDescriptor? fullyQualified = null)
+        public TagHelperPair(TagHelperDescriptor @short, bool caseInsensitiveMatch)
         {
             _short = @short;
-            _fullyQualified = fullyQualified;
+            _caseInsensitiveMatch = caseInsensitiveMatch;
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/RazorCodeActionFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/RazorCodeActionFactory.cs
@@ -18,13 +18,13 @@ internal static class RazorCodeActionFactory
     private readonly static Guid s_generateMethodTelemetryId = new("c14fa003-c752-45fc-bb29-3a123ae5ecef");
     private readonly static Guid s_generateAsyncMethodTelemetryId = new("9058ca47-98e2-4f11-bf7c-a16a444dd939");
 
-    public static RazorVSInternalCodeAction CreateAddComponentUsing(string @namespace, RazorCodeActionResolutionParams resolutionParams)
+    public static RazorVSInternalCodeAction CreateAddComponentUsing(string @namespace, string? newTagName, RazorCodeActionResolutionParams resolutionParams)
     {
         var title = $"@using {@namespace}";
         var data = JToken.FromObject(resolutionParams);
         var codeAction = new RazorVSInternalCodeAction
         {
-            Title = title,
+            Title = newTagName is null ? title : $"{newTagName} - {title}",
             Data = data,
             TelemetryId = s_addComponentUsingTelemetryId,
         };

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/AddUsingsCodeActionProviderFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/AddUsingsCodeActionProviderFactoryTest.cs
@@ -44,7 +44,7 @@ public class AddUsingsCodeActionProviderFactoryTest(ITestOutputHelper testOutput
         var docUri = new Uri("c:/path");
 
         // Act
-        var result = AddUsingsCodeActionProviderHelper.TryCreateAddUsingResolutionParams(fqn, docUri, out var @namespace, out var resolutionParams);
+        var result = AddUsingsCodeActionProviderHelper.TryCreateAddUsingResolutionParams(fqn, docUri, additionalEdit: null, out var @namespace, out var resolutionParams);
 
         // Assert
         Assert.True(result);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ComponentAccessibilityCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ComponentAccessibilityCodeActionProviderTest.cs
@@ -160,6 +160,49 @@ public class ComponentAccessibilityCodeActionProviderTest(ITestOutputHelper test
     }
 
     [Fact]
+    public async Task Handle_ExistingComponent_CaseIncorrect_ReturnsResults()
+    {
+        // Arrange
+        var documentPath = "c:/Test.razor";
+        var contents = """
+            <$$CompOnent></CompOnent>
+            """;
+        TestFileMarkupParser.GetPosition(contents, out contents, out var cursorPosition);
+
+        var request = new VSCodeActionParams()
+        {
+            TextDocument = new VSTextDocumentIdentifier { Uri = new Uri(documentPath) },
+            Range = new Range { Start = new Position(0, 0), End = new Position(0, 0) },
+            Context = new VSInternalCodeActionContext()
+        };
+
+        var location = new SourceLocation(cursorPosition, -1, -1);
+        var context = CreateRazorCodeActionContext(request, location, documentPath, contents, new SourceSpan(contents.IndexOf("CompOnent", StringComparison.Ordinal), 9), supportsFileCreation: true);
+
+        var provider = new ComponentAccessibilityCodeActionProvider(new TagHelperFactsService());
+
+        // Act
+        var commandOrCodeActionContainer = await provider.ProvideAsync(context, default);
+
+        // Assert
+        Assert.NotNull(commandOrCodeActionContainer);
+        Assert.Collection(commandOrCodeActionContainer,
+            e =>
+            {
+                Assert.Equal("Fully.Qualified.Component", e.Title);
+                Assert.NotNull(e.Edit);
+                Assert.NotNull(e.Edit.DocumentChanges);
+                Assert.Null(e.Data);
+            },
+            e =>
+            {
+                Assert.Equal(LanguageServerSR.Create_Component_FromTag_Title, e.Title);
+                Assert.NotNull(e.Data);
+                Assert.Null(e.Edit);
+            });
+    }
+
+    [Fact]
     public async Task Handle_ExistingGenericComponent_SupportsFileCreationTrue_ReturnsResults()
     {
         // Arrange
@@ -348,13 +391,17 @@ public class ComponentAccessibilityCodeActionProviderTest(ITestOutputHelper test
     private static RazorCodeActionContext CreateRazorCodeActionContext(VSCodeActionParams request, SourceLocation location, string filePath, string text, SourceSpan componentSourceSpan, bool supportsFileCreation = true)
     {
         var shortComponent = TagHelperDescriptorBuilder.Create(ComponentMetadata.Component.TagHelperKind, "Fully.Qualified.Component", "TestAssembly");
+        shortComponent.CaseSensitive = true;
         shortComponent.TagMatchingRule(rule => rule.TagName = "Component");
         var fullyQualifiedComponent = TagHelperDescriptorBuilder.Create(ComponentMetadata.Component.TagHelperKind, "Fully.Qualified.Component", "TestAssembly");
+        fullyQualifiedComponent.CaseSensitive = true;
         fullyQualifiedComponent.TagMatchingRule(rule => rule.TagName = "Fully.Qualified.Component");
 
         var shortGenericComponent = TagHelperDescriptorBuilder.Create(ComponentMetadata.Component.TagHelperKind, "Fully.Qualified.GenericComponent<T>", "TestAssembly");
+        shortGenericComponent.CaseSensitive = true;
         shortGenericComponent.TagMatchingRule(rule => rule.TagName = "GenericComponent");
         var fullyQualifiedGenericComponent = TagHelperDescriptorBuilder.Create(ComponentMetadata.Component.TagHelperKind, "Fully.Qualified.GenericComponent<T>", "TestAssembly");
+        fullyQualifiedGenericComponent.CaseSensitive = true;
         fullyQualifiedGenericComponent.TagMatchingRule(rule => rule.TagName = "Fully.Qualified.GenericComponent");
 
         var tagHelpers = ImmutableArray.Create(shortComponent.Build(), fullyQualifiedComponent.Build(), shortGenericComponent.Build(), fullyQualifiedGenericComponent.Build());


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/7658 by providing a better user experience.

Unfortunately we can't be smart and offer to only fix the casing without some more smarts/APIs from the compiler. But I figure this is better than nothing.

Before:
<img width="361" alt="image" src="https://github.com/dotnet/razor/assets/754264/9b34bb9e-4145-4a94-bd81-a2fdbedea964">

Before when there is also an `@bind` attribute:
<img width="476" alt="image" src="https://github.com/dotnet/razor/assets/754264/53a9d66a-0b7d-49f6-8040-325a41e5f995">

After:
<img width="524" alt="FixComponentCase" src="https://github.com/dotnet/razor/assets/754264/b9d1aa5a-6321-4fbd-a951-2598d4d59cb6">

The add using code action is also smarter. Full capabilties:
![BetterTypeQualifying](https://github.com/dotnet/razor/assets/754264/c61b678f-7585-480d-b1b2-3d16131c0dd2)

