### PR TITLE
Use keyword instead of struct

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionListProvider.cs
@@ -148,7 +148,7 @@ internal class RazorCompletionListProvider(
                         FilterText = razorCompletionItem.DisplayText,
                         SortText = razorCompletionItem.SortText,
                         InsertTextFormat = insertTextFormat,
-                        Kind = razorCompletionItem.IsSnippet ? CompletionItemKind.Snippet : CompletionItemKind.Struct, // TODO: Make separate CompletionItemKind for razor directives. See https://github.com/dotnet/razor-tooling/issues/6504 and https://github.com/dotnet/razor-tooling/issues/6505
+                        Kind = razorCompletionItem.IsSnippet ? CompletionItemKind.Snippet : CompletionItemKind.Keyword,
                     };
 
                     directiveCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);


### PR DESCRIPTION
Fixes #6504 by just using keywords, which suit our directive completion better

While #6505 is still open, it's not something we can handle in our codebase. I removed the comment. 