### PR TITLE
Don't show hover info for <Text> components when they're not components

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/HoverInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/HoverInfoService.cs
@@ -8,6 +8,7 @@ using System.Composition;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Tooltip;
@@ -96,6 +97,14 @@ internal sealed class HoverInfoService : IHoverInfoService
         if (_htmlFactsService.TryGetElementInfo(owner, out var containingTagNameToken, out var attributes, closingForwardSlashOrCloseAngleToken: out _) &&
             containingTagNameToken.Span.IntersectsWith(location.AbsoluteIndex))
         {
+            if (owner is MarkupStartTagSyntax or MarkupEndTagSyntax &&
+                containingTagNameToken.Content.Equals(SyntaxConstants.TextTagName, StringComparison.OrdinalIgnoreCase))
+            {
+                // It's possible for there to be a <Text> component that is in scope, and would be found by the GetTagHelperBinding
+                // call below, but a text tag, regardless of casing, inside C# code, is always just a text tag, not a component.
+                return null;
+            }
+
             // Hovering over HTML tag name
             var ancestors = owner.Ancestors().Where(n => n.SpanStart != ownerStart);
             var (parentTag, parentIsTagHelper) = _tagHelperFactsService.GetNearestAncestorTagInfo(ancestors);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperServiceTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperServiceTestBase.cs
@@ -100,6 +100,14 @@ public abstract class TagHelperServiceTestBase : LanguageServerTestBase
             attribute.TypeName = typeof(string).FullName;
         });
 
+        var textComponent = TagHelperDescriptorBuilder.Create(ComponentMetadata.Component.TagHelperKind, "TextTagHelper", "TestAssembly");
+        textComponent.TagMatchingRule(rule => rule.TagName = "Text");
+        textComponent.SetMetadata(
+            TypeName("Text"),
+            TypeNamespace("System"),
+            TypeNameIdentifier("Text"),
+            new(ComponentMetadata.Component.NameMatchKey, ComponentMetadata.Component.FullyQualifiedNameMatch));
+
         var directiveAttribute1 = TagHelperDescriptorBuilder.Create(ComponentMetadata.Component.TagHelperKind, "TestDirectiveAttribute", "TestAssembly");
         directiveAttribute1.TagMatchingRule(rule =>
         {
@@ -235,6 +243,7 @@ public abstract class TagHelperServiceTestBase : LanguageServerTestBase
             builder1WithRequiredParent.Build(),
             builder2.Build(),
             builder3.Build(),
+            textComponent.Build(),
             directiveAttribute1.Build(),
             directiveAttribute2.Build(),
             directiveAttribute3.Build(),

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverInfoServiceTest.cs
@@ -478,6 +478,58 @@ public class HoverInfoServiceTest(ITestOutputHelper testOutput) : TagHelperServi
     }
 
     [Fact]
+    public void GetHoverInfo_TagHelper_TextComponent()
+    {
+        // Arrange
+        var txt = """
+                <$$Text></Text>
+                """;
+        TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
+
+        var codeDocument = CreateCodeDocument(txt, isRazorFile: true, DefaultTagHelpers);
+
+        var service = GetHoverInfoService();
+        var location = new SourceLocation(cursorPosition, -1, -1);
+
+        // Act
+        var hover = service.GetHoverInfo("file.razor", codeDocument, location, CreatePlainTextCapabilities());
+
+        // Assert
+        Assert.Contains("Text", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
+        Assert.Equal(MarkupKind.PlainText, ((MarkupContent)hover.Contents).Kind);
+        var expectedRange = new Range
+        {
+            Start = new Position(0, 1),
+            End = new Position(0, 5),
+        };
+        Assert.Equal(expectedRange, hover.Range);
+    }
+
+    [Fact]
+    public void GetHoverInfo_TagHelper_TextComponent_NestedInCSharp()
+    {
+        // Arrange
+        var txt = """
+                @if (true)
+                {
+                    <$$Text></Text>
+                }
+                """;
+        TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
+
+        var codeDocument = CreateCodeDocument(txt, isRazorFile: true, DefaultTagHelpers);
+
+        var service = GetHoverInfoService();
+        var location = new SourceLocation(cursorPosition, -1, -1);
+
+        // Act
+        var hover = service.GetHoverInfo("file.razor", codeDocument, location, CreatePlainTextCapabilities());
+
+        // Assert
+        Assert.Null(hover);
+    }
+
+    [Fact]
     public void GetHoverInfo_TagHelper_PlainTextAttribute()
     {
         // Arrange

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverInfoServiceTest.cs
@@ -506,6 +506,36 @@ public class HoverInfoServiceTest(ITestOutputHelper testOutput) : TagHelperServi
     }
 
     [Fact]
+    public void GetHoverInfo_TagHelper_TextComponent_NestedInHtml()
+    {
+        // Arrange
+        var txt = """
+                <div>
+                    <$$Text></Text>
+                </div>
+                """;
+        TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
+
+        var codeDocument = CreateCodeDocument(txt, isRazorFile: true, DefaultTagHelpers);
+
+        var service = GetHoverInfoService();
+        var location = new SourceLocation(cursorPosition, -1, -1);
+
+        // Act
+        var hover = service.GetHoverInfo("file.razor", codeDocument, location, CreatePlainTextCapabilities());
+
+        // Assert
+        Assert.Contains("Text", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
+        Assert.Equal(MarkupKind.PlainText, ((MarkupContent)hover.Contents).Kind);
+        var expectedRange = new Range
+        {
+            Start = new Position(1, 5),
+            End = new Position(1, 9),
+        };
+        Assert.Equal(expectedRange, hover.Range);
+    }
+
+    [Fact]
     public void GetHoverInfo_TagHelper_TextComponent_NestedInCSharp()
     {
         // Arrange
@@ -527,6 +557,39 @@ public class HoverInfoServiceTest(ITestOutputHelper testOutput) : TagHelperServi
 
         // Assert
         Assert.Null(hover);
+    }
+
+    [Fact]
+    public void GetHoverInfo_TagHelper_TextComponent_NestedInCSharpAndText()
+    {
+        // Arrange
+        var txt = """
+                @if (true)
+                {
+                    <text>
+                        <$$Text></Text>
+                    </text>
+                }
+                """;
+        TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
+
+        var codeDocument = CreateCodeDocument(txt, isRazorFile: true, DefaultTagHelpers);
+
+        var service = GetHoverInfoService();
+        var location = new SourceLocation(cursorPosition, -1, -1);
+
+        // Act
+        var hover = service.GetHoverInfo("file.razor", codeDocument, location, CreatePlainTextCapabilities());
+
+        // Assert
+        Assert.Contains("Text", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
+        Assert.Equal(MarkupKind.PlainText, ((MarkupContent)hover.Contents).Kind);
+        var expectedRange = new Range
+        {
+            Start = new Position(3, 9),
+            End = new Position(3, 13),
+        };
+        Assert.Equal(expectedRange, hover.Range);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/9713