### PR TITLE
Refresh settings when unified settings change

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -90,9 +90,10 @@
   <PropertyGroup Label="Manual">
     <!-- Several packages from the editor are used for testing HTML support, and share the following version. -->
     <Tooling_HtmlEditorPackageVersion>17.9.67-preview-0001</Tooling_HtmlEditorPackageVersion>
-    <MicrosoftVisualStudioShellPackagesVersion>17.7.37349</MicrosoftVisualStudioShellPackagesVersion>
-    <MicrosoftVisualStudioPackagesVersion>17.7.188</MicrosoftVisualStudioPackagesVersion>
-    <VisualStudioLanguageServerProtocolVersion>17.8.9-preview</VisualStudioLanguageServerProtocolVersion>
+    <MicrosoftVisualStudioShellPackagesVersion>17.9.36400-preview.3</MicrosoftVisualStudioShellPackagesVersion>
+    <MicrosoftVisualStudioPackagesVersion>17.9.80-preview</MicrosoftVisualStudioPackagesVersion>
+    <VisualStudioLanguageServerProtocolVersion>17.9.3-preview</VisualStudioLanguageServerProtocolVersion>
+    <MicrosoftVisualStudioCopilotVersion>0.2.28-beta</MicrosoftVisualStudioCopilotVersion>
     <!-- dotnet/runtime packages -->
     <MicrosoftExtensionsPackageVersion>6.0.0</MicrosoftExtensionsPackageVersion>
     <SystemCompositionPackageVersion>7.0.0</SystemCompositionPackageVersion>
@@ -116,7 +117,7 @@
     <MicrosoftVisualStudioExtensibilityTestingSourceGeneratorVersion>$(MicrosoftVisualStudioExtensibilityTestingXunitVersion)</MicrosoftVisualStudioExtensibilityTestingSourceGeneratorVersion>
     <MicrosoftVisualStudioLanguagePackageVersion>$(MicrosoftVisualStudioPackagesVersion)</MicrosoftVisualStudioLanguagePackageVersion>
     <MicrosoftVisualStudioLanguageIntellisensePackageVersion>$(MicrosoftVisualStudioPackagesVersion)</MicrosoftVisualStudioLanguageIntellisensePackageVersion>
-    <MicrosoftVisualStudioLanguageServerClientImplementationPackageVersion>17.7.4-preview</MicrosoftVisualStudioLanguageServerClientImplementationPackageVersion>
+    <MicrosoftVisualStudioLanguageServerClientImplementationPackageVersion>$(VisualStudioLanguageServerProtocolVersion)</MicrosoftVisualStudioLanguageServerClientImplementationPackageVersion>
     <MicrosoftVisualStudioLanguageServerProtocolPackageVersion>$(VisualStudioLanguageServerProtocolVersion)</MicrosoftVisualStudioLanguageServerProtocolPackageVersion>
     <MicrosoftVisualStudioLanguageServerProtocolExtensionsPackageVersion>$(VisualStudioLanguageServerProtocolVersion)</MicrosoftVisualStudioLanguageServerProtocolExtensionsPackageVersion>
     <MicrosoftVisualStudioLanguageServerProtocolInternalPackageVersion>$(VisualStudioLanguageServerProtocolVersion)</MicrosoftVisualStudioLanguageServerProtocolInternalPackageVersion>
@@ -126,14 +127,14 @@
     <MicrosoftVisualStudioShellFrameworkPackageVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioShellFrameworkPackageVersion>
     <MicrosoftVisualStudioInteropPackageVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftVisualStudioInteropPackageVersion>
     <MicrosoftInternalVisualStudioInteropPackageVersion>$(MicrosoftVisualStudioShellPackagesVersion)</MicrosoftInternalVisualStudioInteropPackageVersion>
-    <MicrosoftVisualStudioRpcContractsPackageVersion>17.7.9</MicrosoftVisualStudioRpcContractsPackageVersion>
+    <MicrosoftVisualStudioRpcContractsPackageVersion>17.9.5-alpha</MicrosoftVisualStudioRpcContractsPackageVersion>
     <MicrosoftVisualStudioTelemetryVersion>17.8.138</MicrosoftVisualStudioTelemetryVersion>
     <MicrosoftVisualStudioTextDataPackageVersion>$(MicrosoftVisualStudioPackagesVersion)</MicrosoftVisualStudioTextDataPackageVersion>
     <MicrosoftVisualStudioTextImplementationPackageVersion>$(MicrosoftVisualStudioPackagesVersion)</MicrosoftVisualStudioTextImplementationPackageVersion>
     <MicrosoftVisualStudioTextLogicPackageVersion>$(MicrosoftVisualStudioPackagesVersion)</MicrosoftVisualStudioTextLogicPackageVersion>
-    <MicrosoftVisualStudioThreadingPackageVersion>17.7.30</MicrosoftVisualStudioThreadingPackageVersion>
+    <MicrosoftVisualStudioThreadingPackageVersion>17.9.1-alpha</MicrosoftVisualStudioThreadingPackageVersion>
     <MicrosoftVisualStudioWebPackageVersion>16.10.0-preview-1-31008-014</MicrosoftVisualStudioWebPackageVersion>
-    <MicrosoftVisualStudioValidationPackageVersion>17.6.11</MicrosoftVisualStudioValidationPackageVersion>
+    <MicrosoftVisualStudioValidationPackageVersion>17.8.8</MicrosoftVisualStudioValidationPackageVersion>
     <MicrosoftVisualStudioComponentModelHostPackageVersion>17.7.124-preview</MicrosoftVisualStudioComponentModelHostPackageVersion>
     <MicrosoftWebToolsLanguagesHtmlPackageVersion>$(Tooling_HtmlEditorPackageVersion)</MicrosoftWebToolsLanguagesHtmlPackageVersion>
     <MicrosoftWebToolsLanguagesLanguageServerServerPackageVersion>$(Tooling_HtmlEditorPackageVersion)</MicrosoftWebToolsLanguagesLanguageServerServerPackageVersion>
@@ -145,7 +146,7 @@
     <NewtonsoftJsonPackageVersion>13.0.3</NewtonsoftJsonPackageVersion>
     <NerdbankStreamsPackageVersion>2.10.69</NerdbankStreamsPackageVersion>
     <NuGetSolutionRestoreManagerInteropVersion>4.8.0</NuGetSolutionRestoreManagerInteropVersion>
-    <StreamJsonRpcPackageVersion>2.16.36</StreamJsonRpcPackageVersion>
+    <StreamJsonRpcPackageVersion>2.17.11</StreamJsonRpcPackageVersion>
     <SystemRuntimeInteropServicesRuntimePackageVersion>4.3.0</SystemRuntimeInteropServicesRuntimePackageVersion>
     <Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion>3.3.4</Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion>
     <Tooling_MicrosoftCodeAnalysisBannedApiAnalyzersPackageVersion>$(Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion)</Tooling_MicrosoftCodeAnalysisBannedApiAnalyzersPackageVersion>

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/IClientSettingsManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/IClientSettingsManager.cs
@@ -19,7 +19,7 @@ internal interface IClientSettingsManager
     ClientSettings GetClientSettings();
 }
 
-internal interface IAdvancedSettingsStorage
+internal interface IAdvancedSettingsStorage : IDisposable
 {
     ClientAdvancedSettings GetAdvancedSettings();
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServer.ContainedLanguage/Microsoft.VisualStudio.LanguageServer.ContainedLanguage.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Copilot" Version="$(MicrosoftVisualStudioCopilotVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="$(MicrosoftVisualStudioLanguageServerProtocolPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol.Extensions" Version="$(MicrosoftVisualStudioLanguageServerProtocolExtensionsPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol.Internal" Version="$(MicrosoftVisualStudioLanguageServerProtocolInternalPackageVersion)" />

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Options/OptionsStorage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Options/OptionsStorage.cs
@@ -9,6 +9,9 @@ using Microsoft.VisualStudio.Editor.Razor;
 using Microsoft.VisualStudio.Settings;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Settings;
+using Microsoft.Internal.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.Utilities.UnifiedSettings;
+using System.Linq;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Options;
 
@@ -19,49 +22,43 @@ internal class OptionsStorage : IAdvancedSettingsStorage
 {
     private readonly WritableSettingsStore _writableSettingsStore;
     private readonly ITelemetryReporter _telemetryReporter;
-
-    private const string Collection = "Razor";
-    private const string FormatOnTypeName = "FormatOnType";
-    private const string AutoClosingTagsName = "AutoClosingTags";
-    private const string AutoInsertAttributeQuotesName = "AutoInsertAttributeQuotes";
-    private const string ColorBackgroundName = "ColorBackground";
-    private const string CommitElementsWithSpaceName = "CommitElementsWithSpace";
-    private const string SnippetsName = "Snippets";
+    private readonly ISettingsReader _unifiedSettingsReader;
+    private readonly IDisposable _unifiedSettingsSubscription;
 
     public bool FormatOnType
     {
-        get => GetBool(FormatOnTypeName, defaultValue: true);
-        set => SetBool(FormatOnTypeName, value);
+        get => GetBool(SettingsNames.FormatOnType.LegacyName, defaultValue: true);
+        set => SetBool(SettingsNames.FormatOnType.LegacyName, value);
     }
 
     public bool AutoClosingTags
     {
-        get => GetBool(AutoClosingTagsName, defaultValue: true);
-        set => SetBool(AutoClosingTagsName, value);
+        get => GetBool(SettingsNames.AutoClosingTags.LegacyName, defaultValue: true);
+        set => SetBool(SettingsNames.AutoClosingTags.LegacyName, value);
     }
 
     public bool AutoInsertAttributeQuotes
     {
-        get => GetBool(AutoInsertAttributeQuotesName, defaultValue: true);
-        set => SetBool(AutoInsertAttributeQuotesName, value);
+        get => GetBool(SettingsNames.AutoInsertAttributeQuotes.LegacyName, defaultValue: true);
+        set => SetBool(SettingsNames.AutoInsertAttributeQuotes.LegacyName, value);
     }
 
     public bool ColorBackground
     {
-        get => GetBool(ColorBackgroundName, defaultValue: false);
-        set => SetBool(ColorBackgroundName, value);
+        get => GetBool(SettingsNames.ColorBackground.LegacyName, defaultValue: false);
+        set => SetBool(SettingsNames.ColorBackground.LegacyName, value);
     }
 
     public bool CommitElementsWithSpace
     {
-        get => GetBool(CommitElementsWithSpaceName, defaultValue: true);
-        set => SetBool(CommitElementsWithSpaceName, value);
+        get => GetBool(SettingsNames.CommitElementsWithSpace.LegacyName, defaultValue: true);
+        set => SetBool(SettingsNames.CommitElementsWithSpace.LegacyName, value);
     }
 
     public SnippetSetting Snippets
     {
-        get => (SnippetSetting)GetInt(SnippetsName, (int)SnippetSetting.All);
-        set => SetInt(SnippetsName, (int)value);
+        get => (SnippetSetting)GetInt(SettingsNames.Snippets.LegacyName, (int)SnippetSetting.All);
+        set => SetInt(SettingsNames.Snippets.LegacyName, (int)value);
     }
 
     [ImportingConstructor]
@@ -70,8 +67,12 @@ internal class OptionsStorage : IAdvancedSettingsStorage
         var shellSettingsManager = new ShellSettingsManager(vsServiceProvider);
         _writableSettingsStore = shellSettingsManager.GetWritableSettingsStore(SettingsScope.UserSettings);
 
-        _writableSettingsStore.CreateCollection(Collection);
+        _writableSettingsStore.CreateCollection(SettingsNames.LegacyCollection);
         _telemetryReporter = telemetryReporter;
+
+        var settingsManager = vsServiceProvider.GetService<SVsUnifiedSettingsManager, Utilities.UnifiedSettings.ISettingsManager>();
+        _unifiedSettingsReader = settingsManager.GetReader();
+        _unifiedSettingsSubscription = _unifiedSettingsReader.SubscribeToChanges(OnUnifiedSettingsChanged, SettingsNames.AllSettings.Select(s => s.UnifiedName).ToArray());
     }
 
     public event EventHandler<ClientAdvancedSettingsChangedEventArgs>? Changed;
@@ -80,9 +81,9 @@ internal class OptionsStorage : IAdvancedSettingsStorage
 
     public bool GetBool(string name, bool defaultValue)
     {
-        if (_writableSettingsStore.PropertyExists(Collection, name))
+        if (_writableSettingsStore.PropertyExists(SettingsNames.LegacyCollection, name))
         {
-            return _writableSettingsStore.GetBoolean(Collection, name);
+            return _writableSettingsStore.GetBoolean(SettingsNames.LegacyCollection, name);
         }
 
         return defaultValue;
@@ -90,7 +91,7 @@ internal class OptionsStorage : IAdvancedSettingsStorage
 
     public void SetBool(string name, bool value)
     {
-        _writableSettingsStore.SetBoolean(Collection, name, value);
+        _writableSettingsStore.SetBoolean(SettingsNames.LegacyCollection, name, value);
         _telemetryReporter.ReportEvent("OptionChanged", Severity.Normal, new Property(name, value));
 
         NotifyChange();
@@ -98,9 +99,9 @@ internal class OptionsStorage : IAdvancedSettingsStorage
 
     public int GetInt(string name, int defaultValue)
     {
-        if (_writableSettingsStore.PropertyExists(Collection, name))
+        if (_writableSettingsStore.PropertyExists(SettingsNames.LegacyCollection, name))
         {
-            return _writableSettingsStore.GetInt32(Collection, name);
+            return _writableSettingsStore.GetInt32(SettingsNames.LegacyCollection, name);
         }
 
         return defaultValue;
@@ -108,7 +109,7 @@ internal class OptionsStorage : IAdvancedSettingsStorage
 
     public void SetInt(string name, int value)
     {
-        _writableSettingsStore.SetInt32(Collection, name, value);
+        _writableSettingsStore.SetInt32(SettingsNames.LegacyCollection, name, value);
         _telemetryReporter.ReportEvent("OptionChanged", Severity.Normal, new Property(name, value));
 
         NotifyChange();
@@ -117,5 +118,15 @@ internal class OptionsStorage : IAdvancedSettingsStorage
     private void NotifyChange()
     {
         Changed?.Invoke(this, new ClientAdvancedSettingsChangedEventArgs(GetAdvancedSettings()));
+    }
+
+    private void OnUnifiedSettingsChanged(SettingsUpdate update)
+    {
+        NotifyChange();
+    }
+
+    public void Dispose()
+    {
+        _unifiedSettingsSubscription.Dispose();
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Options/README.md
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Options/README.md
@@ -1,0 +1,17 @@
+## Adding A New Option To Storage
+
+As of writing this, options are in a limbo between the "legacy" and "unified" settings storage. The unified settings are contained in "razor.registration.json", see [internal documentation](https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/38111/Guide-for-setting-owners)
+for information on the schema for unified settings. When adding a new setting to advanced options, the storage has to account for both locations. The way this is done is that all unified settings have a migration
+in place to update the old setting location. That way, our OptionsStorage only needs to look at the legacy location to retrieve values. Writing of values in unified settings is handled automatically, and we subscribe
+to those changes being made. Follow the following steps when adding a new setting
+
+1. Add the setting to SettingsNames.cs it should include the LegacyName and UnifiedName
+2. Add a field to OptionsStorage.cs using the LegacyName
+3. Add to the razor.registration.json file to include in the unified settings experience
+
+
+## Testing
+
+You can test both the legacy and unified setting if you're an internal user. Make sure that the unified settings feature flag is enabled and restart. Then when you open options
+you should get the unified experience. Test and make sure your setting works as expected for this experience. You can also click the "Advanced" section in unified settings and it will
+open the legacy page to test with.

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Options/SettingsNames.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Options/SettingsNames.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Options;
+
 internal static class SettingsNames
 {
     public record Setting(string LegacyName, string UnifiedName);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Options/SettingsNames.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Options/SettingsNames.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Options;
+internal static class SettingsNames
+{
+    public record Setting(string LegacyName, string UnifiedName);
+
+    public const string LegacyCollection = "Razor";
+    public const string UnifiedCollection = "textEditor.razor.advanced";
+
+    public static readonly Setting FormatOnType = new("FormatOnType", UnifiedCollection + ".formatOnType");
+    public static readonly Setting AutoClosingTags = new("AutoClosingTags", UnifiedCollection + ".autoClosingTags");
+    public static readonly Setting AutoInsertAttributeQuotes = new("AutoInsertAttributeQuotes", UnifiedCollection + ".autoInsertAttributeQuotes");
+    public static readonly Setting ColorBackground = new("ColorBackground", UnifiedCollection + ".colorBackground");
+    public static readonly Setting CommitElementsWithSpace = new("CommitElementsWithSpace", UnifiedCollection + ".commitCharactersWithSpace");
+    public static readonly Setting Snippets = new("Snippets", UnifiedCollection + ".snippets");
+
+    public static readonly Setting[] AllSettings =
+    [
+        FormatOnType,
+        AutoClosingTags,
+        AutoInsertAttributeQuotes,
+        ColorBackground,
+        CommitElementsWithSpace,
+        Snippets,
+    ];
+}

--- a/src/Razor/src/RazorDeployment/RazorDeployment.csproj
+++ b/src/Razor/src/RazorDeployment/RazorDeployment.csproj
@@ -11,6 +11,7 @@
     <VSSDKTargetPlatformRegRootSuffix>RoslynDev</VSSDKTargetPlatformRegRootSuffix>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Copilot" Version="$(MicrosoftVisualStudioCopilotVersion)" />
     <!-- References the main RazorExtension vsix to ensure all the actual code is deployed to the hive. -->
     <ProjectReference Include="..\Microsoft.VisualStudio.RazorExtension.Dependencies\Microsoft.VisualStudio.RazorExtension.Dependencies.csproj" />
     <!-- References the dependencies vsix to ensure that we also deploy any dependencies needed by the RazorExtension that might not be included in public VS instances. -->

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Microsoft.AspNetCore.Razor.Test.Common.Tooling.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Microsoft.AspNetCore.Razor.Test.Common.Tooling.csproj
@@ -48,6 +48,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Test.Utilities" Version="$(MicrosoftCodeAnalysisTestUtilitiesPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(MicrosoftCodeAnalysisWorkspacesCommonPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsPackageVersion)" />
+    <PackageReference Include="Microsoft.VisualStudio.Copilot" Version="$(MicrosoftVisualStudioCopilotVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.Data" Version="$(MicrosoftVisualStudioTextDataPackageVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Text.Implementation" Version="$(MicrosoftVisualStudioTextImplementationPackageVersion)" NoWarn="NU1701" />
     <PackageReference Include="Microsoft.VisualStudio.Text.Logic" Version="$(MicrosoftVisualStudioTextLogicPackageVersion)" />

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/ClientSettingsManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/ClientSettingsManagerTest.cs
@@ -150,5 +150,9 @@ public class ClientSettingsManagerTest(ITestOutputHelper testOutput) : ProjectSn
         {
             return _settings;
         }
+
+        public void Dispose()
+        {
+        }
     }
 }


### PR DESCRIPTION
Finalizes AB#1786418 

Unified settins has been in for a while, but we needed to consume the 17.9 preview packages to be able to subscribe to the change events. This adds that, updates the structures we use to help keep it easy to follow, and adds a readme for people adding new options.

