### PR TITLE
Don't use IRazorLoggerFactory from integration tests.... YET!

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/OutputInProcess.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/OutputInProcess.cs
@@ -4,9 +4,8 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.Test.Common.Logging;
-using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.VisualStudio.Razor.IntegrationTests.Extensions;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
@@ -20,29 +19,33 @@ internal partial class OutputInProcess
 {
     private const string RazorPaneName = "Razor Logger Output";
 
-    private TestOutputLoggerProvider? _testLoggerProvider;
+    // private TestOutputLoggerProvider? _testLoggerProvider;
 
-    public async Task<ILogger> SetupIntegrationTestLoggerAsync(ITestOutputHelper testOutputHelper, CancellationToken cancellationToken)
+#pragma warning disable IDE0060 // Remove unused parameter
+    public Task<ILogger> SetupIntegrationTestLoggerAsync(ITestOutputHelper testOutputHelper, CancellationToken cancellationToken)
+#pragma warning restore IDE0060 // Remove unused parameter
     {
-        var logger = await TestServices.Shell.GetComponentModelServiceAsync<IRazorLoggerFactory>(cancellationToken);
+        return Task.FromResult<ILogger>(NullLogger.Instance);
 
-        // We can't remove logging providers, so we just keep track of ours so we can make sure it points to the right test output helper
-        if (_testLoggerProvider is null)
-        {
-            _testLoggerProvider = new TestOutputLoggerProvider(testOutputHelper);
-            logger.AddLoggerProvider(_testLoggerProvider);
-        }
-        else
-        {
-            _testLoggerProvider.SetTestOutputHelper(testOutputHelper);
-        }
+        // var logger = await TestServices.Shell.GetComponentModelServiceAsync<IRazorLoggerFactory>(cancellationToken);
 
-        return logger.CreateLogger(GetType().Name);
+        // // We can't remove logging providers, so we just keep track of ours so we can make sure it points to the right test output helper
+        // if (_testLoggerProvider is null)
+        // {
+        //     _testLoggerProvider = new TestOutputLoggerProvider(testOutputHelper);
+        //     logger.AddLoggerProvider(_testLoggerProvider);
+        // }
+        // else
+        // {
+        //     _testLoggerProvider.SetTestOutputHelper(testOutputHelper);
+        // }
+
+        // return logger.CreateLogger(GetType().Name);
     }
 
     public void ClearIntegrationTestLogger()
     {
-        _testLoggerProvider?.SetTestOutputHelper(null);
+        // _testLoggerProvider?.SetTestOutputHelper(null);
     }
 
     public async Task<bool> HasErrorsAsync(CancellationToken cancellationToken)

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/LogIntegrationTestAttribute.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/LogIntegrationTestAttribute.cs
@@ -3,10 +3,6 @@
 
 using System;
 using System.Reflection;
-using Microsoft.CodeAnalysis.Razor.Logging;
-using Microsoft.Extensions.Logging;
-using Microsoft.VisualStudio.ComponentModelHost;
-using Microsoft.VisualStudio.Shell;
 using Xunit.Sdk;
 
 namespace Microsoft.VisualStudio.Razor.IntegrationTests;
@@ -16,18 +12,18 @@ public class LogIntegrationTestAttribute : BeforeAfterTestAttribute
 {
     public override void Before(MethodInfo methodUnderTest)
     {
-        GetLogger(methodUnderTest.Name).LogInformation("#### Integration test start.");
+        // GetLogger(methodUnderTest.Name).LogInformation("#### Integration test start.");
     }
 
     public override void After(MethodInfo methodUnderTest)
     {
-        GetLogger(methodUnderTest.Name).LogInformation("#### Integration test end.");
+        // GetLogger(methodUnderTest.Name).LogInformation("#### Integration test end.");
     }
 
-    private static ILogger GetLogger(string testName)
-    {
-        var componentModel = ServiceProvider.GlobalProvider.GetService<SComponentModel, IComponentModel>();
-        var loggerFactory = componentModel.GetService<IRazorLoggerFactory>();
-        return loggerFactory.CreateLogger(testName);
-    }
+    // private static ILogger GetLogger(string testName)
+    // {
+    //     var componentModel = ServiceProvider.GlobalProvider.GetService<SComponentModel, IComponentModel>();
+    //     var loggerFactory = componentModel.GetService<IRazorLoggerFactory>();
+    //     return loggerFactory.CreateLogger(testName);
+    // }
 }


### PR DESCRIPTION
Seems like we can't expect types to be in the MEF composition if they're not in the installed VS version. I guess the test harness bits run in a separate environment to the hive used for the tests? Anyway.

This should hopefully allow our main integration tests to start passing again, and once the actual IRazorLoggerFactory bits are inserted into VS main we can hopefully revert this. Of course, that requires getting our CI unblocked, but thats a problem for another day :)