### PR TITLE
Add feature flag to disable the non-cohost server

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ConfigurableLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ConfigurableLanguageServerFeatureOptions.cs
@@ -24,6 +24,7 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
     private readonly bool? _includeProjectKeyInGeneratedFilePath;
     private readonly bool? _monitorWorkspaceFolderForConfigurationFiles;
     private readonly bool? _useRazorCohostServer;
+    private readonly bool? _disableRazorLanguageServer;
 
     public override bool SupportsFileManipulation => _supportsFileManipulation ?? _defaults.SupportsFileManipulation;
     public override string ProjectConfigurationFileName => _projectConfigurationFileName ?? _defaults.ProjectConfigurationFileName;
@@ -39,6 +40,7 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
     public override bool IncludeProjectKeyInGeneratedFilePath => _includeProjectKeyInGeneratedFilePath ?? _defaults.IncludeProjectKeyInGeneratedFilePath;
     public override bool MonitorWorkspaceFolderForConfigurationFiles => _monitorWorkspaceFolderForConfigurationFiles ?? _defaults.MonitorWorkspaceFolderForConfigurationFiles;
     public override bool UseRazorCohostServer => _useRazorCohostServer ?? _defaults.UseRazorCohostServer;
+    public override bool DisableRazorLanguageServer => _disableRazorLanguageServer ?? _defaults.DisableRazorLanguageServer;
 
     public ConfigurableLanguageServerFeatureOptions(string[] args)
     {
@@ -63,6 +65,7 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
             TryProcessBoolOption(nameof(IncludeProjectKeyInGeneratedFilePath), ref _includeProjectKeyInGeneratedFilePath, option, args, i);
             TryProcessBoolOption(nameof(MonitorWorkspaceFolderForConfigurationFiles), ref _monitorWorkspaceFolderForConfigurationFiles, option, args, i);
             TryProcessBoolOption(nameof(UseRazorCohostServer), ref _useRazorCohostServer, option, args, i);
+            TryProcessBoolOption(nameof(DisableRazorLanguageServer), ref _disableRazorLanguageServer, option, args, i);
         }
     }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
@@ -42,4 +42,6 @@ internal class DefaultLanguageServerFeatureOptions : LanguageServerFeatureOption
     public override bool MonitorWorkspaceFolderForConfigurationFiles => true;
 
     public override bool UseRazorCohostServer => false;
+
+    public override bool DisableRazorLanguageServer => false;
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
@@ -45,4 +45,6 @@ internal abstract class LanguageServerFeatureOptions
     public abstract bool MonitorWorkspaceFolderForConfigurationFiles { get; }
 
     public abstract bool UseRazorCohostServer { get; }
+
+    public abstract bool DisableRazorLanguageServer { get; }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
@@ -16,12 +16,14 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
     private const string IncludeProjectKeyInGeneratedFilePathFeatureFlag = "Razor.LSP.IncludeProjectKeyInGeneratedFilePath";
     private const string UsePreciseSemanticTokenRangesFeatureFlag = "Razor.LSP.UsePreciseSemanticTokenRanges";
     private const string UseRazorCohostServerFeatureFlag = "Razor.LSP.UseRazorCohostServer";
+    private const string DisableRazorLanguageServerFeatureFlag = "Razor.LSP.DisableRazorLanguageServer";
 
     private readonly LSPEditorFeatureDetector _lspEditorFeatureDetector;
     private readonly Lazy<bool> _showAllCSharpCodeActions;
     private readonly Lazy<bool> _includeProjectKeyInGeneratedFilePath;
     private readonly Lazy<bool> _usePreciseSemanticTokenRanges;
     private readonly Lazy<bool> _useRazorCohostServer;
+    private readonly Lazy<bool> _disableRazorLanguageServer;
 
     [ImportingConstructor]
     public VisualStudioWindowsLanguageServerFeatureOptions(LSPEditorFeatureDetector lspEditorFeatureDetector)
@@ -60,6 +62,13 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
             var useRazorCohostServer = featureFlags.IsFeatureEnabled(UseRazorCohostServerFeatureFlag, defaultValue: false);
             return useRazorCohostServer;
         });
+
+        _disableRazorLanguageServer = new Lazy<bool>(() =>
+        {
+            var featureFlags = (IVsFeatureFlags)AsyncPackage.GetGlobalService(typeof(SVsFeatureFlags));
+            var disableRazorLanguageServer = featureFlags.IsFeatureEnabled(DisableRazorLanguageServerFeatureFlag, defaultValue: false);
+            return disableRazorLanguageServer;
+        });
     }
 
     // We don't currently support file creation operations on VS Codespaces or VS Liveshare
@@ -93,4 +102,6 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
     public override bool MonitorWorkspaceFolderForConfigurationFiles => false;
 
     public override bool UseRazorCohostServer => _useRazorCohostServer.Value;
+
+    public override bool DisableRazorLanguageServer => _disableRazorLanguageServer.Value;
 }

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
@@ -68,3 +68,9 @@
 "Value"=dword:00000000
 "Title"="Use Roslyn Cohost server for Razor (requires restart)"
 "PreviewPaneChannels"="IntPreview,int.main"
+
+[$RootKey$\FeatureFlags\Razor\LSP\DisableRazorLanguageServer]
+"Description"="Disables the Razor Language Server so that only the Cohost server is activate. This is probably a bad idea to turn on if you are not on the Razor Tooling team."
+"Value"=dword:00000000
+"Title"="Disable Razor Language Server (requires restart)"
+"PreviewPaneChannels"="IntPreview,int.main"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/TestLanguageServerFeatureOptions.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/TestLanguageServerFeatureOptions.cs
@@ -46,5 +46,7 @@ internal class TestLanguageServerFeatureOptions : LanguageServerFeatureOptions
 
     public override bool MonitorWorkspaceFolderForConfigurationFiles => _monitorWorkspaceFolderForConfigurationFiles;
 
-    public override bool UseRazorCohostServer => throw new System.NotImplementedException();
+    public override bool UseRazorCohostServer => false;
+
+    public override bool DisableRazorLanguageServer => false;
 }


### PR DESCRIPTION
It should be a lot easier to work on cohosting in general, but on things like document handling, if the regular server isn't also running.

Sadly I'm not able to test this, because the new settings UI doesn't work with hives, so I can't turn the feature flag on there, and the old options screen pane has been removed. Can always follow up if things don't disable properly :)