### PR TITLE
Don't get the trace source until we need to use it

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Logging/RazorLogHubTraceProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Logging/RazorLogHubTraceProvider.cs
@@ -10,5 +10,5 @@ namespace Microsoft.VisualStudio.Editor.Razor.Logging;
 internal abstract class RazorLogHubTraceProvider
 {
     public abstract Task InitializeTraceAsync(string logIdentifier, int logHubSessionId, CancellationToken cancellationToken);
-    public abstract TraceSource GetTraceSource();
+    public abstract TraceSource? TryGetTraceSource();
 }

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Telemetry/VSTelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Telemetry/VSTelemetryReporter.cs
@@ -24,7 +24,7 @@ internal class VSTelemetryReporter : TelemetryReporter
             // appinsights keys etc
             : base(ImmutableArray.Create(TelemetryService.DefaultSession))
     {
-        _logger = loggerFactory?.CreateLogger<VSTelemetryReporter>();
+        _logger = loggerFactory.CreateLogger<VSTelemetryReporter>();
     }
 
     protected override bool HandleException(Exception exception, string? message, params object?[] @params)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Logging/RazorLogHubLoggerProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Logging/RazorLogHubLoggerProvider.cs
@@ -22,7 +22,7 @@ internal sealed class RazorLogHubLoggerProvider : IRazorLoggerProvider
 
     public ILogger CreateLogger(string categoryName)
     {
-        return new RazorLogHubLogger(categoryName, _traceProvider.GetTraceSource());
+        return new RazorLogHubLogger(categoryName, _traceProvider);
     }
 
     public void Dispose()

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
@@ -100,7 +100,7 @@ internal class RazorLanguageServerClient(
 
         await EnsureCleanedUpServerAsync().ConfigureAwait(false);
 
-        var traceSource = _traceProvider.GetTraceSource();
+        var traceSource = _traceProvider.TryGetTraceSource();
 
         var lspOptions = RazorLSPOptions.From(_clientSettingsManager.GetClientSettings());
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/VisualStudioWindowsLogHubTraceProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/VisualStudioWindowsLogHubTraceProvider.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
 using System.Composition;
 using System.Diagnostics;
 using System.Threading;
@@ -45,9 +44,9 @@ internal class VisualStudioWindowsLogHubTraceProvider : RazorLogHubTraceProvider
         _traceSource = await traceConfig.RegisterLogSourceAsync(logId, s_logOptions, cancellationToken).ConfigureAwait(false);
     }
 
-    public override TraceSource GetTraceSource()
+    public override TraceSource? TryGetTraceSource()
     {
-        return _traceSource ?? throw new InvalidOperationException("Trace source requested before it was initialized.");
+        return _traceSource;
     }
 
     private async Task<bool> TryInitializeServiceBrokerAsync(CancellationToken cancellationToken)


### PR DESCRIPTION
Hopefully fixes an issue seen in integration tests, and by @alexgav. I was never able to repro it, but I could see it being possible if there is a race between the trace source being initialized, and an error that wants to be reported.