### PR TITLE
Use custom roslyn/diagnostics endpoint if enabled

### DIFF
--- a/SpellingExclusions.dic
+++ b/SpellingExclusions.dic
@@ -3,3 +3,4 @@ Blazor
 csproj
 cshtml
 microsoft
+csharp

--- a/SpellingExclusions.dic
+++ b/SpellingExclusions.dic
@@ -3,4 +3,3 @@ Blazor
 csproj
 cshtml
 microsoft
-csharp

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ConfigurableLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ConfigurableLanguageServerFeatureOptions.cs
@@ -23,6 +23,7 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
     private readonly bool? _updateBuffersForClosedDocuments;
     private readonly bool? _includeProjectKeyInGeneratedFilePath;
     private readonly bool? _monitorWorkspaceFolderForConfigurationFiles;
+    private readonly bool? _useRoslynAnalyzerDiagnostics;
 
     public override bool SupportsFileManipulation => _supportsFileManipulation ?? _defaults.SupportsFileManipulation;
     public override string ProjectConfigurationFileName => _projectConfigurationFileName ?? _defaults.ProjectConfigurationFileName;
@@ -37,6 +38,8 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
     public override bool UpdateBuffersForClosedDocuments => _updateBuffersForClosedDocuments ?? _defaults.UpdateBuffersForClosedDocuments;
     public override bool IncludeProjectKeyInGeneratedFilePath => _includeProjectKeyInGeneratedFilePath ?? _defaults.IncludeProjectKeyInGeneratedFilePath;
     public override bool MonitorWorkspaceFolderForConfigurationFiles => _monitorWorkspaceFolderForConfigurationFiles ?? _defaults.MonitorWorkspaceFolderForConfigurationFiles;
+
+    public override bool UseRoslynAnalyzerDiagnostics => _useRoslynAnalyzerDiagnostics ?? _defaults.UseRoslynAnalyzerDiagnostics;
 
     public ConfigurableLanguageServerFeatureOptions(string[] args)
     {
@@ -60,6 +63,7 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
             TryProcessBoolOption(nameof(UpdateBuffersForClosedDocuments), ref _updateBuffersForClosedDocuments, option, args, i);
             TryProcessBoolOption(nameof(IncludeProjectKeyInGeneratedFilePath), ref _includeProjectKeyInGeneratedFilePath, option, args, i);
             TryProcessBoolOption(nameof(MonitorWorkspaceFolderForConfigurationFiles), ref _monitorWorkspaceFolderForConfigurationFiles, option, args, i);
+            TryProcessBoolOption(nameof(UseRoslynAnalyzerDiagnostics), ref _useRoslynAnalyzerDiagnostics, option, args, i);
         }
     }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
@@ -40,4 +40,6 @@ internal class DefaultLanguageServerFeatureOptions : LanguageServerFeatureOption
     public override bool UsePreciseSemanticTokenRanges => false;
 
     public override bool MonitorWorkspaceFolderForConfigurationFiles => true;
+
+    public override bool UseRoslynAnalyzerDiagnostics => false;
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
@@ -43,4 +43,10 @@ internal abstract class LanguageServerFeatureOptions
     /// razor/monitorProjectConfigurationFilePath notification is sent.
     /// </remarks>
     public abstract bool MonitorWorkspaceFolderForConfigurationFiles { get; }
+
+    /// <summary>
+    /// If enabled, attempts to use a joined custom endpoint provided by Roslyn that will provide diagnostics for generated cs files as well
+    /// as any analyzer diagnostics provided for a given razor document.
+    /// </summary>
+    public abstract bool UseRoslynAnalyzerDiagnostics { get; }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Endpoints/Diagnostics.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Endpoints/Diagnostics.cs
@@ -77,12 +77,13 @@ internal partial class RazorCustomMessageTarget
         }
 
         ReinvocationResponse<VSInternalDiagnosticReport[]?>? response = null;
+        var virtualDocumentIdentifier = identifierFromOriginalRequest.WithUri(virtualDocument.Uri);
         if (_languageServerFeatureOptions.UseRoslynAnalyzerDiagnostics && delegatedLanguageServerName == RazorLSPConstants.RazorCSharpLanguageServerName)
         {
             var diagnosticParams = new RazorDiagnosticsParams
             {
-                RazorTextDocument = identifierFromOriginalRequest,
-                TextDocument = new() { Uri = virtualDocument.Uri },
+                RazorTextDocument = new() { Uri = hostDocument.Uri },
+                TextDocument = virtualDocumentIdentifier,
             };
 
             var lspMethodName = RazorLSPConstants.RoslynDiagnosticsName;
@@ -104,7 +105,7 @@ internal partial class RazorCustomMessageTarget
 
             var request = new VSInternalDocumentDiagnosticsParams
             {
-                TextDocument = identifierFromOriginalRequest.WithUri(virtualDocument.Uri),
+                TextDocument = virtualDocumentIdentifier,
             };
 
             response = await _requestInvoker.ReinvokeRequestOnServerAsync<VSInternalDocumentDiagnosticsParams, VSInternalDiagnosticReport[]?>(

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConstants.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConstants.cs
@@ -26,4 +26,6 @@ internal static class RazorLSPConstants
     public const string RoslynFormatNewFileEndpointName = "roslyn/formatNewFile";
 
     public const string RoslynSemanticTokenRangesEndpointName = "roslyn/semanticTokenRanges";
+
+    public const string RoslynDiagnosticsName = "roslyn/diagnostics";
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
@@ -15,11 +15,13 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
     private const string ShowAllCSharpCodeActionsFeatureFlag = "Razor.LSP.ShowAllCSharpCodeActions";
     private const string IncludeProjectKeyInGeneratedFilePathFeatureFlag = "Razor.LSP.IncludeProjectKeyInGeneratedFilePath";
     private const string UsePreciseSemanticTokenRangesFeatureFlag = "Razor.LSP.UsePreciseSemanticTokenRanges";
+    private const string UseRoslynAnalyzerDiagnosticsFeatureFlag = "Razor.LSP.UseRoslynAnalyzerDiagnostics";
 
     private readonly LSPEditorFeatureDetector _lspEditorFeatureDetector;
     private readonly Lazy<bool> _showAllCSharpCodeActions;
     private readonly Lazy<bool> _includeProjectKeyInGeneratedFilePath;
     private readonly Lazy<bool> _usePreciseSemanticTokenRanges;
+    private readonly Lazy<bool> _useRoslynAnalyzerDiagnostics;
 
     [ImportingConstructor]
     public VisualStudioWindowsLanguageServerFeatureOptions(LSPEditorFeatureDetector lspEditorFeatureDetector)
@@ -49,6 +51,13 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
         {
             var featureFlags = (IVsFeatureFlags)AsyncPackage.GetGlobalService(typeof(SVsFeatureFlags));
             var usePreciseSemanticTokenRanges = featureFlags.IsFeatureEnabled(UsePreciseSemanticTokenRangesFeatureFlag, defaultValue: false);
+            return usePreciseSemanticTokenRanges;
+        });
+
+        _useRoslynAnalyzerDiagnostics = new Lazy<bool>(() =>
+        {
+            var featureFlags = (IVsFeatureFlags)AsyncPackage.GetGlobalService(typeof(SVsFeatureFlags));
+            var usePreciseSemanticTokenRanges = featureFlags.IsFeatureEnabled(UseRoslynAnalyzerDiagnosticsFeatureFlag, defaultValue: true);
             return usePreciseSemanticTokenRanges;
         });
     }
@@ -82,4 +91,6 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
     public override bool UsePreciseSemanticTokenRanges => _usePreciseSemanticTokenRanges.Value;
 
     public override bool MonitorWorkspaceFolderForConfigurationFiles => false;
+
+    public override bool UseRoslynAnalyzerDiagnostics => _useRoslynAnalyzerDiagnostics.Value;
 }

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
@@ -62,3 +62,10 @@
 "Title"="Use precise semantic token ranges when requesting semantic token information on Razor files (requires restart)"
 "PreviewPaneChannels"="*"
 "VisibleToInternalUsersOnlyChannels"="*"
+
+[$RootKey$\FeatureFlags\Razor\LSP\UseRoslynAnalyzerDiagnostics]]
+"Description"="Use Roslyn analyzer diagnostics when requesting diagnostics on razor files. Note: This is experimental, some actions may not apply correctly, or at all!"
+"Value"=dword:00000001
+"Title"="Use Roslyn analyzer diagnostics when requesting diagnostics on razor files (requires restart)"
+"PreviewPaneChannels"="*"
+"VisibleToInternalUsersOnlyChannels"="*"

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
@@ -68,4 +68,3 @@
 "Value"=dword:00000001
 "Title"="Use Roslyn analyzer diagnostics when requesting diagnostics on razor files (requires restart)"
 "PreviewPaneChannels"="*"
-"VisibleToInternalUsersOnlyChannels"="*"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/TestLanguageServerFeatureOptions.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/TestLanguageServerFeatureOptions.cs
@@ -45,4 +45,6 @@ internal class TestLanguageServerFeatureOptions : LanguageServerFeatureOptions
     public override bool IncludeProjectKeyInGeneratedFilePath => _includeProjectKeyInGeneratedFilePath;
 
     public override bool MonitorWorkspaceFolderForConfigurationFiles => _monitorWorkspaceFolderForConfigurationFiles;
+
+    public override bool UseRoslynAnalyzerDiagnostics => false;
 }


### PR DESCRIPTION
The Razor side of https://github.com/dotnet/roslyn/pull/71365 

* [x] Still need manual testing. I hit some MEF things so I'm doing a purge of my cache etc, but putting up as I do so
* [x] Have an off switch, in case somehow we find edgecases that are ruining things for users. I assume this is better than an option?
