### PR TITLE
Move integration tests to .NET 8

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractRazorEditorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractRazorEditorTest.cs
@@ -31,6 +31,8 @@ public abstract class AbstractRazorEditorTest(ITestOutputHelper testOutputHelper
 
     protected virtual string TargetFramework => "net8.0";
 
+    protected virtual string TargetFrameworkElement => $"""<TargetFramework>{TargetFramework}</TargetFramework>""";
+
     public override async Task InitializeAsync()
     {
         await base.InitializeAsync();
@@ -113,7 +115,7 @@ public abstract class AbstractRazorEditorTest(ITestOutputHelper testOutputHelper
         {
             if (line.Contains("<TargetFramework"))
             {
-                sb.AppendLine($"""<TargetFramework>{TargetFramework}</TargetFramework>""");
+                sb.AppendLine(TargetFrameworkElement);
             }
             else
             {

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractRazorEditorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractRazorEditorTest.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -27,6 +28,8 @@ public abstract class AbstractRazorEditorTest(ITestOutputHelper testOutputHelper
     private ILogger? _testLogger;
 
     protected virtual bool ComponentClassificationExpected => true;
+
+    protected virtual string TargetFramework => "net8.0";
 
     public override async Task InitializeAsync()
     {
@@ -93,8 +96,8 @@ public abstract class AbstractRazorEditorTest(ITestOutputHelper testOutputHelper
         using var zip = new ZipArchive(zipStream);
         zip.ExtractToDirectory(solutionPath);
 
-        var slnFile = Directory.EnumerateFiles(solutionPath, "*.sln").First();
-        var projectFile = Directory.EnumerateFiles(solutionPath, "*.csproj", SearchOption.AllDirectories).First();
+        var slnFile = Directory.EnumerateFiles(solutionPath, "*.sln").Single();
+        var projectFile = Directory.EnumerateFiles(solutionPath, "*.csproj", SearchOption.AllDirectories).Single();
 
         PrepareProjectForFirstOpen(projectFile);
 
@@ -105,6 +108,20 @@ public abstract class AbstractRazorEditorTest(ITestOutputHelper testOutputHelper
 
     protected virtual void PrepareProjectForFirstOpen(string projectFileName)
     {
+        var sb = new StringBuilder();
+        foreach (var line in File.ReadAllLines(projectFileName))
+        {
+            if (line.Contains("<TargetFramework"))
+            {
+                sb.AppendLine($"""<TargetFramework>{TargetFramework}</TargetFramework>""");
+            }
+            else
+            {
+                sb.AppendLine(line);
+            }
+        }
+
+        File.WriteAllText(projectFileName, sb.ToString());
     }
 
     private static string CreateTemporaryPath()

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/MultiTargetProjectTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/MultiTargetProjectTests.cs
@@ -3,7 +3,6 @@
 
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -12,23 +11,7 @@ namespace Microsoft.VisualStudio.Razor.IntegrationTests;
 
 public class MultiTargetProjectTests(ITestOutputHelper testOutputHelper) : AbstractRazorEditorTest(testOutputHelper)
 {
-    protected override void PrepareProjectForFirstOpen(string projectFileName)
-    {
-        var sb = new StringBuilder();
-        foreach (var line in File.ReadAllLines(projectFileName))
-        {
-            if (line.Contains("<TargetFramework>"))
-            {
-                sb.AppendLine("<TargetFrameworks>net7.0;net8.0</TargetFrameworks>");
-            }
-            else
-            {
-                sb.AppendLine(line);
-            }
-        }
-
-        File.WriteAllText(projectFileName, sb.ToString());
-    }
+    protected override string TargetFrameworkElement => $"""<TargetFrameworks>net7.0;{TargetFramework}</TargetFrameworks>""";
 
     [IdeFact]
     public async Task ValidateMultipleJsonFiles()

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/MultiTargetProjectTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/MultiTargetProjectTests.cs
@@ -53,8 +53,9 @@ public class MultiTargetProjectTests(ITestOutputHelper testOutputHelper) : Abstr
         Assert.Equal(expectedProjectFileName, actualProjectFileName);
     }
 
-    [IdeFact]
-    public async Task OpenExistingProject_WithReopenedFile()
+    [IdeTheory]
+    [CombinatorialData]
+    public async Task OpenExistingProject_WithReopenedFile(bool deleteProjectRazorJson)
     {
         var solutionPath = await TestServices.SolutionExplorer.GetDirectoryNameAsync(ControlledHangMitigatingCancellationToken);
         var expectedProjectFileName = await TestServices.SolutionExplorer.GetAbsolutePathForProjectRelativeFilePathAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.ProjectFile, ControlledHangMitigatingCancellationToken);
@@ -65,37 +66,12 @@ public class MultiTargetProjectTests(ITestOutputHelper testOutputHelper) : Abstr
 
         await TestServices.SolutionExplorer.CloseSolutionAsync(ControlledHangMitigatingCancellationToken);
 
-        var solutionFileName = Path.Combine(solutionPath, RazorProjectConstants.BlazorSolutionName + ".sln");
-        await TestServices.SolutionExplorer.OpenSolutionAsync(solutionFileName, ControlledHangMitigatingCancellationToken);
-
-        await TestServices.Workspace.WaitForProjectSystemAsync(ControlledHangMitigatingCancellationToken);
-
-        await TestServices.Editor.WaitForSemanticClassificationAsync("class name", ControlledHangMitigatingCancellationToken, count: 1);
-
-        TestServices.Input.Send("1");
-
-        // Make sure the test framework didn't do something weird and create new project
-        var actualProjectFileName = await TestServices.SolutionExplorer.GetAbsolutePathForProjectRelativeFilePathAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.ProjectFile, ControlledHangMitigatingCancellationToken);
-        Assert.Equal(expectedProjectFileName, actualProjectFileName);
-
-        await TestServices.Editor.CloseCodeFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.ErrorCshtmlFile, saveFile: false, ControlledHangMitigatingCancellationToken);
-    }
-
-    [IdeFact]
-    public async Task OpenExistingProject_WithReopenedFile_NoProjectRazorJson()
-    {
-        var solutionPath = await TestServices.SolutionExplorer.GetDirectoryNameAsync(ControlledHangMitigatingCancellationToken);
-        var expectedProjectFileName = await TestServices.SolutionExplorer.GetAbsolutePathForProjectRelativeFilePathAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.ProjectFile, ControlledHangMitigatingCancellationToken);
-
-        // Open SurveyPrompt and make sure its all up and running
-        await TestServices.SolutionExplorer.OpenFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.ErrorCshtmlFile, ControlledHangMitigatingCancellationToken);
-        await TestServices.Editor.WaitForSemanticClassificationAsync("class name", ControlledHangMitigatingCancellationToken, count: 1);
-
-        await TestServices.SolutionExplorer.CloseSolutionAsync(ControlledHangMitigatingCancellationToken);
-
-        // Clear out the project.razor.bin file which ensures our restored file will have to be in the Misc Project
-        var projectRazorJsonFileName = Directory.EnumerateFiles(solutionPath, "project.razor.*.bin", SearchOption.AllDirectories).First();
-        File.Delete(projectRazorJsonFileName);
+        if (deleteProjectRazorJson)
+        {
+            // Clear out the project.razor.bin file which ensures our restored file will have to be in the Misc Project
+            var projectRazorJsonFileName = Directory.EnumerateFiles(solutionPath, "project.razor.*.bin", SearchOption.AllDirectories).First();
+            File.Delete(projectRazorJsonFileName);
+        }
 
         var solutionFileName = Path.Combine(solutionPath, RazorProjectConstants.BlazorSolutionName + ".sln");
         await TestServices.SolutionExplorer.OpenSolutionAsync(solutionFileName, ControlledHangMitigatingCancellationToken);

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/NonRazorSdkTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/NonRazorSdkTests.cs
@@ -31,6 +31,8 @@ public class NonRazorSdkTests(ITestOutputHelper testOutputHelper) : AbstractRazo
         }
 
         File.WriteAllText(projectFileName, sb.ToString());
+
+        base.PrepareProjectForFirstOpen(projectFileName);
     }
 
     [IdeFact]


### PR DESCRIPTION
Sort of fixes https://github.com/dotnet/razor/issues/9368 (but really i think its just not necessary)

Integration test run is green: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=8856230&view=results