### PR TITLE
Update ASP.NET Core runtime used in tests to v8 GA

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -163,7 +163,7 @@
     <!-- Compiler Deps -->
     <DiffPlexVersion>1.5.0</DiffPlexVersion>
     <FluentAssertionsVersion>6.7.0</FluentAssertionsVersion>
-    <MicrosoftAspNetCoreAppVersion>8.0.0-rc.1.23421.29</MicrosoftAspNetCoreAppVersion>
+    <MicrosoftAspNetCoreAppVersion>8.0.0</MicrosoftAspNetCoreAppVersion>
     <MicrosoftBuildLocatorVersion>1.4.1</MicrosoftBuildLocatorVersion>
     <MicrosoftBuildVersion>17.3.0-preview-22364-05</MicrosoftBuildVersion>
     <MicrosoftBuildFrameworkVersion>$(MicrosoftBuildVersion)</MicrosoftBuildFrameworkVersion>

--- a/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/TestFiles/RazorSourceGeneratorComponentTests/ScriptTag/Views_Home_Index.html
+++ b/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/TestFiles/RazorSourceGeneratorComponentTests/ScriptTag/Views_Home_Index.html
@@ -5,7 +5,7 @@
 alert('hello')</script>
 Component:
 1: <script>alert('hello')</script>
-2: <script>alert(&#x27;hello&#x27;)</script>
+2: <script>alert(\u0027hello\u0027)</script>
 3: <div>alert('hello')</div>
 4: <script>
 alert('hello')</script>


### PR DESCRIPTION
Seems better if our tests are executed against the latest runtime version.