### PR TITLE
Add telemetry for time-to-first diagnostic

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -92,7 +92,7 @@
     <Tooling_HtmlEditorPackageVersion>17.9.67-preview-0001</Tooling_HtmlEditorPackageVersion>
     <MicrosoftVisualStudioShellPackagesVersion>17.9.36400-preview.3</MicrosoftVisualStudioShellPackagesVersion>
     <MicrosoftVisualStudioPackagesVersion>17.9.80-preview</MicrosoftVisualStudioPackagesVersion>
-    <VisualStudioLanguageServerProtocolVersion>17.9.3-preview</VisualStudioLanguageServerProtocolVersion>
+    <VisualStudioLanguageServerProtocolVersion>17.9.6-preview</VisualStudioLanguageServerProtocolVersion>
     <MicrosoftVisualStudioCopilotVersion>0.2.28-beta</MicrosoftVisualStudioCopilotVersion>
     <!-- dotnet/runtime packages -->
     <MicrosoftExtensionsPackageVersion>6.0.0</MicrosoftExtensionsPackageVersion>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/DocumentPullDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/DocumentPullDiagnosticsEndpoint.cs
@@ -42,6 +42,12 @@ internal class DocumentPullDiagnosticsEndpoint : IRazorRequestHandler<VSInternal
     public void ApplyCapabilities(VSInternalServerCapabilities serverCapabilities, VSInternalClientCapabilities clientCapabilities)
     {
         serverCapabilities.SupportsDiagnosticRequests = true;
+        if (serverCapabilities.DiagnosticProvider is null)
+        {
+            serverCapabilities.DiagnosticProvider = new VSInternalDiagnosticOptions();
+        }
+
+        serverCapabilities.DiagnosticProvider.DiagnosticKinds = [ VSInternalDiagnosticKind.Syntax];
     }
 
     public TextDocumentIdentifier GetTextDocumentIdentifier(VSInternalDocumentDiagnosticsParams request)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/DocumentPullDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/DocumentPullDiagnosticsEndpoint.cs
@@ -42,12 +42,8 @@ internal class DocumentPullDiagnosticsEndpoint : IRazorRequestHandler<VSInternal
     public void ApplyCapabilities(VSInternalServerCapabilities serverCapabilities, VSInternalClientCapabilities clientCapabilities)
     {
         serverCapabilities.SupportsDiagnosticRequests = true;
-        if (serverCapabilities.DiagnosticProvider is null)
-        {
-            serverCapabilities.DiagnosticProvider = new VSInternalDiagnosticOptions();
-        }
-
-        serverCapabilities.DiagnosticProvider.DiagnosticKinds = [ VSInternalDiagnosticKind.Syntax];
+        serverCapabilities.DiagnosticProvider ??= new();
+        serverCapabilities.DiagnosticProvider.DiagnosticKinds = [VSInternalDiagnosticKind.Syntax];
     }
 
     public TextDocumentIdentifier GetTextDocumentIdentifier(VSInternalDocumentDiagnosticsParams request)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/DocumentPullDiagnosticsEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/DocumentPullDiagnosticsEndpointTest.cs
@@ -18,7 +18,7 @@ public sealed class DocumentPullDiagnosticsEndpointTest(ITestOutputHelper testOu
     public void ApplyCapabilities_AddsExpectedCapabilities()
     {
         // Arrange
-        var documentMappingService = new RazorDocumentMappingService(new FilePathService(TestLanguageServerFeatureOptions.Instance), new TestDocumentContextFactory(), LoggerFactory);
+        var documentMappingService = new RazorDocumentMappingService(FilePathService, new TestDocumentContextFactory(), LoggerFactory);
         var featureOptions = new Mock<LanguageServerFeatureOptions>(MockBehavior.Strict);
         var razorTranslate = new Mock<RazorTranslateDiagnosticsService>(MockBehavior.Strict,
             documentMappingService,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/DocumentPullDiagnosticsEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/DocumentPullDiagnosticsEndpointTest.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics;
+using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
+using Microsoft.AspNetCore.Razor.Test.Common.Logging;
+using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
+using Microsoft.CodeAnalysis.Razor.Logging;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Moq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Diagnostics;
+
+public class DocumentPullDiagnosticsEndpointTest(ITestOutputHelper testOutput)
+{
+    private readonly ITestOutputHelper _testOutput = testOutput;
+
+    [Fact]
+    public void ApplyCapabilities_AddsExpectedCapabilities()
+    {
+        // Arrange
+        var loggerFactory = new RazorLoggerFactory(new[] { new TestOutputLoggerProvider(_testOutput) });
+        var documentMappingService = new RazorDocumentMappingService(new FilePathService(TestLanguageServerFeatureOptions.Instance), new TestDocumentContextFactory(), loggerFactory);
+        var featureOptions = new Mock<LanguageServerFeatureOptions>(MockBehavior.Strict);
+        var razorTranslate = new Mock<RazorTranslateDiagnosticsService>(MockBehavior.Strict,
+            documentMappingService,
+            loggerFactory);
+        var clientConnection = new Mock<IClientConnection>(MockBehavior.Strict);
+        var endpoint = new DocumentPullDiagnosticsEndpoint(
+            featureOptions.Object,
+            razorTranslate.Object,
+            clientConnection.Object,
+            telemetryReporter:null);
+
+        // Act
+        VSInternalServerCapabilities serverCapabilities = new();
+        VSInternalClientCapabilities clientCapabilities = new();
+        endpoint.ApplyCapabilities(serverCapabilities, clientCapabilities);
+
+        // Assert
+        Assert.NotNull(clientCapabilities);
+        Assert.NotNull(serverCapabilities);
+        Assert.NotNull(serverCapabilities.DiagnosticProvider);
+        Assert.NotNull(serverCapabilities.DiagnosticProvider.DiagnosticKinds);
+        Assert.Single(serverCapabilities.DiagnosticProvider.DiagnosticKinds);
+
+        // use the expected value directly; if the underlying library changes values, there is likely a downstream impact
+        Assert.Equal("syntax", serverCapabilities.DiagnosticProvider.DiagnosticKinds[0].Value); 
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/DocumentPullDiagnosticsEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/DocumentPullDiagnosticsEndpointTest.cs
@@ -3,9 +3,7 @@
 
 using Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
-using Microsoft.AspNetCore.Razor.Test.Common.Logging;
 using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
-using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Moq;
@@ -14,26 +12,23 @@ using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Diagnostics;
 
-public class DocumentPullDiagnosticsEndpointTest(ITestOutputHelper testOutput)
+public sealed class DocumentPullDiagnosticsEndpointTest(ITestOutputHelper testOutput) : LanguageServerTestBase(testOutput)
 {
-    private readonly ITestOutputHelper _testOutput = testOutput;
-
     [Fact]
     public void ApplyCapabilities_AddsExpectedCapabilities()
     {
         // Arrange
-        var loggerFactory = new RazorLoggerFactory(new[] { new TestOutputLoggerProvider(_testOutput) });
-        var documentMappingService = new RazorDocumentMappingService(new FilePathService(TestLanguageServerFeatureOptions.Instance), new TestDocumentContextFactory(), loggerFactory);
+        var documentMappingService = new RazorDocumentMappingService(new FilePathService(TestLanguageServerFeatureOptions.Instance), new TestDocumentContextFactory(), LoggerFactory);
         var featureOptions = new Mock<LanguageServerFeatureOptions>(MockBehavior.Strict);
         var razorTranslate = new Mock<RazorTranslateDiagnosticsService>(MockBehavior.Strict,
             documentMappingService,
-            loggerFactory);
+            LoggerFactory);
         var clientConnection = new Mock<IClientConnection>(MockBehavior.Strict);
         var endpoint = new DocumentPullDiagnosticsEndpoint(
             featureOptions.Object,
             razorTranslate.Object,
             clientConnection.Object,
-            telemetryReporter:null);
+            telemetryReporter: null);
 
         // Act
         VSInternalServerCapabilities serverCapabilities = new();
@@ -48,6 +43,6 @@ public class DocumentPullDiagnosticsEndpointTest(ITestOutputHelper testOutput)
         Assert.Single(serverCapabilities.DiagnosticProvider.DiagnosticKinds);
 
         // use the expected value directly; if the underlying library changes values, there is likely a downstream impact
-        Assert.Equal("syntax", serverCapabilities.DiagnosticProvider.DiagnosticKinds[0].Value); 
+        Assert.Equal("syntax", serverCapabilities.DiagnosticProvider.DiagnosticKinds[0].Value);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/DocumentPullDiagnosticsEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/DocumentPullDiagnosticsEndpointTest.cs
@@ -19,13 +19,12 @@ public sealed class DocumentPullDiagnosticsEndpointTest(ITestOutputHelper testOu
     {
         // Arrange
         var documentMappingService = new RazorDocumentMappingService(FilePathService, new TestDocumentContextFactory(), LoggerFactory);
-        var featureOptions = new Mock<LanguageServerFeatureOptions>(MockBehavior.Strict);
         var razorTranslate = new Mock<RazorTranslateDiagnosticsService>(MockBehavior.Strict,
             documentMappingService,
             LoggerFactory);
         var clientConnection = new Mock<IClientConnection>(MockBehavior.Strict);
         var endpoint = new DocumentPullDiagnosticsEndpoint(
-            featureOptions.Object,
+            TestLanguageServerFeatureOptions.Instance,
             razorTranslate.Object,
             clientConnection.Object,
             telemetryReporter: null);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticConverterTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticConverterTest.cs
@@ -6,13 +6,15 @@
 using System.Globalization;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
+using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics;
 
-public class RazorDiagnosticConverterTest
+public class RazorDiagnosticConverterTest(ITestOutputHelper testOutput) : LanguageServerTestBase(testOutput)
 {
     [Fact]
     public void Convert_Converts()


### PR DESCRIPTION
Add telemetry for time-to-first diagnostic

By adding this Diagnostic kind to our set of capabilities, the VS Win system lights up to gather the time to first diagnostic event, so we can track changes in that duration. 
Adds a unittest for the endpoint.