### PR TITLE
Use Roslyn project info in cohost endpoints

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/CohostDocumentContextFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/CohostDocumentContextFactory.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Cohost;
+
+// NOTE: This is not a "normal" MEF export (ie, exporting an interface) purely because of a strange desire to keep API in
+//       RazorCohostRequestContextExtensions looking like the previous code in the non-cohost world.
+[ExportRazorStatelessLspService(typeof(CohostDocumentContextFactory))]
+[method: ImportingConstructor]
+internal class CohostDocumentContextFactory(DocumentSnapshotFactory documentSnapshotFactory) : AbstractRazorLspService
+{
+    private readonly DocumentSnapshotFactory _documentSnapshotFactory = documentSnapshotFactory;
+
+    public VersionedDocumentContext Create(Uri documentUri, TextDocument textDocument)
+    {
+        var documentSnapshot = _documentSnapshotFactory.GetOrCreate(textDocument);
+
+        // TODO: There is no need for this to be "versioned" in cohosting, but easier to fake it for now so that existing
+        //       code can be reused.
+        return new VersionedDocumentContext(documentUri, documentSnapshot, null, -1337);
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/CohostDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/CohostDocumentSnapshot.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Cohost;
+
+internal class CohostDocumentSnapshot(TextDocument textDocument, IProjectSnapshot projectSnapshot) : IDocumentSnapshot
+{
+    private readonly TextDocument _textDocument = textDocument;
+    private readonly IProjectSnapshot _projectSnapshot = projectSnapshot;
+
+    public string? FileKind => FileKinds.GetFileKindFromFilePath(FilePath);
+
+    public string? FilePath => _textDocument.FilePath;
+
+    public string? TargetPath => _textDocument.FilePath;
+
+    public IProjectSnapshot Project => _projectSnapshot;
+
+    public bool SupportsOutput => true;
+
+    public Task<SourceText> GetTextAsync() => _textDocument.GetTextAsync();
+
+    public Task<VersionStamp> GetTextVersionAsync() => _textDocument.GetTextVersionAsync();
+
+    public bool TryGetText([NotNullWhen(true)] out SourceText? result) => _textDocument.TryGetText(out result);
+
+    public bool TryGetTextVersion(out VersionStamp result) => _textDocument.TryGetTextVersion(out result);
+
+    public ImmutableArray<IDocumentSnapshot> GetImports()
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task<RazorCodeDocument> GetGeneratedOutputAsync()
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool TryGetGeneratedOutput([NotNullWhen(true)] out RazorCodeDocument? result)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/CohostProjectSnapshot.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/CohostProjectSnapshot.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.ProjectSystem;
+using Microsoft.AspNetCore.Razor.Utilities;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Cohost;
+
+internal class CohostProjectSnapshot(Project project, DocumentSnapshotFactory documentSnapshotFactory) : IProjectSnapshot
+{
+    private readonly Project _project = project;
+    private readonly DocumentSnapshotFactory _documentSnapshotFactory = documentSnapshotFactory;
+
+    public ProjectKey Key => ProjectKey.From(_project)!.Value;
+
+    public RazorConfiguration? Configuration => throw new NotImplementedException();
+
+    public IEnumerable<string> DocumentFilePaths
+        => _project.AdditionalDocuments
+            .Where(d => d.FilePath.AssumeNotNull().EndsWith(".razor", StringComparison.OrdinalIgnoreCase) || d.FilePath.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase))
+            .Select(d => d.FilePath.AssumeNotNull());
+
+    public string FilePath => _project.FilePath!;
+
+    public string IntermediateOutputPath => FilePathNormalizer.GetNormalizedDirectoryName(_project.CompilationOutputInfo.AssemblyPath);
+
+    public string? RootNamespace => _project.DefaultNamespace;
+
+    public string DisplayName => _project.Name;
+
+    public VersionStamp Version => _project.Version;
+
+    public LanguageVersion CSharpLanguageVersion => ((CSharpParseOptions)_project.ParseOptions!).LanguageVersion;
+
+    public ImmutableArray<TagHelperDescriptor> TagHelpers => throw new NotImplementedException();
+
+    public ProjectWorkspaceState? ProjectWorkspaceState => throw new NotImplementedException();
+
+    public IDocumentSnapshot? GetDocument(string filePath)
+    {
+        var textDocument = _project.AdditionalDocuments.FirstOrDefault(d => d.FilePath == filePath);
+        if (textDocument is null)
+        {
+            return null;
+        }
+
+        return _documentSnapshotFactory.GetOrCreate(textDocument);
+    }
+
+    public RazorProjectEngine GetProjectEngine()
+    {
+        throw new NotImplementedException();
+    }
+
+    public ImmutableArray<IDocumentSnapshot> GetRelatedDocuments(IDocumentSnapshot document)
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool IsImportDocument(IDocumentSnapshot document)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/DocumentSnapshotFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/DocumentSnapshotFactory.cs
@@ -13,9 +13,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Cohost;
 [method: ImportingConstructor]
 internal class DocumentSnapshotFactory(Lazy<ProjectSnapshotFactory> projectSnapshotFactory)
 {
-    private readonly Lazy<ProjectSnapshotFactory> _projectSnapshotFactory = projectSnapshotFactory;
+    private static readonly ConditionalWeakTable<TextDocument, IDocumentSnapshot> _documentSnapshots = new();
 
-    private readonly ConditionalWeakTable<TextDocument, IDocumentSnapshot> _documentSnapshots = new();
+    private readonly Lazy<ProjectSnapshotFactory> _projectSnapshotFactory = projectSnapshotFactory;
 
     public IDocumentSnapshot GetOrCreate(TextDocument textDocument)
     {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/DocumentSnapshotFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/DocumentSnapshotFactory.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using System.Runtime.CompilerServices;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Cohost;
+
+[Export(typeof(DocumentSnapshotFactory)), Shared]
+[method: ImportingConstructor]
+internal class DocumentSnapshotFactory(Lazy<ProjectSnapshotFactory> projectSnapshotFactory)
+{
+    private readonly Lazy<ProjectSnapshotFactory> _projectSnapshotFactory = projectSnapshotFactory;
+
+    private readonly ConditionalWeakTable<TextDocument, IDocumentSnapshot> _documentSnapshots = new();
+
+    public IDocumentSnapshot GetOrCreate(TextDocument textDocument)
+    {
+        if (!_documentSnapshots.TryGetValue(textDocument, out var documentSnapshot))
+        {
+            var projectSnapshot = _projectSnapshotFactory.Value.GetOrCreate(textDocument.Project);
+            documentSnapshot = new CohostDocumentSnapshot(textDocument, projectSnapshot);
+            _documentSnapshots.Add(textDocument, documentSnapshot);
+        }
+
+        return documentSnapshot;
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/ProjectSnapshotFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/ProjectSnapshotFactory.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Composition;
+using System.Runtime.CompilerServices;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Cohost;
+
+[Export(typeof(ProjectSnapshotFactory)), Shared]
+[method: ImportingConstructor]
+internal class ProjectSnapshotFactory(DocumentSnapshotFactory documentSnapshotFactory)
+{
+    private readonly DocumentSnapshotFactory _documentSnapshotFactory = documentSnapshotFactory;
+
+    private readonly ConditionalWeakTable<Project, IProjectSnapshot> _projectSnapshots = new();
+
+    public IProjectSnapshot GetOrCreate(Project project)
+    {
+        if (!_projectSnapshots.TryGetValue(project, out var projectSnapshot))
+        {
+            projectSnapshot = new CohostProjectSnapshot(project, _documentSnapshotFactory);
+            _projectSnapshots.Add(project, projectSnapshot);
+        }
+
+        return projectSnapshot;
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/ProjectSnapshotFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/ProjectSnapshotFactory.cs
@@ -3,16 +3,20 @@
 
 using System.Composition;
 using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Cohost;
 
 [Export(typeof(ProjectSnapshotFactory)), Shared]
 [method: ImportingConstructor]
-internal class ProjectSnapshotFactory(DocumentSnapshotFactory documentSnapshotFactory)
+internal class ProjectSnapshotFactory(DocumentSnapshotFactory documentSnapshotFactory, ITelemetryReporter telemetryReporter, JoinableTaskContext joinableTaskContext)
 {
     private readonly DocumentSnapshotFactory _documentSnapshotFactory = documentSnapshotFactory;
+    private readonly ITelemetryReporter _telemetryReporter = telemetryReporter;
+    private readonly JoinableTaskContext _joinableTaskContext = joinableTaskContext;
 
     private readonly ConditionalWeakTable<Project, IProjectSnapshot> _projectSnapshots = new();
 
@@ -20,7 +24,7 @@ internal class ProjectSnapshotFactory(DocumentSnapshotFactory documentSnapshotFa
     {
         if (!_projectSnapshots.TryGetValue(project, out var projectSnapshot))
         {
-            projectSnapshot = new CohostProjectSnapshot(project, _documentSnapshotFactory);
+            projectSnapshot = new CohostProjectSnapshot(project, _documentSnapshotFactory, _telemetryReporter, _joinableTaskContext);
             _projectSnapshots.Add(project, projectSnapshot);
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/ProjectSnapshotFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/ProjectSnapshotFactory.cs
@@ -14,11 +14,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Cohost;
 [method: ImportingConstructor]
 internal class ProjectSnapshotFactory(DocumentSnapshotFactory documentSnapshotFactory, ITelemetryReporter telemetryReporter, JoinableTaskContext joinableTaskContext)
 {
+    private static readonly ConditionalWeakTable<Project, IProjectSnapshot> _projectSnapshots = new();
+
     private readonly DocumentSnapshotFactory _documentSnapshotFactory = documentSnapshotFactory;
     private readonly ITelemetryReporter _telemetryReporter = telemetryReporter;
     private readonly JoinableTaskContext _joinableTaskContext = joinableTaskContext;
-
-    private readonly ConditionalWeakTable<Project, IProjectSnapshot> _projectSnapshots = new();
 
     public IProjectSnapshot GetOrCreate(Project project)
     {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentVersionCache.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentVersionCache.cs
@@ -64,6 +64,18 @@ internal sealed class DocumentVersionCache() : IDocumentVersionCache, IProjectSn
         }
     }
 
+    public int GetLatestDocumentVersion(string filePath)
+    {
+        using var _ = _lock.EnterReadLock();
+
+        if (!DocumentLookup_NeedsLock.TryGetValue(filePath, out var documentEntries))
+        {
+            return -1;
+        }
+
+        return documentEntries[^1].Version;
+    }
+
     public bool TryGetDocumentVersion(IDocumentSnapshot documentSnapshot, [NotNullWhen(true)] out int? version)
     {
         if (documentSnapshot is null)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IDocumentVersionCache.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IDocumentVersionCache.cs
@@ -10,4 +10,7 @@ internal interface IDocumentVersionCache
 {
     bool TryGetDocumentVersion(IDocumentSnapshot documentSnapshot, [NotNullWhen(true)] out int? version);
     void TrackDocumentVersion(IDocumentSnapshot documentSnapshot, int version);
+
+    // HACK: This is temporary to allow the cohosting and normal language server to co-exist and share code
+    int GetLatestDocumentVersion(string filePath);
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/CohostDocumentColorEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/CohostDocumentColorEndpoint.cs
@@ -21,12 +21,10 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Cohost;
 [method: ImportingConstructor]
 internal sealed class CohostDocumentColorEndpoint(
     IDocumentColorService documentColorService,
-    IDocumentContextFactory documentContextFactory,
     IRazorLoggerFactory loggerFactory)
     : AbstractRazorCohostDocumentRequestHandler<DocumentColorParams, ColorInformation[]>, ICapabilitiesProvider
 {
     private readonly IDocumentColorService _documentColorService = documentColorService;
-    private readonly IDocumentContextFactory _documentContextFactory = documentContextFactory;
     private readonly ILogger _logger = loggerFactory.CreateLogger<CohostDocumentColorEndpoint>();
 
     protected override bool MutatesSolutionState => false;
@@ -41,7 +39,7 @@ internal sealed class CohostDocumentColorEndpoint(
     protected override Task<ColorInformation[]> HandleRequestAsync(DocumentColorParams request, RazorCohostRequestContext context, CancellationToken cancellationToken)
     {
         // TODO: Create document context from request.TextDocument, by looking at request.Solution instead of our project snapshots
-        var documentContext = _documentContextFactory.TryCreateForOpenDocument(request.TextDocument);
+        var documentContext = context.GetRequiredDocumentContext();
 
         _logger.LogDebug("[Cohost] Received document color request for {requestPath} and got document {documentPath}", request.TextDocument.Uri, documentContext?.FilePath);
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/RazorCohostRequestContextExtensions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/RazorCohostRequestContextExtensions.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Razor;
+using Microsoft.AspNetCore.Razor.LanguageServer;
+using Microsoft.AspNetCore.Razor.LanguageServer.Cohost;
+using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Cohost;
+
+internal static class RazorCohostRequestContextExtensions
+{
+    /// <summary>
+    /// Simple method to allow cohosted endpoints to get a document context that is API compatible with <see cref="RazorRequestContext"/>
+    /// </summary>
+    public static VersionedDocumentContext GetRequiredDocumentContext(this RazorCohostRequestContext context)
+    {
+        var documentContextFactory = context.GetRequiredService<CohostDocumentContextFactory>();
+
+        return documentContextFactory.Create(context.Uri.AssumeNotNull(), context.TextDocument.AssumeNotNull());
+    }
+}


### PR DESCRIPTION
Part of https://github.com/dotnet/razor/issues/9519

This PR is the very first baby step towards using the Roslyn project system in cohosting.

What it does:

* Creates document and project snapshots from Roslyn document and project snapshots for document color and semantic tokens requests
* Provides a point for @chsienki and co to put their calls to the source generator to get the generated code (in `CohostDocumentSnapshot.GetGeneratedOutput`) and host outputs (various places in `CohostProjectSnapshot`)

What it doesn't do:

* Anything good for performance. This is blindly discovering tag helpers whenever a project snapshot changes, rather that trying to carry them forward
	* The source generator will do that work
* Remove any of the old systems, meaning everything is running in parallel with the current Razor project system
	* As can be seen with the hacky method on DocumentVersionContext where the new code just blindly assumes the latest version, because document snapshot generation during typing is still coming from the Razor project system

Very much a stepping stone. Next steps is to work out how to get RazorCustomMessageTarget onto using roslyn types, or remove it, or just skip synchronization if cohosting is turned on.