### PR TITLE
Fix and clean up `DocumentVersionCache`

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentVersionCache.DocumentEntry.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentVersionCache.DocumentEntry.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer;
+
+internal sealed partial class DocumentVersionCache
+{
+    private readonly struct DocumentEntry(IDocumentSnapshot document, int version)
+    {
+        public WeakReference<IDocumentSnapshot> Document { get; } = new WeakReference<IDocumentSnapshot>(document);
+
+        public int Version { get; } = version;
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentVersionCache.TestAccessor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentVersionCache.TestAccessor.cs
@@ -48,8 +48,10 @@ internal sealed partial class DocumentVersionCache
 
         public void MarkAsLatestVersion(IDocumentSnapshot document)
         {
-            using var upgradeableLock = _this._lock.EnterUpgradeableReadLock();
-            _this.MarkAsLatestVersion(document, upgradeableLock);
+            using (_this._lock.EnterUpgradeableReadLock())
+            {
+                _this.MarkAsLatestVersion(document);
+            }
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentVersionCache.TestAccessor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentVersionCache.TestAccessor.cs
@@ -48,7 +48,7 @@ internal sealed partial class DocumentVersionCache
 
         public void MarkAsLatestVersion(IDocumentSnapshot document)
         {
-            using var upgradeableLock = _this._lock.EnterUpgradeAbleReadLock();
+            using var upgradeableLock = _this._lock.EnterUpgradeableReadLock();
             _this.MarkAsLatestVersion(document, upgradeableLock);
         }
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentVersionCache.TestAccessor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentVersionCache.TestAccessor.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+#if !NET
+using System.Collections.Generic;
+#endif
 using System.Collections.Immutable;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentVersionCache.TestAccessor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentVersionCache.TestAccessor.cs
@@ -18,6 +18,8 @@ internal sealed partial class DocumentVersionCache
     {
         private readonly DocumentVersionCache _this = @this;
 
+        public record struct DocumentEntry(IDocumentSnapshot? Document, int Version);
+
         public ImmutableDictionary<string, ImmutableArray<DocumentEntry>> GetEntries()
         {
             using var result = new PooledDictionaryBuilder<string, ImmutableArray<DocumentEntry>>();
@@ -44,6 +46,10 @@ internal sealed partial class DocumentVersionCache
             return result.ToImmutable();
         }
 
-        public record struct DocumentEntry(IDocumentSnapshot? Document, int Version);
+        public void MarkAsLatestVersion(IDocumentSnapshot document)
+        {
+            using var upgradeableLock = _this._lock.EnterUpgradeAbleReadLock();
+            _this.MarkAsLatestVersion(document, upgradeableLock);
+        }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentVersionCache.TestAccessor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentVersionCache.TestAccessor.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Microsoft.AspNetCore.Razor.PooledObjects;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer;
+
+internal sealed partial class DocumentVersionCache
+{
+    internal TestAccessor GetTestAccessor() => new(this);
+
+    internal class TestAccessor(DocumentVersionCache @this)
+    {
+        private readonly DocumentVersionCache _this = @this;
+
+        public ImmutableDictionary<string, ImmutableArray<DocumentEntry>> GetEntries()
+        {
+            using var result = new PooledDictionaryBuilder<string, ImmutableArray<DocumentEntry>>();
+            using var _ = _this._lock.EnterReadLock();
+
+            foreach (var (key, entries) in _this._documentLookup_NeedsLock)
+            {
+                using var versions = new PooledArrayBuilder<DocumentEntry>();
+
+                foreach (var entry in entries)
+                {
+                    var document = entry.Document.TryGetTarget(out var target)
+                        ? target
+                        : null;
+
+                    var version = entry.Version;
+
+                    versions.Add(new(document, version));
+                }
+
+                result.Add(key, versions.ToImmutable());
+            }
+
+            return result.ToImmutable();
+        }
+
+        public record struct DocumentEntry(IDocumentSnapshot? Document, int Version);
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentVersionCache.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentVersionCache.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Composition;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -45,6 +46,8 @@ internal sealed partial class DocumentVersionCache() : IDocumentVersionCache, IP
 
     private void TrackDocumentVersion(IDocumentSnapshot documentSnapshot, int version, ReadWriterLocker.UpgradeableReadLock upgradeableReadLock)
     {
+        Debug.Assert(_lock.IsUpgradeableReadLockHeld);
+
         // Need to ensure the write lock covers all uses of documentEntries, not just DocumentLookup
         using (upgradeableReadLock.EnterWriteLock())
         {
@@ -153,6 +156,8 @@ internal sealed partial class DocumentVersionCache() : IDocumentVersionCache, IP
 
     private void CaptureProjectDocumentsAsLatest(IProjectSnapshot projectSnapshot, ReadWriterLocker.UpgradeableReadLock upgradeableReadLock)
     {
+        Debug.Assert(_lock.IsUpgradeableReadLockHeld);
+
         foreach (var documentPath in projectSnapshot.DocumentFilePaths)
         {
             if (_documentLookup_NeedsLock.ContainsKey(documentPath) &&
@@ -165,6 +170,8 @@ internal sealed partial class DocumentVersionCache() : IDocumentVersionCache, IP
 
     private void MarkAsLatestVersion(IDocumentSnapshot document, ReadWriterLocker.UpgradeableReadLock upgradeableReadLock)
     {
+        Debug.Assert(_lock.IsUpgradeableReadLockHeld);
+
         if (!_documentLookup_NeedsLock.TryGetValue(document.FilePath.AssumeNotNull(), out var documentEntries))
         {
             return;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentVersionCache.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentVersionCache.cs
@@ -40,7 +40,7 @@ internal sealed partial class DocumentVersionCache() : IDocumentVersionCache, IP
             throw new ArgumentNullException(nameof(documentSnapshot));
         }
 
-        using var upgradeableReadLock = _lock.EnterUpgradeAbleReadLock();
+        using var upgradeableReadLock = _lock.EnterUpgradeableReadLock();
         TrackDocumentVersion(documentSnapshot, version, upgradeableReadLock);
     }
 
@@ -123,7 +123,7 @@ internal sealed partial class DocumentVersionCache() : IDocumentVersionCache, IP
             return;
         }
 
-        using var upgradeableLock = _lock.EnterUpgradeAbleReadLock();
+        using var upgradeableLock = _lock.EnterUpgradeableReadLock();
 
         switch (args.Kind)
         {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultProjectSnapshotManager.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DefaultProjectSnapshotManager.cs
@@ -432,7 +432,7 @@ internal class DefaultProjectSnapshotManager : ProjectSnapshotManagerBase
         [NotNullWhen(true)] out IProjectSnapshot? oldSnapshot,
         [NotNullWhen(true)] out IProjectSnapshot? newSnapshot)
     {
-        using var upgradeableLock = _rwLocker.EnterUpgradeAbleReadLock();
+        using var upgradeableLock = _rwLocker.EnterUpgradeableReadLock();
 
         if (action is ProjectAddedAction projectAddedAction)
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentVersionCacheTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentVersionCacheTest.cs
@@ -19,12 +19,13 @@ public class DocumentVersionCacheTest(ITestOutputHelper testOutput) : LanguageSe
     {
         // Arrange
         var cache = new DocumentVersionCache();
+        var cacheAccessor = cache.GetTestAccessor();
         var document = TestDocumentSnapshot.Create("C:/file.cshtml");
         cache.TrackDocumentVersion(document, 123);
         var untrackedDocument = TestDocumentSnapshot.Create("C:/other.cshtml");
 
         // Act
-        cache.MarkAsLatestVersion(untrackedDocument);
+        cacheAccessor.MarkAsLatestVersion(untrackedDocument);
 
         // Assert
         Assert.False(cache.TryGetDocumentVersion(untrackedDocument, out var version));
@@ -36,12 +37,13 @@ public class DocumentVersionCacheTest(ITestOutputHelper testOutput) : LanguageSe
     {
         // Arrange
         var cache = new DocumentVersionCache();
+        var cacheAccessor = cache.GetTestAccessor();
         var documentInitial = TestDocumentSnapshot.Create("C:/file.cshtml");
         cache.TrackDocumentVersion(documentInitial, 123);
         var documentLatest = TestDocumentSnapshot.Create(documentInitial.FilePath);
 
         // Act
-        cache.MarkAsLatestVersion(documentLatest);
+        cacheAccessor.MarkAsLatestVersion(documentLatest);
 
         // Assert
         Assert.True(cache.TryGetDocumentVersion(documentLatest, out var version));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/LanguageServerTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/LanguageServerTestBase.cs
@@ -127,6 +127,9 @@ public abstract class LanguageServerTestBase : ToolingTestBase
     protected Task RunOnDispatcherThreadAsync(Action action)
         => Dispatcher.RunOnDispatcherThreadAsync(action, DisposalToken);
 
+    protected Task<T> RunOnDispatcherThreadAsync<T>(Func<T> func)
+        => Dispatcher.RunOnDispatcherThreadAsync(func, DisposalToken);
+
     private class ThrowingRazorSpanMappingService : IRazorSpanMappingService
     {
         public Task<ImmutableArray<RazorMappedSpanResult>> MapSpansAsync(Document document, IEnumerable<TextSpan> spans, CancellationToken cancellationToken)

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ReadWriterLocker.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ReadWriterLocker.cs
@@ -21,14 +21,6 @@ internal class ReadWriterLocker
     public WriteOnlyLock EnterWriteLock() => new WriteOnlyLock(_lock);
     public UpgradeableReadLock EnterUpgradeableReadLock() => new UpgradeableReadLock(_lock);
 
-    public void EnsureNoWriteLock()
-    {
-        if (_lock.IsWriteLockHeld)
-        {
-            throw new InvalidOperationException("Expected no write lock to be held");
-        }
-    }
-
     private static readonly TimeSpan s_maxTimeout = TimeSpan.FromMilliseconds(int.MaxValue);
     private static readonly TimeSpan s_timeout =
 #if DEBUG

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ReadWriterLocker.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ReadWriterLocker.cs
@@ -19,7 +19,7 @@ internal class ReadWriterLocker
 
     public ReadOnlyLock EnterReadLock() => new ReadOnlyLock(_lock);
     public WriteOnlyLock EnterWriteLock() => new WriteOnlyLock(_lock);
-    public UpgradeableReadLock EnterUpgradeAbleReadLock() => new UpgradeableReadLock(_lock);
+    public UpgradeableReadLock EnterUpgradeableReadLock() => new UpgradeableReadLock(_lock);
 
     public void EnsureNoWriteLock()
     {

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ReadWriterLocker.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ReadWriterLocker.cs
@@ -13,6 +13,10 @@ internal class ReadWriterLocker
     // get another read lock on the same thread
     private readonly ReaderWriterLockSlim _lock = new(LockRecursionPolicy.SupportsRecursion);
 
+    public bool IsReadLockHeld => _lock.IsReadLockHeld;
+    public bool IsUpgradeableReadLockHeld => _lock.IsUpgradeableReadLockHeld;
+    public bool IsWriteLockHeld => _lock.IsWriteLockHeld;
+
     public ReadOnlyLock EnterReadLock() => new ReadOnlyLock(_lock);
     public WriteOnlyLock EnterWriteLock() => new WriteOnlyLock(_lock);
     public UpgradeableReadLock EnterUpgradeAbleReadLock() => new UpgradeableReadLock(_lock);


### PR DESCRIPTION
While investigating `ProjectSnapshotManagerDispatcher`, I encountered an issue with `DocumentVersionCache` where it would never exit an upgradeable read lock. This pull request fixes that issue and makes several other changes.

1. `DocumentVersionCache` no longer exposes internal data structures for unit tests. Instead, it provides a `TestAccessor` to avoid allowing unfettered access to a dictionary that should only be accessed within a lock.
2. Tests now use a real dispatcher to modify `ProjectSnapshotManager`, which exposes the issue fixed in this PR.
3. Asserts have been added to verify that methods are called with the correct lock being held.
4. Structs are no longer passed around to indicate the lock state. These were a little broken anyway because they are mutable structs that track their dispose state. However, if they were disposed by an inner method, the dispose state wouldn't be observed by an outer call because the structs were passed by value.

Since I've moved some code around, it might be helpful to review commit-by-commit.