### PR TITLE
Don't use project engines directly in the language server

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/CohostDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/CohostDocumentSnapshot.cs
@@ -70,4 +70,12 @@ internal class CohostDocumentSnapshot(TextDocument textDocument, IProjectSnapsho
         result = _codeDocument;
         return result is not null;
     }
+
+    public IDocumentSnapshot WithText(SourceText text)
+    {
+        var id = _textDocument.Id;
+        var newDocument = _textDocument.Project.Solution.WithAdditionalDocumentText(id, text).GetAdditionalDocument(id).AssumeNotNull();
+
+        return new CohostDocumentSnapshot(newDocument, _projectSnapshot);
+    }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContext.cs
@@ -10,7 +10,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
-using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
@@ -27,8 +26,6 @@ internal class FormattingContext : IDisposable
 
     private IReadOnlyList<FormattingSpan>? _formattingSpans;
     private IReadOnlyDictionary<int, IndentationContext>? _indentations;
-    private RazorProjectEngine? _engine;
-    private ImmutableArray<RazorSourceDocument> _importSources;
 
     private FormattingContext(AdhocWorkspaceFactory workspaceFactory, Uri uri, IDocumentSnapshot originalSnapshot, RazorCodeDocument codeDocument, FormattingOptions options,
         bool isFormatOnType, bool automaticallyAddUsings, int hostDocumentIndex, char triggerCharacter)
@@ -42,14 +39,6 @@ internal class FormattingContext : IDisposable
         AutomaticallyAddUsings = automaticallyAddUsings;
         HostDocumentIndex = hostDocumentIndex;
         TriggerCharacter = triggerCharacter;
-    }
-
-    private FormattingContext(RazorProjectEngine engine, ImmutableArray<RazorSourceDocument> importSources, AdhocWorkspaceFactory workspaceFactory, Uri uri, IDocumentSnapshot originalSnapshot, RazorCodeDocument codeDocument, FormattingOptions options,
-        bool isFormatOnType, bool automaticallyAddUsings, int hostDocumentIndex, char triggerCharacter)
-        : this(workspaceFactory, uri, originalSnapshot, codeDocument, options, isFormatOnType, automaticallyAddUsings, hostDocumentIndex, triggerCharacter)
-    {
-        _engine = engine;
-        _importSources = importSources;
     }
 
     public static bool SkipValidateComponents { get; set; }
@@ -281,22 +270,13 @@ internal class FormattingContext : IDisposable
             throw new ArgumentNullException(nameof(changedText));
         }
 
-        if (_engine is null)
-        {
-            await InitializeProjectEngineAsync().ConfigureAwait(false);
-        }
+        var changedSnapshot = OriginalSnapshot.WithText(changedText);
 
-        Assumes.NotNull(_engine);
-
-        var changedSourceDocument = RazorSourceDocument.Create(changedText, RazorSourceDocumentProperties.Create(OriginalSnapshot.FilePath, OriginalSnapshot.TargetPath));
-
-        var codeDocument = _engine.ProcessDesignTime(changedSourceDocument, OriginalSnapshot.FileKind, _importSources, OriginalSnapshot.Project.TagHelpers);
+        var codeDocument = await changedSnapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
 
         DEBUG_ValidateComponents(CodeDocument, codeDocument);
 
         var newContext = new FormattingContext(
-            _engine,
-            _importSources!,
             _workspaceFactory,
             Uri,
             OriginalSnapshot,
@@ -308,24 +288,6 @@ internal class FormattingContext : IDisposable
             TriggerCharacter);
 
         return newContext;
-    }
-
-    private async Task InitializeProjectEngineAsync()
-    {
-        var engine = OriginalSnapshot.Project.GetProjectEngine();
-
-        var imports = OriginalSnapshot.GetImports();
-        using var importSources = new PooledArrayBuilder<RazorSourceDocument>(imports.Length);
-
-        foreach (var import in imports)
-        {
-            var sourceText = await import.GetTextAsync().ConfigureAwait(false);
-            var source = RazorSourceDocument.Create(sourceText, RazorSourceDocumentProperties.Create(import.FilePath, import.TargetPath));
-            importSources.Add(source);
-        }
-
-        _engine = engine;
-        _importSources = importSources.DrainToImmutable();
     }
 
     /// <summary>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentSnapshot.cs
@@ -61,4 +61,9 @@ internal class DocumentSnapshot : IDocumentSnapshot
         result = null;
         return false;
     }
+
+    public IDocumentSnapshot WithText(SourceText text)
+    {
+        return new DocumentSnapshot(ProjectInternal, State.WithText(text, VersionStamp.Create()));
+    }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshot.cs
@@ -26,4 +26,6 @@ internal interface IDocumentSnapshot
     bool TryGetText([NotNullWhen(true)] out SourceText? result);
     bool TryGetTextVersion(out VersionStamp result);
     bool TryGetGeneratedOutput([NotNullWhen(true)] out RazorCodeDocument? result);
+
+    IDocumentSnapshot WithText(SourceText text);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ImportDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ImportDocumentSnapshot.cs
@@ -76,4 +76,7 @@ internal class ImportDocumentSnapshot : IDocumentSnapshot
 
     public bool TryGetGeneratedOutput([NotNullWhen(true)] out RazorCodeDocument? result)
         => throw new NotSupportedException();
+
+    public IDocumentSnapshot WithText(SourceText text)
+        => throw new NotSupportedException();
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/OnAutoInsertEndpointTest.NetFx.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/OnAutoInsertEndpointTest.NetFx.cs
@@ -363,7 +363,7 @@ public partial class OnAutoInsertEndpointTest
         TestFileMarkupParser.GetPosition(input, out input, out var cursorPosition);
 
         var codeDocument = CreateCodeDocument(input);
-        var razorFilePath = "file://path/test.razor";
+        var razorFilePath = "C:/path/test.razor";
         var languageServer = await CreateLanguageServerAsync(codeDocument, razorFilePath);
 
         var optionsMonitor = GetOptionsMonitor();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndToEndTest.NetFx.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndToEndTest.NetFx.cs
@@ -1026,7 +1026,7 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : SingleServer
     {
         TestFileMarkupParser.GetSpan(input, out input, out var textSpan);
 
-        var razorFilePath = "file://C:/path/test.razor";
+        var razorFilePath = "C:/path/test.razor";
         var codeDocument = CreateCodeDocument(input, filePath: razorFilePath);
         var sourceText = codeDocument.GetSourceText();
         var uri = new Uri(razorFilePath);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingContentValidationPassTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingContentValidationPassTest.cs
@@ -156,9 +156,6 @@ public class Foo { }
             .Setup(d => d.GetGeneratedOutputAsync())
             .ReturnsAsync(codeDocument);
         documentSnapshot
-            .Setup(d => d.Project.GetProjectEngine())
-            .Returns(projectEngine);
-        documentSnapshot
             .Setup(d => d.TargetPath)
             .Returns(path);
         documentSnapshot

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingDiagnosticValidationPassTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingDiagnosticValidationPassTest.cs
@@ -158,29 +158,8 @@ public class Foo { }
         var projectEngine = RazorProjectEngine.Create(builder => builder.SetRootNamespace("Test"));
         var codeDocument = projectEngine.ProcessDesignTime(sourceDocument, fileKind, importSources: default, tagHelpers);
 
-        var documentSnapshot = new Mock<IDocumentSnapshot>(MockBehavior.Strict);
-        documentSnapshot
-            .Setup(d => d.GetImports())
-            .Returns(ImmutableArray<IDocumentSnapshot>.Empty);
-        documentSnapshot
-            .Setup(d => d.GetGeneratedOutputAsync())
-            .ReturnsAsync(codeDocument);
-        documentSnapshot
-            .Setup(d => d.Project.GetProjectEngine())
-            .Returns(projectEngine);
-        documentSnapshot
-            .Setup(d => d.TargetPath)
-            .Returns(path);
-        documentSnapshot
-            .Setup(d => d.Project.TagHelpers)
-            .Returns(tagHelpers);
-        documentSnapshot
-            .Setup(d => d.FileKind)
-            .Returns(fileKind);
-        documentSnapshot
-            .Setup(d => d.FilePath)
-            .Returns(path);
+        var documentSnapshot = FormattingTestBase.CreateDocumentSnapshot(path, tagHelpers, fileKind, ImmutableArray<RazorSourceDocument>.Empty, ImmutableArray<IDocumentSnapshot>.Empty, projectEngine, codeDocument);
 
-        return (codeDocument, documentSnapshot.Object);
+        return (codeDocument, documentSnapshot);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingTestBase.cs
@@ -267,13 +267,22 @@ public class FormattingTestBase : RazorToolingIntegrationTestBase
             Assert.False(codeDocument.GetCSharpDocument().Diagnostics.Any(), "Error creating document:" + Environment.NewLine + string.Join(Environment.NewLine, codeDocument.GetCSharpDocument().Diagnostics));
         }
 
+        var imports = ImmutableArray.Create(importsSnapshot.Object);
+        var importsDocuments = ImmutableArray.Create(importsDocument);
+        var documentSnapshot = CreateDocumentSnapshot(path, tagHelpers, fileKind, importsDocuments, imports, projectEngine, codeDocument);
+
+        return (codeDocument, documentSnapshot);
+    }
+
+    internal static IDocumentSnapshot CreateDocumentSnapshot(string path, ImmutableArray<TagHelperDescriptor> tagHelpers, string? fileKind, ImmutableArray<RazorSourceDocument> importsDocuments, ImmutableArray<IDocumentSnapshot> imports, RazorProjectEngine projectEngine, RazorCodeDocument codeDocument)
+    {
         var documentSnapshot = new Mock<IDocumentSnapshot>(MockBehavior.Strict);
         documentSnapshot
             .Setup(d => d.GetGeneratedOutputAsync())
             .ReturnsAsync(codeDocument);
         documentSnapshot
             .Setup(d => d.GetImports())
-            .Returns(ImmutableArray.Create(importsSnapshot.Object));
+            .Returns(imports);
         documentSnapshot
             .Setup(d => d.Project.GetProjectEngine())
             .Returns(projectEngine);
@@ -292,7 +301,14 @@ public class FormattingTestBase : RazorToolingIntegrationTestBase
         documentSnapshot
             .Setup(d => d.FileKind)
             .Returns(fileKind);
-
-        return (codeDocument, documentSnapshot.Object);
+        documentSnapshot
+            .Setup(d => d.WithText(It.IsAny<SourceText>()))
+            .Returns<SourceText>(text =>
+            {
+                var sourceDocument = RazorSourceDocument.Create(text, RazorSourceDocumentProperties.Create(path, path));
+                var codeDocument = projectEngine.ProcessDesignTime(sourceDocument, fileKind, importsDocuments, tagHelpers);
+                return CreateDocumentSnapshot(path, tagHelpers, fileKind, importsDocuments, imports, projectEngine, codeDocument);
+            });
+        return documentSnapshot.Object;
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingTestBase.cs
@@ -284,9 +284,6 @@ public class FormattingTestBase : RazorToolingIntegrationTestBase
             .Setup(d => d.GetImports())
             .Returns(imports);
         documentSnapshot
-            .Setup(d => d.Project.GetProjectEngine())
-            .Returns(projectEngine);
-        documentSnapshot
             .Setup(d => d.FilePath)
             .Returns(path);
         documentSnapshot

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/MapCode/MapCodeTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/MapCode/MapCodeTest.cs
@@ -11,8 +11,6 @@ using Microsoft.AspNetCore.Razor.LanguageServer.MapCode;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.AspNetCore.Razor.Test.Common.Mef;
-using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
-using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;


### PR DESCRIPTION
There are a few methods in the document/project snapshot system that are problematic and unnecessary in co-hosting. To make their removal from that system easier, I'm going to try to clean some things up around their use, and this is the first PR in that step, by cleaning up the `GetProjectEngine()` method a little bit.

The method is still there, because its used by TagHelperResolvers, but those won't be used in co-hosting so they're not a problem. A future PR will (presumably) split `IProjectSnapshot` up in some way, and so the method itself won't strictly be removed, but rather just not exposed to anything in co-hosting.

I did an integration test run from the midway point of this PR to ensure formatting still works, and it's green: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=8939290&view=results