### PR TITLE
Remove IDocumentSnapshot.GetImports

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/CohostDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/CohostDocumentSnapshot.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
@@ -35,11 +34,6 @@ internal class CohostDocumentSnapshot(TextDocument textDocument, IProjectSnapsho
     public bool TryGetText([NotNullWhen(true)] out SourceText? result) => _textDocument.TryGetText(out result);
 
     public bool TryGetTextVersion(out VersionStamp result) => _textDocument.TryGetTextVersion(out result);
-
-    public ImmutableArray<IDocumentSnapshot> GetImports()
-    {
-        return DocumentState.GetImportsCore(Project, FilePath.AssumeNotNull(), FileKind.AssumeNotNull());
-    }
 
     public async Task<RazorCodeDocument> GetGeneratedOutputAsync()
     {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentSnapshot.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
@@ -26,9 +25,6 @@ internal class DocumentSnapshot : IDocumentSnapshot
         ProjectInternal = project ?? throw new ArgumentNullException(nameof(project));
         State = state ?? throw new ArgumentNullException(nameof(state));
     }
-
-    public virtual ImmutableArray<IDocumentSnapshot> GetImports()
-        => State.GetImports(ProjectInternal);
 
     public Task<SourceText> GetTextAsync()
         => State.GetTextAsync();

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.Text;
@@ -78,11 +79,6 @@ internal class DocumentState
     public Task<(RazorCodeDocument output, VersionStamp inputVersion)> GetGeneratedOutputAndVersionAsync(ProjectSnapshot project, DocumentSnapshot document)
     {
         return ComputedState.GetGeneratedOutputAndVersionAsync(project, document);
-    }
-
-    public ImmutableArray<IDocumentSnapshot> GetImports(ProjectSnapshot project)
-    {
-        return GetImportsCore(project, HostDocument.FilePath, HostDocument.FileKind);
     }
 
     public async Task<SourceText> GetTextAsync()
@@ -502,7 +498,7 @@ internal class DocumentState
 
         internal static async Task<ImmutableArray<ImportItem>> GetImportsAsync(IDocumentSnapshot document)
         {
-            var imports = document.GetImports();
+            var imports = DocumentState.GetImportsCore(document.Project, document.FilePath.AssumeNotNull(), document.FileKind.AssumeNotNull());
             using var result = new PooledArrayBuilder<ImportItem>(imports.Length);
 
             foreach (var snapshot in imports)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshot.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
@@ -16,8 +15,6 @@ internal interface IDocumentSnapshot
     string? TargetPath { get; }
     IProjectSnapshot Project { get; }
     bool SupportsOutput { get; }
-
-    ImmutableArray<IDocumentSnapshot> GetImports();
 
     Task<SourceText> GetTextAsync();
     Task<VersionStamp> GetTextVersionAsync();

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ImportDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ImportDocumentSnapshot.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading.Tasks;
@@ -35,9 +34,6 @@ internal class ImportDocumentSnapshot : IDocumentSnapshot
 
     public Task<RazorCodeDocument> GetGeneratedOutputAsync()
         => throw new NotSupportedException();
-
-    public ImmutableArray<IDocumentSnapshot> GetImports()
-        => ImmutableArray<IDocumentSnapshot>.Empty;
 
     public async Task<SourceText> GetTextAsync()
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingTestBase.cs
@@ -281,9 +281,6 @@ public class FormattingTestBase : RazorToolingIntegrationTestBase
             .Setup(d => d.GetGeneratedOutputAsync())
             .ReturnsAsync(codeDocument);
         documentSnapshot
-            .Setup(d => d.GetImports())
-            .Returns(imports);
-        documentSnapshot
             .Setup(d => d.FilePath)
             .Returns(path);
         documentSnapshot

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/TestDocumentSnapshot.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/TestDocumentSnapshot.cs
@@ -88,11 +88,6 @@ internal class TestDocumentSnapshot : DocumentSnapshot
         return Task.FromResult(_codeDocument);
     }
 
-    public override ImmutableArray<IDocumentSnapshot> GetImports()
-    {
-        return ImmutableArray<IDocumentSnapshot>.Empty;
-    }
-
     public override bool TryGetGeneratedOutput(out RazorCodeDocument result)
     {
         if (_codeDocument is null)


### PR DESCRIPTION
This was going to be part of a larger PR but that is proving to be extremely annoying to do, so I'm pulling this out while I have it.

The `GetImports` method was only used in one place, and was just indirection to call another method on the same class, so this PR just flattens that and simplifies the interface. This just gives us a lower surface area for cohosting.