### PR TITLE
Use ISerializable exception strategy

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServerWrapper.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServerWrapper.cs
@@ -53,6 +53,9 @@ internal sealed class RazorLanguageServerWrapper : IDisposable
             TraceSource = traceSource
         };
 
+        // Get more information about exceptions that occur during RPC method invocations.
+        jsonRpc.ExceptionStrategy = ExceptionProcessing.ISerializable;
+
         var server = new RazorLanguageServer(
             jsonRpc,
             loggerFactory,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServerWrapper.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServerWrapper.cs
@@ -53,9 +53,6 @@ internal sealed class RazorLanguageServerWrapper : IDisposable
             TraceSource = traceSource
         };
 
-        // Get more information about exceptions that occur during RPC method invocations.
-        jsonRpc.ExceptionStrategy = ExceptionProcessing.ISerializable;
-
         var server = new RazorLanguageServer(
             jsonRpc,
             loggerFactory,
@@ -79,6 +76,9 @@ internal sealed class RazorLanguageServerWrapper : IDisposable
         messageFormatter.JsonSerializer.ContractResolver = new CamelCasePropertyNamesContractResolver();
 
         var jsonRpc = new JsonRpc(new HeaderDelimitedMessageHandler(output, input, messageFormatter));
+
+        // Get more information about exceptions that occur during RPC method invocations.
+        jsonRpc.ExceptionStrategy = ExceptionProcessing.ISerializable;
 
         return jsonRpc;
     }


### PR DESCRIPTION
Set our exception strategy such that exceptions our server creates are serialized to the client, and if a client we communicate with throws an exception we get it embedded as an inner exception.