### PR TITLE
Enable MEF diagnostics and fix issues

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -103,6 +103,10 @@ csharp_style_unused_value_expression_statement_preference = discard_variable:non
 # IDE0065
 csharp_using_directive_placement = outside_namespace:suggestion
 
+# Roslyn analyzers
+dotnet_diagnostic.RS0006.severity = error
+dotnet_diagnostic.RS0023.severity = error
+
 # xUnit1004: Test methods should not be skipped
 dotnet_diagnostic.xUnit1004.severity = refactoring
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/CohostDocumentContextFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/CohostDocumentContextFactory.cs
@@ -10,6 +10,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Cohost;
 
 // NOTE: This is not a "normal" MEF export (ie, exporting an interface) purely because of a strange desire to keep API in
 //       RazorCohostRequestContextExtensions looking like the previous code in the non-cohost world.
+[Shared]
 [ExportRazorStatelessLspService(typeof(CohostDocumentContextFactory))]
 [method: ImportingConstructor]
 internal class CohostDocumentContextFactory(DocumentSnapshotFactory documentSnapshotFactory, IDocumentVersionCache documentVersionCache) : AbstractRazorLspService

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Documents/DefaultFileChangeTrackerFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Documents/DefaultFileChangeTrackerFactory.cs
@@ -2,10 +2,12 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Composition;
 using Microsoft.CodeAnalysis.Host.Mef;
 
 namespace Microsoft.VisualStudio.Editor.Razor.Documents;
 
+[Shared]
 [ExportWorkspaceService(typeof(FileChangeTrackerFactory), layer: ServiceLayer.Editor)]
 internal class DefaultFileChangeTrackerFactory : FileChangeTrackerFactory
 {

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Documents/EditorDocumentManagerListener.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Documents/EditorDocumentManagerListener.cs
@@ -24,6 +24,7 @@ namespace Microsoft.VisualStudio.Editor.Razor.Documents;
 // other triggers with lesser priority so we can attach to Changed sooner. We happen to be so important because we control the
 // open/close state of documents. If other triggers depend on a document being open/closed (some do) then we need to ensure we
 // can mark open/closed prior to them running.
+[Shared]
 [Export(typeof(IProjectSnapshotChangeTrigger))]
 internal class EditorDocumentManagerListener : IPriorityProjectSnapshotChangeTrigger
 {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/CohostDocumentColorEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/CohostDocumentColorEndpoint.cs
@@ -15,6 +15,7 @@ using Microsoft.VisualStudio.LanguageServerClient.Razor.Extensions;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Cohost;
 
+[Shared]
 [LanguageServerEndpoint(Methods.TextDocumentDocumentColorName)]
 [ExportRazorStatelessLspService(typeof(CohostDocumentColorEndpoint))]
 [Export(typeof(ICapabilitiesProvider))]

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/CohostSemanticTokensRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/CohostSemanticTokensRangeEndpoint.cs
@@ -16,6 +16,7 @@ using Microsoft.VisualStudio.LanguageServerClient.Razor.Extensions;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Cohost;
 
+[Shared]
 [LanguageServerEndpoint(Methods.TextDocumentSemanticTokensRangeName)]
 [ExportRazorStatelessLspService(typeof(CohostSemanticTokensRangeEndpoint))]
 [Export(typeof(ICapabilitiesProvider))]

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorCustomMessageTarget.cs
@@ -25,6 +25,7 @@ using static Microsoft.VisualStudio.LanguageServer.ContainedLanguage.DefaultLSPD
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor;
 
+[Shared]
 [Export(typeof(IRazorCustomMessageTarget))]
 [Export(typeof(RazorCustomMessageTarget))]
 internal partial class RazorCustomMessageTarget : IRazorCustomMessageTarget


### PR DESCRIPTION
This change enables a couple of the Roslyn analyzers for MEF and fixes the violations. In particular, an error will now be reported for anything exported with MEFv2 that does not also have the `[Shared]` attribute. Like Roslyn, I don't believe Razor has any scenarios where MEF exports aren't intended to be singletons.