### PR TITLE
Move capabilities to a central place

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensBenchmark.cs
@@ -120,8 +120,9 @@ public class RazorSemanticTokensBenchmark : RazorLanguageServerBenchmarkBase
     private void EnsureServicesInitialized()
     {
         var languageServer = RazorLanguageServer.GetInnerLanguageServerForTesting();
+        var legend = new RazorSemanticTokensLegend(new VSInternalClientCapabilities { SupportsVisualStudioExtensions = true });
         RazorSemanticTokenService = languageServer.GetRequiredService<IRazorSemanticTokensInfoService>();
-        RazorSemanticTokenService.ApplyCapabilities(new(), new VSInternalClientCapabilities { SupportsVisualStudioExtensions = true });
+        RazorSemanticTokenService.SetTokensLegend(legend);
         VersionCache = languageServer.GetRequiredService<IDocumentVersionCache>();
         ProjectSnapshotManagerDispatcher = languageServer.GetRequiredService<ProjectSnapshotManagerDispatcher>();
     }

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensScrollingBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensScrollingBenchmark.cs
@@ -58,7 +58,7 @@ public class RazorSemanticTokensScrollingBenchmark : RazorLanguageServerBenchmar
         DocumentContext = new VersionedDocumentContext(documentUri, documentSnapshot, projectContext: null, version: 1);
 
         SemanticTokensLegend = new RazorSemanticTokensLegend(new VSInternalClientCapabilities() { SupportsVisualStudioExtensions = true });
-        RazorSemanticTokenService.ApplyCapabilities(new(), new VSInternalClientCapabilities() { SupportsVisualStudioExtensions = true });
+        RazorSemanticTokenService.SetTokensLegend(SemanticTokensLegend);
 
         var text = await DocumentSnapshot.GetTextAsync().ConfigureAwait(false);
         Range = new Range

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Common/Capabilities.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Common/Capabilities.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Common;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Common/Capabilities.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Common/Capabilities.cs
@@ -8,17 +8,17 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common;
 
 internal static class Capabilities
 {
-    public static void DocumentColorProvider(VSInternalServerCapabilities serverCapabilities)
+    public static void ApplyDocumentColorProvider(VSInternalServerCapabilities serverCapabilities)
     {
         serverCapabilities.DocumentColorProvider = new DocumentColorOptions();
     }
 
-    internal static void SemanticTokensOptions(VSInternalServerCapabilities serverCapabilities, RazorSemanticTokensLegend legend)
+    public static void ApplySemanticTokensOptions(VSInternalServerCapabilities serverCapabilities, SemanticTokensLegend legend)
     {
         serverCapabilities.SemanticTokensOptions = new SemanticTokensOptions
         {
             Full = false,
-            Legend = legend.Legend,
+            Legend = legend,
             Range = true,
         };
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Common/Capabilities.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Common/Capabilities.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Common;
+
+internal static class Capabilities
+{
+    public static void DocumentColorProvider(VSInternalServerCapabilities serverCapabilities)
+    {
+        serverCapabilities.DocumentColorProvider = new DocumentColorOptions();
+    }
+
+    internal static void SemanticTokensOptions(VSInternalServerCapabilities serverCapabilities, RazorSemanticTokensLegend legend)
+    {
+        serverCapabilities.SemanticTokensOptions = new SemanticTokensOptions
+        {
+            Full = false,
+            Legend = legend.Legend,
+            Range = true,
+        };
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Common/VSInternalServerCapabilitiesExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Common/VSInternalServerCapabilitiesExtensions.cs
@@ -5,14 +5,14 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Common;
 
-internal static class Capabilities
+internal static class VSInternalServerCapabilitiesExtensions
 {
-    public static void ApplyDocumentColorProvider(VSInternalServerCapabilities serverCapabilities)
+    public static void EnableDocumentColorProvider(this VSInternalServerCapabilities serverCapabilities)
     {
         serverCapabilities.DocumentColorProvider = new DocumentColorOptions();
     }
 
-    public static void ApplySemanticTokensOptions(VSInternalServerCapabilities serverCapabilities, SemanticTokensLegend legend)
+    public static void EnableSemanticTokens(this VSInternalServerCapabilities serverCapabilities, SemanticTokensLegend legend)
     {
         serverCapabilities.SemanticTokensOptions = new SemanticTokensOptions
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentColor/DocumentColorEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentColor/DocumentColorEndpoint.cs
@@ -20,7 +20,7 @@ internal sealed class DocumentColorEndpoint(IDocumentColorService documentColorS
     public bool MutatesSolutionState => false;
 
     public void ApplyCapabilities(VSInternalServerCapabilities serverCapabilities, VSInternalClientCapabilities clientCapabilities)
-        => Capabilities.DocumentColorProvider(serverCapabilities);
+        => Capabilities.ApplyDocumentColorProvider(serverCapabilities);
 
     public TextDocumentIdentifier GetTextDocumentIdentifier(DocumentColorParams request)
         => request.TextDocument;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentColor/DocumentColorEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentColor/DocumentColorEndpoint.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -19,7 +20,7 @@ internal sealed class DocumentColorEndpoint(IDocumentColorService documentColorS
     public bool MutatesSolutionState => false;
 
     public void ApplyCapabilities(VSInternalServerCapabilities serverCapabilities, VSInternalClientCapabilities clientCapabilities)
-        => _documentColorService.ApplyCapabilities(serverCapabilities, clientCapabilities);
+        => Capabilities.DocumentColorProvider(serverCapabilities);
 
     public TextDocumentIdentifier GetTextDocumentIdentifier(DocumentColorParams request)
         => request.TextDocument;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentColor/DocumentColorEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentColor/DocumentColorEndpoint.cs
@@ -20,7 +20,7 @@ internal sealed class DocumentColorEndpoint(IDocumentColorService documentColorS
     public bool MutatesSolutionState => false;
 
     public void ApplyCapabilities(VSInternalServerCapabilities serverCapabilities, VSInternalClientCapabilities clientCapabilities)
-        => Capabilities.ApplyDocumentColorProvider(serverCapabilities);
+        => serverCapabilities.EnableDocumentColorProvider();
 
     public TextDocumentIdentifier GetTextDocumentIdentifier(DocumentColorParams request)
         => request.TextDocument;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentColor/DocumentColorService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentColor/DocumentColorService.cs
@@ -13,11 +13,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.DocumentColor;
 [method: ImportingConstructor]
 internal sealed class DocumentColorService() : IDocumentColorService
 {
-    public void ApplyCapabilities(VSInternalServerCapabilities serverCapabilities, VSInternalClientCapabilities clientCapabilities)
-    {
-        serverCapabilities.DocumentColorProvider = new DocumentColorOptions();
-    }
-
     public async Task<ColorInformation[]> GetColorInformationAsync(IClientConnection clientConnection, DocumentColorParams request, VersionedDocumentContext? documentContext, CancellationToken cancellationToken)
     {
         // Workaround for Web Tools bug https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1743689 where they sometimes

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentColor/IDocumentColorService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentColor/IDocumentColorService.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.DocumentColor;
 
-internal interface IDocumentColorService : ICapabilitiesProvider
+internal interface IDocumentColorService
 {
     Task<ColorInformation[]> GetColorInformationAsync(IClientConnection clientConnection, DocumentColorParams request, VersionedDocumentContext? documentContext, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/SemanticTokensRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/SemanticTokensRangeEndpoint.cs
@@ -26,7 +26,7 @@ internal sealed class SemanticTokensRangeEndpoint(
     public void ApplyCapabilities(VSInternalServerCapabilities serverCapabilities, VSInternalClientCapabilities clientCapabilities)
     {
         var legend = new RazorSemanticTokensLegend(clientCapabilities);
-        Capabilities.SemanticTokensOptions(serverCapabilities, legend);
+        Capabilities.ApplySemanticTokensOptions(serverCapabilities, legend.Legend);
         _semanticTokensInfoService.SetTokensLegend(legend);
     }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/SemanticTokensRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/SemanticTokensRangeEndpoint.cs
@@ -26,7 +26,7 @@ internal sealed class SemanticTokensRangeEndpoint(
     public void ApplyCapabilities(VSInternalServerCapabilities serverCapabilities, VSInternalClientCapabilities clientCapabilities)
     {
         var legend = new RazorSemanticTokensLegend(clientCapabilities);
-        Capabilities.ApplySemanticTokensOptions(serverCapabilities, legend.Legend);
+        serverCapabilities.EnableSemanticTokens(legend.Legend);
         _semanticTokensInfoService.SetTokensLegend(legend);
     }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/SemanticTokensRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/SemanticTokensRangeEndpoint.cs
@@ -3,6 +3,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -24,7 +25,9 @@ internal sealed class SemanticTokensRangeEndpoint(
 
     public void ApplyCapabilities(VSInternalServerCapabilities serverCapabilities, VSInternalClientCapabilities clientCapabilities)
     {
-        _semanticTokensInfoService.ApplyCapabilities(serverCapabilities, clientCapabilities);
+        var legend = new RazorSemanticTokensLegend(clientCapabilities);
+        Capabilities.SemanticTokensOptions(serverCapabilities, legend);
+        _semanticTokensInfoService.SetTokensLegend(legend);
     }
 
     public TextDocumentIdentifier GetTextDocumentIdentifier(SemanticTokensRangeParams request)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/IRazorSemanticTokenInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/IRazorSemanticTokenInfoService.cs
@@ -7,7 +7,8 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
 
-internal interface IRazorSemanticTokensInfoService : ICapabilitiesProvider
+internal interface IRazorSemanticTokensInfoService
 {
     Task<SemanticTokens?> GetSemanticTokensAsync(IClientConnection clientConnection, TextDocumentIdentifier textDocumentIdentifier, Range range, VersionedDocumentContext documentContext, bool colorBackground, CancellationToken cancellationToken);
+    void SetTokensLegend(RazorSemanticTokensLegend legend);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/RazorSemanticTokensInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/RazorSemanticTokensInfoService.cs
@@ -44,16 +44,10 @@ internal class RazorSemanticTokensInfoService(
 
     private RazorSemanticTokensLegend? _razorSemanticTokensLegend;
 
-    public void ApplyCapabilities(VSInternalServerCapabilities serverCapabilities, VSInternalClientCapabilities clientCapabilities)
+    [MemberNotNull(nameof(_razorSemanticTokensLegend))]
+    public void SetTokensLegend(RazorSemanticTokensLegend legend)
     {
-        _razorSemanticTokensLegend = new RazorSemanticTokensLegend(clientCapabilities);
-
-        serverCapabilities.SemanticTokensOptions = new SemanticTokensOptions
-        {
-            Full = false,
-            Legend = _razorSemanticTokensLegend.Legend,
-            Range = true,
-        };
+        _razorSemanticTokensLegend = legend;
     }
 
     public async Task<SemanticTokens?> GetSemanticTokensAsync(

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/CohostDocumentColorEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/CohostDocumentColorEndpoint.cs
@@ -35,7 +35,7 @@ internal sealed class CohostDocumentColorEndpoint(
         => request.TextDocument.ToRazorTextDocumentIdentifier();
 
     public void ApplyCapabilities(VSInternalServerCapabilities serverCapabilities, VSInternalClientCapabilities _)
-        => Capabilities.ApplyDocumentColorProvider(serverCapabilities);
+        => serverCapabilities.EnableDocumentColorProvider();
 
     protected override Task<ColorInformation[]> HandleRequestAsync(DocumentColorParams request, RazorCohostRequestContext context, CancellationToken cancellationToken)
     {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/CohostDocumentColorEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/CohostDocumentColorEndpoint.cs
@@ -35,7 +35,7 @@ internal sealed class CohostDocumentColorEndpoint(
         => request.TextDocument.ToRazorTextDocumentIdentifier();
 
     public void ApplyCapabilities(VSInternalServerCapabilities serverCapabilities, VSInternalClientCapabilities _)
-        => Capabilities.DocumentColorProvider(serverCapabilities);
+        => Capabilities.ApplyDocumentColorProvider(serverCapabilities);
 
     protected override Task<ColorInformation[]> HandleRequestAsync(DocumentColorParams request, RazorCohostRequestContext context, CancellationToken cancellationToken)
     {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/CohostDocumentColorEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/CohostDocumentColorEndpoint.cs
@@ -5,6 +5,7 @@ using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.DocumentColor;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
 using Microsoft.CodeAnalysis.Razor.Logging;
@@ -33,8 +34,8 @@ internal sealed class CohostDocumentColorEndpoint(
     protected override RazorTextDocumentIdentifier? GetRazorTextDocumentIdentifier(DocumentColorParams request)
         => request.TextDocument.ToRazorTextDocumentIdentifier();
 
-    public void ApplyCapabilities(VSInternalServerCapabilities serverCapabilities, VSInternalClientCapabilities clientCapabilities)
-        => _documentColorService.ApplyCapabilities(serverCapabilities, clientCapabilities);
+    public void ApplyCapabilities(VSInternalServerCapabilities serverCapabilities, VSInternalClientCapabilities _)
+        => Capabilities.DocumentColorProvider(serverCapabilities);
 
     protected override Task<ColorInformation[]> HandleRequestAsync(DocumentColorParams request, RazorCohostRequestContext context, CancellationToken cancellationToken)
     {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/CohostSemanticTokensRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/CohostSemanticTokensRangeEndpoint.cs
@@ -40,7 +40,7 @@ internal sealed class CohostSemanticTokensRangeEndpoint(
     public void ApplyCapabilities(VSInternalServerCapabilities serverCapabilities, VSInternalClientCapabilities clientCapabilities)
     {
         var legend = new RazorSemanticTokensLegend(clientCapabilities);
-        Capabilities.ApplySemanticTokensOptions(serverCapabilities, legend.Legend);
+        serverCapabilities.EnableSemanticTokens(legend.Legend);
         _semanticTokensInfoService.SetTokensLegend(legend);
     }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/CohostSemanticTokensRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/CohostSemanticTokensRangeEndpoint.cs
@@ -40,7 +40,7 @@ internal sealed class CohostSemanticTokensRangeEndpoint(
     public void ApplyCapabilities(VSInternalServerCapabilities serverCapabilities, VSInternalClientCapabilities clientCapabilities)
     {
         var legend = new RazorSemanticTokensLegend(clientCapabilities);
-        Capabilities.SemanticTokensOptions(serverCapabilities, legend);
+        Capabilities.ApplySemanticTokensOptions(serverCapabilities, legend.Legend);
         _semanticTokensInfoService.SetTokensLegend(legend);
     }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/CohostSemanticTokensRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/CohostSemanticTokensRangeEndpoint.cs
@@ -5,6 +5,7 @@ using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
 using Microsoft.CodeAnalysis.Razor.Logging;
@@ -37,7 +38,11 @@ internal sealed class CohostSemanticTokensRangeEndpoint(
         => request.TextDocument.ToRazorTextDocumentIdentifier();
 
     public void ApplyCapabilities(VSInternalServerCapabilities serverCapabilities, VSInternalClientCapabilities clientCapabilities)
-        => _semanticTokensInfoService.ApplyCapabilities(serverCapabilities, clientCapabilities);
+    {
+        var legend = new RazorSemanticTokensLegend(clientCapabilities);
+        Capabilities.SemanticTokensOptions(serverCapabilities, legend);
+        _semanticTokensInfoService.SetTokensLegend(legend);
+    }
 
     protected override Task<SemanticTokens?> HandleRequestAsync(SemanticTokensRangeParams request, RazorCohostRequestContext context, CancellationToken cancellationToken)
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokensTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokensTest.cs
@@ -1011,7 +1011,9 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             featureOptions,
             LoggerFactory,
             telemetryReporter: null);
-        service.ApplyCapabilities(new(), new VSInternalClientCapabilities { SupportsVisualStudioExtensions = true });
+
+        var legend = new RazorSemanticTokensLegend(new VSInternalClientCapabilities { SupportsVisualStudioExtensions = true });
+        service.SetTokensLegend(legend);
         return service;
     }
 


### PR DESCRIPTION
After a chat with @davidwengier I wanted to propose this design for moving forward with CoHosting. This makes it so the services themselves aren't ICapabilitiesProviders, and instead we have that code separate but still centralized. 

It still keeps the endpoints as `ICapabilitiesProvider`