### PR TITLE
Remove `IDocumentSnapshot.Project`

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCSharpFormattingBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCSharpFormattingBenchmark.cs
@@ -36,6 +36,8 @@ public class RazorCSharpFormattingBenchmark : RazorLanguageServerBenchmarkBase
 
     private IDocumentSnapshot DocumentSnapshot { get; set; }
 
+    private IProjectSnapshot ProjectSnapshot { get; set; }
+
     private SourceText DocumentText { get; set; }
 
     /// <summary>
@@ -61,7 +63,7 @@ public class RazorCSharpFormattingBenchmark : RazorLanguageServerBenchmarkBase
         var targetPath = "/Components/Pages/Generated.razor";
 
         DocumentUri = new Uri(_filePath);
-        DocumentSnapshot = GetDocumentSnapshot(projectFilePath, _filePath, targetPath);
+        (DocumentSnapshot, ProjectSnapshot) = GetDocumentAndProjectSnapshot(projectFilePath, _filePath, targetPath);
         DocumentText = await DocumentSnapshot.GetTextAsync();
     }
 
@@ -118,7 +120,7 @@ public class RazorCSharpFormattingBenchmark : RazorLanguageServerBenchmarkBase
             InsertSpaces = true
         };
 
-        var documentContext = new VersionedDocumentContext(DocumentUri, DocumentSnapshot, projectContext: null, version: 1);
+        var documentContext = new VersionedDocumentContext(DocumentUri, DocumentSnapshot, ProjectSnapshot, projectContext: null, version: 1);
 
         var edits = await RazorFormattingService.FormatAsync(documentContext, range: null, options, CancellationToken.None);
 

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCodeActionsBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCodeActionsBenchmark.cs
@@ -27,6 +27,7 @@ public class RazorCodeActionsBenchmark : RazorLanguageServerBenchmarkBase
     private Uri? DocumentUri { get; set; }
     private CodeActionEndpoint? CodeActionEndpoint { get; set; }
     private IDocumentSnapshot? DocumentSnapshot { get; set; }
+    private IProjectSnapshot? ProjectSnapshot { get; set; }
     private SourceText? DocumentText { get; set; }
     private Range? RazorCodeActionRange { get; set; }
     private Range? CSharpCodeActionRange { get; set; }
@@ -75,14 +76,14 @@ public class RazorCodeActionsBenchmark : RazorLanguageServerBenchmarkBase
         var targetPath = "/Components/Pages/Generated.razor";
 
         DocumentUri = new Uri(_filePath);
-        DocumentSnapshot = GetDocumentSnapshot(projectFilePath, _filePath, targetPath);
+        (DocumentSnapshot, ProjectSnapshot) = GetDocumentAndProjectSnapshot(projectFilePath, _filePath, targetPath);
         DocumentText = await DocumentSnapshot.GetTextAsync();
 
         RazorCodeActionRange = ToRange(razorCodeActionIndex);
         CSharpCodeActionRange = ToRange(csharpCodeActionIndex);
         HtmlCodeActionRange = ToRange(htmlCodeActionIndex);
 
-        var documentContext = new VersionedDocumentContext(DocumentUri, DocumentSnapshot, projectContext: null, 1);
+        var documentContext = new VersionedDocumentContext(DocumentUri, DocumentSnapshot, ProjectSnapshot, projectContext: null, 1);
 
         var codeDocument = await documentContext.GetCodeDocumentAsync(CancellationToken.None);
         // Need a root namespace for the Extract to Code Behind light bulb to be happy

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCompletionBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCompletionBenchmark.cs
@@ -27,6 +27,7 @@ public class RazorCompletionBenchmark : RazorLanguageServerBenchmarkBase
     private Uri? DocumentUri { get; set; }
     private RazorCompletionEndpoint? CompletionEndpoint { get; set; }
     private IDocumentSnapshot? DocumentSnapshot { get; set; }
+    private IProjectSnapshot? ProjectSnapshot { get; set; }
     private SourceText? DocumentText { get; set; }
     private Position? RazorPosition { get; set; }
     private RazorRequestContext RazorRequestContext { get; set; }
@@ -74,12 +75,12 @@ public class RazorCompletionBenchmark : RazorLanguageServerBenchmarkBase
         var targetPath = "/Components/Pages/Generated.razor";
 
         DocumentUri = new Uri(_filePath);
-        DocumentSnapshot = GetDocumentSnapshot(projectFilePath, _filePath, targetPath);
+        (DocumentSnapshot, ProjectSnapshot) = GetDocumentAndProjectSnapshot(projectFilePath, _filePath, targetPath);
         DocumentText = await DocumentSnapshot.GetTextAsync();
 
         RazorPosition = ToPosition(razorCodeActionIndex);
 
-        var documentContext = new VersionedDocumentContext(DocumentUri, DocumentSnapshot, projectContext: null, 1);
+        var documentContext = new VersionedDocumentContext(DocumentUri, DocumentSnapshot, ProjectSnapshot, projectContext: null, 1);
         RazorRequestContext = new RazorRequestContext(documentContext, languageServer.GetLspServices(), "lsp/method", uri: null);
 
         Position ToPosition(int index)

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorDiagnosticsBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorDiagnosticsBenchmark.cs
@@ -73,7 +73,7 @@ public class RazorDiagnosticsBenchmark : RazorLanguageServerBenchmarkBase
         SourceText = RazorCodeDocument.Source.Text;
         var documentContext = new Mock<VersionedDocumentContext>(
             MockBehavior.Strict,
-            new object[] { It.IsAny<Uri>(), It.IsAny<IDocumentSnapshot>(), It.IsAny<VSProjectContext>(), It.IsAny<int>() });
+            new object[] { It.IsAny<Uri>(), It.IsAny<IDocumentSnapshot>(), It.IsAny<IProjectSnapshot>(), It.IsAny<VSProjectContext>(), It.IsAny<int>() });
         documentContext
             .Setup(r => r.GetCodeDocumentAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(RazorCodeDocument);

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorDocumentMappingBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorDocumentMappingBenchmark.cs
@@ -48,7 +48,7 @@ public class RazorDocumentMappingBenchmark : RazorLanguageServerBenchmarkBase
 
         var targetPath = "/Components/Pages/Generated.razor";
 
-        DocumentSnapshot = GetDocumentSnapshot(projectFilePath, _filePath, targetPath);
+        (DocumentSnapshot, _) = GetDocumentAndProjectSnapshot(projectFilePath, _filePath, targetPath);
 
         var codeDocument = await DocumentSnapshot.GetGeneratedOutputAsync();
         CSharpDocument = codeDocument.GetCSharpDocument();

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 #nullable disable
@@ -52,7 +52,7 @@ public class RazorLanguageServerBenchmarkBase : ProjectSnapshotManagerBenchmarkB
 
     private protected NoopLogger Logger { get; }
 
-    internal IDocumentSnapshot GetDocumentSnapshot(string projectFilePath, string filePath, string targetPath)
+    internal (IDocumentSnapshot, IProjectSnapshot) GetDocumentAndProjectSnapshot(string projectFilePath, string filePath, string targetPath)
     {
         var intermediateOutputPath = Path.Combine(Path.GetDirectoryName(projectFilePath), "obj");
         var hostProject = new HostProject(projectFilePath, intermediateOutputPath, RazorConfiguration.Default, rootNamespace: null);
@@ -70,7 +70,7 @@ public class RazorLanguageServerBenchmarkBase : ProjectSnapshotManagerBenchmarkB
         var projectSnapshot = projectSnapshotManager.GetLoadedProject(hostProject.Key);
 
         var documentSnapshot = projectSnapshot.GetDocument(filePath);
-        return documentSnapshot;
+        return (documentSnapshot, projectSnapshot);
     }
 
     private class NoopClientNotifierService : IClientConnection, IOnInitialized

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensBenchmark.cs
@@ -61,9 +61,9 @@ public class RazorSemanticTokensBenchmark : RazorLanguageServerBenchmarkBase
         TargetPath = $"/Components/Pages/{fileName}.razor";
 
         var documentUri = new Uri(filePath);
-        var documentSnapshot = GetDocumentSnapshot(ProjectFilePath, filePath, TargetPath);
+        var (documentSnapshot, projectSnapshot) = GetDocumentAndProjectSnapshot(ProjectFilePath, filePath, TargetPath);
         var version = 1;
-        DocumentContext = new VersionedDocumentContext(documentUri, documentSnapshot, projectContext: null, version);
+        DocumentContext = new VersionedDocumentContext(documentUri, documentSnapshot, projectSnapshot, projectContext: null, version);
 
         var text = await DocumentContext.GetSourceTextAsync(CancellationToken.None).ConfigureAwait(false);
         Range = new Range

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensRangeEndpointBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensRangeEndpointBenchmark.cs
@@ -70,9 +70,9 @@ public class RazorSemanticTokensRangeEndpointBenchmark : RazorLanguageServerBenc
         TargetPath = "/Components/Pages/SemanticTokens.razor";
 
         var documentUri = new Uri(filePath);
-        var documentSnapshot = GetDocumentSnapshot(ProjectFilePath, filePath, TargetPath);
+        var (documentSnapshot, projectSnapshot) = GetDocumentAndProjectSnapshot(ProjectFilePath, filePath, TargetPath);
         var version = 1;
-        DocumentContext = new VersionedDocumentContext(documentUri, documentSnapshot, projectContext: null, version);
+        DocumentContext = new VersionedDocumentContext(documentUri, documentSnapshot, projectSnapshot, projectContext: null, version);
 
         var razorOptionsMonitor = RazorLanguageServer.GetRequiredService<RazorLSPOptionsMonitor>();
         var clientConnection = RazorLanguageServer.GetRequiredService<IClientConnection>();

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensScrollingBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensScrollingBenchmark.cs
@@ -54,8 +54,9 @@ public class RazorSemanticTokensScrollingBenchmark : RazorLanguageServerBenchmar
         TargetPath = "/Components/Pages/FormattingTest.razor";
 
         var documentUri = new Uri(filePath);
-        var documentSnapshot = GetDocumentSnapshot(ProjectFilePath, filePath, TargetPath);
-        DocumentContext = new VersionedDocumentContext(documentUri, documentSnapshot, projectContext: null, version: 1);
+        var (documentSnapshot, projectSnapshot) = GetDocumentAndProjectSnapshot(ProjectFilePath, filePath, TargetPath);
+
+        DocumentContext = new VersionedDocumentContext(documentUri, documentSnapshot, projectSnapshot, projectContext: null, version: 1);
 
         SemanticTokensLegend = new RazorSemanticTokensLegend(new VSInternalClientCapabilities() { SupportsVisualStudioExtensions = true });
         RazorSemanticTokenService.ApplyCapabilities(new(), new VSInternalClientCapabilities() { SupportsVisualStudioExtensions = true });

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
@@ -70,7 +70,7 @@ internal sealed class CodeActionEndpoint(
             return null;
         }
 
-        var razorCodeActionContext = await GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot).ConfigureAwait(false);
+        var razorCodeActionContext = await GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot, documentContext.Project).ConfigureAwait(false);
         if (razorCodeActionContext is null)
         {
             return null;
@@ -139,7 +139,7 @@ internal sealed class CodeActionEndpoint(
     }
 
     // internal for testing
-    internal async Task<RazorCodeActionContext?> GenerateRazorCodeActionContextAsync(VSCodeActionParams request, IDocumentSnapshot documentSnapshot)
+    internal async Task<RazorCodeActionContext?> GenerateRazorCodeActionContextAsync(VSCodeActionParams request, IDocumentSnapshot documentSnapshot, IProjectSnapshot projectSnapshot)
     {
         var codeDocument = await documentSnapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
         if (codeDocument.IsUnsupported())
@@ -171,6 +171,7 @@ internal sealed class CodeActionEndpoint(
         var context = new RazorCodeActionContext(
             request,
             documentSnapshot,
+            projectSnapshot,
             codeDocument,
             location.Value,
             sourceText,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ComponentAccessibilityCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ComponentAccessibilityCodeActionProvider.cs
@@ -225,7 +225,7 @@ internal sealed class ComponentAccessibilityCodeActionProvider : IRazorCodeActio
         // Find all matching tag helpers
         using var _ = DictionaryPool<string, TagHelperPair>.GetPooledObject(out var matching);
 
-        foreach (var tagHelper in context.DocumentSnapshot.Project.TagHelpers)
+        foreach (var tagHelper in context.ProjectSnapshot.TagHelpers)
         {
             if (SatisfiesRules(tagHelper.TagMatchingRules, tagName.AsSpan(), parentTagName.AsSpan(), attributes, out var caseInsensitiveMatch))
             {
@@ -234,7 +234,7 @@ internal sealed class ComponentAccessibilityCodeActionProvider : IRazorCodeActio
         }
 
         // Iterate and find the fully qualified version
-        foreach (var tagHelper in context.DocumentSnapshot.Project.TagHelpers)
+        foreach (var tagHelper in context.ProjectSnapshot.TagHelpers)
         {
             if (matching.TryGetValue(tagHelper.Name, out var tagHelperPair))
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/RazorCodeActionContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/RazorCodeActionContext.cs
@@ -13,6 +13,7 @@ internal sealed class RazorCodeActionContext
     public RazorCodeActionContext(
         VSCodeActionParams request,
         IDocumentSnapshot documentSnapshot,
+        IProjectSnapshot projectSnapshot,
         RazorCodeDocument codeDocument,
         SourceLocation location,
         SourceText sourceText,
@@ -21,6 +22,7 @@ internal sealed class RazorCodeActionContext
     {
         Request = request ?? throw new ArgumentNullException(nameof(request));
         DocumentSnapshot = documentSnapshot ?? throw new ArgumentNullException(nameof(documentSnapshot));
+        ProjectSnapshot = projectSnapshot ?? throw new ArgumentNullException(nameof(projectSnapshot));
         CodeDocument = codeDocument ?? throw new ArgumentNullException(nameof(codeDocument));
         Location = location;
         SourceText = sourceText ?? throw new ArgumentNullException(nameof(sourceText));
@@ -30,6 +32,7 @@ internal sealed class RazorCodeActionContext
 
     public VSCodeActionParams Request { get; }
     public IDocumentSnapshot DocumentSnapshot { get; }
+    public IProjectSnapshot ProjectSnapshot { get; }
     public RazorCodeDocument CodeDocument { get; }
     public SourceLocation Location { get; }
     public SourceText SourceText { get; }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeDocumentReferenceHolder.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeDocumentReferenceHolder.cs
@@ -18,7 +18,7 @@ internal class CodeDocumentReferenceHolder : DocumentProcessedListener
         _codeDocumentCache = new();
     }
 
-    public override void DocumentProcessed(RazorCodeDocument codeDocument, IDocumentSnapshot documentSnapshot)
+    public override void DocumentProcessed(RazorCodeDocument codeDocument, IDocumentSnapshot documentSnapshot, IProjectSnapshot projectSnapshot)
     {
         // We capture a reference to the code document after a document has been processed in order to ensure that
         // latest document state information is readily available without re-computation. The DocumentState type

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeDocumentReferenceHolder.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeDocumentReferenceHolder.cs
@@ -25,7 +25,7 @@ internal class CodeDocumentReferenceHolder : DocumentProcessedListener
         // (brains of DocumentSnapshot) will garbage collect its generated output aggressively and due to the
         // nature of LSP being heavily asynchronous (multiple requests for single keystrokes) we don't want to cause
         // multiple parses/regenerations across LSP requests that are all for the same document version.
-        var key = new DocumentKey(documentSnapshot.Project.Key, documentSnapshot.FilePath.AssumeNotNull());
+        var key = new DocumentKey(documentSnapshot.ProjectKey, documentSnapshot.FilePath.AssumeNotNull());
         _codeDocumentCache[key] = codeDocument;
     }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/CohostDocumentContextFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/CohostDocumentContextFactory.cs
@@ -26,6 +26,6 @@ internal class CohostDocumentContextFactory(DocumentSnapshotFactory documentSnap
         //       document versions because TextDocument is inherently versioned.
         var version = _documentVersionCache.GetLatestDocumentVersion(documentSnapshot.FilePath.AssumeNotNull());
 
-        return new VersionedDocumentContext(documentUri, documentSnapshot, null, version);
+        return new VersionedDocumentContext(documentUri, documentSnapshot, documentSnapshot.Project, null, version);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/CohostDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/CohostDocumentSnapshot.cs
@@ -10,10 +10,10 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Cohost;
 
-internal class CohostDocumentSnapshot(TextDocument textDocument, IProjectSnapshot projectSnapshot) : IDocumentSnapshot
+internal class CohostDocumentSnapshot(TextDocument textDocument, CohostProjectSnapshot projectSnapshot) : IDocumentSnapshot
 {
     private readonly TextDocument _textDocument = textDocument;
-    private readonly IProjectSnapshot _projectSnapshot = projectSnapshot;
+    private readonly CohostProjectSnapshot _projectSnapshot = projectSnapshot;
 
     private RazorCodeDocument? _codeDocument;
 
@@ -22,8 +22,6 @@ internal class CohostDocumentSnapshot(TextDocument textDocument, IProjectSnapsho
     public string? FilePath => _textDocument.FilePath;
 
     public string? TargetPath => _textDocument.FilePath;
-
-    public IProjectSnapshot Project => _projectSnapshot;
 
     public bool SupportsOutput => true;
 
@@ -53,8 +51,8 @@ internal class CohostDocumentSnapshot(TextDocument textDocument, IProjectSnapsho
         // and simply compiles when asked, and if a new document snapshot comes in, we compile again. This is presumably worse for perf
         // but since we don't expect users to ever use cohosting without source generators, it's fine for now.
 
-        var imports = await DocumentState.ComputedStateTracker.GetImportsAsync(this).ConfigureAwait(false);
-        _codeDocument = await DocumentState.ComputedStateTracker.GenerateCodeDocumentAsync(Project, this, imports).ConfigureAwait(false);
+        var imports = await DocumentState.ComputedStateTracker.GetImportsAsync(_projectSnapshot, this).ConfigureAwait(false);
+        _codeDocument = await DocumentState.ComputedStateTracker.GenerateCodeDocumentAsync(_projectSnapshot, this, imports).ConfigureAwait(false);
 
         return _codeDocument;
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/CohostDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/CohostDocumentSnapshot.cs
@@ -25,6 +25,8 @@ internal class CohostDocumentSnapshot(TextDocument textDocument, CohostProjectSn
 
     public bool SupportsOutput => true;
 
+    public ProjectKey ProjectKey => _projectSnapshot.Key;
+
     public Task<SourceText> GetTextAsync() => _textDocument.GetTextAsync();
 
     public Task<VersionStamp> GetTextVersionAsync() => _textDocument.GetTextVersionAsync();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/CohostDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/CohostDocumentSnapshot.cs
@@ -27,6 +27,8 @@ internal class CohostDocumentSnapshot(TextDocument textDocument, CohostProjectSn
 
     public ProjectKey ProjectKey => _projectSnapshot.Key;
 
+    internal CohostProjectSnapshot Project => _projectSnapshot;
+
     public Task<SourceText> GetTextAsync() => _textDocument.GetTextAsync();
 
     public Task<VersionStamp> GetTextVersionAsync() => _textDocument.GetTextVersionAsync();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/DocumentSnapshotFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/DocumentSnapshotFactory.cs
@@ -5,7 +5,6 @@ using System;
 using System.Composition;
 using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Cohost;
 
@@ -13,11 +12,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Cohost;
 [method: ImportingConstructor]
 internal class DocumentSnapshotFactory(Lazy<ProjectSnapshotFactory> projectSnapshotFactory)
 {
-    private static readonly ConditionalWeakTable<TextDocument, IDocumentSnapshot> _documentSnapshots = new();
+    private static readonly ConditionalWeakTable<TextDocument, CohostDocumentSnapshot> _documentSnapshots = new();
 
     private readonly Lazy<ProjectSnapshotFactory> _projectSnapshotFactory = projectSnapshotFactory;
 
-    public IDocumentSnapshot GetOrCreate(TextDocument textDocument)
+    public CohostDocumentSnapshot GetOrCreate(TextDocument textDocument)
     {
         if (!_documentSnapshots.TryGetValue(textDocument, out var documentSnapshot))
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/ProjectSnapshotFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/ProjectSnapshotFactory.cs
@@ -5,7 +5,6 @@ using System.Composition;
 using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Cohost;
@@ -14,13 +13,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Cohost;
 [method: ImportingConstructor]
 internal class ProjectSnapshotFactory(DocumentSnapshotFactory documentSnapshotFactory, ITelemetryReporter telemetryReporter, JoinableTaskContext joinableTaskContext)
 {
-    private static readonly ConditionalWeakTable<Project, IProjectSnapshot> _projectSnapshots = new();
+    private static readonly ConditionalWeakTable<Project, CohostProjectSnapshot> _projectSnapshots = new();
 
     private readonly DocumentSnapshotFactory _documentSnapshotFactory = documentSnapshotFactory;
     private readonly ITelemetryReporter _telemetryReporter = telemetryReporter;
     private readonly JoinableTaskContext _joinableTaskContext = joinableTaskContext;
 
-    public IProjectSnapshot GetOrCreate(Project project)
+    public CohostProjectSnapshot GetOrCreate(Project project)
     {
         if (!_projectSnapshots.TryGetValue(project, out var projectSnapshot))
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/DocumentPullDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/DocumentPullDiagnosticsEndpoint.cs
@@ -128,7 +128,7 @@ internal class DocumentPullDiagnosticsEndpoint : IRazorRequestHandler<VSInternal
             return null;
         }
 
-        var convertedDiagnostics = RazorDiagnosticConverter.Convert(diagnostics, sourceText, documentContext.Snapshot);
+        var convertedDiagnostics = RazorDiagnosticConverter.Convert(diagnostics, sourceText, documentContext.Snapshot, documentContext.Project);
 
         return
         [

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticConverter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticConverter.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics;
 
 internal static class RazorDiagnosticConverter
 {
-    public static VSDiagnostic Convert(RazorDiagnostic razorDiagnostic, SourceText sourceText, IDocumentSnapshot? documentSnapshot)
+    public static VSDiagnostic Convert(RazorDiagnostic razorDiagnostic, SourceText sourceText, IDocumentSnapshot? documentSnapshot, IProjectSnapshot? projectSnapshot)
     {
         if (razorDiagnostic is null)
         {
@@ -25,14 +25,14 @@ internal static class RazorDiagnosticConverter
             throw new ArgumentNullException(nameof(sourceText));
         }
 
-        var projects = documentSnapshot is null
+        var projects = documentSnapshot is null || projectSnapshot is null
             ? Array.Empty<VSDiagnosticProjectInformation>()
             : [
                 new VSDiagnosticProjectInformation()
                 {
                     Context = null,
                     ProjectIdentifier = documentSnapshot.ProjectKey.Id,
-                    ProjectName = documentSnapshot.Project.DisplayName
+                    ProjectName = projectSnapshot.DisplayName
                 }
             ];
 
@@ -51,14 +51,14 @@ internal static class RazorDiagnosticConverter
         return diagnostic;
     }
 
-    internal static Diagnostic[] Convert(IReadOnlyList<RazorDiagnostic> diagnostics, SourceText sourceText, IDocumentSnapshot documentSnapshot)
+    internal static Diagnostic[] Convert(IReadOnlyList<RazorDiagnostic> diagnostics, SourceText sourceText, IDocumentSnapshot documentSnapshot, IProjectSnapshot projectSnapshot)
     {
         var convertedDiagnostics = new Diagnostic[diagnostics.Count];
 
         var i = 0;
         foreach (var diagnostic in diagnostics)
         {
-            convertedDiagnostics[i++] = Convert(diagnostic, sourceText, documentSnapshot);
+            convertedDiagnostics[i++] = Convert(diagnostic, sourceText, documentSnapshot, projectSnapshot);
         }
 
         return convertedDiagnostics;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticConverter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticConverter.cs
@@ -31,7 +31,7 @@ internal static class RazorDiagnosticConverter
                 new VSDiagnosticProjectInformation()
                 {
                     Context = null,
-                    ProjectIdentifier = documentSnapshot.Project.Key.Id,
+                    ProjectIdentifier = documentSnapshot.ProjectKey.Id,
                     ProjectName = documentSnapshot.Project.DisplayName
                 }
             ];

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentContext.cs
@@ -23,10 +23,12 @@ internal class DocumentContext
     public DocumentContext(
         Uri uri,
         IDocumentSnapshot snapshot,
+        IProjectSnapshot projectSnapshot,
         VSProjectContext? projectContext)
     {
         Uri = uri;
         Snapshot = snapshot;
+        Project = projectSnapshot;
         _projectContext = projectContext;
     }
 
@@ -38,7 +40,7 @@ internal class DocumentContext
 
     public virtual string FileKind => Snapshot.FileKind.AssumeNotNull();
 
-    public virtual IProjectSnapshot Project => Snapshot.Project;
+    public virtual IProjectSnapshot Project { get; }
 
     public virtual TextDocumentIdentifier Identifier => new VSTextDocumentIdentifier()
     {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentProcessedListener.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentProcessedListener.cs
@@ -10,5 +10,5 @@ internal abstract class DocumentProcessedListener
 {
     public abstract void Initialize(ProjectSnapshotManager projectManager);
 
-    public abstract void DocumentProcessed(RazorCodeDocument codeDocument, IDocumentSnapshot documentSnapshot);
+    public abstract void DocumentProcessed(RazorCodeDocument codeDocument, IDocumentSnapshot documentSnapshot, IProjectSnapshot projectSnapshot);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/GeneratedDocumentSynchronizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/GeneratedDocumentSynchronizer.cs
@@ -42,10 +42,10 @@ internal class GeneratedDocumentSynchronizer : DocumentProcessedListener
 
         var htmlText = codeDocument.GetHtmlSourceText();
 
-        _publisher.PublishHtml(document.Project.Key, filePath, htmlText, hostDocumentVersion.Value);
+        _publisher.PublishHtml(document.ProjectKey, filePath, htmlText, hostDocumentVersion.Value);
 
         var csharpText = codeDocument.GetCSharpSourceText();
 
-        _publisher.PublishCSharp(document.Project.Key, filePath, csharpText, hostDocumentVersion.Value);
+        _publisher.PublishCSharp(document.ProjectKey, filePath, csharpText, hostDocumentVersion.Value);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/GeneratedDocumentSynchronizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/GeneratedDocumentSynchronizer.cs
@@ -28,7 +28,7 @@ internal class GeneratedDocumentSynchronizer : DocumentProcessedListener
     {
     }
 
-    public override void DocumentProcessed(RazorCodeDocument codeDocument, IDocumentSnapshot document)
+    public override void DocumentProcessed(RazorCodeDocument codeDocument, IDocumentSnapshot document, IProjectSnapshot projectSnapshot)
     {
         _dispatcher.AssertDispatcherThread();
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/OpenDocumentGenerator.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/OpenDocumentGenerator.cs
@@ -176,7 +176,7 @@ internal class OpenDocumentGenerator : IProjectSnapshotChangeTrigger, IDisposabl
                 return;
             }
 
-            var key = $"{document.Project.Key.Id}:{document.FilePath.AssumeNotNull()}";
+            var key = $"{document.ProjectKey.Id}:{document.FilePath.AssumeNotNull()}";
             var workItem = new ProcessWorkItem(document, _documentProcessedListeners, _projectSnapshotManagerDispatcher);
             _workQueue.Enqueue(key, workItem);
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/ISnapshotResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/ISnapshotResolver.cs
@@ -19,5 +19,5 @@ internal interface ISnapshotResolver
     /// Finds a <see cref="IDocumentSnapshot"/> for the given document path that is contained within any project, and returns the first
     /// one found if it does. This method should be avoided where possible, and the overload that takes a <see cref="ProjectKey"/> should be used instead
     /// </summary>
-    bool TryResolveDocumentInAnyProject(string documentFilePath, [NotNullWhen(true)] out IDocumentSnapshot? documentSnapshot);
+    bool TryResolveDocumentInAnyProject(string documentFilePath, [NotNullWhen(true)] out IDocumentSnapshot? documentSnapshot, [NotNullWhen(true)] out IProjectSnapshot? projectSnapshot);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
@@ -108,7 +108,7 @@ internal class RazorProjectService(
         // We are okay to use the non-project-key overload of TryResolveDocument here because we really are just checking if the document
         // has been added to _any_ project. AddDocument will take care of adding to all of the necessary ones, and then below we ensure
         // we process them all too
-        if (!_snapshotResolver.TryResolveDocumentInAnyProject(textDocumentPath, out _))
+        if (!_snapshotResolver.TryResolveDocumentInAnyProject(textDocumentPath, out _, out _))
         {
             // Document hasn't been added. This usually occurs when VSCode trumps all other initialization
             // processes and pre-initializes already open documents.

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/SnapshotResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/SnapshotResolver.cs
@@ -74,7 +74,7 @@ internal sealed class SnapshotResolver : ISnapshotResolver
         return miscellaneousProject;
     }
 
-    public bool TryResolveDocumentInAnyProject(string documentFilePath, [NotNullWhen(true)] out IDocumentSnapshot? documentSnapshot)
+    public bool TryResolveDocumentInAnyProject(string documentFilePath, [NotNullWhen(true)] out IDocumentSnapshot? documentSnapshot, [NotNullWhen(true)] out IProjectSnapshot? projectSnapshot)
     {
         _logger.LogTrace("Looking for {documentFilePath}.", documentFilePath);
 
@@ -90,6 +90,7 @@ internal sealed class SnapshotResolver : ISnapshotResolver
         foreach (var project in potentialProjects)
         {
             documentSnapshot = project.GetDocument(normalizedDocumentPath);
+            projectSnapshot = project;
             if (documentSnapshot is not null)
             {
                 _logger.LogTrace("Found {documentFilePath} in {project}", documentFilePath, project.FilePath);
@@ -100,6 +101,7 @@ internal sealed class SnapshotResolver : ISnapshotResolver
         _logger.LogTrace("Looking for {documentFilePath} in miscellaneous project.", documentFilePath);
         var miscellaneousProject = GetMiscellaneousProject();
         documentSnapshot = miscellaneousProject.GetDocument(normalizedDocumentPath);
+        projectSnapshot = miscellaneousProject;
         if (documentSnapshot is not null)
         {
             _logger.LogTrace("Found {documentFilePath} in miscellaneous project.", documentFilePath);
@@ -109,6 +111,7 @@ internal sealed class SnapshotResolver : ISnapshotResolver
         _logger.LogTrace("{documentFilePath} not found in {documents}", documentFilePath, _projectSnapshotManagerAccessor.Instance.GetProjects().SelectMany(p => p.DocumentFilePaths));
 
         documentSnapshot = null;
+        projectSnapshot = null;
         return false;
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
@@ -381,7 +381,7 @@ internal sealed class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenamePar
         }
 
         var originTagHelpers = new List<TagHelperDescriptor>() { primaryTagHelper };
-        var associatedTagHelper = FindAssociatedTagHelper(primaryTagHelper, documentContext.Snapshot.Project.TagHelpers);
+        var associatedTagHelper = FindAssociatedTagHelper(primaryTagHelper, documentContext.Project.TagHelpers);
         if (associatedTagHelper is null)
         {
             Debug.Fail("Components should always have an associated TagHelper.");

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/VersionedDocumentContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/VersionedDocumentContext.cs
@@ -12,8 +12,8 @@ internal class VersionedDocumentContext : DocumentContext
 {
     public virtual int Version { get; }
 
-    public VersionedDocumentContext(Uri uri, IDocumentSnapshot snapshot, VSProjectContext? projectContext, int version)
-        : base(uri, snapshot, projectContext)
+    public VersionedDocumentContext(Uri uri, IDocumentSnapshot snapshot, IProjectSnapshot projectSnapshot, VSProjectContext? projectContext, int version)
+        : base(uri, snapshot, projectSnapshot, projectContext)
     {
         Version = version;
     }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentSnapshot.cs
@@ -16,6 +16,8 @@ internal class DocumentSnapshot : IDocumentSnapshot
     public string TargetPath => State.HostDocument.TargetPath;
     public bool SupportsOutput => true;
 
+    public ProjectKey ProjectKey => ProjectInternal.Key;
+
     public ProjectSnapshot ProjectInternal { get; }
     public DocumentState State { get; }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentSnapshot.cs
@@ -14,7 +14,6 @@ internal class DocumentSnapshot : IDocumentSnapshot
     public string FileKind => State.HostDocument.FileKind;
     public string FilePath => State.HostDocument.FilePath;
     public string TargetPath => State.HostDocument.TargetPath;
-    public IProjectSnapshot Project => ProjectInternal;
     public bool SupportsOutput => true;
 
     public ProjectSnapshot ProjectInternal { get; }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.cs
@@ -422,7 +422,7 @@ internal class DocumentState
             var configurationVersion = project.State.ConfigurationVersion;
             var projectWorkspaceStateVersion = project.State.ProjectWorkspaceStateVersion;
             var documentCollectionVersion = project.State.DocumentCollectionVersion;
-            var imports = await GetImportsAsync(document).ConfigureAwait(false);
+            var imports = await GetImportsAsync(project, document).ConfigureAwait(false);
             var documentVersion = await document.GetTextVersionAsync().ConfigureAwait(false);
 
             // OK now that have the previous output and all of the versions, we can see if anything
@@ -496,9 +496,9 @@ internal class DocumentState
             return RazorSourceDocument.Create(sourceText, RazorSourceDocumentProperties.Create(document.FilePath, projectItem?.RelativePhysicalPath));
         }
 
-        internal static async Task<ImmutableArray<ImportItem>> GetImportsAsync(IDocumentSnapshot document)
+        internal static async Task<ImmutableArray<ImportItem>> GetImportsAsync(IProjectSnapshot project, IDocumentSnapshot document)
         {
-            var imports = DocumentState.GetImportsCore(document.Project, document.FilePath.AssumeNotNull(), document.FileKind.AssumeNotNull());
+            var imports = DocumentState.GetImportsCore(project, document.FilePath.AssumeNotNull(), document.FileKind.AssumeNotNull());
             using var result = new PooledArrayBuilder<ImportItem>(imports.Length);
 
             foreach (var snapshot in imports)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshot.cs
@@ -13,7 +13,6 @@ internal interface IDocumentSnapshot
     string? FileKind { get; }
     string? FilePath { get; }
     string? TargetPath { get; }
-    IProjectSnapshot Project { get; }
     bool SupportsOutput { get; }
 
     Task<SourceText> GetTextAsync();

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshot.cs
@@ -15,6 +15,8 @@ internal interface IDocumentSnapshot
     string? TargetPath { get; }
     bool SupportsOutput { get; }
 
+    ProjectKey ProjectKey { get; }
+
     Task<SourceText> GetTextAsync();
     Task<VersionStamp> GetTextVersionAsync();
     Task<RazorCodeDocument> GetGeneratedOutputAsync();

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ImportDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ImportDocumentSnapshot.cs
@@ -18,7 +18,8 @@ internal class ImportDocumentSnapshot : IDocumentSnapshot
     public string? TargetPath => null;
 
     public bool SupportsOutput => false;
-    public IProjectSnapshot Project => _project;
+
+    public ProjectKey ProjectKey => _project.Key;
 
     private readonly IProjectSnapshot _project;
     private readonly RazorProjectItem _importItem;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/RazorDocumentExcerptService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/RazorDocumentExcerptService.cs
@@ -17,26 +17,12 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Razor;
 
-internal class RazorDocumentExcerptService : DocumentExcerptServiceBase
+internal class RazorDocumentExcerptService(IDocumentSnapshot document, IProjectSnapshot project, IRazorSpanMappingService mappingService)
+    : DocumentExcerptServiceBase
 {
-    private readonly IDocumentSnapshot _document;
-    private readonly IRazorSpanMappingService _mappingService;
-
-    public RazorDocumentExcerptService(IDocumentSnapshot document, IRazorSpanMappingService mappingService)
-    {
-        if (document is null)
-        {
-            throw new ArgumentNullException(nameof(document));
-        }
-
-        if (mappingService is null)
-        {
-            throw new ArgumentNullException(nameof(mappingService));
-        }
-
-        _document = document;
-        _mappingService = mappingService;
-    }
+    private readonly IDocumentSnapshot _document = document ?? throw new ArgumentNullException(nameof(document));
+    private readonly IProjectSnapshot _project = project ?? throw new ArgumentNullException(nameof(project));
+    private readonly IRazorSpanMappingService _mappingService = mappingService ?? throw new ArgumentNullException(nameof(mappingService));
 
     internal override async Task<ExcerptResultInternal?> TryGetExcerptInternalAsync(
         Document document,
@@ -56,8 +42,7 @@ internal class RazorDocumentExcerptService : DocumentExcerptServiceBase
             return null;
         }
 
-        var project = _document.Project;
-        var razorDocument = project.GetDocument(mappedSpans[0].FilePath);
+        var razorDocument = _project.GetDocument(mappedSpans[0].FilePath);
         if (razorDocument is null)
         {
             return null;

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/BackgroundDocumentGenerator.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/BackgroundDocumentGenerator.cs
@@ -287,7 +287,7 @@ internal class BackgroundDocumentGenerator : IProjectSnapshotChangeTrigger
 
             if (!_suppressedDocuments.Contains(filePath))
             {
-                var container = new DefaultDynamicDocumentContainer(document);
+                var container = new DefaultDynamicDocumentContainer(document, project);
                 _infoProvider.UpdateFileInfo(project.Key, container);
             }
         }

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultDynamicDocumentContainer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultDynamicDocumentContainer.cs
@@ -13,21 +13,14 @@ namespace Microsoft.CodeAnalysis.Razor;
 // Given a DocumentSnapshot this class allows the retrieval of a TextLoader for the generated C#
 // and services to help map spans and excerpts to and from the top-level Razor document to behind
 // the scenes C#.
-internal sealed class DefaultDynamicDocumentContainer : DynamicDocumentContainer
+internal sealed class DefaultDynamicDocumentContainer(IDocumentSnapshot documentSnapshot, IProjectSnapshot projectSnapshot)
+    : DynamicDocumentContainer
 {
-    private readonly IDocumentSnapshot _documentSnapshot;
+    private readonly IDocumentSnapshot _documentSnapshot = documentSnapshot ?? throw new ArgumentNullException(nameof(documentSnapshot));
+    private readonly IProjectSnapshot _projectSnapshot = projectSnapshot ?? throw new ArgumentNullException(nameof(projectSnapshot));
+
     private RazorDocumentExcerptService? _excerptService;
     private RazorSpanMappingService? _mappingService;
-
-    public DefaultDynamicDocumentContainer(IDocumentSnapshot documentSnapshot)
-    {
-        if (documentSnapshot is null)
-        {
-            throw new ArgumentNullException(nameof(documentSnapshot));
-        }
-
-        _documentSnapshot = documentSnapshot;
-    }
 
     public override string FilePath => _documentSnapshot.FilePath.AssumeNotNull();
 
@@ -40,7 +33,7 @@ internal sealed class DefaultDynamicDocumentContainer : DynamicDocumentContainer
         if (_excerptService is null)
         {
             var mappingService = GetMappingService();
-            _excerptService = new RazorDocumentExcerptService(_documentSnapshot, mappingService);
+            _excerptService = new RazorDocumentExcerptService(_documentSnapshot, _projectSnapshot, mappingService);
         }
 
         return _excerptService;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/OpenDocumentGenerator.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/OpenDocumentGenerator.cs
@@ -70,7 +70,7 @@ internal sealed class OpenDocumentGenerator(
         // Fortunate this code will be removed in time
         var hostDocumentUri = new Uri(document.FilePath);
 
-        _logger.LogDebug("[Cohost] Updating generated document buffers for {version} of {uri} in {projectKey}", version, hostDocumentUri, document.Project.Key);
+        _logger.LogDebug("[Cohost] Updating generated document buffers for {version} of {uri} in {projectKey}", version, hostDocumentUri, document.ProjectKey);
 
         if (_documentManager.TryGetDocument(hostDocumentUri, out var documentSnapshot))
         {
@@ -81,7 +81,7 @@ internal sealed class OpenDocumentGenerator(
             await _joinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
 
             // CSharp
-            var csharpVirtualDocumentSnapshot = await TryGetCSharpSnapshotAsync(documentSnapshot, document.Project.Key, version, cancellationToken).ConfigureAwait(true);
+            var csharpVirtualDocumentSnapshot = await TryGetCSharpSnapshotAsync(documentSnapshot, document.ProjectKey, version, cancellationToken).ConfigureAwait(true);
 
             Debug.Assert(htmlVirtualDocumentSnapshot is not null && csharpVirtualDocumentSnapshot is not null ||
                 htmlVirtualDocumentSnapshot is null && csharpVirtualDocumentSnapshot is null, "Found a Html XOR a C# document. Expected both or neither.");

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/DefaultCSharpCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/DefaultCSharpCodeActionProviderTest.cs
@@ -341,12 +341,14 @@ $$Path;
 
         var documentSnapshot = Mock.Of<IDocumentSnapshot>(document =>
             document.GetGeneratedOutputAsync() == Task.FromResult(codeDocument) &&
-            document.GetTextAsync() == Task.FromResult(codeDocument.GetSourceText()) &&
-            document.Project.TagHelpers == tagHelpers, MockBehavior.Strict);
+            document.GetTextAsync() == Task.FromResult(codeDocument.GetSourceText()), MockBehavior.Strict);
+
+        var projectSnapshot = Mock.Of<IProjectSnapshot>(project =>
+            project.TagHelpers == tagHelpers, MockBehavior.Strict);
 
         var sourceText = SourceText.From(text);
 
-        var context = new RazorCodeActionContext(request, documentSnapshot, codeDocument, location, sourceText, supportsFileCreation, supportsCodeActionResolve);
+        var context = new RazorCodeActionContext(request, documentSnapshot, projectSnapshot, codeDocument, location, sourceText, supportsFileCreation, supportsCodeActionResolve);
 
         return context;
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/TypeAccessibilityCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/TypeAccessibilityCodeActionProviderTest.cs
@@ -472,12 +472,14 @@ public class TypeAccessibilityCodeActionProviderTest(ITestOutputHelper testOutpu
 
         var documentSnapshot = Mock.Of<IDocumentSnapshot>(document =>
             document.GetGeneratedOutputAsync() == Task.FromResult(codeDocument) &&
-            document.GetTextAsync() == Task.FromResult(codeDocument.GetSourceText()) &&
-            document.Project.TagHelpers == tagHelpers, MockBehavior.Strict);
+            document.GetTextAsync() == Task.FromResult(codeDocument.GetSourceText()), MockBehavior.Strict);
+
+        var projectSnapshot = Mock.Of<IProjectSnapshot>(project =>
+           project.TagHelpers == tagHelpers, MockBehavior.Strict);
 
         var sourceText = SourceText.From(text);
 
-        var context = new RazorCodeActionContext(request, documentSnapshot, codeDocument, location, sourceText, supportsFileCreation, supportsCodeActionResolve: supportsCodeActionResolve);
+        var context = new RazorCodeActionContext(request, documentSnapshot, projectSnapshot, codeDocument, location, sourceText, supportsFileCreation, supportsCodeActionResolve: supportsCodeActionResolve);
 
         return context;
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndToEndTest.NetFx.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndToEndTest.NetFx.cs
@@ -1182,7 +1182,7 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : SingleServer
             var testDocumentSnapshot = TestDocumentSnapshot.Create(FilePath, CodeDocument.GetSourceText().ToString(), CodeAnalysis.VersionStamp.Default, projectWorkspaceState);
             testDocumentSnapshot.With(CodeDocument);
 
-            return CreateDocumentContext(new Uri(FilePath), testDocumentSnapshot);
+            return CreateDocumentContext(new Uri(FilePath), testDocumentSnapshot, testDocumentSnapshot.ProjectInternal);
         }
 
         private static List<TagHelperDescriptor> CreateTagHelperDescriptors()

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
@@ -628,7 +628,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
         };
 
         // Act
-        var razorCodeActionContext = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot);
+        var razorCodeActionContext = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot, documentContext.Project);
 
         // Assert
         Assert.NotNull(razorCodeActionContext);
@@ -669,7 +669,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
         };
 
         // Act
-        var razorCodeActionContext = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot);
+        var razorCodeActionContext = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot, documentContext.Project);
 
         // Assert
         Assert.NotNull(razorCodeActionContext);
@@ -710,7 +710,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             Context = new VSInternalCodeActionContext()
         };
 
-        var context = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot);
+        var context = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot, documentContext.Project);
         Assert.NotNull(context);
 
         // Act
@@ -757,7 +757,7 @@ public class CodeActionEndpointTest : LanguageServerTestBase
             }
         };
 
-        var context = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot);
+        var context = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot, documentContext.Project);
         Assert.NotNull(context);
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Html/DefaultHtmlCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Html/DefaultHtmlCodeActionProviderTest.cs
@@ -156,12 +156,14 @@ public class DefaultHtmlCodeActionProviderTest(ITestOutputHelper testOutput) : L
 
         var documentSnapshot = Mock.Of<IDocumentSnapshot>(document =>
             document.GetGeneratedOutputAsync() == Task.FromResult(codeDocument) &&
-            document.GetTextAsync() == Task.FromResult(codeDocument.GetSourceText()) &&
-            document.Project.TagHelpers == tagHelpers, MockBehavior.Strict);
+            document.GetTextAsync() == Task.FromResult(codeDocument.GetSourceText()), MockBehavior.Strict);
+
+        var projectSnapshot = Mock.Of<IProjectSnapshot>(project =>
+           project.TagHelpers == tagHelpers, MockBehavior.Strict);
 
         var sourceText = SourceText.From(text);
 
-        var context = new RazorCodeActionContext(request, documentSnapshot, codeDocument, location, sourceText, supportsFileCreation, supportsCodeActionResolve);
+        var context = new RazorCodeActionContext(request, documentSnapshot, projectSnapshot, codeDocument, location, sourceText, supportsFileCreation, supportsCodeActionResolve);
 
         return context;
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ComponentAccessibilityCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ComponentAccessibilityCodeActionProviderTest.cs
@@ -469,12 +469,14 @@ public class ComponentAccessibilityCodeActionProviderTest(ITestOutputHelper test
 
         var documentSnapshot = Mock.Of<IDocumentSnapshot>(document =>
             document.GetGeneratedOutputAsync() == Task.FromResult(codeDocument) &&
-            document.GetTextAsync() == Task.FromResult(codeDocument.GetSourceText()) &&
-            document.Project.TagHelpers == tagHelpers, MockBehavior.Strict);
+            document.GetTextAsync() == Task.FromResult(codeDocument.GetSourceText()), MockBehavior.Strict);
+
+        var projectSnapshot = Mock.Of<IProjectSnapshot>(project =>
+           project.TagHelpers == tagHelpers, MockBehavior.Strict);
 
         var sourceText = SourceText.From(text);
 
-        var context = new RazorCodeActionContext(request, documentSnapshot, codeDocument, location, sourceText, supportsFileCreation, supportsCodeActionResolve: true);
+        var context = new RazorCodeActionContext(request, documentSnapshot, projectSnapshot, codeDocument, location, sourceText, supportsFileCreation, supportsCodeActionResolve: true);
 
         return context;
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionProviderTest.cs
@@ -402,9 +402,11 @@ public class ExtractToCodeBehindCodeActionProviderTest(ITestOutputHelper testOut
             document.GetGeneratedOutputAsync() == Task.FromResult(codeDocument) &&
             document.GetTextAsync() == Task.FromResult(codeDocument.GetSourceText()), MockBehavior.Strict);
 
+        var projectSnapshot = Mock.Of<IProjectSnapshot>(MockBehavior.Strict);
+
         var sourceText = SourceText.From(text);
 
-        var context = new RazorCodeActionContext(request, documentSnapshot, codeDocument, location, sourceText, supportsFileCreation, supportsCodeActionResolve: true);
+        var context = new RazorCodeActionContext(request, documentSnapshot, projectSnapshot, codeDocument, location, sourceText, supportsFileCreation, supportsCodeActionResolve: true);
 
         return context;
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/DefinitionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/DefinitionEndpointTest.cs
@@ -362,8 +362,8 @@ public class DefinitionEndpointTest(ITestOutputHelper testOutput) : TagHelperSer
     {
         TestFileMarkupParser.GetPosition(content, out content, out var position);
 
-        SetupDocument(out _, out var documentSnapshot, content, isRazorFile);
-        var documentContext = CreateDocumentContext(new Uri(@"C:\file.razor"), documentSnapshot);
+        SetupDocument(out _, out var documentSnapshot, out var projectSnapshot, content, isRazorFile);
+        var documentContext = CreateDocumentContext(new Uri(@"C:\file.razor"), documentSnapshot, projectSnapshot);
 
         var (descriptor, attributeDescriptor) = await DefinitionEndpoint.GetOriginTagHelperBindingAsync(
             documentContext, position, ignoreAttributes, LoggerFactory.CreateLogger("RazorDefinitionEndpoint"), DisposalToken);
@@ -393,7 +393,7 @@ public class DefinitionEndpointTest(ITestOutputHelper testOutput) : TagHelperSer
     {
         TestFileMarkupParser.GetSpan(content, out content, out var selection);
 
-        SetupDocument(out var codeDocument, out _, content);
+        SetupDocument(out var codeDocument, out _, out _, content);
         var expectedRange = selection.ToRange(codeDocument.GetSourceText());
 
         var mappingService = new RazorDocumentMappingService(FilePathService, new TestDocumentContextFactory(), LoggerFactory);
@@ -403,7 +403,7 @@ public class DefinitionEndpointTest(ITestOutputHelper testOutput) : TagHelperSer
         Assert.Equal(expectedRange, range);
     }
 
-    private void SetupDocument(out RazorCodeDocument codeDocument, out IDocumentSnapshot documentSnapshot, string content, bool isRazorFile = true)
+    private void SetupDocument(out RazorCodeDocument codeDocument, out IDocumentSnapshot documentSnapshot, out IProjectSnapshot projectSnapshot, string content, bool isRazorFile = true)
     {
         var sourceText = SourceText.From(content);
         codeDocument = CreateCodeDocument(content, isRazorFile, DefaultTagHelpers);
@@ -414,6 +414,8 @@ public class DefinitionEndpointTest(ITestOutputHelper testOutput) : TagHelperSer
         Mock.Get(documentSnapshot)
             .Setup(s => s.GetGeneratedOutputAsync())
             .ReturnsAsync(outDoc);
+
+        projectSnapshot = Mock.Of<IProjectSnapshot>(MockBehavior.Strict);
     }
     #endregion
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticConverterTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticConverterTest.cs
@@ -24,7 +24,7 @@ public class RazorDiagnosticConverterTest(ITestOutputHelper testOutput) : Langua
         var sourceText = SourceText.From(string.Empty);
 
         // Act
-        var diagnostic = RazorDiagnosticConverter.Convert(razorDiagnostic, sourceText, documentSnapshot: null);
+        var diagnostic = RazorDiagnosticConverter.Convert(razorDiagnostic, sourceText, documentSnapshot: null, projectSnapshot: null);
 
         // Assert
         Assert.Equal(razorDiagnostic.Id, diagnostic.Code);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsPublisherTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsPublisherTest.cs
@@ -204,7 +204,7 @@ public class RazorDiagnosticsPublisherTest : LanguageServerTestBase
 
                     var project = expectedRazorDiagnostic.Projects.Single();
                     Assert.Equal(_openedDocument.Project.DisplayName, project.ProjectName);
-                    Assert.Equal(_openedDocument.Project.Key.Id, project.ProjectIdentifier);
+                    Assert.Equal(_openedDocument.ProjectKey.Id, project.ProjectIdentifier);
 
                 }
             })
@@ -264,7 +264,7 @@ public class RazorDiagnosticsPublisherTest : LanguageServerTestBase
                 Assert.NotNull(expectedDiagnostic.Projects);
                 var project = expectedDiagnostic.Projects.Single();
                 Assert.Equal(_openedDocument.Project.DisplayName, project.ProjectName);
-                Assert.Equal(_openedDocument.Project.Key.Id, project.ProjectIdentifier);
+                Assert.Equal(_openedDocument.ProjectKey.Id, project.ProjectIdentifier);
             })
             .Returns(Task.CompletedTask);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentContextFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentContextFactoryTest.cs
@@ -190,13 +190,13 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
 
     private class TestDocumentResolver : ISnapshotResolver
     {
-        private readonly IDocumentSnapshot? _documentSnapshot;
+        private readonly TestDocumentSnapshot? _documentSnapshot;
 
         public TestDocumentResolver()
         {
         }
 
-        public TestDocumentResolver(IDocumentSnapshot documentSnapshot)
+        public TestDocumentResolver(TestDocumentSnapshot documentSnapshot)
         {
             _documentSnapshot = documentSnapshot;
         }
@@ -211,15 +211,17 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
             throw new NotImplementedException();
         }
 
-        public bool TryResolveDocumentInAnyProject(string documentFilePath, [NotNullWhen(true)] out IDocumentSnapshot? documentSnapshot)
+        public bool TryResolveDocumentInAnyProject(string documentFilePath, [NotNullWhen(true)] out IDocumentSnapshot? documentSnapshot, [NotNullWhen(true)] out IProjectSnapshot? projectSnapshot)
         {
             if (documentFilePath == _documentSnapshot?.FilePath)
             {
                 documentSnapshot = _documentSnapshot;
+                projectSnapshot = _documentSnapshot.ProjectInternal;
                 return true;
             }
 
             documentSnapshot = null;
+            projectSnapshot = null;
             return false;
         }
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingContentValidationPassTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingContentValidationPassTest.cs
@@ -159,9 +159,6 @@ public class Foo { }
             .Setup(d => d.TargetPath)
             .Returns(path);
         documentSnapshot
-            .Setup(d => d.Project.TagHelpers)
-            .Returns(tagHelpers);
-        documentSnapshot
             .Setup(d => d.FileKind)
             .Returns(fileKind);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingDiagnosticValidationPassTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingDiagnosticValidationPassTest.cs
@@ -158,7 +158,7 @@ public class Foo { }
         var projectEngine = RazorProjectEngine.Create(builder => builder.SetRootNamespace("Test"));
         var codeDocument = projectEngine.ProcessDesignTime(sourceDocument, fileKind, importSources: default, tagHelpers);
 
-        var documentSnapshot = FormattingTestBase.CreateDocumentSnapshot(path, tagHelpers, fileKind, ImmutableArray<RazorSourceDocument>.Empty, ImmutableArray<IDocumentSnapshot>.Empty, projectEngine, codeDocument);
+        var (documentSnapshot, _) = FormattingTestBase.CreateDocumentAndProjectSnapshot(path, tagHelpers, fileKind, ImmutableArray<RazorSourceDocument>.Empty, ImmutableArray<IDocumentSnapshot>.Empty, projectEngine, codeDocument);
 
         return (codeDocument, documentSnapshot);
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingTestBase.cs
@@ -284,7 +284,7 @@ public class FormattingTestBase : RazorToolingIntegrationTestBase
             .Setup(d => d.FilePath)
             .Returns(path);
         documentSnapshot
-            .Setup(d => d.Project.Key)
+            .Setup(d => d.ProjectKey)
             .Returns(TestProjectKey.Create("/obj"));
         documentSnapshot
             .Setup(d => d.TargetPath)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/GeneratedDocumentSynchronizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/GeneratedDocumentSynchronizerTest.cs
@@ -16,7 +16,7 @@ public class GeneratedDocumentSynchronizerTest : LanguageServerTestBase
     private readonly DocumentVersionCache _cache;
     private readonly GeneratedDocumentSynchronizer _synchronizer;
     private readonly TestGeneratedDocumentPublisher _publisher;
-    private readonly IDocumentSnapshot _document;
+    private readonly TestDocumentSnapshot _document;
     private readonly RazorCodeDocument _codeDocument;
 
     public GeneratedDocumentSynchronizerTest(ITestOutputHelper testOutput)
@@ -36,7 +36,7 @@ public class GeneratedDocumentSynchronizerTest : LanguageServerTestBase
 
         // Act
         await Dispatcher.RunOnDispatcherThreadAsync(
-            () => _synchronizer.DocumentProcessed(_codeDocument, _document), DisposalToken);
+            () => _synchronizer.DocumentProcessed(_codeDocument, _document, _document.ProjectInternal), DisposalToken);
 
         // Assert
         Assert.False(_publisher.PublishedCSharp);
@@ -52,7 +52,7 @@ public class GeneratedDocumentSynchronizerTest : LanguageServerTestBase
             _cache.TrackDocumentVersion(_document, version: 1337);
 
             // Act
-            _synchronizer.DocumentProcessed(_codeDocument, _document);
+            _synchronizer.DocumentProcessed(_codeDocument, _document, _document.ProjectInternal);
         }, DisposalToken);
 
         // Assert

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverInfoServiceTest.cs
@@ -18,7 +18,6 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Tooltip;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.AspNetCore.Razor.Test.Common.Mef;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
@@ -983,10 +982,9 @@ public class HoverInfoServiceTest(ITestOutputHelper testOutput) : TagHelperServi
             d.GetGeneratedOutputAsync() == Task.FromResult(codeDocument) &&
             d.FilePath == path &&
             d.FileKind == FileKinds.Component &&
-            d.GetTextAsync() == Task.FromResult(sourceText) &&
-            d.Project == projectSnapshot, MockBehavior.Strict);
+            d.GetTextAsync() == Task.FromResult(sourceText), MockBehavior.Strict);
 
-        var documentContext = new VersionedDocumentContext(new Uri(path), snapshot, projectContext: null, 1337);
+        var documentContext = new VersionedDocumentContext(new Uri(path), snapshot, projectSnapshot, projectContext: null, 1337);
 
         return documentContext;
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/OpenDocumentGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/OpenDocumentGeneratorTest.cs
@@ -206,7 +206,7 @@ public class OpenDocumentGeneratorTest : LanguageServerTestBase
             return _tcs.Task;
         }
 
-        public override void DocumentProcessed(RazorCodeDocument codeDocument, IDocumentSnapshot document)
+        public override void DocumentProcessed(RazorCodeDocument codeDocument, IDocumentSnapshot document, IProjectSnapshot projectSnapshot)
         {
             _tcs.SetResult(document);
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
@@ -1258,7 +1258,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         if (snapshotResolver is null)
         {
             snapshotResolver = new Mock<ISnapshotResolver>(MockBehavior.Strict).Object;
-            Mock.Get(snapshotResolver).Setup(r => r.TryResolveDocumentInAnyProject(It.IsAny<string>(), out It.Ref<IDocumentSnapshot>.IsAny)).Returns(false);
+            Mock.Get(snapshotResolver).Setup(r => r.TryResolveDocumentInAnyProject(It.IsAny<string>(), out It.Ref<IDocumentSnapshot>.IsAny, out It.Ref<IProjectSnapshot>.IsAny)).Returns(false);
         }
 
         var remoteTextLoaderFactory = Mock.Of<RemoteTextLoaderFactory>(factory => factory.Create(It.IsAny<string>()) == Mock.Of<TextLoader>(MockBehavior.Strict), MockBehavior.Strict);
@@ -1310,16 +1310,17 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
 
         public IProjectSnapshot GetMiscellaneousProject() => _miscellaneousProject;
 
-        public bool TryResolveDocumentInAnyProject(string documentFilePath, out IDocumentSnapshot documentSnapshot)
+        public bool TryResolveDocumentInAnyProject(string documentFilePath, out IDocumentSnapshot documentSnapshot, out IProjectSnapshot projectSnapshot)
         {
             if (_projectMappings.TryGetValue(documentFilePath, out var projects))
             {
-                var projectSnapshot = projects.First();
+                projectSnapshot = projects.First();
                 documentSnapshot = projectSnapshot.GetDocument(documentFilePath);
                 return documentSnapshot is not null;
             }
 
             documentSnapshot = _miscellaneousProject.GetDocument(documentFilePath);
+            projectSnapshot = _miscellaneousProject;
             return documentSnapshot is not null;
         }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
@@ -23,7 +23,6 @@ using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.AspNetCore.Razor.Test.Common.Mef;
 using Microsoft.AspNetCore.Razor.Utilities;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Text;
@@ -615,10 +614,9 @@ public class RenameEndpointTest : LanguageServerTestBase
             d.GetGeneratedOutputAsync() == Task.FromResult(codeDocument) &&
             d.FilePath == item.FilePath &&
             d.FileKind == FileKinds.Component &&
-            d.GetTextAsync() == Task.FromResult(sourceText) &&
-            d.Project == projectSnapshot, MockBehavior.Strict);
+            d.GetTextAsync() == Task.FromResult(sourceText), MockBehavior.Strict);
         var version = 1337;
-        var documentSnapshot = new VersionedDocumentContext(new Uri(item.FilePath), snapshot, projectContext: null, version);
+        var documentSnapshot = new VersionedDocumentContext(new Uri(item.FilePath), snapshot, projectSnapshot, projectContext: null, version);
 
         return documentSnapshot;
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokensTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokensTest.cs
@@ -939,7 +939,8 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             .Returns(default(VersionStamp));
 
         var documentSnapshot = Mock.Of<IDocumentSnapshot>(MockBehavior.Strict);
-        var documentContext = new Mock<VersionedDocumentContext>(MockBehavior.Strict, new Uri("c:/path/to/file.razor"), documentSnapshot, /* projectContext */ null, 0);
+        var documentContext = new Mock<VersionedDocumentContext>(MockBehavior.Strict, new Uri("c:/path/to/file.razor"), documentSnapshot, projectSnapshot.Object, /* projectContext */ null, 0);
+
         documentContext.Setup(d => d.GetCodeDocumentAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(document);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SnapshotResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SnapshotResolverTest.cs
@@ -25,7 +25,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var snapshotResolver = CreateSnapshotResolver(normalizedFilePath);
 
         // Act
-        var result = snapshotResolver.TryResolveDocumentInAnyProject(documentFilePath, out var document);
+        var result = snapshotResolver.TryResolveDocumentInAnyProject(documentFilePath, out var document, out _);
 
         // Assert
         Assert.True(result);
@@ -49,7 +49,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
             new EmptyTextLoader(normalizedFilePath));
 
         // Act
-        var result = snapshotResolver.TryResolveDocumentInAnyProject(documentFilePath, out var document);
+        var result = snapshotResolver.TryResolveDocumentInAnyProject(documentFilePath, out var document, out _);
 
         // Assert
         Assert.True(result);
@@ -66,7 +66,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var snapshotResolver = new SnapshotResolver(projectSnapshotManagerAccessor, LoggerFactory);
 
         // Act
-        var result = snapshotResolver.TryResolveDocumentInAnyProject(documentFilePath, out var document);
+        var result = snapshotResolver.TryResolveDocumentInAnyProject(documentFilePath, out var document, out _);
 
         // Assert
         Assert.False(result);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestSnapshotResolver.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestSnapshotResolver.cs
@@ -41,9 +41,10 @@ internal class TestSnapshotResolver : ISnapshotResolver
         return _miscProject;
     }
 
-    public bool TryResolveDocumentInAnyProject(string documentFilePath, [NotNullWhen(true)] out IDocumentSnapshot? documentSnapshot)
+    public bool TryResolveDocumentInAnyProject(string documentFilePath, [NotNullWhen(true)] out IDocumentSnapshot? documentSnapshot, [NotNullWhen(true)] out IProjectSnapshot? projectSnapshot)
     {
         documentSnapshot = null;
+        projectSnapshot = null;
         return false;
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/LanguageServerTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/LanguageServerTestBase.cs
@@ -112,9 +112,9 @@ public abstract class LanguageServerTestBase : ToolingTestBase
         return documentContextFactory;
     }
 
-    internal static VersionedDocumentContext CreateDocumentContext(Uri uri, IDocumentSnapshot snapshot)
+    internal static VersionedDocumentContext CreateDocumentContext(Uri uri, IDocumentSnapshot snapshot, IProjectSnapshot projectSnapshot)
     {
-        return new VersionedDocumentContext(uri, snapshot, projectContext: null, version: 0);
+        return new VersionedDocumentContext(uri, snapshot, projectSnapshot, projectContext: null, version: 0);
     }
 
     internal static IOptionsMonitor<RazorLSPOptions> GetOptionsMonitor(bool enableFormatting = true, bool autoShowCompletion = true, bool autoListParams = true, bool formatOnType = true, bool autoInsertAttributeQuotes = true, bool colorBackground = false, bool commitElementsWithSpace = true)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/TestDocumentContext.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/TestDocumentContext.cs
@@ -16,7 +16,7 @@ internal static class TestDocumentContext
     public static DocumentContext Create(Uri uri, string text)
     {
         var snapshot = TestDocumentSnapshot.Create(uri.GetAbsoluteOrUNCPath(), text);
-        return new DocumentContext(uri, snapshot, projectContext: null);
+        return new DocumentContext(uri, snapshot, snapshot.ProjectInternal, projectContext: null);
     }
 
     public static VersionedDocumentContext From(string filePath, RazorCodeDocument codeDocument, int hostDocumentVersion)
@@ -25,7 +25,7 @@ internal static class TestDocumentContext
         var documentSnapshot = TestDocumentSnapshot.Create(filePath, content);
         documentSnapshot.With(codeDocument);
         var uri = new Uri(filePath);
-        return new VersionedDocumentContext(uri, documentSnapshot, projectContext: null, hostDocumentVersion);
+        return new VersionedDocumentContext(uri, documentSnapshot, documentSnapshot.ProjectInternal, projectContext: null, hostDocumentVersion);
     }
 
     public static DocumentContext From(string filePath, RazorCodeDocument codeDocument)
@@ -34,7 +34,7 @@ internal static class TestDocumentContext
         var documentSnapshot = TestDocumentSnapshot.Create(filePath, content);
         documentSnapshot.With(codeDocument);
         var uri = new Uri(filePath);
-        return new DocumentContext(uri, documentSnapshot, projectContext: null);
+        return new DocumentContext(uri, documentSnapshot, documentSnapshot.ProjectInternal, projectContext: null);
     }
 
     public static DocumentContext From(string filePath)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/TestDocumentSnapshot.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/TestDocumentSnapshot.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Immutable;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/DocumentExcerptServiceTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/DocumentExcerptServiceTestBase.cs
@@ -38,7 +38,7 @@ public abstract class DocumentExcerptServiceTestBase(ITestOutputHelper testOutpu
     }
 
     // Adds the text to a ProjectSnapshot, generates code, and updates the workspace.
-    private (IDocumentSnapshot primary, Document secondary) InitializeDocument(SourceText sourceText)
+    private (IDocumentSnapshot primary, Document secondary, IProjectSnapshot project) InitializeDocument(SourceText sourceText)
     {
         var project = new ProjectSnapshot(
             ProjectState.Create(ProjectEngineFactoryProvider, _hostProject, ProjectWorkspaceState.Default)
@@ -61,7 +61,7 @@ public abstract class DocumentExcerptServiceTestBase(ITestOutputHelper testOutpu
 
         var secondary = solution.Projects.Single().Documents.Single();
 
-        return (primary, secondary);
+        return (primary, secondary, project);
     }
 
     // Maps a span in the primary buffer to the secondary buffer. This is only valid for C# code
@@ -90,16 +90,16 @@ public abstract class DocumentExcerptServiceTestBase(ITestOutputHelper testOutpu
     public async Task<(Document generatedDocument, SourceText razorSourceText, TextSpan primarySpan, TextSpan generatedSpan)> InitializeAsync(string razorSource)
     {
         var (razorSourceText, primarySpan) = CreateText(razorSource);
-        var (primary, generatedDocument) = InitializeDocument(razorSourceText);
+        var (primary, generatedDocument, _) = InitializeDocument(razorSourceText);
         var generatedSpan = await GetSecondarySpanAsync(primary, primarySpan, generatedDocument);
         return (generatedDocument, razorSourceText, primarySpan, generatedSpan);
     }
 
-    internal async Task<(IDocumentSnapshot primary, Document generatedDocument, TextSpan generatedSpan)> InitializeWithSnapshotAsync(string razorSource)
+    internal async Task<(IDocumentSnapshot primary, Document generatedDocument, IProjectSnapshot project, TextSpan generatedSpan)> InitializeWithSnapshotAsync(string razorSource)
     {
         var (razorSourceText, primarySpan) = CreateText(razorSource);
-        var (primary, generatedDocument) = InitializeDocument(razorSourceText);
+        var (primary, generatedDocument, project) = InitializeDocument(razorSourceText);
         var generatedSpan = await GetSecondarySpanAsync(primary, primarySpan, generatedDocument);
-        return (primary, generatedDocument, generatedSpan);
+        return (primary, generatedDocument, project, generatedSpan);
     }
 }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/RazorDocumentExcerptServiceTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/RazorDocumentExcerptServiceTest.cs
@@ -27,9 +27,9 @@ public class RazorDocumentExcerptServiceTest(ITestOutputHelper testOutput) : Doc
 </html>
 ";
 
-        var (primary, secondary, secondarySpan) = await InitializeWithSnapshotAsync(razorSource);
+        var (primary, secondary, project, secondarySpan) = await InitializeWithSnapshotAsync(razorSource);
 
-        var service = CreateExcerptService(primary);
+        var service = CreateExcerptService(primary, project);
 
         // Act
         var options = RazorClassificationOptionsWrapper.Default;
@@ -105,9 +105,9 @@ public class RazorDocumentExcerptServiceTest(ITestOutputHelper testOutput) : Doc
 </html>
 ";
 
-        var (primary, secondary, secondarySpan) = await InitializeWithSnapshotAsync(razorSource);
+        var (primary, secondary, project, secondarySpan) = await InitializeWithSnapshotAsync(razorSource);
 
-        var service = CreateExcerptService(primary);
+        var service = CreateExcerptService(primary, project);
 
         // Act
         var options = RazorClassificationOptionsWrapper.Default;
@@ -158,9 +158,9 @@ public class RazorDocumentExcerptServiceTest(ITestOutputHelper testOutput) : Doc
 </html>
 ";
 
-        var (primary, secondary, secondarySpan) = await InitializeWithSnapshotAsync(razorSource);
+        var (primary, secondary, project, secondarySpan) = await InitializeWithSnapshotAsync(razorSource);
 
-        var service = CreateExcerptService(primary);
+        var service = CreateExcerptService(primary, project);
 
         // Act
         var options = RazorClassificationOptionsWrapper.Default;
@@ -261,9 +261,9 @@ public class RazorDocumentExcerptServiceTest(ITestOutputHelper testOutput) : Doc
 </html>
 ";
 
-        var (primary, secondary, secondarySpan) = await InitializeWithSnapshotAsync(razorSource);
+        var (primary, secondary, project, secondarySpan) = await InitializeWithSnapshotAsync(razorSource);
 
-        var service = CreateExcerptService(primary);
+        var service = CreateExcerptService(primary, project);
 
         // Act
         var options = RazorClassificationOptionsWrapper.Default;
@@ -370,9 +370,9 @@ public class RazorDocumentExcerptServiceTest(ITestOutputHelper testOutput) : Doc
         // Arrange
         var razorSource = @"@{ var [|foo|] = ""Hello, World!""; }";
 
-        var (primary, secondary, secondarySpan) = await InitializeWithSnapshotAsync(razorSource);
+        var (primary, secondary, project, secondarySpan) = await InitializeWithSnapshotAsync(razorSource);
 
-        var service = CreateExcerptService(primary);
+        var service = CreateExcerptService(primary, project);
 
         // Act
         var options = RazorClassificationOptionsWrapper.Default;
@@ -457,8 +457,8 @@ public class RazorDocumentExcerptServiceTest(ITestOutputHelper testOutput) : Doc
             });
     }
 
-    private RazorDocumentExcerptService CreateExcerptService(IDocumentSnapshot document)
+    private RazorDocumentExcerptService CreateExcerptService(IDocumentSnapshot document, IProjectSnapshot project)
     {
-        return new RazorDocumentExcerptService(document, new RazorSpanMappingService(document));
+        return new RazorDocumentExcerptService(document, project, new RazorSpanMappingService(document));
     }
 }


### PR DESCRIPTION
Part of https://github.com/dotnet/razor/issues/9519

In trying to reduce the suface area of `IProjectSnapshot` for cohosting I ran into a problem of the somewhat circular dependency between document and project snapshots. eg, I want to split `IProjectSnapshot` into two types: `IProjectSnapshot` which has the minimum needed to reason about a project and its documents, and `IProjectSnapshotThatCanCompileRazorFiles` for the existing Razor project system, where the project snapshot also has to be able to produce generated code. Obviously that name is not final :)

The problem comes when someone asks a `IProjectSnapshotThatCanCompileRazorFiles` for any documents, they get back an `IDocumentSnapshot`, and if they pass that around and something wants to know about the project it came from, they just get an `IProjectSnapshot` and have potentially lost the extra information that it original came from. This could be solved via runtime validation, and that probably would work perfectly well, but in this case because cohosting is off-by-default and still very early in development, I wanted the reassurance that the compiler gives by making this a compile time check. This could also have been solved with generics via `IDocumentSnapshot<TProject>` but I can't imagine that would have ended well.

It turns out that there were very few spots that needed the project from the `IDocumentSnapshot`, and in every case the source of the document snapshot had the project snapshot right there and available too, so removing the property seemed the most straight forward way of resolving this. Other than some minor Moq annoyance (and who doesn't get annoyed at Moq every now and again) the changes here are pretty much just all plumbing, but looking commit-at-a-time might be a little clearer as to what is going on.