### PR TITLE
Use `IProjectSnapshotManagerAccessor` rather than requesting `IProjectSnapshotManager` as a Roslyn language service

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioDocumentTrackerFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioDocumentTrackerFactory.cs
@@ -6,7 +6,7 @@ using System.Diagnostics;
 using Microsoft.AspNetCore.Razor.ProjectEngineHost;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Editor;
-using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Threading;
 
@@ -19,14 +19,14 @@ internal class DefaultVisualStudioDocumentTrackerFactory : VisualStudioDocumentT
     private readonly ITextDocumentFactoryService _textDocumentFactory;
     private readonly ProjectPathProvider _projectPathProvider;
     private readonly ImportDocumentManager _importDocumentManager;
-    private readonly ProjectSnapshotManager _projectManager;
+    private readonly IProjectSnapshotManagerAccessor _projectManagerAccessor;
     private readonly WorkspaceEditorSettings _workspaceEditorSettings;
     private readonly IProjectEngineFactoryProvider _projectEngineFactoryProvider;
 
     public DefaultVisualStudioDocumentTrackerFactory(
         ProjectSnapshotManagerDispatcher dispatcher,
         JoinableTaskContext joinableTaskContext,
-        ProjectSnapshotManager projectManager,
+        IProjectSnapshotManagerAccessor projectManagerAccessor,
         WorkspaceEditorSettings workspaceEditorSettings,
         ProjectPathProvider projectPathProvider,
         ITextDocumentFactoryService textDocumentFactory,
@@ -35,7 +35,7 @@ internal class DefaultVisualStudioDocumentTrackerFactory : VisualStudioDocumentT
     {
         _dispatcher = dispatcher;
         _joinableTaskContext = joinableTaskContext;
-        _projectManager = projectManager;
+        _projectManagerAccessor = projectManagerAccessor;
         _workspaceEditorSettings = workspaceEditorSettings;
         _projectPathProvider = projectPathProvider;
         _textDocumentFactory = textDocumentFactory;
@@ -63,7 +63,7 @@ internal class DefaultVisualStudioDocumentTrackerFactory : VisualStudioDocumentT
 
         var filePath = textDocument.FilePath;
         var tracker = new DefaultVisualStudioDocumentTracker(
-            _dispatcher, _joinableTaskContext, filePath, projectPath, _projectManager, _workspaceEditorSettings, _projectEngineFactoryProvider, textBuffer, _importDocumentManager);
+            _dispatcher, _joinableTaskContext, filePath, projectPath, _projectManagerAccessor, _workspaceEditorSettings, _projectEngineFactoryProvider, textBuffer, _importDocumentManager);
 
         return tracker;
     }

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioDocumentTrackerFactoryFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DefaultVisualStudioDocumentTrackerFactoryFactory.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Editor;
-using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Threading;
 
@@ -19,12 +19,12 @@ namespace Microsoft.VisualStudio.Editor.Razor;
 internal class DefaultVisualStudioDocumentTrackerFactoryFactory(
     ProjectSnapshotManagerDispatcher dispatcher,
     JoinableTaskContext joinableTaskContext,
+    IProjectSnapshotManagerAccessor projectManagerAccessor,
     ITextDocumentFactoryService textDocumentFactory,
     IProjectEngineFactoryProvider projectEngineFactoryProvider) : ILanguageServiceFactory
 {
     public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
     {
-        var projectManager = languageServices.GetRequiredService<ProjectSnapshotManager>();
         var workspaceEditorSettings = languageServices.GetRequiredService<WorkspaceEditorSettings>();
         var importDocumentManager = languageServices.GetRequiredService<ImportDocumentManager>();
 
@@ -33,7 +33,7 @@ internal class DefaultVisualStudioDocumentTrackerFactoryFactory(
         return new DefaultVisualStudioDocumentTrackerFactory(
             dispatcher,
             joinableTaskContext,
-            projectManager,
+            projectManagerAccessor,
             workspaceEditorSettings,
             projectPathProvider,
             textDocumentFactory,

--- a/src/Razor/src/Microsoft.VisualStudio.LiveShare.Razor/Guest/ProjectSnapshotSynchronizationServiceFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LiveShare.Razor/Guest/ProjectSnapshotSynchronizationServiceFactory.cs
@@ -1,14 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
 using System.ComponentModel.Composition;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor;
-using Microsoft.CodeAnalysis.Razor.ProjectSystem;
-using Microsoft.VisualStudio.LanguageServices;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.LiveShare.Razor.Serialization;
 using Microsoft.VisualStudio.Threading;
 using Newtonsoft.Json;
@@ -16,38 +13,13 @@ using Newtonsoft.Json;
 namespace Microsoft.VisualStudio.LiveShare.Razor.Guest;
 
 [ExportCollaborationService(typeof(ProjectSnapshotSynchronizationService), Scope = SessionScope.Guest)]
-internal class ProjectSnapshotSynchronizationServiceFactory : ICollaborationServiceFactory
+[method: ImportingConstructor]
+internal class ProjectSnapshotSynchronizationServiceFactory(
+    JoinableTaskContext joinableTaskContext,
+    IProjectSnapshotManagerAccessor projectManagerAccessor,
+    IErrorReporter errorReporter,
+    ProjectSnapshotManagerDispatcher dispatcher) : ICollaborationServiceFactory
 {
-    private readonly ProxyAccessor _proxyAccessor;
-    private readonly JoinableTaskContext _joinableTaskContext;
-    private readonly Workspace _workspace;
-
-    [ImportingConstructor]
-    public ProjectSnapshotSynchronizationServiceFactory(
-        ProxyAccessor proxyAccessor,
-        JoinableTaskContext joinableTaskContext,
-        [Import(typeof(VisualStudioWorkspace))] Workspace workspace)
-    {
-        if (proxyAccessor is null)
-        {
-            throw new ArgumentNullException(nameof(proxyAccessor));
-        }
-
-        if (joinableTaskContext is null)
-        {
-            throw new ArgumentNullException(nameof(joinableTaskContext));
-        }
-
-        if (workspace is null)
-        {
-            throw new ArgumentNullException(nameof(workspace));
-        }
-
-        _proxyAccessor = proxyAccessor;
-        _joinableTaskContext = joinableTaskContext;
-        _workspace = workspace;
-    }
-
     public async Task<ICollaborationService> CreateServiceAsync(CollaborationSession sessionContext, CancellationToken cancellationToken)
     {
         // This collaboration service depends on these serializers being immediately available so we need to register these now so the
@@ -55,15 +27,14 @@ internal class ProjectSnapshotSynchronizationServiceFactory : ICollaborationServ
         var serializer = (JsonSerializer)sessionContext.GetService(typeof(JsonSerializer));
         serializer.Converters.RegisterRazorLiveShareConverters();
 
-        var languageServices = _workspace.Services.GetLanguageServices(RazorLanguage.Name);
-        var projectManager = (ProjectSnapshotManagerBase)languageServices.GetRequiredService<ProjectSnapshotManager>();
-
         var projectSnapshotManagerProxy = await sessionContext.GetRemoteServiceAsync<IProjectSnapshotManagerProxy>(typeof(IProjectSnapshotManagerProxy).Name, cancellationToken);
         var synchronizationService = new ProjectSnapshotSynchronizationService(
-            _joinableTaskContext.Factory,
+            joinableTaskContext.Factory,
             sessionContext,
             projectSnapshotManagerProxy,
-            projectManager);
+            projectManagerAccessor,
+            errorReporter,
+            dispatcher);
 
         await synchronizationService.InitializeAsync(cancellationToken);
 

--- a/src/Razor/src/Microsoft.VisualStudio.LiveShare.Razor/Host/DefaultProjectSnapshotManagerProxy.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LiveShare.Razor/Host/DefaultProjectSnapshotManagerProxy.cs
@@ -16,7 +16,7 @@ namespace Microsoft.VisualStudio.LiveShare.Razor.Host;
 internal class DefaultProjectSnapshotManagerProxy : IProjectSnapshotManagerProxy, ICollaborationService, IDisposable
 {
     private readonly CollaborationSession _session;
-    private readonly ProjectSnapshotManagerDispatcher _projectSnapshotManagerDispatcher;
+    private readonly ProjectSnapshotManagerDispatcher _dispatcher;
     private readonly ProjectSnapshotManager _projectSnapshotManager;
     private readonly JoinableTaskFactory _joinableTaskFactory;
     private readonly AsyncSemaphore _latestStateSemaphore;
@@ -28,7 +28,7 @@ internal class DefaultProjectSnapshotManagerProxy : IProjectSnapshotManagerProxy
 
     public DefaultProjectSnapshotManagerProxy(
         CollaborationSession session,
-        ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,
+        ProjectSnapshotManagerDispatcher dispatcher,
         ProjectSnapshotManager projectSnapshotManager,
         JoinableTaskFactory joinableTaskFactory)
     {
@@ -37,9 +37,9 @@ internal class DefaultProjectSnapshotManagerProxy : IProjectSnapshotManagerProxy
             throw new ArgumentNullException(nameof(session));
         }
 
-        if (projectSnapshotManagerDispatcher is null)
+        if (dispatcher is null)
         {
-            throw new ArgumentNullException(nameof(projectSnapshotManagerDispatcher));
+            throw new ArgumentNullException(nameof(dispatcher));
         }
 
         if (projectSnapshotManager is null)
@@ -53,7 +53,7 @@ internal class DefaultProjectSnapshotManagerProxy : IProjectSnapshotManagerProxy
         }
 
         _session = session;
-        _projectSnapshotManagerDispatcher = projectSnapshotManagerDispatcher;
+        _dispatcher = dispatcher;
         _projectSnapshotManager = projectSnapshotManager;
         _joinableTaskFactory = joinableTaskFactory;
 
@@ -81,7 +81,7 @@ internal class DefaultProjectSnapshotManagerProxy : IProjectSnapshotManagerProxy
 
     public void Dispose()
     {
-        _projectSnapshotManagerDispatcher.AssertDispatcherThread();
+        _dispatcher.AssertDispatcherThread();
 
         _projectSnapshotManager.Changed -= ProjectSnapshotManager_Changed;
         _latestStateSemaphore.Dispose();
@@ -133,7 +133,7 @@ internal class DefaultProjectSnapshotManagerProxy : IProjectSnapshotManagerProxy
 
     private void ProjectSnapshotManager_Changed(object sender, ProjectChangeEventArgs args)
     {
-        _projectSnapshotManagerDispatcher.AssertDispatcherThread();
+        _dispatcher.AssertDispatcherThread();
 
         if (_disposed)
         {
@@ -164,7 +164,7 @@ internal class DefaultProjectSnapshotManagerProxy : IProjectSnapshotManagerProxy
 
     private void OnChanged(ProjectChangeEventProxyArgs args)
     {
-        _projectSnapshotManagerDispatcher.AssertDispatcherThread();
+        _dispatcher.AssertDispatcherThread();
 
         if (_disposed)
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/OpenDocumentGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/OpenDocumentGeneratorTest.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System;
-using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultVisualStudioDocumentTrackerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultVisualStudioDocumentTrackerTest.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Editor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.Editor.Razor.Documents;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
@@ -34,7 +35,6 @@ public class DefaultVisualStudioDocumentTrackerTest : ProjectSnapshotManagerDisp
     private Project? _workspaceProject;
     private readonly ImportDocumentManager _importDocumentManager;
     private readonly WorkspaceEditorSettings _workspaceEditorSettings;
-    private readonly List<TagHelperDescriptor> _someTagHelpers;
     private readonly ProjectSnapshotManagerBase _projectManager;
     private readonly DefaultVisualStudioDocumentTracker _documentTracker;
 
@@ -54,12 +54,12 @@ public class DefaultVisualStudioDocumentTrackerTest : ProjectSnapshotManagerDisp
 
         _workspaceEditorSettings = new DefaultWorkspaceEditorSettings(Mock.Of<IClientSettingsManager>(MockBehavior.Strict));
 
-        _someTagHelpers = new List<TagHelperDescriptor>()
-        {
-            TagHelperDescriptorBuilder.Create("test", "test").Build(),
-        };
-
         _projectManager = new TestProjectSnapshotManager(Workspace, ProjectEngineFactoryProvider, Dispatcher) { AllowNotifyListeners = true };
+
+        var projectManagerAccessorMock = new Mock<IProjectSnapshotManagerAccessor>(MockBehavior.Strict);
+        projectManagerAccessorMock
+            .SetupGet(x => x.Instance)
+            .Returns(_projectManager);
 
         _hostProject = new HostProject(_projectPath, TestProjectData.SomeProject.IntermediateOutputPath, FallbackRazorConfiguration.MVC_2_1, _rootNamespace);
         _updatedHostProject = new HostProject(_projectPath, TestProjectData.SomeProject.IntermediateOutputPath, FallbackRazorConfiguration.MVC_2_0, _rootNamespace);
@@ -70,7 +70,7 @@ public class DefaultVisualStudioDocumentTrackerTest : ProjectSnapshotManagerDisp
             JoinableTaskFactory.Context,
             _filePath,
             _projectPath,
-            _projectManager,
+            projectManagerAccessorMock.Object,
             _workspaceEditorSettings,
             ProjectEngineFactoryProvider,
             _textBuffer,

--- a/src/Razor/test/Microsoft.VisualStudio.LiveShare.Razor.Test/Guest/ProjectSnapshotSynchronizationServiceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LiveShare.Razor.Test/Guest/ProjectSnapshotSynchronizationServiceTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 using System.Linq;
@@ -12,8 +10,8 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common.Editor;
 using Microsoft.AspNetCore.Razor.Test.Common.ProjectSystem;
-using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.LiveShare.Razor.Test;
 using Moq;
 using Xunit;
@@ -21,10 +19,10 @@ using Xunit.Abstractions;
 
 namespace Microsoft.VisualStudio.LiveShare.Razor.Guest;
 
-public class ProjectSnapshotSynchronizationServiceTest : WorkspaceTestBase
+public class ProjectSnapshotSynchronizationServiceTest : ProjectSnapshotManagerDispatcherWorkspaceTestBase
 {
     private readonly CollaborationSession _sessionContext;
-    private readonly TestProjectSnapshotManager _projectSnapshotManager;
+    private readonly IProjectSnapshotManagerAccessor _projectManagerAccessor;
     private readonly ProjectWorkspaceState _projectWorkspaceStateWithTagHelpers;
 
     public ProjectSnapshotSynchronizationServiceTest(ITestOutputHelper testOutput)
@@ -32,7 +30,14 @@ public class ProjectSnapshotSynchronizationServiceTest : WorkspaceTestBase
     {
         _sessionContext = new TestCollaborationSession(isHost: false);
 
-        _projectSnapshotManager = new TestProjectSnapshotManager(Workspace, ProjectEngineFactoryProvider, new TestProjectSnapshotManagerDispatcher());
+        var projectManager = new TestProjectSnapshotManager(Workspace, ProjectEngineFactoryProvider, new TestProjectSnapshotManagerDispatcher());
+
+        var projectManagerAccessorMock = new Mock<IProjectSnapshotManagerAccessor>(MockBehavior.Strict);
+        projectManagerAccessorMock
+            .SetupGet(x => x.Instance)
+            .Returns(projectManager);
+
+        _projectManagerAccessor = projectManagerAccessorMock.Object;
 
         _projectWorkspaceStateWithTagHelpers = ProjectWorkspaceState.Create(ImmutableArray.Create(
             TagHelperDescriptorBuilder.Create("TestTagHelper", "TestAssembly").Build()));
@@ -55,13 +60,17 @@ public class ProjectSnapshotSynchronizationServiceTest : WorkspaceTestBase
             JoinableTaskFactory,
             _sessionContext,
             hostProjectManagerProxy,
-            _projectSnapshotManager);
+            _projectManagerAccessor,
+            ErrorReporter,
+            Dispatcher);
 
         // Act
         await synchronizationService.InitializeAsync(DisposalToken);
 
         // Assert
-        var project = Assert.Single(_projectSnapshotManager.GetProjects());
+        var projects = await Dispatcher.RunOnDispatcherThreadAsync(
+            _projectManagerAccessor.Instance.GetProjects, DisposalToken);
+        var project = Assert.Single(projects);
         Assert.Equal("/guest/path/project.csproj", project.FilePath);
         Assert.Same(RazorConfiguration.Default, project.Configuration);
 
@@ -73,7 +82,7 @@ public class ProjectSnapshotSynchronizationServiceTest : WorkspaceTestBase
     }
 
     [Fact]
-    public void UpdateGuestProjectManager_ProjectAdded()
+    public async Task UpdateGuestProjectManager_ProjectAdded()
     {
         // Arrange
         var newHandle = new ProjectSnapshotHandleProxy(
@@ -86,14 +95,18 @@ public class ProjectSnapshotSynchronizationServiceTest : WorkspaceTestBase
             JoinableTaskFactory,
             _sessionContext,
             Mock.Of<IProjectSnapshotManagerProxy>(MockBehavior.Strict),
-            _projectSnapshotManager);
+            _projectManagerAccessor,
+            ErrorReporter,
+            Dispatcher);
         var args = new ProjectChangeEventProxyArgs(older: null, newHandle, ProjectProxyChangeKind.ProjectAdded);
 
         // Act
-        synchronizationService.UpdateGuestProjectManager(args);
+        await synchronizationService.UpdateGuestProjectManagerAsync(args);
 
         // Assert
-        var project = Assert.Single(_projectSnapshotManager.GetProjects());
+        var projects = await Dispatcher.RunOnDispatcherThreadAsync(
+            _projectManagerAccessor.Instance.GetProjects, DisposalToken);
+        var project = Assert.Single(projects);
         Assert.Equal("/guest/path/project.csproj", project.FilePath);
         Assert.Same(RazorConfiguration.Default, project.Configuration);
 
@@ -105,7 +118,7 @@ public class ProjectSnapshotSynchronizationServiceTest : WorkspaceTestBase
     }
 
     [Fact]
-    public void UpdateGuestProjectManager_ProjectRemoved()
+    public async Task UpdateGuestProjectManager_ProjectRemoved()
     {
         // Arrange
         var olderHandle = new ProjectSnapshotHandleProxy(
@@ -118,20 +131,27 @@ public class ProjectSnapshotSynchronizationServiceTest : WorkspaceTestBase
             JoinableTaskFactory,
             _sessionContext,
             Mock.Of<IProjectSnapshotManagerProxy>(MockBehavior.Strict),
-            _projectSnapshotManager);
+            _projectManagerAccessor,
+            ErrorReporter,
+            Dispatcher);
         var hostProject = new HostProject("/guest/path/project.csproj", "/guest/path/obj", RazorConfiguration.Default, "project");
-        _projectSnapshotManager.ProjectAdded(hostProject);
+
+        await Dispatcher.RunOnDispatcherThreadAsync(
+            () => _projectManagerAccessor.Instance.ProjectAdded(hostProject),
+            DisposalToken);
         var args = new ProjectChangeEventProxyArgs(olderHandle, newer: null, ProjectProxyChangeKind.ProjectRemoved);
 
         // Act
-        synchronizationService.UpdateGuestProjectManager(args);
+        await synchronizationService.UpdateGuestProjectManagerAsync(args);
 
         // Assert
-        Assert.Empty(_projectSnapshotManager.GetProjects());
+        var projects = await Dispatcher.RunOnDispatcherThreadAsync(
+            _projectManagerAccessor.Instance.GetProjects, DisposalToken);
+        Assert.Empty(projects);
     }
 
     [Fact]
-    public void UpdateGuestProjectManager_ProjectChanged_ConfigurationChange()
+    public async Task UpdateGuestProjectManager_ProjectChanged_ConfigurationChange()
     {
         // Arrange
         var oldHandle = new ProjectSnapshotHandleProxy(
@@ -151,24 +171,32 @@ public class ProjectSnapshotSynchronizationServiceTest : WorkspaceTestBase
             JoinableTaskFactory,
             _sessionContext,
             Mock.Of<IProjectSnapshotManagerProxy>(MockBehavior.Strict),
-            _projectSnapshotManager);
+            _projectManagerAccessor,
+            ErrorReporter,
+            Dispatcher);
         var hostProject = new HostProject("/guest/path/project.csproj", "/guest/path/obj", RazorConfiguration.Default, "project");
-        _projectSnapshotManager.ProjectAdded(hostProject);
-        _projectSnapshotManager.ProjectConfigurationChanged(hostProject);
+        await Dispatcher.RunOnDispatcherThreadAsync(() =>
+        {
+            var projectManager = _projectManagerAccessor.Instance;
+            projectManager.ProjectAdded(hostProject);
+            projectManager.ProjectConfigurationChanged(hostProject);
+        }, DisposalToken);
         var args = new ProjectChangeEventProxyArgs(oldHandle, newHandle, ProjectProxyChangeKind.ProjectChanged);
 
         // Act
-        synchronizationService.UpdateGuestProjectManager(args);
+        await synchronizationService.UpdateGuestProjectManagerAsync(args);
 
         // Assert
-        var project = Assert.Single(_projectSnapshotManager.GetProjects());
+        var projects = await Dispatcher.RunOnDispatcherThreadAsync(
+            _projectManagerAccessor.Instance.GetProjects, DisposalToken);
+        var project = Assert.Single(projects);
         Assert.Equal("/guest/path/project.csproj", project.FilePath);
         Assert.Same(newConfiguration, project.Configuration);
         Assert.Empty(project.TagHelpers);
     }
 
     [Fact]
-    public void UpdateGuestProjectManager_ProjectChanged_ProjectWorkspaceStateChange()
+    public async Task UpdateGuestProjectManager_ProjectChanged_ProjectWorkspaceStateChange()
     {
         // Arrange
         var oldHandle = new ProjectSnapshotHandleProxy(
@@ -188,17 +216,25 @@ public class ProjectSnapshotSynchronizationServiceTest : WorkspaceTestBase
             JoinableTaskFactory,
             _sessionContext,
             Mock.Of<IProjectSnapshotManagerProxy>(MockBehavior.Strict),
-            _projectSnapshotManager);
+            _projectManagerAccessor,
+            ErrorReporter,
+            Dispatcher);
         var hostProject = new HostProject("/guest/path/project.csproj", "/guest/path/obj", RazorConfiguration.Default, "project");
-        _projectSnapshotManager.ProjectAdded(hostProject);
-        _projectSnapshotManager.ProjectWorkspaceStateChanged(hostProject.Key, oldHandle.ProjectWorkspaceState);
+        await Dispatcher.RunOnDispatcherThreadAsync(() =>
+        {
+            var projectManager = _projectManagerAccessor.Instance;
+            projectManager.ProjectAdded(hostProject);
+            projectManager.ProjectWorkspaceStateChanged(hostProject.Key, oldHandle.ProjectWorkspaceState);
+        }, DisposalToken);
         var args = new ProjectChangeEventProxyArgs(oldHandle, newHandle, ProjectProxyChangeKind.ProjectChanged);
 
         // Act
-        synchronizationService.UpdateGuestProjectManager(args);
+        await synchronizationService.UpdateGuestProjectManagerAsync(args);
 
         // Assert
-        var project = Assert.Single(_projectSnapshotManager.GetProjects());
+        var projects = await Dispatcher.RunOnDispatcherThreadAsync(
+            _projectManagerAccessor.Instance.GetProjects, DisposalToken);
+        var project = Assert.Single(projects);
         Assert.Equal("/guest/path/project.csproj", project.FilePath);
         Assert.Same(RazorConfiguration.Default, project.Configuration);
 


### PR DESCRIPTION
This change avoids requesting `IProjectSnapshotManager` from the Roslyn workspace in a few more places.

Note that there's a lot of effort in the Live Share code to access the `ProjectSnapshotManager` on the main thread rather than the dispatcher thread. I have a sneaking suspicion that was actually incorrect and this might have been missed back when the `ProjectSnapshotManagerDispatcher` was introduced. Since this is Live Share, it's kind of off the beaten path.