### PR TITLE
tooltip fix for hover and code completion on VS code 

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultLSPTagHelperTooltipFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultLSPTagHelperTooltipFactory.cs
@@ -50,9 +50,8 @@ internal class DefaultLSPTagHelperTooltipFactory(ISnapshotResolver snapshotResol
             }
 
             var tagHelperType = descriptionInfo.TagHelperTypeName;
-            var reducedTypeName = ReduceTypeName(tagHelperType);
             StartOrEndBold(descriptionBuilder, markupKind);
-            descriptionBuilder.Append(reducedTypeName);
+            descriptionBuilder.Append(tagHelperType);
             StartOrEndBold(descriptionBuilder, markupKind);
 
             var documentation = descriptionInfo.Documentation;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultLSPTagHelperTooltipFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultLSPTagHelperTooltipFactory.cs
@@ -55,13 +55,10 @@ internal class DefaultLSPTagHelperTooltipFactory(ISnapshotResolver snapshotResol
             // If the reducedTypeName != tagHelperType, then the type is prefixed by a namespace
             if (reducedTypeName != tagHelperType)
             {
-                var removeStartIndex = tagHelperType.Length - reducedTypeName.Length;
-                var TypeNamespace = tagHelperType.Remove(removeStartIndex, reducedTypeName.Length);
-                descriptionBuilder.Append(TypeNamespace);
-
+                descriptionBuilder.Append(tagHelperType[..^reducedTypeName.Length]);
             }
 
-            // We make the reducedTypeName bold while leaving the namespace the intact
+            // We make the reducedTypeName bold while leaving the namespace intact
             StartOrEndBold(descriptionBuilder, markupKind);
             descriptionBuilder.Append(reducedTypeName);
             StartOrEndBold(descriptionBuilder, markupKind);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultLSPTagHelperTooltipFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/DefaultLSPTagHelperTooltipFactory.cs
@@ -50,8 +50,20 @@ internal class DefaultLSPTagHelperTooltipFactory(ISnapshotResolver snapshotResol
             }
 
             var tagHelperType = descriptionInfo.TagHelperTypeName;
+            var reducedTypeName = ReduceTypeName(tagHelperType);
+
+            // If the reducedTypeName != tagHelperType, then the type is prefixed by a namespace
+            if (reducedTypeName != tagHelperType)
+            {
+                var removeStartIndex = tagHelperType.Length - reducedTypeName.Length;
+                var TypeNamespace = tagHelperType.Remove(removeStartIndex, reducedTypeName.Length);
+                descriptionBuilder.Append(TypeNamespace);
+
+            }
+
+            // We make the reducedTypeName bold while leaving the namespace the intact
             StartOrEndBold(descriptionBuilder, markupKind);
-            descriptionBuilder.Append(tagHelperType);
+            descriptionBuilder.Append(reducedTypeName);
             StartOrEndBold(descriptionBuilder, markupKind);
 
             var documentation = descriptionInfo.Documentation;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultLSPTagHelperTooltipFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultLSPTagHelperTooltipFactoryTest.cs
@@ -92,7 +92,7 @@ World", cleanedSummary);
 
         // Assert
         Assert.True(result);
-        Assert.Equal(@"**Microsoft.AspNetCore.SomeTagHelper**
+        Assert.Equal(@"Microsoft.AspNetCore.**SomeTagHelper**
 
 Uses `List<System.String>`s", markdown.Value);
         Assert.Equal(MarkupKind.Markdown, markdown.Kind);
@@ -166,11 +166,11 @@ Uses `List<System.String>`s", markdown.Value);
 
         // Assert
         Assert.True(result);
-        Assert.Equal(@"**Microsoft.AspNetCore.SomeTagHelper**
+        Assert.Equal(@"Microsoft.AspNetCore.**SomeTagHelper**
 
 Uses `List<System.String>`s
 ---
-**Microsoft.AspNetCore.OtherTagHelper**
+Microsoft.AspNetCore.**OtherTagHelper**
 
 Also uses `List<System.String>`s", markdown.Value);
         Assert.Equal(MarkupKind.Markdown, markdown.Kind);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultLSPTagHelperTooltipFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultLSPTagHelperTooltipFactoryTest.cs
@@ -92,7 +92,7 @@ World", cleanedSummary);
 
         // Assert
         Assert.True(result);
-        Assert.Equal(@"**SomeTagHelper**
+        Assert.Equal(@"**Microsoft.AspNetCore.SomeTagHelper**
 
 Uses `List<System.String>`s", markdown.Value);
         Assert.Equal(MarkupKind.Markdown, markdown.Kind);
@@ -115,7 +115,7 @@ Uses `List<System.String>`s", markdown.Value);
 
         // Assert
         Assert.True(result, "TryCreateTooltip should have succeeded");
-        Assert.Equal(@"SomeTagHelper
+        Assert.Equal(@"Microsoft.AspNetCore.SomeTagHelper
 
 Uses `List<System.String>`s", markdown.Value);
         Assert.Equal(MarkupKind.PlainText, markdown.Kind);
@@ -166,11 +166,11 @@ Uses `List<System.String>`s", markdown.Value);
 
         // Assert
         Assert.True(result);
-        Assert.Equal(@"**SomeTagHelper**
+        Assert.Equal(@"**Microsoft.AspNetCore.SomeTagHelper**
 
 Uses `List<System.String>`s
 ---
-**OtherTagHelper**
+**Microsoft.AspNetCore.OtherTagHelper**
 
 Also uses `List<System.String>`s", markdown.Value);
         Assert.Equal(MarkupKind.Markdown, markdown.Kind);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverInfoServiceTest.cs
@@ -101,8 +101,8 @@ public class HoverInfoServiceTest(ITestOutputHelper testOutput) : TagHelperServi
         // Act
         var hover = service.GetHoverInfo("file.cshtml", codeDocument, location, CreateMarkDownCapabilities());
 
-        // Assert
-        Assert.Contains("**SomeChild**", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
+        // Assert addTagHelper.SomeChild
+        Assert.Contains("SomeChild**", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
         var expectedRange = new Range
         {
             Start = new Position(2, 5),

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverInfoServiceTest.cs
@@ -102,7 +102,7 @@ public class HoverInfoServiceTest(ITestOutputHelper testOutput) : TagHelperServi
         var hover = service.GetHoverInfo("file.cshtml", codeDocument, location, CreateMarkDownCapabilities());
 
         // Assert addTagHelper.SomeChild
-        Assert.Contains("SomeChild**", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
+        Assert.Contains("**SomeChild**", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
         var expectedRange = new Range
         {
             Start = new Position(2, 5),

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverInfoServiceTest.cs
@@ -101,7 +101,7 @@ public class HoverInfoServiceTest(ITestOutputHelper testOutput) : TagHelperServi
         // Act
         var hover = service.GetHoverInfo("file.cshtml", codeDocument, location, CreateMarkDownCapabilities());
 
-        // Assert addTagHelper.SomeChild
+        // Assert
         Assert.Contains("**SomeChild**", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
         var expectedRange = new Range
         {


### PR DESCRIPTION
Make the tooltip show the full tagHelperTypeName instead of the reduced name in LSP factory. This method is used in both hover service and code completion service.
Fixes #9638
 
### Summary of the changes
- To make the TryCreateTooltip method in DefaultLSPTagHelperTooltipFactory return the tag helper’s full type name with its namespace, I added the namespace to the descriptionBuilder variable. (see picture below for visualization)
-  I also changed the corresponding unit tests in DefaultLSPTagHelperTooltipFactoryTest.cs and HoverInfoServiceTest.cs to test for the now desired behavior with the full namespace shown in tag helper with the type name in bold. 
- This change only affects the VS code user experience and does not affect that of Visual Studio.

#### Fixes:
- This fixes GitHub issue #9638 where hovering on a razor element tag on VS code shows the reduced element name and not the full name with the name space included.
- Since the method is also used in code completion in VS code, it also shows the full name in the description box that pops out when the user previews a code completion option that happens to be a razor element. 

#### Testing:
- Visual Studio Code version: 1.85.2 
- I checked that the increased length does not pose an issue on the hover display in VS code as the tag name wraps around nicely for up to 1000 characters.
- I also checked the code completion display where the tag name gets truncated at about 100 characters. But that shouldn't be too much of an issue for users since namespace is not usually that long.

#### Before
<img width="439" alt="9862_bfore" src="https://github.com/dotnet/razor/assets/17770319/71519692-5703-403c-9ab9-8f734fcb39b3">

#### After
<img width="444" alt="HeadOutLet_after" src="https://github.com/dotnet/razor/assets/17770319/12a473a3-245d-4ab7-90a5-6716dc637d40">