### PR TITLE
Ensure we include the line count and end char index in remapped spans

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/CodeGeneration/CodeWriterExtensions.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/CodeGeneration/CodeWriterExtensions.cs
@@ -564,7 +564,7 @@ internal static class CodeWriterExtensions
             // If you try and use the line pragma in the design time docs to map back to the original file it will fail,
             // as the path isn't actually valid on windows. As a workaround we apply a simple heuristic to switch the
             // paths back when writing out the design time paths.
-            sourceSpan = new SourceSpan(sourceSpan.FilePath.Replace("/", "\\"), sourceSpan.AbsoluteIndex, sourceSpan.LineIndex, sourceSpan.CharacterIndex, sourceSpan.Length);
+            sourceSpan = new SourceSpan(sourceSpan.FilePath.Replace("/", "\\"), sourceSpan.AbsoluteIndex, sourceSpan.LineIndex, sourceSpan.CharacterIndex, sourceSpan.Length, sourceSpan.LineCount, sourceSpan.EndCharacterIndex);
         }
         return sourceSpan;
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/CodeGeneration/DesignTimeNodeWriterTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/CodeGeneration/DesignTimeNodeWriterTest.cs
@@ -524,7 +524,8 @@ Render Children
 
         var node = new CSharpExpressionIntermediateNode()
         {
-            Source = new SourceSpan(fileName, 0, 0, 0, 3),
+            // Create a fake source span, so we can check it correctly maps in the #line below
+            Source = new SourceSpan(fileName, 0, 2, 3, 6, 1, 2),
         };
         var builder = IntermediateNodeBuilder.Create(node);
         builder.Add(new IntermediateToken()
@@ -540,7 +541,7 @@ Render Children
             $"""
 
             #nullable restore
-            #line (1,1)-(1,1) 6 "{expectedFileName}"
+            #line (3,4)-(4,3) 6 "{expectedFileName}"
             Write(i++);
 
             #line default
@@ -551,6 +552,7 @@ Render Children
             csharp,
             ignoreLineEndingDifferences: true);
     }
+
 
     private DocumentIntermediateNode Lower(RazorCodeDocument codeDocument)
     {


### PR DESCRIPTION
Ensure we include the line count and end char index in remapped spans

Fixes https://github.com/dotnet/razor/issues/9827

