### PR TITLE
[FUSE] Add some missing runtime source mappings

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/CodeGeneration/RuntimeNodeWriter.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/CodeGeneration/RuntimeNodeWriter.cs
@@ -36,6 +36,7 @@ public class RuntimeNodeWriter : IntermediateNodeWriter
         {
             using (context.CodeWriter.BuildLinePragma(node.Source.Value, context))
             {
+                context.AddSourceMappingFor(node);
                 context.CodeWriter.WriteUsing(node.Content);
             }
         }
@@ -73,6 +74,7 @@ public class RuntimeNodeWriter : IntermediateNodeWriter
         {
             if (node.Children[i] is IntermediateToken token && token.IsCSharp)
             {
+                context.AddSourceMappingFor(token);
                 context.CodeWriter.Write(token.Content);
             }
             else
@@ -116,6 +118,7 @@ public class RuntimeNodeWriter : IntermediateNodeWriter
         {
             if (node.Children[i] is IntermediateToken token && token.IsCSharp)
             {
+                context.AddSourceMappingFor(token);
                 context.CodeWriter.Write(token.Content);
             }
             else
@@ -232,6 +235,7 @@ public class RuntimeNodeWriter : IntermediateNodeWriter
             {
                 if (node.Children[i] is IntermediateToken token && token.IsCSharp)
                 {
+                    context.AddSourceMappingFor(token);
                     context.CodeWriter.Write(token.Content);
                 }
                 else
@@ -295,6 +299,7 @@ public class RuntimeNodeWriter : IntermediateNodeWriter
                         continue;
                     }
 
+                    context.AddSourceMappingFor(token);
                     context.CodeWriter.Write(token.Content);
 
                     if (linePragmaScope != null)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/CodeGeneration/RuntimeNodeWriter.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/CodeGeneration/RuntimeNodeWriter.cs
@@ -36,7 +36,6 @@ public class RuntimeNodeWriter : IntermediateNodeWriter
         {
             using (context.CodeWriter.BuildLinePragma(node.Source.Value, context))
             {
-                context.AddSourceMappingFor(node);
                 context.CodeWriter.WriteUsing(node.Content);
             }
         }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentRuntimeNodeWriter.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentRuntimeNodeWriter.cs
@@ -353,7 +353,6 @@ internal class ComponentRuntimeNodeWriter : ComponentNodeWriter
         {
             using (context.CodeWriter.BuildLinePragma(node.Source.Value, context))
             {
-                context.AddSourceMappingFor(node);
                 context.CodeWriter.WriteUsing(node.Content);
             }
         }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentRuntimeNodeWriter.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Components/ComponentRuntimeNodeWriter.cs
@@ -119,6 +119,7 @@ internal class ComponentRuntimeNodeWriter : ComponentNodeWriter
             {
                 if (node.Children[i] is IntermediateToken token && token.IsCSharp)
                 {
+                    context.AddSourceMappingFor(token);
                     WriteCSharpToken(context, token, includeLinePragma: false);
                 }
                 else
@@ -352,6 +353,7 @@ internal class ComponentRuntimeNodeWriter : ComponentNodeWriter
         {
             using (context.CodeWriter.BuildLinePragma(node.Source.Value, context))
             {
+                context.AddSourceMappingFor(node);
                 context.CodeWriter.WriteUsing(node.Content);
             }
         }
@@ -1215,6 +1217,8 @@ internal class ComponentRuntimeNodeWriter : ComponentNodeWriter
             using (context.CodeWriter.BuildLinePragma(token.Source, context))
             {
                 context.CodeWriter.WritePadding(0, token.Source.Value, context);
+
+                context.AddSourceMappingFor(token);
                 context.CodeWriter.Write(token.Content);
             }
             return;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Extensions/DefaultTagHelperTargetExtension.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Extensions/DefaultTagHelperTargetExtension.cs
@@ -567,7 +567,7 @@ internal sealed class DefaultTagHelperTargetExtension : IDefaultTagHelperTargetE
         }
         else if (node is IntermediateToken token)
         {
-            if (context.Options.DesignTime && node.Source != null)
+            if (node.Source != null)
             {
                 context.AddSourceMappingFor(node);
             }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AddAttribute_ImplicitBooleanConversion/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AddAttribute_ImplicitBooleanConversion/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (60:2,7 [42] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (26:0,26 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|c|
+Generated Location: (767:18,26 [1] )
+|c|
+
+Source Location: (44:0,44 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|c|
+Generated Location: (953:26,44 [1] )
+|c|
+
+Source Location: (60:2,7 [42] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private MyClass<string> c = new();
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AddAttribute_ImplicitStringConversion_Bind/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AddAttribute_ImplicitStringConversion_Bind/TestComponent.mappings.txt
@@ -1,4 +1,24 @@
-﻿Source Location: (161:6,7 [42] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (55:1,19 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|true|
+Generated Location: (760:18,19 [4] )
+|true|
+
+Source Location: (112:3,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (938:26,23 [9] )
+|() => { }|
+
+Source Location: (145:4,21 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|c|
+Generated Location: (1109:34,21 [1] )
+|c|
+
+Source Location: (32:0,32 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|c|
+Generated Location: (1283:42,32 [1] )
+|c|
+
+Source Location: (161:6,7 [42] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private MyClass<string> c = new();
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AddAttribute_ImplicitStringConversion_BindUnknown/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AddAttribute_ImplicitStringConversion_BindUnknown/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (42:2,7 [34] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (26:0,26 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|c|
+Generated Location: (791:19,26 [1] )
+|c|
+
+Source Location: (42:2,7 [34] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private MyClass c = new();
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AddAttribute_ImplicitStringConversion_BindUnknown_Assignment/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AddAttribute_ImplicitStringConversion_BindUnknown_Assignment/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (48:2,7 [68] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (26:0,26 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+|c1 = c2|
+Generated Location: (791:19,26 [7] )
+|c1 = c2|
+
+Source Location: (48:2,7 [68] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private MyClass c1 = new();
     private MyClass c2 = new();

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AddAttribute_ImplicitStringConversion_CustomEvent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AddAttribute_ImplicitStringConversion_CustomEvent/TestComponent.mappings.txt
@@ -1,4 +1,29 @@
-﻿Source Location: (180:7,7 [42] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (26:0,26 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|c|
+Generated Location: (767:18,26 [1] )
+|c|
+
+Source Location: (43:1,13 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (997:26,13 [9] )
+|() => { }|
+
+Source Location: (74:2,19 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|true|
+Generated Location: (1167:34,19 [4] )
+|true|
+
+Source Location: (131:4,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1345:42,23 [9] )
+|() => { }|
+
+Source Location: (164:5,21 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|c|
+Generated Location: (1516:50,21 [1] )
+|c|
+
+Source Location: (180:7,7 [42] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private MyClass<string> c = new();
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AddAttribute_ImplicitStringConversion_TypeInference/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AddAttribute_ImplicitStringConversion_TypeInference/TestComponent.mappings.txt
@@ -1,4 +1,24 @@
-﻿Source Location: (155:6,7 [51] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (26:0,26 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|c|
+Generated Location: (767:18,26 [1] )
+|c|
+
+Source Location: (49:1,19 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|true|
+Generated Location: (928:26,19 [4] )
+|true|
+
+Source Location: (106:3,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1106:34,23 [9] )
+|() => { }|
+
+Source Location: (139:4,21 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|c|
+Generated Location: (1277:42,21 [1] )
+|c|
+
+Source Location: (155:6,7 [51] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private readonly MyClass<string> c = new();
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.mappings.txt
@@ -1,0 +1,17 @@
+﻿Source Location: (1:0,1 [30] x:\dir\subdir\Test\TestComponent.cshtml)
+|using System.Threading.Tasks
+|
+Generated Location: (317:11,0 [30] )
+|using System.Threading.Tasks;|
+
+Source Location: (32:1,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (468:18,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (94:2,19 [33] x:\dir\subdir\Test\TestComponent.cshtml)
+|async (e) => await Task.Delay(10)|
+Generated Location: (1165:32,19 [33] )
+|async (e) => await Task.Delay(10)|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_Lambda/TestComponent.mappings.txt
@@ -1,16 +1,4 @@
-﻿Source Location: (1:0,1 [30] x:\dir\subdir\Test\TestComponent.cshtml)
-|using System.Threading.Tasks
-|
-Generated Location: (317:11,0 [30] )
-|using System.Threading.Tasks;|
-
-Source Location: (32:1,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (468:18,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (94:2,19 [33] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (94:2,19 [33] x:\dir\subdir\Test\TestComponent.cshtml)
 |async (e) => await Task.Delay(10)|
 Generated Location: (1165:32,19 [33] )
 |async (e) => await Task.Delay(10)|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.mappings.txt
@@ -1,4 +1,21 @@
-﻿Source Location: (112:3,7 [88] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [30] x:\dir\subdir\Test\TestComponent.cshtml)
+|using System.Threading.Tasks
+|
+Generated Location: (317:11,0 [30] )
+|using System.Threading.Tasks;|
+
+Source Location: (32:1,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (468:18,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (92:2,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+|OnClick|
+Generated Location: (1163:32,17 [7] )
+|OnClick|
+
+Source Location: (112:3,7 [88] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     Task OnClick(MouseEventArgs e)
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_ActionEventArgs_MethodGroup/TestComponent.mappings.txt
@@ -1,16 +1,4 @@
-﻿Source Location: (1:0,1 [30] x:\dir\subdir\Test\TestComponent.cshtml)
-|using System.Threading.Tasks
-|
-Generated Location: (317:11,0 [30] )
-|using System.Threading.Tasks;|
-
-Source Location: (32:1,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (468:18,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (92:2,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (92:2,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |OnClick|
 Generated Location: (1163:32,17 [7] )
 |OnClick|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.mappings.txt
@@ -1,16 +1,4 @@
-﻿Source Location: (1:0,1 [30] x:\dir\subdir\Test\TestComponent.cshtml)
-|using System.Threading.Tasks
-|
-Generated Location: (317:11,0 [30] )
-|using System.Threading.Tasks;|
-
-Source Location: (32:1,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (468:18,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (94:2,19 [32] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (94:2,19 [32] x:\dir\subdir\Test\TestComponent.cshtml)
 |async () => await Task.Delay(10)|
 Generated Location: (1165:32,19 [32] )
 |async () => await Task.Delay(10)|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_Lambda/TestComponent.mappings.txt
@@ -1,0 +1,17 @@
+﻿Source Location: (1:0,1 [30] x:\dir\subdir\Test\TestComponent.cshtml)
+|using System.Threading.Tasks
+|
+Generated Location: (317:11,0 [30] )
+|using System.Threading.Tasks;|
+
+Source Location: (32:1,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (468:18,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (94:2,19 [32] x:\dir\subdir\Test\TestComponent.cshtml)
+|async () => await Task.Delay(10)|
+Generated Location: (1165:32,19 [32] )
+|async () => await Task.Delay(10)|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.mappings.txt
@@ -1,4 +1,21 @@
-﻿Source Location: (112:3,7 [72] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [30] x:\dir\subdir\Test\TestComponent.cshtml)
+|using System.Threading.Tasks
+|
+Generated Location: (317:11,0 [30] )
+|using System.Threading.Tasks;|
+
+Source Location: (32:1,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (468:18,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (92:2,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+|OnClick|
+Generated Location: (1163:32,17 [7] )
+|OnClick|
+
+Source Location: (112:3,7 [72] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     Task OnClick()
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AsyncEventHandler_OnElement_Action_MethodGroup/TestComponent.mappings.txt
@@ -1,16 +1,4 @@
-﻿Source Location: (1:0,1 [30] x:\dir\subdir\Test\TestComponent.cshtml)
-|using System.Threading.Tasks
-|
-Generated Location: (317:11,0 [30] )
-|using System.Threading.Tasks;|
-
-Source Location: (32:1,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (468:18,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (92:2,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (92:2,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |OnClick|
 Generated Location: (1163:32,17 [7] )
 |OnClick|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (895:19,26 [11] )
+|ParentValue|
+
+Source Location: (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression_Generic/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression_Generic/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (54:1,7 [65] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (771:18,30 [11] )
+|ParentValue|
+
+Source Location: (54:1,7 [65] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime ParentValue { get; set; } = DateTime.Now;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression_NestedGeneric/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValueAndExpression_NestedGeneric/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (54:1,7 [89] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (771:18,30 [11] )
+|ParentValue|
+
+Source Location: (54:1,7 [89] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public IEnumerable<DateTime> ParentValue { get; set; } = new [] { DateTime.Now };
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValue_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_SpecifiesValue_WithMatchingProperties/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (895:19,26 [11] )
+|ParentValue|
+
+Source Location: (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_TypeChecked_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_EventCallback_TypeChecked_WithMatchingProperties/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (50:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (895:19,26 [11] )
+|ParentValue|
+
+Source Location: (50:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "42";
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (80:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (895:19,26 [11] )
+|ParentValue|
+
+Source Location: (80:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithoutMatchingProperties/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (80:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (791:19,26 [11] )
+|ParentValue|
+
+Source Location: (80:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (895:19,26 [11] )
+|ParentValue|
+
+Source Location: (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression_Generic/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndExpression_Generic/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (54:1,7 [65] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (771:18,30 [11] )
+|ParentValue|
+
+Source Location: (54:1,7 [65] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime ParentValue { get; set; } = DateTime.Now;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithMatchingProperties/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (895:19,26 [11] )
+|ParentValue|
+
+Source Location: (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValue_WithoutMatchingProperties/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (791:19,26 [11] )
+|ParentValue|
+
+Source Location: (50:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_TypeChecked_WithMatchingProperties/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (50:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (895:19,26 [11] )
+|ParentValue|
+
+Source Location: (50:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "42";
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_Action/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (81:1,7 [82] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (899:19,30 [11] )
+|ParentValue|
+
+Source Location: (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+|Update|
+Generated Location: (1349:28,62 [6] )
+|Update|
+
+Source Location: (81:1,7 [82] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_ActionLambda/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_ActionLambda/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (84:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (899:19,30 [11] )
+|ParentValue|
+
+Source Location: (62:0,62 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1349:28,62 [9] )
+|() => { }|
+
+Source Location: (84:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_AsyncLambdaProducesError/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_AsyncLambdaProducesError/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (135:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (899:19,30 [11] )
+|ParentValue|
+
+Source Location: (60:0,60 [62] x:\dir\subdir\Test\TestComponent.cshtml)
+|(value => { ParentValue = value; return Task.CompletedTask; })|
+Generated Location: (1212:28,60 [62] )
+|(value => { ParentValue = value; return Task.CompletedTask; })|
+
+Source Location: (135:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (86:1,7 [102] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (899:19,30 [11] )
+|ParentValue|
+
+Source Location: (62:0,62 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1797:28,62 [11] )
+|UpdateValue|
+
+Source Location: (86:1,7 [102] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
     public EventCallback UpdateValue { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesAction/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesAction/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (84:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (899:19,30 [11] )
+|ParentValue|
+
+Source Location: (62:0,62 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1797:28,62 [9] )
+|() => { }|
+
+Source Location: (84:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesFunction/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesFunction/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (86:1,7 [106] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (899:19,30 [11] )
+|ParentValue|
+
+Source Location: (62:0,62 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1797:28,62 [11] )
+|UpdateValue|
+
+Source Location: (86:1,7 [106] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningDelegate/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningDelegate/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (81:1,7 [101] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (899:19,30 [11] )
+|ParentValue|
+
+Source Location: (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+|Update|
+Generated Location: (1389:28,62 [6] )
+|Update|
+
+Source Location: (81:1,7 [101] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningLambda/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningLambda/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (111:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (899:19,30 [11] )
+|ParentValue|
+
+Source Location: (62:0,62 [36] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { return Task.CompletedTask; }|
+Generated Location: (1389:28,62 [36] )
+|() => { return Task.CompletedTask; }|
+
+Source Location: (111:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_Action/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (84:1,7 [116] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (899:19,30 [11] )
+|ParentValue|
+
+Source Location: (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1212:28,60 [11] )
+|UpdateValue|
+
+Source Location: (84:1,7 [116] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_ActionLambda/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_ActionLambda/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (101:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (899:19,30 [11] )
+|ParentValue|
+
+Source Location: (60:0,60 [28] x:\dir\subdir\Test\TestComponent.cshtml)
+|value => ParentValue = value|
+Generated Location: (1212:28,60 [28] )
+|value => ParentValue = value|
+
+Source Location: (101:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (84:1,7 [107] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (899:19,30 [11] )
+|ParentValue|
+
+Source Location: (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1536:28,60 [11] )
+|UpdateValue|
+
+Source Location: (84:1,7 [107] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
     public EventCallback<int> UpdateValue { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesAction/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesAction/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (101:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (899:19,30 [11] )
+|ParentValue|
+
+Source Location: (60:0,60 [28] x:\dir\subdir\Test\TestComponent.cshtml)
+|value => ParentValue = value|
+Generated Location: (1536:28,60 [28] )
+|value => ParentValue = value|
+
+Source Location: (101:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesFunction/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesFunction/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (84:1,7 [144] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (899:19,30 [11] )
+|ParentValue|
+
+Source Location: (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1536:28,60 [11] )
+|UpdateValue|
+
+Source Location: (84:1,7 [144] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_ProducesErrorOnOlderLanguageVersions/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_ProducesErrorOnOlderLanguageVersions/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (84:1,7 [116] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (899:19,30 [11] )
+|ParentValue|
+
+Source Location: (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1213:28,60 [11] )
+|UpdateValue|
+
+Source Location: (84:1,7 [116] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningDelegate/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningDelegate/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (84:1,7 [144] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (899:19,30 [11] )
+|ParentValue|
+
+Source Location: (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1239:28,60 [11] )
+|UpdateValue|
+
+Source Location: (84:1,7 [144] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningLambda/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningLambda/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (133:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (899:19,30 [11] )
+|ParentValue|
+
+Source Location: (60:0,60 [60] x:\dir\subdir\Test\TestComponent.cshtml)
+|value => { ParentValue = value; return Task.CompletedTask; }|
+Generated Location: (1239:28,60 [60] )
+|value => { ParentValue = value; return Task.CompletedTask; }|
+
+Source Location: (133:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithStringAttribute_DoesNotUseStringSyntax/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (56:3,1 [37] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (24:0,24 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|person.Name|
+Generated Location: (892:19,24 [11] )
+|person.Name|
+
+Source Location: (56:3,1 [37] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     Person person = new Person();
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithCulture/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithCulture/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [28] x:\dir\subdir\Test\TestComponent.cshtml)
-|using System.Globalization
-|
-Generated Location: (360:12,0 [28] )
-|using System.Globalization;|
-
-Source Location: (48:1,19 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (48:1,19 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
 Generated Location: (969:26,19 [11] )
 |ParentValue|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithCulture/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithCulture/TestComponent.mappings.txt
@@ -1,4 +1,20 @@
-﻿Source Location: (152:2,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [28] x:\dir\subdir\Test\TestComponent.cshtml)
+|using System.Globalization
+|
+Generated Location: (360:12,0 [28] )
+|using System.Globalization;|
+
+Source Location: (48:1,19 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (969:26,19 [11] )
+|ParentValue|
+
+Source Location: (111:1,82 [28] x:\dir\subdir\Test\TestComponent.cshtml)
+|CultureInfo.InvariantCulture|
+Generated Location: (1209:34,82 [28] )
+|CultureInfo.InvariantCulture|
+
+Source Location: (152:2,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WithFormat_WritesAttributes/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (113:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (33:0,33 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|CurrentDate|
+Generated Location: (892:20,33 [11] )
+|CurrentDate|
+
+Source Location: (113:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementFallback_WritesAttributes/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (86:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (33:0,33 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (892:20,33 [11] )
+|ParentValue|
+
+Source Location: (86:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithCulture/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithCulture/TestComponent.mappings.txt
@@ -1,4 +1,20 @@
-﻿Source Location: (156:2,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [28] x:\dir\subdir\Test\TestComponent.cshtml)
+|using System.Globalization
+|
+Generated Location: (360:12,0 [28] )
+|using System.Globalization;|
+
+Source Location: (48:1,19 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (971:26,19 [11] )
+|ParentValue|
+
+Source Location: (115:1,86 [28] x:\dir\subdir\Test\TestComponent.cshtml)
+|CultureInfo.InvariantCulture|
+Generated Location: (1215:34,86 [28] )
+|CultureInfo.InvariantCulture|
+
+Source Location: (156:2,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithCulture/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithCulture/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [28] x:\dir\subdir\Test\TestComponent.cshtml)
-|using System.Globalization
-|
-Generated Location: (360:12,0 [28] )
-|using System.Globalization;|
-
-Source Location: (48:1,19 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (48:1,19 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
 Generated Location: (971:26,19 [11] )
 |ParentValue|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithSuffix_OverridesEvent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithSuffix_OverridesEvent/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (76:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (19:0,19 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (822:19,19 [11] )
+|ParentValue|
+
+Source Location: (76:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElementWithSuffix_WritesAttributes/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (43:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (19:0,19 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (822:19,19 [11] )
+|ParentValue|
+
+Source Location: (43:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingBindAndParamBindSet/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingBindAndParamBindSet/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (73:1,7 [124] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (19:0,19 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (822:19,19 [11] )
+|ParentValue|
+
+Source Location: (49:0,49 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1260:28,49 [11] )
+|UpdateValue|
+
+Source Location: (73:1,7 [124] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingBindValueWithGetSet/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingBindValueWithGetSet/TestComponent.mappings.txt
@@ -1,4 +1,19 @@
-﻿Source Location: (86:1,7 [124] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (13:0,13 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (816:19,13 [11] )
+|ParentValue|
+
+Source Location: (62:0,62 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1267:28,62 [11] )
+|UpdateValue|
+
+Source Location: (38:0,38 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (1549:37,24 [11] )
+|ParentValue|
+
+Source Location: (86:1,7 [124] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingBindWithoutSuffixAndParamBindSetWithSuffix/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingBindWithoutSuffixAndParamBindSetWithSuffix/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (67:1,7 [124] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (13:0,13 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (816:19,13 [11] )
+|ParentValue|
+
+Source Location: (67:1,7 [124] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingSetWithAfter/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingSetWithAfter/TestComponent.mappings.txt
@@ -1,4 +1,19 @@
-﻿Source Location: (91:1,7 [159] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (17:0,17 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (820:19,17 [11] )
+|ParentValue|
+
+Source Location: (41:0,41 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1391:28,41 [11] )
+|UpdateValue|
+
+Source Location: (67:0,67 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|AfterUpdate|
+Generated Location: (1745:36,67 [11] )
+|AfterUpdate|
+
+Source Location: (91:1,7 [159] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithBindAfterAndSuffix/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithBindAfterAndSuffix/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (85:2,7 [131] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (21:0,21 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (824:19,21 [11] )
+|ParentValue|
+
+Source Location: (55:0,55 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|DoSomething|
+Generated Location: (1420:28,55 [11] )
+|DoSomething|
+
+Source Location: (85:2,7 [131] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithEventAsExplicitExpression/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithEventAsExplicitExpression/TestComponent.mappings.txt
@@ -3,6 +3,16 @@
 Generated Location: (642:17,2 [25] )
 | var x = "anotherevent"; |
 
+Source Location: (49:1,19 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (971:26,19 [11] )
+|ParentValue|
+
+Source Location: (83:1,53 [12] x:\dir\subdir\Test\TestComponent.cshtml)
+|x.ToString()|
+Generated Location: (1214:35,53 [12] )
+|x.ToString()|
+
 Source Location: (109:2,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithEventAsExpression/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithEventAsExpression/TestComponent.mappings.txt
@@ -3,6 +3,16 @@
 Generated Location: (642:17,2 [25] )
 | var x = "anotherevent"; |
 
+Source Location: (49:1,19 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (971:26,19 [11] )
+|ParentValue|
+
+Source Location: (82:1,52 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|x|
+Generated Location: (1213:35,52 [1] )
+|x|
+
 Source Location: (96:2,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithGetSetAndSuffix/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithGetSetAndSuffix/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (88:2,7 [144] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (25:0,25 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (828:19,25 [11] )
+|ParentValue|
+
+Source Location: (57:0,57 [12] x:\dir\subdir\Test\TestComponent.cshtml)
+|ValueChanged|
+Generated Location: (1274:28,57 [12] )
+|ValueChanged|
+
+Source Location: (88:2,7 [144] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithStringAttribute_WritesAttributes/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (42:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (18:0,18 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (821:19,18 [11] )
+|ParentValue|
+
+Source Location: (42:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithoutCloseTag/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WithoutCloseTag/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (54:3,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (24:1,17 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (800:20,17 [11] )
+|ParentValue|
+
+Source Location: (54:3,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_WritesAttributes/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (37:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (13:0,13 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (816:19,13 [11] )
+|ParentValue|
+
+Source Location: (37:1,7 [55] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentValue { get; set; } = "hi";
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (94:1,7 [82] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (43:0,43 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (900:19,43 [11] )
+|ParentValue|
+
+Source Location: (75:0,75 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+|Update|
+Generated Location: (1354:28,75 [6] )
+|Update|
+
+Source Location: (94:1,7 [82] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (105:1,7 [147] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (51:0,51 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (924:19,51 [11] )
+|ParentValue|
+
+Source Location: (81:0,81 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1564:28,81 [11] )
+|UpdateValue|
+
+Source Location: (105:1,7 [147] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public CustomValue ParentValue { get; set; } = new CustomValue();
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (105:1,7 [138] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (51:0,51 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (924:19,51 [11] )
+|ParentValue|
+
+Source Location: (81:0,81 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1564:28,81 [11] )
+|UpdateValue|
+
+Source Location: (105:1,7 [138] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public CustomValue ParentValue { get; set; } = new CustomValue();
     public EventCallback<CustomValue> UpdateValue { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (105:1,7 [179] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (51:0,51 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (924:19,51 [11] )
+|ParentValue|
+
+Source Location: (81:0,81 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1564:28,81 [11] )
+|UpdateValue|
+
+Source Location: (105:1,7 [179] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public CustomValue ParentValue { get; set; } = new CustomValue();
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithAfter_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithAfter_Action/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (81:1,7 [82] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (771:18,30 [11] )
+|ParentValue|
+
+Source Location: (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+|Update|
+Generated Location: (1120:26,62 [6] )
+|Update|
+
+Source Location: (81:1,7 [82] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_Action/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (84:1,7 [147] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (771:18,30 [11] )
+|ParentValue|
+
+Source Location: (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1164:26,60 [11] )
+|UpdateValue|
+
+Source Location: (84:1,7 [147] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public CustomValue ParentValue { get; set; } = new CustomValue();
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_EventCallback/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_EventCallback/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (84:1,7 [138] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (771:18,30 [11] )
+|ParentValue|
+
+Source Location: (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1164:26,60 [11] )
+|UpdateValue|
+
+Source Location: (84:1,7 [138] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public CustomValue ParentValue { get; set; } = new CustomValue();
     public EventCallback<CustomValue> UpdateValue { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_Function/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_InferredType_WithGetSet_Function/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (84:1,7 [175] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (30:0,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (771:18,30 [11] )
+|ParentValue|
+
+Source Location: (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1164:26,60 [11] )
+|UpdateValue|
+
+Source Location: (84:1,7 [175] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public CustomValue ParentValue { get; set; } = new CustomValue();
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToInputElementWithDefaultCulture/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToInputElementWithDefaultCulture/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [28] x:\dir\subdir\Test\TestComponent.cshtml)
-|using System.Globalization
-|
-Generated Location: (360:12,0 [28] )
-|using System.Globalization;|
-
-Source Location: (64:1,35 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (64:1,35 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
 Generated Location: (1045:27,35 [11] )
 |ParentValue|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToInputElementWithDefaultCulture/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToInputElementWithDefaultCulture/TestComponent.mappings.txt
@@ -1,4 +1,15 @@
-﻿Source Location: (121:2,7 [44] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [28] x:\dir\subdir\Test\TestComponent.cshtml)
+|using System.Globalization
+|
+Generated Location: (360:12,0 [28] )
+|using System.Globalization;|
+
+Source Location: (64:1,35 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (1045:27,35 [11] )
+|ParentValue|
+
+Source Location: (121:2,7 [44] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; }
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToInputElementWithDefaultCulture_Override/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToInputElementWithDefaultCulture_Override/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [28] x:\dir\subdir\Test\TestComponent.cshtml)
-|using System.Globalization
-|
-Generated Location: (360:12,0 [28] )
-|using System.Globalization;|
-
-Source Location: (64:1,35 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (64:1,35 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
 Generated Location: (1045:27,35 [11] )
 |ParentValue|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToInputElementWithDefaultCulture_Override/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToInputElementWithDefaultCulture_Override/TestComponent.mappings.txt
@@ -1,4 +1,20 @@
-﻿Source Location: (170:2,7 [44] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [28] x:\dir\subdir\Test\TestComponent.cshtml)
+|using System.Globalization
+|
+Generated Location: (360:12,0 [28] )
+|using System.Globalization;|
+
+Source Location: (64:1,35 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (1045:27,35 [11] )
+|ParentValue|
+
+Source Location: (131:1,102 [26] x:\dir\subdir\Test\TestComponent.cshtml)
+|CultureInfo.CurrentCulture|
+Generated Location: (1305:35,102 [26] )
+|CultureInfo.CurrentCulture|
+
+Source Location: (170:2,7 [44] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; }
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndAttributeChildContent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndAttributeChildContent/TestComponent.mappings.txt
@@ -3,8 +3,18 @@
 Generated Location: (642:17,2 [46] )
 | RenderFragment<string> header = (context) => |
 
+Source Location: (55:0,55 [26] x:\dir\subdir\Test\TestComponent.cshtml)
+|context.ToLowerInvariant()|
+Generated Location: (932:26,25 [26] )
+|context.ToLowerInvariant()|
+
 Source Location: (87:0,87 [2] x:\dir\subdir\Test\TestComponent.cshtml)
 |; |
 Generated Location: (1228:35,87 [2] )
 |; |
+
+Source Location: (113:1,21 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+|header|
+Generated Location: (1571:44,21 [6] )
+|header|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndExplicitChildContent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndExplicitChildContent/TestComponent.mappings.txt
@@ -3,8 +3,18 @@
 Generated Location: (642:17,2 [46] )
 | RenderFragment<string> header = (context) => |
 
+Source Location: (55:0,55 [26] x:\dir\subdir\Test\TestComponent.cshtml)
+|context.ToLowerInvariant()|
+Generated Location: (932:26,25 [26] )
+|context.ToLowerInvariant()|
+
 Source Location: (87:0,87 [2] x:\dir\subdir\Test\TestComponent.cshtml)
 |; |
 Generated Location: (1228:35,87 [2] )
 |; |
+
+Source Location: (113:1,21 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+|header|
+Generated Location: (1571:44,21 [6] )
+|header|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputCheckbox_WritesAttributes/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (51:1,7 [41] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (31:0,31 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+|Enabled|
+Generated Location: (828:20,31 [7] )
+|Enabled|
+
+Source Location: (51:1,7 [41] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public bool Enabled { get; set; }
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_CanOverrideEvent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_CanOverrideEvent/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (59:1,15 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (59:1,15 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |CurrentDate|
 Generated Location: (982:26,15 [11] )
 |CurrentDate|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_CanOverrideEvent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_CanOverrideEvent/TestComponent.mappings.txt
@@ -1,4 +1,15 @@
-﻿Source Location: (126:2,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (59:1,15 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|CurrentDate|
+Generated Location: (982:26,15 [11] )
+|CurrentDate|
+
+Source Location: (126:2,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormatFromProperty_WritesAttributes/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (73:1,7 [135] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (27:0,27 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|CurrentDate|
+Generated Location: (820:20,27 [11] )
+|CurrentDate|
+
+Source Location: (55:0,55 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+|Format|
+Generated Location: (1080:29,55 [6] )
+|Format|
+
+Source Location: (73:1,7 [135] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WithFormat_WritesAttributes/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (76:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (27:0,27 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|CurrentDate|
+Generated Location: (820:20,27 [11] )
+|CurrentDate|
+
+Source Location: (76:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputText_WritesAttributes/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (51:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (27:0,27 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (820:20,27 [11] )
+|ParentValue|
+
+Source Location: (51:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultCultureAndDefaultFormat_Override/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultCultureAndDefaultFormat_Override/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (78:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (29:0,29 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|CurrentDate|
+Generated Location: (890:20,29 [11] )
+|CurrentDate|
+
+Source Location: (78:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultFormat/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultFormat/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (53:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (29:0,29 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|CurrentDate|
+Generated Location: (890:20,29 [11] )
+|CurrentDate|
+
+Source Location: (53:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultFormat_Override/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithDefaultFormat_Override/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (78:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (29:0,29 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|CurrentDate|
+Generated Location: (890:20,29 [11] )
+|CurrentDate|
+
+Source Location: (78:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithSuffix/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithSuffix/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (65:1,21 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (65:1,21 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |CurrentDate|
 Generated Location: (988:26,21 [11] )
 |CurrentDate|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithSuffix/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithSuffix/TestComponent.mappings.txt
@@ -1,4 +1,15 @@
-﻿Source Location: (116:2,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (65:1,21 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|CurrentDate|
+Generated Location: (988:26,21 [11] )
+|CurrentDate|
+
+Source Location: (116:2,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithSuffix_CanOverrideEvent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithSuffix_CanOverrideEvent/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (100:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (21:0,21 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|CurrentDate|
+Generated Location: (824:19,21 [11] )
+|CurrentDate|
+
+Source Location: (100:1,7 [77] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public DateTime CurrentDate { get; set; } = new DateTime(2018, 1, 1);
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_IsCaseSensitive/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_IsCaseSensitive/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (39:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (15:0,15 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (752:19,15 [11] )
+|ParentValue|
+
+Source Location: (39:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BuiltIn_BindToInputWithoutType_WritesAttributes/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (39:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (15:0,15 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (752:19,15 [11] )
+|ParentValue|
+
+Source Location: (39:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CanProduceLinePragmasForComponentWithRenderFragment/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CanProduceLinePragmasForComponentWithRenderFragment/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (84:2,3 [22] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (65:1,46 [10] x:\dir\subdir\Test\TestComponent.cshtml)
+|ActionText|
+Generated Location: (999:23,24 [10] )
+|ActionText|
+
+Source Location: (84:2,3 [22] x:\dir\subdir\Test\TestComponent.cshtml)
 |if (!Collapsed)
   {
 |
@@ -6,6 +11,11 @@ Generated Location: (1175:31,3 [22] )
 |if (!Collapsed)
   {
 |
+
+Source Location: (154:5,7 [12] x:\dir\subdir\Test\TestComponent.cshtml)
+|ChildContent|
+Generated Location: (1475:41,24 [12] )
+|ChildContent|
 
 Source Location: (180:7,0 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |  }
@@ -22,6 +32,11 @@ Generated Location: (1865:59,1 [83] )
 |
   [Parameter]
   public RenderFragment ChildContent { get; set; } = (context) => |
+
+Source Location: (288:12,70 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+|context|
+Generated Location: (2153:69,25 [7] )
+|context|
 
 Source Location: (301:13,0 [177] x:\dir\subdir\Test\TestComponent.cshtml)
 |  [Parameter]

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_CombiningMultipleAncestors/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_CombiningMultipleAncestors/TestComponent.mappings.txt
@@ -1,0 +1,10 @@
+﻿Source Location: (19:0,19 [12] x:\dir\subdir\Test\TestComponent.cshtml)
+|int.MaxValue|
+Generated Location: (778:19,19 [12] )
+|int.MaxValue|
+
+Source Location: (59:1,24 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+|"Hello"|
+Generated Location: (1280:30,24 [7] )
+|"Hello"|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_Explicit/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_Explicit/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (32:0,32 [23] x:\dir\subdir\Test\TestComponent.cshtml)
+|Array.Empty<DateTime>()|
+Generated Location: (940:19,32 [23] )
+|Array.Empty<DateTime>()|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_ExplicitOverride/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_ExplicitOverride/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (32:0,32 [23] x:\dir\subdir\Test\TestComponent.cshtml)
+|Array.Empty<DateTime>()|
+Generated Location: (940:19,32 [23] )
+|Array.Empty<DateTime>()|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_GenericChildContent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_GenericChildContent/TestComponent.mappings.txt
@@ -1,0 +1,10 @@
+﻿Source Location: (15:0,15 [23] x:\dir\subdir\Test\TestComponent.cshtml)
+|Array.Empty<DateTime>()|
+Generated Location: (769:19,15 [23] )
+|Array.Empty<DateTime>()|
+
+Source Location: (50:0,50 [12] x:\dir\subdir\Test\TestComponent.cshtml)
+|context.Year|
+Generated Location: (1322:29,25 [12] )
+|context.Year|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_GenericLambda/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_GenericLambda/TestComponent.mappings.txt
@@ -1,0 +1,10 @@
+﻿Source Location: (15:0,15 [23] x:\dir\subdir\Test\TestComponent.cshtml)
+|Array.Empty<DateTime>()|
+Generated Location: (769:19,15 [23] )
+|Array.Empty<DateTime>()|
+
+Source Location: (63:0,63 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|x => x.Year|
+Generated Location: (1315:29,63 [11] )
+|x => x.Year|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_Inferred_MultipleConstraints/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_Inferred_MultipleConstraints/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (39:0,39 [30] x:\dir\subdir\Test\TestComponent.cshtml)
+|Array.Empty<WeatherForecast>()|
+Generated Location: (814:19,39 [30] )
+|Array.Empty<WeatherForecast>()|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_Inferred_MultipleConstraints_ClassesAndInterfaces/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_Inferred_MultipleConstraints_ClassesAndInterfaces/TestComponent.mappings.txt
@@ -1,0 +1,12 @@
+﻿Source Location: (1:0,1 [15] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Models;
+|
+Generated Location: (360:12,0 [15] )
+|using Models;
+|
+
+Source Location: (57:2,39 [30] x:\dir\subdir\Test\TestComponent.cshtml)
+|Array.Empty<WeatherForecast>()|
+Generated Location: (949:26,39 [30] )
+|Array.Empty<WeatherForecast>()|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_Inferred_MultipleConstraints_ClassesAndInterfaces/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_Inferred_MultipleConstraints_ClassesAndInterfaces/TestComponent.mappings.txt
@@ -1,11 +1,4 @@
-﻿Source Location: (1:0,1 [15] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Models;
-|
-Generated Location: (360:12,0 [15] )
-|using Models;
-|
-
-Source Location: (57:2,39 [30] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (57:2,39 [30] x:\dir\subdir\Test\TestComponent.cshtml)
 |Array.Empty<WeatherForecast>()|
 Generated Location: (949:26,39 [30] )
 |Array.Empty<WeatherForecast>()|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_Inferred_MultipleConstraints_GenericClassConstraints/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_Inferred_MultipleConstraints_GenericClassConstraints/TestComponent.mappings.txt
@@ -1,11 +1,4 @@
-﻿Source Location: (1:0,1 [15] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Models;
-|
-Generated Location: (360:12,0 [15] )
-|using Models;
-|
-
-Source Location: (55:1,39 [30] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (55:1,39 [30] x:\dir\subdir\Test\TestComponent.cshtml)
 |Array.Empty<WeatherForecast>()|
 Generated Location: (949:26,39 [30] )
 |Array.Empty<WeatherForecast>()|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_Inferred_MultipleConstraints_GenericClassConstraints/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_Inferred_MultipleConstraints_GenericClassConstraints/TestComponent.mappings.txt
@@ -1,0 +1,12 @@
+﻿Source Location: (1:0,1 [15] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Models;
+|
+Generated Location: (360:12,0 [15] )
+|using Models;
+|
+
+Source Location: (55:1,39 [30] x:\dir\subdir\Test\TestComponent.cshtml)
+|Array.Empty<WeatherForecast>()|
+Generated Location: (949:26,39 [30] )
+|Array.Empty<WeatherForecast>()|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_Inferred_WithConstraints/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_Inferred_WithConstraints/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (39:0,39 [30] x:\dir\subdir\Test\TestComponent.cshtml)
+|Array.Empty<WeatherForecast>()|
+Generated Location: (814:19,39 [30] )
+|Array.Empty<WeatherForecast>()|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_Multilayer/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_Multilayer/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (19:0,19 [23] x:\dir\subdir\Test\TestComponent.cshtml)
+|Array.Empty<DateTime>()|
+Generated Location: (777:19,19 [23] )
+|Array.Empty<DateTime>()|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_MultipleTypes/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_MultipleTypes/TestComponent.mappings.txt
@@ -1,0 +1,15 @@
+﻿Source Location: (16:0,16 [56] x:\dir\subdir\Test\TestComponent.cshtml)
+|new System.Collections.Generic.Dictionary<int, string>()|
+Generated Location: (772:19,16 [56] )
+|new System.Collections.Generic.Dictionary<int, string>()|
+
+Source Location: (83:0,83 [17] x:\dir\subdir\Test\TestComponent.cshtml)
+|DateTime.MinValue|
+Generated Location: (1090:27,83 [17] )
+|DateTime.MinValue|
+
+Source Location: (133:1,29 [23] x:\dir\subdir\Test\TestComponent.cshtml)
+|new[] { 'a', 'b', 'c' }|
+Generated Location: (1687:37,29 [23] )
+|new[] { 'a', 'b', 'c' }|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_NotCascaded_CreatesError/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_NotCascaded_CreatesError/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (15:0,15 [23] x:\dir\subdir\Test\TestComponent.cshtml)
+|Array.Empty<DateTime>()|
+Generated Location: (749:18,15 [23] )
+|Array.Empty<DateTime>()|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_NotCascaded_Explicit/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_NotCascaded_Explicit/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (32:0,32 [23] x:\dir\subdir\Test\TestComponent.cshtml)
+|Array.Empty<DateTime>()|
+Generated Location: (940:19,32 [23] )
+|Array.Empty<DateTime>()|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_NotCascaded_Inferred/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_NotCascaded_Inferred/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (15:0,15 [23] x:\dir\subdir\Test\TestComponent.cshtml)
+|Array.Empty<DateTime>()|
+Generated Location: (769:19,15 [23] )
+|Array.Empty<DateTime>()|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_Override/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_Override/TestComponent.mappings.txt
@@ -1,0 +1,10 @@
+﻿Source Location: (15:0,15 [23] x:\dir\subdir\Test\TestComponent.cshtml)
+|Array.Empty<DateTime>()|
+Generated Location: (769:19,15 [23] )
+|Array.Empty<DateTime>()|
+
+Source Location: (66:0,66 [13] x:\dir\subdir\Test\TestComponent.cshtml)
+|"Some string"|
+Generated Location: (1289:29,66 [13] )
+|"Some string"|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_Override_Multilayer/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_Override_Multilayer/TestComponent.mappings.txt
@@ -1,0 +1,10 @@
+﻿Source Location: (17:0,17 [12] x:\dir\subdir\Test\TestComponent.cshtml)
+|DateTime.Now|
+Generated Location: (775:19,17 [12] )
+|DateTime.Now|
+
+Source Location: (54:1,21 [37] x:\dir\subdir\Test\TestComponent.cshtml)
+|System.Threading.Thread.CurrentThread|
+Generated Location: (1272:30,21 [37] )
+|System.Threading.Thread.CurrentThread|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_ParameterInNamespace/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_ParameterInNamespace/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (59:2,28 [21] x:\dir\subdir\Test\TestComponent.cshtml)
+|new MyClass<string>()|
+Generated Location: (817:19,28 [21] )
+|new MyClass<string>()|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_Partial_CreatesError/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_Partial_CreatesError/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (15:0,15 [23] x:\dir\subdir\Test\TestComponent.cshtml)
+|Array.Empty<DateTime>()|
+Generated Location: (769:19,15 [23] )
+|Array.Empty<DateTime>()|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_Tuple/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_Tuple/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (28:0,28 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+|(1, 2)|
+Generated Location: (793:19,28 [6] )
+|(1, 2)|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_WithSplatAndKey/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_WithSplatAndKey/TestComponent.mappings.txt
@@ -3,6 +3,16 @@
 Generated Location: (642:17,2 [60] )
 | var parentKey = new object(); var childKey = new object(); |
 
+Source Location: (98:1,33 [23] x:\dir\subdir\Test\TestComponent.cshtml)
+|Array.Empty<DateTime>()|
+Generated Location: (971:26,33 [23] )
+|Array.Empty<DateTime>()|
+
+Source Location: (179:2,53 [17] x:\dir\subdir\Test\TestComponent.cshtml)
+|DateTime.MinValue|
+Generated Location: (1519:36,53 [17] )
+|DateTime.MinValue|
+
 Source Location: (145:2,19 [8] x:\dir\subdir\Test\TestComponent.cshtml)
 |childKey|
 Generated Location: (1704:44,19 [8] )

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_WithUnrelatedType_CreatesError/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_WithUnrelatedType_CreatesError/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (15:0,15 [29] x:\dir\subdir\Test\TestComponent.cshtml)
+|new Dictionary<int, string>()|
+Generated Location: (769:19,15 [29] )
+|new Dictionary<int, string>()|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_AtSpecifiedInRazorFileForTypeParameter/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_AtSpecifiedInRazorFileForTypeParameter/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (21:0,21 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|1|
+Generated Location: (887:19,21 [1] )
+|1|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_Generic/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_Generic/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (34:0,34 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|"hi"|
+Generated Location: (896:19,34 [4] )
+|"hi"|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (53:1,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (37:0,37 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (899:19,37 [5] )
+|Value|
+
+Source Location: (53:1,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string Value;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (53:1,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (37:0,37 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (809:19,37 [5] )
+|Value|
+
+Source Location: (53:1,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string Value;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBindWeaklyTyped_TypeInference/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (52:1,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (38:0,38 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+|18|
+Generated Location: (779:18,38 [2] )
+|18|
+
+Source Location: (24:0,24 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (946:26,24 [5] )
+|Value|
+
+Source Location: (52:1,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string Value;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericBind_TypeInference/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (73:2,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (24:0,24 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (765:18,24 [5] )
+|Value|
+
+Source Location: (57:1,24 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (1116:28,24 [5] )
+|Value|
+
+Source Location: (73:2,7 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string Value;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericChildContent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericChildContent/TestComponent.mappings.txt
@@ -1,0 +1,10 @@
+﻿Source Location: (34:0,34 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|"hi"|
+Generated Location: (896:19,34 [4] )
+|"hi"|
+
+Source Location: (51:1,8 [17] x:\dir\subdir\Test\TestComponent.cshtml)
+|context.ToLower()|
+Generated Location: (1280:29,25 [17] )
+|context.ToLower()|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericChildContent_TypeInference/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericChildContent_TypeInference/TestComponent.mappings.txt
@@ -1,0 +1,10 @@
+﻿Source Location: (21:0,21 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|"hi"|
+Generated Location: (762:18,21 [4] )
+|"hi"|
+
+Source Location: (38:1,8 [17] x:\dir\subdir\Test\TestComponent.cshtml)
+|context.ToLower()|
+Generated Location: (1027:27,25 [17] )
+|context.ToLower()|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericWeaklyTypedAttribute/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericWeaklyTypedAttribute/TestComponent.mappings.txt
@@ -1,0 +1,10 @@
+﻿Source Location: (34:0,34 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|"hi"|
+Generated Location: (896:19,34 [4] )
+|"hi"|
+
+Source Location: (50:0,50 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+|17|
+Generated Location: (1147:28,50 [2] )
+|17|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericWeaklyTypedAttribute_TypeInference/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericWeaklyTypedAttribute_TypeInference/TestComponent.mappings.txt
@@ -1,0 +1,10 @@
+﻿Source Location: (21:0,21 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|"hi"|
+Generated Location: (762:18,21 [4] )
+|"hi"|
+
+Source Location: (37:0,37 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+|17|
+Generated Location: (944:26,37 [2] )
+|17|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_Generic_TypeInference/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_Generic_TypeInference/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (21:0,21 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|"hi"|
+Generated Location: (762:18,21 [4] )
+|"hi"|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_Generic_TypeInference_Multiple/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_Generic_TypeInference_Multiple/TestComponent.mappings.txt
@@ -1,0 +1,15 @@
+﻿Source Location: (21:0,21 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|"hi"|
+Generated Location: (762:18,21 [4] )
+|"hi"|
+
+Source Location: (52:1,21 [14] x:\dir\subdir\Test\TestComponent.cshtml)
+|"how are you?"|
+Generated Location: (1078:28,21 [14] )
+|"how are you?"|
+
+Source Location: (93:2,21 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+|"bye!"|
+Generated Location: (1404:38,21 [6] )
+|"bye!"|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_InFunctionsDirective/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_InFunctionsDirective/TestComponent.mappings.txt
@@ -1,4 +1,11 @@
-﻿Source Location: (55:2,2 [34] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Rendering;
+|
+Generated Location: (360:12,0 [50] )
+|using Microsoft.AspNetCore.Components.Rendering;
+|
+
+Source Location: (55:2,2 [34] x:\dir\subdir\Test\TestComponent.cshtml)
 | RenderChildComponent(__builder); |
 Generated Location: (812:24,2 [34] )
 | RenderChildComponent(__builder); |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_InFunctionsDirective/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_InFunctionsDirective/TestComponent.mappings.txt
@@ -1,11 +1,4 @@
-﻿Source Location: (1:0,1 [50] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Rendering;
-|
-Generated Location: (360:12,0 [50] )
-|using Microsoft.AspNetCore.Components.Rendering;
-|
-
-Source Location: (55:2,2 [34] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (55:2,2 [34] x:\dir\subdir\Test\TestComponent.cshtml)
 | RenderChildComponent(__builder); |
 Generated Location: (812:24,2 [34] )
 | RenderChildComponent(__builder); |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_InLocalFunction/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_InLocalFunction/TestComponent.mappings.txt
@@ -1,11 +1,4 @@
-﻿Source Location: (1:0,1 [51] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.RenderTree;
-|
-Generated Location: (360:12,0 [51] )
-|using Microsoft.AspNetCore.Components.RenderTree;
-|
-
-Source Location: (54:1,2 [42] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (54:1,2 [42] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     void RenderChildComponent()
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_InLocalFunction/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_InLocalFunction/TestComponent.mappings.txt
@@ -1,4 +1,11 @@
-﻿Source Location: (54:1,2 [42] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [51] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.RenderTree;
+|
+Generated Location: (360:12,0 [51] )
+|using Microsoft.AspNetCore.Components.RenderTree;
+|
+
+Source Location: (54:1,2 [42] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     void RenderChildComponent()
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_MultipleGenerics/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_MultipleGenerics/TestComponent.mappings.txt
@@ -1,0 +1,15 @@
+﻿Source Location: (46:0,46 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|"hi"|
+Generated Location: (913:19,46 [4] )
+|"hi"|
+
+Source Location: (77:1,22 [17] x:\dir\subdir\Test\TestComponent.cshtml)
+|context.ToLower()|
+Generated Location: (1298:29,25 [17] )
+|context.ToLower()|
+
+Source Location: (158:3,3 [29] x:\dir\subdir\Test\TestComponent.cshtml)
+|System.Math.Max(0, item.Item)|
+Generated Location: (1740:40,25 [29] )
+|System.Math.Max(0, item.Item)|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_MultipleGenerics_TypeInference/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_MultipleGenerics_TypeInference/TestComponent.mappings.txt
@@ -1,0 +1,20 @@
+﻿Source Location: (21:0,21 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|"hi"|
+Generated Location: (762:18,21 [4] )
+|"hi"|
+
+Source Location: (36:0,36 [16] x:\dir\subdir\Test\TestComponent.cshtml)
+|new List<long>()|
+Generated Location: (943:26,36 [16] )
+|new List<long>()|
+
+Source Location: (78:1,22 [17] x:\dir\subdir\Test\TestComponent.cshtml)
+|context.ToLower()|
+Generated Location: (1221:35,25 [17] )
+|context.ToLower()|
+
+Source Location: (159:3,3 [29] x:\dir\subdir\Test\TestComponent.cshtml)
+|System.Math.Max(0, item.Item)|
+Generated Location: (1506:45,25 [29] )
+|System.Math.Max(0, item.Item)|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_NonGenericParameterizedChildContent_TypeInference/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_NonGenericParameterizedChildContent_TypeInference/TestComponent.mappings.txt
@@ -1,0 +1,15 @@
+﻿Source Location: (21:0,21 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|"hi"|
+Generated Location: (762:18,21 [4] )
+|"hi"|
+
+Source Location: (50:1,20 [17] x:\dir\subdir\Test\TestComponent.cshtml)
+|context.ToLower()|
+Generated Location: (977:26,25 [17] )
+|context.ToLower()|
+
+Source Location: (103:2,16 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+|context|
+Generated Location: (1222:35,25 [7] )
+|context|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitEventHandler/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (46:2,7 [98] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|Increment|
+Generated Location: (832:19,23 [9] )
+|Increment|
+
+Source Location: (46:2,7 [98] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private int counter;
     private void Increment(EventArgs e) {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitGenericChildContent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitGenericChildContent/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (28:0,28 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+|context|
+Generated Location: (905:19,25 [7] )
+|context|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitStringParameter/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitStringParameter/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (31:0,31 [13] x:\dir\subdir\Test\TestComponent.cshtml)
+|42.ToString()|
+Generated Location: (910:19,31 [13] )
+|42.ToString()|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithGenericChildContent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithGenericChildContent/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (54:0,54 [26] x:\dir\subdir\Test\TestComponent.cshtml)
+|context.ToLowerInvariant()|
+Generated Location: (1140:23,25 [26] )
+|context.ToLowerInvariant()|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterName/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterName/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (93:2,32 [23] x:\dir\subdir\Test\TestComponent.cshtml)
+|item.ToLowerInvariant()|
+Generated Location: (1151:23,25 [23] )
+|item.ToLowerInvariant()|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterNameOnComponent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterNameOnComponent/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (93:2,32 [23] x:\dir\subdir\Test\TestComponent.cshtml)
+|item.ToLowerInvariant()|
+Generated Location: (1151:23,25 [23] )
+|item.ToLowerInvariant()|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithLambdaEventHandler/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (60:2,7 [87] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (24:0,24 [21] x:\dir\subdir\Test\TestComponent.cshtml)
+|e => { Increment(); }|
+Generated Location: (833:19,24 [21] )
+|e => { Increment(); }|
+
+Source Location: (60:2,7 [87] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private int counter;
     private void Increment() {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithNonPropertyAttributes/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithNonPropertyAttributes/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (55:0,55 [13] x:\dir\subdir\Test\TestComponent.cshtml)
+|43.ToString()|
+Generated Location: (906:20,55 [13] )
+|43.ToString()|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithParameters/TestComponent.mappings.txt
@@ -1,0 +1,15 @@
+﻿Source Location: (31:1,17 [3] x:\dir\subdir\Test\TestComponent.cshtml)
+|123|
+Generated Location: (892:19,17 [3] )
+|123|
+
+Source Location: (55:2,18 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|true|
+Generated Location: (1223:28,18 [4] )
+|true|
+
+Source Location: (114:4,20 [14] x:\dir\subdir\Test\TestComponent.cshtml)
+|new SomeType()|
+Generated Location: (1638:38,20 [14] )
+|new SomeType()|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithWeaklyTypeEventHandler/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithWeaklyTypeEventHandler/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (70:1,26 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (70:1,26 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |OnClick|
 Generated Location: (1095:26,26 [7] )
 |OnClick|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithWeaklyTypeEventHandler/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithWeaklyTypeEventHandler/TestComponent.mappings.txt
@@ -1,4 +1,15 @@
-﻿Source Location: (92:3,7 [60] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (70:1,26 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+|OnClick|
+Generated Location: (1095:26,26 [7] )
+|OnClick|
+
+Source Location: (92:3,7 [60] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private Action<MouseEventArgs> OnClick { get; set; }
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildContent_FromAnotherNamespace/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildContent_FromAnotherNamespace/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [19] x:\dir\subdir\Test\TestComponent.cshtml)
-|using AnotherTest
-|
-Generated Location: (360:12,0 [19] )
-|using AnotherTest;|
-
-Source Location: (119:6,13 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (119:6,13 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |context|
 Generated Location: (1422:33,25 [7] )
 |context|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildContent_FromAnotherNamespace/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildContent_FromAnotherNamespace/TestComponent.mappings.txt
@@ -1,0 +1,16 @@
+﻿Source Location: (1:0,1 [19] x:\dir\subdir\Test\TestComponent.cshtml)
+|using AnotherTest
+|
+Generated Location: (360:12,0 [19] )
+|using AnotherTest;|
+
+Source Location: (119:6,13 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+|context|
+Generated Location: (1422:33,25 [7] )
+|context|
+
+Source Location: (276:12,13 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+|context|
+Generated Location: (2327:53,26 [7] )
+|context|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentImports/_Imports.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentImports/_Imports.mappings.txt
@@ -1,0 +1,17 @@
+﻿Source Location: (1:0,1 [19] x:\dir\subdir\Test\_Imports.razor)
+|using System.Text
+|
+Generated Location: (354:12,0 [19] )
+|using System.Text;|
+
+Source Location: (21:1,1 [25] x:\dir\subdir\Test\_Imports.razor)
+|using System.Reflection
+|
+Generated Location: (488:19,0 [25] )
+|using System.Reflection;|
+
+Source Location: (69:4,1 [3] x:\dir\subdir\Test\_Imports.razor)
+|Foo|
+Generated Location: (889:32,24 [3] )
+|Foo|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentImports/_Imports.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentImports/_Imports.mappings.txt
@@ -1,16 +1,4 @@
-﻿Source Location: (1:0,1 [19] x:\dir\subdir\Test\_Imports.razor)
-|using System.Text
-|
-Generated Location: (354:12,0 [19] )
-|using System.Text;|
-
-Source Location: (21:1,1 [25] x:\dir\subdir\Test\_Imports.razor)
-|using System.Reflection
-|
-Generated Location: (488:19,0 [25] )
-|using System.Reflection;|
-
-Source Location: (69:4,1 [3] x:\dir\subdir\Test\_Imports.razor)
+﻿Source Location: (69:4,1 [3] x:\dir\subdir\Test\_Imports.razor)
 |Foo|
 Generated Location: (889:32,24 [3] )
 |Foo|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentParameter_TypeMismatch_ReportsDiagnostic/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentParameter_TypeMismatch_ReportsDiagnostic/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (27:0,27 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|"very-cool"|
+Generated Location: (901:19,27 [11] )
+|"very-cool"|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithBooleanParameter/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithBooleanParameter/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (74:4,7 [59] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (9:0,9 [8] x:\dir\subdir\Test\TestComponent.cshtml)
+|TestBool|
+Generated Location: (728:18,24 [8] )
+|TestBool|
+
+Source Location: (55:2,25 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|true|
+Generated Location: (1216:29,25 [4] )
+|true|
+
+Source Location: (74:4,7 [59] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     [Parameter]
     public bool TestBool { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithBooleanParameter_Minimized/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithBooleanParameter_Minimized/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (67:4,7 [59] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (9:0,9 [8] x:\dir\subdir\Test\TestComponent.cshtml)
+|TestBool|
+Generated Location: (728:18,24 [8] )
+|TestBool|
+
+Source Location: (67:4,7 [59] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     [Parameter]
     public bool TestBool { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters/TestComponent.mappings.txt
@@ -1,4 +1,11 @@
-﻿Source Location: (52:1,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [40] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components;
+|
+Generated Location: (308:11,0 [40] )
+|using Microsoft.AspNetCore.Components;
+|
+
+Source Location: (52:1,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |TItem1|
 Generated Location: (509:19,0 [6] )
 |TItem1|
@@ -36,6 +43,11 @@ Generated Location: (1649:69,1 [34] )
 |foreach (var item2 in Items2)
 {
 |
+
+Source Location: (234:9,5 [19] x:\dir\subdir\Test\TestComponent.cshtml)
+|ChildContent(item2)|
+Generated Location: (1887:78,24 [19] )
+|ChildContent(item2)|
 
 Source Location: (266:11,0 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |}

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters/TestComponent.mappings.txt
@@ -1,11 +1,4 @@
-﻿Source Location: (1:0,1 [40] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components;
-|
-Generated Location: (308:11,0 [40] )
-|using Microsoft.AspNetCore.Components;
-|
-
-Source Location: (52:1,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (52:1,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |TItem1|
 Generated Location: (509:19,0 [6] )
 |TItem1|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters/UseTestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters/UseTestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [12] x:\dir\subdir\Test\UseTestComponent.cshtml)
-|using Test
-|
-Generated Location: (363:12,0 [12] )
-|using Test;|
-
-Source Location: (35:1,22 [5] x:\dir\subdir\Test\UseTestComponent.cshtml)
+﻿Source Location: (35:1,22 [5] x:\dir\subdir\Test\UseTestComponent.cshtml)
 |item1|
 Generated Location: (910:25,22 [5] )
 |item1|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters/UseTestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters/UseTestComponent.mappings.txt
@@ -1,4 +1,30 @@
-﻿Source Location: (118:5,7 [268] x:\dir\subdir\Test\UseTestComponent.cshtml)
+﻿Source Location: (1:0,1 [12] x:\dir\subdir\Test\UseTestComponent.cshtml)
+|using Test
+|
+Generated Location: (363:12,0 [12] )
+|using Test;|
+
+Source Location: (35:1,22 [5] x:\dir\subdir\Test\UseTestComponent.cshtml)
+|item1|
+Generated Location: (910:25,22 [5] )
+|item1|
+
+Source Location: (49:1,36 [5] x:\dir\subdir\Test\UseTestComponent.cshtml)
+|items|
+Generated Location: (1095:33,36 [5] )
+|items|
+
+Source Location: (62:1,49 [5] x:\dir\subdir\Test\UseTestComponent.cshtml)
+|item1|
+Generated Location: (1293:41,49 [5] )
+|item1|
+
+Source Location: (78:2,8 [7] x:\dir\subdir\Test\UseTestComponent.cshtml)
+|context|
+Generated Location: (1560:50,25 [7] )
+|context|
+
+Source Location: (118:5,7 [268] x:\dir\subdir\Test\UseTestComponent.cshtml)
 |
     Image item1 = new Image() { id = 1, url="https://example.com"};
     static Tag tag1 = new Tag() { description = "A description."};

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters_WithSemicolon/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters_WithSemicolon/TestComponent.mappings.txt
@@ -1,4 +1,11 @@
-﻿Source Location: (52:1,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [40] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components;
+|
+Generated Location: (308:11,0 [40] )
+|using Microsoft.AspNetCore.Components;
+|
+
+Source Location: (52:1,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |TItem1|
 Generated Location: (509:19,0 [6] )
 |TItem1|
@@ -36,6 +43,11 @@ Generated Location: (1649:69,1 [34] )
 |foreach (var item2 in Items2)
 {
 |
+
+Source Location: (237:9,5 [19] x:\dir\subdir\Test\TestComponent.cshtml)
+|ChildContent(item2)|
+Generated Location: (1887:78,24 [19] )
+|ChildContent(item2)|
 
 Source Location: (269:11,0 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |}

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters_WithSemicolon/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters_WithSemicolon/TestComponent.mappings.txt
@@ -1,11 +1,4 @@
-﻿Source Location: (1:0,1 [40] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components;
-|
-Generated Location: (308:11,0 [40] )
-|using Microsoft.AspNetCore.Components;
-|
-
-Source Location: (52:1,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (52:1,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |TItem1|
 Generated Location: (509:19,0 [6] )
 |TItem1|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters_WithSemicolon/UseTestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters_WithSemicolon/UseTestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [12] x:\dir\subdir\Test\UseTestComponent.cshtml)
-|using Test
-|
-Generated Location: (363:12,0 [12] )
-|using Test;|
-
-Source Location: (35:1,22 [5] x:\dir\subdir\Test\UseTestComponent.cshtml)
+﻿Source Location: (35:1,22 [5] x:\dir\subdir\Test\UseTestComponent.cshtml)
 |item1|
 Generated Location: (910:25,22 [5] )
 |item1|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters_WithSemicolon/UseTestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters_WithSemicolon/UseTestComponent.mappings.txt
@@ -1,4 +1,30 @@
-﻿Source Location: (118:5,7 [268] x:\dir\subdir\Test\UseTestComponent.cshtml)
+﻿Source Location: (1:0,1 [12] x:\dir\subdir\Test\UseTestComponent.cshtml)
+|using Test
+|
+Generated Location: (363:12,0 [12] )
+|using Test;|
+
+Source Location: (35:1,22 [5] x:\dir\subdir\Test\UseTestComponent.cshtml)
+|item1|
+Generated Location: (910:25,22 [5] )
+|item1|
+
+Source Location: (49:1,36 [5] x:\dir\subdir\Test\UseTestComponent.cshtml)
+|items|
+Generated Location: (1095:33,36 [5] )
+|items|
+
+Source Location: (62:1,49 [5] x:\dir\subdir\Test\UseTestComponent.cshtml)
+|item1|
+Generated Location: (1293:41,49 [5] )
+|item1|
+
+Source Location: (78:2,8 [7] x:\dir\subdir\Test\UseTestComponent.cshtml)
+|context|
+Generated Location: (1560:50,25 [7] )
+|context|
+
+Source Location: (118:5,7 [268] x:\dir\subdir\Test\UseTestComponent.cshtml)
 |
     Image item1 = new Image() { id = 1, url="https://example.com"};
     static Tag tag1 = new Tag() { description = "A description."};

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithDecimalParameter/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithDecimalParameter/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (77:4,7 [65] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (9:0,9 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|TestDecimal|
+Generated Location: (728:18,24 [11] )
+|TestDecimal|
+
+Source Location: (61:2,28 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|4|
+Generated Location: (1225:29,28 [1] )
+|4|
+
+Source Location: (77:4,7 [65] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     [Parameter]
     public decimal TestDecimal { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithDynamicParameter/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithDynamicParameter/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (77:4,7 [65] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (9:0,9 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|TestDynamic|
+Generated Location: (728:18,24 [11] )
+|TestDynamic|
+
+Source Location: (61:2,28 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|4|
+Generated Location: (1210:29,28 [1] )
+|4|
+
+Source Location: (77:4,7 [65] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     [Parameter]
     public dynamic TestDynamic { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTupleParameter/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTupleParameter/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (7:0,7 [78] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (113:4,23 [8] x:\dir\subdir\Test\TestComponent.cshtml)
+|(32, 16)|
+Generated Location: (923:19,23 [8] )
+|(32, 16)|
+
+Source Location: (7:0,7 [78] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     [Parameter] public (int Horizontal, int Vertical) Gutter { get; set; }
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterArray/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterArray/TestComponent.mappings.txt
@@ -1,11 +1,4 @@
-﻿Source Location: (1:0,1 [40] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components;
-|
-Generated Location: (308:11,0 [40] )
-|using Microsoft.AspNetCore.Components;
-|
-
-Source Location: (52:1,11 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (52:1,11 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |TItem|
 Generated Location: (509:19,0 [5] )
 |TItem|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterArray/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterArray/TestComponent.mappings.txt
@@ -1,7 +1,19 @@
-﻿Source Location: (52:1,11 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [40] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components;
+|
+Generated Location: (308:11,0 [40] )
+|using Microsoft.AspNetCore.Components;
+|
+
+Source Location: (52:1,11 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |TItem|
 Generated Location: (509:19,0 [5] )
 |TItem|
+
+Source Location: (82:5,4 [20] x:\dir\subdir\Test\TestComponent.cshtml)
+|ChildContent(Items1)|
+Generated Location: (1034:33,24 [20] )
+|ChildContent(Items1)|
 
 Source Location: (111:7,1 [33] x:\dir\subdir\Test\TestComponent.cshtml)
 |foreach (var item in Items2)
@@ -12,12 +24,22 @@ Generated Location: (1218:41,1 [33] )
 {
 |
 
+Source Location: (152:9,8 [18] x:\dir\subdir\Test\TestComponent.cshtml)
+|ChildContent(item)|
+Generated Location: (1455:50,24 [18] )
+|ChildContent(item)|
+
 Source Location: (176:10,0 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |}
 |
 Generated Location: (1637:58,0 [3] )
 |}
 |
+
+Source Location: (185:12,4 [22] x:\dir\subdir\Test\TestComponent.cshtml)
+|ChildContent(Items3())|
+Generated Location: (1844:66,24 [22] )
+|ChildContent(Items3())|
 
 Source Location: (222:14,7 [248] x:\dir\subdir\Test\TestComponent.cshtml)
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterArray/UseTestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterArray/UseTestComponent.mappings.txt
@@ -1,4 +1,30 @@
-﻿Source Location: (135:5,7 [208] x:\dir\subdir\Test\UseTestComponent.cshtml)
+﻿Source Location: (1:0,1 [12] x:\dir\subdir\Test\UseTestComponent.cshtml)
+|using Test
+|
+Generated Location: (363:12,0 [12] )
+|using Test;|
+
+Source Location: (35:1,22 [6] x:\dir\subdir\Test\UseTestComponent.cshtml)
+|items1|
+Generated Location: (910:25,22 [6] )
+|items1|
+
+Source Location: (49:1,36 [6] x:\dir\subdir\Test\UseTestComponent.cshtml)
+|items2|
+Generated Location: (1096:33,36 [6] )
+|items2|
+
+Source Location: (63:1,50 [6] x:\dir\subdir\Test\UseTestComponent.cshtml)
+|items3|
+Generated Location: (1296:41,50 [6] )
+|items3|
+
+Source Location: (80:2,8 [22] x:\dir\subdir\Test\UseTestComponent.cshtml)
+|context[0].description|
+Generated Location: (1564:50,25 [22] )
+|context[0].description|
+
+Source Location: (135:5,7 [208] x:\dir\subdir\Test\UseTestComponent.cshtml)
 |
     static Tag tag = new Tag() { description = "A description."};
     Tag[] items1 = new [] { tag };

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterArray/UseTestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterArray/UseTestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [12] x:\dir\subdir\Test\UseTestComponent.cshtml)
-|using Test
-|
-Generated Location: (363:12,0 [12] )
-|using Test;|
-
-Source Location: (35:1,22 [6] x:\dir\subdir\Test\UseTestComponent.cshtml)
+﻿Source Location: (35:1,22 [6] x:\dir\subdir\Test\UseTestComponent.cshtml)
 |items1|
 Generated Location: (910:25,22 [6] )
 |items1|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterValueTuple/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterValueTuple/TestComponent.mappings.txt
@@ -1,4 +1,11 @@
-﻿Source Location: (52:1,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [40] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components;
+|
+Generated Location: (308:11,0 [40] )
+|using Microsoft.AspNetCore.Components;
+|
+
+Source Location: (52:1,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |TItem1|
 Generated Location: (509:19,0 [6] )
 |TItem1|
@@ -8,6 +15,11 @@ Source Location: (71:2,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (644:27,0 [6] )
 |TItem2|
 
+Source Location: (102:6,4 [19] x:\dir\subdir\Test\TestComponent.cshtml)
+|ChildContent(Item1)|
+Generated Location: (1170:41,24 [19] )
+|ChildContent(Item1)|
+
 Source Location: (130:8,1 [33] x:\dir\subdir\Test\TestComponent.cshtml)
 |foreach (var item in Items2)
 {
@@ -16,6 +28,11 @@ Generated Location: (1353:49,1 [33] )
 |foreach (var item in Items2)
 {
 |
+
+Source Location: (171:10,8 [18] x:\dir\subdir\Test\TestComponent.cshtml)
+|ChildContent(item)|
+Generated Location: (1590:58,24 [18] )
+|ChildContent(item)|
 
 Source Location: (195:11,0 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |}

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterValueTuple/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterValueTuple/TestComponent.mappings.txt
@@ -1,11 +1,4 @@
-﻿Source Location: (1:0,1 [40] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components;
-|
-Generated Location: (308:11,0 [40] )
-|using Microsoft.AspNetCore.Components;
-|
-
-Source Location: (52:1,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (52:1,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |TItem1|
 Generated Location: (509:19,0 [6] )
 |TItem1|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterValueTuple/UseTestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterValueTuple/UseTestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [12] x:\dir\subdir\Test\UseTestComponent.cshtml)
-|using Test
-|
-Generated Location: (363:12,0 [12] )
-|using Test;|
-
-Source Location: (34:1,21 [5] x:\dir\subdir\Test\UseTestComponent.cshtml)
+﻿Source Location: (34:1,21 [5] x:\dir\subdir\Test\UseTestComponent.cshtml)
 |item1|
 Generated Location: (909:25,21 [5] )
 |item1|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterValueTuple/UseTestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterValueTuple/UseTestComponent.mappings.txt
@@ -1,4 +1,25 @@
-﻿Source Location: (104:5,7 [176] x:\dir\subdir\Test\UseTestComponent.cshtml)
+﻿Source Location: (1:0,1 [12] x:\dir\subdir\Test\UseTestComponent.cshtml)
+|using Test
+|
+Generated Location: (363:12,0 [12] )
+|using Test;|
+
+Source Location: (34:1,21 [5] x:\dir\subdir\Test\UseTestComponent.cshtml)
+|item1|
+Generated Location: (909:25,21 [5] )
+|item1|
+
+Source Location: (47:1,34 [6] x:\dir\subdir\Test\UseTestComponent.cshtml)
+|items2|
+Generated Location: (1092:33,34 [6] )
+|items2|
+
+Source Location: (64:2,8 [7] x:\dir\subdir\Test\UseTestComponent.cshtml)
+|context|
+Generated Location: (1360:42,25 [7] )
+|context|
+
+Source Location: (104:5,7 [176] x:\dir\subdir\Test\UseTestComponent.cshtml)
 |
     (string, int) item1 = ("A string", 42);
     static (string, int) item2 = ("Another string", 42);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterValueTupleGloballyQualifiedTypes/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterValueTupleGloballyQualifiedTypes/TestComponent.mappings.txt
@@ -1,7 +1,28 @@
-﻿Source Location: (21:1,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|using N
+|
+Generated Location: (360:12,0 [9] )
+|using N;|
+
+Source Location: (21:1,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |TParam|
 Generated Location: (531:20,0 [6] )
 |TParam|
+
+Source Location: (239:11,27 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|1|
+Generated Location: (1037:33,27 [1] )
+|1|
+
+Source Location: (269:13,9 [20] x:\dir\subdir\Test\TestComponent.cshtml)
+|context.I1.MyClassId|
+Generated Location: (1251:41,25 [20] )
+|context.I1.MyClassId|
+
+Source Location: (293:13,33 [21] x:\dir\subdir\Test\TestComponent.cshtml)
+|context.I2.MyStructId|
+Generated Location: (1487:49,25 [21] )
+|context.I2.MyStructId|
 
 Source Location: (38:3,7 [169] x:\dir\subdir\Test\TestComponent.cshtml)
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterValueTupleGloballyQualifiedTypes/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterValueTupleGloballyQualifiedTypes/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [9] x:\dir\subdir\Test\TestComponent.cshtml)
-|using N
-|
-Generated Location: (360:12,0 [9] )
-|using N;|
-
-Source Location: (21:1,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (21:1,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |TParam|
 Generated Location: (531:20,0 [6] )
 |TParam|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterValueTuple_ExplicitGenericArguments/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterValueTuple_ExplicitGenericArguments/TestComponent.mappings.txt
@@ -18,6 +18,11 @@ Source Location: (61:1,18 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (872:36,0 [21] )
 |where TValue : struct|
 
+Source Location: (107:3,21 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|null|
+Generated Location: (1520:49,21 [4] )
+|null|
+
 Source Location: (161:5,7 [87] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     [Parameter]

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.mappings.txt
@@ -1,11 +1,4 @@
-﻿Source Location: (1:0,1 [40] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components;
-|
-Generated Location: (308:11,0 [40] )
-|using Microsoft.AspNetCore.Components;
-|
-
-Source Location: (52:1,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (52:1,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |TItem1|
 Generated Location: (509:19,0 [6] )
 |TItem1|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.mappings.txt
@@ -1,4 +1,11 @@
-﻿Source Location: (52:1,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [40] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components;
+|
+Generated Location: (308:11,0 [40] )
+|using Microsoft.AspNetCore.Components;
+|
+
+Source Location: (52:1,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |TItem1|
 Generated Location: (509:19,0 [6] )
 |TItem1|
@@ -16,6 +23,11 @@ Generated Location: (1082:40,1 [34] )
 |foreach (var item2 in Items2)
 {
 |
+
+Source Location: (146:8,5 [19] x:\dir\subdir\Test\TestComponent.cshtml)
+|ChildContent(item2)|
+Generated Location: (1318:49,24 [19] )
+|ChildContent(item2)|
 
 Source Location: (178:10,0 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |}

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameters_WithSemicolon/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameters_WithSemicolon/TestComponent.mappings.txt
@@ -1,11 +1,4 @@
-﻿Source Location: (1:0,1 [40] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components;
-|
-Generated Location: (308:11,0 [40] )
-|using Microsoft.AspNetCore.Components;
-|
-
-Source Location: (52:1,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (52:1,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |TItem1|
 Generated Location: (509:19,0 [6] )
 |TItem1|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameters_WithSemicolon/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameters_WithSemicolon/TestComponent.mappings.txt
@@ -1,4 +1,11 @@
-﻿Source Location: (52:1,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [40] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components;
+|
+Generated Location: (308:11,0 [40] )
+|using Microsoft.AspNetCore.Components;
+|
+
+Source Location: (52:1,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |TItem1|
 Generated Location: (509:19,0 [6] )
 |TItem1|
@@ -16,6 +23,11 @@ Generated Location: (1082:40,1 [34] )
 |foreach (var item2 in Items2)
 {
 |
+
+Source Location: (148:8,5 [19] x:\dir\subdir\Test\TestComponent.cshtml)
+|ChildContent(item2)|
+Generated Location: (1318:49,24 [19] )
+|ChildContent(item2)|
 
 Source Location: (180:10,0 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |}

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_ComplexContentInAttribute/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_ComplexContentInAttribute/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (52:2,7 [67] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (30:0,30 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+|MyEnum|
+Generated Location: (909:19,30 [6] )
+|MyEnum|
+
+Source Location: (52:2,7 [67] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public enum MyEnum
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_ComplexContentInAttribute_02/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_ComplexContentInAttribute_02/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (52:2,7 [67] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (30:0,30 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+|MyEnum|
+Generated Location: (909:19,30 [6] )
+|MyEnum|
+
+Source Location: (52:2,7 [67] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public enum MyEnum
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_ComplexContentInAttribute_03/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_ComplexContentInAttribute_03/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (63:2,7 [18] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (30:0,30 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|x|
+Generated Location: (909:19,30 [1] )
+|x|
+
+Source Location: (39:0,39 [8] x:\dir\subdir\Test\TestComponent.cshtml)
+|"string"|
+Generated Location: (1071:26,39 [8] )
+|"string"|
+
+Source Location: (63:2,7 [18] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     int x = 1;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_IgnoresStaticAndAliasUsings/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_IgnoresStaticAndAliasUsings/TestComponent.mappings.txt
@@ -1,12 +1,0 @@
-﻿Source Location: (1:0,1 [34] x:\dir\subdir\Test\TestComponent.cshtml)
-|using static Test2.SomeComponent
-|
-Generated Location: (360:12,0 [34] )
-|using static Test2.SomeComponent;|
-
-Source Location: (36:1,1 [19] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Foo = Test3
-|
-Generated Location: (515:19,0 [19] )
-|using Foo = Test3;|
-

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_IgnoresStaticAndAliasUsings/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_IgnoresStaticAndAliasUsings/TestComponent.mappings.txt
@@ -1,0 +1,12 @@
+﻿Source Location: (1:0,1 [34] x:\dir\subdir\Test\TestComponent.cshtml)
+|using static Test2.SomeComponent
+|
+Generated Location: (360:12,0 [34] )
+|using static Test2.SomeComponent;|
+
+Source Location: (36:1,1 [19] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Foo = Test3
+|
+Generated Location: (515:19,0 [19] )
+|using Foo = Test3;|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_MatchingIsCaseSensitive/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_MatchingIsCaseSensitive/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (77:2,43 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|true|
+Generated Location: (1181:23,43 [4] )
+|true|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_MultipleComponentsDifferByCase/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_MultipleComponentsDifferByCase/TestComponent.mappings.txt
@@ -1,0 +1,10 @@
+﻿Source Location: (26:0,26 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|1|
+Generated Location: (901:19,26 [1] )
+|1|
+
+Source Location: (59:1,26 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|2|
+Generated Location: (1395:31,26 [1] )
+|2|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_PreserveWhitespaceDirective_InImports/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_PreserveWhitespaceDirective_InImports/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (23:1,13 [12] x:\dir\subdir\Test\TestComponent.cshtml)
+|DateTime.Now|
+Generated Location: (875:21,24 [12] )
+|DateTime.Now|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_PreserveWhitespaceDirective_OverrideImports/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_PreserveWhitespaceDirective_OverrideImports/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (52:3,13 [12] x:\dir\subdir\Test\TestComponent.cshtml)
+|DateTime.Now|
+Generated Location: (776:19,24 [12] )
+|DateTime.Now|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithCssScope/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithCssScope/TestComponent.mappings.txt
@@ -1,16 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (45:1,1 [49] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Rendering
-|
-Generated Location: (524:19,0 [49] )
-|using Microsoft.AspNetCore.Components.Rendering;|
-
-Source Location: (192:3,61 [3] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (192:3,61 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |123|
 Generated Location: (1321:35,61 [3] )
 |123|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithCssScope/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithCssScope/TestComponent.mappings.txt
@@ -1,4 +1,21 @@
-﻿Source Location: (318:6,30 [20] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (45:1,1 [49] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Rendering
+|
+Generated Location: (524:19,0 [49] )
+|using Microsoft.AspNetCore.Components.Rendering;|
+
+Source Location: (192:3,61 [3] x:\dir\subdir\Test\TestComponent.cshtml)
+|123|
+Generated Location: (1321:35,61 [3] )
+|123|
+
+Source Location: (318:6,30 [20] x:\dir\subdir\Test\TestComponent.cshtml)
 |myComponentReference|
 Generated Location: (2193:52,30 [20] )
 |myComponentReference|
@@ -16,6 +33,11 @@ Source Location: (511:12,38 [18] x:\dir\subdir\Test\TestComponent.cshtml)
 |myElementReference|
 Generated Location: (2917:75,38 [18] )
 |myElementReference|
+
+Source Location: (589:13,30 [10] x:\dir\subdir\Test\TestComponent.cshtml)
+|myVariable|
+Generated Location: (3577:91,30 [10] )
+|myVariable|
 
 Source Location: (639:14,0 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |}
@@ -46,6 +68,16 @@ Generated Location: (4240:112,7 [233] )
         for (var i = 0; i < 10; i++)
         {
 |
+
+Source Location: (912:25,28 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|i|
+Generated Location: (4715:129,28 [1] )
+|i|
+
+Source Location: (925:25,41 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|i|
+Generated Location: (4994:139,25 [1] )
+|i|
 
 Source Location: (933:26,0 [164] x:\dir\subdir\Test\TestComponent.cshtml)
 |        }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithEditorRequiredParameter_ValueSpecifiedUsingBind/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithEditorRequiredParameter_ValueSpecifiedUsingBind/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (78:2,7 [46] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (56:0,56 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+|myField|
+Generated Location: (956:19,56 [7] )
+|myField|
+
+Source Location: (78:2,7 [46] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private string myField = "Some Value";
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithEditorRequiredParameter_ValuesSpecifiedUsingSplatting/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithEditorRequiredParameter_ValuesSpecifiedUsingSplatting/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (54:0,54 [32] x:\dir\subdir\Test\TestComponent.cshtml)
+|new Dictionary<string, object>()|
+Generated Location: (1031:19,54 [32] )
+|new Dictionary<string, object>()|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithEscapedParameterName/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithEscapedParameterName/TestComponent.mappings.txt
@@ -1,0 +1,10 @@
+﻿Source Location: (20:0,20 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|1|
+Generated Location: (889:19,20 [1] )
+|1|
+
+Source Location: (30:0,30 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|2|
+Generated Location: (1221:28,30 [1] )
+|2|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithInitOnlyParameter/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithInitOnlyParameter/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (19:0,19 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|1|
+Generated Location: (887:19,19 [1] )
+|1|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithNamespaceDirective/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithNamespaceDirective/TestComponent.mappings.txt
@@ -1,6 +1,0 @@
-﻿Source Location: (1:0,1 [12] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Test
-|
-Generated Location: (367:12,0 [12] )
-|using Test;|
-

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithNamespaceDirective/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithNamespaceDirective/TestComponent.mappings.txt
@@ -1,0 +1,6 @@
+﻿Source Location: (1:0,1 [12] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Test
+|
+Generated Location: (367:12,0 [12] )
+|using Test;|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithNullableActionParameter/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithNullableActionParameter/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (73:1,7 [61] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (46:0,46 [14] x:\dir\subdir\Test\TestComponent.cshtml)
+|NullableAction|
+Generated Location: (860:19,46 [14] )
+|NullableAction|
+
+Source Location: (73:1,7 [61] x:\dir\subdir\Test\TestComponent.cshtml)
 |
 	[Parameter]
 	public Action NullableAction { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithNullableRenderFragmentParameter/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithNullableRenderFragmentParameter/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (65:1,7 [59] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (46:0,46 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+|Header|
+Generated Location: (893:19,46 [6] )
+|Header|
+
+Source Location: (65:1,7 [59] x:\dir\subdir\Test\TestComponent.cshtml)
 |
 	[Parameter] public RenderFragment Header { get; set; }
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithPreserveWhitespaceDirective_False/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithPreserveWhitespaceDirective_False/TestComponent.mappings.txt
@@ -7,6 +7,11 @@ Generated Location: (690:18,5 [55] )
     {
 |
 
+Source Location: (122:6,13 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|item|
+Generated Location: (949:27,24 [4] )
+|item|
+
 Source Location: (143:8,0 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |    }
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithPreserveWhitespaceDirective_True/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithPreserveWhitespaceDirective_True/TestComponent.mappings.txt
@@ -7,6 +7,11 @@ Generated Location: (794:20,5 [55] )
     {
 |
 
+Source Location: (121:6,13 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|item|
+Generated Location: (1167:31,24 [4] )
+|item|
+
 Source Location: (142:8,0 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |    }
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithRef_Nullable_Generic/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithRef_Nullable_Generic/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (19:0,19 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (45:0,45 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|1|
+Generated Location: (786:18,45 [1] )
+|1|
+
+Source Location: (19:0,19 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |myComponent|
 Generated Location: (961:26,19 [11] )
 |myComponent|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithSplat/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithSplat/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (103:2,7 [93] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (51:0,51 [14] x:\dir\subdir\Test\TestComponent.cshtml)
+|someAttributes|
+Generated Location: (1080:20,51 [14] )
+|someAttributes|
+
+Source Location: (103:2,7 [93] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithSplat_ExplicitExpression/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithSplat_ExplicitExpression/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (106:2,7 [93] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (53:0,53 [14] x:\dir\subdir\Test\TestComponent.cshtml)
+|someAttributes|
+Generated Location: (1082:20,53 [14] )
+|someAttributes|
+
+Source Location: (106:2,7 [93] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithSplat_GenericTypeInference/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithSplat_GenericTypeInference/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (69:2,7 [93] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (20:0,20 [2] x:\dir\subdir\Test\TestComponent.cshtml)
+|18|
+Generated Location: (761:18,20 [2] )
+|18|
+
+Source Location: (39:0,39 [14] x:\dir\subdir\Test\TestComponent.cshtml)
+|someAttributes|
+Generated Location: (943:26,39 [14] )
+|someAttributes|
+
+Source Location: (69:2,7 [93] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithSplat_ImplicitExpression/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithSplat_ImplicitExpression/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (104:2,7 [93] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (52:0,52 [14] x:\dir\subdir\Test\TestComponent.cshtml)
+|someAttributes|
+Generated Location: (1081:20,52 [14] )
+|someAttributes|
+
+Source Location: (104:2,7 [93] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithUsingDirectives/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithUsingDirectives/TestComponent.mappings.txt
@@ -1,6 +1,0 @@
-﻿Source Location: (46:2,1 [13] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Test2
-|
-Generated Location: (360:12,0 [13] )
-|using Test2;|
-

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithUsingDirectives/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithUsingDirectives/TestComponent.mappings.txt
@@ -1,0 +1,6 @@
+﻿Source Location: (46:2,1 [13] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Test2
+|
+Generated Location: (360:12,0 [13] )
+|using Test2;|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithUsingDirectives_AmbiguousImport/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithUsingDirectives_AmbiguousImport/TestComponent.mappings.txt
@@ -1,0 +1,12 @@
+﻿Source Location: (1:0,1 [13] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Test2
+|
+Generated Location: (360:12,0 [13] )
+|using Test2;|
+
+Source Location: (15:1,1 [13] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Test3
+|
+Generated Location: (494:19,0 [13] )
+|using Test3;|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithUsingDirectives_AmbiguousImport/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithUsingDirectives_AmbiguousImport/TestComponent.mappings.txt
@@ -1,12 +1,0 @@
-﻿Source Location: (1:0,1 [13] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Test2
-|
-Generated Location: (360:12,0 [13] )
-|using Test2;|
-
-Source Location: (15:1,1 [13] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Test3
-|
-Generated Location: (494:19,0 [13] )
-|using Test3;|
-

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithWriteOnlyParameter/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithWriteOnlyParameter/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (19:0,19 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|1|
+Generated Location: (887:19,19 [1] )
+|1|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ExplicitExpression/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ExplicitExpression/TestComponent.mappings.txt
@@ -7,3 +7,8 @@ Generated Location: (642:17,2 [39] )
   var myValue = "Expression value";
 |
 
+Source Location: (87:3,43 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+|myValue|
+Generated Location: (1012:28,43 [7] )
+|myValue|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DataDashAttribute_ImplicitExpression/TestComponent.mappings.txt
@@ -7,3 +7,8 @@ Generated Location: (642:17,2 [39] )
   var myValue = "Expression value";
 |
 
+Source Location: (86:3,42 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+|myValue|
+Generated Location: (1011:28,42 [7] )
+|myValue|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessage/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessage/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (73:1,12 [30] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (23:0,23 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+|message|
+Generated Location: (895:19,23 [7] )
+|message|
+
+Source Location: (48:0,48 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+|message|
+Generated Location: (1254:28,48 [7] )
+|message|
+
+Source Location: (73:1,12 [30] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string message = "hi";
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessageChanged/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessageChanged/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (84:1,12 [30] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (31:0,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|(s) => {}|
+Generated Location: (1063:19,31 [9] )
+|(s) => {}|
+
+Source Location: (59:0,59 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+|message|
+Generated Location: (1436:28,59 [7] )
+|message|
+
+Source Location: (84:1,12 [30] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string message = "hi";
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessageExpression/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateComponentParameters_IsAnError_BindMessageExpression/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (87:1,12 [30] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (59:0,59 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|(s) => {}|
+Generated Location: (992:19,59 [9] )
+|(s) => {}|
+
+Source Location: (29:0,29 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+|message|
+Generated Location: (1334:28,29 [7] )
+|message|
+
+Source Location: (87:1,12 [30] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string message = "hi";
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_DifferentCasing_IsAnError_BindValue/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_DifferentCasing_IsAnError_BindValue/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (91:2,40 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (91:2,40 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |text|
 Generated Location: (1164:29,40 [4] )
 |text|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_DifferentCasing_IsAnError_BindValue/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_DifferentCasing_IsAnError_BindValue/TestComponent.mappings.txt
@@ -1,4 +1,15 @@
-﻿Source Location: (127:4,12 [35] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (91:2,40 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|text|
+Generated Location: (1164:29,40 [4] )
+|text|
+
+Source Location: (127:4,12 [35] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private string text = "hi";
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindOnInput/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindOnInput/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (130:2,79 [8] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (130:2,79 [8] x:\dir\subdir\Test\TestComponent.cshtml)
 |() => {}|
 Generated Location: (1216:28,79 [8] )
 |() => {}|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindOnInput/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindOnInput/TestComponent.mappings.txt
@@ -1,4 +1,20 @@
-﻿Source Location: (170:4,12 [35] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (130:2,79 [8] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => {}|
+Generated Location: (1216:28,79 [8] )
+|() => {}|
+
+Source Location: (86:2,35 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|text|
+Generated Location: (1513:37,35 [4] )
+|text|
+
+Source Location: (170:4,12 [35] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private string text = "hi";
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindValue/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindValue/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (91:2,40 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (91:2,40 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |text|
 Generated Location: (1164:29,40 [4] )
 |text|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindValue/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_BindValue/TestComponent.mappings.txt
@@ -1,4 +1,15 @@
-﻿Source Location: (127:4,12 [35] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (91:2,40 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|text|
+Generated Location: (1164:29,40 [4] )
+|text|
+
+Source Location: (127:4,12 [35] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private string text = "hi";
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_EventHandler/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_EventHandler/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (83:2,32 [8] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (83:2,32 [8] x:\dir\subdir\Test\TestComponent.cshtml)
 |() => {}|
 Generated Location: (1173:28,32 [8] )
 |() => {}|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_EventHandler/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/DuplicateMarkupAttributes_IsAnError_EventHandler/TestComponent.mappings.txt
@@ -1,0 +1,11 @@
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (83:2,32 [8] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => {}|
+Generated Location: (1173:28,32 [8] )
+|() => {}|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithKey_AndOtherAttributes/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithKey_AndOtherAttributes/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (49:0,49 [10] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (37:0,37 [3] x:\dir\subdir\Test\TestComponent.cshtml)
+|Min|
+Generated Location: (840:20,37 [3] )
+|Min|
+
+Source Location: (49:0,49 [10] x:\dir\subdir\Test\TestComponent.cshtml)
 |someObject|
 Generated Location: (1061:29,49 [10] )
 |someObject|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithRef_AndOtherAttributes/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithRef_AndOtherAttributes/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (49:0,49 [8] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (37:0,37 [3] x:\dir\subdir\Test\TestComponent.cshtml)
+|Min|
+Generated Location: (840:20,37 [3] )
+|Min|
+
+Source Location: (49:0,49 [8] x:\dir\subdir\Test\TestComponent.cshtml)
 |_element|
 Generated Location: (1098:29,49 [8] )
 |_element|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithSplat/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithSplat/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (106:2,7 [93] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (44:0,44 [14] x:\dir\subdir\Test\TestComponent.cshtml)
+|someAttributes|
+Generated Location: (1044:20,44 [14] )
+|someAttributes|
+
+Source Location: (106:2,7 [93] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithSplat_ExplicitExpression/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithSplat_ExplicitExpression/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (109:2,7 [93] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (46:0,46 [14] x:\dir\subdir\Test\TestComponent.cshtml)
+|someAttributes|
+Generated Location: (1046:20,46 [14] )
+|someAttributes|
+
+Source Location: (109:2,7 [93] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithSplat_ImplicitExpression/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Element_WithSplat_ImplicitExpression/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (107:2,7 [93] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (45:0,45 [14] x:\dir\subdir\Test\TestComponent.cshtml)
+|someAttributes|
+Generated Location: (1045:20,45 [14] )
+|someAttributes|
+
+Source Location: (107:2,7 [93] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private Dictionary<string, object> someAttributes = new Dictionary<string, object>();
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallbackOfT_Array/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallbackOfT_Array/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (49:2,7 [64] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (26:0,26 [8] x:\dir\subdir\Test\TestComponent.cshtml)
+|Selected|
+Generated Location: (767:18,26 [8] )
+|Selected|
+
+Source Location: (49:2,7 [64] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string[] Selected { get; set; } = Array.Empty<string>();
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallbackOfT_GenericComponent_ExplicitType/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallbackOfT_GenericComponent_ExplicitType/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (75:2,7 [28] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (35:0,35 [25] x:\dir\subdir\Test\TestComponent.cshtml)
+|(MyType arg) => counter++|
+Generated Location: (1038:19,35 [25] )
+|(MyType arg) => counter++|
+
+Source Location: (75:2,7 [28] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private int counter;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallbackOfT_GenericComponent_ExplicitType_MethodGroup/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallbackOfT_GenericComponent_ExplicitType_MethodGroup/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (56:2,7 [84] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (33:0,33 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|Increment|
+Generated Location: (1036:19,33 [9] )
+|Increment|
+
+Source Location: (56:2,7 [84] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private int counter;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Explicitly/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Explicitly/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (68:1,24 [61] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (68:1,24 [61] x:\dir\subdir\Test\TestComponent.cshtml)
 |EventCallback.Factory.Create<MouseEventArgs>(this, Increment)|
 Generated Location: (1287:26,24 [61] )
 |EventCallback.Factory.Create<MouseEventArgs>(this, Increment)|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Explicitly/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Explicitly/TestComponent.mappings.txt
@@ -1,4 +1,15 @@
-﻿Source Location: (144:3,7 [87] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (68:1,24 [61] x:\dir\subdir\Test\TestComponent.cshtml)
+|EventCallback.Factory.Create<MouseEventArgs>(this, Increment)|
+Generated Location: (1287:26,24 [61] )
+|EventCallback.Factory.Create<MouseEventArgs>(this, Increment)|
+
+Source Location: (144:3,7 [87] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private int counter;
     private void Increment() {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_Action/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (46:2,7 [87] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|Increment|
+Generated Location: (1122:19,23 [9] )
+|Increment|
+
+Source Location: (46:2,7 [87] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private int counter;
     private void Increment() {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_ActionOfT/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_ActionOfT/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (67:1,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (67:1,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |Increment|
 Generated Location: (1286:26,23 [9] )
 |Increment|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_ActionOfT/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_ActionOfT/TestComponent.mappings.txt
@@ -1,4 +1,15 @@
-﻿Source Location: (90:3,7 [103] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (67:1,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|Increment|
+Generated Location: (1286:26,23 [9] )
+|Increment|
+
+Source Location: (90:3,7 [103] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private int counter;
     private void Increment(MouseEventArgs e) {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTTask/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTTask/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (67:1,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (67:1,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |Increment|
 Generated Location: (1286:26,23 [9] )
 |Increment|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTTask/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTTask/TestComponent.mappings.txt
@@ -1,4 +1,15 @@
-﻿Source Location: (90:3,7 [139] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (67:1,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|Increment|
+Generated Location: (1286:26,23 [9] )
+|Increment|
+
+Source Location: (90:3,7 [139] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private int counter;
     private Task Increment(MouseEventArgs e) {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTask/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_FuncOfTask/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (46:2,7 [123] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|Increment|
+Generated Location: (1122:19,23 [9] )
+|Increment|
+
+Source Location: (46:2,7 [123] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private int counter;
     private Task Increment() {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_TypeMismatch/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_TypeMismatch/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (67:1,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (67:1,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |Increment|
 Generated Location: (1286:26,23 [9] )
 |Increment|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_TypeMismatch/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallbackOfT_Implicitly_TypeMismatch/TestComponent.mappings.txt
@@ -1,4 +1,15 @@
-﻿Source Location: (90:3,7 [104] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (67:1,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|Increment|
+Generated Location: (1286:26,23 [9] )
+|Increment|
+
+Source Location: (90:3,7 [104] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private int counter;
     private void Increment(ChangeEventArgs e) {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Explicitly/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Explicitly/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (84:2,7 [87] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (24:0,24 [45] x:\dir\subdir\Test\TestComponent.cshtml)
+|EventCallback.Factory.Create(this, Increment)|
+Generated Location: (1003:19,24 [45] )
+|EventCallback.Factory.Create(this, Increment)|
+
+Source Location: (84:2,7 [87] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private int counter;
     private void Increment() {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_Action/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (46:2,7 [87] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|Increment|
+Generated Location: (1002:19,23 [9] )
+|Increment|
+
+Source Location: (46:2,7 [87] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private int counter;
     private void Increment() {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_ActionOfObject/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_ActionOfObject/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (46:2,7 [95] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|Increment|
+Generated Location: (1002:19,23 [9] )
+|Increment|
+
+Source Location: (46:2,7 [95] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private int counter;
     private void Increment(object e) {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfTask/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfTask/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (46:2,7 [123] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|Increment|
+Generated Location: (1002:19,23 [9] )
+|Increment|
+
+Source Location: (46:2,7 [123] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private int counter;
     private Task Increment() {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfobjectTask/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallback_CanPassEventCallback_Implicitly_FuncOfobjectTask/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (46:2,7 [131] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (23:0,23 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|Increment|
+Generated Location: (1002:19,23 [9] )
+|Increment|
+
+Source Location: (46:2,7 [131] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     private int counter;
     private Task Increment(object e) {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_AttributeNameIsCaseSensitive/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_AttributeNameIsCaseSensitive/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (81:2,7 [47] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (81:2,7 [47] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     void OnClick(MouseEventArgs e) {
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_AttributeNameIsCaseSensitive/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_AttributeNameIsCaseSensitive/TestComponent.mappings.txt
@@ -1,4 +1,10 @@
-﻿Source Location: (81:2,7 [47] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (81:2,7 [47] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     void OnClick(MouseEventArgs e) {
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_ArbitraryEventName_WithEventArgsMethodGroup/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_ArbitraryEventName_WithEventArgsMethodGroup/TestComponent.mappings.txt
@@ -1,4 +1,15 @@
-﻿Source Location: (81:2,7 [42] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (61:1,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+|OnClick|
+Generated Location: (1055:26,17 [7] )
+|OnClick|
+
+Source Location: (81:2,7 [42] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     void OnClick(EventArgs e) {
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_ArbitraryEventName_WithEventArgsMethodGroup/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_ArbitraryEventName_WithEventArgsMethodGroup/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (61:1,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (61:1,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |OnClick|
 Generated Location: (1055:26,17 [7] )
 |OnClick|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithDelegate/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithDelegate/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (61:1,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (61:1,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |OnClick|
 Generated Location: (1055:26,17 [7] )
 |OnClick|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithDelegate/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithDelegate/TestComponent.mappings.txt
@@ -1,4 +1,15 @@
-﻿Source Location: (81:2,7 [47] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (61:1,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+|OnClick|
+Generated Location: (1055:26,17 [7] )
+|OnClick|
+
+Source Location: (81:2,7 [47] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     void OnClick(MouseEventArgs e) {
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsLambdaDelegate/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsLambdaDelegate/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (61:1,17 [8] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (61:1,17 [8] x:\dir\subdir\Test\TestComponent.cshtml)
 |x => { }|
 Generated Location: (1055:26,17 [8] )
 |x => { }|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsLambdaDelegate/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsLambdaDelegate/TestComponent.mappings.txt
@@ -1,0 +1,11 @@
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (61:1,17 [8] x:\dir\subdir\Test\TestComponent.cshtml)
+|x => { }|
+Generated Location: (1055:26,17 [8] )
+|x => { }|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsMethodGroup/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsMethodGroup/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (61:1,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (61:1,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |OnClick|
 Generated Location: (1055:26,17 [7] )
 |OnClick|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsMethodGroup/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithEventArgsMethodGroup/TestComponent.mappings.txt
@@ -1,4 +1,15 @@
-﻿Source Location: (81:2,7 [47] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (61:1,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+|OnClick|
+Generated Location: (1055:26,17 [7] )
+|OnClick|
+
+Source Location: (81:2,7 [47] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     void OnClick(MouseEventArgs e) {
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithLambdaDelegate/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithLambdaDelegate/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (61:1,17 [8] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (61:1,17 [8] x:\dir\subdir\Test\TestComponent.cshtml)
 |x => { }|
 Generated Location: (1055:26,17 [8] )
 |x => { }|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithLambdaDelegate/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithLambdaDelegate/TestComponent.mappings.txt
@@ -1,0 +1,11 @@
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (61:1,17 [8] x:\dir\subdir\Test\TestComponent.cshtml)
+|x => { }|
+Generated Location: (1055:26,17 [8] )
+|x => { }|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithNoArgMethodGroup/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithNoArgMethodGroup/TestComponent.mappings.txt
@@ -1,4 +1,15 @@
-﻿Source Location: (81:2,7 [31] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (61:1,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+|OnClick|
+Generated Location: (1055:26,17 [7] )
+|OnClick|
+
+Source Location: (81:2,7 [31] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     void OnClick() {
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithNoArgMethodGroup/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithNoArgMethodGroup/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (61:1,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (61:1,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |OnClick|
 Generated Location: (1055:26,17 [7] )
 |OnClick|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithNoArgsLambdaDelegate/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithNoArgsLambdaDelegate/TestComponent.mappings.txt
@@ -1,0 +1,11 @@
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (61:1,17 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1055:26,17 [9] )
+|() => { }|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithNoArgsLambdaDelegate/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithNoArgsLambdaDelegate/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (61:1,17 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (61:1,17 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |() => { }|
 Generated Location: (1055:26,17 [9] )
 |() => { }|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithString/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithString/TestComponent.mappings.txt
@@ -1,6 +1,0 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithString/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithString/TestComponent.mappings.txt
@@ -1,0 +1,6 @@
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithoutCloseTag/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithoutCloseTag/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (70:2,19 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (70:2,19 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |OnClick|
 Generated Location: (1103:27,19 [7] )
 |OnClick|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithoutCloseTag/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_OnElement_WithoutCloseTag/TestComponent.mappings.txt
@@ -1,4 +1,15 @@
-﻿Source Location: (96:4,7 [31] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (70:2,19 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+|OnClick|
+Generated Location: (1103:27,19 [7] )
+|OnClick|
+
+Source Location: (96:4,7 [31] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     void OnClick() {
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_PreventDefault_Duplicates/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_PreventDefault_Duplicates/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (76:1,32 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (76:1,32 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |true|
 Generated Location: (954:26,32 [4] )
 |true|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_PreventDefault_Duplicates/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_PreventDefault_Duplicates/TestComponent.mappings.txt
@@ -1,0 +1,11 @@
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (76:1,32 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|true|
+Generated Location: (954:26,32 [4] )
+|true|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_PreventDefault_StopPropagation/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_PreventDefault_StopPropagation/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (62:1,18 [17] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (62:1,18 [17] x:\dir\subdir\Test\TestComponent.cshtml)
 |() => Foo = false|
 Generated Location: (1057:26,18 [17] )
 |() => Foo = false|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_PreventDefault_StopPropagation/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_PreventDefault_StopPropagation/TestComponent.mappings.txt
@@ -1,4 +1,30 @@
-﻿Source Location: (202:2,7 [30] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (62:1,18 [17] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => Foo = false|
+Generated Location: (1057:26,18 [17] )
+|() => Foo = false|
+
+Source Location: (106:1,62 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|true|
+Generated Location: (1345:35,62 [4] )
+|true|
+
+Source Location: (138:1,94 [3] x:\dir\subdir\Test\TestComponent.cshtml)
+|Foo|
+Generated Location: (1652:44,94 [3] )
+|Foo|
+
+Source Location: (169:1,125 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|false|
+Generated Location: (1989:53,125 [5] )
+|false|
+
+Source Location: (202:2,7 [30] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     bool Foo { get; set; }
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_PreventDefault_StopPropagation_Minimized/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_PreventDefault_StopPropagation_Minimized/TestComponent.mappings.txt
@@ -1,6 +1,0 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_PreventDefault_StopPropagation_Minimized/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_PreventDefault_StopPropagation_Minimized/TestComponent.mappings.txt
@@ -1,0 +1,6 @@
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_WithDelegate_PreventDefault/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_WithDelegate_PreventDefault/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (61:1,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (61:1,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |OnFocus|
 Generated Location: (1055:26,17 [7] )
 |OnFocus|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_WithDelegate_PreventDefault/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventHandler_WithDelegate_PreventDefault/TestComponent.mappings.txt
@@ -1,4 +1,20 @@
-﻿Source Location: (130:2,7 [95] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (61:1,17 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+|OnFocus|
+Generated Location: (1055:26,17 [7] )
+|OnFocus|
+
+Source Location: (95:1,51 [22] x:\dir\subdir\Test\TestComponent.cshtml)
+|ShouldPreventDefault()|
+Generated Location: (1322:35,51 [22] )
+|ShouldPreventDefault()|
+
+Source Location: (130:2,7 [95] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     void OnFocus(FocusEventArgs e) { }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_CSharpError/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_CSharpError/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |() => { }|
 Generated Location: (1093:27,31 [9] )
 |() => { }|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_CSharpError/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_CSharpError/TestComponent.mappings.txt
@@ -1,0 +1,16 @@
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1093:27,31 [9] )
+|() => { }|
+
+Source Location: (98:1,54 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|x|
+Generated Location: (1419:36,54 [1] )
+|x|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_CSharpValue/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_CSharpValue/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |() => { }|
 Generated Location: (1093:27,31 [9] )
 |() => { }|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_CSharpValue/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_CSharpValue/TestComponent.mappings.txt
@@ -1,0 +1,16 @@
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1093:27,31 [9] )
+|() => { }|
+
+Source Location: (99:1,55 [20] x:\dir\subdir\Test\TestComponent.cshtml)
+|"named-form-handler"|
+Generated Location: (1420:36,55 [20] )
+|"named-form-handler"|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_CSharpValue_Integer/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_CSharpValue_Integer/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |() => { }|
 Generated Location: (1093:27,31 [9] )
 |() => { }|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_CSharpValue_Integer/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_CSharpValue_Integer/TestComponent.mappings.txt
@@ -1,4 +1,20 @@
-﻿Source Location: (117:2,7 [18] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1093:27,31 [9] )
+|() => { }|
+
+Source Location: (98:1,54 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|x|
+Generated Location: (1419:36,54 [1] )
+|x|
+
+Source Location: (117:2,7 [18] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     int x = 1;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_ChildContent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_ChildContent/TestComponent.mappings.txt
@@ -1,0 +1,11 @@
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (92:2,8 [12] x:\dir\subdir\Test\TestComponent.cshtml)
+|DateTime.Now|
+Generated Location: (1186:29,24 [12] )
+|DateTime.Now|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_ChildContent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_ChildContent/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (92:2,8 [12] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (92:2,8 [12] x:\dir\subdir\Test\TestComponent.cshtml)
 |DateTime.Now|
 Generated Location: (1186:29,24 [12] )
 |DateTime.Now|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Component/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Component/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (84:1,40 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (84:1,40 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |() => { }|
 Generated Location: (1142:27,40 [9] )
 |() => { }|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Component/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Component/TestComponent.mappings.txt
@@ -1,0 +1,21 @@
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (84:1,40 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1142:27,40 [9] )
+|() => { }|
+
+Source Location: (170:2,40 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1805:41,40 [9] )
+|() => { }|
+
+Source Location: (194:2,64 [20] x:\dir\subdir\Test\TestComponent.cshtml)
+|"named-form-handler"|
+Generated Location: (2079:50,64 [20] )
+|"named-form-handler"|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Component_Generic/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Component_Generic/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (55:1,11 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (55:1,11 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |T|
 Generated Location: (565:20,0 [1] )
 |T|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Component_Generic/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Component_Generic/TestComponent.mappings.txt
@@ -1,7 +1,38 @@
-﻿Source Location: (55:1,11 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (55:1,11 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |T|
 Generated Location: (565:20,0 [1] )
 |T|
+
+Source Location: (98:2,40 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1190:33,40 [9] )
+|() => { }|
+
+Source Location: (151:2,93 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|1|
+Generated Location: (1459:41,93 [1] )
+|1|
+
+Source Location: (198:3,40 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1905:51,40 [9] )
+|() => { }|
+
+Source Location: (222:3,64 [20] x:\dir\subdir\Test\TestComponent.cshtml)
+|"named-form-handler"|
+Generated Location: (2120:59,64 [20] )
+|"named-form-handler"|
+
+Source Location: (256:3,98 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|2|
+Generated Location: (2380:67,98 [1] )
+|2|
 
 Source Location: (270:4,7 [52] x:\dir\subdir\Test\TestComponent.cshtml)
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Component_Generic_RazorLangVersion7/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Component_Generic_RazorLangVersion7/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (55:1,11 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (55:1,11 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |T|
 Generated Location: (565:20,0 [1] )
 |T|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Component_Generic_RazorLangVersion7/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Component_Generic_RazorLangVersion7/TestComponent.mappings.txt
@@ -1,7 +1,38 @@
-﻿Source Location: (55:1,11 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (55:1,11 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |T|
 Generated Location: (565:20,0 [1] )
 |T|
+
+Source Location: (98:2,40 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1190:33,40 [9] )
+|() => { }|
+
+Source Location: (151:2,93 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|1|
+Generated Location: (1459:41,93 [1] )
+|1|
+
+Source Location: (198:3,40 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1905:51,40 [9] )
+|() => { }|
+
+Source Location: (222:3,64 [20] x:\dir\subdir\Test\TestComponent.cshtml)
+|"named-form-handler"|
+Generated Location: (2120:59,64 [20] )
+|"named-form-handler"|
+
+Source Location: (256:3,98 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|2|
+Generated Location: (2380:67,98 [1] )
+|2|
 
 Source Location: (270:4,7 [52] x:\dir\subdir\Test\TestComponent.cshtml)
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Component_RazorLangVersion7/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Component_RazorLangVersion7/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (84:1,40 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (84:1,40 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |() => { }|
 Generated Location: (1143:27,40 [9] )
 |() => { }|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Component_RazorLangVersion7/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Component_RazorLangVersion7/TestComponent.mappings.txt
@@ -1,0 +1,21 @@
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (84:1,40 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1143:27,40 [9] )
+|() => { }|
+
+Source Location: (170:2,40 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1809:41,40 [9] )
+|() => { }|
+
+Source Location: (194:2,64 [20] x:\dir\subdir\Test\TestComponent.cshtml)
+|"named-form-handler"|
+Generated Location: (2084:50,64 [20] )
+|"named-form-handler"|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Duplicate_CSharpValue/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Duplicate_CSharpValue/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |() => { }|
 Generated Location: (1093:27,31 [9] )
 |() => { }|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Duplicate_CSharpValue/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Duplicate_CSharpValue/TestComponent.mappings.txt
@@ -1,4 +1,25 @@
-﻿Source Location: (132:2,7 [44] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1093:27,31 [9] )
+|() => { }|
+
+Source Location: (98:1,54 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|x|
+Generated Location: (1419:36,54 [1] )
+|x|
+
+Source Location: (113:1,69 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|y|
+Generated Location: (1597:44,24 [1] )
+|y|
+
+Source Location: (132:2,7 [44] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string x = "a";
     string y = "b";

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Duplicate_HtmlValue/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Duplicate_HtmlValue/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |() => { }|
 Generated Location: (1093:27,31 [9] )
 |() => { }|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Duplicate_HtmlValue/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Duplicate_HtmlValue/TestComponent.mappings.txt
@@ -1,0 +1,11 @@
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1093:27,31 [9] )
+|() => { }|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_FakeSubmit/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_FakeSubmit/TestComponent.mappings.txt
@@ -1,0 +1,11 @@
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (161:2,45 [20] x:\dir\subdir\Test\TestComponent.cshtml)
+|"named-form-handler"|
+Generated Location: (1597:35,45 [20] )
+|"named-form-handler"|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_FakeSubmit/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_FakeSubmit/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (161:2,45 [20] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (161:2,45 [20] x:\dir\subdir\Test\TestComponent.cshtml)
 |"named-form-handler"|
 Generated Location: (1597:35,45 [20] )
 |"named-form-handler"|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_HtmlValue/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_HtmlValue/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |() => { }|
 Generated Location: (1093:27,31 [9] )
 |() => { }|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_HtmlValue/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_HtmlValue/TestComponent.mappings.txt
@@ -1,0 +1,11 @@
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1093:27,31 [9] )
+|() => { }|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_MissingSubmit/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_MissingSubmit/TestComponent.mappings.txt
@@ -1,0 +1,11 @@
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (137:2,33 [20] x:\dir\subdir\Test\TestComponent.cshtml)
+|"named-form-handler"|
+Generated Location: (1473:33,33 [20] )
+|"named-form-handler"|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_MissingSubmit/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_MissingSubmit/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (137:2,33 [20] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (137:2,33 [20] x:\dir\subdir\Test\TestComponent.cshtml)
 |"named-form-handler"|
 Generated Location: (1473:33,33 [20] )
 |"named-form-handler"|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_MissingUsing/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_MissingUsing/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (137:1,55 [20] x:\dir\subdir\Test\TestComponent.cshtml)
+|"named-form-handler"|
+Generated Location: (1463:28,55 [20] )
+|"named-form-handler"|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_MixedValue/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_MixedValue/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |() => { }|
 Generated Location: (1093:27,31 [9] )
 |() => { }|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_MixedValue/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_MixedValue/TestComponent.mappings.txt
@@ -1,4 +1,25 @@
-﻿Source Location: (140:2,7 [18] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1093:27,31 [9] )
+|() => { }|
+
+Source Location: (105:1,61 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|"literal"|
+Generated Location: (1443:36,61 [9] )
+|"literal"|
+
+Source Location: (117:1,73 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|x|
+Generated Location: (1672:44,73 [1] )
+|x|
+
+Source Location: (140:2,7 [18] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     int x = 1;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_MoreElements_CSharpValue/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_MoreElements_CSharpValue/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |() => { }|
 Generated Location: (1093:27,31 [9] )
 |() => { }|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_MoreElements_CSharpValue/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_MoreElements_CSharpValue/TestComponent.mappings.txt
@@ -1,4 +1,30 @@
-﻿Source Location: (183:3,7 [44] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1093:27,31 [9] )
+|() => { }|
+
+Source Location: (98:1,54 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|x|
+Generated Location: (1419:36,54 [1] )
+|x|
+
+Source Location: (141:2,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (2000:50,31 [9] )
+|() => { }|
+
+Source Location: (164:2,54 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|y|
+Generated Location: (2329:59,54 [1] )
+|y|
+
+Source Location: (183:3,7 [44] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string x = "a";
     string y = "b";

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_MoreElements_HtmlValue/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_MoreElements_HtmlValue/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |() => { }|
 Generated Location: (1093:27,31 [9] )
 |() => { }|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_MoreElements_HtmlValue/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_MoreElements_HtmlValue/TestComponent.mappings.txt
@@ -1,0 +1,16 @@
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1093:27,31 [9] )
+|() => { }|
+
+Source Location: (140:2,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1812:42,31 [9] )
+|() => { }|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Nested/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Nested/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |() => { }|
 Generated Location: (1093:27,31 [9] )
 |() => { }|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Nested/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Nested/TestComponent.mappings.txt
@@ -1,4 +1,30 @@
-﻿Source Location: (405:9,7 [68] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1093:27,31 [9] )
+|() => { }|
+
+Source Location: (161:3,35 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (2030:44,35 [9] )
+|() => { }|
+
+Source Location: (255:5,39 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (3031:61,39 [9] )
+|() => { }|
+
+Source Location: (346:7,35 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (3908:79,35 [9] )
+|() => { }|
+
+Source Location: (405:9,7 [68] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     [Parameter] public RenderFragment ChildContent { get; set; }
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_NoAddNamedEventMethod/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_NoAddNamedEventMethod/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |() => { }|
 Generated Location: (1093:27,31 [9] )
 |() => { }|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_NoAddNamedEventMethod/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_NoAddNamedEventMethod/TestComponent.mappings.txt
@@ -1,0 +1,11 @@
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1093:27,31 [9] )
+|() => { }|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_NotAForm/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_NotAForm/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (74:1,30 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (74:1,30 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |() => { }|
 Generated Location: (1091:27,30 [9] )
 |() => { }|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_NotAForm/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_NotAForm/TestComponent.mappings.txt
@@ -1,0 +1,21 @@
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (74:1,30 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1091:27,30 [9] )
+|() => { }|
+
+Source Location: (154:2,30 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1692:41,30 [9] )
+|() => { }|
+
+Source Location: (178:2,54 [20] x:\dir\subdir\Test\TestComponent.cshtml)
+|"named-form-handler"|
+Generated Location: (1947:50,54 [20] )
+|"named-form-handler"|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_NotAForm_RazorLangVersion7/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_NotAForm_RazorLangVersion7/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (74:1,30 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (74:1,30 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |() => { }|
 Generated Location: (1091:27,30 [9] )
 |() => { }|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_NotAForm_RazorLangVersion7/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_NotAForm_RazorLangVersion7/TestComponent.mappings.txt
@@ -1,0 +1,21 @@
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (74:1,30 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1091:27,30 [9] )
+|() => { }|
+
+Source Location: (154:2,30 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1692:41,30 [9] )
+|() => { }|
+
+Source Location: (178:2,54 [20] x:\dir\subdir\Test\TestComponent.cshtml)
+|"named-form-handler"|
+Generated Location: (1947:50,54 [20] )
+|"named-form-handler"|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Nullability/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Nullability/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |() => { }|
 Generated Location: (1093:27,31 [9] )
 |() => { }|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Nullability/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Nullability/TestComponent.mappings.txt
@@ -1,0 +1,16 @@
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1093:27,31 [9] )
+|() => { }|
+
+Source Location: (98:1,54 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|null|
+Generated Location: (1419:36,54 [4] )
+|null|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_RazorError/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_RazorError/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |() => { }|
 Generated Location: (1093:27,31 [9] )
 |() => { }|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_RazorError/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_RazorError/TestComponent.mappings.txt
@@ -1,0 +1,11 @@
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1093:27,31 [9] )
+|() => { }|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_RazorLangVersion7/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_RazorLangVersion7/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 |() => { }|
 Generated Location: (1093:27,31 [9] )
 |() => { }|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_RazorLangVersion7/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_RazorLangVersion7/TestComponent.mappings.txt
@@ -1,0 +1,11 @@
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (75:1,31 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|() => { }|
+Generated Location: (1093:27,31 [9] )
+|() => { }|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.mappings.txt
@@ -3,6 +3,16 @@
 Generated Location: (401:13,0 [6] )
 |TParam|
 
+Source Location: (65:1,46 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (1045:27,46 [11] )
+|ParentValue|
+
+Source Location: (95:1,76 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1670:36,76 [11] )
+|UpdateValue|
+
 Source Location: (119:2,7 [128] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public TParam ParentValue { get; set; } = default;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.mappings.txt
@@ -3,6 +3,16 @@
 Generated Location: (401:13,0 [6] )
 |TParam|
 
+Source Location: (65:1,46 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (1045:27,46 [11] )
+|ParentValue|
+
+Source Location: (95:1,76 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1670:36,76 [11] )
+|UpdateValue|
+
 Source Location: (119:2,7 [118] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public TParam ParentValue { get; set; } = default;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.mappings.txt
@@ -3,6 +3,16 @@
 Generated Location: (401:13,0 [6] )
 |TParam|
 
+Source Location: (65:1,46 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (1045:27,46 [11] )
+|ParentValue|
+
+Source Location: (95:1,76 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1670:36,76 [11] )
+|UpdateValue|
+
 Source Location: (119:2,7 [155] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public TParam ParentValue { get; set; } = default;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.mappings.txt
@@ -3,6 +3,16 @@
 Generated Location: (401:13,0 [6] )
 |TParam|
 
+Source Location: (65:1,46 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (1045:27,46 [11] )
+|ParentValue|
+
+Source Location: (97:1,78 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+|Update|
+Generated Location: (1505:36,78 [6] )
+|Update|
+
 Source Location: (116:2,7 [79] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public TParam ParentValue { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithAfter_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithAfter_Action/TestComponent.mappings.txt
@@ -3,6 +3,16 @@
 Generated Location: (401:13,0 [6] )
 |TParam|
 
+Source Location: (49:1,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (907:26,30 [11] )
+|ParentValue|
+
+Source Location: (81:1,62 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+|Update|
+Generated Location: (1256:34,62 [6] )
+|Update|
+
 Source Location: (100:2,7 [79] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public TParam ParentValue { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_Action/TestComponent.mappings.txt
@@ -3,6 +3,16 @@
 Generated Location: (401:13,0 [6] )
 |TParam|
 
+Source Location: (49:1,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (907:26,30 [11] )
+|ParentValue|
+
+Source Location: (79:1,60 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1300:34,60 [11] )
+|UpdateValue|
+
 Source Location: (103:2,7 [128] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public TParam ParentValue { get; set; } = default;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_EventCallback/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_EventCallback/TestComponent.mappings.txt
@@ -3,6 +3,16 @@
 Generated Location: (401:13,0 [6] )
 |TParam|
 
+Source Location: (49:1,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (907:26,30 [11] )
+|ParentValue|
+
+Source Location: (79:1,60 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1300:34,60 [11] )
+|UpdateValue|
+
 Source Location: (103:2,7 [118] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public TParam ParentValue { get; set; } = default;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_Function/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_InferredType_WithGetSet_Function/TestComponent.mappings.txt
@@ -3,6 +3,16 @@
 Generated Location: (401:13,0 [6] )
 |TParam|
 
+Source Location: (49:1,30 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentValue|
+Generated Location: (907:26,30 [11] )
+|ParentValue|
+
+Source Location: (79:1,60 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|UpdateValue|
+Generated Location: (1300:34,60 [11] )
+|UpdateValue|
+
 Source Location: (103:2,7 [155] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public TParam ParentValue { get; set; } = default;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_GenericEventCallbackWithGenericTypeParameter_NestedTypeExplicit/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_GenericEventCallbackWithGenericTypeParameter_NestedTypeExplicit/TestComponent.mappings.txt
@@ -1,5 +1,16 @@
-﻿Source Location: (11:0,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (20:1,1 [12] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Test
+|
+Generated Location: (360:12,0 [12] )
+|using Test;|
+
+Source Location: (11:0,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |TChild|
 Generated Location: (534:20,0 [6] )
 |TChild|
+
+Source Location: (69:2,37 [16] x:\dir\subdir\Test\TestComponent.cshtml)
+|(TChild x) => {}|
+Generated Location: (1309:34,37 [16] )
+|(TChild x) => {}|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_GenericEventCallbackWithGenericTypeParameter_NestedTypeExplicit/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_GenericEventCallbackWithGenericTypeParameter_NestedTypeExplicit/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (20:1,1 [12] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Test
-|
-Generated Location: (360:12,0 [12] )
-|using Test;|
-
-Source Location: (11:0,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (11:0,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |TChild|
 Generated Location: (534:20,0 [6] )
 |TChild|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_GenericEventCallbackWithGenericTypeParameter_NestedTypeInference/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_GenericEventCallbackWithGenericTypeParameter_NestedTypeInference/TestComponent.mappings.txt
@@ -1,7 +1,23 @@
-﻿Source Location: (11:0,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (20:1,1 [12] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Test
+|
+Generated Location: (360:12,0 [12] )
+|using Test;|
+
+Source Location: (11:0,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |TChild|
 Generated Location: (534:20,0 [6] )
 |TChild|
+
+Source Location: (51:2,19 [9] x:\dir\subdir\Test\TestComponent.cshtml)
+|ChildItem|
+Generated Location: (1029:33,19 [9] )
+|ChildItem|
+
+Source Location: (71:2,39 [12] x:\dir\subdir\Test\TestComponent.cshtml)
+|MyChildEvent|
+Generated Location: (1293:41,39 [12] )
+|MyChildEvent|
 
 Source Location: (97:4,1 [138] x:\dir\subdir\Test\TestComponent.cshtml)
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_GenericEventCallbackWithGenericTypeParameter_NestedTypeInference/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_GenericEventCallbackWithGenericTypeParameter_NestedTypeInference/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (20:1,1 [12] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Test
-|
-Generated Location: (360:12,0 [12] )
-|using Test;|
-
-Source Location: (11:0,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (11:0,11 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |TChild|
 Generated Location: (534:20,0 [6] )
 |TChild|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_GenericEventCallbackWithGenericTypeParameter_TypeInference/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_GenericEventCallbackWithGenericTypeParameter_TypeInference/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [12] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Test
-|
-Generated Location: (360:12,0 [12] )
-|using Test;|
-
-Source Location: (32:1,19 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (32:1,19 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |3|
 Generated Location: (893:25,19 [1] )
 |3|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_GenericEventCallbackWithGenericTypeParameter_TypeInference/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_GenericEventCallbackWithGenericTypeParameter_TypeInference/TestComponent.mappings.txt
@@ -1,0 +1,16 @@
+﻿Source Location: (1:0,1 [12] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Test
+|
+Generated Location: (360:12,0 [12] )
+|using Test;|
+
+Source Location: (32:1,19 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|3|
+Generated Location: (893:25,19 [1] )
+|3|
+
+Source Location: (44:1,31 [13] x:\dir\subdir\Test\TestComponent.cshtml)
+|(int x) => {}|
+Generated Location: (1141:33,31 [13] )
+|(int x) => {}|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_GenericEventCallbackWithNestedGenericTypeParameter_TypeInference/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_GenericEventCallbackWithNestedGenericTypeParameter_TypeInference/TestComponent.mappings.txt
@@ -1,0 +1,22 @@
+﻿Source Location: (1:0,1 [12] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Test
+|
+Generated Location: (313:11,0 [12] )
+|using Test;|
+
+Source Location: (14:1,1 [34] x:\dir\subdir\Test\TestComponent.cshtml)
+|using System.Collections.Generic
+|
+Generated Location: (446:18,0 [34] )
+|using System.Collections.Generic;|
+
+Source Location: (67:2,19 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|3|
+Generated Location: (1001:31,19 [1] )
+|3|
+
+Source Location: (79:2,31 [26] x:\dir\subdir\Test\TestComponent.cshtml)
+|(IEnumerable<int> x) => {}|
+Generated Location: (1249:39,31 [26] )
+|(IEnumerable<int> x) => {}|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_GenericEventCallbackWithNestedGenericTypeParameter_TypeInference/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_GenericEventCallbackWithNestedGenericTypeParameter_TypeInference/TestComponent.mappings.txt
@@ -1,16 +1,4 @@
-﻿Source Location: (1:0,1 [12] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Test
-|
-Generated Location: (313:11,0 [12] )
-|using Test;|
-
-Source Location: (14:1,1 [34] x:\dir\subdir\Test\TestComponent.cshtml)
-|using System.Collections.Generic
-|
-Generated Location: (446:18,0 [34] )
-|using System.Collections.Generic;|
-
-Source Location: (67:2,19 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (67:2,19 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |3|
 Generated Location: (1001:31,19 [1] )
 |3|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_GenericEventCallback_TypeInference/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_GenericEventCallback_TypeInference/TestComponent.mappings.txt
@@ -1,0 +1,16 @@
+﻿Source Location: (1:0,1 [12] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Test
+|
+Generated Location: (360:12,0 [12] )
+|using Test;|
+
+Source Location: (32:1,19 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|3|
+Generated Location: (893:25,19 [1] )
+|3|
+
+Source Location: (44:1,31 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+|x => {}|
+Generated Location: (1167:33,31 [7] )
+|x => {}|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_GenericEventCallback_TypeInference/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_GenericEventCallback_TypeInference/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [12] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Test
-|
-Generated Location: (360:12,0 [12] )
-|using Test;|
-
-Source Location: (32:1,19 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (32:1,19 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |3|
 Generated Location: (893:25,19 [1] )
 |3|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_NestedGenericEventCallback_TypeInference/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_NestedGenericEventCallback_TypeInference/TestComponent.mappings.txt
@@ -1,0 +1,16 @@
+﻿Source Location: (1:0,1 [12] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Test
+|
+Generated Location: (360:12,0 [12] )
+|using Test;|
+
+Source Location: (32:1,19 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|3|
+Generated Location: (893:25,19 [1] )
+|3|
+
+Source Location: (44:1,31 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+|x => {}|
+Generated Location: (1256:33,31 [7] )
+|x => {}|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_NestedGenericEventCallback_TypeInference/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_NestedGenericEventCallback_TypeInference/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [12] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Test
-|
-Generated Location: (360:12,0 [12] )
-|using Test;|
-
-Source Location: (32:1,19 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (32:1,19 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |3|
 Generated Location: (893:25,19 [1] )
 |3|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_NonGenericEventCallback_TypeInference/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_NonGenericEventCallback_TypeInference/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [12] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Test
-|
-Generated Location: (360:12,0 [12] )
-|using Test;|
-
-Source Location: (32:1,19 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (32:1,19 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |3|
 Generated Location: (893:25,19 [1] )
 |3|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_NonGenericEventCallback_TypeInference/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_NonGenericEventCallback_TypeInference/TestComponent.mappings.txt
@@ -1,0 +1,16 @@
+﻿Source Location: (1:0,1 [12] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Test
+|
+Generated Location: (360:12,0 [12] )
+|using Test;|
+
+Source Location: (32:1,19 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|3|
+Generated Location: (893:25,19 [1] )
+|3|
+
+Source Location: (44:1,31 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+|x => {}|
+Generated Location: (1141:33,31 [7] )
+|x => {}|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_NonGenericParameter_TypeInference/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_NonGenericParameter_TypeInference/TestComponent.mappings.txt
@@ -1,4 +1,20 @@
-﻿Source Location: (68:3,7 [38] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [19] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Test.Shared
+|
+Generated Location: (360:12,0 [19] )
+|using Test.Shared;|
+
+Source Location: (39:1,19 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|3|
+Generated Location: (900:25,19 [1] )
+|3|
+
+Source Location: (48:1,28 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Hello|
+Generated Location: (1070:33,28 [5] )
+|Hello|
+
+Source Location: (68:3,7 [38] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     MyClass Hello = new MyClass();
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_NonGenericParameter_TypeInference/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_NonGenericParameter_TypeInference/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [19] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Test.Shared
-|
-Generated Location: (360:12,0 [19] )
-|using Test.Shared;|
-
-Source Location: (39:1,19 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (39:1,19 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |3|
 Generated Location: (900:25,19 [1] )
 |3|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_NonPrimitiveType/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_NonPrimitiveType/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (38:0,38 [16] x:\dir\subdir\Test\TestComponent.cshtml)
+|new CustomType()|
+Generated Location: (908:19,38 [16] )
+|new CustomType()|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_NonPrimitiveTypeRenderFragment/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_NonPrimitiveTypeRenderFragment/TestComponent.mappings.txt
@@ -1,0 +1,10 @@
+﻿Source Location: (19:0,19 [16] x:\dir\subdir\Test\TestComponent.cshtml)
+|new CustomType()|
+Generated Location: (760:18,19 [16] )
+|new CustomType()|
+
+Source Location: (38:0,38 [18] x:\dir\subdir\Test\TestComponent.cshtml)
+|context.ToString()|
+Generated Location: (987:26,25 [18] )
+|context.ToString()|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_TypeParameterOrdering/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_TypeParameterOrdering/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (191:3,7 [46] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (70:0,70 [15] x:\dir\subdir\Test\TestComponent.cshtml)
+|_componentValue|
+Generated Location: (953:19,70 [15] )
+|_componentValue|
+
+Source Location: (161:1,70 [15] x:\dir\subdir\Test\TestComponent.cshtml)
+|_componentValue|
+Generated Location: (1970:32,70 [15] )
+|_componentValue|
+
+Source Location: (191:3,7 [46] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string _componentValue = string.Empty;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_UnmanagedConstraint/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_UnmanagedConstraint/TestComponent.mappings.txt
@@ -1,0 +1,11 @@
+﻿Source Location: (1:0,1 [12] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Test
+|
+Generated Location: (360:12,0 [12] )
+|using Test;|
+
+Source Location: (37:1,24 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|1|
+Generated Location: (898:25,24 [1] )
+|1|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_UnmanagedConstraint/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_UnmanagedConstraint/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [12] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Test
-|
-Generated Location: (360:12,0 [12] )
-|using Test;|
-
-Source Location: (37:1,24 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (37:1,24 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |1|
 Generated Location: (898:25,24 [1] )
 |1|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithComponentRef_CreatesDiagnostic/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithComponentRef_CreatesDiagnostic/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (38:0,38 [3] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (29:0,29 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|3|
+Generated Location: (885:19,29 [1] )
+|3|
+
+Source Location: (38:0,38 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |_my|
 Generated Location: (1133:28,38 [3] )
 |_my|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithComponentRef_TypeInference_CreatesDiagnostic/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithComponentRef_TypeInference_CreatesDiagnostic/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (28:0,28 [3] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (19:0,19 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|3|
+Generated Location: (760:18,19 [1] )
+|3|
+
+Source Location: (28:0,28 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |_my|
 Generated Location: (944:26,28 [3] )
 |_my|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithFullyQualifiedTagName/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithFullyQualifiedTagName/TestComponent.mappings.txt
@@ -1,0 +1,10 @@
+﻿Source Location: (26:0,26 [4] x:\dir\subdir\Test\TestComponent.cshtml)
+|"hi"|
+Generated Location: (772:18,26 [4] )
+|"hi"|
+
+Source Location: (43:1,8 [17] x:\dir\subdir\Test\TestComponent.cshtml)
+|context.ToLower()|
+Generated Location: (1037:27,25 [17] )
+|context.ToLower()|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithKey/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithKey/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (38:0,38 [8] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (29:0,29 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|3|
+Generated Location: (885:19,29 [1] )
+|3|
+
+Source Location: (38:0,38 [8] x:\dir\subdir\Test\TestComponent.cshtml)
 |_someKey|
 Generated Location: (1094:28,38 [8] )
 |_someKey|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithKey_TypeInference/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithKey_TypeInference/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (28:0,28 [8] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (19:0,19 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|3|
+Generated Location: (760:18,19 [1] )
+|3|
+
+Source Location: (28:0,28 [8] x:\dir\subdir\Test\TestComponent.cshtml)
 |_someKey|
 Generated Location: (930:26,28 [8] )
 |_someKey|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/IncludesMinimizedAttributeValueParameterBeforeLanguageVersion5/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/IncludesMinimizedAttributeValueParameterBeforeLanguageVersion5/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (21:0,21 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|"val"|
+Generated Location: (763:19,21 [5] )
+|"val"|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LeadingWhiteSpace_WithCSharpExpression/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LeadingWhiteSpace_WithCSharpExpression/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (2:0,2 [10] x:\dir\subdir\Test\TestComponent.cshtml)
+|"My value"|
+Generated Location: (678:17,24 [10] )
+|"My value"|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LeadingWhiteSpace_WithComponent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LeadingWhiteSpace_WithComponent/TestComponent.mappings.txt
@@ -1,0 +1,10 @@
+﻿Source Location: (48:1,26 [12] x:\dir\subdir\Test\TestComponent.cshtml)
+|DateTime.Now|
+Generated Location: (998:21,25 [12] )
+|DateTime.Now|
+
+Source Location: (81:2,14 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+|"good"|
+Generated Location: (1380:32,25 [6] )
+|"good"|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.mappings.txt
@@ -1,6 +1,0 @@
-﻿Source Location: (1:0,1 [14] x:\dir\subdir\Test\TestComponent.cshtml)
-|using System
-|
-Generated Location: (333:11,0 [14] )
-|using System;|
-

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LeadingWhiteSpace_WithDirective/TestComponent.mappings.txt
@@ -1,0 +1,6 @@
+﻿Source Location: (1:0,1 [14] x:\dir\subdir\Test\TestComponent.cshtml)
+|using System
+|
+Generated Location: (333:11,0 [14] )
+|using System;|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_LeadingWhiteSpace_WithCSharpExpression/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_LeadingWhiteSpace_WithCSharpExpression/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (2:0,2 [10] x:\dir\subdir\Test\TestComponent.cshtml)
+|"My value"|
+Generated Location: (678:17,24 [10] )
+|"My value"|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_LeadingWhiteSpace_WithComponent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_LeadingWhiteSpace_WithComponent/TestComponent.mappings.txt
@@ -1,0 +1,10 @@
+﻿Source Location: (48:1,26 [12] x:\dir\subdir\Test\TestComponent.cshtml)
+|DateTime.Now|
+Generated Location: (1059:22,25 [12] )
+|DateTime.Now|
+
+Source Location: (81:2,14 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+|"good"|
+Generated Location: (1441:33,25 [6] )
+|"good"|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_LeadingWhiteSpace_WithDirective/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_LeadingWhiteSpace_WithDirective/TestComponent.mappings.txt
@@ -1,6 +1,0 @@
-﻿Source Location: (1:0,1 [14] x:\dir\subdir\Test\TestComponent.cshtml)
-|using System
-|
-Generated Location: (333:11,0 [14] )
-|using System;|
-

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_LeadingWhiteSpace_WithDirective/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_LeadingWhiteSpace_WithDirective/TestComponent.mappings.txt
@@ -1,0 +1,6 @@
+﻿Source Location: (1:0,1 [14] x:\dir\subdir\Test\TestComponent.cshtml)
+|using System
+|
+Generated Location: (333:11,0 [14] )
+|using System;|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_TrailingWhiteSpace_WithCSharpExpression/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_TrailingWhiteSpace_WithCSharpExpression/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (20:2,2 [10] x:\dir\subdir\Test\TestComponent.cshtml)
+|"My value"|
+Generated Location: (748:18,24 [10] )
+|"My value"|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_WhiteSpace_InMarkupInFunctionsBlock/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_WhiteSpace_InMarkupInFunctionsBlock/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [49] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Rendering
-|
-Generated Location: (360:12,0 [49] )
-|using Microsoft.AspNetCore.Components.Rendering;|
-
-Source Location: (57:1,7 [57] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (57:1,7 [57] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     void MyMethod(RenderTreeBuilder __builder)
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_WhiteSpace_InMarkupInFunctionsBlock/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_WhiteSpace_InMarkupInFunctionsBlock/TestComponent.mappings.txt
@@ -1,4 +1,10 @@
-﻿Source Location: (57:1,7 [57] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [49] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Rendering
+|
+Generated Location: (360:12,0 [49] )
+|using Microsoft.AspNetCore.Components.Rendering;|
+
+Source Location: (57:1,7 [57] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     void MyMethod(RenderTreeBuilder __builder)
     {
@@ -17,6 +23,11 @@ Generated Location: (1191:38,13 [46] )
 |for (var i = 0; i < 100; i++)
             {
 |
+
+Source Location: (230:8,21 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|i|
+Generated Location: (1559:49,24 [1] )
+|i|
 
 Source Location: (256:10,0 [15] x:\dir\subdir\Test\TestComponent.cshtml)
 |            }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_Whitespace_BetweenElementAndFunctions/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_Whitespace_BetweenElementAndFunctions/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (31:1,11 [29] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (12:0,12 [3] x:\dir\subdir\Test\TestComponent.cshtml)
+|Foo|
+Generated Location: (747:19,12 [3] )
+|Foo|
+
+Source Location: (31:1,11 [29] x:\dir\subdir\Test\TestComponent.cshtml)
 |
         int Foo = 18;
     |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LinePragma_Multiline/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LinePragma_Multiline/TestComponent.mappings.txt
@@ -1,0 +1,7 @@
+﻿Source Location: (2:0,2 [8] x:\dir\subdir\Test\TestComponent.cshtml)
+|"text"
+|
+Generated Location: (677:17,24 [8] )
+|"text"
+|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/MarkupComment_IsNotIncluded/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/MarkupComment_IsNotIncluded/TestComponent.mappings.txt
@@ -7,3 +7,8 @@ Generated Location: (642:17,2 [39] )
   var myValue = "Expression value";
 |
 
+Source Location: (50:3,6 [7] x:\dir\subdir\Test\TestComponent.cshtml)
+|myValue|
+Generated Location: (885:26,24 [7] )
+|myValue|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/MultipleExplictChildContent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/MultipleExplictChildContent/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (55:2,14 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+|"bye!"|
+Generated Location: (1077:23,25 [6] )
+|"bye!"|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/OmitsMinimizedAttributeValueParameter/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/OmitsMinimizedAttributeValueParameter/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (21:0,21 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|"val"|
+Generated Location: (763:19,21 [5] )
+|"val"|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ProducesEnhancedLinePragmaWhenNecessary/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ProducesEnhancedLinePragmaWhenNecessary/TestComponent.mappings.txt
@@ -1,4 +1,20 @@
-﻿Source Location: (166:11,7 [79] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (41:2,7 [12] x:\dir\subdir\Test\TestComponent.cshtml)
+|DateTime.Now|
+Generated Location: (770:18,24 [12] )
+|DateTime.Now|
+
+Source Location: (96:6,1 [59] x:\dir\subdir\Test\TestComponent.cshtml)
+|JsonToHtml(@"{
+  'key1': 'value1'
+  'key2': 'value2'
+}")|
+Generated Location: (1090:27,24 [59] )
+|JsonToHtml(@"{
+  'key1': 'value1'
+  'key2': 'value2'
+}")|
+
+Source Location: (166:11,7 [79] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string JsonToHtml(string foo)
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ProducesStandardLinePragmaForCSharpCode/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ProducesStandardLinePragmaForCSharpCode/TestComponent.mappings.txt
@@ -7,6 +7,11 @@ Generated Location: (719:18,1 [33] )
 {
 |
 
+Source Location: (74:3,8 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|i|
+Generated Location: (954:27,24 [1] )
+|i|
+
 Source Location: (81:4,0 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |}
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_AsComponentParameter_MixedContent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_AsComponentParameter_MixedContent/TestComponent.mappings.txt
@@ -3,8 +3,23 @@
 Generated Location: (642:17,2 [54] )
 | RenderFragment<Test.Context> template = (context) => |
 
+Source Location: (63:0,63 [13] x:\dir\subdir\Test\TestComponent.cshtml)
+|context.Index|
+Generated Location: (987:27,25 [13] )
+|context.Index|
+
+Source Location: (80:0,80 [22] x:\dir\subdir\Test\TestComponent.cshtml)
+|context.Item.ToLower()|
+Generated Location: (1215:35,25 [22] )
+|context.Item.ToLower()|
+
 Source Location: (107:0,107 [2] x:\dir\subdir\Test\TestComponent.cshtml)
 |; |
 Generated Location: (1527:44,107 [2] )
 |; |
+
+Source Location: (136:1,24 [8] x:\dir\subdir\Test\TestComponent.cshtml)
+|template|
+Generated Location: (1874:53,24 [8] )
+|template|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_ContainsComponent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_ContainsComponent/TestComponent.mappings.txt
@@ -5,6 +5,11 @@ Generated Location: (642:17,2 [45] )
 |
     RenderFragment<Person> p = (person) => |
 
+Source Location: (73:1,69 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|person.Name|
+Generated Location: (1199:29,69 [11] )
+|person.Name|
+
 Source Location: (93:1,89 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_FollowedByComponent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_FollowedByComponent/TestComponent.mappings.txt
@@ -5,12 +5,22 @@ Generated Location: (642:17,2 [45] )
 |
     RenderFragment<Person> p = (person) => |
 
+Source Location: (73:1,69 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|person.Name|
+Generated Location: (1199:29,69 [11] )
+|person.Name|
+
 Source Location: (93:1,89 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |;
 |
 Generated Location: (1547:40,89 [3] )
 |;
 |
+
+Source Location: (116:4,2 [15] x:\dir\subdir\Test\TestComponent.cshtml)
+|"hello, world!"|
+Generated Location: (1906:49,25 [15] )
+|"hello, world!"|
 
 Source Location: (159:7,7 [76] x:\dir\subdir\Test\TestComponent.cshtml)
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_Generic_AsComponentParameter/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_Generic_AsComponentParameter/TestComponent.mappings.txt
@@ -3,8 +3,18 @@
 Generated Location: (642:17,2 [47] )
 | RenderFragment<Person> template = (person) => |
 
+Source Location: (56:0,56 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|person.Name|
+Generated Location: (933:26,25 [11] )
+|person.Name|
+
 Source Location: (73:0,73 [2] x:\dir\subdir\Test\TestComponent.cshtml)
 |; |
 Generated Location: (1200:35,73 [2] )
 |; |
+
+Source Location: (108:1,30 [8] x:\dir\subdir\Test\TestComponent.cshtml)
+|template|
+Generated Location: (1558:44,30 [8] )
+|template|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_Generic_InImplicitExpression/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_Generic_InImplicitExpression/TestComponent.mappings.txt
@@ -1,4 +1,19 @@
-﻿Source Location: (60:1,7 [138] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [25] x:\dir\subdir\Test\TestComponent.cshtml)
+|RenderPerson((person) => |
+Generated Location: (678:17,24 [25] )
+|RenderPerson((person) => |
+
+Source Location: (33:0,33 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|person.Name|
+Generated Location: (871:21,25 [11] )
+|person.Name|
+
+Source Location: (50:0,50 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|)|
+Generated Location: (971:28,0 [1] )
+|)|
+
+Source Location: (60:1,7 [138] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     class Person
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_InCodeBlock/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_InCodeBlock/TestComponent.mappings.txt
@@ -5,6 +5,11 @@ Generated Location: (642:17,2 [45] )
 |
     RenderFragment<Person> p = (person) => |
 
+Source Location: (54:1,50 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|person.Name|
+Generated Location: (931:27,25 [11] )
+|person.Name|
+
 Source Location: (71:1,67 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_InExplicitExpression/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_InExplicitExpression/TestComponent.mappings.txt
@@ -1,4 +1,19 @@
-﻿Source Location: (62:1,7 [138] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (2:0,2 [25] x:\dir\subdir\Test\TestComponent.cshtml)
+|RenderPerson((person) => |
+Generated Location: (678:17,24 [25] )
+|RenderPerson((person) => |
+
+Source Location: (34:0,34 [11] x:\dir\subdir\Test\TestComponent.cshtml)
+|person.Name|
+Generated Location: (871:21,25 [11] )
+|person.Name|
+
+Source Location: (51:0,51 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|)|
+Generated Location: (971:28,0 [1] )
+|)|
+
+Source Location: (62:1,7 [138] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     class Person
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_NonGeneric_AsComponentParameter/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_NonGeneric_AsComponentParameter/TestComponent.mappings.txt
@@ -8,3 +8,8 @@ Source Location: (45:0,45 [2] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (950:27,45 [2] )
 |; |
 
+Source Location: (72:1,22 [8] x:\dir\subdir\Test\TestComponent.cshtml)
+|template|
+Generated Location: (1222:36,22 [8] )
+|template|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_NonGeneric_InImplicitExpression/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_NonGeneric_InImplicitExpression/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (38:1,7 [54] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [13] x:\dir\subdir\Test\TestComponent.cshtml)
+|RenderPerson(|
+Generated Location: (678:17,24 [13] )
+|RenderPerson(|
+
+Source Location: (28:0,28 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|)|
+Generated Location: (767:20,0 [1] )
+|)|
+
+Source Location: (38:1,7 [54] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     object RenderPerson(RenderFragment p) => null;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_597/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_597/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (32:1,7 [24] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (18:0,18 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|y|
+Generated Location: (775:19,18 [1] )
+|y|
+
+Source Location: (32:1,7 [24] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     string y = null;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_609/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_609/TestComponent.mappings.txt
@@ -1,4 +1,14 @@
-﻿Source Location: (73:2,7 [88] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (19:0,19 [8] x:\dir\subdir\Test\TestComponent.cshtml)
+|UserName|
+Generated Location: (776:19,19 [8] )
+|UserName|
+
+Source Location: (46:0,46 [12] x:\dir\subdir\Test\TestComponent.cshtml)
+|UserIsActive|
+Generated Location: (1241:29,46 [12] )
+|UserIsActive|
+
+Source Location: (73:2,7 [88] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string UserName { get; set; }
     public bool UserIsActive { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_784/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_784/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Web
-|
-Generated Location: (360:12,0 [43] )
-|using Microsoft.AspNetCore.Components.Web;|
-
-Source Location: (61:1,17 [16] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (61:1,17 [16] x:\dir\subdir\Test\TestComponent.cshtml)
 |OnComponentHover|
 Generated Location: (1055:26,17 [16] )
 |OnComponentHover|

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_784/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Regression_784/TestComponent.mappings.txt
@@ -1,4 +1,20 @@
-﻿Source Location: (126:2,7 [130] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [43] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Web
+|
+Generated Location: (360:12,0 [43] )
+|using Microsoft.AspNetCore.Components.Web;|
+
+Source Location: (61:1,17 [16] x:\dir\subdir\Test\TestComponent.cshtml)
+|OnComponentHover|
+Generated Location: (1055:26,17 [16] )
+|OnComponentHover|
+
+Source Location: (99:1,55 [13] x:\dir\subdir\Test\TestComponent.cshtml)
+|ParentBgColor|
+Generated Location: (1337:35,55 [13] )
+|ParentBgColor|
+
+Source Location: (126:2,7 [130] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public string ParentBgColor { get; set; } = "#FFFFFF";
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_With_TypeInference/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RenderMode_With_TypeInference/TestComponent.mappings.txt
@@ -13,6 +13,11 @@ Source Location: (127:2,28 [15] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1106:33,28 [15] )
 |RenderModeParam|
 
+Source Location: (161:2,62 [53] x:\dir\subdir\Test\TestComponent.cshtml)
+|Microsoft.AspNetCore.Components.Web.RenderMode.Server|
+Generated Location: (1324:41,62 [53] )
+|Microsoft.AspNetCore.Components.Web.RenderMode.Server|
+
 Source Location: (230:5,1 [67] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     [Parameter] public TRenderMode RenderModeParam { get; set;}

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/SingleLineControlFlowStatements_InCodeBlock/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/SingleLineControlFlowStatements_InCodeBlock/TestComponent.mappings.txt
@@ -1,11 +1,4 @@
-﻿Source Location: (1:0,1 [51] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.RenderTree;
-|
-Generated Location: (360:12,0 [51] )
-|using Microsoft.AspNetCore.Components.RenderTree;
-|
-
-Source Location: (56:2,2 [134] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (56:2,2 [134] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     var output = string.Empty;
     if (__builder == null) output = "Builder is null!";

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/SingleLineControlFlowStatements_InCodeBlock/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/SingleLineControlFlowStatements_InCodeBlock/TestComponent.mappings.txt
@@ -1,4 +1,11 @@
-﻿Source Location: (56:2,2 [134] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [51] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.RenderTree;
+|
+Generated Location: (360:12,0 [51] )
+|using Microsoft.AspNetCore.Components.RenderTree;
+|
+
+Source Location: (56:2,2 [134] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     var output = string.Empty;
     if (__builder == null) output = "Builder is null!";
@@ -10,4 +17,9 @@ Generated Location: (813:24,2 [134] )
     if (__builder == null) output = "Builder is null!";
     else output = "Builder is not null!";
 |
+
+Source Location: (206:6,16 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+|output|
+Generated Location: (1200:36,24 [6] )
+|output|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/SingleLineControlFlowStatements_InCodeDirective/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/SingleLineControlFlowStatements_InCodeDirective/TestComponent.mappings.txt
@@ -1,11 +1,4 @@
-﻿Source Location: (1:0,1 [50] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Rendering;
-|
-Generated Location: (360:12,0 [50] )
-|using Microsoft.AspNetCore.Components.Rendering;
-|
-
-Source Location: (60:2,7 [213] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (60:2,7 [213] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     void RenderChildComponent(RenderTreeBuilder __builder)
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/SingleLineControlFlowStatements_InCodeDirective/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/SingleLineControlFlowStatements_InCodeDirective/TestComponent.mappings.txt
@@ -1,4 +1,11 @@
-﻿Source Location: (60:2,7 [213] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [50] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Rendering;
+|
+Generated Location: (360:12,0 [50] )
+|using Microsoft.AspNetCore.Components.Rendering;
+|
+
+Source Location: (60:2,7 [213] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     void RenderChildComponent(RenderTreeBuilder __builder)
     {
@@ -14,6 +21,11 @@ Generated Location: (866:26,7 [213] )
         if (__builder == null) output = "Builder is null!";
         else output = "Builder is not null!";
 |
+
+Source Location: (293:8,20 [6] x:\dir\subdir\Test\TestComponent.cshtml)
+|output|
+Generated Location: (1324:40,24 [6] )
+|output|
 
 Source Location: (305:9,0 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |    }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.mappings.txt
@@ -1,0 +1,5 @@
+﻿Source Location: (20:2,2 [10] x:\dir\subdir\Test\TestComponent.cshtml)
+|"My value"|
+Generated Location: (748:18,24 [10] )
+|"My value"|
+

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/WhiteSpace_InMarkupInFunctionsBlock/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/WhiteSpace_InMarkupInFunctionsBlock/TestComponent.mappings.txt
@@ -1,10 +1,4 @@
-﻿Source Location: (1:0,1 [49] x:\dir\subdir\Test\TestComponent.cshtml)
-|using Microsoft.AspNetCore.Components.Rendering
-|
-Generated Location: (360:12,0 [49] )
-|using Microsoft.AspNetCore.Components.Rendering;|
-
-Source Location: (57:1,7 [57] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (57:1,7 [57] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     void MyMethod(RenderTreeBuilder __builder)
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/WhiteSpace_InMarkupInFunctionsBlock/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/WhiteSpace_InMarkupInFunctionsBlock/TestComponent.mappings.txt
@@ -1,4 +1,10 @@
-﻿Source Location: (57:1,7 [57] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (1:0,1 [49] x:\dir\subdir\Test\TestComponent.cshtml)
+|using Microsoft.AspNetCore.Components.Rendering
+|
+Generated Location: (360:12,0 [49] )
+|using Microsoft.AspNetCore.Components.Rendering;|
+
+Source Location: (57:1,7 [57] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     void MyMethod(RenderTreeBuilder __builder)
     {
@@ -17,6 +23,11 @@ Generated Location: (1097:36,13 [46] )
 |for (var i = 0; i < 100; i++)
             {
 |
+
+Source Location: (230:8,21 [1] x:\dir\subdir\Test\TestComponent.cshtml)
+|i|
+Generated Location: (1343:45,24 [1] )
+|i|
 
 Source Location: (256:10,0 [15] x:\dir\subdir\Test\TestComponent.cshtml)
 |            }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/WhiteSpace_WithPreserveWhitespace/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/WhiteSpace_WithPreserveWhitespace/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (95:6,11 [29] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (44:2,16 [3] x:\dir\subdir\Test\TestComponent.cshtml)
+|Foo|
+Generated Location: (807:20,16 [3] )
+|Foo|
+
+Source Location: (95:6,11 [29] x:\dir\subdir\Test\TestComponent.cshtml)
 |
         int Foo = 18;
     |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Whitespace_BetweenElementAndFunctions/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Whitespace_BetweenElementAndFunctions/TestComponent.mappings.txt
@@ -1,4 +1,9 @@
-﻿Source Location: (31:1,11 [29] x:\dir\subdir\Test\TestComponent.cshtml)
+﻿Source Location: (12:0,12 [3] x:\dir\subdir\Test\TestComponent.cshtml)
+|Foo|
+Generated Location: (747:19,12 [3] )
+|Foo|
+
+Source Location: (31:1,11 [29] x:\dir\subdir\Test\TestComponent.cshtml)
 |
         int Foo = 18;
     |

--- a/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/SourceMappingsSerializer.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/SourceMappingsSerializer.cs
@@ -5,6 +5,7 @@
 
 using System.Text;
 using Microsoft.AspNetCore.Razor.PooledObjects;
+using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests;
 
@@ -18,11 +19,14 @@ public static class SourceMappingsSerializer
         foreach (var sourceMapping in csharpDocument.SourceMappings)
         {
             builder.Append("Source Location: ");
-            AppendMappingLocation(builder, sourceMapping.OriginalSpan, sourceContent);
+            var sourceCode = GetCodeForSpan(sourceMapping.OriginalSpan, sourceContent);
+            AppendMappingLocation(builder, sourceMapping.OriginalSpan, sourceCode);
 
             builder.Append("Generated Location: ");
-            AppendMappingLocation(builder, sourceMapping.GeneratedSpan, csharpDocument.GeneratedCode);
+            var generatedCode = GetCodeForSpan(sourceMapping.GeneratedSpan, csharpDocument.GeneratedCode);
+            AppendMappingLocation(builder, sourceMapping.GeneratedSpan, generatedCode);
 
+            Assert.Equal(sourceCode, generatedCode);
             builder.AppendLine();
         }
 
@@ -33,13 +37,13 @@ public static class SourceMappingsSerializer
     {
         builder
             .AppendLine(location.ToString())
-            .Append('|');
+            .Append('|')
+            .Append(content)
+            .AppendLine("|");
+    }
 
-        for (var i = 0; i < location.Length; i++)
-        {
-            builder.Append(content[location.AbsoluteIndex + i]);
-        }
-
-        builder.AppendLine("|");
+    private static string GetCodeForSpan(SourceSpan location, string content)
+    {
+        return content[location.AbsoluteIndex..(location.AbsoluteIndex + location.Length)];
     }
 }


### PR DESCRIPTION
Add various line mappings that are missing in runtime documents. 
Commits are split between changes and baseline updates; suggest reviewing separately.

Still have more mappings to be added, but they are more involved so submitting this in parts.

Fixes https://github.com/dotnet/razor/issues/9828

Before:
![image](https://github.com/dotnet/razor/assets/16246502/cf72e505-144c-4acb-b105-f467022d6065)
![image](https://github.com/dotnet/razor/assets/16246502/6b73da1c-a281-4a04-bc81-8154e5519a22)

After:
![image](https://github.com/dotnet/razor/assets/16246502/06584f70-915f-4a31-a9d2-8cc80f14a81b)
![image](https://github.com/dotnet/razor/assets/16246502/c25e2c74-9810-40dc-86e7-64d690d184cd)



