### PR TITLE
Add missing SDK dependency to global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -21,6 +21,7 @@
     "rollForward": "latestPatch"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.24075.5"
+    "Microsoft.DotNet.Arcade.Sdk": "8.0.0-beta.24075.5",
+    "Microsoft.Build.NoTargets": "2.0.1"
   }
 }

--- a/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators.Transport/Microsoft.NET.Sdk.Razor.SourceGenerators.Transport.csproj
+++ b/src/Compiler/Microsoft.NET.Sdk.Razor.SourceGenerators.Transport/Microsoft.NET.Sdk.Razor.SourceGenerators.Transport.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Build.NoTargets/2.0.1">
+<Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>


### PR DESCRIPTION
Contributes to: https://github.com/dotnet/source-build/issues/3170

Backport of changes in https://github.com/dotnet/installer/pull/18478

### Description

Each .NET repo needs to specify all used SDKs in `global.json` file. This change adds the missing SDK.