### PR TITLE
Remove script for building self-contained package

### DIFF
--- a/eng/AfterSolutionBuild.targets
+++ b/eng/AfterSolutionBuild.targets
@@ -12,8 +12,7 @@
     <MSBuild Projects="$(RazorSolutionPath)"
              Targets="Restore" />
     <MSBuild Projects="$(LanguageServerProject)"
-         Properties="TargetFramework=net8.0"
-         Targets="Publish" />
+             Targets="PublishAllRids" />
   </Target>
 
   <Target Name="_PublishDevKitTelemetryRids" AfterTargets="Pack" Condition="'$(DotNetBuildFromSource)' != 'true'">
@@ -25,8 +24,7 @@
     <MSBuild Projects="$(RazorSolutionPath)"
              Targets="Restore" />
     <MSBuild Projects="$(DevKitTelemetryProject)"
-         Properties="TargetFramework=net8.0"
-         Targets="Publish" />
+             Targets="PublishAllRids" />
   </Target>
 
 </Project>

--- a/eng/AfterSolutionBuild.targets
+++ b/eng/AfterSolutionBuild.targets
@@ -12,7 +12,8 @@
     <MSBuild Projects="$(RazorSolutionPath)"
              Targets="Restore" />
     <MSBuild Projects="$(LanguageServerProject)"
-             Targets="Publish" />
+         Properties="TargetFramework=net8.0"
+         Targets="Publish" />
   </Target>
 
   <Target Name="_PublishDevKitTelemetryRids" AfterTargets="Pack" Condition="'$(DotNetBuildFromSource)' != 'true'">
@@ -24,7 +25,8 @@
     <MSBuild Projects="$(RazorSolutionPath)"
              Targets="Restore" />
     <MSBuild Projects="$(DevKitTelemetryProject)"
-             Targets="Publish" />
+         Properties="TargetFramework=net8.0"
+         Targets="Publish" />
   </Target>
 
 </Project>

--- a/eng/AfterSolutionBuild.targets
+++ b/eng/AfterSolutionBuild.targets
@@ -12,7 +12,7 @@
     <MSBuild Projects="$(RazorSolutionPath)"
              Targets="Restore" />
     <MSBuild Projects="$(LanguageServerProject)"
-             Targets="PublishAllRids" />
+             Targets="Publish" />
   </Target>
 
   <Target Name="_PublishDevKitTelemetryRids" AfterTargets="Pack" Condition="'$(DotNetBuildFromSource)' != 'true'">
@@ -24,7 +24,7 @@
     <MSBuild Projects="$(RazorSolutionPath)"
              Targets="Restore" />
     <MSBuild Projects="$(DevKitTelemetryProject)"
-             Targets="PublishAllRids" />
+             Targets="Publish" />
   </Target>
 
 </Project>

--- a/src/Razor/src/Microsoft.VisualStudio.DevKit.Razor/Microsoft.VisualStudio.DevKit.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.DevKit.Razor/Microsoft.VisualStudio.DevKit.Razor.csproj
@@ -7,7 +7,6 @@
     <EnableApiCheck>false</EnableApiCheck>
     <IsShippingPackage>false</IsShippingPackage>
     <RemoveDevicePlatformSupport>true</RemoveDevicePlatformSupport>
-    <SelfContained>false</SelfContained>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/src/Microsoft.VisualStudio.DevKit.Razor/Microsoft.VisualStudio.DevKit.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.DevKit.Razor/Microsoft.VisualStudio.DevKit.Razor.csproj
@@ -5,11 +5,9 @@
     <PublishTargetFramework>net7.0</PublishTargetFramework>
     <Description>Razor is a markup syntax for adding server-side logic to web pages. This package contains the language server assets for C# DevKit.</Description>
     <EnableApiCheck>false</EnableApiCheck>
-    <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('Windows'))">win-x64;win-x86;win-arm64</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('Linux'))">linux-x64;linux-musl-x64;linux-arm64;linux-musl-arm64</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('OSX'))">osx-x64;osx-arm64</RuntimeIdentifiers>
     <IsShippingPackage>false</IsShippingPackage>
     <RemoveDevicePlatformSupport>true</RemoveDevicePlatformSupport>
+    <SelfContained>false</SelfContained>
   </PropertyGroup>
 
   <ItemGroup>
@@ -30,7 +28,7 @@
     <ProjectReference Include="..\Microsoft.AspNetCore.Razor.ProjectEngineHost\Microsoft.AspNetCore.Razor.ProjectEngineHost.csproj" PrivateAssets="all" />
   </ItemGroup>
 
-    <!--
+  <!--
     Technique for publishing multiple RIDs from
     https://github.com/dotnet/cli/issues/9221#issuecomment-387512008
     Example usage:
@@ -47,16 +45,12 @@
 
   <Target Name="PublishAllRids">
     <ItemGroup>
-      <!-- Transform RuntimeIdentifiers property to item -->
-      <RuntimeIdentifierForPublish Include="$(RuntimeIdentifiers)" />
-
-      <!-- Transform RuntimeIdentifierForPublish items to project items to pass to MSBuild task -->
-      <ProjectToPublish Include="@(RuntimeIdentifierForPublish->'$(MSBuildProjectFullPath)')">
-        <AdditionalProperties>RuntimeIdentifier=%(RuntimeIdentifierForPublish.Identity);PublishDir=$(RidsPublishDir)%(RuntimeIdentifierForPublish.Identity)\;TargetFramework=$(PublishTargetFramework)</AdditionalProperties>
+      <ProjectToPublish Include="$(MSBuildProjectFullPath)">
+        <AdditionalProperties>RuntimeIdentifier=;PublishDir=$(RidsPublishDir);TargetFramework=$(PublishTargetFramework);SelfContained=false</AdditionalProperties>
       </ProjectToPublish>
 
       <ProjectToPublish_PlatformAgnostic Include="$(MSBuildProjectFullPath)">
-        <AdditionalProperties>PublishDir=$(RidsPublishDir)\PlatformAgnostic\;UseAppHost=false;TargetFramework=$(PublishTargetFramework)</AdditionalProperties>
+        <AdditionalProperties>PublishDir=$(RidsPublishDir)\PlatformAgnostic\;UseAppHost=false;TargetFramework=$(PublishTargetFramework);SelfContained=false</AdditionalProperties>
       </ProjectToPublish_PlatformAgnostic>
     </ItemGroup>
 

--- a/src/Razor/src/Microsoft.VisualStudio.DevKit.Razor/Microsoft.VisualStudio.DevKit.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.DevKit.Razor/Microsoft.VisualStudio.DevKit.Razor.csproj
@@ -5,6 +5,9 @@
     <PublishTargetFramework>net7.0</PublishTargetFramework>
     <Description>Razor is a markup syntax for adding server-side logic to web pages. This package contains the language server assets for C# DevKit.</Description>
     <EnableApiCheck>false</EnableApiCheck>
+    <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('Windows'))">win-x64;win-x86;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('Linux'))">linux-x64;linux-musl-x64;linux-arm64;linux-musl-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('OSX'))">osx-x64;osx-arm64</RuntimeIdentifiers>
     <IsShippingPackage>false</IsShippingPackage>
     <RemoveDevicePlatformSupport>true</RemoveDevicePlatformSupport>
   </PropertyGroup>
@@ -44,8 +47,12 @@
 
   <Target Name="PublishAllRids">
     <ItemGroup>
-      <ProjectToPublish Include="$(MSBuildProjectFullPath)">
-        <AdditionalProperties>RuntimeIdentifier=;PublishDir=$(RidsPublishDir);TargetFramework=$(PublishTargetFramework);SelfContained=false</AdditionalProperties>
+      <!-- Transform RuntimeIdentifiers property to item -->
+      <RuntimeIdentifierForPublish Include="$(RuntimeIdentifiers)" />
+
+      <!-- Transform RuntimeIdentifierForPublish items to project items to pass to MSBuild task -->
+      <ProjectToPublish Include="@(RuntimeIdentifierForPublish->'$(MSBuildProjectFullPath)')">
+        <AdditionalProperties>RuntimeIdentifier=%(RuntimeIdentifierForPublish.Identity);PublishDir=$(RidsPublishDir)%(RuntimeIdentifierForPublish.Identity)\;TargetFramework=$(PublishTargetFramework);SelfContained=false</AdditionalProperties>
       </ProjectToPublish>
 
       <ProjectToPublish_PlatformAgnostic Include="$(MSBuildProjectFullPath)">

--- a/src/Razor/src/Microsoft.VisualStudio.DevKit.Razor/Microsoft.VisualStudio.DevKit.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.DevKit.Razor/Microsoft.VisualStudio.DevKit.Razor.csproj
@@ -5,9 +5,11 @@
     <PublishTargetFramework>net7.0</PublishTargetFramework>
     <Description>Razor is a markup syntax for adding server-side logic to web pages. This package contains the language server assets for C# DevKit.</Description>
     <EnableApiCheck>false</EnableApiCheck>
+    <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('Windows'))">win-x64;win-x86;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('Linux'))">linux-x64;linux-musl-x64;linux-arm64;linux-musl-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('OSX'))">osx-x64;osx-arm64</RuntimeIdentifiers>
     <IsShippingPackage>false</IsShippingPackage>
     <RemoveDevicePlatformSupport>true</RemoveDevicePlatformSupport>
-    <SelfContained>false</SelfContained>
   </PropertyGroup>
 
   <ItemGroup>
@@ -28,4 +30,37 @@
     <ProjectReference Include="..\Microsoft.AspNetCore.Razor.ProjectEngineHost\Microsoft.AspNetCore.Razor.ProjectEngineHost.csproj" PrivateAssets="all" />
   </ItemGroup>
 
+    <!--
+    Technique for publishing multiple RIDs from
+    https://github.com/dotnet/cli/issues/9221#issuecomment-387512008
+    Example usage:
+     dotnet msbuild -restore -t:PublishAllRids -p:Configuration=Release
+  -->
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+
+    <!-- Enable roll-forward to latest patch.  This allows one restore operation
+        to apply to all of the self-contained publish operations. -->
+    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
+    <RidsPublishDir>$(ArtifactsDir)DevKitTelemetry\$(Configuration)\</RidsPublishDir>
+  </PropertyGroup>
+
+  <Target Name="PublishAllRids">
+    <ItemGroup>
+      <!-- Transform RuntimeIdentifiers property to item -->
+      <RuntimeIdentifierForPublish Include="$(RuntimeIdentifiers)" />
+
+      <!-- Transform RuntimeIdentifierForPublish items to project items to pass to MSBuild task -->
+      <ProjectToPublish Include="@(RuntimeIdentifierForPublish->'$(MSBuildProjectFullPath)')">
+        <AdditionalProperties>RuntimeIdentifier=%(RuntimeIdentifierForPublish.Identity);PublishDir=$(RidsPublishDir)%(RuntimeIdentifierForPublish.Identity)\;TargetFramework=$(PublishTargetFramework)</AdditionalProperties>
+      </ProjectToPublish>
+
+      <ProjectToPublish_PlatformAgnostic Include="$(MSBuildProjectFullPath)">
+        <AdditionalProperties>PublishDir=$(RidsPublishDir)\PlatformAgnostic\;UseAppHost=false;TargetFramework=$(PublishTargetFramework)</AdditionalProperties>
+      </ProjectToPublish_PlatformAgnostic>
+    </ItemGroup>
+
+    <MSBuild Projects="@(ProjectToPublish)" Targets="Publish" BuildInParallel="false" />
+    <MSBuild Projects="@(ProjectToPublish_PlatformAgnostic)" Targets="Publish" BuildInParallel="false" Condition="'$(OS)' == 'WINDOWS_NT'" />
+  </Target>
 </Project>

--- a/src/Razor/src/Microsoft.VisualStudio.DevKit.Razor/Microsoft.VisualStudio.DevKit.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.DevKit.Razor/Microsoft.VisualStudio.DevKit.Razor.csproj
@@ -5,11 +5,9 @@
     <PublishTargetFramework>net7.0</PublishTargetFramework>
     <Description>Razor is a markup syntax for adding server-side logic to web pages. This package contains the language server assets for C# DevKit.</Description>
     <EnableApiCheck>false</EnableApiCheck>
-    <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('Windows'))">win-x64;win-x86;win-arm64</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('Linux'))">linux-x64;linux-musl-x64;linux-arm64;linux-musl-arm64</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('OSX'))">osx-x64;osx-arm64</RuntimeIdentifiers>
     <IsShippingPackage>false</IsShippingPackage>
     <RemoveDevicePlatformSupport>true</RemoveDevicePlatformSupport>
+    <SelfContained>false</SelfContained>
   </PropertyGroup>
 
   <ItemGroup>
@@ -30,37 +28,4 @@
     <ProjectReference Include="..\Microsoft.AspNetCore.Razor.ProjectEngineHost\Microsoft.AspNetCore.Razor.ProjectEngineHost.csproj" PrivateAssets="all" />
   </ItemGroup>
 
-    <!--
-    Technique for publishing multiple RIDs from
-    https://github.com/dotnet/cli/issues/9221#issuecomment-387512008
-    Example usage:
-     dotnet msbuild -restore -t:PublishAllRids -p:Configuration=Release
-  -->
-  <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-
-    <!-- Enable roll-forward to latest patch.  This allows one restore operation
-        to apply to all of the self-contained publish operations. -->
-    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
-    <RidsPublishDir>$(ArtifactsDir)DevKitTelemetry\$(Configuration)\</RidsPublishDir>
-  </PropertyGroup>
-
-  <Target Name="PublishAllRids">
-    <ItemGroup>
-      <!-- Transform RuntimeIdentifiers property to item -->
-      <RuntimeIdentifierForPublish Include="$(RuntimeIdentifiers)" />
-
-      <!-- Transform RuntimeIdentifierForPublish items to project items to pass to MSBuild task -->
-      <ProjectToPublish Include="@(RuntimeIdentifierForPublish->'$(MSBuildProjectFullPath)')">
-        <AdditionalProperties>RuntimeIdentifier=%(RuntimeIdentifierForPublish.Identity);PublishDir=$(RidsPublishDir)%(RuntimeIdentifierForPublish.Identity)\;TargetFramework=$(PublishTargetFramework)</AdditionalProperties>
-      </ProjectToPublish>
-
-      <ProjectToPublish_PlatformAgnostic Include="$(MSBuildProjectFullPath)">
-        <AdditionalProperties>PublishDir=$(RidsPublishDir)\PlatformAgnostic\;UseAppHost=false;TargetFramework=$(PublishTargetFramework)</AdditionalProperties>
-      </ProjectToPublish_PlatformAgnostic>
-    </ItemGroup>
-
-    <MSBuild Projects="@(ProjectToPublish)" Targets="Publish" BuildInParallel="false" />
-    <MSBuild Projects="@(ProjectToPublish_PlatformAgnostic)" Targets="Publish" BuildInParallel="false" Condition="'$(OS)' == 'WINDOWS_NT'" />
-  </Target>
 </Project>

--- a/src/Razor/src/rzls/rzls.csproj
+++ b/src/Razor/src/rzls/rzls.csproj
@@ -8,7 +8,6 @@
     <EnableApiCheck>false</EnableApiCheck>
     <IsShippingPackage>false</IsShippingPackage>
     <RemoveDevicePlatformSupport>true</RemoveDevicePlatformSupport>
-    <SelfContained>false</SelfContained>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/src/rzls/rzls.csproj
+++ b/src/Razor/src/rzls/rzls.csproj
@@ -6,6 +6,9 @@
     <OutputType>Exe</OutputType>
     <Description>Razor is a markup syntax for adding server-side logic to web pages. This package contains a Razor language server.</Description>
     <EnableApiCheck>false</EnableApiCheck>
+    <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('Windows'))">win-x64;win-x86;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('Linux'))">linux-x64;linux-musl-x64;linux-arm64;linux-musl-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('OSX'))">osx-x64;osx-arm64</RuntimeIdentifiers>
     <IsShippingPackage>false</IsShippingPackage>
     <RemoveDevicePlatformSupport>true</RemoveDevicePlatformSupport>
   </PropertyGroup>
@@ -42,8 +45,12 @@
 
   <Target Name="PublishAllRids">
     <ItemGroup>
-      <ProjectToPublish Include="$(MSBuildProjectFullPath)">
-        <AdditionalProperties>RuntimeIdentifier=;PublishDir=$(RidsPublishDir);TargetFramework=$(PublishTargetFramework);SelfContained=false</AdditionalProperties>
+      <!-- Transform RuntimeIdentifiers property to item -->
+      <RuntimeIdentifierForPublish Include="$(RuntimeIdentifiers)" />
+
+      <!-- Transform RuntimeIdentifierForPublish items to project items to pass to MSBuild task -->
+      <ProjectToPublish Include="@(RuntimeIdentifierForPublish->'$(MSBuildProjectFullPath)')">
+        <AdditionalProperties>RuntimeIdentifier=%(RuntimeIdentifierForPublish.Identity);PublishDir=$(RidsPublishDir)%(RuntimeIdentifierForPublish.Identity)\;TargetFramework=$(PublishTargetFramework);SelfContained=false</AdditionalProperties>
       </ProjectToPublish>
 
       <ProjectToPublish_PlatformAgnostic Include="$(MSBuildProjectFullPath)">

--- a/src/Razor/src/rzls/rzls.csproj
+++ b/src/Razor/src/rzls/rzls.csproj
@@ -6,11 +6,9 @@
     <OutputType>Exe</OutputType>
     <Description>Razor is a markup syntax for adding server-side logic to web pages. This package contains a Razor language server.</Description>
     <EnableApiCheck>false</EnableApiCheck>
-    <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('Windows'))">win-x64;win-x86;win-arm64</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('Linux'))">linux-x64;linux-musl-x64;linux-arm64;linux-musl-arm64</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('OSX'))">osx-x64;osx-arm64</RuntimeIdentifiers>
     <IsShippingPackage>false</IsShippingPackage>
     <RemoveDevicePlatformSupport>true</RemoveDevicePlatformSupport>
+    <SelfContained>false</SelfContained>
   </PropertyGroup>
 
   <ItemGroup>
@@ -45,16 +43,12 @@
 
   <Target Name="PublishAllRids">
     <ItemGroup>
-      <!-- Transform RuntimeIdentifiers property to item -->
-      <RuntimeIdentifierForPublish Include="$(RuntimeIdentifiers)" />
-
-      <!-- Transform RuntimeIdentifierForPublish items to project items to pass to MSBuild task -->
-      <ProjectToPublish Include="@(RuntimeIdentifierForPublish->'$(MSBuildProjectFullPath)')">
-        <AdditionalProperties>RuntimeIdentifier=%(RuntimeIdentifierForPublish.Identity);PublishDir=$(RidsPublishDir)%(RuntimeIdentifierForPublish.Identity)\;TargetFramework=$(PublishTargetFramework);SelfContained=true</AdditionalProperties>
+      <ProjectToPublish Include="$(MSBuildProjectFullPath)">
+        <AdditionalProperties>RuntimeIdentifier=;PublishDir=$(RidsPublishDir);TargetFramework=$(PublishTargetFramework);SelfContained=false</AdditionalProperties>
       </ProjectToPublish>
 
       <ProjectToPublish_PlatformAgnostic Include="$(MSBuildProjectFullPath)">
-        <AdditionalProperties>PublishDir=$(RidsPublishDir)\PlatformAgnostic\;UseAppHost=false;TargetFramework=$(PublishTargetFramework);</AdditionalProperties>
+        <AdditionalProperties>PublishDir=$(RidsPublishDir)\PlatformAgnostic\;UseAppHost=false;TargetFramework=$(PublishTargetFramework);SelfContained=false</AdditionalProperties>
       </ProjectToPublish_PlatformAgnostic>
     </ItemGroup>
 

--- a/src/Razor/src/rzls/rzls.csproj
+++ b/src/Razor/src/rzls/rzls.csproj
@@ -6,9 +6,11 @@
     <OutputType>Exe</OutputType>
     <Description>Razor is a markup syntax for adding server-side logic to web pages. This package contains a Razor language server.</Description>
     <EnableApiCheck>false</EnableApiCheck>
+    <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('Windows'))">win-x64;win-x86;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('Linux'))">linux-x64;linux-musl-x64;linux-arm64;linux-musl-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('OSX'))">osx-x64;osx-arm64</RuntimeIdentifiers>
     <IsShippingPackage>false</IsShippingPackage>
     <RemoveDevicePlatformSupport>true</RemoveDevicePlatformSupport>
-    <SelfContained>false</SelfContained>
   </PropertyGroup>
 
   <ItemGroup>
@@ -21,8 +23,42 @@
     </Content>
   </ItemGroup>
 
+  <!--
+    Technique for publishing multiple RIDs from
+    https://github.com/dotnet/cli/issues/9221#issuecomment-387512008
+    Example usage:
+     dotnet msbuild -restore -t:PublishAllRids -p:Configuration=Release
+  -->
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+
+    <!-- Enable roll-forward to latest patch.  This allows one restore operation
+        to apply to all of the self-contained publish operations. -->
+    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
+    <RidsPublishDir>$(ArtifactsDir)LanguageServer\$(Configuration)\</RidsPublishDir>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.DiaSymReader" Version="$(MicrosoftDiaSymReaderVersion)" />
     <PackageReference Include="System.Private.Uri" Version="$(SystemPrivateUriPackageVersion)" />
   </ItemGroup>
+
+  <Target Name="PublishAllRids">
+    <ItemGroup>
+      <!-- Transform RuntimeIdentifiers property to item -->
+      <RuntimeIdentifierForPublish Include="$(RuntimeIdentifiers)" />
+
+      <!-- Transform RuntimeIdentifierForPublish items to project items to pass to MSBuild task -->
+      <ProjectToPublish Include="@(RuntimeIdentifierForPublish->'$(MSBuildProjectFullPath)')">
+        <AdditionalProperties>RuntimeIdentifier=%(RuntimeIdentifierForPublish.Identity);PublishDir=$(RidsPublishDir)%(RuntimeIdentifierForPublish.Identity)\;TargetFramework=$(PublishTargetFramework);SelfContained=true</AdditionalProperties>
+      </ProjectToPublish>
+
+      <ProjectToPublish_PlatformAgnostic Include="$(MSBuildProjectFullPath)">
+        <AdditionalProperties>PublishDir=$(RidsPublishDir)\PlatformAgnostic\;UseAppHost=false;TargetFramework=$(PublishTargetFramework);</AdditionalProperties>
+      </ProjectToPublish_PlatformAgnostic>
+    </ItemGroup>
+
+    <MSBuild Projects="@(ProjectToPublish)" Targets="Publish" BuildInParallel="false" />
+    <MSBuild Projects="@(ProjectToPublish_PlatformAgnostic)" Targets="Publish" BuildInParallel="false" Condition="'$(OS)' == 'WINDOWS_NT'" />
+  </Target>
 </Project>

--- a/src/Razor/src/rzls/rzls.csproj
+++ b/src/Razor/src/rzls/rzls.csproj
@@ -6,11 +6,9 @@
     <OutputType>Exe</OutputType>
     <Description>Razor is a markup syntax for adding server-side logic to web pages. This package contains a Razor language server.</Description>
     <EnableApiCheck>false</EnableApiCheck>
-    <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('Windows'))">win-x64;win-x86;win-arm64</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('Linux'))">linux-x64;linux-musl-x64;linux-arm64;linux-musl-arm64</RuntimeIdentifiers>
-    <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('OSX'))">osx-x64;osx-arm64</RuntimeIdentifiers>
     <IsShippingPackage>false</IsShippingPackage>
     <RemoveDevicePlatformSupport>true</RemoveDevicePlatformSupport>
+    <SelfContained>false</SelfContained>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,42 +21,8 @@
     </Content>
   </ItemGroup>
 
-  <!--
-    Technique for publishing multiple RIDs from
-    https://github.com/dotnet/cli/issues/9221#issuecomment-387512008
-    Example usage:
-     dotnet msbuild -restore -t:PublishAllRids -p:Configuration=Release
-  -->
-  <PropertyGroup>
-    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-
-    <!-- Enable roll-forward to latest patch.  This allows one restore operation
-        to apply to all of the self-contained publish operations. -->
-    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
-    <RidsPublishDir>$(ArtifactsDir)LanguageServer\$(Configuration)\</RidsPublishDir>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.DiaSymReader" Version="$(MicrosoftDiaSymReaderVersion)" />
     <PackageReference Include="System.Private.Uri" Version="$(SystemPrivateUriPackageVersion)" />
   </ItemGroup>
-
-  <Target Name="PublishAllRids">
-    <ItemGroup>
-      <!-- Transform RuntimeIdentifiers property to item -->
-      <RuntimeIdentifierForPublish Include="$(RuntimeIdentifiers)" />
-
-      <!-- Transform RuntimeIdentifierForPublish items to project items to pass to MSBuild task -->
-      <ProjectToPublish Include="@(RuntimeIdentifierForPublish->'$(MSBuildProjectFullPath)')">
-        <AdditionalProperties>RuntimeIdentifier=%(RuntimeIdentifierForPublish.Identity);PublishDir=$(RidsPublishDir)%(RuntimeIdentifierForPublish.Identity)\;TargetFramework=$(PublishTargetFramework);SelfContained=true</AdditionalProperties>
-      </ProjectToPublish>
-
-      <ProjectToPublish_PlatformAgnostic Include="$(MSBuildProjectFullPath)">
-        <AdditionalProperties>PublishDir=$(RidsPublishDir)\PlatformAgnostic\;UseAppHost=false;TargetFramework=$(PublishTargetFramework);</AdditionalProperties>
-      </ProjectToPublish_PlatformAgnostic>
-    </ItemGroup>
-
-    <MSBuild Projects="@(ProjectToPublish)" Targets="Publish" BuildInParallel="false" />
-    <MSBuild Projects="@(ProjectToPublish_PlatformAgnostic)" Targets="Publish" BuildInParallel="false" Condition="'$(OS)' == 'WINDOWS_NT'" />
-  </Target>
 </Project>


### PR DESCRIPTION
﻿### Summary of the changes

- Removed `RuntimeIdentifiers` and self contained packaging related content in csproj
- Set SelfContained to false

Unsure if something else needs to be added,
Also unsure of how best to test the end to end on the extension side.


Related PRs:
- [Allow rzls to launch using standard dotnet (Redo) by maryamariyan · Pull Request #6844 · dotnet/vscode-csharp (github.com)](https://github.com/dotnet/vscode-csharp/pull/6844)
- https://github.com/dotnet/vscode-csharp/pull/5855