### PR TITLE
Move SB metadata to intermediates

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -5,6 +5,7 @@
       <Uri>https://dev.azure.com/dnceng/internal/_git/dotnet-runtime</Uri>
       <Sha>839cdfb0ecca5e0be3dbccd926e7651ef50fdf10</Sha>
     </Dependency>
+    <!-- Intermediate is necessary for source build. -->
     <Dependency Name="Microsoft.SourceBuild.Intermediate.source-build-reference-packages" Version="9.0.0-alpha.1.24075.1">
       <Uri>https://github.com/dotnet/source-build-reference-packages</Uri>
       <Sha>e659f328bf255d3e17e81296117c3aed1d461f2f</Sha>
@@ -13,7 +14,6 @@
     <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.10.0-1.24072.4">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>fc8998c604e2aede0c3a385592ea7c1155dc978f</Sha>
-      <SourceBuild RepoName="roslyn" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.CommonLanguageServerProtocol.Framework" Version="4.10.0-1.24072.4">
       <Uri>https://github.com/dotnet/roslyn</Uri>
@@ -83,6 +83,12 @@
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>fc8998c604e2aede0c3a385592ea7c1155dc978f</Sha>
     </Dependency>
+    <!-- Intermediate is necessary for source build. -->
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.roslyn" Version="4.10.0-1.24072.4">
+      <Uri>https://github.com/dotnet/roslyn</Uri>
+      <Sha>fc8998c604e2aede0c3a385592ea7c1155dc978f</Sha>
+      <SourceBuild RepoName="roslyn" ManagedOnly="true" />
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <!-- Listed as a dependency to workaround https://github.com/dotnet/cli/issues/10528 -->
@@ -93,9 +99,19 @@
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="8.0.0-beta.24081.5">
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>be88b08c41971b52ec11aec05ef31e72185d4a1f</Sha>
+    </Dependency>
+    <!-- Intermediate is necessary for source build. -->
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.arcade" Version="8.0.0-beta.24081.5">
+      <Uri>https://github.com/dotnet/arcade</Uri>
+      <Sha>be88b08c41971b52ec11aec05ef31e72185d4a1f</Sha>
       <SourceBuild RepoName="arcade" ManagedOnly="true" />
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XliffTasks" Version="1.0.0-beta.23475.1" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
+      <Uri>https://github.com/dotnet/xliff-tasks</Uri>
+      <Sha>73f0850939d96131c28cf6ea6ee5aacb4da0083a</Sha>
+    </Dependency>
+    <!-- Intermediate is necessary for source build. -->
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.xliff-tasks" Version="1.0.0-beta.23475.1" CoherentParentDependency="Microsoft.DotNet.Arcade.Sdk">
       <Uri>https://github.com/dotnet/xliff-tasks</Uri>
       <Sha>73f0850939d96131c28cf6ea6ee5aacb4da0083a</Sha>
       <SourceBuild RepoName="xliff-tasks" ManagedOnly="true" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -71,9 +71,9 @@
     <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.10.0-1.24072.4</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
     <MicrosoftSourceBuildIntermediateroslynPackageVersion>4.10.0-1.24072.4</MicrosoftSourceBuildIntermediateroslynPackageVersion>
     <MicrosoftVisualStudioLanguageServicesPackageVersion>4.10.0-1.24072.4</MicrosoftVisualStudioLanguageServicesPackageVersion>
-    <MicrosoftSourceBuildIntermediatearcadeVersion>8.0.0-beta.24081.5</MicrosoftSourceBuildIntermediatearcadeVersion>
+    <MicrosoftSourceBuildIntermediatearcadePackageVersion>8.0.0-beta.24081.5</MicrosoftSourceBuildIntermediatearcadePackageVersion>
     <MicrosoftDotNetXliffTasksPackageVersion>1.0.0-beta.23475.1</MicrosoftDotNetXliffTasksPackageVersion>
-    <MicrosoftSourceBuildIntermediatexlifftasksVersion>1.0.0-beta.23475.1</MicrosoftSourceBuildIntermediatexlifftasksVersion>
+    <MicrosoftSourceBuildIntermediatexlifftasksPackageVersion>1.0.0-beta.23475.1</MicrosoftSourceBuildIntermediatexlifftasksPackageVersion>
     <!--
       Exception - Microsoft.Extensions.ObjectPool and System.Collections.Immutable packages are not updated by automation,
       but are present in Version.Details.xml for source-build PVP flow. See the comment in Version.Details.xml for more information.

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -69,8 +69,11 @@
     <MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>4.10.0-1.24072.4</MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>
     <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>4.10.0-1.24072.4</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
     <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.10.0-1.24072.4</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
+    <MicrosoftSourceBuildIntermediateroslynPackageVersion>4.10.0-1.24072.4</MicrosoftSourceBuildIntermediateroslynPackageVersion>
     <MicrosoftVisualStudioLanguageServicesPackageVersion>4.10.0-1.24072.4</MicrosoftVisualStudioLanguageServicesPackageVersion>
+    <MicrosoftSourceBuildIntermediatearcadeVersion>8.0.0-beta.24081.5</MicrosoftSourceBuildIntermediatearcadeVersion>
     <MicrosoftDotNetXliffTasksPackageVersion>1.0.0-beta.23475.1</MicrosoftDotNetXliffTasksPackageVersion>
+    <MicrosoftSourceBuildIntermediatexlifftasksVersion>1.0.0-beta.23475.1</MicrosoftSourceBuildIntermediatexlifftasksVersion>
     <!--
       Exception - Microsoft.Extensions.ObjectPool and System.Collections.Immutable packages are not updated by automation,
       but are present in Version.Details.xml for source-build PVP flow. See the comment in Version.Details.xml for more information.


### PR DESCRIPTION
The changes in this pull request aim to [improve the UX and guideance around the SourceBuild metadata](https://github.com/dotnet/source-build/issues/3373) by placing the metadata on explicit source-build intermediates.

The changes include:

- Removing existing SourceBuild metadata from all non-intermediate dependencies.
- Defining new explicit intermediate dependencies and adding SourceBuild metadata to those dependencies.

Related to https://github.com/dotnet/source-build/issues/3373 and https://github.com/dotnet/source-build/issues/4073