### PR TITLE
Don't break the world when a project is published

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
@@ -30,7 +30,7 @@ internal abstract class LanguageServerFeatureOptions
     public abstract bool ReturnCodeActionAndRenamePathsWithPrefixedSlash { get; }
 
     /// <summary>
-    /// Whether the file path for the generated C# and Html documents should utilize the project key to
+    /// Whether the file path for the generated C# documents should utilize the project key to
     /// ensure a unique file path per project.
     /// </summary>
     public abstract bool IncludeProjectKeyInGeneratedFilePath { get; }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
@@ -58,10 +58,9 @@ internal class DefaultWindowsRazorProjectHost : WindowsRazorProjectHostBase
         {
             TryGetRootNamespace(update.Value.CurrentState, out var rootNamespace);
 
-            if (TryGetBeforeIntermediateOutputPath(update.Value.ProjectChanges, out var beforeIntermediateOutputPath))
+            if (TryGetBeforeIntermediateOutputPath(update.Value.ProjectChanges, out var beforeIntermediateOutputPath) &&
+                beforeIntermediateOutputPath != intermediatePath)
             {
-                Debug.Assert(beforeIntermediateOutputPath != intermediatePath, "IntermediateOutputPath seems to have changed, but hasn't?");
-
                 // If the intermediate output path is in the ProjectChanges, then we know that it has changed, so we want to ensure we remove the old one,
                 // otherwise this would be seen as an Add, and we'd end up with two active projects
                 await UpdateAsync(() =>

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
@@ -59,6 +60,8 @@ internal class DefaultWindowsRazorProjectHost : WindowsRazorProjectHostBase
 
             if (TryGetBeforeIntermediateOutputPath(update.Value.ProjectChanges, out var beforeIntermediateOutputPath))
             {
+                Debug.Assert(beforeIntermediateOutputPath != intermediatePath, "IntermediateOutputPath seems to have changed, but hasn't?");
+
                 // If the intermediate output path is in the ProjectChanges, then we know that it has changed, so we want to ensure we remove the old one,
                 // otherwise this would be seen as an Add, and we'd end up with two active projects
                 await UpdateAsync(() =>

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
@@ -57,7 +57,7 @@ internal class DefaultWindowsRazorProjectHost : WindowsRazorProjectHostBase
         {
             TryGetRootNamespace(update.Value.CurrentState, out var rootNamespace);
 
-            if (TryGetBeforeIntermeidateOutputPath(update.Value.ProjectChanges, out var beforeIntermediateOutputPath))
+            if (TryGetBeforeIntermediateOutputPath(update.Value.ProjectChanges, out var beforeIntermediateOutputPath))
             {
                 // If the intermediate output path is in the ProjectChanges, then we know that it has changed, so we want to ensure we remove the old one,
                 // otherwise this would be seen as an Add, and we'd end up with two active projects

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
@@ -57,6 +57,12 @@ internal class DefaultWindowsRazorProjectHost : WindowsRazorProjectHostBase
         {
             TryGetRootNamespace(update.Value.CurrentState, out var rootNamespace);
 
+            ProjectKey beforeProjectKey = default;
+            if (TryGetBeforeIntermeidateOutputPath(update.Value.ProjectChanges, out var beforeIntermediateOutputPath))
+            {
+                beforeProjectKey = ProjectKey.FromString(beforeIntermediateOutputPath);
+            }
+
             // We need to deal with the case where the project was uninitialized, but now
             // is valid for Razor. In that case we might have previously seen all of the documents
             // but ignored them because the project wasn't active.
@@ -82,7 +88,7 @@ internal class DefaultWindowsRazorProjectHost : WindowsRazorProjectHostBase
                     ProjectConfigurationFilePathStore.Set(hostProject.Key, projectConfigurationFile);
                 }
 
-                UpdateProjectUnsafe(hostProject);
+                UpdateProjectUnsafe(hostProject, beforeProjectKey);
 
                 for (var i = 0; i < changedDocuments.Length; i++)
                 {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
@@ -106,9 +106,9 @@ internal class FallbackWindowsRazorProjectHost : WindowsRazorProjectHostBase
             return;
         }
 
-        if (TryGetBeforeIntermediateOutputPath(update.Value.ProjectChanges, out var beforeIntermediateOutputPath))
+        if (TryGetBeforeIntermediateOutputPath(update.Value.ProjectChanges, out var beforeIntermediateOutputPath) &&
+            beforeIntermediateOutputPath != intermediatePath)
         {
-            Debug.Assert(beforeIntermediateOutputPath != intermediatePath, "IntermediateOutputPath seems to have changed, but hasn't?");
             // If the intermediate output path is in the ProjectChanges, then we know that it has changed, so we want to ensure we remove the old one,
             // otherwise this would be seen as an Add, and we'd end up with two active projects
             await UpdateAsync(() =>

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
@@ -105,6 +105,17 @@ internal class FallbackWindowsRazorProjectHost : WindowsRazorProjectHostBase
             return;
         }
 
+        if (TryGetBeforeIntermeidateOutputPath(update.Value.ProjectChanges, out var beforeIntermediateOutputPath))
+        {
+            // If the intermediate output path is in the ProjectChanges, then we know that it has changed, so we want to ensure we remove the old one,
+            // otherwise this would be seen as an Add, and we'd end up with two active projects
+            await UpdateAsync(() =>
+            {
+                var beforeProjectKey = ProjectKey.FromString(beforeIntermediateOutputPath);
+                UninitializeProjectUnsafe(beforeProjectKey);
+            }, CancellationToken.None).ConfigureAwait(false);
+        }
+
         // We need to deal with the case where the project was uninitialized, but now
         // is valid for Razor. In that case we might have previously seen all of the documents
         // but ignored them because the project wasn't active.
@@ -114,12 +125,6 @@ internal class FallbackWindowsRazorProjectHost : WindowsRazorProjectHostBase
         // makes us up-to-date.
         var documents = GetCurrentDocuments(update.Value);
         var changedDocuments = GetChangedAndRemovedDocuments(update.Value);
-
-        ProjectKey beforeProjectKey = default;
-        if (TryGetBeforeIntermeidateOutputPath(update.Value.ProjectChanges, out var beforeIntermediateOutputPath))
-        {
-            beforeProjectKey = ProjectKey.FromString(beforeIntermediateOutputPath);
-        }
 
         await UpdateAsync(() =>
         {
@@ -137,7 +142,7 @@ internal class FallbackWindowsRazorProjectHost : WindowsRazorProjectHostBase
                 ProjectConfigurationFilePathStore.Set(hostProject.Key, projectConfigurationFile);
             }
 
-            UpdateProjectUnsafe(hostProject, beforeProjectKey);
+            UpdateProjectUnsafe(hostProject);
 
             for (var i = 0; i < changedDocuments.Length; i++)
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
@@ -105,7 +105,7 @@ internal class FallbackWindowsRazorProjectHost : WindowsRazorProjectHostBase
             return;
         }
 
-        if (TryGetBeforeIntermeidateOutputPath(update.Value.ProjectChanges, out var beforeIntermediateOutputPath))
+        if (TryGetBeforeIntermediateOutputPath(update.Value.ProjectChanges, out var beforeIntermediateOutputPath))
         {
             // If the intermediate output path is in the ProjectChanges, then we know that it has changed, so we want to ensure we remove the old one,
             // otherwise this would be seen as an Add, and we'd end up with two active projects

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
@@ -115,6 +115,12 @@ internal class FallbackWindowsRazorProjectHost : WindowsRazorProjectHostBase
         var documents = GetCurrentDocuments(update.Value);
         var changedDocuments = GetChangedAndRemovedDocuments(update.Value);
 
+        ProjectKey beforeProjectKey = default;
+        if (TryGetBeforeIntermeidateOutputPath(update.Value.ProjectChanges, out var beforeIntermediateOutputPath))
+        {
+            beforeProjectKey = ProjectKey.FromString(beforeIntermediateOutputPath);
+        }
+
         await UpdateAsync(() =>
         {
             var configuration = FallbackRazorConfiguration.SelectConfiguration(version);
@@ -131,7 +137,7 @@ internal class FallbackWindowsRazorProjectHost : WindowsRazorProjectHostBase
                 ProjectConfigurationFilePathStore.Set(hostProject.Key, projectConfigurationFile);
             }
 
-            UpdateProjectUnsafe(hostProject);
+            UpdateProjectUnsafe(hostProject, beforeProjectKey);
 
             for (var i = 0; i < changedDocuments.Length; i++)
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
@@ -107,6 +108,7 @@ internal class FallbackWindowsRazorProjectHost : WindowsRazorProjectHostBase
 
         if (TryGetBeforeIntermediateOutputPath(update.Value.ProjectChanges, out var beforeIntermediateOutputPath))
         {
+            Debug.Assert(beforeIntermediateOutputPath != intermediatePath, "IntermediateOutputPath seems to have changed, but hasn't?");
             // If the intermediate output path is in the ProjectChanges, then we know that it has changed, so we want to ensure we remove the old one,
             // otherwise this would be seen as an Add, and we'd end up with two active projects
             await UpdateAsync(() =>

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
@@ -236,7 +236,7 @@ internal abstract class WindowsRazorProjectHostBase : OnceInitializedOnceDispose
                     UninitializeProjectUnsafe(projectKey);
 
                     var hostProject = new HostProject(newProjectFilePath, current.IntermediateOutputPath, current.Configuration, current.RootNamespace);
-                    UpdateProjectUnsafe(hostProject, beforeProjectKey:default);
+                    UpdateProjectUnsafe(hostProject);
 
                     // This should no-op in the common case, just putting it here for insurance.
                     foreach (var documentFilePath in current.DocumentFilePaths)
@@ -274,7 +274,7 @@ internal abstract class WindowsRazorProjectHostBase : OnceInitializedOnceDispose
         }
     }
 
-    protected void UpdateProjectUnsafe(HostProject project, ProjectKey beforeProjectKey)
+    protected void UpdateProjectUnsafe(HostProject project)
     {
         var projectManager = GetProjectManager();
 
@@ -285,16 +285,6 @@ internal abstract class WindowsRazorProjectHostBase : OnceInitializedOnceDispose
             // If VS did tell us, then this is a no-op.
             projectManager.SolutionOpened();
 
-            // We had a before project, but that is no longer the current project, means the customer did something that changes
-            // the project key.  Remove the old project object.
-            if (!project.Key.Equals(beforeProjectKey))
-            {
-                var before = projectManager.GetLoadedProject(beforeProjectKey);
-                if (before is not null)
-                { 
-                    projectManager.ProjectRemoved(beforeProjectKey);
-                }
-            }
             projectManager.ProjectAdded(project);
         }
         else

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
@@ -235,8 +235,8 @@ internal abstract class WindowsRazorProjectHostBase : OnceInitializedOnceDispose
                 {
                     UninitializeProjectUnsafe(projectKey);
 
-                    var hostProject = new HostProject(newProjectFilePath, current.IntermediateOutputPath, current.Configuration, current.RootNamespace, current.DisplayName);
-                    UpdateProjectUnsafe(hostProject);
+                    var hostProject = new HostProject(newProjectFilePath, current.IntermediateOutputPath, current.Configuration, current.RootNamespace);
+                    UpdateProjectUnsafe(hostProject, beforeProjectKey:default);
 
                     // This should no-op in the common case, just putting it here for insurance.
                     foreach (var documentFilePath in current.DocumentFilePaths)
@@ -274,7 +274,7 @@ internal abstract class WindowsRazorProjectHostBase : OnceInitializedOnceDispose
         }
     }
 
-    protected void UpdateProjectUnsafe(HostProject project)
+    protected void UpdateProjectUnsafe(HostProject project, ProjectKey beforeProjectKey)
     {
         var projectManager = GetProjectManager();
 
@@ -285,6 +285,16 @@ internal abstract class WindowsRazorProjectHostBase : OnceInitializedOnceDispose
             // If VS did tell us, then this is a no-op.
             projectManager.SolutionOpened();
 
+            // We had a before project, but that is no longer the current project, means the customer did something that changes
+            // the project key.  Remove the old project object.
+            if (!project.Key.Equals(beforeProjectKey))
+            {
+                var before = projectManager.GetLoadedProject(beforeProjectKey);
+                if (before is not null)
+                { 
+                    projectManager.ProjectRemoved(beforeProjectKey);
+                }
+            }
             projectManager.ProjectAdded(project);
         }
         else
@@ -330,6 +340,20 @@ internal abstract class WindowsRazorProjectHostBase : OnceInitializedOnceDispose
     private Task UnconfiguredProject_ProjectRenamingAsync(object? sender, ProjectRenamedEventArgs args)
         => OnProjectRenamingAsync(args.OldFullPath, args.NewFullPath);
 
+    protected bool TryGetBeforeIntermeidateOutputPath(IImmutableDictionary<string, IProjectChangeDescription> state,
+        [NotNullWhen(returnValue: true)] out string? path)
+    {
+        if (!state.TryGetValue(ConfigurationGeneralSchemaName, out var rule))
+        {
+            path = null;
+            return false;
+        }
+
+        var beforeValues = rule.Before;
+
+        return TryGetIntermediateOutputPathFromProjectRuleSnapshot(beforeValues, out path);
+    }
+
     // virtual for testing
     protected virtual bool TryGetIntermediateOutputPath(
         IImmutableDictionary<string, IProjectRuleSnapshot> state,
@@ -341,6 +365,11 @@ internal abstract class WindowsRazorProjectHostBase : OnceInitializedOnceDispose
             return false;
         }
 
+        return TryGetIntermediateOutputPathFromProjectRuleSnapshot(rule, out path);
+    }
+
+    private bool TryGetIntermediateOutputPathFromProjectRuleSnapshot(IProjectRuleSnapshot rule, out string? path)
+    {
         if (!rule.Properties.TryGetValue(BaseIntermediateOutputPathPropertyName, out var baseIntermediateOutputPathValue))
         {
             path = null;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
@@ -330,7 +330,7 @@ internal abstract class WindowsRazorProjectHostBase : OnceInitializedOnceDispose
     private Task UnconfiguredProject_ProjectRenamingAsync(object? sender, ProjectRenamedEventArgs args)
         => OnProjectRenamingAsync(args.OldFullPath, args.NewFullPath);
 
-    protected bool TryGetBeforeIntermeidateOutputPath(IImmutableDictionary<string, IProjectChangeDescription> state,
+    protected bool TryGetBeforeIntermediateOutputPath(IImmutableDictionary<string, IProjectChangeDescription> state,
         [NotNullWhen(returnValue: true)] out string? path)
     {
         if (!state.TryGetValue(ConfigurationGeneralSchemaName, out var rule))

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
@@ -1246,6 +1246,110 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
         Assert.Empty(_projectManager.GetProjects());
     }
 
+    [UIFact]
+    public async Task OnProjectChanged_ChangeIntermediateOutputPath_RemovesAndAddsProject()
+    {
+        // Arrange
+        _razorGeneralProperties.Property(Rules.RazorGeneral.RazorLangVersionProperty, "2.1");
+        _razorGeneralProperties.Property(Rules.RazorGeneral.RazorDefaultConfigurationProperty, "MVC-2.1");
+
+        _configurationItems.Item("MVC-2.1");
+        _configurationItems.Property("MVC-2.1", Rules.RazorConfiguration.ExtensionsProperty, "MVC-2.1;Another-Thing");
+
+        _extensionItems.Item("MVC-2.1");
+        _extensionItems.Item("Another-Thing");
+
+        _razorComponentWithTargetPathItems.Item(Path.GetFileName(TestProjectData.SomeProjectComponentFile1.FilePath));
+        _razorComponentWithTargetPathItems.Property(Path.GetFileName(TestProjectData.SomeProjectComponentFile1.FilePath), Rules.RazorComponentWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectComponentFile1.TargetPath);
+
+        _razorComponentWithTargetPathItems.Item(Path.GetFileName(TestProjectData.SomeProjectComponentImportFile1.FilePath));
+        _razorComponentWithTargetPathItems.Property(Path.GetFileName(TestProjectData.SomeProjectComponentImportFile1.FilePath), Rules.RazorComponentWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectComponentImportFile1.TargetPath);
+
+        _razorGenerateWithTargetPathItems.Item(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath));
+        _razorGenerateWithTargetPathItems.Property(Path.GetFileName(TestProjectData.SomeProjectFile1.FilePath), Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.SomeProjectFile1.TargetPath);
+
+        _configurationGeneral.Property(WindowsRazorProjectHostBase.BaseIntermediateOutputPathPropertyName, TestProjectData.SomeProject.IntermediateOutputPath);
+        _configurationGeneral.Property(WindowsRazorProjectHostBase.IntermediateOutputPathPropertyName, "obj");
+
+        var changes = new TestProjectChangeDescription[]
+        {
+             _razorGeneralProperties.ToChange(),
+             _configurationItems.ToChange(),
+             _extensionItems.ToChange(),
+             _razorComponentWithTargetPathItems.ToChange(),
+             _razorGenerateWithTargetPathItems.ToChange(),
+             _configurationGeneral.ToChange(),
+        };
+
+        var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
+        var host = new DefaultWindowsRazorProjectHost(services, _projectManagerAccessor, Dispatcher, _projectConfigurationFilePathStore, languageServerFeatureOptions: null);
+        host.SkipIntermediateOutputPathExistCheck_TestOnly = true;
+
+        await Task.Run(async () => await host.LoadAsync());
+        Assert.Empty(_projectManager.GetProjects());
+
+        // Act - 1
+        await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
+
+        // Assert - 1
+        var snapshot = Assert.Single(_projectManager.GetProjects());
+        Assert.Equal(TestProjectData.SomeProject.FilePath, snapshot.FilePath);
+
+        Assert.Equal(RazorLanguageVersion.Version_2_1, snapshot.Configuration.LanguageVersion);
+        Assert.Equal("MVC-2.1", snapshot.Configuration.ConfigurationName);
+        Assert.Collection(
+            snapshot.Configuration.Extensions.OrderBy(e => e.ExtensionName),
+            e => Assert.Equal("Another-Thing", e.ExtensionName),
+            e => Assert.Equal("MVC-2.1", e.ExtensionName));
+
+        Assert.Collection(
+            snapshot.DocumentFilePaths.OrderBy(d => d),
+            d =>
+            {
+                var document = snapshot.GetDocument(d);
+                Assert.Equal(TestProjectData.SomeProjectComponentImportFile1.FilePath, document.FilePath);
+                Assert.Equal(TestProjectData.SomeProjectComponentImportFile1.TargetPath, document.TargetPath);
+                Assert.Equal(FileKinds.ComponentImport, document.FileKind);
+            },
+            d =>
+            {
+                var document = snapshot.GetDocument(d);
+                Assert.Equal(TestProjectData.SomeProjectFile1.FilePath, document.FilePath);
+                Assert.Equal(TestProjectData.SomeProjectFile1.TargetPath, document.TargetPath);
+            },
+            d =>
+            {
+                var document = snapshot.GetDocument(d);
+                Assert.Equal(TestProjectData.SomeProjectComponentFile1.FilePath, document.FilePath);
+                Assert.Equal(TestProjectData.SomeProjectComponentFile1.TargetPath, document.TargetPath);
+                Assert.Equal(FileKinds.Component, document.FileKind);
+            });
+
+        // Act - 2
+        _configurationGeneral.Property(WindowsRazorProjectHostBase.IntermediateOutputPathPropertyName, "obj2");
+
+        changes = new TestProjectChangeDescription[]
+        {
+             _razorGeneralProperties.ToChange(changes[0].After),
+             _configurationItems.ToChange(changes[1].After),
+             _extensionItems.ToChange(changes[2].After),
+             _razorComponentWithTargetPathItems.ToChange(changes[3].After),
+             _razorGenerateWithTargetPathItems.ToChange(changes[4].After),
+             _configurationGeneral.ToChange(changes[5].After),
+        };
+
+        await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
+
+        // Assert - 2
+        // Changing intermediate output path is effectively removing the old project and adding a new one.
+        snapshot = Assert.Single(_projectManager.GetProjects());
+        Assert.Equal(TestProjectData.SomeProject.FilePath, snapshot.FilePath);
+        Assert.Equal(TestProjectData.SomeProject.IntermediateOutputPath + "2", snapshot.IntermediateOutputPath);
+
+        await Task.Run(async () => await host.DisposeAsync());
+        Assert.Empty(_projectManager.GetProjects());
+    }
+
     private class TestProjectSnapshotManager(
         IProjectEngineFactoryProvider projectEngineFactoryProvider,
         ProjectSnapshotManagerDispatcher dispatcher)


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/9900

When publishing a project, the IntermediateOutputPath get changed to Release during the publish, then back to Debug again at the end. There were two problems with this:

1. We were seeing the change to Release as a new project, and ended up thinking it was multi-targeted
	* The changes to our CPS bits fix this, by uninitializing the old project when the intermediate output path changes. Thanks @phil-allen-msft for the headstart commit on this one.
	* The changes to the `MonitorProjectConfigurationFilePathEndpoint` make the uninitialize in VS also result in the removal of the project in the language server
2. When changing back to Debug, the VS side of things thought this was a new project (because of the above change), but the language server never cleared its understanding of the world, so the two systems were out of sync
	* The changes to the `GeneratedDocumentPublisher` fix this

I will note, there is still a little flakiness here because of the project churn, and if I do a publish and switch back to a Razor file quickly and start editing, things still get a little odd, but at least with these fixes things settle down to correct after the publish is finished, and worst case closing and re-opening a Razor document will get things on the straight and narrow. Previously only restarting VS would help. I didn't think it was worth digging too far in to the churn because cohosting should help out with all of that anyway.

FYI @gabephudson, thanks for your help in reporting and providing feedback.