### PR TITLE
Add textDocument/inlayHints support

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Protocol/DelegatedTypes.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Protocol/DelegatedTypes.cs
@@ -23,6 +23,11 @@ internal record DelegatedPositionParams(
     Position ProjectedPosition,
     RazorLanguageKind ProjectedKind) : IDelegatedParams;
 
+internal record DelegatedInlayHintParams(
+    TextDocumentIdentifierAndVersion Identifier,
+    Range ProjectedRange,
+    RazorLanguageKind ProjectedKind) : IDelegatedParams;
+
 internal record DelegatedValidateBreakpointRangeParams(
     TextDocumentIdentifierAndVersion Identifier,
     Range ProjectedRange,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Protocol/DelegatedTypes.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Protocol/DelegatedTypes.cs
@@ -28,6 +28,11 @@ internal record DelegatedInlayHintParams(
     Range ProjectedRange,
     RazorLanguageKind ProjectedKind) : IDelegatedParams;
 
+internal record DelegatedInlayHintResolveParams(
+    TextDocumentIdentifier Identifier,
+    InlayHint InlayHint,
+    RazorLanguageKind ProjectedKind);
+
 internal record DelegatedValidateBreakpointRangeParams(
     TextDocumentIdentifierAndVersion Identifier,
     Range ProjectedRange,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Protocol/DelegatedTypes.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Protocol/DelegatedTypes.cs
@@ -29,9 +29,9 @@ internal record DelegatedInlayHintParams(
     RazorLanguageKind ProjectedKind) : IDelegatedParams;
 
 internal record DelegatedInlayHintResolveParams(
-    TextDocumentIdentifier Identifier,
+    TextDocumentIdentifierAndVersion Identifier,
     InlayHint InlayHint,
-    RazorLanguageKind ProjectedKind);
+    RazorLanguageKind ProjectedKind) : IDelegatedParams;
 
 internal record DelegatedValidateBreakpointRangeParams(
     TextDocumentIdentifierAndVersion Identifier,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Common/CustomMessageNames.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Common/CustomMessageNames.cs
@@ -38,6 +38,8 @@ internal static class CustomMessageNames
     public const string RazorHtmlOnTypeFormattingEndpoint = "razor/htmlOnTypeFormatting";
     public const string RazorSimplifyMethodEndpointName = "razor/simplifyMethod";
     public const string RazorFormatNewFileEndpointName = "razor/formatNewFile";
+    public const string RazorInlayHintEndpoint = "razor/inlayHint";
+    public const string RazorInlayHintResolveEndpoint = "razor/inlayHintResolve";
 
     // VS Windows only at the moment, but could/should be migrated
     public const string RazorDocumentSymbolEndpoint = "razor/documentSymbol";
@@ -55,9 +57,6 @@ internal static class CustomMessageNames
     public const string RazorImplementationEndpointName = "razor/implementation";
 
     public const string RazorReferencesEndpointName = "razor/references";
-
-    public const string RazorInlayHintEndpoint = "razor/inlayHint";
-    public const string RazorInlayHintResolveEndpoint = "razor/inlayHintResolve";
 
     // Called to get C# diagnostics from Roslyn when publishing diagnostics for VS Code
     public const string RazorCSharpPullDiagnosticsEndpointName = "razor/csharpPullDiagnostics";

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Common/CustomMessageNames.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Common/CustomMessageNames.cs
@@ -57,6 +57,7 @@ internal static class CustomMessageNames
     public const string RazorReferencesEndpointName = "razor/references";
 
     public const string RazorInlayHintEndpoint = "razor/inlayHint";
+    public const string RazorInlayHintResolveEndpoint = "razor/inlayHintResolve";
 
     // Called to get C# diagnostics from Roslyn when publishing diagnostics for VS Code
     public const string RazorCSharpPullDiagnosticsEndpointName = "razor/csharpPullDiagnostics";

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Common/CustomMessageNames.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Common/CustomMessageNames.cs
@@ -56,6 +56,8 @@ internal static class CustomMessageNames
 
     public const string RazorReferencesEndpointName = "razor/references";
 
+    public const string RazorInlayHintEndpoint = "razor/inlayHint";
+
     // Called to get C# diagnostics from Roslyn when publishing diagnostics for VS Code
     public const string RazorCSharpPullDiagnosticsEndpointName = "razor/csharpPullDiagnostics";
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Common/VSInternalServerCapabilitiesExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Common/VSInternalServerCapabilitiesExtensions.cs
@@ -7,6 +7,15 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Common;
 
 internal static class VSInternalServerCapabilitiesExtensions
 {
+    public static void EnableInlayHints(this VSInternalServerCapabilities serverCapabilities)
+    {
+        serverCapabilities.InlayHintOptions = new InlayHintOptions
+        {
+            ResolveProvider = true,
+            WorkDoneProgress = false
+        };
+    }
+
     public static void EnableDocumentColorProvider(this VSInternalServerCapabilities serverCapabilities)
     {
         serverCapabilities.DocumentColorProvider = new DocumentColorOptions();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RazorCodeDocumentExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RazorCodeDocumentExtensions.cs
@@ -1,8 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 
@@ -15,4 +19,50 @@ internal static class RazorCodeDocumentExtensions
             RazorLanguageKind.Html => document.GetHtmlDocument(),
             _ => throw new System.InvalidOperationException(),
         };
+
+    public static bool TryGetMinimalCSharpRange(this RazorCodeDocument codeDocument, Range razorRange, [NotNullWhen(true)] out Range? csharpRange)
+    {
+        SourceSpan? minGeneratedSpan = null;
+        SourceSpan? maxGeneratedSpan = null;
+
+        var sourceText = codeDocument.GetSourceText();
+        var textSpan = razorRange.ToTextSpan(sourceText);
+        var csharpDoc = codeDocument.GetCSharpDocument();
+
+        // We want to find the min and max C# source mapping that corresponds with our Razor range.
+        foreach (var mapping in csharpDoc.SourceMappings)
+        {
+            var mappedTextSpan = mapping.OriginalSpan.AsTextSpan();
+
+            if (textSpan.OverlapsWith(mappedTextSpan))
+            {
+                if (minGeneratedSpan is null || mapping.GeneratedSpan.AbsoluteIndex < minGeneratedSpan.Value.AbsoluteIndex)
+                {
+                    minGeneratedSpan = mapping.GeneratedSpan;
+                }
+
+                var mappingEndIndex = mapping.GeneratedSpan.AbsoluteIndex + mapping.GeneratedSpan.Length;
+                if (maxGeneratedSpan is null || mappingEndIndex > maxGeneratedSpan.Value.AbsoluteIndex + maxGeneratedSpan.Value.Length)
+                {
+                    maxGeneratedSpan = mapping.GeneratedSpan;
+                }
+            }
+        }
+
+        // Create a new projected range based on our calculated min/max source spans.
+        if (minGeneratedSpan is not null && maxGeneratedSpan is not null)
+        {
+            var csharpSourceText = codeDocument.GetCSharpSourceText();
+            var startRange = minGeneratedSpan.Value.ToRange(csharpSourceText);
+            var endRange = maxGeneratedSpan.Value.ToRange(csharpSourceText);
+
+            csharpRange = new Range { Start = startRange.Start, End = endRange.End };
+            Debug.Assert(csharpRange.Start.CompareTo(csharpRange.End) <= 0, "Range.Start should not be larger than Range.End");
+
+            return true;
+        }
+
+        csharpRange = null;
+        return false;
+    }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlayHints/IInlayHintService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlayHints/IInlayHintService.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.InlayHints;
+
+internal interface IInlayHintService
+{
+    Task<InlayHint[]?> GetInlayHintsAsync(IClientConnection clientConnection, VersionedDocumentContext documentContext, Range range, CancellationToken cancellationToken);
+
+    Task<InlayHint?> ResolveInlayHintAsync(IClientConnection clientConnection, InlayHint inlayHint, CancellationToken cancellationToken);
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlayHints/InlayHintEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlayHints/InlayHintEndpoint.cs
@@ -23,12 +23,6 @@ internal sealed class InlayHintEndpoint(LanguageServerFeatureOptions featureOpti
 
     public void ApplyCapabilities(VSInternalServerCapabilities serverCapabilities, VSInternalClientCapabilities clientCapabilities)
     {
-        // Not supported in VS Code
-        if (!_featureOptions.SingleServerSupport)
-        {
-            return;
-        }
-
         serverCapabilities.EnableInlayHints();
     }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlayHints/InlayHintEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlayHints/InlayHintEndpoint.cs
@@ -1,30 +1,23 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
-using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
-using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
-using Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
-using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
-using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.InlayHints;
 
 [LanguageServerEndpoint(Methods.TextDocumentInlayHintName)]
-internal sealed class InlayHintEndpoint(LanguageServerFeatureOptions featureOptions, IRazorDocumentMappingService documentMappingService, IClientConnection clientConnection)
+internal sealed class InlayHintEndpoint(LanguageServerFeatureOptions featureOptions, IInlayHintService inlayHintService, IClientConnection clientConnection)
     : IRazorRequestHandler<InlayHintParams, InlayHint[]?>, ICapabilitiesProvider
 {
     private readonly LanguageServerFeatureOptions _featureOptions = featureOptions;
-    private readonly IRazorDocumentMappingService _documentMappingService = documentMappingService;
-    private readonly IClientConnection _clientConnection = clientConnection ?? throw new ArgumentNullException(nameof(clientConnection));
+    private readonly IInlayHintService _inlayHintService = inlayHintService;
+    private readonly IClientConnection _clientConnection = clientConnection;
 
     public bool MutatesSolutionState => false;
 
@@ -42,63 +35,9 @@ internal sealed class InlayHintEndpoint(LanguageServerFeatureOptions featureOpti
     public TextDocumentIdentifier GetTextDocumentIdentifier(InlayHintParams request)
         => request.TextDocument;
 
-    public async Task<InlayHint[]?> HandleRequestAsync(InlayHintParams request, RazorRequestContext context, CancellationToken cancellationToken)
+    public Task<InlayHint[]?> HandleRequestAsync(InlayHintParams request, RazorRequestContext context, CancellationToken cancellationToken)
     {
         var documentContext = context.GetRequiredDocumentContext();
-        return await GetInlayHintsAsync(documentContext, request.Range, cancellationToken).ConfigureAwait(false);
-    }
-
-    private async Task<InlayHint[]?> GetInlayHintsAsync(VersionedDocumentContext documentContext, Range range, CancellationToken cancellationToken)
-    {
-        var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
-        var csharpDocument = codeDocument.GetCSharpDocument();
-
-        // We are given a range by the client, but our mapping only succeeds if the start and end of the range can both be mapped
-        // to C#. Since that doesn't logically match what we want from inlay hints, we instead get the minimum range of mappable
-        // C# to get hints for. We'll filter that later, to remove the sections that can't be mapped back.
-        if (!_documentMappingService.TryMapToGeneratedDocumentRange(csharpDocument, range, out var projectedRange) &&
-            !RazorSemanticTokensInfoService.TryGetMinimalCSharpRange(codeDocument, range, out projectedRange))
-        {
-            // There's no C# in the range.
-            return null;
-        }
-
-        // For now we only support C# inlay hints. Once Web Tools adds support we'll need to request from both servers and combine
-        // the results, much like folding ranges.
-        var delegatedRequest = new DelegatedInlayHintParams(
-            Identifier: documentContext.Identifier,
-            ProjectedRange: projectedRange,
-            ProjectedKind: RazorLanguageKind.CSharp
-        );
-
-        var inlayHints = await _clientConnection.SendRequestAsync<DelegatedInlayHintParams, InlayHint[]?>(
-            CustomMessageNames.RazorInlayHintEndpoint,
-            delegatedRequest,
-            cancellationToken).ConfigureAwait(false);
-
-        if (inlayHints is null)
-        {
-            return null;
-        }
-
-        var csharpSourceText = codeDocument.GetCSharpSourceText();
-        using var _1 = ArrayBuilderPool<InlayHint>.GetPooledObject(out var inlayHintsBuilder);
-        foreach (var hint in inlayHints)
-        {
-            if (hint.Position.TryGetAbsoluteIndex(csharpSourceText, null, out var absoluteIndex) &&
-                _documentMappingService.TryMapToHostDocumentPosition(csharpDocument, absoluteIndex, out Position? hostDocumentPosition, out _))
-            {
-                hint.Data = new RazorInlayHintWrapper
-                {
-                    TextDocument = documentContext.Identifier,
-                    OriginalData = hint.Data,
-                    OriginalPosition = hint.Position
-                };
-                hint.Position = hostDocumentPosition;
-                inlayHintsBuilder.Add(hint);
-            }
-        }
-
-        return inlayHintsBuilder.ToArray();
+        return _inlayHintService.GetInlayHintsAsync(_clientConnection, documentContext, request.Range, cancellationToken);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlayHints/InlayHintEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlayHints/InlayHintEndpoint.cs
@@ -38,7 +38,7 @@ internal sealed class InlayHintEndpoint(LanguageServerFeatureOptions featureOpti
 
         serverCapabilities.InlayHintOptions = new InlayHintOptions
         {
-            ResolveProvider = false,
+            ResolveProvider = true,
             WorkDoneProgress = false
         };
     }
@@ -89,6 +89,12 @@ internal sealed class InlayHintEndpoint(LanguageServerFeatureOptions featureOpti
             if (hint.Position.TryGetAbsoluteIndex(csharpSourceText, null, out var absoluteIndex) &&
                 _documentMappingService.TryMapToHostDocumentPosition(csharpDocument, absoluteIndex, out Position? hostDocumentPosition, out _))
             {
+                hint.Data = new RazorInlayHintWrapper
+                {
+                    TextDocument = request.TextDocument,
+                    OriginalData = hint.Data,
+                    OriginalPosition = hint.Position
+                };
                 hint.Position = hostDocumentPosition;
                 inlayHintsBuilder.Add(hint);
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlayHints/InlayHintEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlayHints/InlayHintEndpoint.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
+using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
+using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
+using Microsoft.AspNetCore.Razor.PooledObjects;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
+using Microsoft.CommonLanguageServerProtocol.Framework;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.InlayHints;
+
+[LanguageServerEndpoint(Methods.TextDocumentInlayHintName)]
+internal sealed class InlayHintEndpoint(LanguageServerFeatureOptions featureOptions, IRazorDocumentMappingService documentMappingService, IClientConnection clientConnection)
+    : IRazorRequestHandler<InlayHintParams, InlayHint[]?>, ICapabilitiesProvider
+{
+    private readonly LanguageServerFeatureOptions _featureOptions = featureOptions;
+    private readonly IRazorDocumentMappingService _documentMappingService = documentMappingService;
+    private readonly IClientConnection _clientConnection = clientConnection ?? throw new ArgumentNullException(nameof(clientConnection));
+
+    public bool MutatesSolutionState => false;
+
+    public void ApplyCapabilities(VSInternalServerCapabilities serverCapabilities, VSInternalClientCapabilities clientCapabilities)
+    {
+        // Not supported in VS Code
+        if (!_featureOptions.SingleServerSupport)
+        {
+            return;
+        }
+
+        serverCapabilities.InlayHintOptions = new InlayHintOptions
+        {
+            ResolveProvider = false,
+            WorkDoneProgress = false
+        };
+    }
+
+    public TextDocumentIdentifier GetTextDocumentIdentifier(InlayHintParams request)
+        => request.TextDocument;
+
+    public async Task<InlayHint[]?> HandleRequestAsync(InlayHintParams request, RazorRequestContext context, CancellationToken cancellationToken)
+    {
+        var documentContext = context.GetRequiredDocumentContext();
+        var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var csharpDocument = codeDocument.GetCSharpDocument();
+
+        // We are given a range by the client, but our mapping only succeeds if the start and end of the range can both be mapped
+        // to C#. Since that doesn't logically match what we want from inlay hints, we instead get the minimum range of mappable
+        // C# to get hints for. We'll filter that later, to remove the sections that can't be mapped back.
+        if (!_documentMappingService.TryMapToGeneratedDocumentRange(csharpDocument, request.Range, out var projectedRange) &&
+            !RazorSemanticTokensInfoService.TryGetMinimalCSharpRange(codeDocument, request.Range, out projectedRange))
+        {
+            // There's no C# in the range.
+            return null;
+        }
+
+        // For now we only support C# inlay hints. Once Web Tools adds support we'll need to request from both servers and combine
+        // the results, much like folding ranges.
+        var delegatedRequest = new DelegatedInlayHintParams(
+            Identifier: documentContext.Identifier,
+            ProjectedRange: projectedRange,
+            ProjectedKind: RazorLanguageKind.CSharp
+        );
+
+        var inlayHints = await _clientConnection.SendRequestAsync<DelegatedInlayHintParams, InlayHint[]?>(
+            CustomMessageNames.RazorInlayHintEndpoint,
+            delegatedRequest,
+            cancellationToken).ConfigureAwait(false);
+
+        if (inlayHints is null)
+        {
+            return null;
+        }
+
+        var csharpSourceText = codeDocument.GetCSharpSourceText();
+
+        using var _1 = ArrayBuilderPool<InlayHint>.GetPooledObject(out var inlayHintsBuilder);
+
+        foreach (var hint in inlayHints)
+        {
+            if (hint.Position.TryGetAbsoluteIndex(csharpSourceText, null, out var absoluteIndex) &&
+                _documentMappingService.TryMapToHostDocumentPosition(csharpDocument, absoluteIndex, out Position? hostDocumentPosition, out _))
+            {
+                hint.Position = hostDocumentPosition;
+                inlayHintsBuilder.Add(hint);
+            }
+        }
+
+        return inlayHintsBuilder.ToArray();
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlayHints/InlayHintResolveEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlayHints/InlayHintResolveEndpoint.cs
@@ -1,59 +1,25 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
-using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.InlayHints;
 
 [LanguageServerEndpoint(Methods.InlayHintResolveName)]
-internal sealed class InlayHintResolveEndpoint(IRazorDocumentMappingService documentMappingService, IClientConnection clientConnection)
+internal sealed class InlayHintResolveEndpoint(IInlayHintService inlayHintService, IClientConnection clientConnection)
     : IRazorDocumentlessRequestHandler<InlayHint, InlayHint?>
 {
-    private readonly IRazorDocumentMappingService _documentMappingService = documentMappingService;
-    private readonly IClientConnection _clientConnection = clientConnection ?? throw new ArgumentNullException(nameof(clientConnection));
+    private readonly IInlayHintService _inlayHintService = inlayHintService;
+    private readonly IClientConnection _clientConnection = clientConnection;
 
     public bool MutatesSolutionState => false;
 
-    public async Task<InlayHint?> HandleRequestAsync(InlayHint request, RazorRequestContext context, CancellationToken cancellationToken)
+    public Task<InlayHint?> HandleRequestAsync(InlayHint request, RazorRequestContext context, CancellationToken cancellationToken)
     {
-        if (request.Data is not RazorInlayHintWrapper inlayHintWrapper)
-        {
-            return null;
-        }
-
-        var razorPosition = request.Position;
-        request.Position = inlayHintWrapper.OriginalPosition;
-        request.Data = inlayHintWrapper.OriginalData;
-
-        // For now we only support C# inlay hints. Once Web Tools adds support we'll need to request from both servers and combine
-        // the results, much like folding ranges.
-        var delegatedRequest = new DelegatedInlayHintResolveParams(
-            Identifier: inlayHintWrapper.TextDocument,
-            InlayHint: request,
-            ProjectedKind: RazorLanguageKind.CSharp
-        );
-
-        var inlayHint = await _clientConnection.SendRequestAsync<DelegatedInlayHintResolveParams, InlayHint?>(
-            CustomMessageNames.RazorInlayHintResolveEndpoint,
-            delegatedRequest,
-            cancellationToken).ConfigureAwait(false);
-
-        if (inlayHint is null)
-        {
-            return null;
-        }
-
-        Debug.Assert(request.Position == inlayHint.Position, "Resolving inlay hints should not change the position of them.");
-        inlayHint.Position = razorPosition;
-
-        return inlayHint;
+        return _inlayHintService.ResolveInlayHintAsync(_clientConnection, request, cancellationToken);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlayHints/InlayHintResolveEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlayHints/InlayHintResolveEndpoint.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
+using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.CommonLanguageServerProtocol.Framework;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.InlayHints;
+
+[LanguageServerEndpoint(Methods.InlayHintResolveName)]
+internal sealed class InlayHintResolveEndpoint(IRazorDocumentMappingService documentMappingService, IClientConnection clientConnection)
+    : IRazorDocumentlessRequestHandler<InlayHint, InlayHint?>
+{
+    private readonly IRazorDocumentMappingService _documentMappingService = documentMappingService;
+    private readonly IClientConnection _clientConnection = clientConnection ?? throw new ArgumentNullException(nameof(clientConnection));
+
+    public bool MutatesSolutionState => false;
+
+    public async Task<InlayHint?> HandleRequestAsync(InlayHint request, RazorRequestContext context, CancellationToken cancellationToken)
+    {
+        if (request.Data is not RazorInlayHintWrapper inlayHintWrapper)
+        {
+            return null;
+        }
+
+        var razorPosition = request.Position;
+        request.Position = inlayHintWrapper.OriginalPosition;
+        request.Data = inlayHintWrapper.OriginalData;
+
+        // For now we only support C# inlay hints. Once Web Tools adds support we'll need to request from both servers and combine
+        // the results, much like folding ranges.
+        var delegatedRequest = new DelegatedInlayHintResolveParams(
+            Identifier: inlayHintWrapper.TextDocument,
+            InlayHint: request,
+            ProjectedKind: RazorLanguageKind.CSharp
+        );
+
+        var inlayHint = await _clientConnection.SendRequestAsync<DelegatedInlayHintResolveParams, InlayHint?>(
+            CustomMessageNames.RazorInlayHintResolveEndpoint,
+            delegatedRequest,
+            cancellationToken).ConfigureAwait(false);
+
+        if (inlayHint is null)
+        {
+            return null;
+        }
+
+        Debug.Assert(request.Position == inlayHint.Position, "Resolving inlay hints should not change the position of them.");
+        inlayHint.Position = razorPosition;
+
+        return inlayHint;
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlayHints/InlayHintService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlayHints/InlayHintService.cs
@@ -80,12 +80,13 @@ internal sealed class InlayHintService(IRazorDocumentMappingService documentMapp
 
     public async Task<InlayHint?> ResolveInlayHintAsync(IClientConnection clientConnection, InlayHint inlayHint, CancellationToken cancellationToken)
     {
-        if (inlayHint.Data is not JObject dataObj)
+        var inlayHintWrapper = inlayHint.Data as RazorInlayHintWrapper;
+        if (inlayHintWrapper is null &&
+            inlayHint.Data is JObject dataObj)
         {
-            return null;
+            inlayHintWrapper = dataObj.ToObject<RazorInlayHintWrapper>();
         }
 
-        var inlayHintWrapper = dataObj.ToObject<RazorInlayHintWrapper>();
         if (inlayHintWrapper is null)
         {
             return null;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlayHints/InlayHintService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlayHints/InlayHintService.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
-using Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -32,7 +31,7 @@ internal sealed class InlayHintService(IRazorDocumentMappingService documentMapp
         // to C#. Since that doesn't logically match what we want from inlay hints, we instead get the minimum range of mappable
         // C# to get hints for. We'll filter that later, to remove the sections that can't be mapped back.
         if (!_documentMappingService.TryMapToGeneratedDocumentRange(csharpDocument, range, out var projectedRange) &&
-            !RazorSemanticTokensInfoService.TryGetMinimalCSharpRange(codeDocument, range, out projectedRange))
+            !codeDocument.TryGetMinimalCSharpRange(range, out projectedRange))
         {
             // There's no C# in the range.
             return null;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlayHints/InlayHintService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlayHints/InlayHintService.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
+using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
+using Microsoft.AspNetCore.Razor.PooledObjects;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.InlayHints;
+
+[Export(typeof(IInlayHintService))]
+[method: ImportingConstructor]
+internal sealed class InlayHintService(IRazorDocumentMappingService documentMappingService) : IInlayHintService
+{
+    private readonly IRazorDocumentMappingService _documentMappingService = documentMappingService;
+
+    public async Task<InlayHint[]?> GetInlayHintsAsync(IClientConnection clientConnection, VersionedDocumentContext documentContext, Range range, CancellationToken cancellationToken)
+    {
+        var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var csharpDocument = codeDocument.GetCSharpDocument();
+
+        // We are given a range by the client, but our mapping only succeeds if the start and end of the range can both be mapped
+        // to C#. Since that doesn't logically match what we want from inlay hints, we instead get the minimum range of mappable
+        // C# to get hints for. We'll filter that later, to remove the sections that can't be mapped back.
+        if (!_documentMappingService.TryMapToGeneratedDocumentRange(csharpDocument, range, out var projectedRange) &&
+            !RazorSemanticTokensInfoService.TryGetMinimalCSharpRange(codeDocument, range, out projectedRange))
+        {
+            // There's no C# in the range.
+            return null;
+        }
+
+        // For now we only support C# inlay hints. Once Web Tools adds support we'll need to request from both servers and combine
+        // the results, much like folding ranges.
+        var delegatedRequest = new DelegatedInlayHintParams(
+            Identifier: documentContext.Identifier,
+            ProjectedRange: projectedRange,
+            ProjectedKind: RazorLanguageKind.CSharp
+        );
+
+        var inlayHints = await clientConnection.SendRequestAsync<DelegatedInlayHintParams, InlayHint[]?>(
+            CustomMessageNames.RazorInlayHintEndpoint,
+            delegatedRequest,
+            cancellationToken).ConfigureAwait(false);
+
+        if (inlayHints is null)
+        {
+            return null;
+        }
+
+        var csharpSourceText = codeDocument.GetCSharpSourceText();
+        using var _1 = ArrayBuilderPool<InlayHint>.GetPooledObject(out var inlayHintsBuilder);
+        foreach (var hint in inlayHints)
+        {
+            if (hint.Position.TryGetAbsoluteIndex(csharpSourceText, null, out var absoluteIndex) &&
+                _documentMappingService.TryMapToHostDocumentPosition(csharpDocument, absoluteIndex, out Position? hostDocumentPosition, out _))
+            {
+                hint.TextEdits = _documentMappingService.GetHostDocumentEdits(csharpDocument, hint.TextEdits);
+                hint.Data = new RazorInlayHintWrapper
+                {
+                    TextDocument = documentContext.Identifier,
+                    OriginalData = hint.Data,
+                    OriginalPosition = hint.Position
+                };
+                hint.Position = hostDocumentPosition;
+                inlayHintsBuilder.Add(hint);
+            }
+        }
+
+        return inlayHintsBuilder.ToArray();
+    }
+
+    public async Task<InlayHint?> ResolveInlayHintAsync(IClientConnection clientConnection, InlayHint inlayHint, CancellationToken cancellationToken)
+    {
+        if (inlayHint.Data is not JObject dataObj)
+        {
+            return null;
+        }
+
+        var inlayHintWrapper = dataObj.ToObject<RazorInlayHintWrapper>();
+        if (inlayHintWrapper is null)
+        {
+            return null;
+        }
+
+        var razorPosition = inlayHint.Position;
+        inlayHint.Position = inlayHintWrapper.OriginalPosition;
+        inlayHint.Data = inlayHintWrapper.OriginalData;
+
+        // For now we only support C# inlay hints. Once Web Tools adds support we'll need to inlayHint from both servers and combine
+        // the results, much like folding ranges.
+        var delegatedRequest = new DelegatedInlayHintResolveParams(
+            Identifier: inlayHintWrapper.TextDocument,
+            InlayHint: inlayHint,
+            ProjectedKind: RazorLanguageKind.CSharp
+        );
+
+        var resolvedHint = await clientConnection.SendRequestAsync<DelegatedInlayHintResolveParams, InlayHint?>(
+            CustomMessageNames.RazorInlayHintResolveEndpoint,
+            delegatedRequest,
+            cancellationToken).ConfigureAwait(false);
+
+        if (resolvedHint is null)
+        {
+            return null;
+        }
+
+        Debug.Assert(inlayHint.Position == resolvedHint.Position, "Resolving inlay hints should not change the position of them.");
+        resolvedHint.Position = razorPosition;
+
+        return resolvedHint;
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlayHints/InlayHintService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlayHints/InlayHintService.cs
@@ -63,7 +63,11 @@ internal sealed class InlayHintService(IRazorDocumentMappingService documentMapp
             if (hint.Position.TryGetAbsoluteIndex(csharpSourceText, null, out var absoluteIndex) &&
                 _documentMappingService.TryMapToHostDocumentPosition(csharpDocument, absoluteIndex, out Position? hostDocumentPosition, out _))
             {
-                hint.TextEdits = _documentMappingService.GetHostDocumentEdits(csharpDocument, hint.TextEdits);
+                if (hint.TextEdits is not null)
+                {
+                    hint.TextEdits = _documentMappingService.GetHostDocumentEdits(csharpDocument, hint.TextEdits);
+                }
+
                 hint.Data = new RazorInlayHintWrapper
                 {
                     TextDocument = documentContext.Identifier,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlayHints/RazorInlayHintWrapper.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlayHints/RazorInlayHintWrapper.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.InlayHints;
+
+internal class RazorInlayHintWrapper
+{
+    public required TextDocumentIdentifier TextDocument { get; set; }
+    public required object? OriginalData { get; set; }
+    public required Position OriginalPosition { get; set; }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlayHints/RazorInlayHintWrapper.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/InlayHints/RazorInlayHintWrapper.cs
@@ -1,13 +1,14 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.InlayHints;
 
 internal class RazorInlayHintWrapper
 {
-    public required TextDocumentIdentifier TextDocument { get; set; }
+    public required TextDocumentIdentifierAndVersion TextDocument { get; set; }
     public required object? OriginalData { get; set; }
     public required Position OriginalPosition { get; set; }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -200,6 +200,7 @@ internal partial class RazorLanguageServer : AbstractLanguageServer<RazorRequest
             services.AddHandler<MapCodeEndpoint>();
 
             services.AddHandlerWithCapabilities<InlayHintEndpoint>();
+            services.AddHandler<InlayHintResolveEndpoint>();
         }
     }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -199,8 +199,13 @@ internal partial class RazorLanguageServer : AbstractLanguageServer<RazorRequest
             services.AddHandlerWithCapabilities<DocumentSymbolEndpoint>();
             services.AddHandler<MapCodeEndpoint>();
 
-            services.AddHandlerWithCapabilities<InlayHintEndpoint>();
-            services.AddHandler<InlayHintResolveEndpoint>();
+            if (!featureOptions.UseRazorCohostServer)
+            {
+                services.AddSingleton<IInlayHintService, InlayHintService>();
+
+                services.AddHandlerWithCapabilities<InlayHintEndpoint>();
+                services.AddHandler<InlayHintResolveEndpoint>();
+            }
         }
     }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.FindAllReferences;
 using Microsoft.AspNetCore.Razor.LanguageServer.Folding;
 using Microsoft.AspNetCore.Razor.LanguageServer.Implementation;
+using Microsoft.AspNetCore.Razor.LanguageServer.InlayHints;
 using Microsoft.AspNetCore.Razor.LanguageServer.LinkedEditingRange;
 using Microsoft.AspNetCore.Razor.LanguageServer.MapCode;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectContexts;
@@ -197,6 +198,8 @@ internal partial class RazorLanguageServer : AbstractLanguageServer<RazorRequest
             services.AddHandlerWithCapabilities<ProjectContextsEndpoint>();
             services.AddHandlerWithCapabilities<DocumentSymbolEndpoint>();
             services.AddHandler<MapCodeEndpoint>();
+
+            services.AddHandlerWithCapabilities<InlayHintEndpoint>();
         }
     }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/CohostDocumentColorEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/CohostDocumentColorEndpoint.cs
@@ -39,7 +39,6 @@ internal sealed class CohostDocumentColorEndpoint(
 
     protected override Task<ColorInformation[]> HandleRequestAsync(DocumentColorParams request, RazorCohostRequestContext context, CancellationToken cancellationToken)
     {
-        // TODO: Create document context from request.TextDocument, by looking at request.Solution instead of our project snapshots
         var documentContext = context.GetRequiredDocumentContext();
 
         _logger.LogDebug("[Cohost] Received document color request for {requestPath} and got document {documentPath}", request.TextDocument.Uri, documentContext?.FilePath);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/CohostInlayHintEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/CohostInlayHintEndpoint.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.InlayHints;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+using Microsoft.CodeAnalysis.Razor.Logging;
+using Microsoft.CommonLanguageServerProtocol.Framework;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.Extensions;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Cohost;
+
+[Shared]
+[LanguageServerEndpoint(Methods.TextDocumentInlayHintName)]
+[ExportRazorStatelessLspService(typeof(CohostInlayHintEndpoint))]
+[Export(typeof(ICapabilitiesProvider))]
+[method: ImportingConstructor]
+internal sealed class CohostInlayHintEndpoint(
+    IInlayHintService inlayHintService,
+    IRazorLoggerFactory loggerFactory)
+    : AbstractRazorCohostDocumentRequestHandler<InlayHintParams, InlayHint[]?>, ICapabilitiesProvider
+{
+    private readonly IInlayHintService _inlayHintService = inlayHintService;
+    private readonly ILogger _logger = loggerFactory.CreateLogger<CohostInlayHintEndpoint>();
+
+    protected override bool MutatesSolutionState => false;
+    protected override bool RequiresLSPSolution => true;
+
+    protected override RazorTextDocumentIdentifier? GetRazorTextDocumentIdentifier(InlayHintParams request)
+        => request.TextDocument.ToRazorTextDocumentIdentifier();
+
+    public void ApplyCapabilities(VSInternalServerCapabilities serverCapabilities, VSInternalClientCapabilities clientCapabilities)
+        => serverCapabilities.EnableInlayHints();
+
+    protected override Task<InlayHint[]?> HandleRequestAsync(InlayHintParams request, RazorCohostRequestContext context, CancellationToken cancellationToken)
+    {
+        // TODO: Create document context from request.TextDocument, by looking at request.Solution instead of our project snapshots
+        var documentContext = context.GetRequiredDocumentContext();
+
+        _logger.LogDebug("[Cohost] Received inlay hint request for {requestPath} and got document {documentPath}", request.TextDocument.Uri, documentContext.FilePath);
+
+        // TODO: We can't MEF import IRazorCohostClientLanguageServerManager in the constructor. We can make this work
+        //       by having it implement a base class, RazorClientConnectionBase or something, that in turn implements
+        //       AbstractRazorLspService (defined in Roslyn) and then move everything from importing IClientConnection
+        //       to importing the new base class, so we can continue to share services.
+        //
+        //       Until then we have to get the service from the request context.
+        var clientLanguageServerManager = context.GetRequiredService<IRazorCohostClientLanguageServerManager>();
+        var clientConnection = new RazorCohostClientConnection(clientLanguageServerManager);
+
+        return _inlayHintService.GetInlayHintsAsync(clientConnection, documentContext, request.Range, cancellationToken);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/CohostInlayHintEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/CohostInlayHintEndpoint.cs
@@ -40,7 +40,6 @@ internal sealed class CohostInlayHintEndpoint(
 
     protected override Task<InlayHint[]?> HandleRequestAsync(InlayHintParams request, RazorCohostRequestContext context, CancellationToken cancellationToken)
     {
-        // TODO: Create document context from request.TextDocument, by looking at request.Solution instead of our project snapshots
         var documentContext = context.GetRequiredDocumentContext();
 
         _logger.LogDebug("[Cohost] Received inlay hint request for {requestPath} and got document {documentPath}", request.TextDocument.Uri, documentContext.FilePath);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/CohostInlayHintResolveEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/CohostInlayHintResolveEndpoint.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer;
+using Microsoft.AspNetCore.Razor.LanguageServer.InlayHints;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+using Microsoft.CommonLanguageServerProtocol.Framework;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Cohost;
+
+[Shared]
+[LanguageServerEndpoint(Methods.InlayHintResolveName)]
+[ExportRazorStatelessLspService(typeof(CohostInlayHintResolveEndpoint))]
+[Export(typeof(ICapabilitiesProvider))]
+[method: ImportingConstructor]
+internal sealed class CohostInlayHintResolveEndpoint(
+    IInlayHintService inlayHintService)
+    : AbstractRazorCohostRequestHandler<InlayHint, InlayHint?>
+{
+    private readonly IInlayHintService _inlayHintService = inlayHintService;
+
+    protected override bool MutatesSolutionState => false;
+    protected override bool RequiresLSPSolution => true;
+
+    protected override Task<InlayHint?> HandleRequestAsync(InlayHint request, RazorCohostRequestContext context, CancellationToken cancellationToken)
+    {
+        // TODO: We can't MEF import IRazorCohostClientLanguageServerManager in the constructor. We can make this work
+        //       by having it implement a base class, RazorClientConnectionBase or something, that in turn implements
+        //       AbstractRazorLspService (defined in Roslyn) and then move everything from importing IClientConnection
+        //       to importing the new base class, so we can continue to share services.
+        //
+        //       Until then we have to get the service from the request context.
+        var clientLanguageServerManager = context.GetRequiredService<IRazorCohostClientLanguageServerManager>();
+        var clientConnection = new RazorCohostClientConnection(clientLanguageServerManager);
+
+        return _inlayHintService.ResolveInlayHintAsync(clientConnection, request, cancellationToken);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Endpoints/InlayHints.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Endpoints/InlayHints.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.LanguageServerClient.Razor.Extensions;
 using StreamJsonRpc;
@@ -33,6 +35,54 @@ internal partial class RazorCustomMessageTarget
             Methods.TextDocumentInlayHintName,
             delegationDetails.Value.LanguageServerName,
             inlayHintParams,
+            cancellationToken).ConfigureAwait(false);
+        return response?.Response;
+    }
+
+    [JsonRpcMethod(CustomMessageNames.RazorInlayHintResolveEndpoint, UseSingleObjectParameterDeserialization = true)]
+    public async Task<InlayHint?> ProvideInlayHintsResolveAsync(DelegatedInlayHintResolveParams request, CancellationToken cancellationToken)
+    {
+        // We don't really need the text document for inlay hint resolve, but we need to at least know which text
+        // buffer should get the request, so we just ask for any version above version 0, to get the right buffer.
+        string languageServerName;
+        var synchronized = false;
+        VirtualDocumentSnapshot? virtualDocumentSnapshot = null;
+        if (request.ProjectedKind == RazorLanguageKind.Html)
+        {
+            var syncResult = TryReturnPossiblyFutureSnapshot<HtmlVirtualDocumentSnapshot>(0, request.Identifier);
+            if (syncResult?.Synchronized == true)
+            {
+                virtualDocumentSnapshot = syncResult.VirtualSnapshot;
+            }
+
+            languageServerName = RazorLSPConstants.HtmlLanguageServerName;
+        }
+        else if (request.ProjectedKind == RazorLanguageKind.CSharp)
+        {
+            var syncResult = TryReturnPossiblyFutureSnapshot<CSharpVirtualDocumentSnapshot>(0, request.Identifier);
+            if (syncResult?.Synchronized == true)
+            {
+                virtualDocumentSnapshot = syncResult.VirtualSnapshot;
+            }
+
+            languageServerName = RazorLSPConstants.RazorCSharpLanguageServerName;
+        }
+        else
+        {
+            Debug.Fail("Unexpected RazorLanguageKind. This shouldn't really happen in a real scenario.");
+            return null;
+        }
+
+        if (!synchronized || virtualDocumentSnapshot is null)
+        {
+            return null;
+        }
+
+        var response = await _requestInvoker.ReinvokeRequestOnServerAsync<InlayHint, InlayHint>(
+            virtualDocumentSnapshot.Snapshot.TextBuffer,
+            Methods.TextDocumentInlayHintName,
+            languageServerName,
+            request.InlayHint,
             cancellationToken).ConfigureAwait(false);
         return response?.Response;
     }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Endpoints/InlayHints.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Endpoints/InlayHints.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.LanguageServerClient.Razor.Extensions;
+using StreamJsonRpc;
+
+namespace Microsoft.VisualStudio.LanguageServerClient.Razor;
+
+internal partial class RazorCustomMessageTarget
+{
+    [JsonRpcMethod(CustomMessageNames.RazorInlayHintEndpoint, UseSingleObjectParameterDeserialization = true)]
+    public async Task<InlayHint[]?> ProvideInlayHintsAsync(DelegatedInlayHintParams request, CancellationToken cancellationToken)
+    {
+        var delegationDetails = await GetProjectedRequestDetailsAsync(request, cancellationToken).ConfigureAwait(false);
+        if (delegationDetails is null)
+        {
+            return default;
+        }
+
+        var inlayHintParams = new InlayHintParams
+        {
+            TextDocument = request.Identifier.TextDocumentIdentifier.WithUri(delegationDetails.Value.ProjectedUri),
+            Range = request.ProjectedRange
+        };
+
+        var response = await _requestInvoker.ReinvokeRequestOnServerAsync<InlayHintParams, InlayHint[]?>(
+            delegationDetails.Value.TextBuffer,
+            Methods.TextDocumentInlayHintName,
+            delegationDetails.Value.LanguageServerName,
+            inlayHintParams,
+            cancellationToken).ConfigureAwait(false);
+        return response?.Response;
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Endpoints/InlayHints.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Endpoints/InlayHints.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
-using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.LanguageServerClient.Razor.Extensions;
 using StreamJsonRpc;
@@ -42,46 +40,16 @@ internal partial class RazorCustomMessageTarget
     [JsonRpcMethod(CustomMessageNames.RazorInlayHintResolveEndpoint, UseSingleObjectParameterDeserialization = true)]
     public async Task<InlayHint?> ProvideInlayHintsResolveAsync(DelegatedInlayHintResolveParams request, CancellationToken cancellationToken)
     {
-        // We don't really need the text document for inlay hint resolve, but we need to at least know which text
-        // buffer should get the request, so we just ask for any version above version 0, to get the right buffer.
-        string languageServerName;
-        var synchronized = false;
-        VirtualDocumentSnapshot? virtualDocumentSnapshot = null;
-        if (request.ProjectedKind == RazorLanguageKind.Html)
+        var delegationDetails = await GetProjectedRequestDetailsAsync(request, cancellationToken).ConfigureAwait(false);
+        if (delegationDetails is null)
         {
-            var syncResult = TryReturnPossiblyFutureSnapshot<HtmlVirtualDocumentSnapshot>(0, request.Identifier);
-            if (syncResult?.Synchronized == true)
-            {
-                virtualDocumentSnapshot = syncResult.VirtualSnapshot;
-            }
-
-            languageServerName = RazorLSPConstants.HtmlLanguageServerName;
-        }
-        else if (request.ProjectedKind == RazorLanguageKind.CSharp)
-        {
-            var syncResult = TryReturnPossiblyFutureSnapshot<CSharpVirtualDocumentSnapshot>(0, request.Identifier);
-            if (syncResult?.Synchronized == true)
-            {
-                virtualDocumentSnapshot = syncResult.VirtualSnapshot;
-            }
-
-            languageServerName = RazorLSPConstants.RazorCSharpLanguageServerName;
-        }
-        else
-        {
-            Debug.Fail("Unexpected RazorLanguageKind. This shouldn't really happen in a real scenario.");
-            return null;
-        }
-
-        if (!synchronized || virtualDocumentSnapshot is null)
-        {
-            return null;
+            return default;
         }
 
         var response = await _requestInvoker.ReinvokeRequestOnServerAsync<InlayHint, InlayHint>(
-            virtualDocumentSnapshot.Snapshot.TextBuffer,
+            delegationDetails.Value.TextBuffer,
             Methods.TextDocumentInlayHintName,
-            languageServerName,
+            delegationDetails.Value.LanguageServerName,
             request.InlayHint,
             cancellationToken).ConfigureAwait(false);
         return response?.Response;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/InlayHints/InlayHintEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/InlayHints/InlayHintEndpointTest.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
+using Microsoft.AspNetCore.Razor.LanguageServer.InlayHints;
+using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.InlayHints;
+
+public class InlayHintEndpointTest(ITestOutputHelper testOutput) : SingleServerDelegatingEndpointTestBase(testOutput)
+{
+    [Fact]
+    public Task InlayHints()
+        => VerifyInlayHintsAsync(
+            """
+
+            <div></div>
+
+            @functions {
+                private void M(string thisIsMyString)
+                {
+                    var {|int:x|} = 5;
+
+                    var {|string:y|} = "Hello";
+
+                    M({|thisIsMyString:"Hello"|});
+                }
+            }
+            
+            """);
+
+    private async Task VerifyInlayHintsAsync(string input)
+    {
+        TestFileMarkupParser.GetSpans(input, out input, out ImmutableDictionary<string, ImmutableArray<TextSpan>> spansDict);
+        var codeDocument = CreateCodeDocument(input);
+        var razorFilePath = "C:/path/to/file.razor";
+
+        var languageServer = await CreateLanguageServerAsync(codeDocument, razorFilePath);
+
+        var endpoint = new InlayHintEndpoint(TestLanguageServerFeatureOptions.Instance, DocumentMappingService, languageServer);
+
+        var request = new InlayHintParams()
+        {
+            TextDocument = new VSTextDocumentIdentifier
+            {
+                Uri = new Uri(razorFilePath)
+            },
+            Range = new()
+            {
+                Start = new(0, 0),
+                End = new(codeDocument.Source.Text.Lines.Count, 0)
+            }
+        };
+        var documentContext = DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument);
+        var requestContext = CreateRazorRequestContext(documentContext);
+
+        // Act
+        var hints = await endpoint.HandleRequestAsync(request, requestContext, DisposalToken);
+
+        // Assert
+        Assert.NotNull(hints);
+        Assert.Equal(spansDict.Values.Count(), hints.Length);
+
+        var sourceText = SourceText.From(input);
+        foreach (var hint in hints)
+        {
+            // Because our test input data can't have colons in the input, but parameter info returned from Roslyn does, we have to strip them off.
+            var label = hint.Label.First.TrimEnd(':');
+            Assert.True(spansDict.TryGetValue(label, out var spans), $"Expected {label} to be in test provided markers");
+
+            var span = Assert.Single(spans);
+            var expectedRange = span.ToRange(sourceText);
+            // Inlay hints only have a position, so we ignore the end of the range that comes from the test input
+            Assert.Equal(expectedRange.Start, hint.Position);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokensTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokensTest.cs
@@ -891,7 +891,7 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
         {
             // Note that the expected lengths are different on Windows vs. Unix.
             var expectedCsharpRangeLength = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 970 : 938;
-            Assert.True(RazorSemanticTokensInfoService.TryGetMinimalCSharpRange(codeDocument, razorRange, out var csharpRange));
+            Assert.True(codeDocument.TryGetMinimalCSharpRange(razorRange, out var csharpRange));
             var textSpan = csharpRange.ToTextSpan(csharpSourceText);
             Assert.Equal(expectedCsharpRangeLength, textSpan.Length);
         }
@@ -1139,7 +1139,7 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
         }
 
         if (!documentMappingService.TryMapToGeneratedDocumentRange(codeDocument.GetCSharpDocument(), razorRange, out var range) &&
-            !RazorSemanticTokensInfoService.TryGetMinimalCSharpRange(codeDocument, razorRange, out range))
+            !codeDocument.TryGetMinimalCSharpRange(razorRange, out range))
         {
             // No C# in the range.
             return null;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SingleServerDelegatingEndpointTestBase.TestLanguageServer.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SingleServerDelegatingEndpointTestBase.TestLanguageServer.cs
@@ -62,6 +62,7 @@ public abstract partial class SingleServerDelegatingEndpointTestBase
                 CustomMessageNames.RazorDocumentSymbolEndpoint => await HandleDocumentSymbolAsync(@params),
                 CustomMessageNames.RazorProjectContextsEndpoint => await HandleProjectContextsAsync(@params),
                 CustomMessageNames.RazorSimplifyMethodEndpointName => HandleSimplifyMethod(@params),
+                CustomMessageNames.RazorInlayHintEndpoint => await HandleInlayHintAsync(@params),
                 _ => throw new NotImplementedException($"I don't know how to handle the '{method}' method.")
             };
 
@@ -88,6 +89,25 @@ public abstract partial class SingleServerDelegatingEndpointTestBase
 
             return _csharpServer.ExecuteRequestAsync<VSGetProjectContextsParams, VSProjectContextList>(
                 VSMethods.GetProjectContextsName,
+                delegatedRequest,
+                _cancellationToken);
+        }
+
+        private Task<InlayHint[]> HandleInlayHintAsync<TParams>(TParams @params)
+        {
+            var delegatedParams = Assert.IsType<DelegatedInlayHintParams>(@params);
+
+            var delegatedRequest = new InlayHintParams
+            {
+                TextDocument = new TextDocumentIdentifier
+                {
+                    Uri = _csharpDocumentUri,
+                },
+                Range = delegatedParams.ProjectedRange
+            };
+
+            return _csharpServer.ExecuteRequestAsync<InlayHintParams, InlayHint[]>(
+                Methods.TextDocumentInlayHintName,
                 delegatedRequest,
                 _cancellationToken);
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SingleServerDelegatingEndpointTestBase.TestLanguageServer.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SingleServerDelegatingEndpointTestBase.TestLanguageServer.cs
@@ -63,6 +63,7 @@ public abstract partial class SingleServerDelegatingEndpointTestBase
                 CustomMessageNames.RazorProjectContextsEndpoint => await HandleProjectContextsAsync(@params),
                 CustomMessageNames.RazorSimplifyMethodEndpointName => HandleSimplifyMethod(@params),
                 CustomMessageNames.RazorInlayHintEndpoint => await HandleInlayHintAsync(@params),
+                CustomMessageNames.RazorInlayHintResolveEndpoint => await HandleInlayHintResolveAsync(@params),
                 _ => throw new NotImplementedException($"I don't know how to handle the '{method}' method.")
             };
 
@@ -108,6 +109,18 @@ public abstract partial class SingleServerDelegatingEndpointTestBase
 
             return _csharpServer.ExecuteRequestAsync<InlayHintParams, InlayHint[]>(
                 Methods.TextDocumentInlayHintName,
+                delegatedRequest,
+                _cancellationToken);
+        }
+
+        private Task<InlayHint> HandleInlayHintResolveAsync<TParams>(TParams @params)
+        {
+            var delegatedParams = Assert.IsType<DelegatedInlayHintResolveParams>(@params);
+
+            var delegatedRequest = delegatedParams.InlayHint;
+
+            return _csharpServer.ExecuteRequestAsync<InlayHint, InlayHint>(
+                Methods.InlayHintResolveName,
                 delegatedRequest,
                 _cancellationToken);
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/CSharpTestLspServer.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/CSharpTestLspServer.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Microsoft.VisualStudio.Composition;
@@ -53,8 +54,6 @@ public sealed class CSharpTestLspServer : IAsyncDisposable
             ExceptionStrategy = ExceptionProcessing.ISerializable,
         };
 
-        _languageServer = CreateLanguageServer(_serverRpc, testWorkspace, languageServerFactory, exportProvider, serverCapabilities);
-
         _clientMessageFormatter = CreateJsonMessageFormatter(languageServerFactory);
         _clientMessageHandler = new HeaderDelimitedMessageHandler(clientStream, clientStream, _clientMessageFormatter);
         _clientRpc = new JsonRpc(_clientMessageHandler)
@@ -62,7 +61,13 @@ public sealed class CSharpTestLspServer : IAsyncDisposable
             ExceptionStrategy = ExceptionProcessing.ISerializable,
         };
 
+        // Roslyn will call back to us to get configuration options when the server is initialized, so this is how we configure
+        // what it options we need
+        _clientRpc.AddLocalRpcTarget(new WorkspaceConfigurationHandler());
+
         _clientRpc.StartListening();
+
+        _languageServer = CreateLanguageServer(_serverRpc, testWorkspace, languageServerFactory, exportProvider, serverCapabilities);
 
         static JsonMessageFormatter CreateJsonMessageFormatter(IRazorLanguageServerFactoryWrapper languageServerFactory)
         {
@@ -204,6 +209,26 @@ public sealed class CSharpTestLspServer : IAsyncDisposable
             // To avoid exposing types from VS.LSP.Protocol across the Razor <-> Roslyn API boundary, and therefore
             // requiring us to agree on dependency versions, we use JSON as a transport mechanism.
             return JsonConvert.SerializeObject(_serverCapabilities);
+        }
+    }
+
+    private class WorkspaceConfigurationHandler
+    {
+        [JsonRpcMethod(Methods.WorkspaceConfigurationName, UseSingleObjectParameterDeserialization = true)]
+        public string[]? GetConfigurationOptions(ConfigurationParams configurationParams)
+        {
+            using var _ = ListPool<string>.GetPooledObject(out var values);
+            values.SetCapacityIfLarger(configurationParams.Items.Length);
+
+            foreach (var item in configurationParams.Items)
+            {
+                values.Add(item.Section switch
+                {
+                    _ => ""
+                });
+            }
+
+            return values.ToArray();
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/CSharpTestLspServer.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/CSharpTestLspServer.cs
@@ -224,6 +224,8 @@ public sealed class CSharpTestLspServer : IAsyncDisposable
             {
                 values.Add(item.Section switch
                 {
+                    "csharp|inlay_hints.dotnet_enable_inlay_hints_for_parameters" => "true",
+                    "csharp|inlay_hints.csharp_enable_inlay_hints_for_types" => "true",
                     _ => ""
                 });
             }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/CSharpTestLspServerHelpers.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/CSharpTestLspServerHelpers.cs
@@ -74,6 +74,10 @@ internal static class CSharpTestLspServerHelpers
                 },
             },
             SupportsDiagnosticRequests = true,
+            Workspace = new()
+            {
+                Configuration = true
+            }
         };
 
         return await CSharpTestLspServer.CreateAsync(

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/CSharpTestLspServerHelpers.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/CSharpTestLspServerHelpers.cs
@@ -72,6 +72,10 @@ internal static class CSharpTestLspServerHelpers
                         SnippetSupport = true
                     }
                 },
+                InlayHint = new()
+                {
+                    ResolveSupport = new InlayHintResolveSupportSetting { Properties = ["tooltip"] }
+                }
             },
             SupportsDiagnosticRequests = true,
             Workspace = new()


### PR DESCRIPTION
Adds inlay hint support for Razor in VS and VS Code, cohosting and regular.

Goes with https://github.com/dotnet/vscode-csharp/pull/6857 for the VS Code side.