### PR TITLE
Use inclusive mapping for breakpoint validation

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Common/VSInternalServerCapabilitiesExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Common/VSInternalServerCapabilitiesExtensions.cs
@@ -21,4 +21,9 @@ internal static class VSInternalServerCapabilitiesExtensions
             Range = true,
         };
     }
+
+    public static void EnableValidateBreakpointRange(this VSInternalServerCapabilities serverCapabilities)
+    {
+        serverCapabilities.BreakableRangeProvider = true;
+    }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Debugging/ValidateBreakpointRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Debugging/ValidateBreakpointRangeEndpoint.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
@@ -16,19 +15,18 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Debugging;
 
 [RazorLanguageServerEndpoint(VSInternalMethods.TextDocumentValidateBreakableRangeName)]
-internal class ValidateBreakpointRangeEndpoint : AbstractRazorDelegatingEndpoint<ValidateBreakpointRangeParams, Range?>, ICapabilitiesProvider
+internal class ValidateBreakpointRangeEndpoint(
+    IRazorDocumentMappingService documentMappingService,
+    LanguageServerFeatureOptions languageServerFeatureOptions,
+    IClientConnection clientConnection,
+    IRazorLoggerFactory loggerFactory)
+    : AbstractRazorDelegatingEndpoint<ValidateBreakpointRangeParams, Range?>(
+        languageServerFeatureOptions,
+        documentMappingService,
+        clientConnection,
+        loggerFactory.CreateLogger<ValidateBreakpointRangeEndpoint>()), ICapabilitiesProvider
 {
-    private readonly IRazorDocumentMappingService _documentMappingService;
-
-    public ValidateBreakpointRangeEndpoint(
-        IRazorDocumentMappingService documentMappingService,
-        LanguageServerFeatureOptions languageServerFeatureOptions,
-        IClientConnection clientConnection,
-        IRazorLoggerFactory loggerFactory)
-        : base(languageServerFeatureOptions, documentMappingService, clientConnection, loggerFactory.CreateLogger<ValidateBreakpointRangeEndpoint>())
-    {
-        _documentMappingService = documentMappingService ?? throw new ArgumentNullException(nameof(documentMappingService));
-    }
+    private readonly IRazorDocumentMappingService _documentMappingService = documentMappingService;
 
     protected override bool OnlySingleServer => false;
 
@@ -36,7 +34,7 @@ internal class ValidateBreakpointRangeEndpoint : AbstractRazorDelegatingEndpoint
 
     public void ApplyCapabilities(VSInternalServerCapabilities serverCapabilities, VSInternalClientCapabilities clientCapabilities)
     {
-        serverCapabilities.BreakableRangeProvider = true;
+        serverCapabilities.EnableValidateBreakpointRange();
     }
 
     protected override Task<Range?> TryHandleAsync(ValidateBreakpointRangeParams request, RazorRequestContext requestContext, DocumentPositionInfo positionInfo, CancellationToken cancellationToken)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Debugging/ValidateBreakpointRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Debugging/ValidateBreakpointRangeEndpoint.cs
@@ -78,7 +78,7 @@ internal class ValidateBreakpointRangeEndpoint : AbstractRazorDelegatingEndpoint
         var documentContext = requestContext.GetRequiredDocumentContext();
         var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
 
-        if (_documentMappingService.TryMapToHostDocumentRange(codeDocument.GetCSharpDocument(), delegatedResponse, out var projectedRange))
+        if (_documentMappingService.TryMapToHostDocumentRange(codeDocument.GetCSharpDocument(), delegatedResponse, MappingBehavior.Inclusive, out var projectedRange))
         {
             return projectedRange;
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Debugging/ValidateBreakpointRangeEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Debugging/ValidateBreakpointRangeEndpointTest.cs
@@ -23,6 +23,38 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Debugging;
 public class ValidateBreakpointRangeEndpointTest(ITestOutputHelper testOutput) : SingleServerDelegatingEndpointTestBase(testOutput)
 {
     [Fact]
+    public async Task Handle_CSharpInHtml_ValidBreakpoint()
+    {
+        var input = """
+                <div></div>
+
+                @{
+                    var currentCount = 1;
+                }
+
+                <p>@{|breakpoint:{|expected:currentCount|}|}</p>
+                """;
+
+        await VerifyBreakpointRangeAsync(input);
+    }
+
+    [Fact]
+    public async Task Handle_CSharpInAttribute_ValidBreakpoint()
+    {
+        var input = """
+                <div></div>
+
+                @{
+                    var currentCount = 1;
+                }
+
+                <button class="btn btn-primary" disabled="@({|breakpoint:{|expected:currentCount > 3|}|})">Click me</button>
+                """;
+
+        await VerifyBreakpointRangeAsync(input);
+    }
+
+    [Fact]
     public async Task Handle_CSharp_ValidBreakpoint()
     {
         var input = """

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Debugging/ValidateBreakpointRangeEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Debugging/ValidateBreakpointRangeEndpointTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
@@ -139,7 +137,7 @@ public class ValidateBreakpointRangeEndpointTest(ITestOutputHelper testOutput) :
         Assert.Equal(expectedRange, result);
     }
 
-    private async Task<Range> GetBreakpointRangeAsync(RazorCodeDocument codeDocument, string razorFilePath, TextSpan breakpointSpan)
+    private async Task<Range?> GetBreakpointRangeAsync(RazorCodeDocument codeDocument, string razorFilePath, TextSpan breakpointSpan)
     {
         var languageServer = await CreateLanguageServerAsync(codeDocument, razorFilePath);
 
@@ -154,7 +152,7 @@ public class ValidateBreakpointRangeEndpointTest(ITestOutputHelper testOutput) :
             Range = breakpointSpan.ToRange(codeDocument.GetSourceText())
         };
 
-        var documentContext = DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument);
+        var documentContext = DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument).AssumeNotNull();
         var requestContext = CreateValidateBreakpointRangeRequestContext(documentContext);
 
         return await endpoint.HandleRequestAsync(request, requestContext, DisposalToken);


### PR DESCRIPTION
Noticed while looking at https://github.com/dotnet/razor/issues/9846, that when placing a breakpoint on one of the expressions in:

```
<button class="btn btn-primary" @onclick="IncrementCount" disabled="@(currentCount > 3)">Click me</button>
```

The breakpoint got placed correctly, but any edit would then remove it. This fixes that. Seems in [my previous PR](https://github.com/dotnet/razor/pull/9236) when I said "use inclusive mapping everywhere" I missed a spot :)
This ~might also~ doens't fix #9846 itself ~, but I can't be sure as I seem to be unable to build and run Blazor apps at the moment :)~ :(