### PR TITLE
Fixes Razor when ".." is in the intermediate object path

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.TestAccessor.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.TestAccessor.cs
@@ -16,6 +16,7 @@ internal partial class WindowsRazorProjectHostBase
 
         internal bool GetIntermediateOutputPathFromProjectChange(IImmutableDictionary<string, IProjectRuleSnapshot> state, out string? result)
         {
+            _this.SkipIntermediateOutputPathExistCheck_TestOnly = true;
             return _this.TryGetIntermediateOutputPath(state, out result);
         }
     }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.TestAccessor.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.TestAccessor.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.VisualStudio.ProjectSystem.Properties;
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+internal partial class WindowsRazorProjectHostBase
+{
+    internal TestAccessor GetTestAccessor() => new(this);
+
+    internal sealed class TestAccessor(WindowsRazorProjectHostBase @this)
+    {
+        private readonly WindowsRazorProjectHostBase _this = @this;
+
+        internal bool GetIntermediateOutputPathFromProjectChange(IImmutableDictionary<string, IProjectRuleSnapshot> state, out string? result)
+        {
+            return _this.TryGetIntermediateOutputPath(state, out result);
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
@@ -17,7 +17,7 @@ using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
-internal abstract class WindowsRazorProjectHostBase : OnceInitializedOnceDisposedAsync, IProjectDynamicLoadComponent
+internal abstract partial class WindowsRazorProjectHostBase : OnceInitializedOnceDisposedAsync, IProjectDynamicLoadComponent
 {
     private static readonly DataflowLinkOptions s_dataflowLinkOptions = new DataflowLinkOptions() { PropagateCompletion = true };
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
@@ -401,7 +401,7 @@ internal abstract class WindowsRazorProjectHostBase : OnceInitializedOnceDispose
             }
         }
 
-        path = joinedPath;
+        path = Path.GetFullPath(joinedPath);
         return true;
     }
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
@@ -762,7 +762,7 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
     {
 
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
-        var host = new TestWindowsRazorProjectHost(services, _projectManagerAccessor, Dispatcher, _projectConfigurationFilePathStore, languageServerFeatureOptions: null);
+        var host = new DefaultWindowsRazorProjectHost(services, _projectManagerAccessor, Dispatcher, _projectConfigurationFilePathStore, languageServerFeatureOptions: null);
 
         var state = TestProjectRuleSnapshot.CreateProperties(
              WindowsRazorProjectHostBase.ConfigurationGeneralSchemaName,
@@ -775,30 +775,11 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
         var dict = ImmutableDictionary<string, IProjectRuleSnapshot>.Empty;
         dict = dict.Add(WindowsRazorProjectHostBase.ConfigurationGeneralSchemaName, state);
 
-        var result = host.GetIntermediateOutputPathFromProjectChange(dict,
+        var result = host.GetTestAccessor().GetIntermediateOutputPathFromProjectChange(dict,
             out var combinedIntermediateOutputPath);
 
         Assert.True(result);
         Assert.Equal(expectedCombinedIOP, combinedIntermediateOutputPath);
-    }
-
-    internal class TestWindowsRazorProjectHost : DefaultWindowsRazorProjectHost
-    {
-        public TestWindowsRazorProjectHost(IUnconfiguredProjectCommonServices commonServices,
-            IProjectSnapshotManagerAccessor projectManagerAccessor,
-            ProjectSnapshotManagerDispatcher dispatcher,
-            ProjectConfigurationFilePathStore projectConfigurationFilePathStore,
-            LanguageServerFeatureOptions languageServerFeatureOptions)
-            : base(commonServices, projectManagerAccessor, dispatcher, projectConfigurationFilePathStore, languageServerFeatureOptions)
-        {
-            SkipIntermediateOutputPathExistCheck_TestOnly = true;
-        }
-
-        // Enable access to protected method for testing
-        internal bool GetIntermediateOutputPathFromProjectChange(IImmutableDictionary<string,IProjectRuleSnapshot> state, out string result)
-        {
-            return base.TryGetIntermediateOutputPath(state, out result);
-        }
     }
 
     [UIFact]
@@ -1050,7 +1031,7 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
     }
 
     [UIFact]
-    public async Task OnProjectChanged_VersionRemoved_DeinitializesProject()
+    public async Task OnProjectChanged_VersionRemoved_DeInitializesProject()
     {
         // Arrange
         _razorGeneralProperties.Property(Rules.RazorGeneral.RazorLangVersionProperty, "2.1");

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
@@ -751,16 +751,15 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
 
     [UITheory]
     // Standard setup.  BaseIntermediateOutputPath ends in obj and IntermediateOutputPath starts with obj
-    [InlineData("C:\\my repo root\\solution folder\\projectFolder\\obj\\", "obj\\Debug\\net8.0", "C:\\my repo root\\solution folder\\projectFolder\\obj\\Debug\\net8.0")]
+    [InlineData(@"C:\my repo root\solution folder\projectFolder\obj\", @"obj\Debug\net8.0", @"C:\my repo root\solution folder\projectFolder\obj\Debug\net8.0")]
     // ArtifactsPath in use as ../artifacts
-    [InlineData("C:\\my repo root\\solution folder\\projectFolder\\../artifacts\\obj\\projectName\\", "C:\\my repo root\\solution folder\\projectFolder\\../artifacts\\obj\\projectName\\debug", "C:\\my repo root\\solution folder\\artifacts\\obj\\projectName\\debug")]
+    [InlineData(@"C:\my repo root\solution folder\projectFolder\../artifacts\obj\projectName\", @"C:\my repo root\solution folder\projectFolder\../artifacts\obj\projectName\debug", @"C:\my repo root\solution folder\artifacts\obj\projectName\debug")]
     // .... and ArtifactsPivot is $(ArtifactsPivot)\_MyCustomPivot
-    [InlineData("C:\\my repo root\\solution folder\\projectFolder\\../artifacts\\obj\\projectName\\", "C:\\my repo root\\solution folder\\projectFolder\\../artifacts\\obj\\projectName\\_MyCustomPivot", "C:\\my repo root\\solution folder\\artifacts\\obj\\projectName\\_MyCustomPivot")]
-    // Set BIOP to ..\\..\\artifacts\\obj\\$(MSBuildProjectFolder), pre-ArtifactsPath existing
-    [InlineData("C:\\my repo root\\solution folder\\projectFolder\\..\\..\\artifacts\\obj\\projectName", "..\\..\\artifacts\\obj\\projectName\\Debug\\net8.0", "C:\\my repo root\\artifacts\\obj\\projectName\\Debug\\net8.0")]
+    [InlineData(@"C:\my repo root\solution folder\projectFolder\../artifacts\obj\projectName\", @"C:\my repo root\solution folder\projectFolder\../artifacts\obj\projectName\_MyCustomPivot", @"C:\my repo root\solution folder\artifacts\obj\projectName\_MyCustomPivot")]
+    // Set BIOP to ..\..\artifacts\obj\$(MSBuildProjectFolder), pre-ArtifactsPath existing
+    [InlineData(@"C:\my repo root\solution folder\projectFolder\..\..\artifacts\obj\projectName", @"..\..\artifacts\obj\projectName\Debug\net8.0", @"C:\my repo root\artifacts\obj\projectName\Debug\net8.0")]
     public void IntermediateOutputPathCalculationHandlesRelativePaths(string baseIntermediateOutputPath, string intermediateOutputPath, string expectedCombinedIOP)
     {
-
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
         var host = new DefaultWindowsRazorProjectHost(services, _projectManagerAccessor, Dispatcher, _projectConfigurationFilePathStore, languageServerFeatureOptions: null);
 


### PR DESCRIPTION
Fixes #9812 and #9906

ISSUE:
Because we are are keying off of the intermediate object path instead of the csproj file path, the intermediate object path may have ".." in it from normal MSBuiild properties, but that means the same logical string has two different representations.

FIX:
Normalize the path.  There's an adjoining and similiar change in Roslyn to likewise make.  (Will link).  There is alternative fix to pursue where Razor instead does the  normalization.

TESTING:
Unittests pulled from manul testing with ".." in BaseIntermediateOutputPath and ArtifactsPath
