### PR TITLE
Fix the capitalizationof razorComponentAttribute

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Models/SemanticTokenTypes.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Models/SemanticTokenTypes.cs
@@ -20,7 +20,7 @@ internal sealed class SemanticTokenTypes
     private static readonly string s_razorCommentStarType = "razorCommentStar";
     private static readonly string s_razorCommentTransitionType = "razorCommentTransition";
     private static readonly string s_razorCommentType = "razorComment";
-    private static readonly string s_razorComponentAttributeType = "RazorComponentAttribute";
+    private static readonly string s_razorComponentAttributeType = "razorComponentAttribute";
     private static readonly string s_razorComponentElementType = "razorComponentElement";
     private static readonly string s_razorDirectiveAttributeType = "razorDirectiveAttribute";
     private static readonly string s_razorDirectiveColonType = "razorDirectiveColon";

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/TestFiles/GetSemanticTokens_Razor_ComponentAttributeAsync.semantic.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/TestFiles/GetSemanticTokens_Razor_ComponentAttributeAsync.semantic.txt
@@ -3,7 +3,7 @@
 0 1 12 razorDirective 0 [addTagHelper]
 1 0 1 markupTagDelimiter 0 [<]
 0 1 10 razorComponentElement 0 [Component1]
-0 11 8 RazorComponentAttribute 0 [bool-val]
+0 11 8 razorComponentAttribute 0 [bool-val]
 0 8 1 markupOperator 0 [=]
 0 1 1 markupAttributeQuote 0 ["]
 0 1 1 markupAttributeQuote 0 ["]

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/TestFiles/GetSemanticTokens_Razor_ComponentAttribute_DoesntGetABackground.semantic.txt
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/TestFiles/GetSemanticTokens_Razor_ComponentAttribute_DoesntGetABackground.semantic.txt
@@ -5,7 +5,7 @@
 0 1 3 variable 4 [Now]
 2 0 1 markupTagDelimiter 0 [<]
 0 1 10 razorComponentElement 0 [Component1]
-0 11 5 RazorComponentAttribute 0 [Title]
+0 11 5 razorComponentAttribute 0 [Title]
 0 5 1 markupOperator 0 [=]
 0 1 1 markupAttributeQuote 0 ["]
 0 1 1 markupAttributeQuote 0 ["]


### PR DESCRIPTION
This pull request solves issue #9376 which highlights the inconsistent capitalization of the string value for the `RazorComponentAttribute` in the `RazorSemanticTokenTypes.cs`. 

These changes will not affect the semantic token recognition in Visual Studio, as an additional case check has been added to the VSlanguageServerClient repo to account for the transition (see [RP](https://devdiv.visualstudio.com/DevDiv/_git/VSLanguageServerClient/pullrequest/502662)). However, to reflect the capitalization change in VS Code, we will need to [insert Razor into the VS Code C# Extension](https://github.com/dotnet/razor/blob/main/docs/InsertingRazorIntoVSCodeCSharp.md) and update the `package.json` file in the vscode-csharp repo ([this line](https://github.com/dotnet/vscode-csharp/blob/b8ca3132427020cc5d1741d0f64990f8e736ce73/package.json#L4891)) in the same pull request.

### Summary of the changes

- Change the capitalization of "RazorComponentAttribute" to "razorComponentAttribute" in RazorSemanticTokensLegend.cs
- Update two semantic.txt files used for unit testing to match the changes.

Fixes:
- This pull request ensures consistency in capitalization and will not impact the user experience. 

### Before
<img width="602" alt="Casing_visual_before" src="https://github.com/dotnet/razor/assets/17770319/04da6488-b430-4483-9468-0fa7a10e2768">


### After
<img width="661" alt="Casing_visual_after" src="https://github.com/dotnet/razor/assets/17770319/f616cea9-aeec-4dda-b89b-816d0a9eed7a">

