### PR TITLE
Fix stack overflow exception in `ReportFault`

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Telemetry/TelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Telemetry/TelemetryReporter.cs
@@ -107,7 +107,7 @@ internal abstract class TelemetryReporter : ITelemetryReporter
         ReportFault(exception, message, 0, @params);
     }
 
-    private void ReportFault(Exception exception, string? message, int depth, params object?[] @params)
+    protected void ReportFault(Exception exception, string? message, int depth, params object?[] @params)
     {
         if (depth > RecursionDepthLimit)
         {

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Telemetry/TelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Telemetry/TelemetryReporter.cs
@@ -15,6 +15,8 @@ namespace Microsoft.AspNetCore.Razor.Telemetry;
 
 internal abstract class TelemetryReporter : ITelemetryReporter
 {
+    private const int RecursionDepthLimit = 10;
+
     protected ImmutableArray<TelemetrySession> TelemetrySessions { get; set; }
 
     protected TelemetryReporter(ImmutableArray<TelemetrySession> telemetrySessions = default)
@@ -107,7 +109,7 @@ internal abstract class TelemetryReporter : ITelemetryReporter
 
     private void ReportFault(Exception exception, string? message, int depth, params object?[] @params)
     {
-        if (depth > 10)
+        if (depth > RecursionDepthLimit)
         {
             // exceeded recursion depth limit
             return;

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Telemetry/VSTelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Telemetry/VSTelemetryReporter.cs
@@ -26,11 +26,11 @@ internal class VSTelemetryReporter : TelemetryReporter
         _logger = loggerFactory.CreateLogger<VSTelemetryReporter>();
     }
 
-    protected override bool HandleException(Exception exception, string? message, params object?[] @params)
+    protected override bool HandleException(Exception exception, string? message, int depth, params object?[] @params)
     {
         if (exception is RemoteInvocationException remoteInvocationException)
         {
-            if (ReportRemoteInvocationException(remoteInvocationException, @params))
+            if (ReportRemoteInvocationException(remoteInvocationException, depth, @params))
             {
                 return true;
             }
@@ -39,12 +39,12 @@ internal class VSTelemetryReporter : TelemetryReporter
         return false;
     }
 
-    private bool ReportRemoteInvocationException(RemoteInvocationException remoteInvocationException, object?[] @params)
+    private bool ReportRemoteInvocationException(RemoteInvocationException remoteInvocationException, int depth, object?[] @params)
     {
         if (remoteInvocationException.InnerException is Exception innerException)
         {
             // innerException might be an OperationCancelled or Aggregate, use the full ReportFault to unwrap it consistently.
-            ReportFault(innerException, "RIE: " + remoteInvocationException.Message);
+            ReportFault(innerException, "RIE: " + remoteInvocationException.Message, depth + 1);
             return true;
         }
         else if (@params.Length < 2)
@@ -54,6 +54,7 @@ internal class VSTelemetryReporter : TelemetryReporter
             ReportFault(
                 remoteInvocationException,
                 remoteInvocationException.Message,
+                depth + 1,
                 remoteInvocationException.ErrorCode,
                 remoteInvocationException.DeserializedErrorData);
             return true;


### PR DESCRIPTION
﻿### Summary of the changes

Seems like when an `OperationCanceledException` or `AggregateException` is thrown, the `ReportFault` method is called recursively. If the inner exception of these exceptions is also an `OperationCanceledException` or `AggregateException`, the method will keep calling itself, leading to a stack overflow. The same issue is happening with `ReportRemoteInvocationException` method. 

Added tests to confirm I can reproduce the problem. Added fix by adding a depth parameter that stops the recursion after hitting a limit (picked 10 as limit). I am open to fixing in a different way.

Resolves: [WorkItem#1928072](https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1928072)
