### PR TITLE
Fix the GitHub automation for tracking the milestone on merged PRs

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -240,7 +240,8 @@ configuration:
     - if:
       - payloadType: Pull_Request
       - isAction:
-          action: Null
+          action: Closed
+      - isMerged
       - targetsBranch:
           branch: main
       then:
@@ -248,4 +249,4 @@ configuration:
           milestone: Next
       description: '[PRs] Milestone tracking'
 onFailure: 
-onSuccess: 
+onSuccess:


### PR DESCRIPTION
https://github.com/dotnet/razor/pull/9895 had an issue slip through in the migration from FabricBot. The 'merged' action is no longer supported; and there previously wasn't a way to filter to only merged PRs. There's now an `isMerged` condition that can be used.

@JohannesLampel for review.

Please note that all PRs that have been merged since https://github.com/dotnet/razor/pull/9895 have not been automatically updated with the 'Next' milestone as desired.