### PR TITLE
Skip reporting fault when the inner-most exception is OperationCanceledException

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Telemetry/TelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Telemetry/TelemetryReporter.cs
@@ -104,13 +104,14 @@ internal abstract class TelemetryReporter : ITelemetryReporter
     {
         try
         {
-            if (exception is OperationCanceledException { InnerException: { } oceInnerException })
+            if (exception is OperationCanceledException oce)
             {
-                ReportFault(oceInnerException, message, @params);
-                return;
-            }
-            else if (exception is OperationCanceledException)
-            {
+                // We don't want to report operation canceled, but don't want to miss out if there is something useful inside it
+                if (oce.InnerException is not null)
+                {
+                    ReportFault(oce.InnerException, message, @params);
+                }
+
                 return;
             }
 

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Telemetry/TelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Telemetry/TelemetryReporter.cs
@@ -109,6 +109,10 @@ internal abstract class TelemetryReporter : ITelemetryReporter
                 ReportFault(oceInnerException, message, @params);
                 return;
             }
+            else if (exception is OperationCanceledException)
+            {
+                return;
+            }
 
             if (exception is AggregateException aggregateException)
             {

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TelemetryReporterTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TelemetryReporterTests.cs
@@ -354,7 +354,7 @@ public class TelemetryReporterTests
     [InlineData(typeof(RemoteInvocationException), 3)]
     [InlineData(typeof(OperationCanceledException), 3)]
     [InlineData(typeof(AggregateException), 15000)]
-    public void ReportFault_NestedOperationCanceledException_NoStackOverflowException(Type exceptionType, int depth)
+    public void ReportFault_NestedException_NoStackOverflowException(Type exceptionType, int depth)
     {
         // Arrange
         var reporter = new TestTelemetryReporter(new RazorLoggerFactory([]));

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TelemetryReporterTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TelemetryReporterTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.VisualStudio.Editor.Razor.Test.Shared;
@@ -323,6 +324,66 @@ public class TelemetryReporterTests
             });
     }
 
+    [Fact]
+    public void ReportFault_OperationCanceledExceptionWithoutInnerException_SkipsFaultReport()
+    {
+        // Arrange
+        var reporter = new TestTelemetryReporter(new RazorLoggerFactory([]));
+        var exception = new OperationCanceledException("OCE", innerException: null);
+
+        // Act
+        reporter.ReportFault(exception, "Test message");
+
+        // Assert
+        Assert.Empty(reporter.Events);
+    }
+
+    [Fact]
+    public void ReportFault_TaskCanceledExceptionWithoutInnerException_SkipsFaultReport()
+    {
+        // Arrange
+        var reporter = new TestTelemetryReporter(new RazorLoggerFactory([]));
+        var exception = new TaskCanceledException("TCE", innerException: null);
+
+        // Act
+        reporter.ReportFault(exception, "Test message");
+
+        // Assert
+        Assert.Empty(reporter.Events);
+    }
+
+    [Theory]
+    [InlineData(3)]
+    public void ReportFault_InnerExceptionOfOCEIsAnotherOCE_SkipsFaultReport(int depth)
+    {
+        // Arrange
+        var reporter = new TestTelemetryReporter(new RazorLoggerFactory([]));
+        var innerMostException = new OperationCanceledException();
+        var exception = CreateNestedException(typeof(OperationCanceledException), depth, innerMostException);
+
+        // Act
+        reporter.ReportFault(exception, "Test message");
+
+        // Assert
+        Assert.Empty(reporter.Events);
+    }
+
+    [Theory]
+    [InlineData(3)]
+    public void ReportFault_InnerExceptionOfOCEIsNotAnOCE_ReportsFault(int depth)
+    {
+        // Arrange
+        var reporter = new TestTelemetryReporter(new RazorLoggerFactory([]));
+        var innerMostException = new Exception();
+        var exception = CreateNestedException(typeof(OperationCanceledException), depth, innerMostException);
+
+        // Act
+        reporter.ReportFault(exception, "Test message");
+
+        // Assert
+        Assert.NotEmpty(reporter.Events);
+    }
+
     [Theory]
     [InlineData(3)]
     public void ReportFault_InnerMostExceptionIsOperationCanceledException_SkipsFaultReport(int depth)
@@ -352,11 +413,17 @@ public class TelemetryReporterTests
 
     private Exception CreateException(Type exceptionType, string message, Exception? innerException)
     {
-        if (exceptionType == typeof(OperationCanceledException))
+        if (!typeof(Exception).IsAssignableFrom(exceptionType))
         {
-            return new OperationCanceledException(message, innerException);
+            throw new ArgumentException($"{exceptionType} is not a type of Exception.");
         }
 
-        throw new ArgumentException($"{exceptionType} was not expected.");
+        var constructor = exceptionType.GetConstructor(new[] { typeof(string), typeof(Exception) });
+        if (constructor == null)
+        {
+            throw new ArgumentException($"{exceptionType} does not have a constructor that accepts a string message and an Exception.");
+        }
+
+        return (Exception)constructor.Invoke(new object[] { message, innerException });
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TelemetryReporterTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TelemetryReporterTests.cs
@@ -324,55 +324,6 @@ public class TelemetryReporterTests
     }
 
     [Theory]
-    [InlineData(typeof(RemoteInvocationException), 3)]
-    [InlineData(typeof(OperationCanceledException), 3)]
-    [InlineData(typeof(AggregateException), 15000)]
-    public void ReportFault_MixedTypeNestedExceptions_NoStackOverflowException(Type exceptionType, int depth)
-    {
-        // Arrange
-        var reporter = new TestTelemetryReporter(new RazorLoggerFactory([]));
-        var exception = new RemoteInvocationException("Test", 0,
-                innerException: CreateNestedException(typeof(AggregateException), 3,
-                    innerMostException: CreateNestedException(exceptionType, depth,
-                        innerMostException: new ApplicationException("expectedText")
-                    )
-                )
-            );
-
-        // Act
-        reporter.ReportFault(exception, exception.Message);
-
-        // Assert
-        Assert.Collection(reporter.Events,
-            e1 =>
-            {
-                Assert.Equal("dotnet/razor/fault", e1.Name);
-            });
-    }
-
-    [Theory]
-    [InlineData(typeof(RemoteInvocationException), 3)]
-    [InlineData(typeof(OperationCanceledException), 3)]
-    [InlineData(typeof(AggregateException), 15000)]
-    public void ReportFault_NestedException_NoStackOverflowException(Type exceptionType, int depth)
-    {
-        // Arrange
-        var reporter = new TestTelemetryReporter(new RazorLoggerFactory([]));
-        var innerMostException = new ApplicationException("expectedText");
-        var exception = CreateNestedException(exceptionType, depth, innerMostException);
-
-        // Act
-        reporter.ReportFault(exception, "Test message");
-
-        // Assert
-        Assert.Collection(reporter.Events,
-            e1 =>
-            {
-                Assert.Equal("dotnet/razor/fault", e1.Name);
-            });
-    }
-
-    [Theory]
     [InlineData(3)]
     public void ReportFault_InnerMostExceptionIsOperationCanceledException_SkipsFaultReport(int depth)
     {
@@ -404,24 +355,6 @@ public class TelemetryReporterTests
         if (exceptionType == typeof(OperationCanceledException))
         {
             return new OperationCanceledException(message, innerException);
-        }
-        else if (exceptionType == typeof(AggregateException))
-        {
-            if (innerException == null)
-            {
-                throw new ArgumentNullException("AggregateException requires non-null inner exception");
-            }
-
-            return new AggregateException(message, innerException);
-        }
-        else if (exceptionType == typeof(RemoteInvocationException))
-        {
-            if (innerException is null)
-            {
-                return new RemoteInvocationException(message, 0, errorData: null);
-            }
-
-            return new RemoteInvocationException(message, 0, innerException);
         }
 
         throw new ArgumentException($"{exceptionType} was not expected.");

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TelemetryReporterTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TelemetryReporterTests.cs
@@ -424,6 +424,6 @@ public class TelemetryReporterTests
             throw new ArgumentException($"{exceptionType} does not have a constructor that accepts a string message and an Exception.");
         }
 
-        return (Exception)constructor.Invoke(new object[] { message, innerException });
+        return (Exception)constructor.Invoke(new object[] { message, innerException! });
     }
 }


### PR DESCRIPTION
Skips fault reporting when the inner-most exception is `OperationCanceledException`.

Resolves: [WorkItem#1774918](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1774918/)