### PR TITLE
Bump immutable collections and objectpool packages to 8.0.0

### DIFF
--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -4,7 +4,7 @@
 <UsageData>
   <IgnorePatterns>
     <!-- Prebuilts showing in repo build only - ignoring. -->
-    <UsagePattern IdentityGlob="Microsoft.Extensions.ObjectPool/6.0.0" />
+    <UsagePattern IdentityGlob="Microsoft.Extensions.ObjectPool/8.0.0" />
 
     <!--
       Ignoring the following prebuilts. NetPrevious targeting is needed in repo legs

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -121,11 +121,11 @@
          Without these entries, due to PVP flow work, SBRP packages would be consumed causing runtime issue. -->
     <Dependency Name="Microsoft.Extensions.ObjectPool" Version="8.0.0">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
-      <Sha>ae1a6cbe225b99c0bf38b7e31bf60cb653b73a52</Sha>
+      <Sha>3f1acb59718cadf111a0a796681e3d3509bb3381</Sha>
     </Dependency>
     <Dependency Name="System.Collections.Immutable" Version="8.0.0">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4822e3c3aa77eb82b2fb33c9321f923cf11ddde6</Sha>
+      <Sha>5535e31a712343a63f5d7d796cd874e563e5ac14</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -119,11 +119,11 @@
     <!-- Necessary for source-build. This allows Microsoft.Extensions.ObjectPool and System.Collections.Immutable packages
          to be retrieved from live source-build and their content consumed by packages produced by razor.
          Without these entries, due to PVP flow work, SBRP packages would be consumed causing runtime issue. -->
-    <Dependency Name="Microsoft.Extensions.ObjectPool" Version="6.0.0">
+    <Dependency Name="Microsoft.Extensions.ObjectPool" Version="8.0.0">
       <Uri>https://github.com/dotnet/aspnetcore</Uri>
       <Sha>ae1a6cbe225b99c0bf38b7e31bf60cb653b73a52</Sha>
     </Dependency>
-    <Dependency Name="System.Collections.Immutable" Version="6.0.0">
+    <Dependency Name="System.Collections.Immutable" Version="8.0.0">
       <Uri>https://github.com/dotnet/runtime</Uri>
       <Sha>4822e3c3aa77eb82b2fb33c9321f923cf11ddde6</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -78,8 +78,8 @@
       Exception - Microsoft.Extensions.ObjectPool and System.Collections.Immutable packages are not updated by automation,
       but are present in Version.Details.xml for source-build PVP flow. See the comment in Version.Details.xml for more information.
     -->
-    <MicrosoftExtensionsObjectPoolPackageVersion>6.0.0</MicrosoftExtensionsObjectPoolPackageVersion>
-    <SystemCollectionsImmutablePackageVersion>6.0.0</SystemCollectionsImmutablePackageVersion>
+    <MicrosoftExtensionsObjectPoolPackageVersion>8.0.0</MicrosoftExtensionsObjectPoolPackageVersion>
+    <SystemCollectionsImmutablePackageVersion>8.0.0</SystemCollectionsImmutablePackageVersion>
   </PropertyGroup>
   <!--
 

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/AssemblyBindingRedirects.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/AssemblyBindingRedirects.cs
@@ -36,8 +36,8 @@ using Microsoft.VisualStudio.Shell;
     GenerateCodeBase = true,
     PublicKeyToken = "adb9793829ddae60",
     OldVersionLowerBound = "0.0.0.0",
-    OldVersionUpperBound = "6.0.0.0",
-    NewVersion = "6.0.0.0")]
+    OldVersionUpperBound = "8.0.0.0",
+    NewVersion = "8.0.0.0")]
 [assembly: ProvideBindingRedirection(
     AssemblyName = "Microsoft.Extensions.Options",
     GenerateCodeBase = true,


### PR DESCRIPTION
It turns out that our System.Immutable.Collections package version was already bumped to 8.0.0 with the Roslyn update. This PR bumps our pinned version of System.Immutable.Collections to match, and also bumps Microsoft.Extensions.ObjectPool.