### PR TITLE
Avoid allocations in tag helper binding and parse tree rewrites (+ bonus fixes!)

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/TagHelperBlockRewriterTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/TagHelperBlockRewriterTest.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using Microsoft.AspNetCore.Razor.Language.Components;
 using Xunit;
@@ -14,8 +15,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy;
 
 public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
 {
-    public static TagHelperDescriptor[] SymbolBoundAttributes_Descriptors = new[]
-    {
+    public static ImmutableArray<TagHelperDescriptor> SymbolBoundAttributes_Descriptors =
+    [
         TagHelperDescriptorBuilder.Create("CatchAllTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule =>
                 rule
@@ -52,7 +53,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
                 .Metadata(PropertyName("StringProperty2"))
                 .TypeName(typeof(string).FullName))
             .Build()
-    };
+    ];
 
     [Fact]
     public void CanHandleSymbolBoundAttributes1()
@@ -96,15 +97,15 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         EvaluateData(SymbolBoundAttributes_Descriptors, "<div bound #local='value'></div>");
     }
 
-    public static TagHelperDescriptor[] WithoutEndTag_Descriptors = new TagHelperDescriptor[]
-    {
+    public static ImmutableArray<TagHelperDescriptor> WithoutEndTag_Descriptors =
+    [
         TagHelperDescriptorBuilder.Create("InputTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule =>
                 rule
                 .RequireTagName("input")
                 .RequireTagStructure(TagStructure.WithoutEndTag))
             .Build()
-    };
+    ];
 
     [Fact]
     public void CanHandleWithoutEndTagTagStructure1()
@@ -136,25 +137,23 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         EvaluateData(WithoutEndTag_Descriptors, "<div><input><input></div>");
     }
 
-    public static TagHelperDescriptor[] GetTagStructureCompatibilityDescriptors(TagStructure structure1, TagStructure structure2)
+    public static ImmutableArray<TagHelperDescriptor> GetTagStructureCompatibilityDescriptors(TagStructure structure1, TagStructure structure2)
     {
-        var descriptors = new TagHelperDescriptor[]
-        {
-                TagHelperDescriptorBuilder.Create("InputTagHelper1", "SomeAssembly")
-                    .TagMatchingRuleDescriptor(rule =>
-                        rule
-                        .RequireTagName("input")
-                        .RequireTagStructure(structure1))
-                    .Build(),
-                TagHelperDescriptorBuilder.Create("InputTagHelper2", "SomeAssembly")
-                    .TagMatchingRuleDescriptor(rule =>
-                        rule
-                        .RequireTagName("input")
-                        .RequireTagStructure(structure2))
-                    .Build()
-        };
-
-        return descriptors;
+        return
+        [
+            TagHelperDescriptorBuilder.Create("InputTagHelper1", "SomeAssembly")
+                .TagMatchingRuleDescriptor(rule =>
+                    rule
+                    .RequireTagName("input")
+                    .RequireTagStructure(structure1))
+                .Build(),
+            TagHelperDescriptorBuilder.Create("InputTagHelper2", "SomeAssembly")
+                .TagMatchingRuleDescriptor(rule =>
+                    rule
+                    .RequireTagName("input")
+                    .RequireTagStructure(structure2))
+                .Build()
+        ];
     }
 
     [Fact]
@@ -241,22 +240,22 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
     public void AllowsCompatibleTagStructures_DirectiveAttribute_SelfClosing()
     {
         // Arrange
-        var descriptors = new TagHelperDescriptor[]
-        {
-                TagHelperDescriptorBuilder.Create("InputTagHelper1", "SomeAssembly")
-                    .TagMatchingRuleDescriptor(rule =>
-                    {
-                        rule
-                            .RequireTagName("*")
-                            .RequireAttributeDescriptor(b =>
-                            {
-                                b.Name = "@onclick";
-                                b.SetMetadata(Attributes.IsDirectiveAttribute);
-                            });
-                    })
-                    .Metadata(SpecialKind(ComponentMetadata.EventHandler.TagHelperKind))
-                    .Build(),
-        };
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
+            TagHelperDescriptorBuilder.Create("InputTagHelper1", "SomeAssembly")
+                .TagMatchingRuleDescriptor(rule =>
+                {
+                    rule
+                        .RequireTagName("*")
+                        .RequireAttributeDescriptor(b =>
+                        {
+                            b.Name = "@onclick";
+                            b.SetMetadata(Attributes.IsDirectiveAttribute);
+                        });
+                })
+                .Metadata(SpecialKind(ComponentMetadata.EventHandler.TagHelperKind))
+                .Build(),
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, "<input @onclick=\"@test\"/>");
@@ -266,23 +265,23 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
     public void AllowsCompatibleTagStructures_DirectiveAttribute_Void()
     {
         // Arrange
-        var descriptors = new TagHelperDescriptor[]
-        {
-                TagHelperDescriptorBuilder.Create("InputTagHelper1", "SomeAssembly")
-                    .TagMatchingRuleDescriptor(rule =>
-                    {
-                        rule
-                            .RequireTagName("*")
-                            .RequireAttributeDescriptor(b =>
-                            {
-                                b.Name = "@onclick";
-                                b.SetMetadata(Attributes.IsDirectiveAttribute);
-                            });
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
+            TagHelperDescriptorBuilder.Create("InputTagHelper1", "SomeAssembly")
+                .TagMatchingRuleDescriptor(rule =>
+                {
+                    rule
+                        .RequireTagName("*")
+                        .RequireAttributeDescriptor(b =>
+                        {
+                            b.Name = "@onclick";
+                            b.SetMetadata(Attributes.IsDirectiveAttribute);
+                        });
 
-                    })
-                    .Metadata(SpecialKind(ComponentMetadata.EventHandler.TagHelperKind))
-                    .Build(),
-        };
+                })
+                .Metadata(SpecialKind(ComponentMetadata.EventHandler.TagHelperKind))
+                .Build(),
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, "<input @onclick=\"@test\">");
@@ -456,8 +455,8 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         RunParseTreeRewriterTest("<str<strong></p></strong>", "strong", "p");
     }
 
-    public static TagHelperDescriptor[] CodeTagHelperAttributes_Descriptors = new TagHelperDescriptor[]
-    {
+    public static ImmutableArray<TagHelperDescriptor> CodeTagHelperAttributes_Descriptors =
+    [
         TagHelperDescriptorBuilder.Create("PersonTagHelper", "personAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("person"))
             .BoundAttributeDescriptor(attribute =>
@@ -476,7 +475,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
                 .Metadata(PropertyName("Name"))
                 .TypeName(typeof(string).FullName))
             .Build()
-    };
+    ];
 
     [Fact]
     public void UnderstandsMultipartNonStringTagHelperAttributes()
@@ -868,8 +867,8 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         RunParseTreeRewriterTest("<p class1=''class2=\"\"class3= />", "p");
     }
 
-    public static TagHelperDescriptor[] EmptyTagHelperBoundAttribute_Descriptors = new TagHelperDescriptor[]
-    {
+    public static ImmutableArray<TagHelperDescriptor> EmptyTagHelperBoundAttribute_Descriptors =
+    [
         TagHelperDescriptorBuilder.Create("mythTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("myth"))
             .BoundAttributeDescriptor(attribute =>
@@ -883,7 +882,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
                 .Metadata(PropertyName("Name"))
                 .TypeName(typeof(string).FullName))
             .Build()
-    };
+    ];
 
     [Fact]
     public void CreatesErrorForEmptyTagHelperBoundAttributes1()
@@ -1282,8 +1281,8 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         RunParseTreeRewriterTest(document, "input");
     }
 
-    public static TagHelperDescriptor[] MinimizedAttribute_Descriptors = new TagHelperDescriptor[]
-    {
+    public static ImmutableArray<TagHelperDescriptor> MinimizedAttribute_Descriptors =
+    [
         TagHelperDescriptorBuilder.Create("InputTagHelper1", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule =>
                 rule
@@ -1338,7 +1337,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
                 .Metadata(PropertyName("BoundRequiredString"))
                 .TypeName(typeof(int).FullName))
             .Build(),
-    };
+    ];
 
     [Fact]
     public void UnderstandsMinimizedAttributes_Document1()
@@ -2160,25 +2159,25 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var document = "<input boundbool boundbooldict-key />";
-        var descriptors = new TagHelperDescriptor[]
-        {
-                TagHelperDescriptorBuilder.Create("InputTagHelper", "SomeAssembly")
-                    .TagMatchingRuleDescriptor(rule =>
-                        rule
-                        .RequireTagName("input"))
-                    .BoundAttributeDescriptor(attribute =>
-                        attribute
-                        .Name("boundbool")
-                        .Metadata(PropertyName("BoundBoolProp"))
-                        .TypeName(typeof(bool).FullName))
-                    .BoundAttributeDescriptor(attribute =>
-                        attribute
-                        .Name("boundbooldict")
-                        .Metadata(PropertyName("BoundBoolDictProp"))
-                        .TypeName("System.Collections.Generic.IDictionary<string, bool>")
-                        .AsDictionary("boundbooldict-", typeof(bool).FullName))
-                    .Build(),
-        };
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
+            TagHelperDescriptorBuilder.Create("InputTagHelper", "SomeAssembly")
+                .TagMatchingRuleDescriptor(rule =>
+                    rule
+                    .RequireTagName("input"))
+                .BoundAttributeDescriptor(attribute =>
+                    attribute
+                    .Name("boundbool")
+                    .Metadata(PropertyName("BoundBoolProp"))
+                    .TypeName(typeof(bool).FullName))
+                .BoundAttributeDescriptor(attribute =>
+                    attribute
+                    .Name("boundbooldict")
+                    .Metadata(PropertyName("BoundBoolDictProp"))
+                    .TypeName("System.Collections.Generic.IDictionary<string, bool>")
+                    .AsDictionary("boundbooldict-", typeof(bool).FullName))
+                .Build(),
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, document);
@@ -2189,25 +2188,25 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var document = "<input boundbool boundbooldict-key />";
-        var descriptors = new TagHelperDescriptor[]
-        {
-                TagHelperDescriptorBuilder.Create("InputTagHelper", "SomeAssembly")
-                    .TagMatchingRuleDescriptor(rule =>
-                        rule
-                        .RequireTagName("input"))
-                    .BoundAttributeDescriptor(attribute =>
-                        attribute
-                        .Name("boundbool")
-                        .Metadata(PropertyName("BoundBoolProp"))
-                        .TypeName(typeof(bool).FullName))
-                    .BoundAttributeDescriptor(attribute =>
-                        attribute
-                        .Name("boundbooldict")
-                        .Metadata(PropertyName("BoundBoolDictProp"))
-                        .TypeName("System.Collections.Generic.IDictionary<string, bool>")
-                        .AsDictionary("boundbooldict-", typeof(bool).FullName))
-                    .Build(),
-        };
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
+            TagHelperDescriptorBuilder.Create("InputTagHelper", "SomeAssembly")
+                .TagMatchingRuleDescriptor(rule =>
+                    rule
+                    .RequireTagName("input"))
+                .BoundAttributeDescriptor(attribute =>
+                    attribute
+                    .Name("boundbool")
+                    .Metadata(PropertyName("BoundBoolProp"))
+                    .TypeName(typeof(bool).FullName))
+                .BoundAttributeDescriptor(attribute =>
+                    attribute
+                    .Name("boundbooldict")
+                    .Metadata(PropertyName("BoundBoolDictProp"))
+                    .TypeName("System.Collections.Generic.IDictionary<string, bool>")
+                    .AsDictionary("boundbooldict-", typeof(bool).FullName))
+                .Build(),
+        ];
 
         var featureFlags = CreateFeatureFlags();
 
@@ -2220,8 +2219,8 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var document = @"<input @bind-value=""Message"" @bind-value:event=""onchange"" />";
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             TagHelperDescriptorBuilder.Create(ComponentMetadata.Bind.TagHelperKind, "Bind", ComponentsApi.AssemblyName)
                 .Metadata(
                     SpecialKind(ComponentMetadata.Bind.TagHelperKind),
@@ -2251,7 +2250,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
                         p.SetMetadata(PropertyName("Event"));
                     }))
                 .Build(),
-        };
+        ];
 
         var featureFlags = CreateFeatureFlags(allowCSharpInMarkupAttributeArea: false);
 
@@ -2264,8 +2263,8 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var document = @"<input @bind-foo @bind-foo:param />";
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             TagHelperDescriptorBuilder.Create(ComponentMetadata.Bind.TagHelperKind, "Bind", ComponentsApi.AssemblyName)
                 .Metadata(
                     SpecialKind(ComponentMetadata.Bind.TagHelperKind),
@@ -2296,7 +2295,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
                         p.SetMetadata(PropertyName("Param"));
                     }))
                 .Build(),
-        };
+        ];
 
         var featureFlags = CreateFeatureFlags(allowCSharpInMarkupAttributeArea: false);
 
@@ -2305,21 +2304,21 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
     }
 
     private static RazorParserFeatureFlags CreateFeatureFlags(
-            bool allowMinimizedBooleanTagHelperAttributes = false,
-            bool allowHtmlCommentsInTagHelper = false,
-            bool allowComponentFileKind = false,
-            bool allowRazorInCodeBlockDirectives = false,
-            bool allowUsingVariableDeclarations = false,
-            bool allowConditionalDataDashAttributesInComponents = false,
-            bool allowCSharpInMarkupAttributeArea = true,
-            bool allowNullableForgivenessOperator = false)
-            => new(
-                allowMinimizedBooleanTagHelperAttributes,
-                allowHtmlCommentsInTagHelper,
-                allowComponentFileKind,
-                allowRazorInCodeBlockDirectives,
-                allowUsingVariableDeclarations,
-                allowConditionalDataDashAttributesInComponents,
-                allowCSharpInMarkupAttributeArea,
-                allowNullableForgivenessOperator);
+        bool allowMinimizedBooleanTagHelperAttributes = false,
+        bool allowHtmlCommentsInTagHelper = false,
+        bool allowComponentFileKind = false,
+        bool allowRazorInCodeBlockDirectives = false,
+        bool allowUsingVariableDeclarations = false,
+        bool allowConditionalDataDashAttributesInComponents = false,
+        bool allowCSharpInMarkupAttributeArea = true,
+        bool allowNullableForgivenessOperator = false)
+        => new(
+            allowMinimizedBooleanTagHelperAttributes,
+            allowHtmlCommentsInTagHelper,
+            allowComponentFileKind,
+            allowRazorInCodeBlockDirectives,
+            allowUsingVariableDeclarations,
+            allowConditionalDataDashAttributesInComponents,
+            allowCSharpInMarkupAttributeArea,
+            allowNullableForgivenessOperator);
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/TagHelperParseTreeRewriterTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/TagHelperParseTreeRewriterTest.cs
@@ -55,10 +55,10 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
         var errorSink = new ErrorSink();
         var parseResult = ParseDocument(documentContent);
         var document = parseResult.Root;
+        var binder = new TagHelperBinder(tagHelperPrefix: null, tagHelpers: []);
         var parseTreeRewriter = new TagHelperParseTreeRewriter.Rewriter(
             parseResult.Source,
-            tagHelperPrefix: null,
-            descriptors: [],
+            binder,
             parseResult.Options,
             errorSink);
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/TagHelperParseTreeRewriterTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/TagHelperParseTreeRewriterTest.cs
@@ -70,7 +70,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
         Assert.Empty(errorSink.Errors);
 
         // Act
-        var pairs = parseTreeRewriter.GetAttributeNameValuePairs(element.StartTag);
+        var pairs = TagHelperParseTreeRewriter.Rewriter.GetAttributeNameValuePairs(element.StartTag);
 
         // Assert
         Assert.Equal(expectedPairs, pairs);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/TagHelperParseTreeRewriterTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/TagHelperParseTreeRewriterTest.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
@@ -56,8 +57,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
         var document = parseResult.Root;
         var parseTreeRewriter = new TagHelperParseTreeRewriter.Rewriter(
             parseResult.Source,
-            null,
-            Array.Empty<TagHelperDescriptor>(),
+            tagHelperPrefix: null,
+            descriptors: [],
             parseResult.Options,
             errorSink);
 
@@ -75,8 +76,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
         Assert.Equal(expectedPairs, pairs);
     }
 
-    public static TagHelperDescriptor[] PartialRequiredParentTags_Descriptors = new TagHelperDescriptor[]
-    {
+    public static ImmutableArray<TagHelperDescriptor> PartialRequiredParentTags_Descriptors =
+    [
         TagHelperDescriptorBuilder.Create("StrongTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("strong"))
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
@@ -87,7 +88,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
         TagHelperDescriptorBuilder.Create("PTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"))
             .Build(),
-    };
+    ];
 
     [Fact]
     public void UnderstandsPartialRequiredParentTags1()
@@ -131,8 +132,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
         EvaluateData(PartialRequiredParentTags_Descriptors, document);
     }
 
-    public static TagHelperDescriptor[] NestedVoidSelfClosingRequiredParent_Descriptors = new TagHelperDescriptor[]
-    {
+    public static ImmutableArray<TagHelperDescriptor> NestedVoidSelfClosingRequiredParent_Descriptors =
+    [
         TagHelperDescriptorBuilder.Create("InputTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule =>
                 rule
@@ -152,10 +153,10 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
         TagHelperDescriptorBuilder.Create("PTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"))
             .Build(),
-    };
+    ];
 
-    public static TagHelperDescriptor[] CatchAllAttribute_Descriptors = new TagHelperDescriptor[]
-    {
+    public static ImmutableArray<TagHelperDescriptor> CatchAllAttribute_Descriptors =
+    [
         TagHelperDescriptorBuilder.Create("InputTagHelper1", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule
                 .RequireTagName("*")
@@ -165,7 +166,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
                 }))
             .Metadata(SpecialKind(ComponentMetadata.EventHandler.EventArgsType))
             .Build(),
-    };
+    ];
 
     [Fact]
     public void UnderstandsInvalidHtml()
@@ -230,8 +231,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
         EvaluateData(NestedVoidSelfClosingRequiredParent_Descriptors, document);
     }
 
-    public static TagHelperDescriptor[] NestedRequiredParent_Descriptors = new TagHelperDescriptor[]
-    {
+    public static ImmutableArray<TagHelperDescriptor> NestedRequiredParent_Descriptors =
+    [
         TagHelperDescriptorBuilder.Create("StrongTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule =>
                 rule
@@ -245,7 +246,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
         TagHelperDescriptorBuilder.Create("PTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"))
             .Build(),
-    };
+    ];
 
     [Fact]
     public void UnderstandsNestedRequiredParent1()
@@ -287,8 +288,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<th:p><th:strong></th:strong></th:p>";
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             TagHelperDescriptorBuilder.Create("PTagHelper", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"))
                 .AllowChildTag("strong")
@@ -296,7 +297,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
             TagHelperDescriptorBuilder.Create("StrongTagHelper", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("strong"))
                 .Build(),
-        };
+        ];
 
         // Act & Assert
         EvaluateData(
@@ -310,8 +311,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<th:p><th:strong></th:strong></th:p>";
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             TagHelperDescriptorBuilder.Create("PTagHelper", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"))
                 .AllowChildTag("strong")
@@ -319,7 +320,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
             TagHelperDescriptorBuilder.Create("StrongTagHelper", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("strong").RequireParentTag("p"))
                 .Build(),
-        };
+        ];
 
         // Act & Assert
         EvaluateData(
@@ -334,8 +335,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
         // Rewrite_InvalidStructure_UnderstandsTagHelperPrefixAndAllowedChildrenAndRequireParent
         // Arrange
         var documentContent = "<th:p></th:strong></th:p>";
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             TagHelperDescriptorBuilder.Create("PTagHelper", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"))
                 .AllowChildTag("strong")
@@ -343,7 +344,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
             TagHelperDescriptorBuilder.Create("StrongTagHelper", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("strong").RequireParentTag("p"))
                 .Build(),
-        };
+        ];
 
         // Act & Assert
         EvaluateData(
@@ -357,13 +358,13 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<th:p><strong></strong></th:p>";
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             TagHelperDescriptorBuilder.Create("PTagHelper", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"))
                 .AllowChildTag("strong")
                 .Build(),
-        };
+        ];
 
         // Act & Assert
         EvaluateData(
@@ -439,13 +440,13 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
                 </strong>
             </p>
             """;
-        var descriptors = new TagHelperDescriptor[]
-        {
-                TagHelperDescriptorBuilder.Create("PTagHelper", "SomeAssembly")
-                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"))
-                    .AllowChildTag("br")
-                    .Build()
-        };
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
+            TagHelperDescriptorBuilder.Create("PTagHelper", "SomeAssembly")
+                .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"))
+                .AllowChildTag("br")
+                .Build()
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
@@ -456,8 +457,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<strong required><strong></strong></strong>";
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             TagHelperDescriptorBuilder.Create("StrongTagHelper", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule =>
                     rule
@@ -465,7 +466,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
                     .RequireAttributeDescriptor(attribute => attribute.Name("required")))
                 .AllowChildTag("br")
                 .Build()
-        };
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
@@ -476,8 +477,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<p><strong>Hello World</strong><br></p>";
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             TagHelperDescriptorBuilder.Create("PTagHelper1", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"))
                 .AllowChildTag("strong")
@@ -495,7 +496,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
                     .RequireTagName("br")
                     .RequireTagStructure(TagStructure.WithoutEndTag))
                 .Build(),
-        };
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
@@ -506,8 +507,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<p><strong>Hello World</strong><br></p>";
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             TagHelperDescriptorBuilder.Create("PTagHelper1", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"))
                 .AllowChildTag("strong")
@@ -525,7 +526,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
                     .RequireTagName("br")
                     .RequireTagStructure(TagStructure.WithoutEndTag))
                 .Build(),
-        };
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
@@ -536,7 +537,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<p><br /></p>";
-        var descriptors = TagHelperParseTreeRewriterTest.GetAllowedChildrenTagHelperDescriptors(new[] { "br" });
+        var descriptors = GetAllowedChildrenTagHelperDescriptors(["br"]);
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
@@ -683,13 +684,13 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<p><custom><br>:<strong><strong>Hello</strong></strong>:<input></custom></p>";
-        var descriptors = TagHelperParseTreeRewriterTest.GetAllowedChildrenTagHelperDescriptors(new[] { "custom", "strong" });
+        var descriptors = GetAllowedChildrenTagHelperDescriptors(["custom", "strong"]);
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
     }
 
-    private static TagHelperDescriptor[] GetAllowedChildrenTagHelperDescriptors(string[] allowedChildren)
+    private static ImmutableArray<TagHelperDescriptor> GetAllowedChildrenTagHelperDescriptors(string[] allowedChildren)
     {
         var pTagHelperBuilder = TagHelperDescriptorBuilder.Create("PTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"));
@@ -701,8 +702,9 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
             pTagHelperBuilder.AllowChildTag(childTag);
             strongTagHelperBuilder.AllowChildTag(childTag);
         }
-        var descriptors = new TagHelperDescriptor[]
-        {
+
+        return
+        [
             pTagHelperBuilder.Build(),
             strongTagHelperBuilder.Build(),
             TagHelperDescriptorBuilder.Create("BRTagHelper", "SomeAssembly")
@@ -711,9 +713,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
                     .RequireTagName("br")
                     .RequireTagStructure(TagStructure.WithoutEndTag))
                 .Build(),
-        };
-
-        return descriptors;
+        ];
     }
 
     [Fact]
@@ -733,10 +733,10 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
             pTagHelperBuilder.AllowChildTag(childTag);
         }
 
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             pTagHelperBuilder.Build()
-        };
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, document);
@@ -758,10 +758,10 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
             pTagHelperBuilder.AllowChildTag(childTag);
         }
 
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             pTagHelperBuilder.Build()
-        };
+        ];
 
         // Act & Assert
         EvaluateData(
@@ -788,10 +788,10 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
             pTagHelperBuilder.AllowChildTag(childTag);
         }
 
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             pTagHelperBuilder.Build()
-        };
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, document);
@@ -814,10 +814,10 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
             pTagHelperBuilder.AllowChildTag(childTag);
         }
 
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             pTagHelperBuilder.Build()
-        };
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, document);
@@ -843,10 +843,10 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
             pTagHelperBuilder.AllowChildTag(childTag);
         }
 
-        var descriptors = new TagHelperDescriptor[]
-        {
-                pTagHelperBuilder.Build()
-        };
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
+            pTagHelperBuilder.Build()
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, document);
@@ -857,8 +857,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<p></</p>";
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             TagHelperDescriptorBuilder.Create("PTagHelper", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"))
                 .AllowChildTag("custom")
@@ -866,7 +866,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
             TagHelperDescriptorBuilder.Create("CatchAllTagHelper", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
                 .Build(),
-        };
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
@@ -877,8 +877,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<th:p></</th:p>";
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             TagHelperDescriptorBuilder.Create("PTagHelper", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"))
                 .AllowChildTag("custom")
@@ -886,7 +886,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
             TagHelperDescriptorBuilder.Create("CatchAllTagHelper", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
                 .Build(),
-        };
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, documentContent, "th:");
@@ -897,15 +897,15 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<input>";
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             TagHelperDescriptorBuilder.Create("InputTagHelper", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule =>
                     rule
                     .RequireTagName("input")
                     .RequireTagStructure(TagStructure.WithoutEndTag))
                 .Build()
-        };
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
@@ -916,15 +916,15 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "</input>";
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             TagHelperDescriptorBuilder.Create("InputTagHelper", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule =>
                     rule
                     .RequireTagName("input")
                     .RequireTagStructure(TagStructure.WithoutEndTag))
                 .Build()
-        };
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
@@ -935,8 +935,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<input>";
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             TagHelperDescriptorBuilder.Create("InputTagHelper1", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule =>
                     rule
@@ -949,14 +949,14 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
                     .RequireTagName("input")
                     .RequireTagStructure(TagStructure.NormalOrSelfClosing))
                 .Build()
-        };
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
     }
 
-    public static TagHelperDescriptor[] RequiredAttribute_Descriptors = new TagHelperDescriptor[]
-    {
+    public static ImmutableArray<TagHelperDescriptor> RequiredAttribute_Descriptors =
+    [
         TagHelperDescriptorBuilder.Create("pTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule =>
                 rule
@@ -976,7 +976,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
                 .RequireTagName("*")
                 .RequireAttributeDescriptor(attribute => attribute.Name("catchAll")))
             .Build()
-    };
+    ];
 
     [Fact]
     public void RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly1()
@@ -1158,8 +1158,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
         EvaluateData(RequiredAttribute_Descriptors, "<div style=\"\" class=\"btn\" catchAll=\"hi\" >words<strong>and</strong>spaces</div>");
     }
 
-    public static TagHelperDescriptor[] NestedRequiredAttribute_Descriptors = new TagHelperDescriptor[]
-    {
+    public static ImmutableArray<TagHelperDescriptor> NestedRequiredAttribute_Descriptors =
+    [
         TagHelperDescriptorBuilder.Create("pTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule =>
                 rule
@@ -1172,7 +1172,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
                 .RequireTagName("*")
                 .RequireAttributeDescriptor(attribute => attribute.Name("catchAll")))
             .Build(),
-    };
+    ];
 
     [Fact]
     public void NestedRequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly1()
@@ -1234,15 +1234,15 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
         EvaluateData(NestedRequiredAttribute_Descriptors, "<strong catchAll=\"hi\"><strong><strong><strong catchAll=\"hi\"><strong></strong></strong></strong></strong></strong>");
     }
 
-    public static TagHelperDescriptor[] MalformedRequiredAttribute_Descriptors = new TagHelperDescriptor[]
-    {
+    public static ImmutableArray<TagHelperDescriptor> MalformedRequiredAttribute_Descriptors =
+    [
         TagHelperDescriptorBuilder.Create("pTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule =>
                 rule
                 .RequireTagName("p")
                 .RequireAttributeDescriptor(attribute => attribute.Name("class")))
             .Build(),
-    };
+    ];
 
     [Fact]
     public void RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly1()
@@ -1311,8 +1311,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
         EvaluateData(MalformedRequiredAttribute_Descriptors, document);
     }
 
-    public static TagHelperDescriptor[] PrefixedTagHelperColon_Descriptors = new TagHelperDescriptor[]
-    {
+    public static ImmutableArray<TagHelperDescriptor> PrefixedTagHelperColon_Descriptors =
+    [
         TagHelperDescriptorBuilder.Create("mythTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("myth"))
             .Build(),
@@ -1324,14 +1324,14 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
                 .Metadata(PropertyName("Bound"))
                 .TypeName(typeof(bool).FullName))
             .Build()
-    };
+    ];
 
-    public static TagHelperDescriptor[] PrefixedTagHelperCatchAll_Descriptors = new TagHelperDescriptor[]
-    {
+    public static ImmutableArray<TagHelperDescriptor> PrefixedTagHelperCatchAll_Descriptors =
+    [
         TagHelperDescriptorBuilder.Create("mythTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
             .Build(),
-    };
+    ];
 
     [Fact]
     public void AllowsPrefixedTagHelpers1()
@@ -1921,8 +1921,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
         RunParseTreeRewriterTest("<input>Foo</input>");
     }
 
-    public static TagHelperDescriptor[] CaseSensitive_Descriptors = new TagHelperDescriptor[]
-    {
+    public static ImmutableArray<TagHelperDescriptor> CaseSensitive_Descriptors =
+    [
         TagHelperDescriptorBuilder.Create("pTagHelper", "SomeAssembly")
             .SetCaseSensitive()
             .BoundAttributeDescriptor(attribute =>
@@ -1941,7 +1941,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
                 .RequireTagName("*")
                 .RequireAttributeDescriptor(attribute => attribute.Name("catchAll")))
             .Build(),
-    };
+    ];
 
     [Fact]
     public void HandlesCaseSensitiveTagHelpersCorrectly1()

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/TagHelperRewritingTestBase.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/TagHelperRewritingTestBase.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy;
@@ -17,7 +18,7 @@ public class TagHelperRewritingTestBase() : ParserTestBase(layer: TestProject.La
         EvaluateData(descriptors, documentContent);
     }
 
-    internal IReadOnlyList<TagHelperDescriptor> BuildDescriptors(params string[] tagNames)
+    internal ImmutableArray<TagHelperDescriptor> BuildDescriptors(params string[] tagNames)
     {
         var descriptors = new List<TagHelperDescriptor>();
 
@@ -29,11 +30,11 @@ public class TagHelperRewritingTestBase() : ParserTestBase(layer: TestProject.La
             descriptors.Add(descriptor);
         }
 
-        return descriptors.AsReadOnly();
+        return descriptors.ToImmutableArray();
     }
 
     internal void EvaluateData(
-        IReadOnlyList<TagHelperDescriptor> descriptors,
+        ImmutableArray<TagHelperDescriptor> descriptors,
         string documentContent,
         string tagHelperPrefix = null,
         RazorParserFeatureFlags featureFlags = null)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/TagHelperRewritingTestBase.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/Legacy/TagHelperRewritingTestBase.cs
@@ -41,7 +41,8 @@ public class TagHelperRewritingTestBase() : ParserTestBase(layer: TestProject.La
     {
         var syntaxTree = ParseDocument(documentContent, featureFlags: featureFlags);
 
-        var rewrittenTree = TagHelperParseTreeRewriter.Rewrite(syntaxTree, tagHelperPrefix, descriptors, out _);
+        var binder = new TagHelperBinder(tagHelperPrefix, descriptors);
+        var rewrittenTree = TagHelperParseTreeRewriter.Rewrite(syntaxTree, binder, out _);
 
         Assert.Equal(syntaxTree.Root.FullWidth, rewrittenTree.Root.FullWidth);
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeDescriptorExtensions.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/BoundAttributeDescriptorExtensions.cs
@@ -48,7 +48,7 @@ public static class BoundAttributeDescriptorExtensions
             return true;
         }
 
-        var isIndexerNameMatch = TagHelperMatchingConventions.SatisfiesBoundAttributeIndexer(name.AsSpan(), attribute);
+        var isIndexerNameMatch = TagHelperMatchingConventions.SatisfiesBoundAttributeIndexer(attribute, name.AsSpan());
         return isIndexerNameMatch && attribute.IsIndexerStringProperty;
     }
 
@@ -59,7 +59,7 @@ public static class BoundAttributeDescriptorExtensions
             return true;
         }
 
-        var isIndexerNameMatch = TagHelperMatchingConventions.SatisfiesBoundAttributeIndexer(name.AsSpan(), attribute);
+        var isIndexerNameMatch = TagHelperMatchingConventions.SatisfiesBoundAttributeIndexer(attribute, name.AsSpan());
         return isIndexerNameMatch && attribute.IsIndexerBooleanProperty;
     }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorIntermediateNodeLoweringPhase.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorIntermediateNodeLoweringPhase.cs
@@ -1094,7 +1094,7 @@ internal class DefaultRazorIntermediateNodeLoweringPhase : RazorEnginePhaseBase,
                         TagHelper = associatedDescriptor,
                         AttributeStructure = node.TagHelperAttributeInfo.AttributeStructure,
                         Source = null,
-                        IsIndexerNameMatch = TagHelperMatchingConventions.SatisfiesBoundAttributeIndexer(attributeName.AsSpan(), associatedAttributeDescriptor),
+                        IsIndexerNameMatch = TagHelperMatchingConventions.SatisfiesBoundAttributeIndexer(associatedAttributeDescriptor, attributeName.AsSpan()),
                     };
 
                     _builder.Add(setTagHelperProperty);
@@ -1137,7 +1137,7 @@ internal class DefaultRazorIntermediateNodeLoweringPhase : RazorEnginePhaseBase,
                         TagHelper = associatedDescriptor,
                         AttributeStructure = node.TagHelperAttributeInfo.AttributeStructure,
                         Source = BuildSourceSpanFromNode(attributeValueNode),
-                        IsIndexerNameMatch = TagHelperMatchingConventions.SatisfiesBoundAttributeIndexer(attributeName.AsSpan(), associatedAttributeDescriptor),
+                        IsIndexerNameMatch = TagHelperMatchingConventions.SatisfiesBoundAttributeIndexer(associatedAttributeDescriptor, attributeName.AsSpan()),
                     };
 
                     _builder.Push(setTagHelperProperty);
@@ -1862,8 +1862,8 @@ internal class DefaultRazorIntermediateNodeLoweringPhase : RazorEnginePhaseBase,
                 foreach (var associatedDescriptor in associatedDescriptors)
                 {
                     if (TagHelperMatchingConventions.TryGetFirstBoundAttributeMatch(
-                        attributeName,
                         associatedDescriptor,
+                        attributeName,
                         out var associatedAttributeDescriptor,
                         out var indexerMatch,
                         out _,
@@ -1925,8 +1925,8 @@ internal class DefaultRazorIntermediateNodeLoweringPhase : RazorEnginePhaseBase,
                 foreach (var associatedDescriptor in associatedDescriptors)
                 {
                     if (TagHelperMatchingConventions.TryGetFirstBoundAttributeMatch(
-                        attributeName,
                         associatedDescriptor,
+                        attributeName,
                         out var associatedAttributeDescriptor,
                         out var indexerMatch,
                         out var parameterMatch,
@@ -2011,8 +2011,8 @@ internal class DefaultRazorIntermediateNodeLoweringPhase : RazorEnginePhaseBase,
                 foreach (var associatedDescriptor in associatedDescriptors)
                 {
                     if (TagHelperMatchingConventions.TryGetFirstBoundAttributeMatch(
-                        attributeName,
                         associatedDescriptor,
+                        attributeName,
                         out var associatedAttributeDescriptor,
                         out var indexerMatch,
                         out _,
@@ -2065,8 +2065,8 @@ internal class DefaultRazorIntermediateNodeLoweringPhase : RazorEnginePhaseBase,
                 foreach (var associatedDescriptor in associatedDescriptors)
                 {
                     if (TagHelperMatchingConventions.TryGetFirstBoundAttributeMatch(
-                        attributeName,
                         associatedDescriptor,
+                        attributeName,
                         out var associatedAttributeDescriptor,
                         out var indexerMatch,
                         out var parameterMatch,

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorTagHelperContextDiscoveryPhase.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorTagHelperContextDiscoveryPhase.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System;
-using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorTagHelperContextDiscoveryPhase.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorTagHelperContextDiscoveryPhase.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -35,6 +36,8 @@ internal sealed class DefaultRazorTagHelperContextDiscoveryPhase : RazorEnginePh
 
         var parserOptions = codeDocument.GetParserOptions();
 
+        using var _ = HashSetPool<TagHelperDescriptor>.GetPooledObject(out var matches);
+
         // We need to find directives in all of the *imports* as well as in the main razor file
         //
         // The imports come logically before the main razor file and are in the order they
@@ -44,11 +47,11 @@ internal sealed class DefaultRazorTagHelperContextDiscoveryPhase : RazorEnginePh
             (parserOptions == null || parserOptions.FeatureFlags.AllowComponentFileKind))
         {
             codeDocument.TryComputeNamespace(fallbackToRootNamespace: true, out var currentNamespace);
-            visitor = new ComponentDirectiveVisitor(codeDocument.Source.FilePath, descriptors, currentNamespace);
+            visitor = new ComponentDirectiveVisitor(codeDocument.Source.FilePath, descriptors, currentNamespace, matches);
         }
         else
         {
-            visitor = new TagHelperDirectiveVisitor(descriptors);
+            visitor = new TagHelperDirectiveVisitor(descriptors, matches);
         }
 
         if (codeDocument.GetImportSyntaxTrees() is { IsDefault: false } imports)
@@ -64,9 +67,7 @@ internal sealed class DefaultRazorTagHelperContextDiscoveryPhase : RazorEnginePh
         // This will always be null for a component document.
         var tagHelperPrefix = visitor.TagHelperPrefix;
 
-        descriptors = visitor.Matches.ToArray();
-
-        var context = TagHelperDocumentContext.Create(tagHelperPrefix, descriptors);
+        var context = TagHelperDocumentContext.Create(tagHelperPrefix, matches.ToImmutableArray());
         codeDocument.SetTagHelperContext(context);
         codeDocument.SetPreTagHelperSyntaxTree(syntaxTree);
     }
@@ -106,9 +107,9 @@ internal sealed class DefaultRazorTagHelperContextDiscoveryPhase : RazorEnginePh
         return span;
     }
 
-    internal abstract class DirectiveVisitor : SyntaxWalker
+    internal abstract class DirectiveVisitor(HashSet<TagHelperDescriptor> matches) : SyntaxWalker
     {
-        public abstract HashSet<TagHelperDescriptor> Matches { get; }
+        protected readonly HashSet<TagHelperDescriptor> Matches = matches;
 
         public abstract string TagHelperPrefix { get; }
 
@@ -120,10 +121,12 @@ internal sealed class DefaultRazorTagHelperContextDiscoveryPhase : RazorEnginePh
         private readonly List<TagHelperDescriptor> _tagHelpers;
         private string _tagHelperPrefix;
 
-        public TagHelperDirectiveVisitor(IReadOnlyList<TagHelperDescriptor> tagHelpers)
+        public TagHelperDirectiveVisitor(IReadOnlyList<TagHelperDescriptor> tagHelpers, HashSet<TagHelperDescriptor> matches)
+            : base(matches)
         {
             // We don't want to consider components in a view document.
             _tagHelpers = new();
+
             for (var i = 0; i < tagHelpers.Count; i++)
             {
                 var tagHelper = tagHelpers[i];
@@ -135,8 +138,6 @@ internal sealed class DefaultRazorTagHelperContextDiscoveryPhase : RazorEnginePh
         }
 
         public override string TagHelperPrefix => _tagHelperPrefix;
-
-        public override HashSet<TagHelperDescriptor> Matches { get; } = new HashSet<TagHelperDescriptor>();
 
         public override void Visit(RazorSyntaxTree tree)
         {
@@ -157,6 +158,7 @@ internal sealed class DefaultRazorTagHelperContextDiscoveryPhase : RazorEnginePh
                 {
                     case null:
                         continue;
+
                     case AddTagHelperChunkGenerator addTagHelper:
                         if (addTagHelper.AssemblyName == null)
                         {
@@ -170,15 +172,16 @@ internal sealed class DefaultRazorTagHelperContextDiscoveryPhase : RazorEnginePh
                             continue;
                         }
 
-                        for (var i = 0; i < _tagHelpers.Count; i++)
+                        foreach (var tagHelper in _tagHelpers)
                         {
-                            var tagHelper = _tagHelpers[i];
                             if (MatchesDirective(tagHelper, addTagHelper.TypePattern, addTagHelper.AssemblyName))
                             {
                                 Matches.Add(tagHelper);
                             }
                         }
+
                         break;
+
                     case RemoveTagHelperChunkGenerator removeTagHelper:
                         if (removeTagHelper.AssemblyName == null)
                         {
@@ -193,31 +196,33 @@ internal sealed class DefaultRazorTagHelperContextDiscoveryPhase : RazorEnginePh
                             continue;
                         }
 
-                        for (var i = 0; i < _tagHelpers.Count; i++)
+                        foreach (var tagHelper in _tagHelpers)
                         {
-                            var tagHelper = _tagHelpers[i];
                             if (MatchesDirective(tagHelper, removeTagHelper.TypePattern, removeTagHelper.AssemblyName))
                             {
                                 Matches.Remove(tagHelper);
                             }
                         }
+
                         break;
+
                     case TagHelperPrefixDirectiveChunkGenerator tagHelperPrefix:
                         if (!string.IsNullOrEmpty(tagHelperPrefix.DirectiveText))
                         {
                             // We only expect to see a single one of these per file, but that's enforced at another level.
                             _tagHelperPrefix = tagHelperPrefix.DirectiveText;
                         }
+
                         break;
                 }
             }
         }
 
-        private bool AssemblyContainsTagHelpers(string assemblyName, IReadOnlyList<TagHelperDescriptor> tagHelpers)
+        private static bool AssemblyContainsTagHelpers(string assemblyName, List<TagHelperDescriptor> tagHelpers)
         {
-            for (var i = 0; i < tagHelpers.Count; i++)
+            foreach (var tagHelper in tagHelpers)
             {
-                if (string.Equals(tagHelpers[i].AssemblyName, assemblyName, StringComparison.Ordinal))
+                if (tagHelper.AssemblyName == assemblyName)
                 {
                     return true;
                 }
@@ -233,7 +238,8 @@ internal sealed class DefaultRazorTagHelperContextDiscoveryPhase : RazorEnginePh
         private readonly string _filePath;
         private RazorSourceDocument _source;
 
-        public ComponentDirectiveVisitor(string filePath, IReadOnlyList<TagHelperDescriptor> tagHelpers, string currentNamespace)
+        public ComponentDirectiveVisitor(string filePath, IReadOnlyList<TagHelperDescriptor> tagHelpers, string currentNamespace, HashSet<TagHelperDescriptor> matches)
+            : base(matches)
         {
             _filePath = filePath;
 
@@ -280,8 +286,6 @@ internal sealed class DefaultRazorTagHelperContextDiscoveryPhase : RazorEnginePh
 
             _notFullyQualifiedComponents = builder.DrainToImmutable();
         }
-
-        public override HashSet<TagHelperDescriptor> Matches { get; } = new HashSet<TagHelperDescriptor>();
 
         // There is no support for tag helper prefix in component documents.
         public override string TagHelperPrefix => null;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorTagHelperRewritePhase.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorTagHelperRewritePhase.cs
@@ -11,7 +11,7 @@ internal sealed class DefaultRazorTagHelperRewritePhase : RazorEnginePhaseBase
     {
         var syntaxTree = codeDocument.GetPreTagHelperSyntaxTree();
         var context = codeDocument.GetTagHelperContext();
-        if (syntaxTree is null || context.TagHelpers.Count == 0)
+        if (syntaxTree is null || context.TagHelpers.Length == 0)
         {
             // No descriptors, no-op.
             return;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorTagHelperRewritePhase.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/DefaultRazorTagHelperRewritePhase.cs
@@ -5,6 +5,7 @@
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 
 namespace Microsoft.AspNetCore.Razor.Language;
+
 internal sealed class DefaultRazorTagHelperRewritePhase : RazorEnginePhaseBase
 {
     protected override void ExecuteCore(RazorCodeDocument codeDocument)
@@ -17,7 +18,8 @@ internal sealed class DefaultRazorTagHelperRewritePhase : RazorEnginePhaseBase
             return;
         }
 
-        var rewrittenSyntaxTree = TagHelperParseTreeRewriter.Rewrite(syntaxTree, context.Prefix, context.TagHelpers, out var usedHelpers);
+        var binder = context.GetBinder();
+        var rewrittenSyntaxTree = TagHelperParseTreeRewriter.Rewrite(syntaxTree, binder, out var usedHelpers);
 
         codeDocument.SetReferencedTagHelpers(usedHelpers);
         codeDocument.SetSyntaxTree(rewrittenSyntaxTree);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/CodeBlockEditHandler.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/CodeBlockEditHandler.cs
@@ -81,7 +81,7 @@ internal class CodeBlockEditHandler : SpanEditHandler
     {
         var relativePosition = change.Span.AbsoluteIndex - target.Position;
 
-        if (target.GetContent().IndexOfAny(new[] { '{', '}', '@', '<', '*', }, relativePosition, change.Span.Length) >= 0)
+        if (target.GetContent().IndexOfAny(['{', '}', '@', '<', '*',], relativePosition, change.Span.Length) >= 0)
         {
             return true;
         }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/TagHelperBlockRewriter.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/TagHelperBlockRewriter.cs
@@ -30,7 +30,7 @@ internal static class TagHelperBlockRewriter
         foreach (var descriptor in bindingResult.Descriptors)
         {
             var boundRules = bindingResult.Mappings[descriptor];
-            var nonDefaultRule = boundRules.FirstOrDefault(rule => rule.TagStructure != TagStructure.Unspecified);
+            var nonDefaultRule = boundRules.FirstOrDefault(static rule => rule.TagStructure != TagStructure.Unspecified);
 
             if (nonDefaultRule?.TagStructure == TagStructure.WithoutEndTag)
             {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/TagHelperBlockRewriter.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/TagHelperBlockRewriter.cs
@@ -437,7 +437,7 @@ internal static class TagHelperBlockRewriter
     {
         foreach (var descriptor in descriptors)
         {
-            if (TagHelperMatchingConventions.TryGetFirstBoundAttributeMatch(name, descriptor, out var firstBoundAttribute, out var indexerMatch, out var _, out var _))
+            if (TagHelperMatchingConventions.TryGetFirstBoundAttributeMatch(descriptor, name, out var firstBoundAttribute, out var indexerMatch, out var _, out var _))
             {
                 if (indexerMatch)
                 {
@@ -468,8 +468,8 @@ internal static class TagHelperBlockRewriter
         foreach (var descriptor in descriptors)
         {
             if (TagHelperMatchingConventions.TryGetFirstBoundAttributeMatch(
-                name,
                 descriptor,
+                name,
                 out var firstBoundAttribute,
                 out var indexerMatch,
                 out var parameterMatch,

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/TagHelperParseTreeRewriter.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/TagHelperParseTreeRewriter.cs
@@ -353,7 +353,7 @@ internal static class TagHelperParseTreeRewriter
                 foreach (var descriptor in tagHelperBinding.Descriptors)
                 {
                     var boundRules = tagHelperBinding.Mappings[descriptor];
-                    var invalidRule = boundRules.FirstOrDefault(rule => rule.TagStructure == TagStructure.WithoutEndTag);
+                    var invalidRule = boundRules.FirstOrDefault(static rule => rule.TagStructure == TagStructure.WithoutEndTag);
 
                     if (invalidRule != null)
                     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/TagHelperParseTreeRewriter.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/TagHelperParseTreeRewriter.cs
@@ -15,7 +15,7 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy;
 
 internal static class TagHelperParseTreeRewriter
 {
-    public static RazorSyntaxTree Rewrite(RazorSyntaxTree syntaxTree, string tagHelperPrefix, IReadOnlyList<TagHelperDescriptor> descriptors, out ISet<TagHelperDescriptor> usedDescriptors)
+    public static RazorSyntaxTree Rewrite(RazorSyntaxTree syntaxTree, string tagHelperPrefix, ImmutableArray<TagHelperDescriptor> descriptors, out ISet<TagHelperDescriptor> usedDescriptors)
     {
         var errorSink = new ErrorSink();
 
@@ -69,7 +69,7 @@ internal static class TagHelperParseTreeRewriter
         public Rewriter(
             RazorSourceDocument source,
             string tagHelperPrefix,
-            IReadOnlyList<TagHelperDescriptor> descriptors,
+            ImmutableArray<TagHelperDescriptor> descriptors,
             RazorParserOptions options,
             ErrorSink errorSink)
         {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/TagHelperSpanInternal.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Legacy/TagHelperSpanInternal.cs
@@ -1,29 +1,11 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
-using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy;
 
-internal struct TagHelperSpanInternal
+internal readonly record struct TagHelperSpanInternal(SourceSpan Span, TagHelperBinding Binding)
 {
-    public TagHelperSpanInternal(SourceSpan span, TagHelperBinding binding)
-    {
-        if (binding == null)
-        {
-            throw new ArgumentNullException(nameof(binding));
-        }
-
-        Span = span;
-        Binding = binding;
-    }
-
-    public TagHelperBinding Binding { get; }
-
-    public IEnumerable<TagHelperDescriptor> TagHelpers => Binding.Descriptors;
-
-    public SourceSpan Span { get; }
+    public ImmutableArray<TagHelperDescriptor> TagHelpers => Binding.Descriptors;
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/PublicAPI.Shipped.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/PublicAPI.Shipped.txt
@@ -66,8 +66,6 @@
 ~abstract Microsoft.AspNetCore.Razor.Language.RazorSyntaxTree.Source.get -> Microsoft.AspNetCore.Razor.Language.RazorSourceDocument
 ~abstract Microsoft.AspNetCore.Razor.Language.TagHelperDescriptorProviderContext.Items.get -> Microsoft.AspNetCore.Razor.Language.ItemCollection
 ~abstract Microsoft.AspNetCore.Razor.Language.TagHelperDescriptorProviderContext.Results.get -> System.Collections.Generic.ICollection<Microsoft.AspNetCore.Razor.Language.TagHelperDescriptor>
-~abstract Microsoft.AspNetCore.Razor.Language.TagHelperDocumentContext.Prefix.get -> string
-~abstract Microsoft.AspNetCore.Razor.Language.TagHelperDocumentContext.TagHelpers.get -> System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Razor.Language.TagHelperDescriptor>
 ~Microsoft.AspNetCore.Razor.Language.AssemblyExtension.Assembly.get -> System.Reflection.Assembly
 ~Microsoft.AspNetCore.Razor.Language.AssemblyExtension.AssemblyExtension(string extensionName, System.Reflection.Assembly assembly) -> void
 ~Microsoft.AspNetCore.Razor.Language.CodeGeneration.LinePragma.FilePath.get -> string
@@ -642,7 +640,6 @@
 ~static Microsoft.AspNetCore.Razor.Language.RazorCodeDocumentExtensions.GetFileKind(this Microsoft.AspNetCore.Razor.Language.RazorCodeDocument document) -> string
 ~static Microsoft.AspNetCore.Razor.Language.RazorCodeDocumentExtensions.GetParserOptions(this Microsoft.AspNetCore.Razor.Language.RazorCodeDocument document) -> Microsoft.AspNetCore.Razor.Language.RazorParserOptions
 ~static Microsoft.AspNetCore.Razor.Language.RazorCodeDocumentExtensions.GetSyntaxTree(this Microsoft.AspNetCore.Razor.Language.RazorCodeDocument document) -> Microsoft.AspNetCore.Razor.Language.RazorSyntaxTree
-~static Microsoft.AspNetCore.Razor.Language.RazorCodeDocumentExtensions.GetTagHelperContext(this Microsoft.AspNetCore.Razor.Language.RazorCodeDocument document) -> Microsoft.AspNetCore.Razor.Language.TagHelperDocumentContext
 ~static Microsoft.AspNetCore.Razor.Language.RazorCodeDocumentExtensions.SetCodeGenerationOptions(this Microsoft.AspNetCore.Razor.Language.RazorCodeDocument document, Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptions codeGenerationOptions) -> void
 ~static Microsoft.AspNetCore.Razor.Language.RazorCodeDocumentExtensions.SetCSharpDocument(this Microsoft.AspNetCore.Razor.Language.RazorCodeDocument document, Microsoft.AspNetCore.Razor.Language.RazorCSharpDocument csharp) -> void
 ~static Microsoft.AspNetCore.Razor.Language.RazorCodeDocumentExtensions.SetCssScope(this Microsoft.AspNetCore.Razor.Language.RazorCodeDocument document, string cssScope) -> void
@@ -650,7 +647,6 @@
 ~static Microsoft.AspNetCore.Razor.Language.RazorCodeDocumentExtensions.SetFileKind(this Microsoft.AspNetCore.Razor.Language.RazorCodeDocument document, string fileKind) -> void
 ~static Microsoft.AspNetCore.Razor.Language.RazorCodeDocumentExtensions.SetParserOptions(this Microsoft.AspNetCore.Razor.Language.RazorCodeDocument document, Microsoft.AspNetCore.Razor.Language.RazorParserOptions parserOptions) -> void
 ~static Microsoft.AspNetCore.Razor.Language.RazorCodeDocumentExtensions.SetSyntaxTree(this Microsoft.AspNetCore.Razor.Language.RazorCodeDocument document, Microsoft.AspNetCore.Razor.Language.RazorSyntaxTree syntaxTree) -> void
-~static Microsoft.AspNetCore.Razor.Language.RazorCodeDocumentExtensions.SetTagHelperContext(this Microsoft.AspNetCore.Razor.Language.RazorCodeDocument document, Microsoft.AspNetCore.Razor.Language.TagHelperDocumentContext context) -> void
 ~static Microsoft.AspNetCore.Razor.Language.RazorCodeDocumentExtensions.TryComputeNamespace(this Microsoft.AspNetCore.Razor.Language.RazorCodeDocument document, bool fallbackToRootNamespace, out string namespace) -> bool
 ~static Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptions.Create(System.Action<Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptionsBuilder> configure) -> Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptions
 ~static Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptions.CreateDefault() -> Microsoft.AspNetCore.Razor.Language.RazorCodeGenerationOptions
@@ -685,7 +681,6 @@
 ~static Microsoft.AspNetCore.Razor.Language.TagHelperDescriptorExtensions.KindUsesDefaultTagHelperRuntime(this Microsoft.AspNetCore.Razor.Language.TagHelperDescriptor tagHelper) -> bool
 ~static Microsoft.AspNetCore.Razor.Language.TagHelperDescriptorProviderContext.Create() -> Microsoft.AspNetCore.Razor.Language.TagHelperDescriptorProviderContext
 ~static Microsoft.AspNetCore.Razor.Language.TagHelperDescriptorProviderContext.Create(System.Collections.Generic.ICollection<Microsoft.AspNetCore.Razor.Language.TagHelperDescriptor> results) -> Microsoft.AspNetCore.Razor.Language.TagHelperDescriptorProviderContext
-~static Microsoft.AspNetCore.Razor.Language.TagHelperDocumentContext.Create(string prefix, System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Razor.Language.TagHelperDescriptor> tagHelpers) -> Microsoft.AspNetCore.Razor.Language.TagHelperDocumentContext
 ~static readonly Microsoft.AspNetCore.Razor.Language.Components.ComponentCodeDirective.Directive -> Microsoft.AspNetCore.Razor.Language.DirectiveDescriptor
 ~static readonly Microsoft.AspNetCore.Razor.Language.Extensions.FunctionsDirective.Directive -> Microsoft.AspNetCore.Razor.Language.DirectiveDescriptor
 ~static readonly Microsoft.AspNetCore.Razor.Language.Extensions.InheritsDirective.Directive -> Microsoft.AspNetCore.Razor.Language.DirectiveDescriptor
@@ -1185,8 +1180,6 @@ Microsoft.AspNetCore.Razor.Language.TagHelperDescriptorBuilderExtensions
 Microsoft.AspNetCore.Razor.Language.TagHelperDescriptorExtensions
 Microsoft.AspNetCore.Razor.Language.TagHelperDescriptorProviderContext
 Microsoft.AspNetCore.Razor.Language.TagHelperDescriptorProviderContext.TagHelperDescriptorProviderContext() -> void
-Microsoft.AspNetCore.Razor.Language.TagHelperDocumentContext
-Microsoft.AspNetCore.Razor.Language.TagHelperDocumentContext.TagHelperDocumentContext() -> void
 Microsoft.AspNetCore.Razor.Language.TagHelperMetadata
 Microsoft.AspNetCore.Razor.Language.TagHelperMetadata.Common
 Microsoft.AspNetCore.Razor.Language.TagHelperMetadata.Runtime

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/PublicAPI.Shipped.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/PublicAPI.Shipped.txt
@@ -406,13 +406,6 @@
 ~Microsoft.AspNetCore.Razor.Language.SourceSpan.FilePath.get -> string
 ~Microsoft.AspNetCore.Razor.Language.SourceSpan.SourceSpan(string filePath, int absoluteIndex, int lineIndex, int characterIndex, int length) -> void
 ~Microsoft.AspNetCore.Razor.Language.SourceSpan.SourceSpan(string filePath, int absoluteIndex, int lineIndex, int characterIndex, int length, int lineCount, int endCharacterIndex) -> void
-~Microsoft.AspNetCore.Razor.Language.TagHelperBinding.Attributes.get -> System.Collections.Generic.IReadOnlyList<System.Collections.Generic.KeyValuePair<string, string>>
-~Microsoft.AspNetCore.Razor.Language.TagHelperBinding.Descriptors.get -> System.Collections.Generic.IEnumerable<Microsoft.AspNetCore.Razor.Language.TagHelperDescriptor>
-~Microsoft.AspNetCore.Razor.Language.TagHelperBinding.GetBoundRules(Microsoft.AspNetCore.Razor.Language.TagHelperDescriptor descriptor) -> System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Razor.Language.TagMatchingRuleDescriptor>
-~Microsoft.AspNetCore.Razor.Language.TagHelperBinding.Mappings.get -> System.Collections.Generic.IReadOnlyDictionary<Microsoft.AspNetCore.Razor.Language.TagHelperDescriptor, System.Collections.Generic.IReadOnlyList<Microsoft.AspNetCore.Razor.Language.TagMatchingRuleDescriptor>>
-~Microsoft.AspNetCore.Razor.Language.TagHelperBinding.ParentTagName.get -> string
-~Microsoft.AspNetCore.Razor.Language.TagHelperBinding.TagHelperPrefix.get -> string
-~Microsoft.AspNetCore.Razor.Language.TagHelperBinding.TagName.get -> string
 ~override Microsoft.AspNetCore.Razor.Language.AssemblyExtension.ExtensionName.get -> string
 ~override Microsoft.AspNetCore.Razor.Language.CodeGeneration.DesignTimeNodeWriter.BeginWriterScope(Microsoft.AspNetCore.Razor.Language.CodeGeneration.CodeRenderingContext context, string writer) -> void
 ~override Microsoft.AspNetCore.Razor.Language.CodeGeneration.DesignTimeNodeWriter.EndWriterScope(Microsoft.AspNetCore.Razor.Language.CodeGeneration.CodeRenderingContext context) -> void
@@ -1187,8 +1180,6 @@ Microsoft.AspNetCore.Razor.Language.SourceSpan.LineIndex.get -> int
 Microsoft.AspNetCore.Razor.Language.SourceSpan.SourceSpan(int absoluteIndex, int length) -> void
 Microsoft.AspNetCore.Razor.Language.SourceSpan.SourceSpan(int absoluteIndex, int lineIndex, int characterIndex, int length) -> void
 Microsoft.AspNetCore.Razor.Language.SourceSpan.SourceSpan(Microsoft.AspNetCore.Razor.Language.SourceLocation location, int contentLength) -> void
-Microsoft.AspNetCore.Razor.Language.TagHelperBinding
-Microsoft.AspNetCore.Razor.Language.TagHelperBinding.IsAttributeMatch.get -> bool
 Microsoft.AspNetCore.Razor.Language.TagHelperConventions
 Microsoft.AspNetCore.Razor.Language.TagHelperDescriptorBuilderExtensions
 Microsoft.AspNetCore.Razor.Language.TagHelperDescriptorExtensions

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorCodeDocument.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorCodeDocument.cs
@@ -8,17 +8,12 @@ namespace Microsoft.AspNetCore.Razor.Language;
 
 public sealed class RazorCodeDocument
 {
+    public RazorSourceDocument Source { get; }
     public ImmutableArray<RazorSourceDocument> Imports { get; }
     public ItemCollection Items { get; }
-    public RazorSourceDocument Source { get; }
 
-    internal RazorCodeDocument(RazorSourceDocument source, ImmutableArray<RazorSourceDocument> imports)
+    private RazorCodeDocument(RazorSourceDocument source, ImmutableArray<RazorSourceDocument> imports)
     {
-        if (source == null)
-        {
-            throw new ArgumentNullException(nameof(source));
-        }
-
         Source = source;
         Imports = imports.NullToEmpty();
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorCodeDocumentExtensions.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorCodeDocumentExtensions.cs
@@ -22,7 +22,7 @@ public static class RazorCodeDocumentExtensions
     private static readonly object CssScopeKey = new object();
     private static readonly object NamespaceKey = new object();
 
-    public static TagHelperDocumentContext GetTagHelperContext(this RazorCodeDocument document)
+    internal static TagHelperDocumentContext GetTagHelperContext(this RazorCodeDocument document)
     {
         if (document == null)
         {
@@ -32,7 +32,7 @@ public static class RazorCodeDocumentExtensions
         return (TagHelperDocumentContext)document.Items[typeof(TagHelperDocumentContext)];
     }
 
-    public static void SetTagHelperContext(this RazorCodeDocument document, TagHelperDocumentContext context)
+    internal static void SetTagHelperContext(this RazorCodeDocument document, TagHelperDocumentContext context)
     {
         if (document == null)
         {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/InternalSyntax/SyntaxToken.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/InternalSyntax/SyntaxToken.cs
@@ -60,26 +60,20 @@ internal class SyntaxToken : RazorSyntaxNode
         return new Syntax.SyntaxToken(this, parent, position);
     }
 
-    protected override void WriteTokenTo(TextWriter writer, bool leading, bool trailing)
+    protected override void WriteTokenTo(TextWriter writer, bool includeLeadingTrivia, bool includeTrailingTrivia)
     {
-        if (leading)
+        if (includeLeadingTrivia)
         {
             var trivia = GetLeadingTrivia();
-            if (trivia != null)
-            {
-                trivia.WriteTo(writer, true, true);
-            }
+            trivia?.WriteTo(writer, includeLeadingTrivia: true, includeTrailingTrivia: true);
         }
 
         writer.Write(Content);
 
-        if (trailing)
+        if (includeTrailingTrivia)
         {
             var trivia = GetTrailingTrivia();
-            if (trivia != null)
-            {
-                trivia.WriteTo(writer, true, true);
-            }
+            trivia?.WriteTo(writer, includeLeadingTrivia: true, includeTrailingTrivia: true);
         }
     }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/InternalSyntax/SyntaxTrivia.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/InternalSyntax/SyntaxTrivia.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 
 namespace Microsoft.AspNetCore.Razor.Language.Syntax.InternalSyntax;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/MarkupTagHelperElementSyntax.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/MarkupTagHelperElementSyntax.cs
@@ -8,22 +8,11 @@ internal sealed partial class MarkupTagHelperElementSyntax
     private static readonly string TagHelperInfoKey = typeof(TagHelperInfo).Name;
 
     public TagHelperInfo? TagHelperInfo
-    {
-        get
-        {
-            return this.GetAnnotationValue(TagHelperInfoKey) as TagHelperInfo;
-        }
-    }
+        => this.GetAnnotationValue(TagHelperInfoKey) as TagHelperInfo;
 
     public MarkupTagHelperElementSyntax WithTagHelperInfo(TagHelperInfo info)
     {
-        var existingAnnotations = GetAnnotations();
-
-        var newAnnotations = new SyntaxAnnotation[existingAnnotations.Length + 1];
-        existingAnnotations.CopyTo(newAnnotations, 0);
-        newAnnotations[^1] = new(TagHelperInfoKey, info);
-
-        var newGreen = Green.WithAnnotationsGreen(newAnnotations);
+        var newGreen = Green.WithAnnotationsGreen([.. GetAnnotations(), new(TagHelperInfoKey, info)]);
 
         return (MarkupTagHelperElementSyntax)newGreen.CreateRed(Parent, Position);
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/MarkupTagHelperElementSyntax.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/MarkupTagHelperElementSyntax.cs
@@ -1,33 +1,29 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
-using System.Collections.Generic;
-
 namespace Microsoft.AspNetCore.Razor.Language.Syntax;
 
 internal sealed partial class MarkupTagHelperElementSyntax
 {
     private static readonly string TagHelperInfoKey = typeof(TagHelperInfo).Name;
 
-    public TagHelperInfo TagHelperInfo
+    public TagHelperInfo? TagHelperInfo
     {
         get
         {
-            var tagHelperInfo = this.GetAnnotationValue(TagHelperInfoKey) as TagHelperInfo;
-            return tagHelperInfo;
+            return this.GetAnnotationValue(TagHelperInfoKey) as TagHelperInfo;
         }
     }
 
     public MarkupTagHelperElementSyntax WithTagHelperInfo(TagHelperInfo info)
     {
-        var annotations = new List<SyntaxAnnotation>(GetAnnotations())
-            {
-                new SyntaxAnnotation(TagHelperInfoKey, info)
-            };
+        var existingAnnotations = GetAnnotations();
 
-        var newGreen = Green.WithAnnotationsGreen(annotations.ToArray());
+        var newAnnotations = new SyntaxAnnotation[existingAnnotations.Length + 1];
+        existingAnnotations.CopyTo(newAnnotations, 0);
+        newAnnotations[^1] = new(TagHelperInfoKey, info);
+
+        var newGreen = Green.WithAnnotationsGreen(newAnnotations);
 
         return (MarkupTagHelperElementSyntax)newGreen.CreateRed(Parent, Position);
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/SyntaxNodeExtensions.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/Syntax/SyntaxNodeExtensions.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.AspNetCore.Razor.Language.Syntax;
@@ -203,8 +204,10 @@ internal static class SyntaxNodeExtensions
 
     public static string GetContent<TNode>(this TNode node) where TNode : SyntaxNode
     {
-        using var writer = new System.IO.StringWriter();
+        using var _ = StringBuilderPool.GetPooledObject(out var builder);
+        using var writer = new System.IO.StringWriter(builder);
         node.Green.WriteTo(writer);
+
         return writer.ToString();
     }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperBinder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperBinder.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -16,14 +14,14 @@ namespace Microsoft.AspNetCore.Razor.Language;
 internal sealed class TagHelperBinder
 {
     private readonly Dictionary<string, HashSet<TagHelperDescriptor>> _registrations;
-    private readonly string _tagHelperPrefix;
+    private readonly string? _tagHelperPrefix;
 
     /// <summary>
     /// Instantiates a new instance of the <see cref="TagHelperBinder"/>.
     /// </summary>
     /// <param name="tagHelperPrefix">The tag helper prefix being used by the document.</param>
     /// <param name="descriptors">The descriptors that the <see cref="TagHelperBinder"/> will pull from.</param>
-    public TagHelperBinder(string tagHelperPrefix, IReadOnlyList<TagHelperDescriptor> descriptors)
+    public TagHelperBinder(string? tagHelperPrefix, IReadOnlyList<TagHelperDescriptor> descriptors)
     {
         _tagHelperPrefix = tagHelperPrefix;
         // To reduce the frequency of dictionary resizes we use the incoming number of descriptors as a heuristic
@@ -46,13 +44,13 @@ internal sealed class TagHelperBinder
     /// <param name="parentIsTagHelper">Is the parent tag of the given <paramref name="tagName"/> tag a tag helper.</param>
     /// <returns><see cref="TagHelperDescriptor"/>s that apply to the given HTML tag criteria.
     /// Will return <c>null</c> if no <see cref="TagHelperDescriptor"/>s are a match.</returns>
-    public TagHelperBinding GetBinding(
+    public TagHelperBinding? GetBinding(
         string tagName,
         ImmutableArray<KeyValuePair<string, string>> attributes,
-        string parentTagName,
+        string? parentTagName,
         bool parentIsTagHelper)
     {
-        if (!string.IsNullOrEmpty(_tagHelperPrefix) &&
+        if (!_tagHelperPrefix.IsNullOrEmpty() &&
             (tagName.Length <= _tagHelperPrefix.Length ||
             !tagName.StartsWith(_tagHelperPrefix, StringComparison.OrdinalIgnoreCase)))
         {
@@ -92,12 +90,12 @@ internal sealed class TagHelperBinder
             }
         }
 
-        Dictionary<TagHelperDescriptor, IReadOnlyList<TagMatchingRuleDescriptor>> applicableDescriptorMappings = null;
+        Dictionary<TagHelperDescriptor, IReadOnlyList<TagMatchingRuleDescriptor>>? applicableDescriptorMappings = null;
         foreach (var descriptor in descriptors)
         {
             // We're avoiding descriptor.TagMatchingRules.Where and applicableRules.Any() to avoid
             // Enumerator allocations on this hot path
-            List<TagMatchingRuleDescriptor> applicableRules = null;
+            List<TagMatchingRuleDescriptor>? applicableRules = null;
             foreach (var rule in descriptor.TagMatchingRules)
             {
                 if (TagHelperMatchingConventions.SatisfiesRule(tagNameWithoutPrefix, parentTagNameWithoutPrefix, attributes, rule))

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperBinder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperBinder.cs
@@ -58,7 +58,7 @@ internal sealed class TagHelperBinder
     {
         if (!TagHelperPrefix.IsNullOrEmpty() &&
             (tagName.Length <= TagHelperPrefix.Length ||
-            !tagName.StartsWith(TagHelperPrefix, StringComparison.OrdinalIgnoreCase)))
+             !tagName.StartsWith(TagHelperPrefix, StringComparison.OrdinalIgnoreCase)))
         {
             // The tagName doesn't have the tag helper prefix, we can short circuit.
             return null;
@@ -104,7 +104,7 @@ internal sealed class TagHelperBinder
             TagHelperPrefix);
 
         static void FindApplicableDescriptors(
-            IEnumerable<TagHelperDescriptor> descriptors,
+            HashSet<TagHelperDescriptor> descriptors,
             ReadOnlySpan<char> tagNameWithoutPrefix,
             ReadOnlySpan<char> parentTagNameWithoutPrefix,
             ImmutableArray<KeyValuePair<string, string>> attributes,
@@ -136,19 +136,18 @@ internal sealed class TagHelperBinder
     {
         foreach (var rule in descriptor.TagMatchingRules)
         {
-            var registrationKey =
-                string.Equals(rule.TagName, TagHelperMatchingConventions.ElementCatchAllName, StringComparison.Ordinal) ?
-                TagHelperMatchingConventions.ElementCatchAllName :
-                TagHelperPrefix + rule.TagName;
+            var registrationKey = rule.TagName == TagHelperMatchingConventions.ElementCatchAllName
+                ? TagHelperMatchingConventions.ElementCatchAllName
+                : TagHelperPrefix + rule.TagName;
 
             // Ensure there's a HashSet to add the descriptor to.
-            if (!_registrations.TryGetValue(registrationKey, out HashSet<TagHelperDescriptor> descriptorSet))
+            if (!_registrations.TryGetValue(registrationKey, out var descriptorSet))
             {
                 descriptorSet = [];
                 _registrations[registrationKey] = descriptorSet;
             }
 
-            _ = descriptorSet.Add(descriptor);
+            descriptorSet.Add(descriptor);
         }
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperBinder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperBinder.cs
@@ -110,10 +110,10 @@ internal sealed class TagHelperBinder
             ImmutableArray<KeyValuePair<string, string>> attributes,
             Dictionary<TagHelperDescriptor, ImmutableArray<TagMatchingRuleDescriptor>> applicableDescriptors)
         {
+            using var applicableRules = new PooledArrayBuilder<TagMatchingRuleDescriptor>();
+
             foreach (var descriptor in descriptors)
             {
-                using var applicableRules = new PooledArrayBuilder<TagMatchingRuleDescriptor>();
-
                 foreach (var rule in descriptor.TagMatchingRules)
                 {
                     if (TagHelperMatchingConventions.SatisfiesRule(rule, tagNameWithoutPrefix, parentTagNameWithoutPrefix, attributes))
@@ -126,6 +126,8 @@ internal sealed class TagHelperBinder
                 {
                     applicableDescriptors[descriptor] = applicableRules.DrainToImmutable();
                 }
+
+                applicableRules.Clear();
             }
         }
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperBinder.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperBinder.cs
@@ -21,11 +21,11 @@ internal sealed class TagHelperBinder
     /// </summary>
     /// <param name="tagHelperPrefix">The tag helper prefix being used by the document.</param>
     /// <param name="descriptors">The descriptors that the <see cref="TagHelperBinder"/> will pull from.</param>
-    public TagHelperBinder(string? tagHelperPrefix, IReadOnlyList<TagHelperDescriptor> descriptors)
+    public TagHelperBinder(string? tagHelperPrefix, ImmutableArray<TagHelperDescriptor> descriptors)
     {
         _tagHelperPrefix = tagHelperPrefix;
         // To reduce the frequency of dictionary resizes we use the incoming number of descriptors as a heuristic
-        _registrations = new Dictionary<string, HashSet<TagHelperDescriptor>>(descriptors.Count, StringComparer.OrdinalIgnoreCase);
+        _registrations = new Dictionary<string, HashSet<TagHelperDescriptor>>(descriptors.Length, StringComparer.OrdinalIgnoreCase);
 
         // Populate our registrations
         foreach (var descriptor in descriptors)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperBinding.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperBinding.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.Razor.Language;
 
-public sealed class TagHelperBinding
+internal sealed class TagHelperBinding
 {
     internal TagHelperBinding(
         string tagName,

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperBinding.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperBinding.cs
@@ -2,17 +2,27 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Microsoft.AspNetCore.Razor.Language;
 
 internal sealed class TagHelperBinding
 {
+    public string TagName { get; }
+    public string? ParentTagName { get; }
+    public ImmutableArray<KeyValuePair<string, string>> Attributes { get; }
+    public FrozenDictionary<TagHelperDescriptor, ImmutableArray<TagMatchingRuleDescriptor>> Mappings { get; }
+    public string? TagHelperPrefix { get; }
+
+    public ImmutableArray<TagHelperDescriptor> Descriptors => Mappings.Keys;
+
     internal TagHelperBinding(
         string tagName,
-        IReadOnlyList<KeyValuePair<string, string>> attributes,
+        ImmutableArray<KeyValuePair<string, string>> attributes,
         string? parentTagName,
-        IReadOnlyDictionary<TagHelperDescriptor, IReadOnlyList<TagMatchingRuleDescriptor>> mappings,
+        FrozenDictionary<TagHelperDescriptor, ImmutableArray<TagMatchingRuleDescriptor>> mappings,
         string? tagHelperPrefix)
     {
         TagName = tagName;
@@ -21,8 +31,6 @@ internal sealed class TagHelperBinding
         Mappings = mappings;
         TagHelperPrefix = tagHelperPrefix;
     }
-
-    public IEnumerable<TagHelperDescriptor> Descriptors => Mappings.Keys;
 
     /// <summary>
     /// Gets a value that indicates whether the the binding matched on attributes only.
@@ -54,17 +62,7 @@ internal sealed class TagHelperBinding
         }
     }
 
-    public string TagName { get; }
-
-    public string? ParentTagName { get; }
-
-    public IReadOnlyList<KeyValuePair<string, string>> Attributes { get; }
-
-    public IReadOnlyDictionary<TagHelperDescriptor, IReadOnlyList<TagMatchingRuleDescriptor>> Mappings { get; }
-
-    public string? TagHelperPrefix { get; }
-
-    public IReadOnlyList<TagMatchingRuleDescriptor> GetBoundRules(TagHelperDescriptor descriptor)
+    public ImmutableArray<TagMatchingRuleDescriptor> GetBoundRules(TagHelperDescriptor descriptor)
     {
         if (descriptor == null)
         {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperBinding.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperBinding.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 
@@ -13,16 +11,15 @@ internal sealed class TagHelperBinding
     internal TagHelperBinding(
         string tagName,
         IReadOnlyList<KeyValuePair<string, string>> attributes,
-        string parentTagName,
+        string? parentTagName,
         IReadOnlyDictionary<TagHelperDescriptor, IReadOnlyList<TagMatchingRuleDescriptor>> mappings,
-        string tagHelperPrefix)
+        string? tagHelperPrefix)
     {
         TagName = tagName;
         Attributes = attributes;
         ParentTagName = parentTagName;
         Mappings = mappings;
         TagHelperPrefix = tagHelperPrefix;
-
     }
 
     public IEnumerable<TagHelperDescriptor> Descriptors => Mappings.Keys;
@@ -59,13 +56,13 @@ internal sealed class TagHelperBinding
 
     public string TagName { get; }
 
-    public string ParentTagName { get; }
+    public string? ParentTagName { get; }
 
     public IReadOnlyList<KeyValuePair<string, string>> Attributes { get; }
 
     public IReadOnlyDictionary<TagHelperDescriptor, IReadOnlyList<TagMatchingRuleDescriptor>> Mappings { get; }
 
-    public string TagHelperPrefix { get; }
+    public string? TagHelperPrefix { get; }
 
     public IReadOnlyList<TagMatchingRuleDescriptor> GetBoundRules(TagHelperDescriptor descriptor)
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperBinding.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperBinding.cs
@@ -61,14 +61,4 @@ internal sealed class TagHelperBinding
             return true;
         }
     }
-
-    public ImmutableArray<TagMatchingRuleDescriptor> GetBoundRules(TagHelperDescriptor descriptor)
-    {
-        if (descriptor == null)
-        {
-            throw new ArgumentNullException(nameof(descriptor));
-        }
-
-        return Mappings[descriptor];
-    }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDocumentContext.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDocumentContext.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Razor.Language;
 /// The binding information for Tag Helpers resulted to a <see cref="RazorCodeDocument"/>. Represents the
 /// Tag Helper information after processing by directives.
 /// </summary>
-public abstract class TagHelperDocumentContext
+internal abstract class TagHelperDocumentContext
 {
     public static TagHelperDocumentContext Create(string prefix, IEnumerable<TagHelperDescriptor> tagHelpers)
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDocumentContext.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDocumentContext.cs
@@ -15,6 +15,8 @@ internal sealed class TagHelperDocumentContext
     public string? Prefix { get; }
     public ImmutableArray<TagHelperDescriptor> TagHelpers { get; }
 
+    private TagHelperBinder? _binder;
+
     private TagHelperDocumentContext(string? prefix, ImmutableArray<TagHelperDescriptor> tagHelpers)
     {
         Prefix = prefix;
@@ -29,5 +31,10 @@ internal sealed class TagHelperDocumentContext
         }
 
         return new(prefix, tagHelpers);
+    }
+
+    public TagHelperBinder GetBinder()
+    {
+        return _binder ?? InterlockedOperations.Initialize(ref _binder, new TagHelperBinder(Prefix, TagHelpers));
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDocumentContext.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDocumentContext.cs
@@ -2,8 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
+using System.Collections.Immutable;
 
 namespace Microsoft.AspNetCore.Razor.Language;
 
@@ -14,27 +13,17 @@ namespace Microsoft.AspNetCore.Razor.Language;
 internal sealed class TagHelperDocumentContext
 {
     public string? Prefix { get; }
-    public IReadOnlyList<TagHelperDescriptor> TagHelpers { get; }
+    public ImmutableArray<TagHelperDescriptor> TagHelpers { get; }
 
-    private TagHelperDocumentContext(string? prefix, IReadOnlyList<TagHelperDescriptor> tagHelpers)
+    private TagHelperDocumentContext(string? prefix, ImmutableArray<TagHelperDescriptor> tagHelpers)
     {
         Prefix = prefix;
         TagHelpers = tagHelpers;
     }
 
-    public static TagHelperDocumentContext Create(string? prefix, IEnumerable<TagHelperDescriptor> tagHelpers)
+    public static TagHelperDocumentContext Create(string? prefix, ImmutableArray<TagHelperDescriptor> tagHelpers)
     {
-        if (tagHelpers == null)
-        {
-            throw new ArgumentNullException(nameof(tagHelpers));
-        }
-
-        return new(prefix, tagHelpers.ToArray());
-    }
-
-    internal static TagHelperDocumentContext Create(string? prefix, IReadOnlyList<TagHelperDescriptor> tagHelpers)
-    {
-        if (tagHelpers == null)
+        if (tagHelpers.IsDefault)
         {
             throw new ArgumentNullException(nameof(tagHelpers));
         }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDocumentContext.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperDocumentContext.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,45 +11,34 @@ namespace Microsoft.AspNetCore.Razor.Language;
 /// The binding information for Tag Helpers resulted to a <see cref="RazorCodeDocument"/>. Represents the
 /// Tag Helper information after processing by directives.
 /// </summary>
-internal abstract class TagHelperDocumentContext
+internal sealed class TagHelperDocumentContext
 {
-    public static TagHelperDocumentContext Create(string prefix, IEnumerable<TagHelperDescriptor> tagHelpers)
+    public string? Prefix { get; }
+    public IReadOnlyList<TagHelperDescriptor> TagHelpers { get; }
+
+    private TagHelperDocumentContext(string? prefix, IReadOnlyList<TagHelperDescriptor> tagHelpers)
+    {
+        Prefix = prefix;
+        TagHelpers = tagHelpers;
+    }
+
+    public static TagHelperDocumentContext Create(string? prefix, IEnumerable<TagHelperDescriptor> tagHelpers)
     {
         if (tagHelpers == null)
         {
             throw new ArgumentNullException(nameof(tagHelpers));
         }
 
-        return new DefaultTagHelperDocumentContext(prefix, tagHelpers.ToArray());
+        return new(prefix, tagHelpers.ToArray());
     }
 
-    internal static TagHelperDocumentContext Create(string prefix, IReadOnlyList<TagHelperDescriptor> tagHelpers)
+    internal static TagHelperDocumentContext Create(string? prefix, IReadOnlyList<TagHelperDescriptor> tagHelpers)
     {
         if (tagHelpers == null)
         {
             throw new ArgumentNullException(nameof(tagHelpers));
         }
 
-        return new DefaultTagHelperDocumentContext(prefix, tagHelpers);
-    }
-
-    public abstract string Prefix { get; }
-
-    public abstract IReadOnlyList<TagHelperDescriptor> TagHelpers { get; }
-
-    private class DefaultTagHelperDocumentContext : TagHelperDocumentContext
-    {
-        private readonly string _prefix;
-        private readonly IReadOnlyList<TagHelperDescriptor> _tagHelpers;
-
-        public DefaultTagHelperDocumentContext(string prefix, IReadOnlyList<TagHelperDescriptor> tagHelpers)
-        {
-            _prefix = prefix;
-            _tagHelpers = tagHelpers;
-        }
-
-        public override string Prefix => _prefix;
-
-        public override IReadOnlyList<TagHelperDescriptor> TagHelpers => _tagHelpers;
+        return new(prefix, tagHelpers);
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperInfo.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperInfo.cs
@@ -3,4 +3,4 @@
 
 namespace Microsoft.AspNetCore.Razor.Language;
 
-internal record TagHelperInfo(string TagName, TagMode TagMode, TagHelperBinding BindingResult);
+internal sealed record TagHelperInfo(string TagName, TagMode TagMode, TagHelperBinding BindingResult);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperInfo.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperInfo.cs
@@ -1,25 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 namespace Microsoft.AspNetCore.Razor.Language;
 
-internal class TagHelperInfo
-{
-    public TagHelperInfo(
-        string tagName,
-        TagMode tagMode,
-        TagHelperBinding bindingResult)
-    {
-        TagName = tagName;
-        TagMode = tagMode;
-        BindingResult = bindingResult;
-    }
-
-    public string TagName { get; }
-
-    public TagMode TagMode { get; }
-
-    public TagHelperBinding BindingResult { get; }
-}
+internal record TagHelperInfo(string TagName, TagMode TagMode, TagHelperBinding BindingResult);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperSpanVisitor.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagHelperSpanVisitor.cs
@@ -31,7 +31,7 @@ internal class TagHelperSpanVisitor : SyntaxWalker
 
     public override void VisitMarkupTagHelperElement(MarkupTagHelperElementSyntax node)
     {
-        var span = new TagHelperSpanInternal(node.GetSourceSpan(_source), node.TagHelperInfo.BindingResult);
+        var span = new TagHelperSpanInternal(node.GetSourceSpan(_source), node.TagHelperInfo.AssumeNotNull().BindingResult);
         _spans.Add(span);
 
         base.VisitMarkupTagHelperElement(node);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagMode.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/TagMode.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 namespace Microsoft.AspNetCore.Razor.Language;
 
 /// <summary>

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/DefaultRazorTagHelperBinderPhaseTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/DefaultRazorTagHelperBinderPhaseTest.cs
@@ -25,7 +25,7 @@ public class DefaultRazorTagHelperContextDiscoveryPhaseTest : RazorProjectEngine
         // Arrange
         var projectEngine = RazorProjectEngine.Create(builder =>
         {
-            builder.AddTagHelpers(new TagHelperDescriptor[0]);
+            builder.AddTagHelpers([]);
         });
 
         var phase = new DefaultRazorTagHelperContextDiscoveryPhase()
@@ -34,11 +34,11 @@ public class DefaultRazorTagHelperContextDiscoveryPhaseTest : RazorProjectEngine
         };
         var expectedDiagnostics = new[]
         {
-                RazorDiagnosticFactory.CreateParsing_UnterminatedStringLiteral(
-                    new SourceSpan(new SourceLocation(14 + Environment.NewLine.Length, 1, 14), contentLength: 1)),
-                RazorDiagnosticFactory.CreateParsing_InvalidTagHelperLookupText(
-                    new SourceSpan(new SourceLocation(14 + Environment.NewLine.Length, 1, 14), contentLength: 1), "\"")
-            };
+            RazorDiagnosticFactory.CreateParsing_UnterminatedStringLiteral(
+                new SourceSpan(new SourceLocation(14 + Environment.NewLine.Length, 1, 14), contentLength: 1)),
+            RazorDiagnosticFactory.CreateParsing_InvalidTagHelperLookupText(
+                new SourceSpan(new SourceLocation(14 + Environment.NewLine.Length, 1, 14), contentLength: 1), "\"")
+        };
 
         var content =
         @"
@@ -64,7 +64,7 @@ public class DefaultRazorTagHelperContextDiscoveryPhaseTest : RazorProjectEngine
         // Arrange
         var projectEngine = RazorProjectEngine.Create(builder =>
         {
-            builder.AddTagHelpers(new TagHelperDescriptor[0]);
+            builder.AddTagHelpers([]);
         });
 
         var phase = new DefaultRazorTagHelperContextDiscoveryPhase()
@@ -73,11 +73,11 @@ public class DefaultRazorTagHelperContextDiscoveryPhaseTest : RazorProjectEngine
         };
         var expectedDiagnostics = new[]
         {
-                RazorDiagnosticFactory.CreateParsing_UnterminatedStringLiteral(
-                    new SourceSpan(new SourceLocation(17 + Environment.NewLine.Length, 1, 17), contentLength: 1)),
-                RazorDiagnosticFactory.CreateParsing_InvalidTagHelperLookupText(
-                    new SourceSpan(new SourceLocation(17 + Environment.NewLine.Length, 1, 17), contentLength: 1), "\"")
-            };
+            RazorDiagnosticFactory.CreateParsing_UnterminatedStringLiteral(
+                new SourceSpan(new SourceLocation(17 + Environment.NewLine.Length, 1, 17), contentLength: 1)),
+            RazorDiagnosticFactory.CreateParsing_InvalidTagHelperLookupText(
+                new SourceSpan(new SourceLocation(17 + Environment.NewLine.Length, 1, 17), contentLength: 1), "\"")
+        };
 
         var content =
         @"
@@ -103,7 +103,7 @@ public class DefaultRazorTagHelperContextDiscoveryPhaseTest : RazorProjectEngine
         // Arrange
         var projectEngine = RazorProjectEngine.Create(builder =>
         {
-            builder.AddTagHelpers(new TagHelperDescriptor[0]);
+            builder.AddTagHelpers([]);
         });
 
         var phase = new DefaultRazorTagHelperContextDiscoveryPhase()
@@ -142,17 +142,17 @@ public class DefaultRazorTagHelperContextDiscoveryPhaseTest : RazorProjectEngine
         // Arrange
         var projectEngine = RazorProjectEngine.Create(builder =>
         {
-            builder.AddTagHelpers(new[]
-            {
-                    CreateTagHelperDescriptor(
-                        tagName: "form",
-                        typeName: "TestFormTagHelper",
-                        assemblyName: "TestAssembly"),
-                    CreateTagHelperDescriptor(
-                        tagName: "input",
-                        typeName: "TestInputTagHelper",
-                        assemblyName: "TestAssembly"),
-            });
+            builder.AddTagHelpers(
+            [
+                CreateTagHelperDescriptor(
+                    tagName: "form",
+                    typeName: "TestFormTagHelper",
+                    assemblyName: "TestAssembly"),
+                CreateTagHelperDescriptor(
+                    tagName: "input",
+                    typeName: "TestInputTagHelper",
+                    assemblyName: "TestAssembly"),
+            ]);
         });
 
         var discoveryPhase = new DefaultRazorTagHelperContextDiscoveryPhase()
@@ -189,15 +189,15 @@ public class DefaultRazorTagHelperContextDiscoveryPhaseTest : RazorProjectEngine
         var projectEngine = CreateProjectEngine();
         var tagHelpers = new[]
         {
-                CreateTagHelperDescriptor(
-                    tagName: "form",
-                    typeName: "TestFormTagHelper",
-                    assemblyName: "TestAssembly"),
-                CreateTagHelperDescriptor(
-                    tagName: "input",
-                    typeName: "TestInputTagHelper",
-                    assemblyName: "TestAssembly"),
-            };
+            CreateTagHelperDescriptor(
+                tagName: "form",
+                typeName: "TestFormTagHelper",
+                assemblyName: "TestAssembly"),
+            CreateTagHelperDescriptor(
+                tagName: "input",
+                typeName: "TestInputTagHelper",
+                assemblyName: "TestAssembly"),
+        };
 
         var discoveryPhase = new DefaultRazorTagHelperContextDiscoveryPhase()
         {
@@ -233,15 +233,15 @@ public class DefaultRazorTagHelperContextDiscoveryPhaseTest : RazorProjectEngine
         // Arrange
         var tagHelpers = new[]
         {
-                CreateTagHelperDescriptor(
-                    tagName: "form",
-                    typeName: "TestFormTagHelper",
-                    assemblyName: "TestAssembly"),
-                CreateTagHelperDescriptor(
-                    tagName: "input",
-                    typeName: "TestInputTagHelper",
-                    assemblyName: "TestAssembly"),
-            };
+            CreateTagHelperDescriptor(
+                tagName: "form",
+                typeName: "TestFormTagHelper",
+                assemblyName: "TestAssembly"),
+            CreateTagHelperDescriptor(
+                tagName: "input",
+                typeName: "TestInputTagHelper",
+                assemblyName: "TestAssembly"),
+        };
         var projectEngine = RazorProjectEngine.Create(builder => builder.AddTagHelpers(tagHelpers));
 
         var discoveryPhase = new DefaultRazorTagHelperContextDiscoveryPhase()
@@ -278,15 +278,15 @@ public class DefaultRazorTagHelperContextDiscoveryPhaseTest : RazorProjectEngine
         // Arrange
         var tagHelpers = new[]
         {
-                CreateTagHelperDescriptor(
-                    tagName: "form",
-                    typeName: "TestFormTagHelper",
-                    assemblyName: "TestAssembly"),
-                CreateTagHelperDescriptor(
-                    tagName: "input",
-                    typeName: "TestInputTagHelper",
-                    assemblyName: "TestAssembly"),
-            };
+            CreateTagHelperDescriptor(
+                tagName: "form",
+                typeName: "TestFormTagHelper",
+                assemblyName: "TestAssembly"),
+            CreateTagHelperDescriptor(
+                tagName: "input",
+                typeName: "TestInputTagHelper",
+                assemblyName: "TestAssembly"),
+        };
         var projectEngine = RazorProjectEngine.Create(builder => builder.AddTagHelpers(tagHelpers));
 
         var phase = new DefaultRazorTagHelperContextDiscoveryPhase()
@@ -298,7 +298,7 @@ public class DefaultRazorTagHelperContextDiscoveryPhaseTest : RazorProjectEngine
         var codeDocument = RazorCodeDocument.Create(sourceDocument);
         var originalTree = RazorSyntaxTree.Parse(sourceDocument);
         codeDocument.SetSyntaxTree(originalTree);
-        codeDocument.SetTagHelpers(tagHelpers: Array.Empty<TagHelperDescriptor>());
+        codeDocument.SetTagHelpers(tagHelpers: []);
 
         // Act
         phase.Execute(codeDocument);
@@ -319,21 +319,21 @@ public class DefaultRazorTagHelperContextDiscoveryPhaseTest : RazorProjectEngine
             tagName: "form",
             typeName: "TestFormTagHelper",
             assemblyName: "TestAssembly",
-            ruleBuilders: new Action<TagMatchingRuleDescriptorBuilder>[]
-            {
-                    ruleBuilder => ruleBuilder
-                        .RequireAttributeDescriptor(attribute => attribute
-                            .Name("a")
-                            .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)),
-                    ruleBuilder => ruleBuilder
-                        .RequireAttributeDescriptor(attribute => attribute
-                            .Name("b")
-                            .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)),
-            });
+            ruleBuilders:
+            [
+                ruleBuilder => ruleBuilder
+                    .RequireAttributeDescriptor(attribute => attribute
+                        .Name("a")
+                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)),
+                ruleBuilder => ruleBuilder
+                    .RequireAttributeDescriptor(attribute => attribute
+                        .Name("b")
+                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)),
+            ]);
 
         var projectEngine = RazorProjectEngine.Create(builder =>
         {
-            builder.AddTagHelpers(new[] { descriptor });
+            builder.AddTagHelpers([descriptor]);
         });
 
         var discoveryPhase = new DefaultRazorTagHelperContextDiscoveryPhase()
@@ -367,7 +367,7 @@ public class DefaultRazorTagHelperContextDiscoveryPhaseTest : RazorProjectEngine
 
         var formTagHelper = Assert.Single(tagHelperNodes);
         Assert.Equal("form", formTagHelper.TagHelperInfo.TagName);
-        Assert.Equal(2, formTagHelper.TagHelperInfo.BindingResult.Mappings[descriptor].Count);
+        Assert.Equal(2, formTagHelper.TagHelperInfo.BindingResult.Mappings[descriptor].Length);
     }
 
     [Fact]
@@ -378,21 +378,21 @@ public class DefaultRazorTagHelperContextDiscoveryPhaseTest : RazorProjectEngine
             tagName: "form",
             typeName: "TestFormTagHelper",
             assemblyName: "TestAssembly",
-            ruleBuilders: new Action<TagMatchingRuleDescriptorBuilder>[]
-            {
-                    ruleBuilder => ruleBuilder
-                        .RequireAttributeDescriptor(attribute => attribute
-                            .Name("a")
-                            .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)),
-                    ruleBuilder => ruleBuilder
-                        .RequireAttributeDescriptor(attribute => attribute
-                            .Name("b")
-                            .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)),
-            });
+            ruleBuilders:
+            [
+                ruleBuilder => ruleBuilder
+                    .RequireAttributeDescriptor(attribute => attribute
+                        .Name("a")
+                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)),
+                ruleBuilder => ruleBuilder
+                    .RequireAttributeDescriptor(attribute => attribute
+                        .Name("b")
+                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)),
+            ]);
 
         var projectEngine = RazorProjectEngine.Create(builder =>
         {
-            builder.AddTagHelpers(new[] { descriptor });
+            builder.AddTagHelpers([descriptor]);
         });
 
         var discoveryPhase = new DefaultRazorTagHelperContextDiscoveryPhase()
@@ -426,7 +426,7 @@ public class DefaultRazorTagHelperContextDiscoveryPhaseTest : RazorProjectEngine
 
         var formTagHelper = Assert.Single(tagHelperNodes);
         Assert.Equal("form", formTagHelper.TagHelperInfo.TagName);
-        Assert.Equal(2, formTagHelper.TagHelperInfo.BindingResult.Mappings[descriptor].Count);
+        Assert.Equal(2, formTagHelper.TagHelperInfo.BindingResult.Mappings[descriptor].Length);
     }
 
     [Fact]
@@ -435,11 +435,11 @@ public class DefaultRazorTagHelperContextDiscoveryPhaseTest : RazorProjectEngine
         // Arrange
         var featureTagHelpers = new[]
         {
-                CreateTagHelperDescriptor(
-                    tagName: "input",
-                    typeName: "TestInputTagHelper",
-                    assemblyName: "TestAssembly"),
-            };
+            CreateTagHelperDescriptor(
+                tagName: "input",
+                typeName: "TestInputTagHelper",
+                assemblyName: "TestAssembly"),
+        };
         var projectEngine = RazorProjectEngine.Create(builder => builder.AddTagHelpers(featureTagHelpers));
 
         var discoveryPhase = new DefaultRazorTagHelperContextDiscoveryPhase()
@@ -458,11 +458,11 @@ public class DefaultRazorTagHelperContextDiscoveryPhaseTest : RazorProjectEngine
 
         var codeDocumentTagHelpers = new[]
         {
-                CreateTagHelperDescriptor(
-                    tagName: "form",
-                    typeName: "TestFormTagHelper",
-                    assemblyName: "TestAssembly"),
-            };
+            CreateTagHelperDescriptor(
+                tagName: "form",
+                typeName: "TestFormTagHelper",
+                assemblyName: "TestAssembly"),
+        };
         codeDocument.SetTagHelpers(codeDocumentTagHelpers);
 
         // Act
@@ -566,17 +566,17 @@ public class DefaultRazorTagHelperContextDiscoveryPhaseTest : RazorProjectEngine
         // Arrange
         var projectEngine = RazorProjectEngine.Create(builder =>
         {
-            builder.AddTagHelpers(new[]
-            {
-                    CreateTagHelperDescriptor(
-                        tagName: "form",
-                        typeName: "TestFormTagHelper",
-                        assemblyName: "TestAssembly"),
-                    CreateTagHelperDescriptor(
-                        tagName: "input",
-                        typeName: "TestInputTagHelper",
-                        assemblyName: "TestAssembly"),
-            });
+            builder.AddTagHelpers(
+            [
+                CreateTagHelperDescriptor(
+                    tagName: "form",
+                    typeName: "TestFormTagHelper",
+                    assemblyName: "TestAssembly"),
+                CreateTagHelperDescriptor(
+                    tagName: "input",
+                    typeName: "TestInputTagHelper",
+                    assemblyName: "TestAssembly"),
+            ]);
         });
 
         var discoveryPhase = new DefaultRazorTagHelperContextDiscoveryPhase()
@@ -602,9 +602,9 @@ public class DefaultRazorTagHelperContextDiscoveryPhaseTest : RazorProjectEngine
             new RazorDiagnosticDescriptor("RZ9999", "Initial test error", RazorDiagnosticSeverity.Error),
             new SourceSpan(SourceLocation.Zero, contentLength: 1));
         var expectedRewritingError = RazorDiagnosticFactory.CreateParsing_TagHelperFoundMalformedTagHelper(
-            new SourceSpan(new SourceLocation(Environment.NewLine.Length * 2 + 30, 2, 1), contentLength: 4), "form");
+            new SourceSpan(new SourceLocation((Environment.NewLine.Length * 2) + 30, 2, 1), contentLength: 4), "form");
 
-        var erroredOriginalTree = RazorSyntaxTree.Create(originalTree.Root, originalTree.Source, new[] { initialError }, originalTree.Options);
+        var erroredOriginalTree = RazorSyntaxTree.Create(originalTree.Root, originalTree.Source, [initialError], originalTree.Options);
         codeDocument.SetSyntaxTree(erroredOriginalTree);
 
         // Act
@@ -615,7 +615,7 @@ public class DefaultRazorTagHelperContextDiscoveryPhaseTest : RazorProjectEngine
         var outputTree = codeDocument.GetSyntaxTree();
         Assert.Empty(originalTree.Diagnostics);
         Assert.NotSame(erroredOriginalTree, outputTree);
-        Assert.Equal(new[] { initialError, expectedRewritingError }, outputTree.Diagnostics);
+        Assert.Equal([initialError, expectedRewritingError], outputTree.Diagnostics);
     }
 
     private static string AssemblyA => "TestAssembly";
@@ -725,7 +725,7 @@ public class DefaultRazorTagHelperContextDiscoveryPhaseTest : RazorProjectEngine
         var parser = new RazorParser();
         var syntaxTree = parser.Parse(sourceDocument);
         var matches = new HashSet<TagHelperDescriptor>();
-        var visitor = new DefaultRazorTagHelperContextDiscoveryPhase.TagHelperDirectiveVisitor(tagHelpers: new List<TagHelperDescriptor>(), matches);
+        var visitor = new DefaultRazorTagHelperContextDiscoveryPhase.TagHelperDirectiveVisitor(tagHelpers: [], matches);
 
         // Act
         visitor.Visit(syntaxTree.Root);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/TagHelperBlockRewriterTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/TagHelperBlockRewriterTest.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using Microsoft.AspNetCore.Razor.Language.Components;
 using Xunit;
@@ -14,8 +15,8 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy;
 
 public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
 {
-    public static TagHelperDescriptor[] SymbolBoundAttributes_Descriptors = new[]
-    {
+    public static ImmutableArray<TagHelperDescriptor> SymbolBoundAttributes_Descriptors =
+    [
         TagHelperDescriptorBuilder.Create("CatchAllTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule =>
                 rule
@@ -52,7 +53,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
                 .Metadata(PropertyName("StringProperty2"))
                 .TypeName(typeof(string).FullName))
             .Build()
-    };
+    ];
 
     [Fact]
     public void CanHandleSymbolBoundAttributes1()
@@ -96,15 +97,15 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         EvaluateData(SymbolBoundAttributes_Descriptors, "<div bound #local='value'></div>");
     }
 
-    public static TagHelperDescriptor[] WithoutEndTag_Descriptors = new TagHelperDescriptor[]
-    {
+    public static ImmutableArray<TagHelperDescriptor> WithoutEndTag_Descriptors =
+    [
         TagHelperDescriptorBuilder.Create("InputTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule =>
                 rule
                 .RequireTagName("input")
                 .RequireTagStructure(TagStructure.WithoutEndTag))
             .Build()
-    };
+    ];
 
     [Fact]
     public void CanHandleWithoutEndTagTagStructure1()
@@ -136,25 +137,23 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         EvaluateData(WithoutEndTag_Descriptors, "<div><input><input></div>");
     }
 
-    public static TagHelperDescriptor[] GetTagStructureCompatibilityDescriptors(TagStructure structure1, TagStructure structure2)
+    public static ImmutableArray<TagHelperDescriptor> GetTagStructureCompatibilityDescriptors(TagStructure structure1, TagStructure structure2)
     {
-        var descriptors = new TagHelperDescriptor[]
-        {
-                TagHelperDescriptorBuilder.Create("InputTagHelper1", "SomeAssembly")
-                    .TagMatchingRuleDescriptor(rule =>
-                        rule
-                        .RequireTagName("input")
-                        .RequireTagStructure(structure1))
-                    .Build(),
-                TagHelperDescriptorBuilder.Create("InputTagHelper2", "SomeAssembly")
-                    .TagMatchingRuleDescriptor(rule =>
-                        rule
-                        .RequireTagName("input")
-                        .RequireTagStructure(structure2))
-                    .Build()
-        };
-
-        return descriptors;
+        return
+        [
+            TagHelperDescriptorBuilder.Create("InputTagHelper1", "SomeAssembly")
+                .TagMatchingRuleDescriptor(rule =>
+                    rule
+                    .RequireTagName("input")
+                    .RequireTagStructure(structure1))
+                .Build(),
+            TagHelperDescriptorBuilder.Create("InputTagHelper2", "SomeAssembly")
+                .TagMatchingRuleDescriptor(rule =>
+                    rule
+                    .RequireTagName("input")
+                    .RequireTagStructure(structure2))
+                .Build()
+        ];
     }
 
     [Fact]
@@ -241,22 +240,22 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
     public void AllowsCompatibleTagStructures_DirectiveAttribute_SelfClosing()
     {
         // Arrange
-        var descriptors = new TagHelperDescriptor[]
-        {
-                TagHelperDescriptorBuilder.Create("InputTagHelper1", "SomeAssembly")
-                    .TagMatchingRuleDescriptor(rule =>
-                    {
-                        rule
-                            .RequireTagName("*")
-                            .RequireAttributeDescriptor(b =>
-                            {
-                                b.Name = "@onclick";
-                                b.SetMetadata(Attributes.IsDirectiveAttribute);
-                            });
-                    })
-                    .Metadata(SpecialKind(ComponentMetadata.EventHandler.TagHelperKind))
-                    .Build(),
-        };
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
+            TagHelperDescriptorBuilder.Create("InputTagHelper1", "SomeAssembly")
+                .TagMatchingRuleDescriptor(rule =>
+                {
+                    rule
+                        .RequireTagName("*")
+                        .RequireAttributeDescriptor(b =>
+                        {
+                            b.Name = "@onclick";
+                            b.SetMetadata(Attributes.IsDirectiveAttribute);
+                        });
+                })
+                .Metadata(SpecialKind(ComponentMetadata.EventHandler.TagHelperKind))
+                .Build(),
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, "<input @onclick=\"@test\"/>");
@@ -266,23 +265,23 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
     public void AllowsCompatibleTagStructures_DirectiveAttribute_Void()
     {
         // Arrange
-        var descriptors = new TagHelperDescriptor[]
-        {
-                TagHelperDescriptorBuilder.Create("InputTagHelper1", "SomeAssembly")
-                    .TagMatchingRuleDescriptor(rule =>
-                    {
-                        rule
-                            .RequireTagName("*")
-                            .RequireAttributeDescriptor(b =>
-                            {
-                                b.Name = "@onclick";
-                                b.SetMetadata(Attributes.IsDirectiveAttribute);
-                            });
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
+            TagHelperDescriptorBuilder.Create("InputTagHelper1", "SomeAssembly")
+                .TagMatchingRuleDescriptor(rule =>
+                {
+                    rule
+                        .RequireTagName("*")
+                        .RequireAttributeDescriptor(b =>
+                        {
+                            b.Name = "@onclick";
+                            b.SetMetadata(Attributes.IsDirectiveAttribute);
+                        });
 
-                    })
-                    .Metadata(SpecialKind(ComponentMetadata.EventHandler.TagHelperKind))
-                    .Build(),
-        };
+                })
+                .Metadata(SpecialKind(ComponentMetadata.EventHandler.TagHelperKind))
+                .Build(),
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, "<input @onclick=\"@test\">");
@@ -456,8 +455,8 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         RunParseTreeRewriterTest("<str<strong></p></strong>", "strong", "p");
     }
 
-    public static TagHelperDescriptor[] CodeTagHelperAttributes_Descriptors = new TagHelperDescriptor[]
-    {
+    public static ImmutableArray<TagHelperDescriptor> CodeTagHelperAttributes_Descriptors =
+    [
         TagHelperDescriptorBuilder.Create("PersonTagHelper", "personAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("person"))
             .BoundAttributeDescriptor(attribute =>
@@ -476,7 +475,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
                 .Metadata(PropertyName("Name"))
                 .TypeName(typeof(string).FullName))
             .Build()
-    };
+    ];
 
     [Fact]
     public void UnderstandsMultipartNonStringTagHelperAttributes()
@@ -868,8 +867,8 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         RunParseTreeRewriterTest("<p class1=''class2=\"\"class3= />", "p");
     }
 
-    public static TagHelperDescriptor[] EmptyTagHelperBoundAttribute_Descriptors = new TagHelperDescriptor[]
-    {
+    public static ImmutableArray<TagHelperDescriptor> EmptyTagHelperBoundAttribute_Descriptors =
+    [
         TagHelperDescriptorBuilder.Create("mythTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("myth"))
             .BoundAttributeDescriptor(attribute =>
@@ -883,7 +882,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
                 .Metadata(PropertyName("Name"))
                 .TypeName(typeof(string).FullName))
             .Build()
-    };
+    ];
 
     [Fact]
     public void CreatesErrorForEmptyTagHelperBoundAttributes1()
@@ -1282,8 +1281,8 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
         RunParseTreeRewriterTest(document, "input");
     }
 
-    public static TagHelperDescriptor[] MinimizedAttribute_Descriptors = new TagHelperDescriptor[]
-    {
+    public static ImmutableArray<TagHelperDescriptor> MinimizedAttribute_Descriptors =
+    [
         TagHelperDescriptorBuilder.Create("InputTagHelper1", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule =>
                 rule
@@ -1338,7 +1337,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
                 .Metadata(PropertyName("BoundRequiredString"))
                 .TypeName(typeof(int).FullName))
             .Build(),
-    };
+    ];
 
     [Fact]
     public void UnderstandsMinimizedAttributes_Document1()
@@ -2160,25 +2159,25 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var document = "<input boundbool boundbooldict-key />";
-        var descriptors = new TagHelperDescriptor[]
-        {
-                TagHelperDescriptorBuilder.Create("InputTagHelper", "SomeAssembly")
-                    .TagMatchingRuleDescriptor(rule =>
-                        rule
-                        .RequireTagName("input"))
-                    .BoundAttributeDescriptor(attribute =>
-                        attribute
-                        .Name("boundbool")
-                        .Metadata(PropertyName("BoundBoolProp"))
-                        .TypeName(typeof(bool).FullName))
-                    .BoundAttributeDescriptor(attribute =>
-                        attribute
-                        .Name("boundbooldict")
-                        .Metadata(PropertyName("BoundBoolDictProp"))
-                        .TypeName("System.Collections.Generic.IDictionary<string, bool>")
-                        .AsDictionary("boundbooldict-", typeof(bool).FullName))
-                    .Build(),
-        };
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
+            TagHelperDescriptorBuilder.Create("InputTagHelper", "SomeAssembly")
+                .TagMatchingRuleDescriptor(rule =>
+                    rule
+                    .RequireTagName("input"))
+                .BoundAttributeDescriptor(attribute =>
+                    attribute
+                    .Name("boundbool")
+                    .Metadata(PropertyName("BoundBoolProp"))
+                    .TypeName(typeof(bool).FullName))
+                .BoundAttributeDescriptor(attribute =>
+                    attribute
+                    .Name("boundbooldict")
+                    .Metadata(PropertyName("BoundBoolDictProp"))
+                    .TypeName("System.Collections.Generic.IDictionary<string, bool>")
+                    .AsDictionary("boundbooldict-", typeof(bool).FullName))
+                .Build(),
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, document);
@@ -2189,25 +2188,25 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var document = "<input boundbool boundbooldict-key />";
-        var descriptors = new TagHelperDescriptor[]
-        {
-                TagHelperDescriptorBuilder.Create("InputTagHelper", "SomeAssembly")
-                    .TagMatchingRuleDescriptor(rule =>
-                        rule
-                        .RequireTagName("input"))
-                    .BoundAttributeDescriptor(attribute =>
-                        attribute
-                        .Name("boundbool")
-                        .Metadata(PropertyName("BoundBoolProp"))
-                        .TypeName(typeof(bool).FullName))
-                    .BoundAttributeDescriptor(attribute =>
-                        attribute
-                        .Name("boundbooldict")
-                        .Metadata(PropertyName("BoundBoolDictProp"))
-                        .TypeName("System.Collections.Generic.IDictionary<string, bool>")
-                        .AsDictionary("boundbooldict-", typeof(bool).FullName))
-                    .Build(),
-        };
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
+            TagHelperDescriptorBuilder.Create("InputTagHelper", "SomeAssembly")
+                .TagMatchingRuleDescriptor(rule =>
+                    rule
+                    .RequireTagName("input"))
+                .BoundAttributeDescriptor(attribute =>
+                    attribute
+                    .Name("boundbool")
+                    .Metadata(PropertyName("BoundBoolProp"))
+                    .TypeName(typeof(bool).FullName))
+                .BoundAttributeDescriptor(attribute =>
+                    attribute
+                    .Name("boundbooldict")
+                    .Metadata(PropertyName("BoundBoolDictProp"))
+                    .TypeName("System.Collections.Generic.IDictionary<string, bool>")
+                    .AsDictionary("boundbooldict-", typeof(bool).FullName))
+                .Build(),
+        ];
 
         var featureFlags = CreateFeatureFlags();
 
@@ -2220,8 +2219,8 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var document = @"<input @bind-value=""Message"" @bind-value:event=""onchange"" />";
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             TagHelperDescriptorBuilder.Create(ComponentMetadata.Bind.TagHelperKind, "Bind", ComponentsApi.AssemblyName)
                 .Metadata(
                     SpecialKind(ComponentMetadata.Bind.TagHelperKind),
@@ -2251,7 +2250,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
                         p.SetMetadata(PropertyName("Event"));
                     }))
                 .Build(),
-        };
+        ];
 
         var featureFlags = CreateFeatureFlags(allowCSharpInMarkupAttributeArea: false);
 
@@ -2264,8 +2263,8 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var document = @"<input @bind-foo @bind-foo:param />";
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             TagHelperDescriptorBuilder.Create(ComponentMetadata.Bind.TagHelperKind, "Bind", ComponentsApi.AssemblyName)
                 .Metadata(
                     SpecialKind(ComponentMetadata.Bind.TagHelperKind),
@@ -2296,7 +2295,7 @@ public class TagHelperBlockRewriterTest : TagHelperRewritingTestBase
                         p.SetMetadata(PropertyName("Param"));
                     }))
                 .Build(),
-        };
+        ];
 
         var featureFlags = CreateFeatureFlags(allowCSharpInMarkupAttributeArea: false);
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/TagHelperParseTreeRewriterTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/TagHelperParseTreeRewriterTest.cs
@@ -55,10 +55,10 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
         var errorSink = new ErrorSink();
         var parseResult = ParseDocument(documentContent);
         var document = parseResult.Root;
+        var binder = new TagHelperBinder(tagHelperPrefix: null, tagHelpers: []);
         var parseTreeRewriter = new TagHelperParseTreeRewriter.Rewriter(
             parseResult.Source,
-            tagHelperPrefix: null,
-            descriptors: [],
+            binder,
             parseResult.Options,
             errorSink);
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/TagHelperParseTreeRewriterTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/TagHelperParseTreeRewriterTest.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
@@ -56,8 +57,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
         var document = parseResult.Root;
         var parseTreeRewriter = new TagHelperParseTreeRewriter.Rewriter(
             parseResult.Source,
-            null,
-            Array.Empty<TagHelperDescriptor>(),
+            tagHelperPrefix: null,
+            descriptors: [],
             parseResult.Options,
             errorSink);
 
@@ -75,8 +76,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
         Assert.Equal(expectedPairs, pairs);
     }
 
-    public static TagHelperDescriptor[] PartialRequiredParentTags_Descriptors = new TagHelperDescriptor[]
-    {
+    public static ImmutableArray<TagHelperDescriptor> PartialRequiredParentTags_Descriptors =
+    [
         TagHelperDescriptorBuilder.Create("StrongTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("strong"))
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
@@ -87,7 +88,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
         TagHelperDescriptorBuilder.Create("PTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"))
             .Build(),
-    };
+    ];
 
     [Fact]
     public void UnderstandsPartialRequiredParentTags1()
@@ -131,8 +132,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
         EvaluateData(PartialRequiredParentTags_Descriptors, document);
     }
 
-    public static TagHelperDescriptor[] NestedVoidSelfClosingRequiredParent_Descriptors = new TagHelperDescriptor[]
-    {
+    public static ImmutableArray<TagHelperDescriptor> NestedVoidSelfClosingRequiredParent_Descriptors =
+    [
         TagHelperDescriptorBuilder.Create("InputTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule =>
                 rule
@@ -152,10 +153,10 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
         TagHelperDescriptorBuilder.Create("PTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"))
             .Build(),
-    };
+    ];
 
-    public static TagHelperDescriptor[] CatchAllAttribute_Descriptors = new TagHelperDescriptor[]
-    {
+    public static ImmutableArray<TagHelperDescriptor> CatchAllAttribute_Descriptors =
+    [
         TagHelperDescriptorBuilder.Create("InputTagHelper1", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule
                 .RequireTagName("*")
@@ -165,7 +166,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
                 }))
             .Metadata(SpecialKind(ComponentMetadata.EventHandler.EventArgsType))
             .Build(),
-    };
+    ];
 
     [Fact]
     public void UnderstandsInvalidHtml()
@@ -230,8 +231,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
         EvaluateData(NestedVoidSelfClosingRequiredParent_Descriptors, document);
     }
 
-    public static TagHelperDescriptor[] NestedRequiredParent_Descriptors = new TagHelperDescriptor[]
-    {
+    public static ImmutableArray<TagHelperDescriptor> NestedRequiredParent_Descriptors =
+    [
         TagHelperDescriptorBuilder.Create("StrongTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule =>
                 rule
@@ -245,7 +246,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
         TagHelperDescriptorBuilder.Create("PTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"))
             .Build(),
-    };
+    ];
 
     [Fact]
     public void UnderstandsNestedRequiredParent1()
@@ -287,8 +288,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<th:p><th:strong></th:strong></th:p>";
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             TagHelperDescriptorBuilder.Create("PTagHelper", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"))
                 .AllowChildTag("strong")
@@ -296,7 +297,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
             TagHelperDescriptorBuilder.Create("StrongTagHelper", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("strong"))
                 .Build(),
-        };
+        ];
 
         // Act & Assert
         EvaluateData(
@@ -310,8 +311,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<th:p><th:strong></th:strong></th:p>";
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             TagHelperDescriptorBuilder.Create("PTagHelper", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"))
                 .AllowChildTag("strong")
@@ -319,7 +320,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
             TagHelperDescriptorBuilder.Create("StrongTagHelper", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("strong").RequireParentTag("p"))
                 .Build(),
-        };
+        ];
 
         // Act & Assert
         EvaluateData(
@@ -334,8 +335,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
         // Rewrite_InvalidStructure_UnderstandsTagHelperPrefixAndAllowedChildrenAndRequireParent
         // Arrange
         var documentContent = "<th:p></th:strong></th:p>";
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             TagHelperDescriptorBuilder.Create("PTagHelper", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"))
                 .AllowChildTag("strong")
@@ -343,7 +344,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
             TagHelperDescriptorBuilder.Create("StrongTagHelper", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("strong").RequireParentTag("p"))
                 .Build(),
-        };
+        ];
 
         // Act & Assert
         EvaluateData(
@@ -357,13 +358,13 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<th:p><strong></strong></th:p>";
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             TagHelperDescriptorBuilder.Create("PTagHelper", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"))
                 .AllowChildTag("strong")
                 .Build(),
-        };
+        ];
 
         // Act & Assert
         EvaluateData(
@@ -439,13 +440,13 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
                 </strong>
             </p>
             """;
-        var descriptors = new TagHelperDescriptor[]
-        {
-                TagHelperDescriptorBuilder.Create("PTagHelper", "SomeAssembly")
-                    .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"))
-                    .AllowChildTag("br")
-                    .Build()
-        };
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
+            TagHelperDescriptorBuilder.Create("PTagHelper", "SomeAssembly")
+                .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"))
+                .AllowChildTag("br")
+                .Build()
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
@@ -456,8 +457,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<strong required><strong></strong></strong>";
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             TagHelperDescriptorBuilder.Create("StrongTagHelper", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule =>
                     rule
@@ -465,7 +466,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
                     .RequireAttributeDescriptor(attribute => attribute.Name("required")))
                 .AllowChildTag("br")
                 .Build()
-        };
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
@@ -476,8 +477,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<p><strong>Hello World</strong><br></p>";
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             TagHelperDescriptorBuilder.Create("PTagHelper1", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"))
                 .AllowChildTag("strong")
@@ -495,7 +496,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
                     .RequireTagName("br")
                     .RequireTagStructure(TagStructure.WithoutEndTag))
                 .Build(),
-        };
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
@@ -506,8 +507,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<p><strong>Hello World</strong><br></p>";
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             TagHelperDescriptorBuilder.Create("PTagHelper1", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"))
                 .AllowChildTag("strong")
@@ -525,7 +526,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
                     .RequireTagName("br")
                     .RequireTagStructure(TagStructure.WithoutEndTag))
                 .Build(),
-        };
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
@@ -536,7 +537,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<p><br /></p>";
-        var descriptors = TagHelperParseTreeRewriterTest.GetAllowedChildrenTagHelperDescriptors(new[] { "br" });
+        var descriptors = GetAllowedChildrenTagHelperDescriptors(["br"]);
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
@@ -551,7 +552,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
             <br />
             </p>
             """;
-        var descriptors = TagHelperParseTreeRewriterTest.GetAllowedChildrenTagHelperDescriptors(new[] { "br" });
+        var descriptors = GetAllowedChildrenTagHelperDescriptors(["br"]);
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
@@ -562,7 +563,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<p><br></p>";
-        var descriptors = TagHelperParseTreeRewriterTest.GetAllowedChildrenTagHelperDescriptors(new[] { "strong" });
+        var descriptors = GetAllowedChildrenTagHelperDescriptors(["strong"]);
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
@@ -573,7 +574,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<p>Hello</p>";
-        var descriptors = TagHelperParseTreeRewriterTest.GetAllowedChildrenTagHelperDescriptors(new[] { "strong" });
+        var descriptors = GetAllowedChildrenTagHelperDescriptors(["strong"]);
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
@@ -584,7 +585,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<p><hr /></p>";
-        var descriptors = TagHelperParseTreeRewriterTest.GetAllowedChildrenTagHelperDescriptors(new[] { "br", "strong" });
+        var descriptors = GetAllowedChildrenTagHelperDescriptors(["br", "strong"]);
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
@@ -595,7 +596,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<p><br>Hello</p>";
-        var descriptors = TagHelperParseTreeRewriterTest.GetAllowedChildrenTagHelperDescriptors(new[] { "strong" });
+        var descriptors = GetAllowedChildrenTagHelperDescriptors(["strong"]);
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
@@ -606,7 +607,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<p><strong>Title:</strong><br />Something</p>";
-        var descriptors = TagHelperParseTreeRewriterTest.GetAllowedChildrenTagHelperDescriptors(new[] { "strong" });
+        var descriptors = GetAllowedChildrenTagHelperDescriptors(["strong"]);
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
@@ -617,7 +618,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<p><strong>Title:</strong><br />Something</p>";
-        var descriptors = TagHelperParseTreeRewriterTest.GetAllowedChildrenTagHelperDescriptors(new[] { "strong", "br" });
+        var descriptors = GetAllowedChildrenTagHelperDescriptors(["strong", "br"]);
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
@@ -628,7 +629,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<p>  <strong>Title:</strong>  <br />  Something</p>";
-        var descriptors = TagHelperParseTreeRewriterTest.GetAllowedChildrenTagHelperDescriptors(new[] { "strong", "br" });
+        var descriptors = GetAllowedChildrenTagHelperDescriptors(["strong", "br"]);
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
@@ -639,7 +640,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<p><strong>Title:<br><em>A Very Cool</em></strong><br />Something</p>";
-        var descriptors = TagHelperParseTreeRewriterTest.GetAllowedChildrenTagHelperDescriptors(new[] { "strong" });
+        var descriptors = GetAllowedChildrenTagHelperDescriptors(["strong"]);
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
@@ -650,7 +651,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<p><custom>Title:<br><em>A Very Cool</em></custom><br />Something</p>";
-        var descriptors = TagHelperParseTreeRewriterTest.GetAllowedChildrenTagHelperDescriptors(new[] { "custom" });
+        var descriptors = GetAllowedChildrenTagHelperDescriptors(["custom"]);
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
@@ -661,7 +662,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<p></</p>";
-        var descriptors = TagHelperParseTreeRewriterTest.GetAllowedChildrenTagHelperDescriptors(new[] { "custom" });
+        var descriptors = GetAllowedChildrenTagHelperDescriptors(["custom"]);
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
@@ -672,7 +673,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<p><</p>";
-        var descriptors = TagHelperParseTreeRewriterTest.GetAllowedChildrenTagHelperDescriptors(new[] { "custom" });
+        var descriptors = GetAllowedChildrenTagHelperDescriptors(["custom"]);
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
@@ -683,13 +684,13 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<p><custom><br>:<strong><strong>Hello</strong></strong>:<input></custom></p>";
-        var descriptors = TagHelperParseTreeRewriterTest.GetAllowedChildrenTagHelperDescriptors(new[] { "custom", "strong" });
+        var descriptors = GetAllowedChildrenTagHelperDescriptors(["custom", "strong"]);
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
     }
 
-    private static TagHelperDescriptor[] GetAllowedChildrenTagHelperDescriptors(string[] allowedChildren)
+    private static ImmutableArray<TagHelperDescriptor> GetAllowedChildrenTagHelperDescriptors(string[] allowedChildren)
     {
         var pTagHelperBuilder = TagHelperDescriptorBuilder.Create("PTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"));
@@ -701,8 +702,9 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
             pTagHelperBuilder.AllowChildTag(childTag);
             strongTagHelperBuilder.AllowChildTag(childTag);
         }
-        var descriptors = new TagHelperDescriptor[]
-        {
+
+        return
+        [
             pTagHelperBuilder.Build(),
             strongTagHelperBuilder.Build(),
             TagHelperDescriptorBuilder.Create("BRTagHelper", "SomeAssembly")
@@ -711,9 +713,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
                     .RequireTagName("br")
                     .RequireTagStructure(TagStructure.WithoutEndTag))
                 .Build(),
-        };
-
-        return descriptors;
+        ];
     }
 
     [Fact]
@@ -733,10 +733,10 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
             pTagHelperBuilder.AllowChildTag(childTag);
         }
 
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             pTagHelperBuilder.Build()
-        };
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, document);
@@ -758,10 +758,10 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
             pTagHelperBuilder.AllowChildTag(childTag);
         }
 
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             pTagHelperBuilder.Build()
-        };
+        ];
 
         // Act & Assert
         EvaluateData(
@@ -788,10 +788,10 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
             pTagHelperBuilder.AllowChildTag(childTag);
         }
 
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             pTagHelperBuilder.Build()
-        };
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, document);
@@ -814,10 +814,10 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
             pTagHelperBuilder.AllowChildTag(childTag);
         }
 
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             pTagHelperBuilder.Build()
-        };
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, document);
@@ -843,10 +843,10 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
             pTagHelperBuilder.AllowChildTag(childTag);
         }
 
-        var descriptors = new TagHelperDescriptor[]
-        {
-                pTagHelperBuilder.Build()
-        };
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
+            pTagHelperBuilder.Build()
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, document);
@@ -857,8 +857,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<p></</p>";
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             TagHelperDescriptorBuilder.Create("PTagHelper", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"))
                 .AllowChildTag("custom")
@@ -866,7 +866,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
             TagHelperDescriptorBuilder.Create("CatchAllTagHelper", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
                 .Build(),
-        };
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
@@ -877,8 +877,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<th:p></</th:p>";
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             TagHelperDescriptorBuilder.Create("PTagHelper", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"))
                 .AllowChildTag("custom")
@@ -886,7 +886,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
             TagHelperDescriptorBuilder.Create("CatchAllTagHelper", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
                 .Build(),
-        };
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, documentContent, "th:");
@@ -897,15 +897,15 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<input>";
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             TagHelperDescriptorBuilder.Create("InputTagHelper", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule =>
                     rule
                     .RequireTagName("input")
                     .RequireTagStructure(TagStructure.WithoutEndTag))
                 .Build()
-        };
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
@@ -916,15 +916,15 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "</input>";
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             TagHelperDescriptorBuilder.Create("InputTagHelper", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule =>
                     rule
                     .RequireTagName("input")
                     .RequireTagStructure(TagStructure.WithoutEndTag))
                 .Build()
-        };
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
@@ -935,8 +935,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
     {
         // Arrange
         var documentContent = "<input>";
-        var descriptors = new TagHelperDescriptor[]
-        {
+        ImmutableArray<TagHelperDescriptor> descriptors =
+        [
             TagHelperDescriptorBuilder.Create("InputTagHelper1", "SomeAssembly")
                 .TagMatchingRuleDescriptor(rule =>
                     rule
@@ -949,14 +949,14 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
                     .RequireTagName("input")
                     .RequireTagStructure(TagStructure.NormalOrSelfClosing))
                 .Build()
-        };
+        ];
 
         // Act & Assert
         EvaluateData(descriptors, documentContent);
     }
 
-    public static TagHelperDescriptor[] RequiredAttribute_Descriptors = new TagHelperDescriptor[]
-    {
+    public static ImmutableArray<TagHelperDescriptor> RequiredAttribute_Descriptors =
+    [
         TagHelperDescriptorBuilder.Create("pTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule =>
                 rule
@@ -976,7 +976,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
                 .RequireTagName("*")
                 .RequireAttributeDescriptor(attribute => attribute.Name("catchAll")))
             .Build()
-    };
+    ];
 
     [Fact]
     public void RequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly1()
@@ -1158,8 +1158,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
         EvaluateData(RequiredAttribute_Descriptors, "<div style=\"\" class=\"btn\" catchAll=\"hi\" >words<strong>and</strong>spaces</div>");
     }
 
-    public static TagHelperDescriptor[] NestedRequiredAttribute_Descriptors = new TagHelperDescriptor[]
-    {
+    public static ImmutableArray<TagHelperDescriptor> NestedRequiredAttribute_Descriptors =
+    [
         TagHelperDescriptorBuilder.Create("pTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule =>
                 rule
@@ -1172,7 +1172,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
                 .RequireTagName("*")
                 .RequireAttributeDescriptor(attribute => attribute.Name("catchAll")))
             .Build(),
-    };
+    ];
 
     [Fact]
     public void NestedRequiredAttributeDescriptorsCreateTagHelperBlocksCorrectly1()
@@ -1234,15 +1234,15 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
         EvaluateData(NestedRequiredAttribute_Descriptors, "<strong catchAll=\"hi\"><strong><strong><strong catchAll=\"hi\"><strong></strong></strong></strong></strong></strong>");
     }
 
-    public static TagHelperDescriptor[] MalformedRequiredAttribute_Descriptors = new TagHelperDescriptor[]
-    {
+    public static ImmutableArray<TagHelperDescriptor> MalformedRequiredAttribute_Descriptors =
+    [
         TagHelperDescriptorBuilder.Create("pTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule =>
                 rule
                 .RequireTagName("p")
                 .RequireAttributeDescriptor(attribute => attribute.Name("class")))
             .Build(),
-    };
+    ];
 
     [Fact]
     public void RequiredAttributeDescriptorsCreateMalformedTagHelperBlocksCorrectly1()
@@ -1311,8 +1311,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
         EvaluateData(MalformedRequiredAttribute_Descriptors, document);
     }
 
-    public static TagHelperDescriptor[] PrefixedTagHelperColon_Descriptors = new TagHelperDescriptor[]
-    {
+    public static ImmutableArray<TagHelperDescriptor> PrefixedTagHelperColon_Descriptors =
+    [
         TagHelperDescriptorBuilder.Create("mythTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("myth"))
             .Build(),
@@ -1324,14 +1324,14 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
                 .Metadata(PropertyName("Bound"))
                 .TypeName(typeof(bool).FullName))
             .Build()
-    };
+    ];
 
-    public static TagHelperDescriptor[] PrefixedTagHelperCatchAll_Descriptors = new TagHelperDescriptor[]
-    {
+    public static ImmutableArray<TagHelperDescriptor> PrefixedTagHelperCatchAll_Descriptors =
+    [
         TagHelperDescriptorBuilder.Create("mythTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
             .Build(),
-    };
+    ];
 
     [Fact]
     public void AllowsPrefixedTagHelpers1()
@@ -1921,8 +1921,8 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
         RunParseTreeRewriterTest("<input>Foo</input>");
     }
 
-    public static TagHelperDescriptor[] CaseSensitive_Descriptors = new TagHelperDescriptor[]
-    {
+    public static ImmutableArray<TagHelperDescriptor> CaseSensitive_Descriptors =
+    [
         TagHelperDescriptorBuilder.Create("pTagHelper", "SomeAssembly")
             .SetCaseSensitive()
             .BoundAttributeDescriptor(attribute =>
@@ -1941,7 +1941,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
                 .RequireTagName("*")
                 .RequireAttributeDescriptor(attribute => attribute.Name("catchAll")))
             .Build(),
-    };
+    ];
 
     [Fact]
     public void HandlesCaseSensitiveTagHelpersCorrectly1()

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/TagHelperParseTreeRewriterTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/TagHelperParseTreeRewriterTest.cs
@@ -70,7 +70,7 @@ public class TagHelperParseTreeRewriterTest : TagHelperRewritingTestBase
         Assert.Empty(errorSink.Errors);
 
         // Act
-        var pairs = parseTreeRewriter.GetAttributeNameValuePairs(element.StartTag);
+        var pairs = TagHelperParseTreeRewriter.Rewriter.GetAttributeNameValuePairs(element.StartTag);
 
         // Assert
         Assert.Equal(expectedPairs, pairs);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/TagHelperRewritingTestBase.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/TagHelperRewritingTestBase.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy;
@@ -17,7 +18,7 @@ public class TagHelperRewritingTestBase() : ParserTestBase(layer: TestProject.La
         EvaluateData(descriptors, documentContent);
     }
 
-    internal IReadOnlyList<TagHelperDescriptor> BuildDescriptors(params string[] tagNames)
+    internal ImmutableArray<TagHelperDescriptor> BuildDescriptors(params string[] tagNames)
     {
         var descriptors = new List<TagHelperDescriptor>();
 
@@ -29,11 +30,11 @@ public class TagHelperRewritingTestBase() : ParserTestBase(layer: TestProject.La
             descriptors.Add(descriptor);
         }
 
-        return descriptors.AsReadOnly();
+        return descriptors.ToImmutableArray();
     }
 
     internal void EvaluateData(
-        IReadOnlyList<TagHelperDescriptor> descriptors,
+        ImmutableArray<TagHelperDescriptor> descriptors,
         string documentContent,
         string tagHelperPrefix = null,
         RazorParserFeatureFlags featureFlags = null)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/TagHelperRewritingTestBase.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/TagHelperRewritingTestBase.cs
@@ -41,7 +41,8 @@ public class TagHelperRewritingTestBase() : ParserTestBase(layer: TestProject.La
     {
         var syntaxTree = ParseDocument(documentContent, featureFlags: featureFlags);
 
-        var rewrittenTree = TagHelperParseTreeRewriter.Rewrite(syntaxTree, tagHelperPrefix, descriptors, out _);
+        var binder = new TagHelperBinder(tagHelperPrefix, descriptors);
+        var rewrittenTree = TagHelperParseTreeRewriter.Rewrite(syntaxTree, binder, out _);
 
         Assert.Equal(syntaxTree.Root.FullWidth, rewrittenTree.Root.FullWidth);
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/RazorCodeDocumentExtensionsTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/RazorCodeDocumentExtensionsTest.cs
@@ -144,7 +144,7 @@ public class RazorCodeDocumentExtensionsTest
         // Arrange
         var codeDocument = TestRazorCodeDocument.CreateEmpty();
 
-        var expected = TagHelperDocumentContext.Create(null, new TagHelperDescriptor[0]);
+        var expected = TagHelperDocumentContext.Create(prefix: null, tagHelpers: []);
         codeDocument.Items[typeof(TagHelperDocumentContext)] = expected;
 
         // Act
@@ -160,7 +160,7 @@ public class RazorCodeDocumentExtensionsTest
         // Arrange
         var codeDocument = TestRazorCodeDocument.CreateEmpty();
 
-        var expected = TagHelperDocumentContext.Create(null, new TagHelperDescriptor[0]);
+        var expected = TagHelperDocumentContext.Create(prefix: null, tagHelpers: []);
 
         // Act
         codeDocument.SetTagHelperContext(expected);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/RazorCodeDocumentTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/RazorCodeDocumentTest.cs
@@ -9,40 +9,6 @@ namespace Microsoft.AspNetCore.Razor.Language;
 public class RazorCodeDocumentTest
 {
     [Fact]
-    public void Ctor()
-    {
-        // Arrange
-        var source = TestRazorSourceDocument.Create();
-
-        var imports = ImmutableArray.Create(
-            TestRazorSourceDocument.Create());
-
-        // Act
-        var code = new RazorCodeDocument(source, imports);
-
-        // Assert
-        Assert.Same(source, code.Source);
-        Assert.NotNull(code.Items);
-
-        Assert.Collection(imports, d => Assert.Same(imports[0], d));
-    }
-
-    [Fact]
-    public void Ctor_AllowsDefaultForImports()
-    {
-        // Arrange
-        var source = TestRazorSourceDocument.Create();
-
-        // Act
-        var code = new RazorCodeDocument(source, imports: default);
-
-        // Assert
-        Assert.Same(source, code.Source);
-        Assert.NotNull(code.Items);
-        Assert.Empty(code.Imports);
-    }
-
-    [Fact]
     public void Create()
     {
         // Arrange

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TagHelperBinderTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TagHelperBinderTest.cs
@@ -34,10 +34,10 @@ public class TagHelperBinderTest
             parentIsTagHelper: false);
 
         // Assert
-        Assert.Equal(expectedDescriptors, bindingResult.Descriptors);
+        Assert.Equal<TagHelperDescriptor>(expectedDescriptors, bindingResult.Descriptors);
         Assert.Equal("th:div", bindingResult.TagName);
         Assert.Equal("body", bindingResult.ParentTagName);
-        Assert.Equal(expectedAttributes, bindingResult.Attributes);
+        Assert.Equal<KeyValuePair<string, string>>(expectedAttributes, bindingResult.Attributes);
         Assert.Equal("th:", bindingResult.TagHelperPrefix);
         Assert.Equal<TagMatchingRuleDescriptor>(divTagHelper.TagMatchingRules, bindingResult.Mappings[divTagHelper]);
     }
@@ -78,7 +78,7 @@ public class TagHelperBinderTest
             else
             {
                 Assert.NotNull(bindingResult);
-                Assert.Equal(expectedDescriptors, bindingResult.Descriptors);
+                Assert.Equal<TagHelperDescriptor>(expectedDescriptors, bindingResult.Descriptors);
 
                 Assert.Equal(tagName, bindingResult.TagName);
                 var mapping = Assert.Single(bindingResult.Mappings[multiTagHelper]);
@@ -217,7 +217,7 @@ public class TagHelperBinderTest
             parentIsTagHelper: false);
 
         // Assert
-        Assert.Equal((IEnumerable<TagHelperDescriptor>)expectedDescriptors, bindingResult.Descriptors);
+        Assert.Equal<TagHelperDescriptor>(expectedDescriptors, bindingResult.Descriptors);
     }
 
     public static TheoryData RequiredAttributeData
@@ -270,7 +270,7 @@ public class TagHelperBinderTest
                 .Build();
             ImmutableArray<TagHelperDescriptor> defaultAvailableDescriptors =
                 [divDescriptor, inputDescriptor, catchAllDescriptor, catchAllDescriptor2];
-            ImmutableArray<TagHelperDescriptor>  defaultWildcardDescriptors =
+            ImmutableArray<TagHelperDescriptor> defaultWildcardDescriptors =
                 [inputWildcardPrefixDescriptor, catchAllWildcardPrefixDescriptor];
             Func<string, KeyValuePair<string, string>> kvp =
                 (name) => new KeyValuePair<string, string>(name, "test value");
@@ -378,7 +378,7 @@ public class TagHelperBinderTest
 
         // Act
         var bindingResult = tagHelperBinder.GetBinding(tagName, providedAttributes, parentTagName: "p", parentIsTagHelper: false);
-        var descriptors = bindingResult?.Descriptors.ToImmutableArray() ?? default;
+        var descriptors = bindingResult?.Descriptors ?? default;
 
         // Assert
         if (expectedDescriptors.IsDefault)

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TagHelperBinderTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TagHelperBinderTest.cs
@@ -21,7 +21,7 @@ public class TagHelperBinderTest
         var divTagHelper = TagHelperDescriptorBuilder.Create("DivTagHelper", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
             .Build();
-        var expectedDescriptors = new[] { divTagHelper };
+        ImmutableArray<TagHelperDescriptor> expectedDescriptors = [divTagHelper];
         var expectedAttributes = ImmutableArray.Create(
             new KeyValuePair<string, string>("class", "something"));
         var tagHelperBinder = new TagHelperBinder("th:", expectedDescriptors);
@@ -51,7 +51,7 @@ public class TagHelperBinderTest
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("a"))
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("img"))
             .Build();
-        var expectedDescriptors = new[] { multiTagHelper };
+        ImmutableArray<TagHelperDescriptor> expectedDescriptors = [multiTagHelper];
         var tagHelperBinder = new TagHelperBinder("", expectedDescriptors);
 
         TestTagName("div", multiTagHelper.TagMatchingRules[0]);
@@ -103,13 +103,13 @@ public class TagHelperBinderTest
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("table"))
             .Build();
 
-        var tagHelperBinder = new TagHelperBinder("", new[] { multiTagHelper1, multiTagHelper2 });
+        var tagHelperBinder = new TagHelperBinder("", [multiTagHelper1, multiTagHelper2]);
 
-        TestTagName("div", new[] { multiTagHelper1, multiTagHelper2 }, new[] { multiTagHelper1.TagMatchingRules[0], multiTagHelper2.TagMatchingRules[0] });
-        TestTagName("a", new[] { multiTagHelper1 }, new[] { multiTagHelper1.TagMatchingRules[1] });
-        TestTagName("img", new[] { multiTagHelper1 }, new[] { multiTagHelper1.TagMatchingRules[2] });
-        TestTagName("p", new[] { multiTagHelper2 }, new[] { multiTagHelper2.TagMatchingRules[1] });
-        TestTagName("table", new[] { multiTagHelper2 }, new[] { multiTagHelper2.TagMatchingRules[2] });
+        TestTagName("div", [multiTagHelper1, multiTagHelper2], [multiTagHelper1.TagMatchingRules[0], multiTagHelper2.TagMatchingRules[0]]);
+        TestTagName("a", [multiTagHelper1], [multiTagHelper1.TagMatchingRules[1]]);
+        TestTagName("img", [multiTagHelper1], [multiTagHelper1.TagMatchingRules[2]]);
+        TestTagName("p", [multiTagHelper2], [multiTagHelper2.TagMatchingRules[1]]);
+        TestTagName("table", [multiTagHelper2], [multiTagHelper2.TagMatchingRules[2]]);
         TestTagName("*", null, null);
 
 
@@ -118,7 +118,7 @@ public class TagHelperBinderTest
             // Act
             var bindingResult = tagHelperBinder.GetBinding(
                 tagName: tagName,
-                attributes: ImmutableArray<KeyValuePair<string, string>>.Empty,
+                attributes: [],
                 parentTagName: "body",
                 parentIsTagHelper: false);
 
@@ -167,32 +167,32 @@ public class TagHelperBinderTest
             return new TheoryData<
                 string, // tagName
                 string, // parentTagName
-                IReadOnlyList<TagHelperDescriptor>, // availableDescriptors
-                IReadOnlyList<TagHelperDescriptor>> // expectedDescriptors
+                ImmutableArray<TagHelperDescriptor>, // availableDescriptors
+                ImmutableArray<TagHelperDescriptor>> // expectedDescriptors
                 {
                     {
                         "strong",
                         "p",
-                        new[] { strongPDivParent },
-                        new[] { strongPDivParent }
+                        [strongPDivParent],
+                        [strongPDivParent]
                     },
                     {
                         "strong",
                         "div",
-                        new[] { strongPDivParent, catchAllPParent },
-                        new[] { strongPDivParent }
+                        [strongPDivParent, catchAllPParent],
+                        [strongPDivParent]
                     },
                     {
                         "strong",
                         "p",
-                        new[] { strongPDivParent, catchAllPParent },
-                        new[] { strongPDivParent, catchAllPParent }
+                        [strongPDivParent, catchAllPParent],
+                        [strongPDivParent, catchAllPParent]
                     },
                     {
                         "custom",
                         "p",
-                        new[] { strongPDivParent, catchAllPParent },
-                        new[] { catchAllPParent }
+                        [strongPDivParent, catchAllPParent],
+                        [catchAllPParent]
                     },
                 };
         }
@@ -203,11 +203,11 @@ public class TagHelperBinderTest
     public void GetBinding_ReturnsBindingResultWithDescriptorsParentTags(
         string tagName,
         string parentTagName,
-        object availableDescriptors,
-        object expectedDescriptors)
+        ImmutableArray<TagHelperDescriptor> availableDescriptors,
+        ImmutableArray<TagHelperDescriptor> expectedDescriptors)
     {
         // Arrange
-        var tagHelperBinder = new TagHelperBinder(null, (IReadOnlyList<TagHelperDescriptor>)availableDescriptors);
+        var tagHelperBinder = new TagHelperBinder(null, availableDescriptors);
 
         // Act
         var bindingResult = tagHelperBinder.GetBinding(
@@ -268,98 +268,98 @@ public class TagHelperBinderTest
                         .Name("prefix-")
                         .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch)))
                 .Build();
-            var defaultAvailableDescriptors =
-                new[] { divDescriptor, inputDescriptor, catchAllDescriptor, catchAllDescriptor2 };
-            var defaultWildcardDescriptors =
-                new[] { inputWildcardPrefixDescriptor, catchAllWildcardPrefixDescriptor };
+            ImmutableArray<TagHelperDescriptor> defaultAvailableDescriptors =
+                [divDescriptor, inputDescriptor, catchAllDescriptor, catchAllDescriptor2];
+            ImmutableArray<TagHelperDescriptor>  defaultWildcardDescriptors =
+                [inputWildcardPrefixDescriptor, catchAllWildcardPrefixDescriptor];
             Func<string, KeyValuePair<string, string>> kvp =
                 (name) => new KeyValuePair<string, string>(name, "test value");
 
             return new TheoryData<
                 string, // tagName
                 ImmutableArray<KeyValuePair<string, string>>, // providedAttributes
-                IEnumerable<TagHelperDescriptor>, // availableDescriptors
-                IEnumerable<TagHelperDescriptor>> // expectedDescriptors
+                ImmutableArray<TagHelperDescriptor>, // availableDescriptors
+                ImmutableArray<TagHelperDescriptor>> // expectedDescriptors
                 {
                     {
                         "div",
                         ImmutableArray.Create(kvp("custom")),
                         defaultAvailableDescriptors,
-                        null
+                        default
                     },
-                    { "div", ImmutableArray.Create(kvp("style")), defaultAvailableDescriptors, new[] { divDescriptor } },
-                    { "div", ImmutableArray.Create(kvp("class")), defaultAvailableDescriptors, new[] { catchAllDescriptor } },
+                    { "div", ImmutableArray.Create(kvp("style")), defaultAvailableDescriptors, [divDescriptor] },
+                    { "div", ImmutableArray.Create(kvp("class")), defaultAvailableDescriptors, [catchAllDescriptor] },
                     {
                         "div",
                         ImmutableArray.Create(kvp("class"), kvp("style")),
                         defaultAvailableDescriptors,
-                        new[] { divDescriptor, catchAllDescriptor }
+                        [divDescriptor, catchAllDescriptor]
                     },
                     {
                         "div",
                         ImmutableArray.Create(kvp("class"), kvp("style"), kvp("custom")),
                         defaultAvailableDescriptors,
-                        new[] { divDescriptor, catchAllDescriptor, catchAllDescriptor2 }
+                        [divDescriptor, catchAllDescriptor, catchAllDescriptor2]
                     },
                     {
                         "input",
                         ImmutableArray.Create(kvp("class"), kvp("style")),
                         defaultAvailableDescriptors,
-                        new[] { inputDescriptor, catchAllDescriptor }
+                        [inputDescriptor, catchAllDescriptor]
                     },
                     {
                         "input",
                         ImmutableArray.Create(kvp("nodashprefixA")),
                         defaultWildcardDescriptors,
-                        new[] { inputWildcardPrefixDescriptor }
+                        [inputWildcardPrefixDescriptor]
                     },
                     {
                         "input",
                         ImmutableArray.Create(kvp("nodashprefix-ABC-DEF"), kvp("random")),
                         defaultWildcardDescriptors,
-                        new[] { inputWildcardPrefixDescriptor }
+                        [inputWildcardPrefixDescriptor]
                     },
                     {
                         "input",
                         ImmutableArray.Create(kvp("prefixABCnodashprefix")),
                         defaultWildcardDescriptors,
-                        null
+                        default
                     },
                     {
                         "input",
                         ImmutableArray.Create(kvp("prefix-")),
                         defaultWildcardDescriptors,
-                        null
+                        default
                     },
                     {
                         "input",
                         ImmutableArray.Create(kvp("nodashprefix")),
                         defaultWildcardDescriptors,
-                        null
+                        default
                     },
                     {
                         "input",
                         ImmutableArray.Create(kvp("prefix-A")),
                         defaultWildcardDescriptors,
-                        new[] { catchAllWildcardPrefixDescriptor }
+                        [catchAllWildcardPrefixDescriptor]
                     },
                     {
                         "input",
                         ImmutableArray.Create(kvp("prefix-ABC-DEF"), kvp("random")),
                         defaultWildcardDescriptors,
-                        new[] { catchAllWildcardPrefixDescriptor }
+                        [catchAllWildcardPrefixDescriptor]
                     },
                     {
                         "input",
                         ImmutableArray.Create(kvp("prefix-abc"), kvp("nodashprefix-def")),
                         defaultWildcardDescriptors,
-                        new[] { inputWildcardPrefixDescriptor, catchAllWildcardPrefixDescriptor }
+                        [inputWildcardPrefixDescriptor, catchAllWildcardPrefixDescriptor]
                     },
                     {
                         "input",
                         ImmutableArray.Create(kvp("class"), kvp("prefix-abc"), kvp("onclick"), kvp("nodashprefix-def"), kvp("style")),
                         defaultWildcardDescriptors,
-                        new[] { inputWildcardPrefixDescriptor, catchAllWildcardPrefixDescriptor }
+                        [inputWildcardPrefixDescriptor, catchAllWildcardPrefixDescriptor]
                     },
                 };
         }
@@ -370,17 +370,25 @@ public class TagHelperBinderTest
     public void GetBinding_ReturnsBindingResultDescriptorsWithRequiredAttributes(
         string tagName,
         ImmutableArray<KeyValuePair<string, string>> providedAttributes,
-        object availableDescriptors,
-        object expectedDescriptors)
+        ImmutableArray<TagHelperDescriptor> availableDescriptors,
+        ImmutableArray<TagHelperDescriptor> expectedDescriptors)
     {
         // Arrange
-        var tagHelperBinder = new TagHelperBinder(null, (IReadOnlyList<TagHelperDescriptor>)availableDescriptors);
+        var tagHelperBinder = new TagHelperBinder(null, availableDescriptors);
 
         // Act
         var bindingResult = tagHelperBinder.GetBinding(tagName, providedAttributes, parentTagName: "p", parentIsTagHelper: false);
+        var descriptors = bindingResult?.Descriptors.ToImmutableArray() ?? default;
 
         // Assert
-        Assert.Equal((IEnumerable<TagHelperDescriptor>)expectedDescriptors, bindingResult?.Descriptors);
+        if (expectedDescriptors.IsDefault)
+        {
+            Assert.True(descriptors.IsDefault);
+        }
+        else
+        {
+            Assert.Equal<TagHelperDescriptor>(expectedDescriptors, descriptors);
+        }
     }
 
     [Fact]
@@ -390,7 +398,7 @@ public class TagHelperBinderTest
         var catchAllDescriptor = TagHelperDescriptorBuilder.Create("foo1", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName(TagHelperMatchingConventions.ElementCatchAllName))
             .Build();
-        var descriptors = new[] { catchAllDescriptor };
+        ImmutableArray<TagHelperDescriptor> descriptors = [catchAllDescriptor];
         var tagHelperBinder = new TagHelperBinder("th", descriptors);
 
         // Act
@@ -411,7 +419,7 @@ public class TagHelperBinderTest
         var catchAllDescriptor = TagHelperDescriptorBuilder.Create("foo1", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName(TagHelperMatchingConventions.ElementCatchAllName))
             .Build();
-        var descriptors = new[] { catchAllDescriptor };
+        ImmutableArray<TagHelperDescriptor> descriptors = [catchAllDescriptor];
         var tagHelperBinder = new TagHelperBinder("th:", descriptors);
 
         // Act
@@ -440,7 +448,7 @@ public class TagHelperBinderTest
         var divDescriptor = TagHelperDescriptorBuilder.Create("foo1", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
             .Build();
-        var descriptors = new[] { divDescriptor };
+        ImmutableArray<TagHelperDescriptor> descriptors = [divDescriptor];
         var tagHelperBinder = new TagHelperBinder("th:", descriptors);
 
         // Act
@@ -464,7 +472,7 @@ public class TagHelperBinderTest
         var divDescriptor = TagHelperDescriptorBuilder.Create("foo1", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName(tagName))
             .Build();
-        var descriptors = new[] { divDescriptor };
+        ImmutableArray<TagHelperDescriptor> descriptors = [divDescriptor];
         var tagHelperBinder = new TagHelperBinder("th:", descriptors);
 
         // Act
@@ -488,7 +496,7 @@ public class TagHelperBinderTest
         var spanDescriptor = TagHelperDescriptorBuilder.Create("foo2", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("span"))
             .Build();
-        var descriptors = new TagHelperDescriptor[] { divDescriptor, spanDescriptor };
+        ImmutableArray<TagHelperDescriptor> descriptors = [divDescriptor, spanDescriptor];
         var tagHelperBinder = new TagHelperBinder(null, descriptors);
 
         // Act
@@ -515,7 +523,7 @@ public class TagHelperBinderTest
         var catchAllDescriptor = TagHelperDescriptorBuilder.Create("foo3", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName(TagHelperMatchingConventions.ElementCatchAllName))
             .Build();
-        var descriptors = new TagHelperDescriptor[] { divDescriptor, spanDescriptor, catchAllDescriptor };
+        ImmutableArray<TagHelperDescriptor> descriptors = [divDescriptor, spanDescriptor, catchAllDescriptor];
         var tagHelperBinder = new TagHelperBinder(null, descriptors);
 
         // Act
@@ -549,7 +557,7 @@ public class TagHelperBinderTest
         var divDescriptor = TagHelperDescriptorBuilder.Create("foo1", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
             .Build();
-        var descriptors = new TagHelperDescriptor[] { divDescriptor, divDescriptor };
+        ImmutableArray<TagHelperDescriptor> descriptors = [divDescriptor, divDescriptor];
         var tagHelperBinder = new TagHelperBinder(null, descriptors);
 
         // Act
@@ -577,7 +585,7 @@ public class TagHelperBinderTest
             .TagMatchingRuleDescriptor(rule => rule
                 .RequireTagName("span"))
             .Build();
-        var descriptors = new TagHelperDescriptor[] { multiRuleDescriptor };
+        ImmutableArray<TagHelperDescriptor> descriptors = [multiRuleDescriptor];
         var tagHelperBinder = new TagHelperBinder(null, descriptors);
 
         // Act
@@ -605,7 +613,7 @@ public class TagHelperBinderTest
         var pDescriptor = TagHelperDescriptorBuilder.Create("foo2", "SomeAssembly")
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("p"))
             .Build();
-        var descriptors = new[] { divDescriptor, pDescriptor };
+        ImmutableArray<TagHelperDescriptor> descriptors = [divDescriptor, pDescriptor];
         var tagHelperBinder = new TagHelperBinder("th:", descriptors);
 
         // Act
@@ -633,7 +641,7 @@ public class TagHelperBinderTest
             .Metadata(MakeTrue(TagHelperMetadata.Common.ClassifyAttributesOnly))
             .Build();
 
-        var descriptors = new[] { divDescriptor, };
+        ImmutableArray<TagHelperDescriptor> descriptors = [divDescriptor];
         var tagHelperBinder = new TagHelperBinder("", descriptors);
 
         // Act
@@ -661,7 +669,7 @@ public class TagHelperBinderTest
             .Metadata(MakeTrue(TagHelperMetadata.Common.ClassifyAttributesOnly))
             .Build();
 
-        var descriptors = new[] { divDescriptor1, divDescriptor2, };
+        ImmutableArray<TagHelperDescriptor> descriptors = [divDescriptor1, divDescriptor2];
         var tagHelperBinder = new TagHelperBinder("", descriptors);
 
         // Act
@@ -688,7 +696,7 @@ public class TagHelperBinderTest
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
             .Build();
 
-        var descriptors = new[] { divDescriptor1, divDescriptor2, };
+        ImmutableArray<TagHelperDescriptor> descriptors = [divDescriptor1, divDescriptor2];
         var tagHelperBinder = new TagHelperBinder("", descriptors);
 
         // Act
@@ -710,7 +718,7 @@ public class TagHelperBinderTest
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
             .SetCaseSensitive()
             .Build();
-        var expectedDescriptors = new[] { divTagHelper };
+        ImmutableArray<TagHelperDescriptor> expectedDescriptors = [divTagHelper];
         var expectedAttributes = ImmutableArray.Create(
             new KeyValuePair<string, string>("class", "something"));
         var tagHelperBinder = new TagHelperBinder("th:", expectedDescriptors);
@@ -736,7 +744,7 @@ public class TagHelperBinderTest
                 .RequireAttributeDescriptor(attribute => attribute.Name("class")))
             .SetCaseSensitive()
             .Build();
-        var expectedDescriptors = new[] { divTagHelper };
+        ImmutableArray<TagHelperDescriptor> expectedDescriptors = [divTagHelper];
         var expectedAttributes = ImmutableArray.Create(
             new KeyValuePair<string, string>("CLASS", "something"));
         var tagHelperBinder = new TagHelperBinder(null, expectedDescriptors);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TagHelperMatchingConventionsTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TagHelperMatchingConventionsTest.cs
@@ -152,7 +152,7 @@ public class TagHelperMatchingConventionsTest
         var requiredAttibute = builder.Build();
 
         // Act
-        var result = TagHelperMatchingConventions.SatisfiesRequiredAttribute(attributeName, attributeValue, requiredAttibute);
+        var result = TagHelperMatchingConventions.SatisfiesRequiredAttribute(requiredAttibute, attributeName, attributeValue);
 
         // Assert
         Assert.Equal(expectedResult, result);

--- a/src/Compiler/perf/Microbenchmarks/RazorTagHelperParsingBenchmark.cs
+++ b/src/Compiler/perf/Microbenchmarks/RazorTagHelperParsingBenchmark.cs
@@ -41,7 +41,8 @@ public class RazorTagHelperParsingBenchmark
             });
         BlazorServerTagHelpersDemoFile = fileSystem.GetItem(Path.Combine(blazorServerTagHelpersFilePath), FileKinds.Component);
 
-        ComponentDirectiveVisitor = new ComponentDirectiveVisitor(blazorServerTagHelpersFilePath, tagHelpers, currentNamespace: null);
+        var matches = new HashSet<TagHelperDescriptor>();
+        ComponentDirectiveVisitor = new ComponentDirectiveVisitor(blazorServerTagHelpersFilePath, tagHelpers, currentNamespace: null, matches);
         var codeDocument = ProjectEngine.ProcessDesignTime(BlazorServerTagHelpersDemoFile);
         SyntaxTree = codeDocument.GetSyntaxTree();
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.LegacyEditor/IRazorTagHelperDocumentContext.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.LegacyEditor/IRazorTagHelperDocumentContext.cs
@@ -7,6 +7,6 @@ namespace Microsoft.AspNetCore.Razor.ExternalAccess.LegacyEditor;
 
 internal interface IRazorTagHelperDocumentContext
 {
-    string Prefix { get; }
+    string? Prefix { get; }
     ImmutableArray<IRazorTagHelperDescriptor> TagHelpers { get; }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.LegacyEditor/InternalAPI.Unshipped.txt
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.LegacyEditor/InternalAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+Microsoft.AspNetCore.Razor.ExternalAccess.LegacyEditor.IRazorTagHelperDocumentContext.Prefix.get -> string?
 static Microsoft.AspNetCore.Razor.ExternalAccess.LegacyEditor.RazorWrapperFactory.GetWrappedTagHelperFactsService() -> Microsoft.AspNetCore.Razor.ExternalAccess.LegacyEditor.IRazorTagHelperFactsService!
 static Microsoft.AspNetCore.Razor.ExternalAccess.LegacyEditor.RazorWrapperFactory.WrapClientSettingsManager(object! obj) -> Microsoft.AspNetCore.Razor.ExternalAccess.LegacyEditor.IRazorEditorSettingsManager!
 *REMOVED*static Microsoft.AspNetCore.Razor.ExternalAccess.LegacyEditor.RazorWrapperFactory.WrapEditorSettingsManager(object! obj) -> Microsoft.AspNetCore.Razor.ExternalAccess.LegacyEditor.IRazorEditorSettingsManager!

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.LegacyEditor/RazorWrapperFactory.TagHelperBindingWrapper.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.LegacyEditor/RazorWrapperFactory.TagHelperBindingWrapper.cs
@@ -17,7 +17,7 @@ internal static partial class RazorWrapperFactory
 
         public ImmutableArray<IRazorTagMatchingRuleDescriptor> GetBoundRules(IRazorTagHelperDescriptor descriptor)
         {
-            return WrapAll(Object.GetBoundRules(Unwrap(descriptor)), Wrap);
+            return WrapAll(Object.Mappings[Unwrap(descriptor)], Wrap);
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.LegacyEditor/RazorWrapperFactory.TagHelperDocumentContextWrapper.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.LegacyEditor/RazorWrapperFactory.TagHelperDocumentContextWrapper.cs
@@ -12,7 +12,7 @@ internal static partial class RazorWrapperFactory
     {
         private ImmutableArray<IRazorTagHelperDescriptor> _tagHelpers;
 
-        public string Prefix => Object.Prefix!;
+        public string? Prefix => Object.Prefix;
 
         public ImmutableArray<IRazorTagHelperDescriptor> TagHelpers
             => InitializeArrayWithWrappedItems(ref _tagHelpers, Object.TagHelpers, Wrap);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.LegacyEditor/RazorWrapperFactory.TagHelperDocumentContextWrapper.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.LegacyEditor/RazorWrapperFactory.TagHelperDocumentContextWrapper.cs
@@ -12,7 +12,7 @@ internal static partial class RazorWrapperFactory
     {
         private ImmutableArray<IRazorTagHelperDescriptor> _tagHelpers;
 
-        public string Prefix => Object.Prefix;
+        public string Prefix => Object.Prefix!;
 
         public ImmutableArray<IRazorTagHelperDescriptor> TagHelpers
             => InitializeArrayWithWrappedItems(ref _tagHelpers, Object.TagHelpers, Wrap);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.LegacyEditor/RazorWrapperFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.LegacyEditor/RazorWrapperFactory.cs
@@ -94,7 +94,7 @@ internal static partial class RazorWrapperFactory
 
     private static ImmutableArray<TResult> InitializeArrayWithWrappedItems<TInner, TResult>(
         ref ImmutableArray<TResult> location,
-        IReadOnlyList<TInner> list,
+        ImmutableArray<TInner> list,
         Func<TInner, TResult> createWrapper)
         where TInner : class
         where TResult : class

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.LegacyEditor/RazorWrapperFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.LegacyEditor/RazorWrapperFactory.cs
@@ -107,21 +107,6 @@ internal static partial class RazorWrapperFactory
         return location;
     }
 
-    private static ImmutableArray<TResult> InitializeArrayWithWrappedItems<TInner, TResult>(
-        ref ImmutableArray<TResult> location,
-        IEnumerable<TInner> list,
-        Func<TInner, TResult> createWrapper)
-        where TInner : class
-        where TResult : class
-    {
-        if (location.IsDefault)
-        {
-            ImmutableInterlocked.InterlockedInitialize(ref location, WrapAll(list, createWrapper));
-        }
-
-        return location;
-    }
-
     private static T Unwrap<T>(object obj)
         where T : class
         => ((Wrapper<T>)obj).Object;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
@@ -146,12 +146,12 @@ internal sealed class AutoClosingTagOnAutoInsertProvider : IOnAutoInsertProvider
         if (closeAngle.Parent is MarkupTagHelperStartTagSyntax
             {
                 ForwardSlash: null,
-                Parent: MarkupTagHelperElementSyntax tagHelperElement
+                Parent: MarkupTagHelperElementSyntax { TagHelperInfo.BindingResult: var binding } tagHelperElement
             } startTagHelper)
         {
             name = startTagHelper.Name.Content;
 
-            if (!TryGetTagHelperAutoClosingBehavior(tagHelperElement.TagHelperInfo.BindingResult, out autoClosingBehavior))
+            if (!TryGetTagHelperAutoClosingBehavior(binding, out autoClosingBehavior))
             {
                 autoClosingBehavior = InferAutoClosingBehavior(name, caseSensitive: true);
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
@@ -190,7 +190,7 @@ internal sealed class AutoClosingTagOnAutoInsertProvider : IOnAutoInsertProvider
 
         foreach (var descriptor in bindingResult.Descriptors)
         {
-            var tagMatchingRules = bindingResult.GetBoundRules(descriptor);
+            var tagMatchingRules = bindingResult.Mappings[descriptor];
             foreach (var tagMatchingRule in tagMatchingRules)
             {
                 if (tagMatchingRule.TagStructure == TagStructure.Unspecified)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/AutoInsert/AutoClosingTagOnAutoInsertProvider.cs
@@ -191,10 +191,8 @@ internal sealed class AutoClosingTagOnAutoInsertProvider : IOnAutoInsertProvider
         foreach (var descriptor in bindingResult.Descriptors)
         {
             var tagMatchingRules = bindingResult.GetBoundRules(descriptor);
-            for (var i = 0; i < tagMatchingRules.Count; i++)
+            foreach (var tagMatchingRule in tagMatchingRules)
             {
-                var tagMatchingRule = tagMatchingRules[i];
-
                 if (tagMatchingRule.TagStructure == TagStructure.Unspecified)
                 {
                     // The current tag matching rule isn't specified so it should never be used as the resolved tag structure since it

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ComponentAccessibilityCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ComponentAccessibilityCodeActionProvider.cs
@@ -247,8 +247,8 @@ internal sealed class ComponentAccessibilityCodeActionProvider : IRazorCodeActio
         foreach (var rule in tagMatchingRules)
         {
             // We have to match parent tag and attributes regardless, so check them first and exit early if there is a fail
-            if (!TagHelperMatchingConventions.SatisfiesParentTag(parentTagNameWithoutPrefix, rule) ||
-               !TagHelperMatchingConventions.SatisfiesAttributes(tagAttributes, rule))
+            if (!TagHelperMatchingConventions.SatisfiesParentTag(rule, parentTagNameWithoutPrefix) ||
+               !TagHelperMatchingConventions.SatisfiesAttributes(rule, tagAttributes))
             {
                 return false;
             }
@@ -259,11 +259,11 @@ internal sealed class ComponentAccessibilityCodeActionProvider : IRazorCodeActio
             {
                 return false;
             }
-            else if (TagHelperMatchingConventions.SatisfiesTagName(tagNameWithoutPrefix, rule))
+            else if (TagHelperMatchingConventions.SatisfiesTagName(rule, tagNameWithoutPrefix))
             {
                 // Nothing to do, just loop around to the next rule
             }
-            else if (TagHelperMatchingConventions.SatisfiesTagName(tagNameWithoutPrefix, rule, StringComparison.OrdinalIgnoreCase))
+            else if (TagHelperMatchingConventions.SatisfiesTagName(rule, tagNameWithoutPrefix, StringComparison.OrdinalIgnoreCase))
             {
                 // Because the code action will be fixing the casing of the tag, we don't need all the rules to be consistent.
                 caseInsensitiveMatch = true;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/GenerateMethodCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/GenerateMethodCodeActionProvider.cs
@@ -75,13 +75,12 @@ internal class GenerateMethodCodeActionProvider : IRazorCodeActionProvider
         }
 
         // MarkupTagHelperElement > MarkupTagHelperStartTag > MarkupTagHelperDirectiveAttribute 
-        var tagHelperElement = commonParent.Parent.Parent as MarkupTagHelperElementSyntax;
-        if (tagHelperElement is null)
+        if (commonParent.Parent.Parent is not MarkupTagHelperElementSyntax { TagHelperInfo.BindingResult: var binding })
         {
             return false;
         }
 
-        foreach (var tagHelperDescriptor in tagHelperElement.TagHelperInfo.BindingResult.Descriptors)
+        foreach (var tagHelperDescriptor in binding.Descriptors)
         {
             foreach (var attribute in tagHelperDescriptor.BoundAttributes)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LspTagHelperCompletionService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LspTagHelperCompletionService.cs
@@ -183,7 +183,7 @@ internal class LspTagHelperCompletionService : ITagHelperCompletionService
 
             foreach (var rule in possibleDescriptor.TagMatchingRules)
             {
-                if (!TagHelperMatchingConventions.SatisfiesParentTag(completionContext.ContainingParentTagName.AsSpanOrDefault(), rule))
+                if (!TagHelperMatchingConventions.SatisfiesParentTag(rule, completionContext.ContainingParentTagName.AsSpanOrDefault()))
                 {
                     continue;
                 }
@@ -225,7 +225,7 @@ internal class LspTagHelperCompletionService : ITagHelperCompletionService
                 }
 
                 // If we think this completion should be added based on tag name, thats great, but lets also make sure the attributes are correct
-                if (addRuleCompletions && (!checkAttributeRules || TagHelperMatchingConventions.SatisfiesAttributes(tagAttributes, rule)))
+                if (addRuleCompletions && (!checkAttributeRules || TagHelperMatchingConventions.SatisfiesAttributes(rule, tagAttributes)))
                 {
                     UpdateCompletions(prefix + rule.TagName, possibleDescriptor, elementCompletions);
                 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
@@ -132,12 +132,13 @@ internal class TagHelperCompletionProvider : IRazorCompletionItemProvider
         RazorCompletionOptions options)
     {
         var ancestors = containingAttribute.Parent.Ancestors();
-        var nonDirectiveAttributeTagHelpers = tagHelperDocumentContext.TagHelpers.Where(tagHelper => !tagHelper.BoundAttributes.Any(static attribute => attribute.IsDirectiveAttribute));
+        var nonDirectiveAttributeTagHelpers = tagHelperDocumentContext.TagHelpers.WhereAsArray(
+            static tagHelper => !tagHelper.BoundAttributes.Any(static attribute => attribute.IsDirectiveAttribute));
         var filteredContext = TagHelperDocumentContext.Create(tagHelperDocumentContext.Prefix, nonDirectiveAttributeTagHelpers);
         var (ancestorTagName, ancestorIsTagHelper) = TagHelperFacts.GetNearestAncestorTagInfo(ancestors);
         var attributeCompletionContext = new AttributeCompletionContext(
             filteredContext,
-            existingCompletions: Array.Empty<string>(),
+            existingCompletions: [],
             containingTagName,
             selectedAttributeName,
             attributes,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/DefinitionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/DefinitionEndpoint.cs
@@ -206,7 +206,13 @@ internal sealed class DefinitionEndpoint(
             return (null, null);
         }
 
-        var originTagDescriptor = tagHelperElement.TagHelperInfo.BindingResult.Descriptors.FirstOrDefault(d => !d.IsAttributeDescriptor());
+        if (tagHelperElement.TagHelperInfo?.BindingResult is not TagHelperBinding binding)
+        {
+            logger.LogInformation("MarkupTagHelperElement does not contain TagHelperInfo.");
+            return (null, null);
+        }
+
+        var originTagDescriptor = binding.Descriptors.FirstOrDefault(static d => !d.IsAttributeDescriptor());
         if (originTagDescriptor is null)
         {
             logger.LogInformation("Origin TagHelper descriptor is null.");

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingVisitor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingVisitor.cs
@@ -215,20 +215,8 @@ internal class FormattingVisitor : SyntaxWalker
 
         static bool IsComponentTagHelperNode(MarkupTagHelperElementSyntax node)
         {
-            var tagHelperInfo = node.TagHelperInfo;
-
-            if (tagHelperInfo is null)
-            {
-                return false;
-            }
-
-            var descriptors = tagHelperInfo.BindingResult?.Descriptors;
-            if (descriptors is null)
-            {
-                return false;
-            }
-
-            return descriptors.Any(d => d.IsComponentOrChildContentTagHelper);
+            return node.TagHelperInfo?.BindingResult?.Descriptors is { Length: > 0 } descriptors &&
+                   descriptors.Any(static d => d.IsComponentOrChildContentTagHelper);
         }
 
         static bool ParentHasProperty(MarkupTagHelperElementSyntax parentComponent, string? propertyName)
@@ -266,22 +254,14 @@ internal class FormattingVisitor : SyntaxWalker
 
         static bool HasUnspecifiedCascadingTypeParameter(MarkupTagHelperElementSyntax node)
         {
-            var tagHelperInfo = node.TagHelperInfo;
-
-            if (tagHelperInfo is null)
-            {
-                return false;
-            }
-
-            var descriptors = tagHelperInfo.BindingResult?.Descriptors;
-            if (descriptors is null)
+            if (node.TagHelperInfo?.BindingResult?.Descriptors is not { Length: > 0 } descriptors)
             {
                 return false;
             }
 
             // A cascading type parameter will mean the generated code will get a TypeInference class generated
             // for it, which we need to account for with an extra level of indentation in our expected C# indentation
-            var hasCascadingGenericParameters = descriptors.Any(d => d.SuppliesCascadingGenericParameters());
+            var hasCascadingGenericParameters = descriptors.Any(static d => d.SuppliesCascadingGenericParameters());
             if (!hasCascadingGenericParameters)
             {
                 return false;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/HoverService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/HoverService.cs
@@ -258,7 +258,7 @@ internal sealed class HoverService(
     {
         var descriptionInfos = boundAttributes.SelectAsArray(boundAttribute =>
         {
-            var isIndexer = TagHelperMatchingConventions.SatisfiesBoundAttributeIndexer(attributeName.AsSpan(), boundAttribute);
+            var isIndexer = TagHelperMatchingConventions.SatisfiesBoundAttributeIndexer(boundAttribute, attributeName.AsSpan());
             return BoundAttributeDescriptionInfo.From(boundAttribute, isIndexer);
         });
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorSyntaxFacts.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorSyntaxFacts.cs
@@ -119,7 +119,7 @@ internal static class RazorSyntaxFacts
         if (node is CSharpCodeBlockSyntax block &&
             block.Children.FirstOrDefault() is RazorDirectiveSyntax directive &&
             directive.Body is RazorDirectiveBodySyntax directiveBody &&
-            directiveBody.Keyword.GetContent().Equals("code"))
+            directiveBody.Keyword.GetContent() == "code")
         {
             return directiveBody.CSharpCode;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -14,6 +15,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -25,33 +27,25 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring;
 
 [RazorLanguageServerEndpoint(Methods.TextDocumentRenameName)]
-internal sealed class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenameParams, WorkspaceEdit?>, ICapabilitiesProvider
+internal sealed class RenameEndpoint(
+    ProjectSnapshotManagerDispatcher dispatcher,
+    RazorComponentSearchEngine componentSearchEngine,
+    IProjectSnapshotManagerAccessor projectSnapshotManagerAccessor,
+    LanguageServerFeatureOptions languageServerFeatureOptions,
+    IRazorDocumentMappingService documentMappingService,
+    IClientConnection clientConnection,
+    IRazorLoggerFactory loggerFactory)
+    : AbstractRazorDelegatingEndpoint<RenameParams, WorkspaceEdit?>(
+        languageServerFeatureOptions,
+        documentMappingService,
+        clientConnection,
+        loggerFactory.CreateLogger<RenameEndpoint>()), ICapabilitiesProvider
 {
-    private readonly ProjectSnapshotManagerDispatcher _projectSnapshotManagerDispatcher;
-    private readonly IDocumentContextFactory _documentContextFactory;
-    private readonly IProjectSnapshotManager _projectSnapshotManager;
-    private readonly RazorComponentSearchEngine _componentSearchEngine;
-    private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
-    private readonly IRazorDocumentMappingService _documentMappingService;
-
-    public RenameEndpoint(
-        ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,
-        IDocumentContextFactory documentContextFactory,
-        RazorComponentSearchEngine componentSearchEngine,
-        IProjectSnapshotManagerAccessor projectSnapshotManagerAccessor,
-        LanguageServerFeatureOptions languageServerFeatureOptions,
-        IRazorDocumentMappingService documentMappingService,
-        IClientConnection clientConnection,
-        IRazorLoggerFactory loggerFactory)
-        : base(languageServerFeatureOptions, documentMappingService, clientConnection, loggerFactory.CreateLogger<RenameEndpoint>())
-    {
-        _projectSnapshotManagerDispatcher = projectSnapshotManagerDispatcher ?? throw new ArgumentNullException(nameof(projectSnapshotManagerDispatcher));
-        _documentContextFactory = documentContextFactory ?? throw new ArgumentNullException(nameof(documentContextFactory));
-        _componentSearchEngine = componentSearchEngine ?? throw new ArgumentNullException(nameof(componentSearchEngine));
-        _projectSnapshotManager = projectSnapshotManagerAccessor?.Instance ?? throw new ArgumentNullException(nameof(projectSnapshotManagerAccessor));
-        _languageServerFeatureOptions = languageServerFeatureOptions ?? throw new ArgumentNullException(nameof(languageServerFeatureOptions));
-        _documentMappingService = documentMappingService ?? throw new ArgumentNullException(nameof(documentMappingService));
-    }
+    private readonly ProjectSnapshotManagerDispatcher _projectSnapshotManagerDispatcher = dispatcher;
+    private readonly IProjectSnapshotManager _projectSnapshotManager = projectSnapshotManagerAccessor.Instance;
+    private readonly RazorComponentSearchEngine _componentSearchEngine = componentSearchEngine;
+    private readonly LanguageServerFeatureOptions _languageServerFeatureOptions = languageServerFeatureOptions;
+    private readonly IRazorDocumentMappingService _documentMappingService = documentMappingService;
 
     public void ApplyCapabilities(VSInternalServerCapabilities serverCapabilities, VSInternalClientCapabilities clientCapabilities)
     {
@@ -111,7 +105,7 @@ internal sealed class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenamePar
         var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
 
         var originTagHelpers = await GetOriginTagHelpersAsync(documentContext, absoluteIndex, cancellationToken).ConfigureAwait(false);
-        if (originTagHelpers is null || originTagHelpers.Count == 0)
+        if (originTagHelpers.IsDefaultOrEmpty)
         {
             return null;
         }
@@ -156,12 +150,14 @@ internal sealed class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenamePar
         };
     }
 
-    private async Task<List<IDocumentSnapshot?>> GetAllDocumentSnapshotsAsync(DocumentContext skipDocumentContext, CancellationToken cancellationToken)
+    private async Task<ImmutableArray<IDocumentSnapshot?>> GetAllDocumentSnapshotsAsync(DocumentContext skipDocumentContext, CancellationToken cancellationToken)
     {
-        var documentSnapshots = new List<IDocumentSnapshot?>();
-        var documentPaths = new HashSet<string>();
+        using var documentSnapshots = new PooledArrayBuilder<IDocumentSnapshot?>();
+        using var _ = StringHashSetPool.GetPooledObject(out var documentPaths);
 
-        var projects = await _projectSnapshotManagerDispatcher.RunOnDispatcherThreadAsync(() => _projectSnapshotManager.GetProjects(), cancellationToken).ConfigureAwait(false);
+        var projects = await _projectSnapshotManagerDispatcher
+            .RunOnDispatcherThreadAsync(() => _projectSnapshotManager.GetProjects(), cancellationToken)
+            .ConfigureAwait(false);
 
         foreach (var project in projects)
         {
@@ -174,27 +170,25 @@ internal sealed class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenamePar
                 }
 
                 // Don't add duplicates between projects
-                if (documentPaths.Contains(documentPath))
+                if (!documentPaths.Add(documentPath))
                 {
                     continue;
                 }
 
                 // Add to the list and add the path to the set
-                var snapshot = project.GetDocument(documentPath);
-                if (snapshot is null)
+                if (project.GetDocument(documentPath) is not { } snapshot)
                 {
-                    throw new NotImplementedException($"{documentPath} in project {project.FilePath} but not retrievable");
+                    throw new InvalidOperationException($"{documentPath} in project {project.FilePath} but not retrievable");
                 }
 
                 documentSnapshots.Add(snapshot);
-                documentPaths.Add(documentPath);
             }
         }
 
-        return documentSnapshots;
+        return documentSnapshots.DrainToImmutable();
     }
 
-    public RenameFile GetFileRenameForComponent(IDocumentSnapshot documentSnapshot, string newPath)
+    private RenameFile GetFileRenameForComponent(IDocumentSnapshot documentSnapshot, string newPath)
     {
         // VS Code in Windows expects path to start with '/'
         var filePath = documentSnapshot.FilePath.AssumeNotNull();
@@ -238,7 +232,7 @@ internal sealed class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenamePar
 
     private async Task AddEditsForCodeDocumentAsync(
         List<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>> documentChanges,
-        IReadOnlyList<TagHelperDescriptor> originTagHelpers,
+        ImmutableArray<TagHelperDescriptor> originTagHelpers,
         string newName,
         IDocumentSnapshot? documentSnapshot)
     {
@@ -273,9 +267,9 @@ internal sealed class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenamePar
         AddEditsForCodeDocument(documentChanges, originTagHelpers, newName, uri, codeDocument);
     }
 
-    public static void AddEditsForCodeDocument(
+    private static void AddEditsForCodeDocument(
         List<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>> documentChanges,
-        IReadOnlyList<TagHelperDescriptor> originTagHelpers,
+        ImmutableArray<TagHelperDescriptor> originTagHelpers,
         string newName,
         Uri uri,
         RazorCodeDocument codeDocument)
@@ -286,10 +280,9 @@ internal sealed class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenamePar
             .Where(n => n.Kind == SyntaxKind.MarkupTagHelperElement)
             .OfType<MarkupTagHelperElementSyntax>();
 
-        for (var i = 0; i < originTagHelpers.Count; i++)
+        foreach (var originTagHelper in originTagHelpers)
         {
             var editedName = newName;
-            var originTagHelper = originTagHelpers[i];
             if (originTagHelper.IsComponentFullyQualifiedNameMatch)
             {
                 // Fully qualified binding, our "new name" needs to be fully qualified.
@@ -305,56 +298,57 @@ internal sealed class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenamePar
 
             foreach (var node in tagHelperElements)
             {
-                if (node is MarkupTagHelperElementSyntax tagHelperElement && BindingContainsTagHelper(originTagHelper, tagHelperElement.TagHelperInfo.BindingResult))
+                if (node is MarkupTagHelperElementSyntax { TagHelperInfo.BindingResult: var binding } tagHelperElement &&
+                    BindingContainsTagHelper(originTagHelper, binding))
                 {
                     documentChanges.Add(new TextDocumentEdit
                     {
                         TextDocument = documentIdentifier,
-                        Edits = CreateEditsForMarkupTagHelperElement(tagHelperElement, codeDocument, editedName).ToArray(),
+                        Edits = CreateEditsForMarkupTagHelperElement(tagHelperElement, codeDocument, editedName),
                     });
                 }
             }
         }
     }
 
-    public static IReadOnlyCollection<TextEdit> CreateEditsForMarkupTagHelperElement(MarkupTagHelperElementSyntax element, RazorCodeDocument codeDocument, string newName)
+    private static TextEdit[] CreateEditsForMarkupTagHelperElement(MarkupTagHelperElementSyntax element, RazorCodeDocument codeDocument, string newName)
     {
-        var edits = new List<TextEdit>
+        using var _ = ListPool<TextEdit>.GetPooledObject(out var edits);
+
+        edits.Add(new()
         {
-            new TextEdit()
-            {
-                Range = element.StartTag.Name.GetRange(codeDocument.Source),
-                NewText = newName,
-            },
-        };
-        if (element.EndTag != null)
+            Range = element.StartTag.Name.GetRange(codeDocument.Source),
+            NewText = newName
+        });
+
+        if (element.EndTag is MarkupTagHelperEndTagSyntax endTag)
         {
             edits.Add(new TextEdit()
             {
-                Range = element.EndTag.Name.GetRange(codeDocument.Source),
+                Range = endTag.Name.GetRange(codeDocument.Source),
                 NewText = newName,
             });
         }
 
-        return edits;
+        return [.. edits];
     }
 
     private static bool BindingContainsTagHelper(TagHelperDescriptor tagHelper, TagHelperBinding potentialBinding) =>
         potentialBinding.Descriptors.Any(descriptor => descriptor.Equals(tagHelper));
 
-    private static async Task<IReadOnlyList<TagHelperDescriptor>?> GetOriginTagHelpersAsync(DocumentContext documentContext, int absoluteIndex, CancellationToken cancellationToken)
+    private static async Task<ImmutableArray<TagHelperDescriptor>> GetOriginTagHelpersAsync(DocumentContext documentContext, int absoluteIndex, CancellationToken cancellationToken)
     {
         var owner = await documentContext.GetSyntaxNodeAsync(absoluteIndex, cancellationToken).ConfigureAwait(false);
         if (owner is null)
         {
             Debug.Fail("Owner should never be null.");
-            return null;
+            return default;
         }
 
         var node = owner.FirstAncestorOrSelf<SyntaxNode>(n => n.Kind == SyntaxKind.MarkupTagHelperStartTag);
         if (node is not MarkupTagHelperStartTagSyntax tagHelperStartTag)
         {
-            return null;
+            return default;
         }
 
         // Ensure the rename action was invoked on the component name
@@ -364,56 +358,55 @@ internal sealed class RenameEndpoint : AbstractRazorDelegatingEndpoint<RenamePar
         // contexts. (https://github.com/dotnet/aspnetcore/issues/26407)
         if (!tagHelperStartTag.Name.FullSpan.IntersectsWith(absoluteIndex))
         {
-            return null;
+            return default;
         }
 
-        if (tagHelperStartTag?.Parent is not MarkupTagHelperElementSyntax tagHelperElement)
+        if (tagHelperStartTag?.Parent is not MarkupTagHelperElementSyntax { TagHelperInfo.BindingResult: var binding })
         {
-            return null;
+            return default;
         }
 
         // Can only have 1 component TagHelper belonging to an element at a time
-        var primaryTagHelper = tagHelperElement.TagHelperInfo.BindingResult.Descriptors.FirstOrDefault(descriptor => descriptor.IsComponentTagHelper);
+        var primaryTagHelper = binding.Descriptors.FirstOrDefault(static d => d.IsComponentTagHelper);
         if (primaryTagHelper is null)
         {
-            return null;
+            return default;
         }
 
-        var originTagHelpers = new List<TagHelperDescriptor>() { primaryTagHelper };
+        using var originTagHelpers = new PooledArrayBuilder<TagHelperDescriptor>();
+        originTagHelpers.Add(primaryTagHelper);
+
         var tagHelpers = await documentContext.Snapshot.Project.GetTagHelpersAsync(cancellationToken).ConfigureAwait(false);
         var associatedTagHelper = FindAssociatedTagHelper(primaryTagHelper, tagHelpers);
         if (associatedTagHelper is null)
         {
             Debug.Fail("Components should always have an associated TagHelper.");
-            return null;
+            return default;
         }
 
         originTagHelpers.Add(associatedTagHelper);
 
-        return originTagHelpers;
+        return originTagHelpers.DrainToImmutable();
     }
 
-    private static TagHelperDescriptor? FindAssociatedTagHelper(TagHelperDescriptor tagHelper, IReadOnlyList<TagHelperDescriptor> tagHelpers)
+    private static TagHelperDescriptor? FindAssociatedTagHelper(TagHelperDescriptor tagHelper, ImmutableArray<TagHelperDescriptor> tagHelpers)
     {
         var typeName = tagHelper.GetTypeName();
         var assemblyName = tagHelper.AssemblyName;
-        for (var i = 0; i < tagHelpers.Count; i++)
+        foreach (var currentTagHelper in tagHelpers)
         {
-            var currentTagHelper = tagHelpers[i];
-
             if (tagHelper == currentTagHelper)
             {
                 // Same as the primary, we're looking for our other pair.
                 continue;
             }
 
-            var currentTypeName = currentTagHelper.GetTypeName();
-            if (!string.Equals(typeName, currentTypeName, StringComparison.Ordinal))
+            if (typeName != currentTagHelper.GetTypeName())
             {
                 continue;
             }
 
-            if (!string.Equals(assemblyName, currentTagHelper.AssemblyName, StringComparison.Ordinal))
+            if (assemblyName != currentTagHelper.AssemblyName)
             {
                 continue;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/TagHelperSemanticRangeVisitor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/TagHelperSemanticRangeVisitor.cs
@@ -480,9 +480,9 @@ internal sealed class TagHelperSemanticRangeVisitor : SyntaxWalker
 
     private static bool IsComponent(SyntaxNode node)
     {
-        if (node is MarkupTagHelperElementSyntax element)
+        if (node is MarkupTagHelperElementSyntax { TagHelperInfo.BindingResult: var binding })
         {
-            var componentDescriptor = element.TagHelperInfo.BindingResult.Descriptors.FirstOrDefault(d => d.IsComponentTagHelper);
+            var componentDescriptor = binding.Descriptors.FirstOrDefault(static d => d.IsComponentTagHelper);
             return componentDescriptor is not null;
         }
         else if (node is MarkupTagHelperStartTagSyntax startTag)
@@ -517,9 +517,9 @@ internal sealed class TagHelperSemanticRangeVisitor : SyntaxWalker
             throw new ArgumentNullException(nameof(node));
         }
 
-        if (node.StartTag != null && node.StartTag.Name != null)
+        if (node.StartTag?.Name != null &&
+            node.TagHelperInfo is { BindingResult: var binding })
         {
-            var binding = node.TagHelperInfo.BindingResult;
             return !binding.IsAttributeMatch;
         }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
@@ -110,7 +110,7 @@ internal class DirectiveAttributeCompletionItemProvider : DirectiveAttributeComp
 
                     foreach (var parameterDescriptor in attributeDescriptor.Parameters)
                     {
-                        if (!attributes.Any(name => TagHelperMatchingConventions.SatisfiesBoundAttributeWithParameter(name, attributeDescriptor, parameterDescriptor)))
+                        if (!attributes.Any(name => TagHelperMatchingConventions.SatisfiesBoundAttributeWithParameter(parameterDescriptor, name, attributeDescriptor)))
                         {
                             // This bound attribute parameter has not had a completion entry added for it, re-represent the base attribute name in the completion list
                             AddCompletion(attributeDescriptor.Name, attributeDescriptor, descriptor);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeParameterCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeParameterCompletionItemProvider.cs
@@ -97,7 +97,7 @@ internal class DirectiveAttributeParameterCompletionItemProvider : DirectiveAttr
                 {
                     foreach (var parameterDescriptor in boundAttributeParameters)
                     {
-                        if (attributes.Any(name => TagHelperMatchingConventions.SatisfiesBoundAttributeWithParameter(name, attributeDescriptor, parameterDescriptor)))
+                        if (attributes.Any(name => TagHelperMatchingConventions.SatisfiesBoundAttributeWithParameter(parameterDescriptor, name, attributeDescriptor)))
                         {
                             // There's already an existing attribute that satisfies this parameter, don't show it in the completion list.
                             continue;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperFacts.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperFacts.cs
@@ -34,17 +34,14 @@ internal static class TagHelperFacts
             return null;
         }
 
-        var descriptors = documentContext.TagHelpers;
-        if (descriptors is { Length: 0 })
+        if (documentContext.TagHelpers.Length == 0)
         {
             return null;
         }
 
-        var prefix = documentContext.Prefix;
-        var tagHelperBinder = new TagHelperBinder(prefix, descriptors);
-        var binding = tagHelperBinder.GetBinding(tagName, attributes, parentTag, parentIsTagHelper);
+        var binder = documentContext.GetBinder();
 
-        return binding;
+        return binder.GetBinding(tagName, attributes, parentTag, parentIsTagHelper);
     }
 
     public static ImmutableArray<BoundAttributeDescriptor> GetBoundTagHelperAttributes(

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperFacts.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperFacts.cs
@@ -121,8 +121,8 @@ internal static class TagHelperFacts
         {
             foreach (var rule in tagHelper.TagMatchingRules)
             {
-                if (TagHelperMatchingConventions.SatisfiesTagName(tagNameWithoutPrefix, rule) &&
-                    TagHelperMatchingConventions.SatisfiesParentTag(parentTag.AsSpanOrDefault(), rule))
+                if (TagHelperMatchingConventions.SatisfiesTagName(rule, tagNameWithoutPrefix) &&
+                    TagHelperMatchingConventions.SatisfiesParentTag(rule, parentTag.AsSpanOrDefault()))
                 {
                     matchingDescriptors.Add(tagHelper);
                     break;
@@ -151,7 +151,7 @@ internal static class TagHelperFacts
         {
             foreach (var rule in descriptor.TagMatchingRules)
             {
-                if (TagHelperMatchingConventions.SatisfiesParentTag(parentTag.AsSpanOrDefault(), rule))
+                if (TagHelperMatchingConventions.SatisfiesParentTag(rule, parentTag.AsSpanOrDefault()))
                 {
                     matchingDescriptors.Add(descriptor);
                     break;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperFacts.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/TagHelperFacts.cs
@@ -35,7 +35,7 @@ internal static class TagHelperFacts
         }
 
         var descriptors = documentContext.TagHelpers;
-        if (descriptors is null or { Count: 0 })
+        if (descriptors is { Length: 0 })
         {
             return null;
         }
@@ -101,8 +101,7 @@ internal static class TagHelperFacts
             throw new ArgumentNullException(nameof(tagName));
         }
 
-        var tagHelpers = documentContext?.TagHelpers;
-        if (tagHelpers is not { Count: > 0 })
+        if (documentContext?.TagHelpers is not { Length: > 0 } tagHelpers)
         {
             return ImmutableArray<TagHelperDescriptor>.Empty;
         }
@@ -117,10 +116,9 @@ internal static class TagHelperFacts
         using var matchingDescriptors = new PooledArrayBuilder<TagHelperDescriptor>();
 
         var tagNameWithoutPrefix = tagName.AsSpan()[prefix.Length..];
-        for (var i = 0; i < tagHelpers.Count; i++)
-        {
-            var tagHelper = tagHelpers[i];
 
+        foreach (var tagHelper in tagHelpers)
+        {
             foreach (var rule in tagHelper.TagMatchingRules)
             {
                 if (TagHelperMatchingConventions.SatisfiesTagName(tagNameWithoutPrefix, rule) &&
@@ -142,18 +140,15 @@ internal static class TagHelperFacts
             throw new ArgumentNullException(nameof(documentContext));
         }
 
-        var tagHelpers = documentContext?.TagHelpers;
-        if (tagHelpers is not { Count: > 0 })
+        if (documentContext?.TagHelpers is not { Length: > 0 } tagHelpers)
         {
             return ImmutableArray<TagHelperDescriptor>.Empty;
         }
 
         using var matchingDescriptors = new PooledArrayBuilder<TagHelperDescriptor>();
 
-        for (var i = 0; i < tagHelpers.Count; i++)
+        foreach (var descriptor in tagHelpers)
         {
-            var descriptor = tagHelpers[i];
-
             foreach (var rule in descriptor.TagMatchingRules)
             {
                 if (TagHelperMatchingConventions.SatisfiesParentTag(parentTag.AsSpanOrDefault(), rule))

--- a/src/Razor/src/Microsoft.VisualStudio.LegacyEditor.Razor/Completion/LegacyTagHelperCompletionService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LegacyEditor.Razor/Completion/LegacyTagHelperCompletionService.cs
@@ -189,7 +189,7 @@ internal sealed class LegacyTagHelperCompletionService : ITagHelperCompletionSer
 
             foreach (var rule in possibleDescriptor.TagMatchingRules)
             {
-                if (!TagHelperMatchingConventions.SatisfiesParentTag(completionContext.ContainingTagName.AsSpanOrDefault(), rule))
+                if (!TagHelperMatchingConventions.SatisfiesParentTag(rule, completionContext.ContainingTagName.AsSpanOrDefault()))
                 {
                     continue;
                 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DirectiveAttributeTransitionCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DirectiveAttributeTransitionCompletionItemProviderTest.cs
@@ -24,7 +24,7 @@ public class DirectiveAttributeTransitionCompletionItemProviderTest : ToolingTes
     public DirectiveAttributeTransitionCompletionItemProviderTest(ITestOutputHelper testOutput)
         : base(testOutput)
     {
-        _tagHelperDocumentContext = TagHelperDocumentContext.Create(prefix: string.Empty, Array.Empty<TagHelperDescriptor>());
+        _tagHelperDocumentContext = TagHelperDocumentContext.Create(prefix: string.Empty, tagHelpers: []);
         _provider = new DirectiveAttributeTransitionCompletionItemProvider();
     }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/LanguageServerTagHelperCompletionServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/LanguageServerTagHelperCompletionServiceTest.cs
@@ -34,12 +34,10 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                     .AsDictionary("asp-route-", typeof(string).FullName))
                 .Build(),
         ];
+
         var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["asp-route-..."] =
-            [
-                documentDescriptors[0].BoundAttributes.Last(),
-            ]
+            ["asp-route-..."] = [documentDescriptors[0].BoundAttributes.Last()]
         });
 
         var completionContext = BuildAttributeCompletionContext(
@@ -72,16 +70,11 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                     .AsDictionary("asp-route-", typeof(string).FullName))
                 .Build(),
         ];
+
         var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["asp-all-route-data"] =
-            [
-                documentDescriptors[0].BoundAttributes.Last(),
-            ],
-            ["asp-route-..."] =
-            [
-                documentDescriptors[0].BoundAttributes.Last(),
-            ]
+            ["asp-all-route-data"] = [documentDescriptors[0].BoundAttributes.Last()],
+            ["asp-route-..."] = [documentDescriptors[0].BoundAttributes.Last()]
         });
 
         var completionContext = BuildAttributeCompletionContext(
@@ -122,16 +115,11 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                     .AsDictionary("asp-route-", typeof(string).FullName))
                 .Build(),
         ];
+
         var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["asp-all-route-data"] =
-            [
-                documentDescriptors[0].BoundAttributes.Last(),
-            ],
-            ["asp-route-..."] =
-            [
-                documentDescriptors[0].BoundAttributes.Last(),
-            ]
+            ["asp-all-route-data"] = [documentDescriptors[0].BoundAttributes.Last()],
+            ["asp-route-..."] = [documentDescriptors[0].BoundAttributes.Last()]
         });
 
         var completionContext = BuildAttributeCompletionContext(
@@ -171,13 +159,11 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                     .Metadata(PropertyName("Class")))
                 .Build(),
         ];
+
         var expectedCompletions = AttributeCompletionResult.Create(new()
         {
             ["onclick"] = [],
-            ["visible"] =
-            [
-                documentDescriptors[0].BoundAttributes.Last()
-            ]
+            ["visible"] = [documentDescriptors[0].BoundAttributes.Last()]
         });
 
         var existingCompletions = new[] { "onclick" };
@@ -220,13 +206,11 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                     .Metadata(PropertyName("Class")))
                 .Build(),
         ];
+
         var expectedCompletions = AttributeCompletionResult.Create(new()
         {
             ["onclick"] = [],
-            ["visible"] =
-            [
-                documentDescriptors[0].BoundAttributes.Last()
-            ]
+            ["visible"] = [documentDescriptors[0].BoundAttributes.Last()]
         });
 
         var existingCompletions = new[] { "onclick" };
@@ -271,6 +255,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                     .Metadata(PropertyName("Class")))
                 .Build(),
         ];
+
         var expectedCompletions = AttributeCompletionResult.Create(new()
         {
             ["onclick"] = []
@@ -312,6 +297,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                     .RequireAttributeDescriptor(attribute => attribute.Name("class")))
                 .Build(),
         ];
+
         var expectedCompletions = AttributeCompletionResult.Create(new()
         {
             ["class"] = [],
@@ -362,14 +348,12 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                     .Metadata(PropertyName("Class")))
                 .Build(),
         ];
+
         var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["class"] = [..documentDescriptors[1].BoundAttributes],
+            ["class"] = [.. documentDescriptors[1].BoundAttributes],
             ["onclick"] = [],
-            ["repeat"] =
-            [
-                documentDescriptors[0].BoundAttributes.First()
-            ]
+            ["repeat"] = [documentDescriptors[0].BoundAttributes.First()]
         });
 
         var existingCompletions = new[] { "onclick" };
@@ -420,19 +404,13 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                     .Metadata(PropertyName("Visible")))
                 .Build(),
         ];
+
         var expectedCompletions = AttributeCompletionResult.Create(new()
         {
             ["onclick"] = [],
-            ["class"] = [..documentDescriptors[1].BoundAttributes],
-            ["repeat"] =
-            [
-                documentDescriptors[0].BoundAttributes.First()
-            ],
-            ["visible"] =
-            [
-                documentDescriptors[0].BoundAttributes.Last(),
-                documentDescriptors[2].BoundAttributes.First(),
-            ]
+            ["class"] = [.. documentDescriptors[1].BoundAttributes],
+            ["repeat"] = [documentDescriptors[0].BoundAttributes.First()],
+            ["visible"] = [documentDescriptors[0].BoundAttributes.Last(), documentDescriptors[2].BoundAttributes.First()]
         });
 
         var existingCompletions = new[] { "class", "onclick" };
@@ -464,10 +442,11 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .TagOutputHint("div")
                 .Build(),
         ];
+
         var expectedCompletions = AttributeCompletionResult.Create(new()
         {
             ["class"] = [],
-            ["repeat"] = [..documentDescriptors[0].BoundAttributes]
+            ["repeat"] = [.. documentDescriptors[0].BoundAttributes]
         });
 
         var existingCompletions = new[] { "class" };
@@ -498,9 +477,10 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                     .Metadata(PropertyName("Repeat")))
                 .Build(),
         ];
+
         var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["repeat"] = new HashSet<BoundAttributeDescriptor>(documentDescriptors[0].BoundAttributes)
+            ["repeat"] = [.. documentDescriptors[0].BoundAttributes]
         });
 
         var existingCompletions = new[] { "class" };
@@ -531,6 +511,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                     .Metadata(PropertyName("Repeat")))
                 .Build(),
         ];
+
         var expectedCompletions = AttributeCompletionResult.Create(new()
         {
             ["class"] = [],
@@ -586,6 +567,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                     .RequireAttributeDescriptor(attribute => attribute.Name("special")))
                 .Build(),
         ];
+
         var expectedCompletions = AttributeCompletionResult.Create(new()
         {
             ["class"] = [],
@@ -618,6 +600,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                     .RequireAttributeDescriptor(attribute => attribute.Name("special")))
                 .Build(),
         ];
+
         var expectedCompletions = AttributeCompletionResult.Create(new()
         {
             ["class"] = [],
@@ -653,6 +636,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .TagOutputHint("table")
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create([]);
 
         var existingCompletions = new[] { "table" };
@@ -688,6 +672,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .Metadata(ComponentMetadata.Component.NameMatchKey, ComponentMetadata.Component.FullyQualifiedNameMatch)
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["Test"] = [documentDescriptors[0]],
@@ -723,6 +708,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .TagOutputHint("tr")
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["my-table"] = [documentDescriptors[0]]
@@ -756,6 +742,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li"))
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["th:li"] = [documentDescriptors[1], documentDescriptors[0]],
@@ -789,6 +776,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li"))
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["th:superli"] = [documentDescriptors[0]],
@@ -825,6 +813,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .SetCaseSensitive()
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["myli"] = [documentDescriptors[0]],
@@ -861,6 +850,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .SetCaseSensitive()
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["LI"] = [documentDescriptors[0]],
@@ -895,6 +885,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["superli"] = [documentDescriptors[0], documentDescriptors[1]],
@@ -927,6 +918,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["th:superli"] = [documentDescriptors[0], documentDescriptors[1]],
@@ -962,6 +954,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("strong"))
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["strong"] = [documentDescriptors[0], documentDescriptors[1]],
@@ -996,6 +989,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li"))
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["li"] = [documentDescriptors[0], documentDescriptors[1]],
@@ -1029,6 +1023,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["li"] = [documentDescriptors[1]],
@@ -1061,6 +1056,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .TagOutputHint("strong")
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["div"] = [documentDescriptors[0]],
@@ -1091,6 +1087,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li").RequireParentTag("ol"))
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["li"] = [documentDescriptors[0]],
@@ -1122,6 +1119,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .AllowChildTag("child-tag")
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["outer-child-tag"] = [documentDescriptors[0]],
@@ -1157,6 +1155,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .AllowChildTag("child-tag")
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["child-tag"] = [documentDescriptors[0]],
@@ -1189,6 +1188,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .AllowChildTag("div")
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create([]);
 
         var completionContext = BuildElementCompletionContext(
@@ -1218,6 +1218,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .AllowChildTag("div")
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["b"] = [],
@@ -1252,6 +1253,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .AllowChildTag("bold")
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["b"] = [],
@@ -1285,6 +1287,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .AllowChildTag("div")
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["b"] = [],
@@ -1324,6 +1327,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .AllowChildTag("bold")
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["strong"] = [documentDescriptors[0]],
@@ -1362,6 +1366,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                     }))
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["form"] = [documentDescriptors[0]]
@@ -1401,6 +1406,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                     }))
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create([]);
 
         var completionContext = BuildElementCompletionContext(
@@ -1433,6 +1439,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                     }))
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["component"] = [documentDescriptors[0]],

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/LanguageServerTagHelperCompletionServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/LanguageServerTagHelperCompletionServiceTest.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -24,8 +23,8 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetAttributeCompletions_OnlyIndexerNamePrefix()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("FormTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("form"))
@@ -34,19 +33,19 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                     .Metadata(PropertyName("RouteValues"))
                     .AsDictionary("asp-route-", typeof(string).FullName))
                 .Build(),
-        };
-        var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+        ];
+        var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["asp-route-..."] = new HashSet<BoundAttributeDescriptor>()
-            {
+            ["asp-route-..."] =
+            [
                 documentDescriptors[0].BoundAttributes.Last(),
-            }
+            ]
         });
 
         var completionContext = BuildAttributeCompletionContext(
             documentDescriptors,
-            Array.Empty<string>(),
-            attributes: ImmutableArray<KeyValuePair<string, string>>.Empty,
+            existingCompletions: [],
+            attributes: [],
             currentTagName: "form");
         var service = CreateTagHelperCompletionFactsService();
 
@@ -61,8 +60,8 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetAttributeCompletions_BoundDictionaryAttribute_ReturnsPrefixIndexerAndFullSetter()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("FormTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("form"))
@@ -72,23 +71,23 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                     .Metadata(PropertyName("RouteValues"))
                     .AsDictionary("asp-route-", typeof(string).FullName))
                 .Build(),
-        };
-        var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+        ];
+        var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["asp-all-route-data"] = new HashSet<BoundAttributeDescriptor>()
-            {
+            ["asp-all-route-data"] =
+            [
                 documentDescriptors[0].BoundAttributes.Last(),
-            },
-            ["asp-route-..."] = new HashSet<BoundAttributeDescriptor>()
-            {
+            ],
+            ["asp-route-..."] =
+            [
                 documentDescriptors[0].BoundAttributes.Last(),
-            }
+            ]
         });
 
         var completionContext = BuildAttributeCompletionContext(
             documentDescriptors,
-            Array.Empty<string>(),
-            attributes: ImmutableArray<KeyValuePair<string, string>>.Empty,
+            existingCompletions: [],
+            attributes: [],
             currentTagName: "form");
         var service = CreateTagHelperCompletionFactsService();
 
@@ -103,8 +102,8 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetAttributeCompletions_RequiredBoundDictionaryAttribute_ReturnsPrefixIndexerAndFullSetter()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("FormTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("form")
@@ -122,23 +121,23 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                     .Metadata(PropertyName("RouteValues"))
                     .AsDictionary("asp-route-", typeof(string).FullName))
                 .Build(),
-        };
-        var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+        ];
+        var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["asp-all-route-data"] = new HashSet<BoundAttributeDescriptor>()
-            {
+            ["asp-all-route-data"] =
+            [
                 documentDescriptors[0].BoundAttributes.Last(),
-            },
-            ["asp-route-..."] = new HashSet<BoundAttributeDescriptor>()
-            {
+            ],
+            ["asp-route-..."] =
+            [
                 documentDescriptors[0].BoundAttributes.Last(),
-            }
+            ]
         });
 
         var completionContext = BuildAttributeCompletionContext(
             documentDescriptors,
-            Array.Empty<string>(),
-            attributes: ImmutableArray<KeyValuePair<string, string>>.Empty,
+            existingCompletions: [],
+            attributes: [],
             currentTagName: "form");
         var service = CreateTagHelperCompletionFactsService();
 
@@ -153,8 +152,8 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetAttributeCompletions_DoesNotReturnCompletionsForAlreadySuppliedAttributes()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("div")
@@ -171,23 +170,23 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                     .TypeName(typeof(string).FullName)
                     .Metadata(PropertyName("Class")))
                 .Build(),
-        };
-        var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+        ];
+        var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["onclick"] = new HashSet<BoundAttributeDescriptor>(),
-            ["visible"] = new HashSet<BoundAttributeDescriptor>()
-            {
+            ["onclick"] = [],
+            ["visible"] =
+            [
                 documentDescriptors[0].BoundAttributes.Last()
-            }
+            ]
         });
 
         var existingCompletions = new[] { "onclick" };
         var completionContext = BuildAttributeCompletionContext(
             documentDescriptors,
             existingCompletions,
-            attributes: ImmutableArray.Create(
+            attributes: [
                 KeyValuePair.Create("class", "something"),
-                KeyValuePair.Create("repeat", "4")),
+                KeyValuePair.Create("repeat", "4")],
             currentTagName: "div");
         var service = CreateTagHelperCompletionFactsService();
 
@@ -202,8 +201,8 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetAttributeCompletions_ReturnsCompletionForAlreadySuppliedAttribute_IfCurrentAttributeMatches()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("div")
@@ -220,24 +219,24 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                     .TypeName(typeof(string).FullName)
                     .Metadata(PropertyName("Class")))
                 .Build(),
-        };
-        var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+        ];
+        var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["onclick"] = new HashSet<BoundAttributeDescriptor>(),
-            ["visible"] = new HashSet<BoundAttributeDescriptor>()
-            {
+            ["onclick"] = [],
+            ["visible"] =
+            [
                 documentDescriptors[0].BoundAttributes.Last()
-            }
+            ]
         });
 
         var existingCompletions = new[] { "onclick" };
         var completionContext = BuildAttributeCompletionContext(
             documentDescriptors,
             existingCompletions,
-            attributes: ImmutableArray.Create(
+            attributes: [
                 KeyValuePair.Create("class", "something"),
                 KeyValuePair.Create("repeat", "4"),
-                KeyValuePair.Create("visible", "false")),
+                KeyValuePair.Create("visible", "false")],
             currentTagName: "div",
             currentAttributeName: "visible");
         var service = CreateTagHelperCompletionFactsService();
@@ -253,8 +252,8 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetAttributeCompletions_DoesNotReturnAlreadySuppliedAttribute_IfCurrentAttributeDoesNotMatch()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("div")
@@ -271,20 +270,20 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                     .TypeName(typeof(string).FullName)
                     .Metadata(PropertyName("Class")))
                 .Build(),
-        };
-        var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+        ];
+        var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["onclick"] = new HashSet<BoundAttributeDescriptor>()
+            ["onclick"] = []
         });
 
         var existingCompletions = new[] { "onclick" };
         var completionContext = BuildAttributeCompletionContext(
             documentDescriptors,
             existingCompletions,
-            attributes: ImmutableArray.Create(
+            attributes: [
                 KeyValuePair.Create("class", "something"),
                 KeyValuePair.Create("repeat", "4"),
-                KeyValuePair.Create("visible", "false")),
+                KeyValuePair.Create("visible", "false")],
             currentTagName: "div",
             currentAttributeName: "repeat");
         var service = CreateTagHelperCompletionFactsService();
@@ -300,8 +299,8 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetAttributeCompletions_PossibleDescriptorsReturnUnboundRequiredAttributesWithExistingCompletions()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("div")
@@ -312,12 +311,12 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                     .RequireTagName("*")
                     .RequireAttributeDescriptor(attribute => attribute.Name("class")))
                 .Build(),
-        };
-        var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+        ];
+        var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["class"] = new HashSet<BoundAttributeDescriptor>(),
-            ["onclick"] = new HashSet<BoundAttributeDescriptor>(),
-            ["repeat"] = new HashSet<BoundAttributeDescriptor>()
+            ["class"] = [],
+            ["onclick"] = [],
+            ["repeat"] = []
         });
 
         var existingCompletions = new[] { "onclick", "class" };
@@ -338,8 +337,8 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetAttributeCompletions_PossibleDescriptorsReturnBoundRequiredAttributesWithExistingCompletions()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("div")
@@ -362,15 +361,15 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                     .TypeName(typeof(string).FullName)
                     .Metadata(PropertyName("Class")))
                 .Build(),
-        };
-        var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+        ];
+        var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["class"] = new HashSet<BoundAttributeDescriptor>(documentDescriptors[1].BoundAttributes),
-            ["onclick"] = new HashSet<BoundAttributeDescriptor>(),
-            ["repeat"] = new HashSet<BoundAttributeDescriptor>()
-            {
+            ["class"] = [..documentDescriptors[1].BoundAttributes],
+            ["onclick"] = [],
+            ["repeat"] =
+            [
                 documentDescriptors[0].BoundAttributes.First()
-            }
+            ]
         });
 
         var existingCompletions = new[] { "onclick" };
@@ -391,8 +390,8 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetAttributeCompletions_AppliedDescriptorsReturnAllBoundAttributesWithExistingCompletionsForSchemaTags()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
                 .BoundAttributeDescriptor(attribute => attribute
@@ -420,20 +419,20 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                     .TypeName(typeof(bool).FullName)
                     .Metadata(PropertyName("Visible")))
                 .Build(),
-        };
-        var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+        ];
+        var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["onclick"] = new HashSet<BoundAttributeDescriptor>(),
-            ["class"] = new HashSet<BoundAttributeDescriptor>(documentDescriptors[1].BoundAttributes),
-            ["repeat"] = new HashSet<BoundAttributeDescriptor>()
-            {
+            ["onclick"] = [],
+            ["class"] = [..documentDescriptors[1].BoundAttributes],
+            ["repeat"] =
+            [
                 documentDescriptors[0].BoundAttributes.First()
-            },
-            ["visible"] = new HashSet<BoundAttributeDescriptor>()
-            {
+            ],
+            ["visible"] =
+            [
                 documentDescriptors[0].BoundAttributes.Last(),
                 documentDescriptors[2].BoundAttributes.First(),
-            }
+            ]
         });
 
         var existingCompletions = new[] { "class", "onclick" };
@@ -454,8 +453,8 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetAttributeCompletions_AppliedTagOutputHintDescriptorsReturnBoundAttributesWithExistingCompletionsForNonSchemaTags()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("CustomTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("custom"))
                 .BoundAttributeDescriptor(attribute => attribute
@@ -464,11 +463,11 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                     .Metadata(PropertyName("Repeat")))
                 .TagOutputHint("div")
                 .Build(),
-        };
-        var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+        ];
+        var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["class"] = new HashSet<BoundAttributeDescriptor>(),
-            ["repeat"] = new HashSet<BoundAttributeDescriptor>(documentDescriptors[0].BoundAttributes)
+            ["class"] = [],
+            ["repeat"] = [..documentDescriptors[0].BoundAttributes]
         });
 
         var existingCompletions = new[] { "class" };
@@ -489,8 +488,8 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetAttributeCompletions_AppliedDescriptorsReturnBoundAttributesCompletionsForNonSchemaTags()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("CustomTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("custom"))
                 .BoundAttributeDescriptor(attribute => attribute
@@ -498,8 +497,8 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                     .TypeName(typeof(bool).FullName)
                     .Metadata(PropertyName("Repeat")))
                 .Build(),
-        };
-        var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+        ];
+        var expectedCompletions = AttributeCompletionResult.Create(new()
         {
             ["repeat"] = new HashSet<BoundAttributeDescriptor>(documentDescriptors[0].BoundAttributes)
         });
@@ -522,8 +521,8 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetAttributeCompletions_AppliedDescriptorsReturnBoundAttributesWithExistingCompletionsForSchemaTags()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
                 .BoundAttributeDescriptor(attribute => attribute
@@ -531,11 +530,11 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                     .TypeName(typeof(bool).FullName)
                     .Metadata(PropertyName("Repeat")))
                 .Build(),
-        };
-        var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+        ];
+        var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["class"] = new HashSet<BoundAttributeDescriptor>(),
-            ["repeat"] = new HashSet<BoundAttributeDescriptor>(documentDescriptors[0].BoundAttributes)
+            ["class"] = [],
+            ["repeat"] = [..documentDescriptors[0].BoundAttributes]
         });
 
         var existingCompletions = new[] { "class" };
@@ -556,14 +555,14 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetAttributeCompletions_NoDescriptorsReturnsExistingCompletions()
     {
         // Arrange
-        var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+        var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["class"] = new HashSet<BoundAttributeDescriptor>(),
+            ["class"] = [],
         });
 
         var existingCompletions = new[] { "class" };
         var completionContext = BuildAttributeCompletionContext(
-            Enumerable.Empty<TagHelperDescriptor>(),
+            descriptors: [],
             existingCompletions,
             currentTagName: "div");
         var service = CreateTagHelperCompletionFactsService();
@@ -579,17 +578,17 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetAttributeCompletions_NoDescriptorsForUnprefixedTagReturnsExistingCompletions()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("div")
                     .RequireAttributeDescriptor(attribute => attribute.Name("special")))
                 .Build(),
-        };
-        var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+        ];
+        var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["class"] = new HashSet<BoundAttributeDescriptor>(),
+            ["class"] = [],
         });
 
         var existingCompletions = new[] { "class" };
@@ -611,17 +610,17 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetAttributeCompletions_NoDescriptorsForTagReturnsExistingCompletions()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("MyTableTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("table")
                     .RequireAttributeDescriptor(attribute => attribute.Name("special")))
                 .Build(),
-        };
-        var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+        ];
+        var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["class"] = new HashSet<BoundAttributeDescriptor>(),
+            ["class"] = [],
         });
 
         var existingCompletions = new[] { "class" };
@@ -642,8 +641,8 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetElementCompletions_IgnoresDirectiveAttributes()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("BindAttribute", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("input"))
                 .BoundAttributeDescriptor(builder =>
@@ -653,8 +652,8 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 })
                 .TagOutputHint("table")
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>());
+        ];
+        var expectedCompletions = ElementCompletionResult.Create([]);
 
         var existingCompletions = new[] { "table" };
         var completionContext = BuildElementCompletionContext(
@@ -675,8 +674,8 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetElementCompletions_FiltersFullyQualifiedElementsIfShortNameExists()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("TestTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("Test"))
                 .Build(),
@@ -688,16 +687,16 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("Test2Assembly.Test"))
                 .Metadata(ComponentMetadata.Component.NameMatchKey, ComponentMetadata.Component.FullyQualifiedNameMatch)
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["Test"] = new HashSet<TagHelperDescriptor>() { documentDescriptors[0] },
-            ["Test2Assembly.Test"] = new HashSet<TagHelperDescriptor>() { documentDescriptors[2] },
+            ["Test"] = [documentDescriptors[0]],
+            ["Test2Assembly.Test"] = [documentDescriptors[2]],
         });
 
         var completionContext = BuildElementCompletionContext(
             documentDescriptors,
-            Array.Empty<string>(),
+            existingCompletions: [],
             containingTagName: "body",
             containingParentTagName: null);
         var service = CreateTagHelperCompletionFactsService();
@@ -713,8 +712,8 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetElementCompletions_TagOutputHintDoesNotFallThroughToSchemaCheck()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("MyTableTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("my-table"))
                 .TagOutputHint("table")
@@ -723,10 +722,10 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("my-tr"))
                 .TagOutputHint("tr")
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["my-table"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] }
+            ["my-table"] = [documentDescriptors[0]]
         });
 
         var existingCompletions = new[] { "table", "div" };
@@ -748,18 +747,18 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetElementCompletions_CatchAllsOnlyApplyToCompletionsStartingWithPrefix()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("CatchAllTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
                 .Build(),
             TagHelperDescriptorBuilder.Create("LiTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li"))
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["th:li"] = new HashSet<TagHelperDescriptor> { documentDescriptors[1], documentDescriptors[0] },
+            ["th:li"] = [documentDescriptors[1], documentDescriptors[0]],
         });
 
         var existingCompletions = new[] { "li" };
@@ -781,19 +780,19 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetElementCompletions_TagHelperPrefixIsPrependedToTagHelperCompletions()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("SuperLiTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("superli"))
                 .Build(),
             TagHelperDescriptorBuilder.Create("LiTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li"))
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["th:superli"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
-            ["th:li"] = new HashSet<TagHelperDescriptor> { documentDescriptors[1] },
+            ["th:superli"] = [documentDescriptors[0]],
+            ["th:li"] = [documentDescriptors[1]],
         });
 
         var existingCompletions = new[] { "li" };
@@ -815,8 +814,8 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetElementCompletions_IsCaseSensitive()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("MyliTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("myli"))
                 .SetCaseSensitive()
@@ -825,11 +824,11 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("MYLI"))
                 .SetCaseSensitive()
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["myli"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
-            ["MYLI"] = new HashSet<TagHelperDescriptor> { documentDescriptors[1] },
+            ["myli"] = [documentDescriptors[0]],
+            ["MYLI"] = [documentDescriptors[1]],
         });
 
         var existingCompletions = new[] { "li" };
@@ -851,8 +850,8 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetElementCompletions_HTMLSchemaTagName_IsCaseSensitive()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("LITagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("LI"))
                 .SetCaseSensitive()
@@ -861,11 +860,11 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li"))
                 .SetCaseSensitive()
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["LI"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
-            ["li"] = new HashSet<TagHelperDescriptor> { documentDescriptors[1] },
+            ["LI"] = [documentDescriptors[0]],
+            ["li"] = [documentDescriptors[1]],
         });
 
         var existingCompletions = new[] { "li" };
@@ -887,18 +886,18 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetElementCompletions_CatchAllsApplyToOnlyTagHelperCompletions()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("SuperLiTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("superli"))
                 .Build(),
             TagHelperDescriptorBuilder.Create("CatchAll", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["superli"] = new HashSet<TagHelperDescriptor>() { documentDescriptors[0], documentDescriptors[1] },
+            ["superli"] = [documentDescriptors[0], documentDescriptors[1]],
         });
 
         var existingCompletions = new[] { "li" };
@@ -919,18 +918,18 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetElementCompletions_CatchAllsApplyToNonTagHelperCompletionsIfStartsWithTagHelperPrefix()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("SuperLiTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("superli"))
                 .Build(),
             TagHelperDescriptorBuilder.Create("CatchAll", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["th:superli"] = new HashSet<TagHelperDescriptor>() { documentDescriptors[0], documentDescriptors[1] },
+            ["th:superli"] = [documentDescriptors[0], documentDescriptors[1]],
         });
 
         var existingCompletions = new[] { "th:li" };
@@ -952,8 +951,8 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetElementCompletions_AllowsMultiTargetingTagHelpers()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("BoldTagHelper1", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("strong"))
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("b"))
@@ -962,12 +961,12 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
             TagHelperDescriptorBuilder.Create("BoldTagHelper2", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("strong"))
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["strong"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0], documentDescriptors[1] },
-            ["b"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
-            ["bold"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
+            ["strong"] = [documentDescriptors[0], documentDescriptors[1]],
+            ["b"] = [documentDescriptors[0]],
+            ["bold"] = [documentDescriptors[0]],
         });
 
         var existingCompletions = new[] { "strong", "b", "bold" };
@@ -988,18 +987,18 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetElementCompletions_CombinesDescriptorsOnExistingCompletions()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("LiTagHelper1", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li"))
                 .Build(),
             TagHelperDescriptorBuilder.Create("LiTagHelper2", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li"))
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["li"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0], documentDescriptors[1] },
+            ["li"] = [documentDescriptors[0], documentDescriptors[1]],
         });
 
         var existingCompletions = new[] { "li" };
@@ -1017,8 +1016,8 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetElementCompletions_NewCompletionsForSchemaTagsNotInExistingCompletionsAreIgnored()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("SuperLiTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("superli"))
                 .Build(),
@@ -1029,11 +1028,11 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
             TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["li"] = new HashSet<TagHelperDescriptor> { documentDescriptors[1] },
-            ["superli"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
+            ["li"] = [documentDescriptors[1]],
+            ["superli"] = [documentDescriptors[0]],
         });
 
         var existingCompletions = new[] { "li" };
@@ -1051,8 +1050,8 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetElementCompletions_OutputHintIsCrossReferencedWithExistingCompletions()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
                 .TagOutputHint("li")
@@ -1061,11 +1060,11 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li"))
                 .TagOutputHint("strong")
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["div"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
-            ["li"] = new HashSet<TagHelperDescriptor> { documentDescriptors[1] },
+            ["div"] = [documentDescriptors[0]],
+            ["li"] = [documentDescriptors[1]],
         });
 
         var existingCompletions = new[] { "li" };
@@ -1083,18 +1082,18 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetElementCompletions_EnsuresDescriptorsHaveSatisfiedParent()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("LiTagHelper1", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li"))
                 .Build(),
             TagHelperDescriptorBuilder.Create("LiTagHelper2", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li").RequireParentTag("ol"))
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["li"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
+            ["li"] = [documentDescriptors[0]],
         });
 
         var existingCompletions = new[] { "li" };
@@ -1112,8 +1111,8 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetElementCompletions_NoContainingParentTag_DoesNotGetCompletionForRuleWithParentTag()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("Tag1", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("outer-child-tag"))
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("child-tag").RequireParentTag("parent-tag"))
@@ -1122,16 +1121,16 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("parent-tag"))
                 .AllowChildTag("child-tag")
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["outer-child-tag"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
-            ["parent-tag"] = new HashSet<TagHelperDescriptor> { documentDescriptors[1] },
+            ["outer-child-tag"] = [documentDescriptors[0]],
+            ["parent-tag"] = [documentDescriptors[1]],
         });
 
         var completionContext = BuildElementCompletionContext(
             documentDescriptors,
-            existingCompletions: Enumerable.Empty<string>(),
+            existingCompletions: [],
             containingTagName: null,
             containingParentTagName: null);
         var service = CreateTagHelperCompletionFactsService();
@@ -1147,8 +1146,8 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetElementCompletions_WithContainingParentTag_GetsCompletionForRuleWithParentTag()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("Tag1", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("outer-child-tag"))
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("child-tag").RequireParentTag("parent-tag"))
@@ -1157,15 +1156,15 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("parent-tag"))
                 .AllowChildTag("child-tag")
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["child-tag"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
+            ["child-tag"] = [documentDescriptors[0]],
         });
 
         var completionContext = BuildElementCompletionContext(
             documentDescriptors,
-            existingCompletions: Enumerable.Empty<string>(),
+            existingCompletions: [],
             containingTagName: "child-tag",
             containingParentTagName: "parent-tag");
         var service = CreateTagHelperCompletionFactsService();
@@ -1181,21 +1180,20 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetElementCompletions_AllowedChildrenAreIgnoredWhenAtRoot()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("CatchAll", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
                 .AllowChildTag("b")
                 .AllowChildTag("bold")
                 .AllowChildTag("div")
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>());
+        ];
+        var expectedCompletions = ElementCompletionResult.Create([]);
 
-        var existingCompletions = Enumerable.Empty<string>();
         var completionContext = BuildElementCompletionContext(
             documentDescriptors,
-            existingCompletions,
+            existingCompletions: [],
             containingTagName: null,
             containingParentTagName: null);
         var service = CreateTagHelperCompletionFactsService();
@@ -1211,24 +1209,28 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetElementCompletions_DoesNotReturnExistingCompletionsWhenAllowedChildren()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("BoldParent", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
                 .AllowChildTag("b")
                 .AllowChildTag("bold")
                 .AllowChildTag("div")
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["b"] = new HashSet<TagHelperDescriptor>(),
-            ["bold"] = new HashSet<TagHelperDescriptor>(),
-            ["div"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] }
+            ["b"] = [],
+            ["bold"] = [],
+            ["div"] = [documentDescriptors[0]]
         });
 
         var existingCompletions = new[] { "p", "em" };
-        var completionContext = BuildElementCompletionContext(documentDescriptors, existingCompletions, containingTagName: "thing", containingParentTagName: "div");
+        var completionContext = BuildElementCompletionContext(
+            documentDescriptors,
+            existingCompletions,
+            containingTagName: "thing",
+            containingParentTagName: "div");
         var service = CreateTagHelperCompletionFactsService();
 
         // Act
@@ -1242,21 +1244,25 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetElementCompletions_CapturesAllAllowedChildTagsFromParentTagHelpers_NoneTagHelpers()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("BoldParent", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
                 .AllowChildTag("b")
                 .AllowChildTag("bold")
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["b"] = new HashSet<TagHelperDescriptor>(),
-            ["bold"] = new HashSet<TagHelperDescriptor>(),
+            ["b"] = [],
+            ["bold"] = [],
         });
 
-        var completionContext = BuildElementCompletionContext(documentDescriptors, Enumerable.Empty<string>(), containingTagName: "", containingParentTagName: "div");
+        var completionContext = BuildElementCompletionContext(
+            documentDescriptors,
+            existingCompletions: [],
+            containingTagName: "",
+            containingParentTagName: "div");
         var service = CreateTagHelperCompletionFactsService();
 
         // Act
@@ -1270,23 +1276,27 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetElementCompletions_CapturesAllAllowedChildTagsFromParentTagHelpers_SomeTagHelpers()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("BoldParent", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
                 .AllowChildTag("b")
                 .AllowChildTag("bold")
                 .AllowChildTag("div")
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["b"] = new HashSet<TagHelperDescriptor>(),
-            ["bold"] = new HashSet<TagHelperDescriptor>(),
-            ["div"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] }
+            ["b"] = [],
+            ["bold"] = [],
+            ["div"] = [documentDescriptors[0]]
         });
 
-        var completionContext = BuildElementCompletionContext(documentDescriptors, Enumerable.Empty<string>(), containingTagName: "", containingParentTagName: "div");
+        var completionContext = BuildElementCompletionContext(
+            documentDescriptors,
+            existingCompletions: [],
+            containingTagName: "",
+            containingParentTagName: "div");
         var service = CreateTagHelperCompletionFactsService();
 
         // Act
@@ -1300,8 +1310,8 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetElementCompletions_CapturesAllAllowedChildTagsFromParentTagHelpers_AllTagHelpers()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("BoldParentCatchAll", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
                 .AllowChildTag("strong")
@@ -1313,16 +1323,20 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                 .AllowChildTag("b")
                 .AllowChildTag("bold")
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["strong"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
-            ["b"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
-            ["bold"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
-            ["div"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0], documentDescriptors[1] },
+            ["strong"] = [documentDescriptors[0]],
+            ["b"] = [documentDescriptors[0]],
+            ["bold"] = [documentDescriptors[0]],
+            ["div"] = [documentDescriptors[0], documentDescriptors[1]],
         });
 
-        var completionContext = BuildElementCompletionContext(documentDescriptors, Enumerable.Empty<string>(), containingTagName: "", containingParentTagName: "div");
+        var completionContext = BuildElementCompletionContext(
+            documentDescriptors,
+            existingCompletions: [],
+            containingTagName: "",
+            containingParentTagName: "div");
         var service = CreateTagHelperCompletionFactsService();
 
         // Act
@@ -1336,8 +1350,8 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetElementCompletions_MustSatisfyAttributeRules_WithAttributes()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("FormTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("form")
@@ -1347,16 +1361,21 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                         builder.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch;
                     }))
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["form"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] }
+            ["form"] = [documentDescriptors[0]]
         });
 
         var attributes = ImmutableArray.Create(
             KeyValuePair.Create("asp-route-id", "123"));
 
-        var completionContext = BuildElementCompletionContext(documentDescriptors, existingCompletions: ["form"], containingTagName: "", containingParentTagName: "div", attributes: attributes);
+        var completionContext = BuildElementCompletionContext(
+            documentDescriptors,
+            existingCompletions: ["form"],
+            containingTagName: "",
+            containingParentTagName: "div",
+            attributes: attributes);
         var service = CreateTagHelperCompletionFactsService();
 
         // Act
@@ -1370,8 +1389,8 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetElementCompletions_MustSatisfyAttributeRules_NoAttributes()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("FormTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("form")
@@ -1381,10 +1400,14 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                         builder.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch;
                     }))
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>());
+        ];
+        var expectedCompletions = ElementCompletionResult.Create([]);
 
-        var completionContext = BuildElementCompletionContext(documentDescriptors, existingCompletions: ["form"], containingTagName: "", containingParentTagName: "div");
+        var completionContext = BuildElementCompletionContext(
+            documentDescriptors,
+            existingCompletions: ["form"],
+            containingTagName: "",
+            containingParentTagName: "div");
         var service = CreateTagHelperCompletionFactsService();
 
         // Act
@@ -1398,8 +1421,8 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     public void GetElementCompletions_MustSatisfyAttributeRules_NoAttributes_AllowedIfNotHtml()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("ComponentTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("component")
@@ -1409,13 +1432,17 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
                         builder.NameComparisonMode = RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch;
                     }))
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["component"] = new HashSet<TagHelperDescriptor>() { documentDescriptors[0] },
+            ["component"] = [documentDescriptors[0]],
         });
 
-        var completionContext = BuildElementCompletionContext(documentDescriptors, Enumerable.Empty<string>(), containingTagName: "", containingParentTagName: "div");
+        var completionContext = BuildElementCompletionContext(
+            documentDescriptors,
+            existingCompletions: [],
+            containingTagName: "",
+            containingParentTagName: "div");
         var service = CreateTagHelperCompletionFactsService();
 
         // Act
@@ -1425,8 +1452,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
         AssertCompletionsAreEquivalent(expectedCompletions, completions);
     }
 
-    private static LspTagHelperCompletionService CreateTagHelperCompletionFactsService()
-        => new LspTagHelperCompletionService();
+    private static LspTagHelperCompletionService CreateTagHelperCompletionFactsService() => new();
 
     private static void AssertCompletionsAreEquivalent(ElementCompletionResult expected, ElementCompletionResult actual)
     {
@@ -1453,7 +1479,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     }
 
     private static ElementCompletionContext BuildElementCompletionContext(
-        IEnumerable<TagHelperDescriptor> descriptors,
+        ImmutableArray<TagHelperDescriptor> descriptors,
         IEnumerable<string> existingCompletions,
         string containingTagName,
         string containingParentTagName = "body",
@@ -1477,7 +1503,7 @@ public class LanguageServerTagHelperCompletionServiceTest(ITestOutputHelper test
     }
 
     private static AttributeCompletionContext BuildAttributeCompletionContext(
-        IEnumerable<TagHelperDescriptor> descriptors,
+        ImmutableArray<TagHelperDescriptor> descriptors,
         IEnumerable<string> existingCompletions,
         string currentTagName,
         string currentAttributeName = null,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/LegacyRazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/LegacyRazorCompletionEndpointTest.cs
@@ -415,7 +415,7 @@ public class LegacyRazorCompletionEndpointTest : LanguageServerTestBase
         builder.TagMatchingRule(rule => rule.TagName = "Test");
         builder.Metadata(TypeName("TestNamespace.TestTagHelper"));
         var tagHelper = builder.Build();
-        var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, new[] { tagHelper });
+        var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, [tagHelper]);
         var codeDocument = CreateCodeDocument("@in");
         codeDocument.SetTagHelperContext(tagHelperContext);
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
@@ -458,7 +458,7 @@ public class LegacyRazorCompletionEndpointTest : LanguageServerTestBase
         builder.TagMatchingRule(rule => rule.TagName = "Test");
         builder.Metadata(TypeName("TestNamespace.TestTagHelper"));
         var tagHelper = builder.Build();
-        var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, new[] { tagHelper });
+        var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, [tagHelper]);
         var codeDocument = CreateCodeDocument("@inje");
         codeDocument.SetTagHelperContext(tagHelperContext);
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
@@ -495,7 +495,7 @@ public class LegacyRazorCompletionEndpointTest : LanguageServerTestBase
         builder.TagMatchingRule(rule => rule.TagName = "Test");
         builder.Metadata(TypeName("TestNamespace.TestTagHelper"));
         var tagHelper = builder.Build();
-        var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, new[] { tagHelper });
+        var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, [tagHelper]);
         var codeDocument = CreateCodeDocument("@inje");
         codeDocument.SetTagHelperContext(tagHelperContext);
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
@@ -539,7 +539,7 @@ public class LegacyRazorCompletionEndpointTest : LanguageServerTestBase
         builder.TagMatchingRule(rule => rule.TagName = "Test");
         builder.Metadata(TypeName("TestNamespace.TestTagHelper"));
         var tagHelper = builder.Build();
-        var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, new[] { tagHelper });
+        var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, [tagHelper]);
         var codeDocument = CreateCodeDocument("<");
         codeDocument.SetTagHelperContext(tagHelperContext);
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
@@ -579,7 +579,7 @@ public class LegacyRazorCompletionEndpointTest : LanguageServerTestBase
         });
         builder.Metadata(TypeName("TestNamespace.TestTagHelper"));
         var tagHelper = builder.Build();
-        var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, new[] { tagHelper });
+        var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, [tagHelper]);
         var codeDocument = CreateCodeDocument("<test  ");
         codeDocument.SetTagHelperContext(tagHelperContext);
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
@@ -609,7 +609,7 @@ public class LegacyRazorCompletionEndpointTest : LanguageServerTestBase
         var sourceDocument = TestRazorSourceDocument.Create(text);
         var syntaxTree = RazorSyntaxTree.Parse(sourceDocument);
         codeDocument.SetSyntaxTree(syntaxTree);
-        var tagHelperDocumentContext = TagHelperDocumentContext.Create(prefix: string.Empty, Enumerable.Empty<TagHelperDescriptor>());
+        var tagHelperDocumentContext = TagHelperDocumentContext.Create(prefix: string.Empty, tagHelpers: []);
         codeDocument.SetTagHelperContext(tagHelperDocumentContext);
         return codeDocument;
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionListProvierTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionListProvierTest.cs
@@ -412,7 +412,7 @@ public class RazorCompletionListProvierTest : LanguageServerTestBase
         builder.TagMatchingRule(rule => rule.TagName = "Test");
         builder.Metadata(TypeName("TestNamespace.TestTagHelper"));
         var tagHelper = builder.Build();
-        var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, new[] { tagHelper });
+        var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, [tagHelper]);
         var codeDocument = CreateCodeDocument("@in");
         codeDocument.SetTagHelperContext(tagHelperContext);
         var documentContext = TestDocumentContext.From(documentPath, codeDocument, hostDocumentVersion: 0);
@@ -446,7 +446,7 @@ public class RazorCompletionListProvierTest : LanguageServerTestBase
         builder.TagMatchingRule(rule => rule.TagName = "Test");
         builder.Metadata(TypeName("TestNamespace.TestTagHelper"));
         var tagHelper = builder.Build();
-        var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, new[] { tagHelper });
+        var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, [tagHelper]);
         var codeDocument = CreateCodeDocument("@inje");
         codeDocument.SetTagHelperContext(tagHelperContext);
         var documentContext = TestDocumentContext.From(documentPath, codeDocument, hostDocumentVersion: 0);
@@ -474,7 +474,7 @@ public class RazorCompletionListProvierTest : LanguageServerTestBase
         builder.TagMatchingRule(rule => rule.TagName = "Test");
         builder.Metadata(TypeName("TestNamespace.TestTagHelper"));
         var tagHelper = builder.Build();
-        var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, new[] { tagHelper });
+        var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, [tagHelper]);
         var codeDocument = CreateCodeDocument("@inje");
         codeDocument.SetTagHelperContext(tagHelperContext);
         var documentContext = TestDocumentContext.From(documentPath, codeDocument, hostDocumentVersion: 0);
@@ -509,7 +509,7 @@ public class RazorCompletionListProvierTest : LanguageServerTestBase
         builder.TagMatchingRule(rule => rule.TagName = "Test");
         builder.Metadata(TypeName("TestNamespace.TestTagHelper"));
         var tagHelper = builder.Build();
-        var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, new[] { tagHelper });
+        var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, [tagHelper]);
         var codeDocument = CreateCodeDocument("<");
         codeDocument.SetTagHelperContext(tagHelperContext);
         var documentContext = TestDocumentContext.From(documentPath, codeDocument, hostDocumentVersion: 0);
@@ -539,7 +539,7 @@ public class RazorCompletionListProvierTest : LanguageServerTestBase
         });
         builder.Metadata(TypeName("TestNamespace.TestTagHelper"));
         var tagHelper = builder.Build();
-        var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, new[] { tagHelper });
+        var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, [tagHelper]);
         var codeDocument = CreateCodeDocument("<test  ");
         codeDocument.SetTagHelperContext(tagHelperContext);
         var documentContext = TestDocumentContext.From(documentPath, codeDocument, hostDocumentVersion: 0);
@@ -568,7 +568,7 @@ public class RazorCompletionListProvierTest : LanguageServerTestBase
         });
         builder.SetMetadata(TypeName("TestNamespace.TestTagHelper"));
         var tagHelper = builder.Build();
-        var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, new[] { tagHelper });
+        var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, [tagHelper]);
         var codeDocument = CreateCodeDocument("<test  ");
         codeDocument.SetTagHelperContext(tagHelperContext);
         var documentContext = TestDocumentContext.From(documentPath, codeDocument, hostDocumentVersion: 0);
@@ -594,7 +594,7 @@ public class RazorCompletionListProvierTest : LanguageServerTestBase
         var sourceDocument = TestRazorSourceDocument.Create(text);
         var syntaxTree = RazorSyntaxTree.Parse(sourceDocument);
         codeDocument.SetSyntaxTree(syntaxTree);
-        var tagHelperDocumentContext = TagHelperDocumentContext.Create(prefix: string.Empty, Enumerable.Empty<TagHelperDescriptor>());
+        var tagHelperDocumentContext = TagHelperDocumentContext.Create(prefix: string.Empty, tagHelpers: []);
         codeDocument.SetTagHelperContext(tagHelperDocumentContext);
         return codeDocument;
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointDelegationTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointDelegationTest.cs
@@ -61,7 +61,6 @@ public class RenameEndpointDelegationTest(ITestOutputHelper testOutput) : Single
 
         var endpoint = new RenameEndpoint(
             Dispatcher,
-            DocumentContextFactory,
             searchEngine,
             projectSnapshotManagerAccessor,
             LanguageServerFeatureOptions,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
@@ -716,7 +716,6 @@ public class RenameEndpointTest : LanguageServerTestBase
 
         var endpoint = new RenameEndpoint(
             Dispatcher,
-            _documentContextFactory,
             searchEngine,
             projectSnapshotManagerAccessor,
             languageServerFeatureOptions,

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DefaultRazorCompletionFactsServiceTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DefaultRazorCompletionFactsServiceTest.cs
@@ -20,7 +20,7 @@ public class DefaultRazorCompletionFactsServiceTest(ITestOutputHelper testOutput
     {
         // Arrange
         var syntaxTree = RazorSyntaxTree.Parse(TestRazorSourceDocument.Create());
-        var tagHelperDocumentContext = TagHelperDocumentContext.Create(prefix: null, Enumerable.Empty<TagHelperDescriptor>());
+        var tagHelperDocumentContext = TagHelperDocumentContext.Create(prefix: null, tagHelpers: []);
         var completionItem1 = new RazorCompletionItem("displayText1", "insertText1", RazorCompletionItemKind.Directive);
         var context = new RazorCompletionContext(0, null, syntaxTree, tagHelperDocumentContext);
         var provider1 = Mock.Of<IRazorCompletionItemProvider>(p => p.GetCompletionItems(context) == ImmutableArray.Create(completionItem1), MockBehavior.Strict);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DefaultRazorCompletionFactsServiceTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DefaultRazorCompletionFactsServiceTest.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Moq;

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.cs
@@ -165,7 +165,7 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
     public void GetAttributeCompletions_NoDescriptorsForTag_ReturnsEmptyCollection()
     {
         // Arrange
-        var documentContext = TagHelperDocumentContext.Create(string.Empty, Enumerable.Empty<TagHelperDescriptor>());
+        var documentContext = TagHelperDocumentContext.Create(string.Empty, tagHelpers: []);
 
         // Act
         var completions = _provider.GetAttributeCompletions("@bin", "foobarbaz", _emptyAttributes, documentContext);
@@ -181,7 +181,7 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
         var descriptor = TagHelperDescriptorBuilder.Create("CatchAll", "TestAssembly");
         descriptor.BoundAttributeDescriptor(boundAttribute => boundAttribute.Name = "Test");
         descriptor.TagMatchingRule(rule => rule.RequireTagName("*"));
-        var documentContext = TagHelperDocumentContext.Create(string.Empty, new[] { descriptor.Build() });
+        var documentContext = TagHelperDocumentContext.Create(string.Empty, [descriptor.Build()]);
 
         // Act
         var completions = _provider.GetAttributeCompletions("@bin", "input", _emptyAttributes, documentContext);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeParameterCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeParameterCompletionItemProviderTest.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.IntegrationTests;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeParameterCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeParameterCompletionItemProviderTest.cs
@@ -92,7 +92,7 @@ public class DirectiveAttributeParameterCompletionItemProviderTest : RazorToolin
     public void GetAttributeParameterCompletions_NoDescriptorsForTag_ReturnsEmptyCollection()
     {
         // Arrange
-        var documentContext = TagHelperDocumentContext.Create(string.Empty, Enumerable.Empty<TagHelperDescriptor>());
+        var documentContext = TagHelperDocumentContext.Create(string.Empty, tagHelpers: []);
 
         // Act
         var completions = _provider.GetAttributeParameterCompletions("@bin", string.Empty, "foobarbaz", _emptyAttributes, documentContext);
@@ -108,7 +108,7 @@ public class DirectiveAttributeParameterCompletionItemProviderTest : RazorToolin
         var descriptor = TagHelperDescriptorBuilder.Create("CatchAll", "TestAssembly");
         descriptor.BoundAttributeDescriptor(boundAttribute => boundAttribute.Name = "Test");
         descriptor.TagMatchingRule(rule => rule.RequireTagName("*"));
-        var documentContext = TagHelperDocumentContext.Create(string.Empty, new[] { descriptor.Build() });
+        var documentContext = TagHelperDocumentContext.Create(string.Empty, [descriptor.Build()]);
 
         // Act
         var completions = _provider.GetAttributeParameterCompletions("@bin", string.Empty, "input", _emptyAttributes, documentContext);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
@@ -3,7 +3,6 @@
 
 #nullable disable
 
-using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Extensions;

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
@@ -434,7 +434,7 @@ public class DirectiveCompletionItemProviderTest : ToolingTestBase
 
     private static RazorCompletionContext CreateRazorCompletionContext(int absoluteIndex, RazorSyntaxTree syntaxTree, CompletionReason reason = CompletionReason.Invoked)
     {
-        var tagHelperDocumentContext = TagHelperDocumentContext.Create(prefix: string.Empty, Array.Empty<TagHelperDescriptor>());
+        var tagHelperDocumentContext = TagHelperDocumentContext.Create(prefix: string.Empty, tagHelpers: []);
         var owner = syntaxTree.Root.FindInnermostNode(absoluteIndex);
         owner = RazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, absoluteIndex);
         return new RazorCompletionContext(absoluteIndex, owner, syntaxTree, tagHelperDocumentContext, reason);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/MarkupTransitionCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/MarkupTransitionCompletionItemProviderTest.cs
@@ -328,7 +328,7 @@ public class MarkupTransitionCompletionItemProviderTest(ITestOutputHelper testOu
 
     private static RazorCompletionContext CreateRazorCompletionContext(int absoluteIndex, RazorSyntaxTree syntaxTree)
     {
-        var tagHelperDocumentContext = TagHelperDocumentContext.Create(prefix: string.Empty, Array.Empty<TagHelperDescriptor>());
+        var tagHelperDocumentContext = TagHelperDocumentContext.Create(prefix: string.Empty, tagHelpers: []);
 
         var owner = syntaxTree.Root.FindInnermostNode(absoluteIndex, includeWhitespace: true, walkMarkersBack: true);
         owner = RazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, absoluteIndex);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/TagHelperFactsTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/TagHelperFactsTest.cs
@@ -20,12 +20,12 @@ public class TagHelperFactsTest(ITestOutputHelper testOutput) : ToolingTestBase(
     public void GetTagHelperBinding_DoesNotAllowOptOutCharacterPrefix()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("TestType", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
                 .Build()
-        };
+        ];
         var documentContext = TagHelperDocumentContext.Create(string.Empty, documentDescriptors);
 
         // Act
@@ -39,8 +39,8 @@ public class TagHelperFactsTest(ITestOutputHelper testOutput) : ToolingTestBase(
     public void GetTagHelperBinding_WorksAsExpected()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("TestType", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule =>
                     rule
@@ -66,7 +66,7 @@ public class TagHelperFactsTest(ITestOutputHelper testOutput) : ToolingTestBase(
                         .TypeName(typeof(string).FullName)
                         .Metadata(PropertyName("AspFor")))
                 .Build(),
-        };
+        ];
         var documentContext = TagHelperDocumentContext.Create(string.Empty, documentDescriptors);
         var attributes = ImmutableArray.Create(
             new KeyValuePair<string, string>("asp-for", "Name"));
@@ -85,8 +85,8 @@ public class TagHelperFactsTest(ITestOutputHelper testOutput) : ToolingTestBase(
     public void GetBoundTagHelperAttributes_MatchesPrefixedAttributeName()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("TestType", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("a"))
                 .BoundAttributeDescriptor(attribute =>
@@ -101,7 +101,7 @@ public class TagHelperFactsTest(ITestOutputHelper testOutput) : ToolingTestBase(
                         .Metadata(PropertyName("AspRoute"))
                         .AsDictionaryAttribute("asp-route-", typeof(string).FullName))
                 .Build()
-        };
+        ];
         var expectedAttributeDescriptors = new[]
         {
             documentDescriptors[0].BoundAttributes.Last()
@@ -120,8 +120,8 @@ public class TagHelperFactsTest(ITestOutputHelper testOutput) : ToolingTestBase(
     public void GetBoundTagHelperAttributes_MatchesAttributeName()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("TestType", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("input"))
                 .BoundAttributeDescriptor(attribute =>
@@ -135,7 +135,7 @@ public class TagHelperFactsTest(ITestOutputHelper testOutput) : ToolingTestBase(
                         .TypeName(typeof(string).FullName)
                         .Metadata(PropertyName("AspExtra")))
                 .Build()
-        };
+        ];
         var expectedAttributeDescriptors = new[]
         {
             documentDescriptors[0].BoundAttributes.First()
@@ -154,12 +154,12 @@ public class TagHelperFactsTest(ITestOutputHelper testOutput) : ToolingTestBase(
     public void GetTagHelpersGivenTag_DoesNotAllowOptOutCharacterPrefix()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("TestType", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
                 .Build()
-        };
+        ];
         var documentContext = TagHelperDocumentContext.Create(string.Empty, documentDescriptors);
 
         // Act
@@ -173,36 +173,36 @@ public class TagHelperFactsTest(ITestOutputHelper testOutput) : ToolingTestBase(
     public void GetTagHelpersGivenTag_RequiresTagName()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("TestType", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("strong"))
                 .Build()
-        };
+        ];
         var documentContext = TagHelperDocumentContext.Create(string.Empty, documentDescriptors);
 
         // Act
         var descriptors = TagHelperFacts.GetTagHelpersGivenTag(documentContext, "strong", "p");
 
         // Assert
-        Assert.Equal(documentDescriptors, descriptors);
+        Assert.Equal<TagHelperDescriptor>(documentDescriptors, descriptors);
     }
 
     [Fact]
     public void GetTagHelpersGivenTag_RestrictsTagHelpersBasedOnTagName()
     {
         // Arrange
-        var expectedDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> expectedDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("TestType", "TestAssembly")
                 .TagMatchingRuleDescriptor(
                     rule => rule
                         .RequireTagName("a")
                         .RequireParentTag("div"))
                 .Build()
-        };
-        var documentDescriptors = new[]
-        {
+        ];
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             expectedDescriptors[0],
             TagHelperDescriptorBuilder.Create("TestType2", "TestAssembly")
                 .TagMatchingRuleDescriptor(
@@ -210,57 +210,57 @@ public class TagHelperFactsTest(ITestOutputHelper testOutput) : ToolingTestBase(
                         .RequireTagName("strong")
                         .RequireParentTag("div"))
                 .Build()
-        };
+        ];
         var documentContext = TagHelperDocumentContext.Create(string.Empty, documentDescriptors);
 
         // Act
         var descriptors = TagHelperFacts.GetTagHelpersGivenTag(documentContext, "a", "div");
 
         // Assert
-        Assert.Equal(expectedDescriptors, descriptors);
+        Assert.Equal<TagHelperDescriptor>(expectedDescriptors, descriptors);
     }
 
     [Fact]
     public void GetTagHelpersGivenTag_RestrictsTagHelpersBasedOnTagHelperPrefix()
     {
         // Arrange
-        var expectedDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> expectedDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("TestType", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("strong"))
                 .Build()
-        };
-        var documentDescriptors = new[]
-        {
+        ];
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             expectedDescriptors[0],
             TagHelperDescriptorBuilder.Create("TestType2", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("thstrong"))
                 .Build()
-        };
+        ];
         var documentContext = TagHelperDocumentContext.Create("th", documentDescriptors);
 
         // Act
         var descriptors = TagHelperFacts.GetTagHelpersGivenTag(documentContext, "thstrong", "div");
 
         // Assert
-        Assert.Equal(expectedDescriptors, descriptors);
+        Assert.Equal<TagHelperDescriptor>(expectedDescriptors, descriptors);
     }
 
     [Fact]
     public void GetTagHelpersGivenTag_RestrictsTagHelpersBasedOnParent()
     {
         // Arrange
-        var expectedDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> expectedDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("TestType", "TestAssembly")
                 .TagMatchingRuleDescriptor(
                     rule => rule
                         .RequireTagName("strong")
                         .RequireParentTag("div"))
                 .Build()
-        };
-        var documentDescriptors = new[]
-        {
+        ];
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             expectedDescriptors[0],
             TagHelperDescriptorBuilder.Create("TestType2", "TestAssembly")
                 .TagMatchingRuleDescriptor(
@@ -268,41 +268,41 @@ public class TagHelperFactsTest(ITestOutputHelper testOutput) : ToolingTestBase(
                         .RequireTagName("strong")
                         .RequireParentTag("p"))
                 .Build()
-        };
+        ];
         var documentContext = TagHelperDocumentContext.Create(string.Empty, documentDescriptors);
 
         // Act
         var descriptors = TagHelperFacts.GetTagHelpersGivenTag(documentContext, "strong", "div");
 
         // Assert
-        Assert.Equal(expectedDescriptors, descriptors);
+        Assert.Equal<TagHelperDescriptor>(expectedDescriptors, descriptors);
     }
 
     [Fact]
     public void GetTagHelpersGivenParent_AllowsRootParentTag()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("TestType", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
                 .Build()
-        };
+        ];
         var documentContext = TagHelperDocumentContext.Create(string.Empty, documentDescriptors);
 
         // Act
         var descriptors = TagHelperFacts.GetTagHelpersGivenParent(documentContext, parentTag: null /* root */);
 
         // Assert
-        Assert.Equal(documentDescriptors, descriptors);
+        Assert.Equal<TagHelperDescriptor>(documentDescriptors, descriptors);
     }
 
     [Fact]
     public void GetTagHelpersGivenParent_AllowsRootParentTagForParentRestrictedTagHelperDescriptors()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
                 .Build(),
@@ -311,7 +311,7 @@ public class TagHelperFactsTest(ITestOutputHelper testOutput) : ToolingTestBase(
                     .RequireTagName("p")
                     .RequireParentTag("body"))
                 .Build()
-        };
+        ];
         var documentContext = TagHelperDocumentContext.Create(string.Empty, documentDescriptors);
 
         // Act
@@ -326,36 +326,36 @@ public class TagHelperFactsTest(ITestOutputHelper testOutput) : ToolingTestBase(
     public void GetTagHelpersGivenParent_AllowsUnspecifiedParentTagHelpers()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("TestType", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
                 .Build()
-        };
+        ];
         var documentContext = TagHelperDocumentContext.Create(string.Empty, documentDescriptors);
 
         // Act
         var descriptors = TagHelperFacts.GetTagHelpersGivenParent(documentContext, "p");
 
         // Assert
-        Assert.Equal(documentDescriptors, descriptors);
+        Assert.Equal<TagHelperDescriptor>(documentDescriptors, descriptors);
     }
 
     [Fact]
     public void GetTagHelpersGivenParent_RestrictsTagHelpersBasedOnParent()
     {
         // Arrange
-        var expectedDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> expectedDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("TestType", "TestAssembly")
                 .TagMatchingRuleDescriptor(
                     rule => rule
                         .RequireTagName("p")
                         .RequireParentTag("div"))
                 .Build()
-        };
-        var documentDescriptors = new[]
-        {
+        ];
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             expectedDescriptors[0],
             TagHelperDescriptorBuilder.Create("TestType2", "TestAssembly")
                 .TagMatchingRuleDescriptor(
@@ -363,13 +363,13 @@ public class TagHelperFactsTest(ITestOutputHelper testOutput) : ToolingTestBase(
                         .RequireTagName("strong")
                         .RequireParentTag("p"))
                 .Build()
-        };
+        ];
         var documentContext = TagHelperDocumentContext.Create(string.Empty, documentDescriptors);
 
         // Act
         var descriptors = TagHelperFacts.GetTagHelpersGivenParent(documentContext, "div");
 
         // Assert
-        Assert.Equal(expectedDescriptors, descriptors);
+        Assert.Equal<TagHelperDescriptor>(expectedDescriptors, descriptors);
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/Completion/LegacyTagHelperCompletionServiceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/Completion/LegacyTagHelperCompletionServiceTest.cs
@@ -32,12 +32,10 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                     .AsDictionary("asp-route-", typeof(string).FullName))
                 .Build(),
         ];
+
         var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["asp-route-..."] =
-            [
-                documentDescriptors[0].BoundAttributes.Last(),
-            ]
+            ["asp-route-..."] = [documentDescriptors[0].BoundAttributes.Last()]
         });
 
         var completionContext = BuildAttributeCompletionContext(
@@ -70,16 +68,11 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                     .AsDictionary("asp-route-", typeof(string).FullName))
                 .Build(),
         ];
+
         var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["asp-all-route-data"] =
-            [
-                documentDescriptors[0].BoundAttributes.Last(),
-            ],
-            ["asp-route-..."] =
-            [
-                documentDescriptors[0].BoundAttributes.Last(),
-            ]
+            ["asp-all-route-data"] = [documentDescriptors[0].BoundAttributes.Last()],
+            ["asp-route-..."] = [documentDescriptors[0].BoundAttributes.Last()]
         });
 
         var completionContext = BuildAttributeCompletionContext(
@@ -120,16 +113,11 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                     .AsDictionary("asp-route-", typeof(string).FullName))
                 .Build(),
         ];
+
         var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["asp-all-route-data"] =
-            [
-                documentDescriptors[0].BoundAttributes.Last(),
-            ],
-            ["asp-route-..."] =
-            [
-                documentDescriptors[0].BoundAttributes.Last(),
-            ]
+            ["asp-all-route-data"] = [documentDescriptors[0].BoundAttributes.Last()],
+            ["asp-route-..."] = [documentDescriptors[0].BoundAttributes.Last()]
         });
 
         var completionContext = BuildAttributeCompletionContext(
@@ -169,13 +157,11 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                     .Metadata(PropertyName("Class")))
                 .Build(),
         ];
+
         var expectedCompletions = AttributeCompletionResult.Create(new()
         {
             ["onclick"] = [],
-            ["visible"] =
-            [
-                documentDescriptors[0].BoundAttributes.Last()
-            ]
+            ["visible"] = [documentDescriptors[0].BoundAttributes.Last()]
         });
 
         var existingCompletions = new[] { "onclick" };
@@ -218,13 +204,11 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                     .Metadata(PropertyName("Class")))
                 .Build(),
         ];
+
         var expectedCompletions = AttributeCompletionResult.Create(new()
         {
             ["onclick"] = [],
-            ["visible"] =
-            [
-                documentDescriptors[0].BoundAttributes.Last()
-            ]
+            ["visible"] = [documentDescriptors[0].BoundAttributes.Last()]
         });
 
         var existingCompletions = new[] { "onclick" };
@@ -269,6 +253,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                     .Metadata(PropertyName("Class")))
                 .Build(),
         ];
+
         var expectedCompletions = AttributeCompletionResult.Create(new()
         {
             ["onclick"] = []
@@ -310,6 +295,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                     .RequireAttributeDescriptor(attribute => attribute.Name("class")))
                 .Build(),
         ];
+
         var expectedCompletions = AttributeCompletionResult.Create(new()
         {
             ["class"] = [],
@@ -360,14 +346,12 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                     .Metadata(PropertyName("Class")))
                 .Build(),
         ];
+
         var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["class"] = [..documentDescriptors[1].BoundAttributes],
+            ["class"] = [.. documentDescriptors[1].BoundAttributes],
             ["onclick"] = [],
-            ["repeat"] =
-            [
-                documentDescriptors[0].BoundAttributes.First()
-            ]
+            ["repeat"] = [documentDescriptors[0].BoundAttributes.First()]
         });
 
         var existingCompletions = new[] { "onclick" };
@@ -421,16 +405,9 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
         var expectedCompletions = AttributeCompletionResult.Create(new()
         {
             ["onclick"] = [],
-            ["class"] = [..documentDescriptors[1].BoundAttributes],
-            ["repeat"] =
-            [
-                documentDescriptors[0].BoundAttributes.First()
-            ],
-            ["visible"] =
-            [
-                documentDescriptors[0].BoundAttributes.Last(),
-                documentDescriptors[2].BoundAttributes.First(),
-            ]
+            ["class"] = [.. documentDescriptors[1].BoundAttributes],
+            ["repeat"] = [documentDescriptors[0].BoundAttributes.First()],
+            ["visible"] = [documentDescriptors[0].BoundAttributes.Last(), documentDescriptors[2].BoundAttributes.First()]
         });
 
         var existingCompletions = new[] { "class", "onclick" };
@@ -462,10 +439,11 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 .TagOutputHint("div")
                 .Build(),
         ];
+
         var expectedCompletions = AttributeCompletionResult.Create(new()
         {
             ["class"] = [],
-            ["repeat"] = [..documentDescriptors[0].BoundAttributes]
+            ["repeat"] = [.. documentDescriptors[0].BoundAttributes]
         });
 
         var existingCompletions = new[] { "class" };
@@ -496,9 +474,10 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                     .Metadata(PropertyName("Repeat")))
                 .Build(),
         ];
+
         var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["repeat"] = [..documentDescriptors[0].BoundAttributes]
+            ["repeat"] = [.. documentDescriptors[0].BoundAttributes]
         });
 
         var existingCompletions = new[] { "class" };
@@ -529,6 +508,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                     .Metadata(PropertyName("Repeat")))
                 .Build(),
         ];
+
         var expectedCompletions = AttributeCompletionResult.Create(new()
         {
             ["class"] = [],
@@ -584,6 +564,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                     .RequireAttributeDescriptor(attribute => attribute.Name("special")))
                 .Build(),
         ];
+
         var expectedCompletions = AttributeCompletionResult.Create(new()
         {
             ["class"] = [],
@@ -616,6 +597,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                     .RequireAttributeDescriptor(attribute => attribute.Name("special")))
                 .Build(),
         ];
+
         var expectedCompletions = AttributeCompletionResult.Create(new()
         {
             ["class"] = [],
@@ -651,6 +633,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 .TagOutputHint("table")
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["table"] = [],
@@ -689,6 +672,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 .Metadata(ComponentMetadata.Component.NameMatchKey, ComponentMetadata.Component.FullyQualifiedNameMatch)
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["Test"] = [documentDescriptors[0]],
@@ -724,6 +708,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 .TagOutputHint("tr")
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["my-table"] = [documentDescriptors[0]],
@@ -758,6 +743,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li"))
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["th:li"] = [documentDescriptors[1], documentDescriptors[0]],
@@ -792,6 +778,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li"))
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["th:superli"] = [documentDescriptors[0]],
@@ -829,6 +816,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 .SetCaseSensitive()
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["myli"] = [documentDescriptors[0]],
@@ -866,6 +854,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 .SetCaseSensitive()
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["LI"] = [documentDescriptors[0]],
@@ -900,6 +889,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["superli"] = [documentDescriptors[0], documentDescriptors[1]],
@@ -933,6 +923,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["th:superli"] = [documentDescriptors[0], documentDescriptors[1]],
@@ -969,6 +960,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("strong"))
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["strong"] = [documentDescriptors[0], documentDescriptors[1]],
@@ -1003,6 +995,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li"))
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["li"] = [documentDescriptors[0], documentDescriptors[1]],
@@ -1036,6 +1029,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["li"] = [documentDescriptors[1]],
@@ -1068,6 +1062,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 .TagOutputHint("strong")
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["div"] = [documentDescriptors[0]],
@@ -1098,6 +1093,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li").RequireParentTag("ol"))
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["li"] = [documentDescriptors[0]],
@@ -1129,6 +1125,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 .AllowChildTag("child-tag")
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["outer-child-tag"] = [documentDescriptors[0]],
@@ -1164,6 +1161,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 .AllowChildTag("child-tag")
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["child-tag"] = [documentDescriptors[0]],
@@ -1196,6 +1194,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 .AllowChildTag("div")
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create([]);
 
         var completionContext = BuildElementCompletionContext(
@@ -1225,6 +1224,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 .AllowChildTag("div")
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["b"] = [],
@@ -1255,6 +1255,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 .AllowChildTag("bold")
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["b"] = [],
@@ -1288,6 +1289,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 .AllowChildTag("div")
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["b"] = [],
@@ -1327,6 +1329,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 .AllowChildTag("bold")
                 .Build(),
         ];
+
         var expectedCompletions = ElementCompletionResult.Create(new()
         {
             ["strong"] = [documentDescriptors[0]],

--- a/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/Completion/LegacyTagHelperCompletionServiceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/Completion/LegacyTagHelperCompletionServiceTest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -22,8 +21,8 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetAttributeCompletions_OnlyIndexerNamePrefix()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("FormTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("form"))
@@ -32,19 +31,19 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                     .Metadata(PropertyName("RouteValues"))
                     .AsDictionary("asp-route-", typeof(string).FullName))
                 .Build(),
-        };
-        var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+        ];
+        var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["asp-route-..."] = new HashSet<BoundAttributeDescriptor>()
-            {
+            ["asp-route-..."] =
+            [
                 documentDescriptors[0].BoundAttributes.Last(),
-            }
+            ]
         });
 
         var completionContext = BuildAttributeCompletionContext(
             documentDescriptors,
-            Array.Empty<string>(),
-            attributes: ImmutableArray<KeyValuePair<string, string>>.Empty,
+            existingCompletions: [],
+            attributes: [],
             currentTagName: "form");
         var service = CreateTagHelperCompletionFactsService();
 
@@ -59,8 +58,8 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetAttributeCompletions_BoundDictionaryAttribute_ReturnsPrefixIndexerAndFullSetter()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("FormTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("form"))
@@ -70,23 +69,23 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                     .Metadata(PropertyName("RouteValues"))
                     .AsDictionary("asp-route-", typeof(string).FullName))
                 .Build(),
-        };
-        var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+        ];
+        var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["asp-all-route-data"] = new HashSet<BoundAttributeDescriptor>()
-            {
+            ["asp-all-route-data"] =
+            [
                 documentDescriptors[0].BoundAttributes.Last(),
-            },
-            ["asp-route-..."] = new HashSet<BoundAttributeDescriptor>()
-            {
+            ],
+            ["asp-route-..."] =
+            [
                 documentDescriptors[0].BoundAttributes.Last(),
-            }
+            ]
         });
 
         var completionContext = BuildAttributeCompletionContext(
             documentDescriptors,
-            Array.Empty<string>(),
-            attributes: ImmutableArray<KeyValuePair<string, string>>.Empty,
+            existingCompletions: [],
+            attributes: [],
             currentTagName: "form");
         var service = CreateTagHelperCompletionFactsService();
 
@@ -101,8 +100,8 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetAttributeCompletions_RequiredBoundDictionaryAttribute_ReturnsPrefixIndexerAndFullSetter()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("FormTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("form")
@@ -120,23 +119,23 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                     .Metadata(PropertyName("RouteValues"))
                     .AsDictionary("asp-route-", typeof(string).FullName))
                 .Build(),
-        };
-        var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+        ];
+        var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["asp-all-route-data"] = new HashSet<BoundAttributeDescriptor>()
-            {
+            ["asp-all-route-data"] =
+            [
                 documentDescriptors[0].BoundAttributes.Last(),
-            },
-            ["asp-route-..."] = new HashSet<BoundAttributeDescriptor>()
-            {
+            ],
+            ["asp-route-..."] =
+            [
                 documentDescriptors[0].BoundAttributes.Last(),
-            }
+            ]
         });
 
         var completionContext = BuildAttributeCompletionContext(
             documentDescriptors,
-            Array.Empty<string>(),
-            attributes: ImmutableArray<KeyValuePair<string, string>>.Empty,
+            existingCompletions: [],
+            attributes: [],
             currentTagName: "form");
         var service = CreateTagHelperCompletionFactsService();
 
@@ -151,8 +150,8 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetAttributeCompletions_DoesNotReturnCompletionsForAlreadySuppliedAttributes()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("div")
@@ -169,23 +168,23 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                     .TypeName(typeof(string).FullName)
                     .Metadata(PropertyName("Class")))
                 .Build(),
-        };
-        var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+        ];
+        var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["onclick"] = new HashSet<BoundAttributeDescriptor>(),
-            ["visible"] = new HashSet<BoundAttributeDescriptor>()
-            {
+            ["onclick"] = [],
+            ["visible"] =
+            [
                 documentDescriptors[0].BoundAttributes.Last()
-            }
+            ]
         });
 
         var existingCompletions = new[] { "onclick" };
         var completionContext = BuildAttributeCompletionContext(
             documentDescriptors,
             existingCompletions,
-            attributes: ImmutableArray.Create(
+            attributes: [
                 KeyValuePair.Create("class", "something"),
-                KeyValuePair.Create("repeat", "4")),
+                KeyValuePair.Create("repeat", "4")],
             currentTagName: "div");
         var service = CreateTagHelperCompletionFactsService();
 
@@ -200,8 +199,8 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetAttributeCompletions_ReturnsCompletionForAlreadySuppliedAttribute_IfCurrentAttributeMatches()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("div")
@@ -218,24 +217,24 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                     .TypeName(typeof(string).FullName)
                     .Metadata(PropertyName("Class")))
                 .Build(),
-        };
-        var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+        ];
+        var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["onclick"] = new HashSet<BoundAttributeDescriptor>(),
-            ["visible"] = new HashSet<BoundAttributeDescriptor>()
-            {
+            ["onclick"] = [],
+            ["visible"] =
+            [
                 documentDescriptors[0].BoundAttributes.Last()
-            }
+            ]
         });
 
         var existingCompletions = new[] { "onclick" };
         var completionContext = BuildAttributeCompletionContext(
             documentDescriptors,
             existingCompletions,
-            attributes: ImmutableArray.Create(
+            attributes: [
                 KeyValuePair.Create("class", "something"),
                 KeyValuePair.Create("repeat", "4"),
-                KeyValuePair.Create("visible", "false")),
+                KeyValuePair.Create("visible", "false")],
             currentTagName: "div",
             currentAttributeName: "visible");
         var service = CreateTagHelperCompletionFactsService();
@@ -251,8 +250,8 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetAttributeCompletions_DoesNotReturnAlreadySuppliedAttribute_IfCurrentAttributeDoesNotMatch()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("div")
@@ -269,20 +268,20 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                     .TypeName(typeof(string).FullName)
                     .Metadata(PropertyName("Class")))
                 .Build(),
-        };
-        var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+        ];
+        var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["onclick"] = new HashSet<BoundAttributeDescriptor>()
+            ["onclick"] = []
         });
 
         var existingCompletions = new[] { "onclick" };
         var completionContext = BuildAttributeCompletionContext(
             documentDescriptors,
             existingCompletions,
-            attributes: ImmutableArray.Create(
+            attributes: [
                 KeyValuePair.Create("class", "something"),
                 KeyValuePair.Create("repeat", "4"),
-                KeyValuePair.Create("visible", "false")),
+                KeyValuePair.Create("visible", "false")],
             currentTagName: "div",
             currentAttributeName: "repeat");
         var service = CreateTagHelperCompletionFactsService();
@@ -298,8 +297,8 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetAttributeCompletions_PossibleDescriptorsReturnUnboundRequiredAttributesWithExistingCompletions()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("div")
@@ -310,12 +309,12 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                     .RequireTagName("*")
                     .RequireAttributeDescriptor(attribute => attribute.Name("class")))
                 .Build(),
-        };
-        var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+        ];
+        var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["class"] = new HashSet<BoundAttributeDescriptor>(),
-            ["onclick"] = new HashSet<BoundAttributeDescriptor>(),
-            ["repeat"] = new HashSet<BoundAttributeDescriptor>()
+            ["class"] = [],
+            ["onclick"] = [],
+            ["repeat"] = []
         });
 
         var existingCompletions = new[] { "onclick", "class" };
@@ -336,8 +335,8 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetAttributeCompletions_PossibleDescriptorsReturnBoundRequiredAttributesWithExistingCompletions()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("div")
@@ -360,15 +359,15 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                     .TypeName(typeof(string).FullName)
                     .Metadata(PropertyName("Class")))
                 .Build(),
-        };
-        var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+        ];
+        var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["class"] = new HashSet<BoundAttributeDescriptor>(documentDescriptors[1].BoundAttributes),
-            ["onclick"] = new HashSet<BoundAttributeDescriptor>(),
-            ["repeat"] = new HashSet<BoundAttributeDescriptor>()
-            {
+            ["class"] = [..documentDescriptors[1].BoundAttributes],
+            ["onclick"] = [],
+            ["repeat"] =
+            [
                 documentDescriptors[0].BoundAttributes.First()
-            }
+            ]
         });
 
         var existingCompletions = new[] { "onclick" };
@@ -389,8 +388,8 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetAttributeCompletions_AppliedDescriptorsReturnAllBoundAttributesWithExistingCompletionsForSchemaTags()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
                 .BoundAttributeDescriptor(attribute => attribute
@@ -418,20 +417,20 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                     .TypeName(typeof(bool).FullName)
                     .Metadata(PropertyName("Visible")))
                 .Build(),
-        };
-        var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+        ];
+        var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["onclick"] = new HashSet<BoundAttributeDescriptor>(),
-            ["class"] = new HashSet<BoundAttributeDescriptor>(documentDescriptors[1].BoundAttributes),
-            ["repeat"] = new HashSet<BoundAttributeDescriptor>()
-            {
+            ["onclick"] = [],
+            ["class"] = [..documentDescriptors[1].BoundAttributes],
+            ["repeat"] =
+            [
                 documentDescriptors[0].BoundAttributes.First()
-            },
-            ["visible"] = new HashSet<BoundAttributeDescriptor>()
-            {
+            ],
+            ["visible"] =
+            [
                 documentDescriptors[0].BoundAttributes.Last(),
                 documentDescriptors[2].BoundAttributes.First(),
-            }
+            ]
         });
 
         var existingCompletions = new[] { "class", "onclick" };
@@ -452,8 +451,8 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetAttributeCompletions_AppliedTagOutputHintDescriptorsReturnBoundAttributesWithExistingCompletionsForNonSchemaTags()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("CustomTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("custom"))
                 .BoundAttributeDescriptor(attribute => attribute
@@ -462,11 +461,11 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                     .Metadata(PropertyName("Repeat")))
                 .TagOutputHint("div")
                 .Build(),
-        };
-        var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+        ];
+        var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["class"] = new HashSet<BoundAttributeDescriptor>(),
-            ["repeat"] = new HashSet<BoundAttributeDescriptor>(documentDescriptors[0].BoundAttributes)
+            ["class"] = [],
+            ["repeat"] = [..documentDescriptors[0].BoundAttributes]
         });
 
         var existingCompletions = new[] { "class" };
@@ -487,8 +486,8 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetAttributeCompletions_AppliedDescriptorsReturnBoundAttributesCompletionsForNonSchemaTags()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("CustomTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("custom"))
                 .BoundAttributeDescriptor(attribute => attribute
@@ -496,10 +495,10 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                     .TypeName(typeof(bool).FullName)
                     .Metadata(PropertyName("Repeat")))
                 .Build(),
-        };
-        var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+        ];
+        var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["repeat"] = new HashSet<BoundAttributeDescriptor>(documentDescriptors[0].BoundAttributes)
+            ["repeat"] = [..documentDescriptors[0].BoundAttributes]
         });
 
         var existingCompletions = new[] { "class" };
@@ -520,8 +519,8 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetAttributeCompletions_AppliedDescriptorsReturnBoundAttributesWithExistingCompletionsForSchemaTags()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
                 .BoundAttributeDescriptor(attribute => attribute
@@ -529,11 +528,11 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                     .TypeName(typeof(bool).FullName)
                     .Metadata(PropertyName("Repeat")))
                 .Build(),
-        };
-        var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+        ];
+        var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["class"] = new HashSet<BoundAttributeDescriptor>(),
-            ["repeat"] = new HashSet<BoundAttributeDescriptor>(documentDescriptors[0].BoundAttributes)
+            ["class"] = [],
+            ["repeat"] = [..documentDescriptors[0].BoundAttributes]
         });
 
         var existingCompletions = new[] { "class" };
@@ -554,14 +553,14 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetAttributeCompletions_NoDescriptorsReturnsExistingCompletions()
     {
         // Arrange
-        var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+        var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["class"] = new HashSet<BoundAttributeDescriptor>(),
+            ["class"] = [],
         });
 
         var existingCompletions = new[] { "class" };
         var completionContext = BuildAttributeCompletionContext(
-            Enumerable.Empty<TagHelperDescriptor>(),
+            descriptors: [],
             existingCompletions,
             currentTagName: "div");
         var service = CreateTagHelperCompletionFactsService();
@@ -577,17 +576,17 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetAttributeCompletions_NoDescriptorsForUnprefixedTagReturnsExistingCompletions()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("div")
                     .RequireAttributeDescriptor(attribute => attribute.Name("special")))
                 .Build(),
-        };
-        var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+        ];
+        var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["class"] = new HashSet<BoundAttributeDescriptor>(),
+            ["class"] = [],
         });
 
         var existingCompletions = new[] { "class" };
@@ -609,17 +608,17 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetAttributeCompletions_NoDescriptorsForTagReturnsExistingCompletions()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("MyTableTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule
                     .RequireTagName("table")
                     .RequireAttributeDescriptor(attribute => attribute.Name("special")))
                 .Build(),
-        };
-        var expectedCompletions = AttributeCompletionResult.Create(new Dictionary<string, HashSet<BoundAttributeDescriptor>>()
+        ];
+        var expectedCompletions = AttributeCompletionResult.Create(new()
         {
-            ["class"] = new HashSet<BoundAttributeDescriptor>(),
+            ["class"] = [],
         });
 
         var existingCompletions = new[] { "class" };
@@ -640,8 +639,8 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetElementCompletions_IgnoresDirectiveAttributes()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("BindAttribute", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("input"))
                 .BoundAttributeDescriptor(builder =>
@@ -651,10 +650,10 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 })
                 .TagOutputHint("table")
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["table"] = new HashSet<TagHelperDescriptor>(),
+            ["table"] = [],
         });
 
         var existingCompletions = new[] { "table" };
@@ -676,8 +675,8 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetElementCompletions_FiltersFullyQualifiedElementsIfShortNameExists()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("TestTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("Test"))
                 .Build(),
@@ -689,16 +688,16 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("Test2Assembly.Test"))
                 .Metadata(ComponentMetadata.Component.NameMatchKey, ComponentMetadata.Component.FullyQualifiedNameMatch)
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["Test"] = new HashSet<TagHelperDescriptor>() { documentDescriptors[0] },
-            ["Test2Assembly.Test"] = new HashSet<TagHelperDescriptor>() { documentDescriptors[2] },
+            ["Test"] = [documentDescriptors[0]],
+            ["Test2Assembly.Test"] = [documentDescriptors[2]],
         });
 
         var completionContext = BuildElementCompletionContext(
             documentDescriptors,
-            Array.Empty<string>(),
+            existingCompletions: [],
             containingTagName: "body",
             containingParentTagName: null);
         var service = CreateTagHelperCompletionFactsService();
@@ -714,8 +713,8 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetElementCompletions_TagOutputHintDoesNotFallThroughToSchemaCheck()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("MyTableTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("my-table"))
                 .TagOutputHint("table")
@@ -724,11 +723,11 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("my-tr"))
                 .TagOutputHint("tr")
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["my-table"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
-            ["table"] = new HashSet<TagHelperDescriptor>(),
+            ["my-table"] = [documentDescriptors[0]],
+            ["table"] = [],
         });
 
         var existingCompletions = new[] { "table" };
@@ -750,19 +749,19 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetElementCompletions_CatchAllsOnlyApplyToCompletionsStartingWithPrefix()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("CatchAllTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
                 .Build(),
             TagHelperDescriptorBuilder.Create("LiTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li"))
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["th:li"] = new HashSet<TagHelperDescriptor> { documentDescriptors[1], documentDescriptors[0] },
-            ["li"] = new HashSet<TagHelperDescriptor>(),
+            ["th:li"] = [documentDescriptors[1], documentDescriptors[0]],
+            ["li"] = [],
         });
 
         var existingCompletions = new[] { "li" };
@@ -784,20 +783,20 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetElementCompletions_TagHelperPrefixIsPrependedToTagHelperCompletions()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("SuperLiTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("superli"))
                 .Build(),
             TagHelperDescriptorBuilder.Create("LiTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li"))
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["th:superli"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
-            ["th:li"] = new HashSet<TagHelperDescriptor> { documentDescriptors[1] },
-            ["li"] = new HashSet<TagHelperDescriptor>(),
+            ["th:superli"] = [documentDescriptors[0]],
+            ["th:li"] = [documentDescriptors[1]],
+            ["li"] = [],
         });
 
         var existingCompletions = new[] { "li" };
@@ -819,8 +818,8 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetElementCompletions_IsCaseSensitive()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("MyliTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("myli"))
                 .SetCaseSensitive()
@@ -829,12 +828,12 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("MYLI"))
                 .SetCaseSensitive()
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["myli"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
-            ["MYLI"] = new HashSet<TagHelperDescriptor> { documentDescriptors[1] },
-            ["li"] = new HashSet<TagHelperDescriptor> { },
+            ["myli"] = [documentDescriptors[0]],
+            ["MYLI"] = [documentDescriptors[1]],
+            ["li"] = [],
         });
 
         var existingCompletions = new[] { "li" };
@@ -856,8 +855,8 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetElementCompletions_HTMLSchemaTagName_IsCaseSensitive()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("LITagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("LI"))
                 .SetCaseSensitive()
@@ -866,11 +865,11 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li"))
                 .SetCaseSensitive()
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["LI"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
-            ["li"] = new HashSet<TagHelperDescriptor> { documentDescriptors[1] },
+            ["LI"] = [documentDescriptors[0]],
+            ["li"] = [documentDescriptors[1]],
         });
 
         var existingCompletions = new[] { "li" };
@@ -892,19 +891,19 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetElementCompletions_CatchAllsApplyToOnlyTagHelperCompletions()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("SuperLiTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("superli"))
                 .Build(),
             TagHelperDescriptorBuilder.Create("CatchAll", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["superli"] = new HashSet<TagHelperDescriptor>() { documentDescriptors[0], documentDescriptors[1] },
-            ["li"] = new HashSet<TagHelperDescriptor>(),
+            ["superli"] = [documentDescriptors[0], documentDescriptors[1]],
+            ["li"] = [],
         });
 
         var existingCompletions = new[] { "li" };
@@ -925,19 +924,19 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetElementCompletions_CatchAllsApplyToNonTagHelperCompletionsIfStartsWithTagHelperPrefix()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("SuperLiTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("superli"))
                 .Build(),
             TagHelperDescriptorBuilder.Create("CatchAll", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["th:superli"] = new HashSet<TagHelperDescriptor>() { documentDescriptors[0], documentDescriptors[1] },
-            ["th:li"] = new HashSet<TagHelperDescriptor>() { documentDescriptors[1] },
+            ["th:superli"] = [documentDescriptors[0], documentDescriptors[1]],
+            ["th:li"] = [documentDescriptors[1]],
         });
 
         var existingCompletions = new[] { "th:li" };
@@ -959,8 +958,8 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetElementCompletions_AllowsMultiTargetingTagHelpers()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("BoldTagHelper1", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("strong"))
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("b"))
@@ -969,12 +968,12 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
             TagHelperDescriptorBuilder.Create("BoldTagHelper2", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("strong"))
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["strong"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0], documentDescriptors[1] },
-            ["b"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
-            ["bold"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
+            ["strong"] = [documentDescriptors[0], documentDescriptors[1]],
+            ["b"] = [documentDescriptors[0]],
+            ["bold"] = [documentDescriptors[0]],
         });
 
         var existingCompletions = new[] { "strong", "b", "bold" };
@@ -995,18 +994,18 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetElementCompletions_CombinesDescriptorsOnExistingCompletions()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("LiTagHelper1", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li"))
                 .Build(),
             TagHelperDescriptorBuilder.Create("LiTagHelper2", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li"))
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["li"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0], documentDescriptors[1] },
+            ["li"] = [documentDescriptors[0], documentDescriptors[1]],
         });
 
         var existingCompletions = new[] { "li" };
@@ -1024,8 +1023,8 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetElementCompletions_NewCompletionsForSchemaTagsNotInExistingCompletionsAreIgnored()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("SuperLiTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("superli"))
                 .Build(),
@@ -1036,11 +1035,11 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
             TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["li"] = new HashSet<TagHelperDescriptor> { documentDescriptors[1] },
-            ["superli"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
+            ["li"] = [documentDescriptors[1]],
+            ["superli"] = [documentDescriptors[0]],
         });
 
         var existingCompletions = new[] { "li" };
@@ -1058,8 +1057,8 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetElementCompletions_OutputHintIsCrossReferencedWithExistingCompletions()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("DivTagHelper", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
                 .TagOutputHint("li")
@@ -1068,11 +1067,11 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li"))
                 .TagOutputHint("strong")
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["div"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
-            ["li"] = new HashSet<TagHelperDescriptor> { documentDescriptors[1] },
+            ["div"] = [documentDescriptors[0]],
+            ["li"] = [documentDescriptors[1]],
         });
 
         var existingCompletions = new[] { "li" };
@@ -1090,18 +1089,18 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetElementCompletions_EnsuresDescriptorsHaveSatisfiedParent()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("LiTagHelper1", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li"))
                 .Build(),
             TagHelperDescriptorBuilder.Create("LiTagHelper2", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("li").RequireParentTag("ol"))
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["li"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
+            ["li"] = [documentDescriptors[0]],
         });
 
         var existingCompletions = new[] { "li" };
@@ -1119,8 +1118,8 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetElementCompletions_NoContainingParentTag_DoesNotGetCompletionForRuleWithParentTag()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("Tag1", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("outer-child-tag"))
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("child-tag").RequireParentTag("parent-tag"))
@@ -1129,16 +1128,16 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("parent-tag"))
                 .AllowChildTag("child-tag")
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["outer-child-tag"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
-            ["parent-tag"] = new HashSet<TagHelperDescriptor> { documentDescriptors[1] },
+            ["outer-child-tag"] = [documentDescriptors[0]],
+            ["parent-tag"] = [documentDescriptors[1]],
         });
 
         var completionContext = BuildElementCompletionContext(
             documentDescriptors,
-            existingCompletions: Enumerable.Empty<string>(),
+            existingCompletions: [],
             containingTagName: null,
             containingParentTagName: null);
         var service = CreateTagHelperCompletionFactsService();
@@ -1154,8 +1153,8 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetElementCompletions_WithContainingParentTag_GetsCompletionForRuleWithParentTag()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("Tag1", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("outer-child-tag"))
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("child-tag").RequireParentTag("parent-tag"))
@@ -1164,15 +1163,15 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("parent-tag"))
                 .AllowChildTag("child-tag")
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["child-tag"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
+            ["child-tag"] = [documentDescriptors[0]],
         });
 
         var completionContext = BuildElementCompletionContext(
             documentDescriptors,
-            existingCompletions: Enumerable.Empty<string>(),
+            existingCompletions: [],
             containingTagName: "parent-tag",
             containingParentTagName: null);
         var service = CreateTagHelperCompletionFactsService();
@@ -1188,21 +1187,20 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetElementCompletions_AllowedChildrenAreIgnoredWhenAtRoot()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("CatchAll", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
                 .AllowChildTag("b")
                 .AllowChildTag("bold")
                 .AllowChildTag("div")
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>());
+        ];
+        var expectedCompletions = ElementCompletionResult.Create([]);
 
-        var existingCompletions = Enumerable.Empty<string>();
         var completionContext = BuildElementCompletionContext(
             documentDescriptors,
-            existingCompletions,
+            existingCompletions: [],
             containingTagName: null,
             containingParentTagName: null);
         var service = CreateTagHelperCompletionFactsService();
@@ -1218,20 +1216,20 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetElementCompletions_DoesNotReturnExistingCompletionsWhenAllowedChildren()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("BoldParent", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
                 .AllowChildTag("b")
                 .AllowChildTag("bold")
                 .AllowChildTag("div")
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["b"] = new HashSet<TagHelperDescriptor>(),
-            ["bold"] = new HashSet<TagHelperDescriptor>(),
-            ["div"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] }
+            ["b"] = [],
+            ["bold"] = [],
+            ["div"] = [documentDescriptors[0]]
         });
 
         var existingCompletions = new[] { "p", "em" };
@@ -1249,21 +1247,25 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetElementCompletions_CapturesAllAllowedChildTagsFromParentTagHelpers_NoneTagHelpers()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("BoldParent", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
                 .AllowChildTag("b")
                 .AllowChildTag("bold")
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["b"] = new HashSet<TagHelperDescriptor>(),
-            ["bold"] = new HashSet<TagHelperDescriptor>(),
+            ["b"] = [],
+            ["bold"] = [],
         });
 
-        var completionContext = BuildElementCompletionContext(documentDescriptors, Enumerable.Empty<string>(), containingTagName: "div", containingParentTagName: "");
+        var completionContext = BuildElementCompletionContext(
+            documentDescriptors,
+            existingCompletions: [],
+            containingTagName: "div",
+            containingParentTagName: "");
         var service = CreateTagHelperCompletionFactsService();
 
         // Act
@@ -1277,23 +1279,27 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetElementCompletions_CapturesAllAllowedChildTagsFromParentTagHelpers_SomeTagHelpers()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("BoldParent", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("div"))
                 .AllowChildTag("b")
                 .AllowChildTag("bold")
                 .AllowChildTag("div")
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["b"] = new HashSet<TagHelperDescriptor>(),
-            ["bold"] = new HashSet<TagHelperDescriptor>(),
-            ["div"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] }
+            ["b"] = [],
+            ["bold"] = [],
+            ["div"] = [documentDescriptors[0]]
         });
 
-        var completionContext = BuildElementCompletionContext(documentDescriptors, Enumerable.Empty<string>(), containingTagName: "div", containingParentTagName: "");
+        var completionContext = BuildElementCompletionContext(
+            documentDescriptors,
+            existingCompletions: [],
+            containingTagName: "div",
+            containingParentTagName: "");
         var service = CreateTagHelperCompletionFactsService();
 
         // Act
@@ -1307,8 +1313,8 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     public void GetElementCompletions_CapturesAllAllowedChildTagsFromParentTagHelpers_AllTagHelpers()
     {
         // Arrange
-        var documentDescriptors = new[]
-        {
+        ImmutableArray<TagHelperDescriptor> documentDescriptors =
+        [
             TagHelperDescriptorBuilder.Create("BoldParentCatchAll", "TestAssembly")
                 .TagMatchingRuleDescriptor(rule => rule.RequireTagName("*"))
                 .AllowChildTag("strong")
@@ -1320,16 +1326,20 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
                 .AllowChildTag("b")
                 .AllowChildTag("bold")
                 .Build(),
-        };
-        var expectedCompletions = ElementCompletionResult.Create(new Dictionary<string, HashSet<TagHelperDescriptor>>()
+        ];
+        var expectedCompletions = ElementCompletionResult.Create(new()
         {
-            ["strong"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
-            ["b"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
-            ["bold"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0] },
-            ["div"] = new HashSet<TagHelperDescriptor> { documentDescriptors[0], documentDescriptors[1] },
+            ["strong"] = [documentDescriptors[0]],
+            ["b"] = [documentDescriptors[0]],
+            ["bold"] = [documentDescriptors[0]],
+            ["div"] = [documentDescriptors[0], documentDescriptors[1]],
         });
 
-        var completionContext = BuildElementCompletionContext(documentDescriptors, Enumerable.Empty<string>(), containingTagName: "div", containingParentTagName: "");
+        var completionContext = BuildElementCompletionContext(
+            documentDescriptors,
+            existingCompletions: [],
+            containingTagName: "div",
+            containingParentTagName: "");
         var service = CreateTagHelperCompletionFactsService();
 
         // Act
@@ -1339,7 +1349,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
         AssertCompletionsAreEquivalent(expectedCompletions, completions);
     }
 
-    private static LegacyTagHelperCompletionService CreateTagHelperCompletionFactsService() => new LegacyTagHelperCompletionService();
+    private static LegacyTagHelperCompletionService CreateTagHelperCompletionFactsService() => new();
 
     private static void AssertCompletionsAreEquivalent(ElementCompletionResult expected, ElementCompletionResult actual)
     {
@@ -1366,7 +1376,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     }
 
     private static ElementCompletionContext BuildElementCompletionContext(
-        IEnumerable<TagHelperDescriptor> descriptors,
+        ImmutableArray<TagHelperDescriptor> descriptors,
         IEnumerable<string> existingCompletions,
         string? containingTagName,
         string? containingParentTagName = "body",
@@ -1378,7 +1388,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
             documentContext,
             existingCompletions,
             containingTagName,
-            attributes: ImmutableArray<KeyValuePair<string, string>>.Empty,
+            attributes: [],
             containingParentTagName: containingParentTagName,
             containingParentIsTagHelper: containingParentIsTagHelper,
             inHTMLSchema: (tag) => tag == "strong" || tag == "b" || tag == "bold" || tag == "li" || tag == "div");
@@ -1387,7 +1397,7 @@ public class LegacyTagHelperCompletionServiceTest(ITestOutputHelper testOutput) 
     }
 
     private static AttributeCompletionContext BuildAttributeCompletionContext(
-        IEnumerable<TagHelperDescriptor> descriptors,
+        ImmutableArray<TagHelperDescriptor> descriptors,
         IEnumerable<string> existingCompletions,
         string currentTagName,
         string? currentAttributeName = null,

--- a/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/Completion/RazorDirectiveCompletionSourceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/Completion/RazorDirectiveCompletionSourceTest.cs
@@ -204,7 +204,7 @@ public class RazorDirectiveCompletionSourceTest(ITestOutputHelper testOutput) : 
         var syntaxTree = CreateSyntaxTree(text, directives);
         var codeDocument = RazorCodeDocument.Create(RazorSourceDocument.Create(text, RazorSourceDocumentProperties.Default));
         codeDocument.SetSyntaxTree(syntaxTree);
-        codeDocument.SetTagHelperContext(TagHelperDocumentContext.Create(prefix: null, Enumerable.Empty<TagHelperDescriptor>()));
+        codeDocument.SetTagHelperContext(TagHelperDocumentContext.Create(prefix: null, tagHelpers: []));
         var parserMock = new StrictMock<IVisualStudioRazorParser>();
         parserMock
             .Setup(p => p.GetLatestCodeDocumentAsync(It.IsAny<ITextSnapshot>(), It.IsAny<CancellationToken>()))

--- a/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/Completion/RazorDirectiveCompletionSourceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/Completion/RazorDirectiveCompletionSourceTest.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Immutable;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;

--- a/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/Language/Legacy/TagHelperSpan/TagHelperSpanWriter.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/Language/Legacy/TagHelperSpan/TagHelperSpanWriter.cs
@@ -1,22 +1,14 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.IO;
 
 namespace Microsoft.AspNetCore.Razor.Language.Legacy;
 
-internal class TagHelperSpanWriter
+internal class TagHelperSpanWriter(TextWriter writer, RazorSyntaxTree syntaxTree)
 {
-    private readonly RazorSyntaxTree _syntaxTree;
-    private readonly TextWriter _writer;
-
-    public TagHelperSpanWriter(TextWriter writer, RazorSyntaxTree syntaxTree)
-    {
-        _writer = writer;
-        _syntaxTree = syntaxTree;
-    }
+    private readonly RazorSyntaxTree _syntaxTree = syntaxTree;
+    private readonly TextWriter _writer = writer;
 
     public virtual void Visit()
     {

--- a/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/Language/TestRazorCodeDocument.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/Language/TestRazorCodeDocument.cs
@@ -10,17 +10,17 @@ public static class TestRazorCodeDocument
     public static RazorCodeDocument CreateEmpty()
     {
         var source = TestRazorSourceDocument.Create(content: string.Empty);
-        return new RazorCodeDocument(source, imports: default);
+        return RazorCodeDocument.Create(source, imports: default);
     }
 
     public static RazorCodeDocument Create(string content, bool normalizeNewLines = false)
     {
         var source = TestRazorSourceDocument.Create(content, normalizeNewLines: normalizeNewLines);
-        return new RazorCodeDocument(source, imports: default);
+        return RazorCodeDocument.Create(source, imports: default);
     }
 
     public static RazorCodeDocument Create(RazorSourceDocument source, ImmutableArray<RazorSourceDocument> imports)
     {
-        return new RazorCodeDocument(source, imports);
+        return RazorCodeDocument.Create(source, imports);
     }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
@@ -103,6 +103,11 @@ internal static class ImmutableArrayExtensions
 
     public static ImmutableArray<T> WhereAsArray<T>(this ImmutableArray<T> source, Func<T, bool> predicate)
     {
+        if (source is [])
+        {
+            return ImmutableArray<T>.Empty;
+        }
+
         using var builder = new PooledArrayBuilder<T>();
 
         foreach (var item in source)

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
@@ -101,6 +101,21 @@ internal static class ImmutableArrayExtensions
         return builder.DrainToImmutable();
     }
 
+    public static ImmutableArray<T> WhereAsArray<T>(this ImmutableArray<T> source, Func<T, bool> predicate)
+    {
+        using var builder = new PooledArrayBuilder<T>();
+
+        foreach (var item in source)
+        {
+            if (predicate(item))
+            {
+                builder.Add(item);
+            }
+        }
+
+        return builder.DrainToImmutable();
+    }
+
     /// <summary>
     /// Executes a binary search over an array, but allows the caller to decide what constitutes a match
     /// </summary>


### PR DESCRIPTION
The changes here are mostly in the compiler, but there are also several changes across tooling. This should address https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1950355, which is a MemWatson that seems to have stared reporting with 17.9. This particular MemWatson is for excessive instances of `Dictionary<string, HashSet<TagHelperDescriptor>>+Entry[]`. The largest source of dictionaries of this share are produced by the `TagHelperBinder`.

- `TagHelperBinder..ctor(string?, ImmutableArray<TagHelperDescriptor>)` creates and populates a new `Dictionary<string, HashSet<TagHelperDescriptor>>` that is used by `TagHelperBinder.GetBinding(...)`. Both the compiler and tooling create a `TagHelperBinder` whenever needed, but I've changed this to cache a binder on `TagHelperDocumentContext`. The compiler and tooling both exclusively instantiate `TagHelperBinders` with the data from `TagHelperDocumentContext`, so it seems reasonable to cache it there. This avoids extra dictionaries being produced by tooling features like hover and completion.
- I've cleaned up the logic in `TagHelperBinder.GetBinding(...)` to use pooled data structures to avoid creating new dictionaries and lists.
- I've changed `TagHelperBinding` to no longer expose properties of type `IReadOnlyList<>` and `IReadOnlyDictionary<,>`. It now exposes `ImmutableArray<>` and `FrozenDictionary<,>` (yay!).
- I've updated `TagHelperParseTreeRewriter` to use pooled collections rather than creating scratch collections.
- I've rewritten the logic in `TagHelperParseTreeRewriter` that determines whether a child tag is allowed for a particular tag helper. This avoids a ton of linear lookups.
- Lots of logic changes to avoid boxing struct enumerators.

A couple of bonus fixes:
- The `GetContent` syntax node extension method now uses a pooled `StringBuilder` rather than creating a new one everytime it's called. Similar changes have been rolled into `GreenNode.ToString()` and `GreenNode.ToFullString()`.
- The `GreenNode.WriteTo()` method now uses a `PooledArrayBuilder` as a stack rather than new instance of `Stack<>`.
- `MarkupTagHelperElementSyntax.WithTagHelperInfo(...)` no longer creates a `List<>` to add a single annotation just to call `ToArray()` in the end.

There are a lot of changes in tests. Much of these are to respond to new nullability annotations and flowing `ImmutableArray<>` through APIs to avoid boxing.

## Compiler Benchmarks

**Note**: To make it easy on myself, I only ran these on .NET 8. Getting them to run on .NET Framework requires more effort, and improvements were already present.

``` ini

BenchmarkDotNet=v0.13.5.2136-nightly, OS=Windows 11 (10.0.26052.1000)
Intel Core i7-8700 CPU 3.20GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET SDK=8.0.101
  [Host]     : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
```

### Results on `main`:

|                                                Method |     Mean |    Error |   StdDev |   Median |      Min |      Max |     Gen0 |    Gen1 | Allocated |
|------------------------------------------------------ |---------:|---------:|---------:|---------:|---------:|---------:|---------:|--------:|----------:|
| &#39;Razor Design Time Code Generation of MSN.com&#39; | 77.93 ms | 1.502 ms | 1.788 ms | 77.86 ms | 75.16 ms | 81.70 ms |||  38.16 MB |
|     &#39;Razor Runtime Code Generation of MSN.com&#39; | 84.05 ms | 1.603 ms | 1.646 ms | 83.37 ms | 82.07 ms | 87.89 ms |||   51.3 MB |
| &#39;TagHelper Design Time Processing&#39; | 1,805.15 μs | 35.019 μs | 34.393 μs | 1,798.32 μs | 1,768.38 μs | 1,893.60 μs |||  719738 B |
|      &#39;Component Directive Parsing&#39; |    44.10 μs |  0.291 μs |  0.258 μs |    44.07 μs |    43.79 μs |    44.65 μs |||     576 B |
| &#39;Razor Design Time Syntax Tree Generation of MSN.com&#39; | 25.98 ms | 0.506 ms | 0.742 ms | 25.60 ms | 25.08 ms | 27.62 ms |  93.7500 | 31.2500 |  13.98 MB |
|     &#39;Razor Runtime Syntax Tree Generation of MSN.com&#39; | 25.84 ms | 0.478 ms | 0.587 ms | 25.62 ms | 25.28 ms | 27.11 ms | 125.0000 | 93.7500 |  13.98 MB |

### Results on `tag-helper-binding` branch:

|                                                Method |     Mean |    Error |   StdDev |   Median |      Min |      Max |     Gen0 |    Gen1 | Allocated |
|------------------------------------------------------ |---------:|---------:|---------:|---------:|---------:|---------:|---------:|--------:|----------:|
| &#39;Razor Design Time Code Generation of MSN.com&#39; | 78.67 ms | 1.527 ms | 3.860 ms | 77.93 ms | 73.32 ms | 89.63 ms |||  37.16 MB |
|     &#39;Razor Runtime Code Generation of MSN.com&#39; | 82.71 ms | 1.434 ms | 1.341 ms | 82.43 ms | 80.42 ms | 84.76 ms |||  42.99 MB |
| &#39;TagHelper Design Time Processing&#39; | 1,755.66 μs | 33.282 μs | 55.606 μs | 1,743.24 μs | 1,694.06 μs | 1,881.31 μs |||  652290 B |
|      &#39;Component Directive Parsing&#39; |    39.23 μs |  0.094 μs |  0.078 μs |    39.23 μs |    39.12 μs |    39.39 μs |||     576 B |
| &#39;Razor Design Time Syntax Tree Generation of MSN.com&#39; | 25.23 ms | 0.177 ms | 0.148 ms | 25.20 ms | 24.90 ms | 25.53 ms |  93.7500 | 31.2500 |  13.98 MB |
|     &#39;Razor Runtime Syntax Tree Generation of MSN.com&#39; | 24.91 ms | 0.336 ms | 0.280 ms | 24.81 ms | 24.67 ms | 25.68 ms | 125.0000 | 93.7500 |  13.98 MB |

## Tooling Benchmarks

**Note**: I decided to use the "Razor Completion" benchmark as representative of the change, since completion is a feature that ultimately calls into `TagHelperBinder.GetBinding(...)` via `TagHelperFacts`.

``` ini

BenchmarkDotNet=v0.13.5.2136-nightly, OS=Windows 11 (10.0.26052.1000)
Intel Core i7-8700 CPU 3.20GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET SDK=8.0.101
  [Host]     : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
  Job-OQDJZO : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
  Job-SDUUNZ : .NET Framework 4.8.1 (4.8.9181.0), X64 RyuJIT VectorSize=256

PowerPlanMode=00000000-0000-0000-0000-000000000000  

```
### Results on `main`:

|             Method |        Job |            Toolchain |       Mean |    Error |   StdDev |     Median |        Min |        Max |     Gen0 |    Gen1 |    Gen2 |  Allocated |
|------------------- |----------- |--------------------- |-----------:|---------:|---------:|-----------:|-----------:|-----------:|---------:|--------:|--------:|-----------:|
| &#39;Razor Completion&#39; | Job-LQHVDD |             .NET 8.0 |   920.9 μs | 15.56 μs | 14.55 μs |   921.4 μs |   899.3 μs |   952.6 μs |   5.8594 |  3.9063 |       - | 1012.56 KB |
| &#39;Razor Completion&#39; | Job-CPYNNW | .NET Framework 4.7.2 | 2,614.7 μs | 51.94 μs | 61.83 μs | 2,606.7 μs | 2,529.6 μs | 2,749.9 μs | 179.6875 | 66.4063 | 11.7188 | 1044.46 KB |

### Results on `tag-helper-binding` branch:

|             Method |        Job |            Toolchain |       Mean |    Error |   StdDev |     Median |        Min |        Max |     Gen0 |    Gen1 | Allocated |
|------------------- |----------- |--------------------- |-----------:|---------:|---------:|-----------:|-----------:|-----------:|---------:|--------:|----------:|
| &#39;Razor Completion&#39; | Job-OQDJZO |             .NET 8.0 |   711.1 μs | 10.48 μs |  9.81 μs |   709.4 μs |   697.6 μs |   729.3 μs |   4.8828 |  3.9063 | 781.19 KB |
| &#39;Razor Completion&#39; | Job-SDUUNZ | .NET Framework 4.7.2 | 1,959.7 μs | 25.86 μs | 40.26 μs | 1,962.0 μs | 1,885.9 μs | 2,103.1 μs | 121.0938 | 58.5938 | 763.55 KB |
