### PR TITLE
Update tooling benchmark targets

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks.csproj
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>$(DefaultNetCoreTargetFrameworks);$(DefaultNetFxTargetFramework)</TargetFrameworks>
+    <TargetFrameworks>$(DefaultNetCoreTargetFramework);$(DefaultNetFxTargetFramework)</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ServerGarbageCollection>true</ServerGarbageCollection>

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Program.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Program.cs
@@ -57,7 +57,7 @@ internal class Program
             .AddAnalyser(DefaultConfig.Instance.GetAnalysers().ToArray()) // copy default analysers
             .AddExporter(MarkdownExporter.GitHub) // export to GitHub markdown
             .AddColumnProvider(DefaultColumnProviders.Instance) // display default columns (method name, args etc)
-            .AddJob(GetJob(CsProjCoreToolchain.NetCoreApp70)) // tell BDN that these are our default settings
+            .AddJob(GetJob(CsProjCoreToolchain.NetCoreApp80)) // tell BDN that these are our default settings
             .AddJob(GetJob(CsProjClassicNetToolchain.Net472))
             .AddDiagnoser(MemoryDiagnoser.Default)
             .AddExporter(JsonExporter.Full)


### PR DESCRIPTION
The tooling benchmarks were still using `net7.0` as a target and also compiling with `net7.0`. This change ensures that benchmarks only run and compile on `net8.0` and `net4.2`.