### PR TITLE
Add TagHelperCompletionBenchmark

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/TagHelperCompletionBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/TagHelperCompletionBenchmark.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using BenchmarkDotNet.Attributes;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.Completion;
+using Microsoft.CodeAnalysis.Razor.Completion;
+using Microsoft.VisualStudio.Editor.Razor;
+
+namespace Microsoft.AspNetCore.Razor.Microbenchmarks.LanguageServer;
+
+public class TagHelperCompletionBenchmark
+{
+    // These were gleaned by creating a Blazor Server app, opening Counter.razor, typing a '<' in the editor,
+    // and breaking into LspTagHelperCompletionService.GetElementCompletions(...) in the debugger.
+    private static readonly string[] s_existingElementCompletions =
+    [
+        "html", "head", "title", "base", "link", "meta", "style", "script", "noscript", "body", "section", "nav", "article", "aside",
+        "h1", "h2", "h3", "h4", "h5", "h6", "header", "footer", "address", "p", "br", "pre", "dialog", "blockquote", "ol", "ul", "li",
+        "dl", "dt", "dd", "a", "em", "strong", "small", "cite", "bdi", "q", "dfn", "abbr", "code", "var", "samp", "kbd", "sub", "sup",
+        "i", "b", "u", "s", "mark", "progress", "meter", "time", "ruby", "rtc", "rt", "rp", "bdo", "span", "ins", "del", "figure",
+        "img", "iframe", "embed", "object", "param", "details", "summary", "command", "menu", "menuitem", "legend", "div", "main",
+        "template", "polymer-element", "ng-form", "ng-include", "ng-pluralize", "ng-switch", "ng-view", "source", "track", "audio",
+        "video", "picture", "hr", "wbr", "form", "fieldset", "label", "input", "button", "select", "datalist", "optgroup", "option",
+        "textarea", "keygen", "output", "canvas", "map", "area", "math", "svg", "table", "caption", "colgroup", "col", "thead", "tfoot",
+        "tbody", "tr", "th", "td", "content", "shadow"
+    ];
+
+    [Benchmark]
+    public object GetAttributeCompletions()
+    {
+        var tagHelperCompletionService = new LspTagHelperCompletionService();
+        var context = new AttributeCompletionContext(
+            TagHelperDocumentContext.Create(prefix: null, CommonResources.TelerikTagHelpers),
+            existingCompletions: [],
+            currentTagName: "PageTitle",
+            currentAttributeName: null,
+            attributes: [],
+            currentParentTagName: "PageTitle",
+            currentParentIsTagHelper: true,
+            inHTMLSchema: HtmlFacts.IsHtmlTagName);
+
+        return tagHelperCompletionService.GetAttributeCompletions(context);
+    }
+
+    [Benchmark]
+    public object GetElementCompletions()
+    {
+        var tagHelperCompletionService = new LspTagHelperCompletionService();
+        var context = new ElementCompletionContext(
+            TagHelperDocumentContext.Create(prefix: null, CommonResources.TelerikTagHelpers),
+            existingCompletions: s_existingElementCompletions,
+            containingTagName: null,
+            attributes: [],
+            containingParentTagName: null,
+            containingParentIsTagHelper: false,
+            inHTMLSchema: HtmlFacts.IsHtmlTagName);
+
+        return tagHelperCompletionService.GetElementCompletions(context);
+    }
+}


### PR DESCRIPTION
This is a simple change to add a benchmark specifically for TagHelper completion. The results on my machine look like so:

``` ini

BenchmarkDotNet=v0.13.5.2136-nightly, OS=Windows 11 (10.0.26058.1000)
Intel Core i7-8700 CPU 3.20GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
.NET SDK=8.0.101
  [Host]     : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
  Job-LANPFL : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
  Job-XNVIXV : .NET Framework 4.8.1 (4.8.9181.0), X64 RyuJIT VectorSize=256

PowerPlanMode=00000000-0000-0000-0000-000000000000  

```
|                  Method |        Job |            Toolchain |     Mean |   Error |  StdDev |   Median |      Min |      Max |    Gen0 |    Gen1 | Allocated |
|------------------------ |----------- |--------------------- |---------:|--------:|--------:|---------:|---------:|---------:|--------:|--------:|----------:|
| GetAttributeCompletions | Job-LANPFL |             .NET 8.0 | 302.5 μs | 3.29 μs | 3.08 μs | 303.1 μs | 298.2 μs | 307.7 μs |  3.4180 |  0.4883 |  329.8 KB |
|   GetElementCompletions | Job-LANPFL |             .NET 8.0 | 230.2 μs | 1.40 μs | 1.24 μs | 230.6 μs | 227.5 μs | 231.7 μs |  0.7324 |       - |  81.75 KB |
| GetAttributeCompletions | Job-XNVIXV | .NET Framework 4.7.2 | 530.7 μs | 3.88 μs | 3.63 μs | 530.3 μs | 524.8 μs | 537.6 μs | 53.7109 | 17.5781 | 330.69 KB |
|   GetElementCompletions | Job-XNVIXV | .NET Framework 4.7.2 | 451.8 μs | 5.15 μs | 4.82 μs | 449.8 μs | 446.1 μs | 461.6 μs | 13.1836 |  1.4648 |  82.01 KB |