### PR TITLE
Copied aspnetcorerazor.tmLanguage.json from dotnet/vscode-csharp

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.json
@@ -525,6 +525,15 @@
         },
         {
           "include": "#using-directive"
+        },
+        {
+          "include": "#rendermode-directive"
+        },
+        {
+          "include": "#preservewhitespace-directive"
+        },
+        {
+          "include": "#typeparam-directive"
         }
       ]
     },
@@ -846,6 +855,75 @@
         },
         "4": {
           "name": "entity.name.variable.property.cs"
+        }
+      }
+    },
+    "rendermode-directive": {
+      "name": "meta.directive",
+      "match": "(@)(rendermode)\\s+([^$]+)?",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.control.razor.directive.rendermode"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "source.cs#type"
+            }
+          ]
+        }
+      }
+    },
+    "preservewhitespace-directive": {
+      "name": "meta.directive",
+      "match": "(@)(preservewhitespace)\\s+([^$]+)?",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.control.razor.directive.preservewhitespace"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "source.cs#boolean-literal"
+            }
+          ]
+        }
+      }
+    },
+    "typeparam-directive": {
+      "name": "meta.directive",
+      "match": "(@)(typeparam)\\s+([^$]+)?",
+      "captures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "#transition"
+            }
+          ]
+        },
+        "2": {
+          "name": "keyword.control.razor.directive.typeparam"
+        },
+        "3": {
+          "patterns": [
+            {
+              "include": "source.cs#type"
+            }
+          ]
         }
       }
     },


### PR DESCRIPTION
This pull request fixes #9882, where Textmate did not support the newly added directives: rendermode, preservewhitespace, and typeparam. The TextMate grammar for Razor is located in the dotnet/vscode-csharp repository, and a separate pull request (dotnet/vscode-csharp#6887) has been submitted with the fix and tests.

## Summary of the changes

The Razor tmLanguage.json file was copied from the vscode-csharp repository to reflect the latest changes, including the addition of grammar support for rendermode, preservewhitespace, and typeparam.


## Fixes:

The lack of coloring for the new directives using TextMate.

### Before
<img width="355" alt="before_visual_studio" src="https://github.com/dotnet/razor/assets/17770319/a21a1a6b-a707-40d0-8e6f-1b003e31ea23">

### After
<img width="377" alt="after_visual_studio" src="https://github.com/dotnet/razor/assets/17770319/ca3f057a-7968-4fba-bc1b-33e696f45f46">

