### PR TITLE
We need to use full type name in the check

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshotExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshotExtensions.cs
@@ -41,7 +41,7 @@ internal static class IProjectSnapshotExtensions
     public static ImmutableArray<TagHelperDescriptor> GetTagHelpersSynchronously(this IProjectSnapshot projectSnapshot)
     {
         var canResolveTagHelpersSynchronously = projectSnapshot is ProjectSnapshot ||
-            projectSnapshot.GetType().Name == "Microsoft.VisualStudio.LegacyEditor.Razor.EphemeralProjectSnapshot";
+            projectSnapshot.GetType().FullName == "Microsoft.VisualStudio.LegacyEditor.Razor.EphemeralProjectSnapshot";
 
         Debug.Assert(canResolveTagHelpersSynchronously, "The ProjectSnapshot in the VisualStudioDocumentTracker should not be a cohosted project.");
         var tagHelperTask = projectSnapshot.GetTagHelpersAsync(CancellationToken.None);


### PR DESCRIPTION
﻿### Summary of the changes

Since we are comparing project snapshot type name with full type name string, we should use FullName instead of just Name

Fixes:

I was hitting this assert after re-opening a project (with a Razor page previously open, legacy editor enabled)

<img width="1703" alt="image" src="https://github.com/dotnet/razor/assets/1863656/9f5cd97b-4653-4a55-8d24-5ecb2fb6d763">

Not sure if it was causing any intermittent tag helper discovery issues or just the noisy assert.