### PR TITLE
Fix directive completion at EOF (last line of file)

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionFactsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionFactsService.cs
@@ -71,8 +71,11 @@ internal class RazorCompletionFactsService : IRazorCompletionFactsService
         // node that FindInnermostNode will return is not the request index, so we won't end up walking that back.
         // If we ever move to roslyn-style trivia, where whitespace is attached to the token, we can remove this, and simply check
         // to see whether the absolute index is in the Span of the node in the relevant providers.
+        // Note - this also addresses directives, including with cursor at EOF, e.g. @fun|
         if (originalNode.SpanStart == requestIndex
-            && originalNode.GetFirstToken() is { } startToken
+            // allow zero-length tokens for cases when cursor is at EOF,
+            // e.g. see https://developercommunity.visualstudio.com/t/Razor-directive-completions-missing-at-t/10585436
+            && originalNode.GetFirstToken(includeZeroWidth: true) is { } startToken
             && startToken.GetPreviousToken() is { } previousToken)
         {
             Debug.Assert(previousToken.Span.End == requestIndex);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionFactsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionFactsService.cs
@@ -74,7 +74,7 @@ internal class RazorCompletionFactsService : IRazorCompletionFactsService
         // Note - this also addresses directives, including with cursor at EOF, e.g. @fun|
         if (originalNode.SpanStart == requestIndex
             // allow zero-length tokens for cases when cursor is at EOF,
-            // e.g. see https://developercommunity.visualstudio.com/t/Razor-directive-completions-missing-at-t/10585436
+            // e.g. see https://github.com/dotnet/razor/issues/9955
             && originalNode.GetFirstToken(includeZeroWidth: true) is { } startToken
             && startToken.GetPreviousToken() is { } previousToken)
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionListProvierTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionListProvierTest.cs
@@ -358,6 +358,7 @@ public class RazorCompletionListProvierTest : LanguageServerTestBase
     [InlineData("@page\r\n<div></div>\r\n@f$$")]
     [InlineData("@page\r\n<div></div>\r\n@f$$\r\n")]
     [WorkItem("https://github.com/dotnet/razor-tooling/issues/4547")]
+    [WorkItem("https://github.com/dotnet/razor/issues/9955")]    
     public async Task GetCompletionListAsync_ProvidesDirectiveCompletionItems(string documentText)
     {
         // Arrange


### PR DESCRIPTION
The issue here was that FindInnerMostNode returns empty MarkupLiteral node (containing only a marker) and AdjustSyntaxNodeForWordBoundary wasn't working for zero-length tokens in originalNode. Changing the code to allow it seems to fix things.

﻿### Summary of the changes

-Allow adjustment of the originalNode including cases when it contains zero-length tokens only. That fixes the case where cursor is at the very end of the file, e.g. in the image below "functions" was missing

![image](https://github.com/dotnet/razor/assets/1863656/34699c6a-6e70-44eb-bdd6-dc935a99d6c9)

Fixes:

https://developercommunity.visualstudio.com/t/Razor-directive-completions-missing-at-t/10585436
https://github.com/dotnet/razor/issues/9955