### PR TITLE
Remove name hack from Razor.Test.Common.Tooling

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Microsoft.AspNetCore.Razor.Test.Common.Tooling.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Microsoft.AspNetCore.Razor.Test.Common.Tooling.csproj
@@ -6,10 +6,6 @@
 
     <RootNamespace>Microsoft.AspNetCore.Razor.Test.Common</RootNamespace>
 
-    <!-- This is a temporary measure because Microsoft.CodeAnalysis.ExternalAccess.Razor does not yet provide IVT to
-         Microsoft.AspNetCore.Razor.Test.Common.Tooling. However, it *does* provide IVT to this assembly name. -->
-    <AssemblyName>Microsoft.AspNetCore.Razor.LanguageServer.Test.Common</AssemblyName>
-
     <!-- To generate baselines, run tests with /p:GenerateBaselines=true -->
     <DefineConstants Condition="'$(GenerateBaselines)'=='true'">$(DefineConstants);GENERATE_BASELINES</DefineConstants>
     <DefineConstants>$(DefineConstants);__RemoveThisBitTo__GENERATE_BASELINES</DefineConstants>


### PR DESCRIPTION
Awhile back, I'd made Common.Tooling compile to a different assembly name that Roslyn's Razor EA assembly provided IVT to. Awhile back, we updated to a newer Roslyn that fixed the IVT, so this hack can be removed.