### PR TITLE
Add feature flag for fuse

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/PublicAPI.Unshipped.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/PublicAPI.Unshipped.txt
@@ -17,7 +17,7 @@ abstract Microsoft.AspNetCore.Razor.Language.MetadataCollection.Keys.get -> Syst
 abstract Microsoft.AspNetCore.Razor.Language.MetadataCollection.this[string! key].get -> string?
 abstract Microsoft.AspNetCore.Razor.Language.MetadataCollection.TryGetValue(string! key, out string? value) -> bool
 abstract Microsoft.AspNetCore.Razor.Language.MetadataCollection.Values.get -> System.Collections.Generic.IEnumerable<string?>!
-abstract Microsoft.AspNetCore.Razor.Language.RazorConfiguration.SuppressDesignTime.get -> bool
+abstract Microsoft.AspNetCore.Razor.Language.RazorConfiguration.ForceRuntimeCodeGeneration.get -> bool
 abstract Microsoft.AspNetCore.Razor.Language.RazorSourceDocumentProperties.FilePath.get -> string?
 abstract Microsoft.AspNetCore.Razor.Language.RazorSourceDocumentProperties.RelativePath.get -> string?
 abstract Microsoft.AspNetCore.Razor.Language.TagHelperCollector<T>.Collect(Microsoft.CodeAnalysis.ISymbol! symbol, System.Collections.Generic.ICollection<Microsoft.AspNetCore.Razor.Language.TagHelperDescriptor!>! results) -> void

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorConfiguration.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorConfiguration.cs
@@ -52,7 +52,7 @@ public abstract class RazorConfiguration : IEquatable<RazorConfiguration>
 
     public abstract bool UseConsolidatedMvcViews { get; }
 
-    public abstract bool SuppressDesignTime { get; }
+    public abstract bool ForceRuntimeCodeGeneration { get; }
 
     internal RazorConfiguration WithVersion(RazorLanguageVersion version)
     {
@@ -91,7 +91,7 @@ public abstract class RazorConfiguration : IEquatable<RazorConfiguration>
             return false;
         }
 
-        if (SuppressDesignTime != other.SuppressDesignTime)
+        if (ForceRuntimeCodeGeneration != other.ForceRuntimeCodeGeneration)
         {
             return false;
         }
@@ -112,7 +112,7 @@ public abstract class RazorConfiguration : IEquatable<RazorConfiguration>
         var hash = HashCodeCombiner.Start();
         hash.Add(LanguageVersion);
         hash.Add(ConfigurationName);
-        hash.Add(SuppressDesignTime);
+        hash.Add(ForceRuntimeCodeGeneration);
 
         for (var i = 0; i < Extensions.Count; i++)
         {
@@ -135,7 +135,7 @@ public abstract class RazorConfiguration : IEquatable<RazorConfiguration>
             ConfigurationName = configurationName;
             Extensions = extensions;
             UseConsolidatedMvcViews = useConsolidatedMvcViews;
-            SuppressDesignTime = suppressDesignTime;
+            ForceRuntimeCodeGeneration = suppressDesignTime;
         }
 
         public override string ConfigurationName { get; }
@@ -146,6 +146,6 @@ public abstract class RazorConfiguration : IEquatable<RazorConfiguration>
 
         public override bool UseConsolidatedMvcViews { get; }
 
-        public override bool SuppressDesignTime { get; }
+        public override bool ForceRuntimeCodeGeneration { get; }
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorProjectEngine.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/src/RazorProjectEngine.cs
@@ -109,7 +109,7 @@ public class RazorProjectEngine
             throw new ArgumentNullException(nameof(projectItem));
         }
 
-        var codeDocument = Configuration.SuppressDesignTime
+        var codeDocument = Configuration.ForceRuntimeCodeGeneration
             ? CreateCodeDocumentCore(projectItem)
             : CreateCodeDocumentDesignTimeCore(projectItem);
         ProcessCore(codeDocument);
@@ -127,7 +127,7 @@ public class RazorProjectEngine
             throw new ArgumentNullException(nameof(source));
         }
 
-        var codeDocument = Configuration.SuppressDesignTime
+        var codeDocument = Configuration.ForceRuntimeCodeGeneration
             ? CreateCodeDocumentCore(source, fileKind, importSources, tagHelpers, configureParser: null, configureCodeGeneration: null)
             : CreateCodeDocumentDesignTimeCore(source, fileKind, importSources, tagHelpers, configureParser: null, configureCodeGeneration: null);
         ProcessCore(codeDocument);

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Resources/project.razor.json
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Resources/project.razor.json
@@ -1,5 +1,5 @@
 {
-  "__Version": 3,
+  "__Version": 4,
   "SerializedFilePath": "C:\\Users\\admin\\location\\blazorserver\\obj\\Debug\\net7.0\\project.razor.json",
   "FilePath": "C:\\Users\\admin\\location\\blazorserver\\blazorserver.csproj",
   "Configuration": {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ConfigurableLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ConfigurableLanguageServerFeatureOptions.cs
@@ -25,7 +25,7 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
     private readonly bool? _monitorWorkspaceFolderForConfigurationFiles;
     private readonly bool? _useRazorCohostServer;
     private readonly bool? _disableRazorLanguageServer;
-    private readonly bool? _enableFuse;
+    private readonly bool? _forceRuntimeCodeGeneration;
 
     public override bool SupportsFileManipulation => _supportsFileManipulation ?? _defaults.SupportsFileManipulation;
     public override string ProjectConfigurationFileName => _projectConfigurationFileName ?? _defaults.ProjectConfigurationFileName;
@@ -42,7 +42,7 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
     public override bool MonitorWorkspaceFolderForConfigurationFiles => _monitorWorkspaceFolderForConfigurationFiles ?? _defaults.MonitorWorkspaceFolderForConfigurationFiles;
     public override bool UseRazorCohostServer => _useRazorCohostServer ?? _defaults.UseRazorCohostServer;
     public override bool DisableRazorLanguageServer => _disableRazorLanguageServer ?? _defaults.DisableRazorLanguageServer;
-    public override bool EnableFuse => _enableFuse ?? _defaults.EnableFuse;
+    public override bool ForceRuntimeCodeGeneration => _forceRuntimeCodeGeneration ?? _defaults.ForceRuntimeCodeGeneration;
 
     public ConfigurableLanguageServerFeatureOptions(string[] args)
     {
@@ -68,7 +68,7 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
             TryProcessBoolOption(nameof(MonitorWorkspaceFolderForConfigurationFiles), ref _monitorWorkspaceFolderForConfigurationFiles, option, args, i);
             TryProcessBoolOption(nameof(UseRazorCohostServer), ref _useRazorCohostServer, option, args, i);
             TryProcessBoolOption(nameof(DisableRazorLanguageServer), ref _disableRazorLanguageServer, option, args, i);
-            TryProcessBoolOption(nameof(EnableFuse), ref _enableFuse, option, args, i);
+            TryProcessBoolOption(nameof(ForceRuntimeCodeGeneration), ref _forceRuntimeCodeGeneration, option, args, i);
         }
     }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ConfigurableLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ConfigurableLanguageServerFeatureOptions.cs
@@ -25,6 +25,7 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
     private readonly bool? _monitorWorkspaceFolderForConfigurationFiles;
     private readonly bool? _useRazorCohostServer;
     private readonly bool? _disableRazorLanguageServer;
+    private readonly bool? _enableFuse;
 
     public override bool SupportsFileManipulation => _supportsFileManipulation ?? _defaults.SupportsFileManipulation;
     public override string ProjectConfigurationFileName => _projectConfigurationFileName ?? _defaults.ProjectConfigurationFileName;
@@ -41,6 +42,7 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
     public override bool MonitorWorkspaceFolderForConfigurationFiles => _monitorWorkspaceFolderForConfigurationFiles ?? _defaults.MonitorWorkspaceFolderForConfigurationFiles;
     public override bool UseRazorCohostServer => _useRazorCohostServer ?? _defaults.UseRazorCohostServer;
     public override bool DisableRazorLanguageServer => _disableRazorLanguageServer ?? _defaults.DisableRazorLanguageServer;
+    public override bool EnableFuse => _enableFuse ?? _defaults.EnableFuse;
 
     public ConfigurableLanguageServerFeatureOptions(string[] args)
     {
@@ -66,6 +68,7 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
             TryProcessBoolOption(nameof(MonitorWorkspaceFolderForConfigurationFiles), ref _monitorWorkspaceFolderForConfigurationFiles, option, args, i);
             TryProcessBoolOption(nameof(UseRazorCohostServer), ref _useRazorCohostServer, option, args, i);
             TryProcessBoolOption(nameof(DisableRazorLanguageServer), ref _disableRazorLanguageServer, option, args, i);
+            TryProcessBoolOption(nameof(EnableFuse), ref _enableFuse, option, args, i);
         }
     }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
@@ -44,4 +44,6 @@ internal class DefaultLanguageServerFeatureOptions : LanguageServerFeatureOption
     public override bool UseRazorCohostServer => false;
 
     public override bool DisableRazorLanguageServer => false;
+
+    public override bool EnableFuse => false;
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
@@ -45,5 +45,5 @@ internal class DefaultLanguageServerFeatureOptions : LanguageServerFeatureOption
 
     public override bool DisableRazorLanguageServer => false;
 
-    public override bool EnableFuse => false;
+    public override bool ForceRuntimeCodeGeneration => false;
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/Json/ObjectReaders.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/Json/ObjectReaders.cs
@@ -41,6 +41,7 @@ internal static partial class ObjectReaders
     {
         var configurationName = reader.ReadNonNullString(nameof(RazorConfiguration.ConfigurationName));
         var languageVersionText = reader.ReadNonNullString(nameof(RazorConfiguration.LanguageVersion));
+        var suppressDesignTime = reader.ReadBooleanOrFalse(nameof(RazorConfiguration.SuppressDesignTime));
         var extensions = reader.ReadArrayOrEmpty(nameof(RazorConfiguration.Extensions),
             static r =>
             {
@@ -52,7 +53,7 @@ internal static partial class ObjectReaders
             ? version
             : RazorLanguageVersion.Version_2_1;
 
-        return RazorConfiguration.Create(languageVersion, configurationName, extensions);
+        return RazorConfiguration.Create(languageVersion, configurationName, extensions, suppressDesignTime: suppressDesignTime);
     }
 
     public static RazorDiagnostic ReadDiagnostic(JsonDataReader reader)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/Json/ObjectReaders.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/Json/ObjectReaders.cs
@@ -41,7 +41,7 @@ internal static partial class ObjectReaders
     {
         var configurationName = reader.ReadNonNullString(nameof(RazorConfiguration.ConfigurationName));
         var languageVersionText = reader.ReadNonNullString(nameof(RazorConfiguration.LanguageVersion));
-        var suppressDesignTime = reader.ReadBooleanOrFalse(nameof(RazorConfiguration.SuppressDesignTime));
+        var suppressDesignTime = reader.ReadBooleanOrFalse(nameof(RazorConfiguration.ForceRuntimeCodeGeneration));
         var extensions = reader.ReadArrayOrEmpty(nameof(RazorConfiguration.Extensions),
             static r =>
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/Json/ObjectWriters.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/Json/ObjectWriters.cs
@@ -34,7 +34,7 @@ internal static class ObjectWriters
             : value.LanguageVersion.ToString();
 
         writer.Write(nameof(value.LanguageVersion), languageVersionText);
-        writer.Write(nameof(value.SuppressDesignTime), value.SuppressDesignTime);
+        writer.Write(nameof(value.ForceRuntimeCodeGeneration), value.ForceRuntimeCodeGeneration);
 
         writer.WriteArrayIfNotNullOrEmpty(nameof(value.Extensions), value.Extensions, static (w, v) => w.Write(v.ExtensionName));
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/Json/ObjectWriters.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/Json/ObjectWriters.cs
@@ -34,6 +34,7 @@ internal static class ObjectWriters
             : value.LanguageVersion.ToString();
 
         writer.Write(nameof(value.LanguageVersion), languageVersionText);
+        writer.Write(nameof(value.SuppressDesignTime), value.SuppressDesignTime);
 
         writer.WriteArrayIfNotNullOrEmpty(nameof(value.Extensions), value.Extensions, static (w, v) => w.Write(v.ExtensionName));
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/Json/SerializationFormat.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/Json/SerializationFormat.cs
@@ -9,5 +9,5 @@ internal static class SerializationFormat
     // or any of the types that compose it changes. This includes: RazorConfiguration,
     // ProjectWorkspaceState, TagHelperDescriptor, and DocumentSnapshotHandle.
     // NOTE: If this version is changed, a coordinated insertion is required between Roslyn and Razor for the C# extension.
-    public const int Version = 3;
+    public const int Version = 4;
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/RazorConfigurationFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/RazorConfigurationFormatter.cs
@@ -21,8 +21,9 @@ internal sealed class RazorConfigurationFormatter : ValueFormatter<RazorConfigur
 
         var configurationName = CachedStringFormatter.Instance.Deserialize(ref reader, options);
         var languageVersionText = CachedStringFormatter.Instance.Deserialize(ref reader, options);
+        var suppressDesignTime = reader.ReadBoolean();
 
-        count -= 2;
+        count -= 3;
 
         using var builder = new PooledArrayBuilder<RazorExtension>();
 
@@ -38,15 +39,14 @@ internal sealed class RazorConfigurationFormatter : ValueFormatter<RazorConfigur
             ? version
             : RazorLanguageVersion.Version_2_1;
 
-        // TODO: right now we hardcode the suppress design time flag, we need to thread it through a feature flag at a later date
-        return RazorConfiguration.Create(languageVersion, configurationName, extensions, suppressDesignTime: true);
+        return RazorConfiguration.Create(languageVersion, configurationName, extensions, suppressDesignTime: suppressDesignTime);
     }
 
     public override void Serialize(ref MessagePackWriter writer, RazorConfiguration value, SerializerCachingOptions options)
     {
         // Write two values + one value per extension.
         var extensions = value.Extensions;
-        var count = extensions.Count + 2;
+        var count = extensions.Count + 3;
 
         writer.WriteArrayHeader(count);
 
@@ -61,7 +61,9 @@ internal sealed class RazorConfigurationFormatter : ValueFormatter<RazorConfigur
             CachedStringFormatter.Instance.Serialize(ref writer, value.LanguageVersion.ToString(), options);
         }
 
-        count -= 2;
+        writer.Write(value.SuppressDesignTime);
+
+        count -= 3;
 
         for (var i = 0; i < count; i++)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/RazorConfigurationFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/RazorConfigurationFormatter.cs
@@ -61,7 +61,7 @@ internal sealed class RazorConfigurationFormatter : ValueFormatter<RazorConfigur
             CachedStringFormatter.Instance.Serialize(ref writer, value.LanguageVersion.ToString(), options);
         }
 
-        writer.Write(value.SuppressDesignTime);
+        writer.Write(value.ForceRuntimeCodeGeneration);
 
         count -= 3;
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
@@ -49,8 +49,7 @@ internal abstract class LanguageServerFeatureOptions
     public abstract bool DisableRazorLanguageServer { get; }
 
     /// <summary>
-    /// Whether the "fuse" feature of razor is enabled, which uses the runtime output of razor in the IDE
-    /// instead of the design time output.
+    /// When enabled, design time code will not be generated. All tooling will be using runtime code generation.
     /// </summary>
-    public abstract bool EnableFuse { get; }
+    public abstract bool ForceRuntimeCodeGeneration { get; }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
@@ -47,4 +47,10 @@ internal abstract class LanguageServerFeatureOptions
     public abstract bool UseRazorCohostServer { get; }
 
     public abstract bool DisableRazorLanguageServer { get; }
+
+    /// <summary>
+    /// Whether the "fuse" feature of razor is enabled, which uses the runtime output of razor in the IDE
+    /// instead of the design time output.
+    /// </summary>
+    public abstract bool EnableFuse { get; }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/FallbackRazorConfiguration.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/FallbackRazorConfiguration.cs
@@ -104,7 +104,7 @@ internal class FallbackRazorConfiguration : RazorConfiguration
         ConfigurationName = configurationName;
         Extensions = extensions;
         UseConsolidatedMvcViews = useConsolidatedMvcViews;
-        SuppressDesignTime = suppressDesignTime;
+        ForceRuntimeCodeGeneration = suppressDesignTime;
     }
 
     public override string ConfigurationName { get; }
@@ -115,5 +115,5 @@ internal class FallbackRazorConfiguration : RazorConfiguration
 
     public override bool UseConsolidatedMvcViews { get; }
 
-    public override bool SuppressDesignTime { get; }
+    public override bool ForceRuntimeCodeGeneration { get; }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSystemRazorConfiguration.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSystemRazorConfiguration.cs
@@ -13,7 +13,7 @@ internal class ProjectSystemRazorConfiguration : RazorConfiguration
     public override IReadOnlyList<RazorExtension> Extensions { get; }
     public override RazorLanguageVersion LanguageVersion { get; }
     public override bool UseConsolidatedMvcViews { get; }
-    public override bool SuppressDesignTime { get; }
+    public override bool ForceRuntimeCodeGeneration { get; }
 
     public ProjectSystemRazorConfiguration(
         RazorLanguageVersion languageVersion,
@@ -26,6 +26,6 @@ internal class ProjectSystemRazorConfiguration : RazorConfiguration
         ConfigurationName = configurationName ?? throw new ArgumentNullException(nameof(configurationName));
         Extensions = extensions ?? throw new ArgumentNullException(nameof(extensions));
         UseConsolidatedMvcViews = useConsolidatedMvcViews;
-        SuppressDesignTime = suppressDesignTime;
+        ForceRuntimeCodeGeneration = suppressDesignTime;
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSystemRazorConfiguration.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSystemRazorConfiguration.cs
@@ -19,9 +19,8 @@ internal class ProjectSystemRazorConfiguration : RazorConfiguration
         RazorLanguageVersion languageVersion,
         string configurationName,
         RazorExtension[] extensions,
-        bool useConsolidatedMvcViews = false,
-        // TODO: right now we hardcode the suppress design time flag, we need to thread it through a feature flag at a later date
-        bool suppressDesignTime = true)  
+        bool suppressDesignTime,  
+        bool useConsolidatedMvcViews = false)
     {
         LanguageVersion = languageVersion ?? throw new ArgumentNullException(nameof(languageVersion));
         ConfigurationName = configurationName ?? throw new ArgumentNullException(nameof(configurationName));

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
@@ -66,7 +66,7 @@ internal class DefaultWindowsRazorProjectHost : WindowsRazorProjectHostBase
 
     protected override async Task HandleProjectChangeAsync(string sliceDimensions, IProjectVersionedValue<IProjectSubscriptionUpdate> update)
     {
-        if (TryGetConfiguration(update.Value.CurrentState, _languageServerFeatureOptions.EnableFuse, out var configuration) &&
+        if (TryGetConfiguration(update.Value.CurrentState, _languageServerFeatureOptions.ForceRuntimeCodeGeneration, out var configuration) &&
             TryGetIntermediateOutputPath(update.Value.CurrentState, out var intermediatePath))
         {
             TryGetRootNamespace(update.Value.CurrentState, out var rootNamespace);
@@ -128,7 +128,7 @@ internal class DefaultWindowsRazorProjectHost : WindowsRazorProjectHostBase
     // Internal for testing
     internal static bool TryGetConfiguration(
         IImmutableDictionary<string, IProjectRuleSnapshot> state,
-        bool? suppressDesignTime,
+        bool suppressDesignTime,
         [NotNullWhen(returnValue: true)] out RazorConfiguration? configuration)
     {
         if (!TryGetDefaultConfiguration(state, out var defaultConfiguration))
@@ -156,8 +156,7 @@ internal class DefaultWindowsRazorProjectHost : WindowsRazorProjectHostBase
             return false;
         }
 
-        suppressDesignTime ??= false;
-        configuration = new ProjectSystemRazorConfiguration(languageVersion, configurationItem.Key, extensions, suppressDesignTime: suppressDesignTime.Value);
+        configuration = new ProjectSystemRazorConfiguration(languageVersion, configurationItem.Key, extensions, suppressDesignTime);
         return true;
     }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
@@ -50,16 +50,16 @@ internal class DefaultWindowsRazorProjectHost : WindowsRazorProjectHostBase
     }
 
     // Internal for testing
-#pragma warning disable CS8618 // Non-nullable variable must contain a non-null value when exiting constructor. Consider declaring it as nullable.
     internal DefaultWindowsRazorProjectHost(
-#pragma warning restore CS8618 // Non-nullable variable must contain a non-null value when exiting constructor. Consider declaring it as nullable.
         IUnconfiguredProjectCommonServices commonServices,
         Workspace workspace,
         ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,
         ProjectConfigurationFilePathStore projectConfigurationFilePathStore,
-        ProjectSnapshotManagerBase projectManager)
+        ProjectSnapshotManagerBase projectManager,
+        LanguageServerFeatureOptions languageServerFeatureOptions)
         : base(commonServices, workspace, projectSnapshotManagerDispatcher, projectConfigurationFilePathStore, projectManager)
     {
+        _languageServerFeatureOptions = languageServerFeatureOptions;
     }
 
     protected override ImmutableHashSet<string> GetRuleNames() => s_ruleNames;
@@ -90,11 +90,8 @@ internal class DefaultWindowsRazorProjectHost : WindowsRazorProjectHostBase
 
                 var hostProject = new HostProject(CommonServices.UnconfiguredProject.FullPath, intermediatePath, configuration, rootNamespace, displayName);
 
-                if (_languageServerFeatureOptions is not null)
-                {
-                    var projectConfigurationFile = Path.Combine(intermediatePath, _languageServerFeatureOptions.ProjectConfigurationFileName);
-                    ProjectConfigurationFilePathStore.Set(hostProject.Key, projectConfigurationFile);
-                }
+                var projectConfigurationFile = Path.Combine(intermediatePath, _languageServerFeatureOptions.ProjectConfigurationFileName);
+                ProjectConfigurationFilePathStore.Set(hostProject.Key, projectConfigurationFile);
 
                 UpdateProjectUnsafe(hostProject);
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
@@ -66,7 +66,7 @@ internal class DefaultWindowsRazorProjectHost : WindowsRazorProjectHostBase
 
     protected override async Task HandleProjectChangeAsync(string sliceDimensions, IProjectVersionedValue<IProjectSubscriptionUpdate> update)
     {
-        if (TryGetConfiguration(update.Value.CurrentState, out var configuration) &&
+        if (TryGetConfiguration(update.Value.CurrentState, _languageServerFeatureOptions.EnableFuse, out var configuration) &&
             TryGetIntermediateOutputPath(update.Value.CurrentState, out var intermediatePath))
         {
             TryGetRootNamespace(update.Value.CurrentState, out var rootNamespace);
@@ -128,6 +128,7 @@ internal class DefaultWindowsRazorProjectHost : WindowsRazorProjectHostBase
     // Internal for testing
     internal static bool TryGetConfiguration(
         IImmutableDictionary<string, IProjectRuleSnapshot> state,
+        bool? suppressDesignTime,
         [NotNullWhen(returnValue: true)] out RazorConfiguration? configuration)
     {
         if (!TryGetDefaultConfiguration(state, out var defaultConfiguration))
@@ -155,7 +156,8 @@ internal class DefaultWindowsRazorProjectHost : WindowsRazorProjectHostBase
             return false;
         }
 
-        configuration = new ProjectSystemRazorConfiguration(languageVersion, configurationItem.Key, extensions);
+        suppressDesignTime ??= false;
+        configuration = new ProjectSystemRazorConfiguration(languageVersion, configurationItem.Key, extensions, suppressDesignTime: suppressDesignTime.Value);
         return true;
     }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
@@ -17,7 +17,7 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
     private const string UsePreciseSemanticTokenRangesFeatureFlag = "Razor.LSP.UsePreciseSemanticTokenRanges";
     private const string UseRazorCohostServerFeatureFlag = "Razor.LSP.UseRazorCohostServer";
     private const string DisableRazorLanguageServerFeatureFlag = "Razor.LSP.DisableRazorLanguageServer";
-    private const string EnableFuseFeatureFlag = "Razor.LSP.EnableFuse";
+    private const string ForceRuntimeCodeGenerationFeatureFlag = "Razor.LSP.ForceRuntimeCodeGeneration";
 
     private readonly LSPEditorFeatureDetector _lspEditorFeatureDetector;
     private readonly Lazy<bool> _showAllCSharpCodeActions;
@@ -25,7 +25,7 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
     private readonly Lazy<bool> _usePreciseSemanticTokenRanges;
     private readonly Lazy<bool> _useRazorCohostServer;
     private readonly Lazy<bool> _disableRazorLanguageServer;
-    private readonly Lazy<bool> _enableFuse;
+    private readonly Lazy<bool> _forceRuntimeCodeGeneration;
 
     [ImportingConstructor]
     public VisualStudioWindowsLanguageServerFeatureOptions(LSPEditorFeatureDetector lspEditorFeatureDetector)
@@ -72,10 +72,10 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
             return disableRazorLanguageServer;
         });
 
-        _enableFuse = new Lazy<bool>(() =>
+        _forceRuntimeCodeGeneration = new Lazy<bool>(() =>
         {
             var featureFlags = (IVsFeatureFlags)Package.GetGlobalService(typeof(SVsFeatureFlags));
-            var disableRazorLanguageServer = featureFlags.IsFeatureEnabled(EnableFuseFeatureFlag, defaultValue: false);
+            var disableRazorLanguageServer = featureFlags.IsFeatureEnabled(ForceRuntimeCodeGenerationFeatureFlag, defaultValue: false);
             return disableRazorLanguageServer;
         });
     }
@@ -115,5 +115,5 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
     public override bool DisableRazorLanguageServer => _disableRazorLanguageServer.Value;
 
     /// <inheritdoc />
-    public override bool EnableFuse => _enableFuse.Value;
+    public override bool ForceRuntimeCodeGeneration => _forceRuntimeCodeGeneration.Value;
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioWindowsLanguageServerFeatureOptions.cs
@@ -17,6 +17,7 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
     private const string UsePreciseSemanticTokenRangesFeatureFlag = "Razor.LSP.UsePreciseSemanticTokenRanges";
     private const string UseRazorCohostServerFeatureFlag = "Razor.LSP.UseRazorCohostServer";
     private const string DisableRazorLanguageServerFeatureFlag = "Razor.LSP.DisableRazorLanguageServer";
+    private const string EnableFuseFeatureFlag = "Razor.LSP.EnableFuse";
 
     private readonly LSPEditorFeatureDetector _lspEditorFeatureDetector;
     private readonly Lazy<bool> _showAllCSharpCodeActions;
@@ -24,6 +25,7 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
     private readonly Lazy<bool> _usePreciseSemanticTokenRanges;
     private readonly Lazy<bool> _useRazorCohostServer;
     private readonly Lazy<bool> _disableRazorLanguageServer;
+    private readonly Lazy<bool> _enableFuse;
 
     [ImportingConstructor]
     public VisualStudioWindowsLanguageServerFeatureOptions(LSPEditorFeatureDetector lspEditorFeatureDetector)
@@ -37,36 +39,43 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
 
         _showAllCSharpCodeActions = new Lazy<bool>(() =>
         {
-            var featureFlags = (IVsFeatureFlags)AsyncPackage.GetGlobalService(typeof(SVsFeatureFlags));
+            var featureFlags = (IVsFeatureFlags)Package.GetGlobalService(typeof(SVsFeatureFlags));
             var showAllCSharpCodeActions = featureFlags.IsFeatureEnabled(ShowAllCSharpCodeActionsFeatureFlag, defaultValue: false);
             return showAllCSharpCodeActions;
         });
 
         _includeProjectKeyInGeneratedFilePath = new Lazy<bool>(() =>
         {
-            var featureFlags = (IVsFeatureFlags)AsyncPackage.GetGlobalService(typeof(SVsFeatureFlags));
+            var featureFlags = (IVsFeatureFlags)Package.GetGlobalService(typeof(SVsFeatureFlags));
             var includeProjectKeyInGeneratedFilePath = featureFlags.IsFeatureEnabled(IncludeProjectKeyInGeneratedFilePathFeatureFlag, defaultValue: true);
             return includeProjectKeyInGeneratedFilePath;
         });
 
         _usePreciseSemanticTokenRanges = new Lazy<bool>(() =>
         {
-            var featureFlags = (IVsFeatureFlags)AsyncPackage.GetGlobalService(typeof(SVsFeatureFlags));
+            var featureFlags = (IVsFeatureFlags)Package.GetGlobalService(typeof(SVsFeatureFlags));
             var usePreciseSemanticTokenRanges = featureFlags.IsFeatureEnabled(UsePreciseSemanticTokenRangesFeatureFlag, defaultValue: false);
             return usePreciseSemanticTokenRanges;
         });
 
         _useRazorCohostServer = new Lazy<bool>(() =>
         {
-            var featureFlags = (IVsFeatureFlags)AsyncPackage.GetGlobalService(typeof(SVsFeatureFlags));
+            var featureFlags = (IVsFeatureFlags)Package.GetGlobalService(typeof(SVsFeatureFlags));
             var useRazorCohostServer = featureFlags.IsFeatureEnabled(UseRazorCohostServerFeatureFlag, defaultValue: false);
             return useRazorCohostServer;
         });
 
         _disableRazorLanguageServer = new Lazy<bool>(() =>
         {
-            var featureFlags = (IVsFeatureFlags)AsyncPackage.GetGlobalService(typeof(SVsFeatureFlags));
+            var featureFlags = (IVsFeatureFlags)Package.GetGlobalService(typeof(SVsFeatureFlags));
             var disableRazorLanguageServer = featureFlags.IsFeatureEnabled(DisableRazorLanguageServerFeatureFlag, defaultValue: false);
+            return disableRazorLanguageServer;
+        });
+
+        _enableFuse = new Lazy<bool>(() =>
+        {
+            var featureFlags = (IVsFeatureFlags)Package.GetGlobalService(typeof(SVsFeatureFlags));
+            var disableRazorLanguageServer = featureFlags.IsFeatureEnabled(EnableFuseFeatureFlag, defaultValue: false);
             return disableRazorLanguageServer;
         });
     }
@@ -104,4 +113,7 @@ internal class VisualStudioWindowsLanguageServerFeatureOptions : LanguageServerF
     public override bool UseRazorCohostServer => _useRazorCohostServer.Value;
 
     public override bool DisableRazorLanguageServer => _disableRazorLanguageServer.Value;
+
+    /// <inheritdoc />
+    public override bool EnableFuse => _enableFuse.Value;
 }

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
@@ -74,3 +74,10 @@
 "Value"=dword:00000000
 "Title"="Disable Razor Language Server (requires restart)"
 "PreviewPaneChannels"="IntPreview,int.main"
+
+[$RootKey$\FeatureFlags\Razor\LSP\EnableFuse]
+"Description"="Enable combined design time/runtime code generation for Razor files"
+"Value"=dword:00000000
+"Title"="Enable 'fuse' for Razor files (requires restart)"
+"PreviewPaneChannels"="*"
+"VisibleToInternalUsersOnlyChannels"="*"

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
@@ -75,9 +75,8 @@
 "Title"="Disable Razor Language Server (requires restart)"
 "PreviewPaneChannels"="IntPreview,int.main"
 
-[$RootKey$\FeatureFlags\Razor\LSP\EnableFuse]
+[$RootKey$\FeatureFlags\Razor\LSP\ForceRuntimeCodeGeneration]
 "Description"="Enable combined design time/runtime code generation for Razor files"
 "Value"=dword:00000000
-"Title"="Enable 'fuse' for Razor files (requires restart)"
-"PreviewPaneChannels"="*"
-"VisibleToInternalUsersOnlyChannels"="*"
+"Title"="Force use of runtime code generation for Razor (requires restart)"
+"PreviewPaneChannels"="IntPreview,int.main"

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/Serialization/ProjectSnapshotHandleSerializationTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/Serialization/ProjectSnapshotHandleSerializationTest.cs
@@ -36,7 +36,8 @@ public class ProjectSnapshotHandleSerializationTest(ITestOutputHelper testOutput
                 {
                     new ProjectSystemRazorExtension("Test-Extension1"),
                     new ProjectSystemRazorExtension("Test-Extension2"),
-                }),
+                },
+                suppressDesignTime: false),
             "Test");
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/TestLanguageServerFeatureOptions.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/TestLanguageServerFeatureOptions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 internal class TestLanguageServerFeatureOptions(
     bool includeProjectKeyInGeneratedFilePath = false,
     bool monitorWorkspaceFolderForConfigurationFiles = true,
-    bool enableFuse = false) : LanguageServerFeatureOptions
+    bool forceRuntimeCodeGeneration = false) : LanguageServerFeatureOptions
 {
     public static readonly LanguageServerFeatureOptions Instance = new TestLanguageServerFeatureOptions();
 
@@ -42,5 +42,5 @@ internal class TestLanguageServerFeatureOptions(
 
     public override bool DisableRazorLanguageServer => false;
 
-    public override bool ForceRuntimeCodeGeneration => enableFuse;
+    public override bool ForceRuntimeCodeGeneration => forceRuntimeCodeGeneration;
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/TestLanguageServerFeatureOptions.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/TestLanguageServerFeatureOptions.cs
@@ -42,5 +42,5 @@ internal class TestLanguageServerFeatureOptions(
 
     public override bool DisableRazorLanguageServer => false;
 
-    public override bool EnableFuse => enableFuse;
+    public override bool ForceRuntimeCodeGeneration => enableFuse;
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/TestLanguageServerFeatureOptions.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/TestLanguageServerFeatureOptions.cs
@@ -5,20 +5,12 @@ using Microsoft.CodeAnalysis.Razor.Workspaces;
 
 namespace Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 
-internal class TestLanguageServerFeatureOptions : LanguageServerFeatureOptions
+internal class TestLanguageServerFeatureOptions(
+    bool includeProjectKeyInGeneratedFilePath = false,
+    bool monitorWorkspaceFolderForConfigurationFiles = true,
+    bool enableFuse = false) : LanguageServerFeatureOptions
 {
     public static readonly LanguageServerFeatureOptions Instance = new TestLanguageServerFeatureOptions();
-
-    private readonly bool _includeProjectKeyInGeneratedFilePath;
-    private readonly bool _monitorWorkspaceFolderForConfigurationFiles;
-
-    public TestLanguageServerFeatureOptions(
-        bool includeProjectKeyInGeneratedFilePath = false,
-        bool monitorWorkspaceFolderForConfigurationFiles = true)
-    {
-        _includeProjectKeyInGeneratedFilePath = includeProjectKeyInGeneratedFilePath;
-        _monitorWorkspaceFolderForConfigurationFiles = monitorWorkspaceFolderForConfigurationFiles;
-    }
 
     public override bool SupportsFileManipulation => false;
 
@@ -42,11 +34,13 @@ internal class TestLanguageServerFeatureOptions : LanguageServerFeatureOptions
 
     public override bool UpdateBuffersForClosedDocuments => false;
 
-    public override bool IncludeProjectKeyInGeneratedFilePath => _includeProjectKeyInGeneratedFilePath;
+    public override bool IncludeProjectKeyInGeneratedFilePath => includeProjectKeyInGeneratedFilePath;
 
-    public override bool MonitorWorkspaceFolderForConfigurationFiles => _monitorWorkspaceFolderForConfigurationFiles;
+    public override bool MonitorWorkspaceFolderForConfigurationFiles => monitorWorkspaceFolderForConfigurationFiles;
 
     public override bool UseRazorCohostServer => false;
 
     public override bool DisableRazorLanguageServer => false;
+
+    public override bool EnableFuse => enableFuse;
 }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Serialization/RazorConfigurationSerializationTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Serialization/RazorConfigurationSerializationTest.cs
@@ -23,7 +23,8 @@ public class RazorConfigurationSerializationTest(ITestOutputHelper testOutput) :
             {
                 new ProjectSystemRazorExtension("Test-Extension1"),
                 new ProjectSystemRazorExtension("Test-Extension2"),
-            });
+            },
+            suppressDesignTime: true);
 
         // Act
         var json = JsonDataConvert.SerializeObject(configuration, ObjectWriters.WriteProperties);
@@ -39,6 +40,7 @@ public class RazorConfigurationSerializationTest(ITestOutputHelper testOutput) :
             e => Assert.Equal("Test-Extension1", e.ExtensionName),
             e => Assert.Equal("Test-Extension2", e.ExtensionName));
         Assert.Equal(configuration.LanguageVersion, obj.LanguageVersion);
+        Assert.Equal(configuration.SuppressDesignTime, obj.SuppressDesignTime);
     }
 
     [Fact]

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Serialization/RazorConfigurationSerializationTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Serialization/RazorConfigurationSerializationTest.cs
@@ -40,7 +40,7 @@ public class RazorConfigurationSerializationTest(ITestOutputHelper testOutput) :
             e => Assert.Equal("Test-Extension1", e.ExtensionName),
             e => Assert.Equal("Test-Extension2", e.ExtensionName));
         Assert.Equal(configuration.LanguageVersion, obj.LanguageVersion);
-        Assert.Equal(configuration.SuppressDesignTime, obj.SuppressDesignTime);
+        Assert.Equal(configuration.ForceRuntimeCodeGeneration, obj.ForceRuntimeCodeGeneration);
     }
 
     [Fact]

--- a/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.Test/OOPTagHelperResolverTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Remote.Razor.Test/OOPTagHelperResolverTest.cs
@@ -37,7 +37,7 @@ public partial class OOPTagHelperResolverTest : TagHelperDescriptorTestBase
         _hostProject_For_2_0 = new HostProject("Test.csproj", "/obj", FallbackRazorConfiguration.MVC_2_0, rootNamespace: null);
         _hostProject_For_NonSerializableConfiguration = new HostProject(
             "Test.csproj", "/obj",
-            new ProjectSystemRazorConfiguration(RazorLanguageVersion.Version_2_1, "Random-0.1", []), rootNamespace: null);
+            new ProjectSystemRazorConfiguration(RazorLanguageVersion.Version_2_1, "Random-0.1", [], suppressDesignTime: false), rootNamespace: null);
 
         _customFactories =
         [

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultProjectSnapshotProjectEngineFactoryTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/DefaultProjectSnapshotProjectEngineFactoryTest.cs
@@ -42,15 +42,15 @@ public class DefaultProjectSnapshotProjectEngineFactoryTest : ToolingTestBase
 
         var hostProject_For_2_1 = new HostProject(
             projectFilePath, intermediateOutputPath,
-            new ProjectSystemRazorConfiguration(RazorLanguageVersion.Version_2_1, "MVC-2.1", Array.Empty<RazorExtension>()), "Test");
+            new ProjectSystemRazorConfiguration(RazorLanguageVersion.Version_2_1, "MVC-2.1", Array.Empty<RazorExtension>(), suppressDesignTime: false), "Test");
 
         var hostProject_For_3_0 = new HostProject(
             projectFilePath, intermediateOutputPath,
-            new ProjectSystemRazorConfiguration(RazorLanguageVersion.Version_3_0, "MVC-3.0", Array.Empty<RazorExtension>()), "Test");
+            new ProjectSystemRazorConfiguration(RazorLanguageVersion.Version_3_0, "MVC-3.0", Array.Empty<RazorExtension>(), suppressDesignTime: false), "Test");
 
         var hostProject_For_UnknownConfiguration = new HostProject(
             projectFilePath, intermediateOutputPath,
-            new ProjectSystemRazorConfiguration(RazorLanguageVersion.Version_2_1, "Random-0.1", Array.Empty<RazorExtension>()), rootNamespace: null);
+            new ProjectSystemRazorConfiguration(RazorLanguageVersion.Version_2_1, "Random-0.1", Array.Empty<RazorExtension>(), suppressDesignTime: false), rootNamespace: null);
 
         var projectEngineFactory = Mock.Of<ProjectSnapshotProjectEngineFactory>(MockBehavior.Strict);
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
@@ -448,7 +448,7 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
         var projectState = new Dictionary<string, IProjectRuleSnapshot>().ToImmutableDictionary();
 
         // Act
-        var result = DefaultWindowsRazorProjectHost.TryGetConfiguration(projectState, suppressDesignTime: null, out var configuration);
+        var result = DefaultWindowsRazorProjectHost.TryGetConfiguration(projectState, suppressDesignTime: false, out var configuration);
 
         // Assert
         Assert.False(result);
@@ -470,7 +470,7 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
         }.ToImmutableDictionary();
 
         // Act
-        var result = DefaultWindowsRazorProjectHost.TryGetConfiguration(projectState, suppressDesignTime: null, out var configuration);
+        var result = DefaultWindowsRazorProjectHost.TryGetConfiguration(projectState, suppressDesignTime: false, out var configuration);
 
         // Assert
         Assert.False(result);
@@ -493,7 +493,7 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
         }.ToImmutableDictionary();
 
         // Act
-        var result = DefaultWindowsRazorProjectHost.TryGetConfiguration(projectState, suppressDesignTime: null, out var configuration);
+        var result = DefaultWindowsRazorProjectHost.TryGetConfiguration(projectState, suppressDesignTime: false, out var configuration);
 
         // Assert
         Assert.False(result);
@@ -522,7 +522,7 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
         }.ToImmutableDictionary();
 
         // Act
-        var result = DefaultWindowsRazorProjectHost.TryGetConfiguration(projectState, suppressDesignTime: null, out var configuration);
+        var result = DefaultWindowsRazorProjectHost.TryGetConfiguration(projectState, suppressDesignTime: false, out var configuration);
 
         // Assert
         Assert.True(result);
@@ -556,7 +556,7 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
         }.ToImmutableDictionary();
 
         // Act
-        var result = DefaultWindowsRazorProjectHost.TryGetConfiguration(projectState, suppressDesignTime: null, out var configuration);
+        var result = DefaultWindowsRazorProjectHost.TryGetConfiguration(projectState, suppressDesignTime: false, out var configuration);
 
         // Assert
         Assert.True(result);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.Editor;
+using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Moq;
@@ -39,6 +40,7 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
 
         var projectConfigurationFilePathStore = new Mock<ProjectConfigurationFilePathStore>(MockBehavior.Strict);
         projectConfigurationFilePathStore.Setup(s => s.Remove(It.IsAny<ProjectKey>())).Verifiable();
+        projectConfigurationFilePathStore.Setup(s => s.Set(It.IsAny<ProjectKey>(), It.IsAny<string>())).Verifiable();
         _projectConfigurationFilePathStore = projectConfigurationFilePathStore.Object;
 
         _configurationItems = new ItemCollection(Rules.RazorConfiguration.SchemaName);
@@ -622,7 +624,7 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
     {
         // Arrange
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
-        var host = new DefaultWindowsRazorProjectHost(services, Workspace, Dispatcher, _projectConfigurationFilePathStore, _projectManager);
+        var host = new DefaultWindowsRazorProjectHost(services, Workspace, Dispatcher, _projectConfigurationFilePathStore, _projectManager, new TestLanguageServerFeatureOptions());
 
         // Act & Assert
         await host.LoadAsync();
@@ -637,7 +639,7 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
     {
         // Arrange
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
-        var host = new DefaultWindowsRazorProjectHost(services, Workspace, Dispatcher, _projectConfigurationFilePathStore, _projectManager);
+        var host = new DefaultWindowsRazorProjectHost(services, Workspace, Dispatcher, _projectConfigurationFilePathStore, _projectManager, new TestLanguageServerFeatureOptions());
 
         // Act & Assert
         await Task.Run(async () => await host.LoadAsync());
@@ -656,7 +658,7 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
         };
 
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
-        var host = new DefaultWindowsRazorProjectHost(services, Workspace, Dispatcher, _projectConfigurationFilePathStore, _projectManager);
+        var host = new DefaultWindowsRazorProjectHost(services, Workspace, Dispatcher, _projectConfigurationFilePathStore, _projectManager, new TestLanguageServerFeatureOptions());
 
         // Act & Assert
         await Task.Run(async () => await host.LoadAsync());
@@ -700,7 +702,7 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
 
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
 
-        var host = new DefaultWindowsRazorProjectHost(services, Workspace, Dispatcher, _projectConfigurationFilePathStore, _projectManager);
+        var host = new DefaultWindowsRazorProjectHost(services, Workspace, Dispatcher, _projectConfigurationFilePathStore, _projectManager, new TestLanguageServerFeatureOptions());
         host.SkipIntermediateOutputPathExistCheck_TestOnly = true;
 
         await Task.Run(async () => await host.LoadAsync());
@@ -764,7 +766,7 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
         };
 
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
-        var host = new DefaultWindowsRazorProjectHost(services, Workspace, Dispatcher, _projectConfigurationFilePathStore, _projectManager);
+        var host = new DefaultWindowsRazorProjectHost(services, Workspace, Dispatcher, _projectConfigurationFilePathStore, _projectManager, new TestLanguageServerFeatureOptions());
 
         await Task.Run(async () => await host.LoadAsync());
         Assert.Empty(_projectManager.GetProjects());
@@ -815,7 +817,7 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
         };
 
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
-        var host = new DefaultWindowsRazorProjectHost(services, Workspace, Dispatcher, _projectConfigurationFilePathStore, _projectManager);
+        var host = new DefaultWindowsRazorProjectHost(services, Workspace, Dispatcher, _projectConfigurationFilePathStore, _projectManager, new TestLanguageServerFeatureOptions());
         host.SkipIntermediateOutputPathExistCheck_TestOnly = true;
 
         await Task.Run(async () => await host.LoadAsync());
@@ -866,7 +868,7 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
         };
 
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
-        var host = new DefaultWindowsRazorProjectHost(services, Workspace, Dispatcher, _projectConfigurationFilePathStore, _projectManager);
+        var host = new DefaultWindowsRazorProjectHost(services, Workspace, Dispatcher, _projectConfigurationFilePathStore, _projectManager, new TestLanguageServerFeatureOptions());
         host.SkipIntermediateOutputPathExistCheck_TestOnly = true;
 
         await Task.Run(async () => await host.LoadAsync());
@@ -1022,7 +1024,7 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
         };
 
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
-        var host = new DefaultWindowsRazorProjectHost(services, Workspace, Dispatcher, _projectConfigurationFilePathStore, _projectManager);
+        var host = new DefaultWindowsRazorProjectHost(services, Workspace, Dispatcher, _projectConfigurationFilePathStore, _projectManager, new TestLanguageServerFeatureOptions());
         host.SkipIntermediateOutputPathExistCheck_TestOnly = true;
 
         await Task.Run(async () => await host.LoadAsync());
@@ -1097,7 +1099,7 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
         };
 
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
-        var host = new DefaultWindowsRazorProjectHost(services, Workspace, Dispatcher, _projectConfigurationFilePathStore, _projectManager);
+        var host = new DefaultWindowsRazorProjectHost(services, Workspace, Dispatcher, _projectConfigurationFilePathStore, _projectManager, new TestLanguageServerFeatureOptions());
         host.SkipIntermediateOutputPathExistCheck_TestOnly = true;
 
         await Task.Run(async () => await host.LoadAsync());
@@ -1177,7 +1179,7 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
 
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
 
-        var host = new DefaultWindowsRazorProjectHost(services, Workspace, Dispatcher, _projectConfigurationFilePathStore, _projectManager);
+        var host = new DefaultWindowsRazorProjectHost(services, Workspace, Dispatcher, _projectConfigurationFilePathStore, _projectManager, new TestLanguageServerFeatureOptions());
         host.SkipIntermediateOutputPathExistCheck_TestOnly = true;
 
         await Task.Run(async () => await host.LoadAsync());

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
@@ -610,7 +610,7 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
         Assert.True(result);
         Assert.Equal(expectedLanguageVersion, configuration.LanguageVersion);
         Assert.Equal(expectedConfigurationName, configuration.ConfigurationName);
-        Assert.True(configuration.SuppressDesignTime);
+        Assert.True(configuration.ForceRuntimeCodeGeneration);
         Assert.Collection(
             configuration.Extensions.OrderBy(e => e.ExtensionName),
             extension => Assert.Equal(expectedExtension1Name, extension.ExtensionName),

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
@@ -448,7 +448,7 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
         var projectState = new Dictionary<string, IProjectRuleSnapshot>().ToImmutableDictionary();
 
         // Act
-        var result = DefaultWindowsRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
+        var result = DefaultWindowsRazorProjectHost.TryGetConfiguration(projectState, suppressDesignTime: null, out var configuration);
 
         // Assert
         Assert.False(result);
@@ -470,7 +470,7 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
         }.ToImmutableDictionary();
 
         // Act
-        var result = DefaultWindowsRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
+        var result = DefaultWindowsRazorProjectHost.TryGetConfiguration(projectState, suppressDesignTime: null, out var configuration);
 
         // Assert
         Assert.False(result);
@@ -493,7 +493,7 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
         }.ToImmutableDictionary();
 
         // Act
-        var result = DefaultWindowsRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
+        var result = DefaultWindowsRazorProjectHost.TryGetConfiguration(projectState, suppressDesignTime: null, out var configuration);
 
         // Assert
         Assert.False(result);
@@ -522,7 +522,7 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
         }.ToImmutableDictionary();
 
         // Act
-        var result = DefaultWindowsRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
+        var result = DefaultWindowsRazorProjectHost.TryGetConfiguration(projectState, suppressDesignTime: null, out var configuration);
 
         // Assert
         Assert.True(result);
@@ -556,7 +556,7 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
         }.ToImmutableDictionary();
 
         // Act
-        var result = DefaultWindowsRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
+        var result = DefaultWindowsRazorProjectHost.TryGetConfiguration(projectState, suppressDesignTime: null, out var configuration);
 
         // Assert
         Assert.True(result);
@@ -604,12 +604,13 @@ public class DefaultWindowsRazorProjectHostTest : ProjectSnapshotManagerDispatch
         }.ToImmutableDictionary();
 
         // Act
-        var result = DefaultWindowsRazorProjectHost.TryGetConfiguration(projectState, out var configuration);
+        var result = DefaultWindowsRazorProjectHost.TryGetConfiguration(projectState, suppressDesignTime: true, out var configuration);
 
         // Assert
         Assert.True(result);
         Assert.Equal(expectedLanguageVersion, configuration.LanguageVersion);
         Assert.Equal(expectedConfigurationName, configuration.ConfigurationName);
+        Assert.True(configuration.SuppressDesignTime);
         Assert.Collection(
             configuration.Extensions.OrderBy(e => e.ExtensionName),
             extension => Assert.Equal(expectedExtension1Name, extension.ExtensionName),


### PR DESCRIPTION
Adds a feature flag and console flag in rzls for "fuse" as a feature. 

Commits are separated by addition of the flag in tooling, and pushing that through to `RazorConfiguration`