### PR TITLE
Remove String.Split(...) in CSharpCodeParser

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpCodeParserTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/CSharpCodeParserTest.cs
@@ -110,15 +110,10 @@ public class CSharpCodeParserTest
     {
         // Arrange
         var expectedDiagnostics = (IEnumerable<RazorDiagnostic>)expectedErrors;
-        var source = TestRazorSourceDocument.Create();
-        var options = RazorParserOptions.CreateDefault();
-        var context = new ParserContext(source, options);
-
-        var parser = new CSharpCodeParser(context);
         var diagnostics = new List<RazorDiagnostic>();
 
         // Act
-        parser.ValidateTagHelperPrefix(directiveText, directiveLocation, diagnostics);
+        CSharpCodeParser.ValidateTagHelperPrefix(directiveText, directiveLocation, diagnostics);
 
         // Assert
         Assert.Equal(expectedDiagnostics, diagnostics);
@@ -134,12 +129,6 @@ public class CSharpCodeParserTest
     public void ParseAddOrRemoveDirective_CalculatesAssemblyLocationInLookupText(string text)
     {
         // Arrange
-        var source = TestRazorSourceDocument.Create();
-        var options = RazorParserOptions.CreateDefault();
-        var context = new ParserContext(source, options);
-
-        var parser = new CSharpCodeParser(context);
-
         var directive = new CSharpCodeParser.ParsedDirective()
         {
             DirectiveText = text,
@@ -148,7 +137,7 @@ public class CSharpCodeParserTest
         var diagnostics = new List<RazorDiagnostic>();
 
         // Act
-        var result = parser.ParseAddOrRemoveDirective(directive, SourceLocation.Zero, diagnostics);
+        var result = CSharpCodeParser.ParseAddOrRemoveDirective(directive, SourceLocation.Zero, diagnostics);
 
         // Assert
         Assert.Empty(diagnostics);
@@ -172,12 +161,6 @@ public class CSharpCodeParserTest
     public void ParseAddOrRemoveDirective_CreatesErrorIfInvalidLookupText_DoesNotThrow(string directiveText, int errorLength)
     {
         // Arrange
-        var source = TestRazorSourceDocument.Create();
-        var options = RazorParserOptions.CreateDefault();
-        var context = new ParserContext(source, options);
-
-        var parser = new CSharpCodeParser(context);
-
         var directive = new CSharpCodeParser.ParsedDirective()
         {
             DirectiveText = directiveText
@@ -188,7 +171,7 @@ public class CSharpCodeParserTest
             new SourceSpan(new SourceLocation(1, 2, 3), errorLength), directiveText);
 
         // Act
-        var result = parser.ParseAddOrRemoveDirective(directive, new SourceLocation(1, 2, 3), diagnostics);
+        var result = CSharpCodeParser.ParseAddOrRemoveDirective(directive, new SourceLocation(1, 2, 3), diagnostics);
 
         // Assert
         Assert.Same(directive, result);

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/CSharpCodeParser.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/CSharpCodeParser.cs
@@ -1271,7 +1271,7 @@ internal class CSharpCodeParser : TokenizerBackedParser<CSharpTokenizer>
     }
 
     // Internal for testing.
-    internal ParsedDirective ParseAddOrRemoveDirective(ParsedDirective directive, SourceLocation directiveLocation, List<RazorDiagnostic> errors)
+    internal static ParsedDirective ParseAddOrRemoveDirective(ParsedDirective directive, SourceLocation directiveLocation, List<RazorDiagnostic> errors)
     {
         // Ensure that we have valid lookupStrings to work with. The valid format is "typeName, assemblyName"
         var text = directive.DirectiveText;
@@ -1323,7 +1323,7 @@ internal class CSharpCodeParser : TokenizerBackedParser<CSharpTokenizer>
     }
 
     // Internal for testing.
-    internal void ValidateTagHelperPrefix(
+    internal static void ValidateTagHelperPrefix(
         string prefix,
         SourceLocation directiveLocation,
         List<RazorDiagnostic> diagnostics)

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/CSharpCodeParser.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/CSharpCodeParser.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -12,10 +13,10 @@ namespace Microsoft.AspNetCore.Razor.Language.Legacy;
 
 internal class CSharpCodeParser : TokenizerBackedParser<CSharpTokenizer>
 {
-    private static readonly HashSet<char> InvalidNonWhitespaceNameCharacters = new HashSet<char>(new[]
-    {
-            '@', '!', '<', '/', '?', '[', '>', ']', '=', '"', '\'', '*'
-        });
+    private static readonly FrozenSet<char> InvalidNonWhitespaceNameCharacters = new HashSet<char>(
+    [
+        '@', '!', '<', '/', '?', '[', '>', ']', '=', '"', '\'', '*'
+    ]).ToFrozenSet();
 
     private static readonly Func<SyntaxToken, bool> IsValidStatementSpacingToken =
         IsSpacingTokenIncludingNewLinesAndComments;


### PR DESCRIPTION
@ToddGrun noticed a call to `String.Split(...)` showing up in a Speedometer. The fix was trivial enough, so I went ahead and applied it. While in the code, I made a few other tweaks that I hope will be useful.

![image](https://github.com/dotnet/razor/assets/116161/438886b8-649d-4eeb-806c-df0ccd2b6f97)
