### PR TITLE
Add using directive support.

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/CSharpCodeParser.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/CSharpCodeParser.cs
@@ -30,6 +30,14 @@ internal class CSharpCodeParser : TokenizerBackedParser<CSharpTokenizer>
             builder.Description = Resources.AddTagHelperDirective_Description;
         });
 
+    internal static readonly DirectiveDescriptor UsingDirectiveDescriptor = DirectiveDescriptor.CreateDirective(
+        SyntaxConstants.CSharp.UsingKeyword,
+        DirectiveKind.SingleLine,
+        builder =>
+        {
+            builder.Description = Resources.UsingDirective_Description;
+        });
+
     internal static readonly DirectiveDescriptor RemoveTagHelperDirectiveDescriptor = DirectiveDescriptor.CreateDirective(
         SyntaxConstants.CSharp.RemoveTagHelperKeyword,
         DirectiveKind.SingleLine,

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/SyntaxConstants.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/SyntaxConstants.cs
@@ -17,6 +17,7 @@ internal static class SyntaxConstants
     public static class CSharp
     {
         public const int UsingKeywordLength = 5;
+        public const string UsingKeyword = "using";
         public const string TagHelperPrefixKeyword = "tagHelperPrefix";
         public const string AddTagHelperKeyword = "addTagHelper";
         public const string RemoveTagHelperKeyword = "removeTagHelper";

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Resources.resx
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Resources.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -594,5 +594,8 @@
   </data>
   <data name="DirectiveExpectsIdentifierOrExpression" xml:space="preserve">
     <value>The '{0}' directive expects an identifier or explicit razor expression ("@()").</value>
+  </data>
+  <data name="UsingDirective_Description" xml:space="preserve">
+    <value>Adds the C# using directive to the generated view</value>
   </data>
 </root>

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Resources.resx
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Resources.resx
@@ -596,6 +596,6 @@
     <value>The '{0}' directive expects an identifier or explicit razor expression ("@()").</value>
   </data>
   <data name="UsingDirective_Description" xml:space="preserve">
-    <value>Adds the C# using directive to the generated view</value>
+    <value>Adds the C# using directive to the generated view.</value>
   </data>
 </root>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/SnippetResponseRewriter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/SnippetResponseRewriter.cs
@@ -19,9 +19,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation;
 /// </remarks>
 internal class SnippetResponseRewriter : DelegatedCompletionResponseRewriter
 {
-    private static readonly FrozenDictionary<string, string> s_snippetToLabel = new Dictionary<string, string>()
+    private static readonly FrozenDictionary<string, (string Label, string SortText)> s_snippetToCompletionData = new Dictionary<string, (string Label, string SortText)>()
     {
-        ["using"] = $"using {SR.Statement}"
+        // Modifying label of the C# using snippet to "using statement" to disambiguate from
+        // Razor @using directive, and also appending a space to sort text to make sure it's sorted
+        // after Razor "using" keyword and "using directive ..." entries (which use "using" as sort text)
+        ["using"] = (Label:$"using {SR.Statement}", SortText:"using ")
     }
     .ToFrozenDictionary();
 
@@ -38,9 +41,10 @@ internal class SnippetResponseRewriter : DelegatedCompletionResponseRewriter
                     continue;
                 }
 
-                if (s_snippetToLabel.TryGetValue(item.Label, out var newLabel))
+                if (s_snippetToCompletionData.TryGetValue(item.Label, out var completionData))
                 {
-                    item.Label = newLabel;
+                    item.Label = completionData.Label;
+                    item.SortText = completionData.SortText;
                 }
             }
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/SnippetResponseRewriter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/SnippetResponseRewriter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,10 +19,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation;
 /// </remarks>
 internal class SnippetResponseRewriter : DelegatedCompletionResponseRewriter
 {
-    private static readonly IReadOnlyDictionary<string, string> s_snippetToLabel = new Dictionary<string, string>()
+    private static readonly FrozenDictionary<string, string> s_snippetToLabel = new Dictionary<string, string>()
     {
         ["using"] = $"using {SR.Statement}"
-    };
+    }
+    .ToFrozenDictionary();
 
     public override int Order => ExecutionBehaviorOrder.ChangesCompletionItems;
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/SnippetResponseRewriter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/SnippetResponseRewriter.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation;
+
+/// <summary>
+/// Modifies delegated snippet completion items
+/// </summary>
+/// <remarks>
+/// At the moment primarily used to modify C# "using" snippet to "using statement" snippet
+/// in order to disambiguate it from Razor "using directive" snippet
+/// </remarks>
+internal class SnippetResponseRewriter : DelegatedCompletionResponseRewriter
+{
+    private static readonly IReadOnlyDictionary<string, string> s_snippetToLabel = new Dictionary<string, string>()
+    {
+        ["using"] = $"using {SR.Statement}"
+    };
+
+    public override int Order => ExecutionBehaviorOrder.ChangesCompletionItems;
+
+    public override Task<VSInternalCompletionList> RewriteAsync(VSInternalCompletionList completionList, int hostDocumentIndex, DocumentContext hostDocumentContext, DelegatedCompletionParams delegatedParameters, CancellationToken cancellationToken)
+    {
+        foreach (var item in completionList.Items)
+        {
+            if (item.Kind == CompletionItemKind.Snippet)
+            {
+                if (item.Label is null)
+                {
+                    continue;
+                }
+
+                if (s_snippetToLabel.TryGetValue(item.Label, out var newLabel))
+                {
+                    item.Label = newLabel;
+                }
+            }
+        }
+
+        return Task.FromResult(completionList);
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionItemResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionItemResolver.cs
@@ -39,7 +39,30 @@ internal class RazorCompletionItemResolver : CompletionItemResolver
             return null;
         }
 
-        var associatedRazorCompletion = razorCompletionResolveContext.CompletionItems.FirstOrDefault(completion => string.Equals(completion.DisplayText, completionItem.Label, StringComparison.Ordinal));
+        var associatedRazorCompletion = razorCompletionResolveContext.CompletionItems.FirstOrDefault(completion =>
+        {
+            if (!string.Equals(completion.DisplayText, completionItem.Label, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            // We may have items of different types with the same label (e.g. snippet and keyword)
+            if (clientCapabilities is not null)
+            {
+                // CompletionItem.Kind and RazorCompletionItem.Kind are not compatible/comparable, so we need to convert
+                // Razor completion item to VS completion item (as logic to convert just the kind is not easy to separate from
+                // the rest of the conversion logic) prior to comparing them
+                RazorCompletionListProvider.TryConvert(completion, clientCapabilities, out var convertedRazorCompletionItem);
+                if (convertedRazorCompletionItem != null)
+                {
+                    return completionItem.Kind == convertedRazorCompletionItem.Kind;
+                }
+            }
+
+            // If display text matches but we couldn't convert razor completion item to VS completion item for some reason,
+            // do what previous version of the code did and return true.
+            return true;
+        });
         if (associatedRazorCompletion is null)
         {
             return null;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionItemResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionItemResolver.cs
@@ -41,7 +41,7 @@ internal class RazorCompletionItemResolver : CompletionItemResolver
 
         var associatedRazorCompletion = razorCompletionResolveContext.CompletionItems.FirstOrDefault(completion =>
         {
-            if (!string.Equals(completion.DisplayText, completionItem.Label, StringComparison.Ordinal))
+            if (completion.DisplayText != completionItem.Label)
             {
                 return false;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionItemResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionItemResolver.cs
@@ -52,8 +52,7 @@ internal class RazorCompletionItemResolver : CompletionItemResolver
                 // CompletionItem.Kind and RazorCompletionItem.Kind are not compatible/comparable, so we need to convert
                 // Razor completion item to VS completion item (as logic to convert just the kind is not easy to separate from
                 // the rest of the conversion logic) prior to comparing them
-                RazorCompletionListProvider.TryConvert(completion, clientCapabilities, out var convertedRazorCompletionItem);
-                if (convertedRazorCompletionItem != null)
+                if (RazorCompletionListProvider.TryConvert(completion, clientCapabilities, out var convertedRazorCompletionItem))
                 {
                     return completionItem.Kind == convertedRazorCompletionItem.Kind;
                 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionResolveEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionResolveEndpoint.cs
@@ -50,7 +50,7 @@ internal class RazorCompletionResolveEndpoint : IVSCompletionResolveEndpoint, IC
 
             // See if this is the right completion list for this corresponding completion item. We cross-check this based on label only given that
             // is what users interact with.
-            if (cacheEntry.CompletionList.Items.Any(completion => string.Equals(completionItem.Label, completion.Label, StringComparison.Ordinal) &&
+            if (cacheEntry.CompletionList.Items.Any(completion => completionItem.Label == completion.Label &&
               // Check the Kind as well, e.g. we may have a Razor snippet and a C# keyword with the same label, etc.
                                                                   completionItem.Kind == completion.Kind))
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionResolveEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionResolveEndpoint.cs
@@ -50,7 +50,9 @@ internal class RazorCompletionResolveEndpoint : IVSCompletionResolveEndpoint, IC
 
             // See if this is the right completion list for this corresponding completion item. We cross-check this based on label only given that
             // is what users interact with.
-            if (cacheEntry.CompletionList.Items.Any(completion => string.Equals(completionItem.Label, completion.Label, StringComparison.Ordinal)))
+            if (cacheEntry.CompletionList.Items.Any(completion => string.Equals(completionItem.Label, completion.Label, StringComparison.Ordinal) &&
+              // Check the Kind as well, e.g. we may have a Razor snippet and a C# keyword with the same label, etc.
+                                                                  completionItem.Kind == completion.Kind))
             {
                 originalRequestContext = cacheEntry.Context;
                 containingCompletionList = cacheEntry.CompletionList;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionResolveEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionResolveEndpoint.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
@@ -90,6 +90,7 @@ internal static class IServiceCollectionExtensions
         services.AddSingleton<DelegatedCompletionResponseRewriter, TextEditResponseRewriter>();
         services.AddSingleton<DelegatedCompletionResponseRewriter, DesignTimeHelperResponseRewriter>();
         services.AddSingleton<DelegatedCompletionResponseRewriter, HtmlCommitCharacterResponseRewriter>();
+        services.AddSingleton<DelegatedCompletionResponseRewriter, SnippetResponseRewriter>();
 
         services.AddSingleton<AggregateCompletionItemResolver>();
         services.AddSingleton<CompletionItemResolver, RazorCompletionItemResolver>();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/SR.resx
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/SR.resx
@@ -195,4 +195,7 @@
   <data name="Version_Should_Not_Be_Null" xml:space="preserve">
     <value>Provided version should not be null.</value>
   </data>
+  <data name="Statement" xml:space="preserve">
+    <value>statement</value>
+  </data>
 </root>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.cs.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.cs.xlf
@@ -102,6 +102,11 @@
         <target state="translated">Aktivovat znovu dokončení…</target>
         <note />
       </trans-unit>
+      <trans-unit id="Statement">
+        <source>statement</source>
+        <target state="new">statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TagHelper_Attribute_Glyph">
         <source>Razor TagHelper Attribute Glyph</source>
         <target state="translated">Piktogram atributu Razor TagHelper</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.de.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.de.xlf
@@ -102,6 +102,11 @@
         <target state="translated">"Abschlüsse erneut auslösen..."</target>
         <note />
       </trans-unit>
+      <trans-unit id="Statement">
+        <source>statement</source>
+        <target state="new">statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TagHelper_Attribute_Glyph">
         <source>Razor TagHelper Attribute Glyph</source>
         <target state="translated">Razor TagHelper-Attributsymbol</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.es.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.es.xlf
@@ -102,6 +102,11 @@
         <target state="translated">"Volver a desencadenar las finalizaciones..."</target>
         <note />
       </trans-unit>
+      <trans-unit id="Statement">
+        <source>statement</source>
+        <target state="new">statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TagHelper_Attribute_Glyph">
         <source>Razor TagHelper Attribute Glyph</source>
         <target state="translated">Glifo del atributo TagHelper de Razor</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.fr.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.fr.xlf
@@ -102,6 +102,11 @@
         <target state="translated">« Déclencher à nouveau les complétions... »</target>
         <note />
       </trans-unit>
+      <trans-unit id="Statement">
+        <source>statement</source>
+        <target state="new">statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TagHelper_Attribute_Glyph">
         <source>Razor TagHelper Attribute Glyph</source>
         <target state="translated">Glyphe d’attribut Razor TagHelper</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.it.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.it.xlf
@@ -102,6 +102,11 @@
         <target state="translated">"Riattiva i completamenti..."</target>
         <note />
       </trans-unit>
+      <trans-unit id="Statement">
+        <source>statement</source>
+        <target state="new">statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TagHelper_Attribute_Glyph">
         <source>Razor TagHelper Attribute Glyph</source>
         <target state="translated">Glifo attributo TagHelper Razor</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.ja.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.ja.xlf
@@ -102,6 +102,11 @@
         <target state="translated">"再トリガーの完了..."</target>
         <note />
       </trans-unit>
+      <trans-unit id="Statement">
+        <source>statement</source>
+        <target state="new">statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TagHelper_Attribute_Glyph">
         <source>Razor TagHelper Attribute Glyph</source>
         <target state="translated">Razor TagHelper 属性のグリフ</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.ko.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.ko.xlf
@@ -102,6 +102,11 @@
         <target state="translated">"완료된 항목 다시 트리거"</target>
         <note />
       </trans-unit>
+      <trans-unit id="Statement">
+        <source>statement</source>
+        <target state="new">statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TagHelper_Attribute_Glyph">
         <source>Razor TagHelper Attribute Glyph</source>
         <target state="translated">Razor TagHelper 특성 문자 모양</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.pl.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.pl.xlf
@@ -102,6 +102,11 @@
         <target state="translated">"Ponownie wyzwalaj uzupełniania..."</target>
         <note />
       </trans-unit>
+      <trans-unit id="Statement">
+        <source>statement</source>
+        <target state="new">statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TagHelper_Attribute_Glyph">
         <source>Razor TagHelper Attribute Glyph</source>
         <target state="translated">Symbol atrybutu pomocnika tagów składni Razor</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.pt-BR.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.pt-BR.xlf
@@ -102,6 +102,11 @@
         <target state="translated">"Disparar conclusões novamente..."</target>
         <note />
       </trans-unit>
+      <trans-unit id="Statement">
+        <source>statement</source>
+        <target state="new">statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TagHelper_Attribute_Glyph">
         <source>Razor TagHelper Attribute Glyph</source>
         <target state="translated">Atributo Glyph Razor TagHelper</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.ru.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.ru.xlf
@@ -102,6 +102,11 @@
         <target state="translated">"Повторный запуск завершений..."</target>
         <note />
       </trans-unit>
+      <trans-unit id="Statement">
+        <source>statement</source>
+        <target state="new">statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TagHelper_Attribute_Glyph">
         <source>Razor TagHelper Attribute Glyph</source>
         <target state="translated">Глиф атрибута TagHelper Razor</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.tr.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.tr.xlf
@@ -102,6 +102,11 @@
         <target state="translated">"Tamamlamaları yeniden tetikleyin..."</target>
         <note />
       </trans-unit>
+      <trans-unit id="Statement">
+        <source>statement</source>
+        <target state="new">statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TagHelper_Attribute_Glyph">
         <source>Razor TagHelper Attribute Glyph</source>
         <target state="translated">Razor TagHelper Öznitelik Karakteri</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.zh-Hans.xlf
@@ -102,6 +102,11 @@
         <target state="translated">“重新触发完成…”</target>
         <note />
       </trans-unit>
+      <trans-unit id="Statement">
+        <source>statement</source>
+        <target state="new">statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TagHelper_Attribute_Glyph">
         <source>Razor TagHelper Attribute Glyph</source>
         <target state="translated">Razor TagHelper 特性字形</target>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Resources/xlf/SR.zh-Hant.xlf
@@ -102,6 +102,11 @@
         <target state="translated">"重新觸發完成..."</target>
         <note />
       </trans-unit>
+      <trans-unit id="Statement">
+        <source>statement</source>
+        <target state="new">statement</target>
+        <note />
+      </trans-unit>
       <trans-unit id="TagHelper_Attribute_Glyph">
         <source>Razor TagHelper Attribute Glyph</source>
         <target state="translated">Razor TagHelper 屬性字元</target>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
@@ -35,7 +36,7 @@ internal class DirectiveCompletionItemProvider : IRazorCompletionItemProvider
 
     // internal for testing
     // Do not forget to update both insert and display text !important
-    internal static readonly IReadOnlyDictionary<string, (string InsertText, string DisplayText)> s_singleLineDirectiveSnippets = new Dictionary<string, (string InsertText, string DisplayText)>(StringComparer.Ordinal)
+    internal static readonly FrozenDictionary<string, (string InsertText, string DisplayText)> s_singleLineDirectiveSnippets = new Dictionary<string, (string InsertText, string DisplayText)>(StringComparer.Ordinal)
     {
         ["addTagHelper"] = ("addTagHelper ${1:*}, ${2:Microsoft.AspNetCore.Mvc.TagHelpers}", "addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers"),
         ["attribute"] = ("attribute [${1:Authorize}]$0", "attribute [Authorize]"),
@@ -51,7 +52,8 @@ internal class DirectiveCompletionItemProvider : IRazorCompletionItemProvider
         ["tagHelperPrefix"] = ("tagHelperPrefix ${1:prefix}$0", "tagHelperPrefix prefix"),
         ["typeparam"] = ("typeparam ${1:T}$0", "typeparam T"),
         ["using"] = ("using ${1:MyNamespace}$0", "using MyNamespace")
-    };
+    }
+    .ToFrozenDictionary();
 
     public ImmutableArray<RazorCompletionItem> GetCompletionItems(RazorCompletionContext context)
     {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
@@ -165,7 +165,7 @@ internal class DirectiveCompletionItemProvider : IRazorCompletionItemProvider
             if (s_singleLineDirectiveSnippets.TryGetValue(directive.Directive, out var snippetTexts))
             {
                 var snippetCompletionItem = new RazorCompletionItem(
-                    $"{completionDisplayText} {SR.Directive}",
+                    $"{completionDisplayText} {SR.Directive} ...",
                     snippetTexts.InsertText,
                     RazorCompletionItemKind.Directive,
                     // Use the same sort text here as the directive completion item so both items are grouped together

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
@@ -155,7 +155,7 @@ internal class DirectiveCompletionItemProvider : IRazorCompletionItemProvider
                 // Make sort text one less than display text so if there are any delegated completion items
                 // with the same display text in the combined completion list, they will be sorted below
                 // our items.
-                sortText: completionDisplayText[..Math.Max(1, completionDisplayText.Length - 1)],
+                sortText: completionDisplayText,
                 commitCharacters: commitCharacters,
                 isSnippet: false);
             var completionDescription = new DirectiveCompletionDescription(directive.Description);
@@ -169,7 +169,7 @@ internal class DirectiveCompletionItemProvider : IRazorCompletionItemProvider
                     snippetTexts.InsertText,
                     RazorCompletionItemKind.Directive,
                     // Use the same sort text here as the directive completion item so both items are grouped together
-                    sortText: completionItem.SortText,
+                    sortText: completionDisplayText,
                     commitCharacters: commitCharacters,
                     isSnippet: true);
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources/SR.resx
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources/SR.resx
@@ -120,6 +120,9 @@
   <data name="ArgumentCannotBeNullOrEmpty" xml:space="preserve">
     <value>Value cannot be null or an empty string.</value>
   </data>
+  <data name="Directive" xml:space="preserve">
+    <value>directive</value>
+  </data>
   <data name="DirectiveSnippetDescription" xml:space="preserve">
     <value>Insert a directive code snippet
 [Tab] to navigate between elements, [Enter] to complete</value>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources/xlf/SR.cs.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources/xlf/SR.cs.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Hodnota nesmí být null ani prázdný řetězec.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Directive">
+        <source>directive</source>
+        <target state="new">directive</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DirectiveSnippetDescription">
         <source>Insert a directive code snippet
 [Tab] to navigate between elements, [Enter] to complete</source>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources/xlf/SR.de.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources/xlf/SR.de.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Der Wert darf nicht NULL oder eine leere Zeichenfolge sein.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Directive">
+        <source>directive</source>
+        <target state="new">directive</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DirectiveSnippetDescription">
         <source>Insert a directive code snippet
 [Tab] to navigate between elements, [Enter] to complete</source>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources/xlf/SR.es.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources/xlf/SR.es.xlf
@@ -7,6 +7,11 @@
         <target state="translated">El valor no puede ser nulo ni una cadena vacía.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Directive">
+        <source>directive</source>
+        <target state="new">directive</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DirectiveSnippetDescription">
         <source>Insert a directive code snippet
 [Tab] to navigate between elements, [Enter] to complete</source>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources/xlf/SR.fr.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources/xlf/SR.fr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">La valeur ne peut pas être Null ni être une chaîne vide.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Directive">
+        <source>directive</source>
+        <target state="new">directive</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DirectiveSnippetDescription">
         <source>Insert a directive code snippet
 [Tab] to navigate between elements, [Enter] to complete</source>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources/xlf/SR.it.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources/xlf/SR.it.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Il valore non può essere null o una stringa vuota.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Directive">
+        <source>directive</source>
+        <target state="new">directive</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DirectiveSnippetDescription">
         <source>Insert a directive code snippet
 [Tab] to navigate between elements, [Enter] to complete</source>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources/xlf/SR.ja.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources/xlf/SR.ja.xlf
@@ -7,6 +7,11 @@
         <target state="translated">値を null または空の文字列にすることはできません。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Directive">
+        <source>directive</source>
+        <target state="new">directive</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DirectiveSnippetDescription">
         <source>Insert a directive code snippet
 [Tab] to navigate between elements, [Enter] to complete</source>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources/xlf/SR.ko.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources/xlf/SR.ko.xlf
@@ -7,6 +7,11 @@
         <target state="translated">값은 null이거나 빈 문자열일 수 없습니다.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Directive">
+        <source>directive</source>
+        <target state="new">directive</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DirectiveSnippetDescription">
         <source>Insert a directive code snippet
 [Tab] to navigate between elements, [Enter] to complete</source>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources/xlf/SR.pl.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources/xlf/SR.pl.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Wartość nie może być wartością null ani pustym ciągiem.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Directive">
+        <source>directive</source>
+        <target state="new">directive</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DirectiveSnippetDescription">
         <source>Insert a directive code snippet
 [Tab] to navigate between elements, [Enter] to complete</source>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources/xlf/SR.pt-BR.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources/xlf/SR.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="translated">O valor não pode ser nulo ou uma cadeia de caracteres vazia.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Directive">
+        <source>directive</source>
+        <target state="new">directive</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DirectiveSnippetDescription">
         <source>Insert a directive code snippet
 [Tab] to navigate between elements, [Enter] to complete</source>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources/xlf/SR.ru.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources/xlf/SR.ru.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Значение не может быть NULL или пустой строкой.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Directive">
+        <source>directive</source>
+        <target state="new">directive</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DirectiveSnippetDescription">
         <source>Insert a directive code snippet
 [Tab] to navigate between elements, [Enter] to complete</source>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources/xlf/SR.tr.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources/xlf/SR.tr.xlf
@@ -7,6 +7,11 @@
         <target state="translated">Değer null veya boş bir dize olamaz.</target>
         <note />
       </trans-unit>
+      <trans-unit id="Directive">
+        <source>directive</source>
+        <target state="new">directive</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DirectiveSnippetDescription">
         <source>Insert a directive code snippet
 [Tab] to navigate between elements, [Enter] to complete</source>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources/xlf/SR.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="translated">值不能为 null 或空字符串。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Directive">
+        <source>directive</source>
+        <target state="new">directive</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DirectiveSnippetDescription">
         <source>Insert a directive code snippet
 [Tab] to navigate between elements, [Enter] to complete</source>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Resources/xlf/SR.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="translated">值不能為 Null 或空字串。</target>
         <note />
       </trans-unit>
+      <trans-unit id="Directive">
+        <source>directive</source>
+        <target state="new">directive</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DirectiveSnippetDescription">
         <source>Insert a directive code snippet
 [Tab] to navigate between elements, [Enter] to complete</source>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/SnippetResponseRewriterTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/SnippetResponseRewriterTest.cs
@@ -38,10 +38,12 @@ public class SnippetResponseRewriterTest(ITestOutputHelper testOutput)
             completion =>
             {
                 Assert.Equal("using statement", completion.Label);
+                Assert.Equal("using ", completion.SortText);
             },
             completion =>
             {
                 Assert.Equal("if", completion.Label);
+                Assert.Equal("if", completion.SortText);
             }
         );
     }
@@ -69,10 +71,12 @@ public class SnippetResponseRewriterTest(ITestOutputHelper testOutput)
             completion =>
             {
                 Assert.Equal("using", completion.Label);
+                Assert.Equal("using", completion.SortText);
             },
             completion =>
             {
                 Assert.Equal("if", completion.Label);
+                Assert.Equal("if", completion.SortText);
             }
         );
     }
@@ -100,10 +104,12 @@ public class SnippetResponseRewriterTest(ITestOutputHelper testOutput)
             completion =>
             {
                 Assert.Equal("using", completion.Label);
+                Assert.Equal("using", completion.SortText);
             },
             completion =>
             {
                 Assert.Equal("if", completion.Label);
+                Assert.Equal("if", completion.SortText);
             }
         );
     }
@@ -131,17 +137,25 @@ public class SnippetResponseRewriterTest(ITestOutputHelper testOutput)
             completion =>
             {
                 Assert.Null(completion.Label);
+                Assert.Null(completion.SortText);
             },
             completion =>
             {
                 Assert.Equal("using statement", completion.Label);
+                Assert.Equal("using ", completion.SortText);
             }
         );
     }
 
     private static VSInternalCompletionList GenerateCompletionList(params (string? Label, CompletionItemKind Kind)[] itemsData)
     {
-        var items = itemsData.Select(itemData => new VSInternalCompletionItem() { Label = itemData.Label!, Kind = itemData.Kind}).ToArray();
+        var items = itemsData.Select(itemData => new VSInternalCompletionItem()
+            {
+                Label = itemData.Label!,
+                SortText = itemData.Label,
+                Kind = itemData.Kind})
+        .ToArray();
+
         return new VSInternalCompletionList()
         {
             Items = items

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/SnippetResponseRewriterTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/SnippetResponseRewriterTest.cs
@@ -11,6 +11,7 @@ using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Completion.Delegation;
+
 public class SnippetResponseRewriterTest(ITestOutputHelper testOutput)
     : ResponseRewriterTestBase(new SnippetResponseRewriter(), testOutput)
 {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/SnippetResponseRewriterTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/SnippetResponseRewriterTest.cs
@@ -1,0 +1,149 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.Completion.Delegation;
+public class SnippetResponseRewriterTest(ITestOutputHelper testOutput)
+    : ResponseRewriterTestBase(new SnippetResponseRewriter(), testOutput)
+{
+    [Fact]
+    public async Task RewriteAsync_ChangesUsingSnippetLabel()
+    {
+        // Arrange
+        var documentContent = "@$$";
+        TestFileMarkupParser.GetPosition(documentContent, out documentContent, out var cursorPosition);
+        var delegatedCompletionList = GenerateCompletionList(
+            ("using", CompletionItemKind.Snippet),
+            ("if", CompletionItemKind.Keyword)
+            );
+        var rewriter = new SnippetResponseRewriter();
+
+        // Act
+        var rewrittenCompletionList = await GetRewrittenCompletionListAsync(
+            cursorPosition, documentContent, delegatedCompletionList, rewriter);
+
+        // Assert
+        Assert.Null(rewrittenCompletionList.CommitCharacters);
+        Assert.Collection(
+            rewrittenCompletionList.Items,
+            completion =>
+            {
+                Assert.Equal("using statement", completion.Label);
+            },
+            completion =>
+            {
+                Assert.Equal("if", completion.Label);
+            }
+        );
+    }
+
+    [Fact]
+    public async Task RewriteAsync_DoesNotChangeUsingKeywordLabel()
+    {
+        // Arrange
+        var documentContent = "@$$";
+        TestFileMarkupParser.GetPosition(documentContent, out documentContent, out var cursorPosition);
+        var delegatedCompletionList = GenerateCompletionList(
+            ("using", CompletionItemKind.Keyword),
+            ("if", CompletionItemKind.Keyword)
+            );
+        var rewriter = new SnippetResponseRewriter();
+
+        // Act
+        var rewrittenCompletionList = await GetRewrittenCompletionListAsync(
+            cursorPosition, documentContent, delegatedCompletionList, rewriter);
+
+        // Assert
+        Assert.Null(rewrittenCompletionList.CommitCharacters);
+        Assert.Collection(
+            rewrittenCompletionList.Items,
+            completion =>
+            {
+                Assert.Equal("using", completion.Label);
+            },
+            completion =>
+            {
+                Assert.Equal("if", completion.Label);
+            }
+        );
+    }
+
+    [Fact]
+    public async Task RewriteAsync_DoesNotChangeIfSnippetLabel()
+    {
+        // Arrange
+        var documentContent = "@$$";
+        TestFileMarkupParser.GetPosition(documentContent, out documentContent, out var cursorPosition);
+        var delegatedCompletionList = GenerateCompletionList(
+            ("using", CompletionItemKind.Keyword),
+            ("if", CompletionItemKind.Snippet)
+            );
+        var rewriter = new SnippetResponseRewriter();
+
+        // Act
+        var rewrittenCompletionList = await GetRewrittenCompletionListAsync(
+            cursorPosition, documentContent, delegatedCompletionList, rewriter);
+
+        // Assert
+        Assert.Null(rewrittenCompletionList.CommitCharacters);
+        Assert.Collection(
+            rewrittenCompletionList.Items,
+            completion =>
+            {
+                Assert.Equal("using", completion.Label);
+            },
+            completion =>
+            {
+                Assert.Equal("if", completion.Label);
+            }
+        );
+    }
+
+    [Fact]
+    public async Task RewriteAsync_HandlesNullLabels()
+    {
+        // Arrange
+        var documentContent = "@$$";
+        TestFileMarkupParser.GetPosition(documentContent, out documentContent, out var cursorPosition);
+        var delegatedCompletionList = GenerateCompletionList(
+            (null, CompletionItemKind.Keyword),
+            ("using", CompletionItemKind.Snippet)
+            );
+        var rewriter = new SnippetResponseRewriter();
+
+        // Act
+        var rewrittenCompletionList = await GetRewrittenCompletionListAsync(
+            cursorPosition, documentContent, delegatedCompletionList, rewriter);
+
+        // Assert
+        Assert.Null(rewrittenCompletionList.CommitCharacters);
+        Assert.Collection(
+            rewrittenCompletionList.Items,
+            completion =>
+            {
+                Assert.Null(completion.Label);
+            },
+            completion =>
+            {
+                Assert.Equal("using statement", completion.Label);
+            }
+        );
+    }
+
+    private static VSInternalCompletionList GenerateCompletionList(params (string? Label, CompletionItemKind Kind)[] itemsData)
+    {
+        var items = itemsData.Select(itemData => new VSInternalCompletionItem() { Label = itemData.Label!, Kind = itemData.Kind}).ToArray();
+        return new VSInternalCompletionList()
+        {
+            Items = items
+        };
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DirectiveVerifier.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DirectiveVerifier.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.Razor.Completion;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion;
+
+internal static class DirectiveVerifier
+{
+    private static readonly Action<CompletionItem>[] s_defaultDirectiveCollectionVerifiers;
+
+    public static Action<CompletionItem>[] DefaultDirectiveCollectionVerifiers => s_defaultDirectiveCollectionVerifiers;
+
+    static DirectiveVerifier()
+    {
+        var defaultDirectiveVerifierList = new List<Action<CompletionItem>>(DirectiveCompletionItemProvider.DefaultDirectives.Count() * 2);
+
+        foreach (var directive in DirectiveCompletionItemProvider.DefaultDirectives)
+        {
+            defaultDirectiveVerifierList.Add(item => Assert.Equal(directive.Directive, item.InsertText));
+            defaultDirectiveVerifierList.Add(item => AssertDirectiveSnippet(item, directive.Directive));
+        }
+
+        s_defaultDirectiveCollectionVerifiers = defaultDirectiveVerifierList.ToArray();
+    }
+
+    private static void AssertDirectiveSnippet(CompletionItem completionItem, string directive)
+    {
+        Assert.StartsWith(directive, completionItem.InsertText);
+        Assert.Equal(DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets[directive].InsertText, completionItem.InsertText);
+        Assert.Equal(CompletionItemKind.Snippet, completionItem.Kind);
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/LegacyRazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/LegacyRazorCompletionEndpointTest.cs
@@ -396,12 +396,7 @@ public class LegacyRazorCompletionEndpointTest : LanguageServerTestBase
 
         // These are the default directives that don't need to be separately registered, they should always be part of the completion list.
         Assert.Collection(completionList.Items,
-            item => Assert.Equal("addTagHelper", item.InsertText),
-            item => AssertDirectiveSnippet(item, "addTagHelper"),
-            item => Assert.Equal("removeTagHelper", item.InsertText),
-            item => AssertDirectiveSnippet(item, "removeTagHelper"),
-            item => Assert.Equal("tagHelperPrefix", item.InsertText),
-            item => AssertDirectiveSnippet(item, "tagHelperPrefix")
+            DirectiveVerifier.DefaultDirectiveCollectionVerifiers
         );
     }
 
@@ -440,12 +435,7 @@ public class LegacyRazorCompletionEndpointTest : LanguageServerTestBase
 
         // Assert
         Assert.Collection(completionList.Items,
-            item => Assert.Equal("addTagHelper", item.InsertText),
-            item => AssertDirectiveSnippet(item, "addTagHelper"),
-            item => Assert.Equal("removeTagHelper", item.InsertText),
-            item => AssertDirectiveSnippet(item, "removeTagHelper"),
-            item => Assert.Equal("tagHelperPrefix", item.InsertText),
-            item => AssertDirectiveSnippet(item, "tagHelperPrefix")
+            DirectiveVerifier.DefaultDirectiveCollectionVerifiers
         );
     }
 
@@ -520,12 +510,7 @@ public class LegacyRazorCompletionEndpointTest : LanguageServerTestBase
 
         // Assert
         Assert.Collection(completionList.Items,
-            item => Assert.Equal("addTagHelper", item.InsertText),
-            item => AssertDirectiveSnippet(item, "addTagHelper"),
-            item => Assert.Equal("removeTagHelper", item.InsertText),
-            item => AssertDirectiveSnippet(item, "removeTagHelper"),
-            item => Assert.Equal("tagHelperPrefix", item.InsertText),
-            item => AssertDirectiveSnippet(item, "tagHelperPrefix")
+            DirectiveVerifier.DefaultDirectiveCollectionVerifiers
         );
     }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionListProvierTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionListProvierTest.cs
@@ -376,12 +376,7 @@ public class RazorCompletionListProvierTest : LanguageServerTestBase
 
         // These are the default directives that don't need to be separately registered, they should always be part of the completion list.
         Assert.Collection(completionList.Items,
-            item => Assert.Equal("addTagHelper", item.InsertText),
-            item => AssertDirectiveSnippet(item, "addTagHelper"),
-            item => Assert.Equal("removeTagHelper", item.InsertText),
-            item => AssertDirectiveSnippet(item, "removeTagHelper"),
-            item => Assert.Equal("tagHelperPrefix", item.InsertText),
-            item => AssertDirectiveSnippet(item, "tagHelperPrefix")
+            DirectiveVerifier.DefaultDirectiveCollectionVerifiers
         );
     }
 
@@ -437,12 +432,7 @@ public class RazorCompletionListProvierTest : LanguageServerTestBase
 
         // Assert
         Assert.Collection(completionList.Items,
-            item => Assert.Equal("addTagHelper", item.InsertText),
-            item => AssertDirectiveSnippet(item, "addTagHelper"),
-            item => Assert.Equal("removeTagHelper", item.InsertText),
-            item => AssertDirectiveSnippet(item, "removeTagHelper"),
-            item => Assert.Equal("tagHelperPrefix", item.InsertText),
-            item => AssertDirectiveSnippet(item, "tagHelperPrefix")
+            DirectiveVerifier.DefaultDirectiveCollectionVerifiers
         );
     }
 
@@ -499,12 +489,7 @@ public class RazorCompletionListProvierTest : LanguageServerTestBase
 
         // Assert
         Assert.Collection(completionList.Items,
-            item => Assert.Equal("addTagHelper", item.InsertText),
-            item => AssertDirectiveSnippet(item, "addTagHelper"),
-            item => Assert.Equal("removeTagHelper", item.InsertText),
-            item => AssertDirectiveSnippet(item, "removeTagHelper"),
-            item => Assert.Equal("tagHelperPrefix", item.InsertText),
-            item => AssertDirectiveSnippet(item, "tagHelperPrefix")
+            DirectiveVerifier.DefaultDirectiveCollectionVerifiers
         );
     }
 
@@ -606,12 +591,5 @@ public class RazorCompletionListProvierTest : LanguageServerTestBase
         var tagHelperDocumentContext = TagHelperDocumentContext.Create(prefix: string.Empty, tagHelpers: []);
         codeDocument.SetTagHelperContext(tagHelperDocumentContext);
         return codeDocument;
-    }
-
-    private static void AssertDirectiveSnippet(CompletionItem completionItem, string directive)
-    {
-        Assert.StartsWith(directive, completionItem.InsertText);
-        Assert.Equal(DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets[directive].InsertText, completionItem.InsertText);
-        Assert.Equal(CompletionItemKind.Snippet, completionItem.Kind);
     }
 }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
@@ -3,10 +3,11 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Extensions;
-using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
@@ -17,12 +18,20 @@ namespace Microsoft.CodeAnalysis.Razor.Completion;
 
 public class DirectiveCompletionItemProviderTest : ToolingTestBase
 {
-    private static readonly IReadOnlyList<DirectiveDescriptor> s_defaultDirectives = new[]
+    private static readonly Action<RazorCompletionItem>[] s_defaultDirectiveCollectionVerifiers;
+
+    static DirectiveCompletionItemProviderTest()
     {
-        CSharpCodeParser.AddTagHelperDirectiveDescriptor,
-        CSharpCodeParser.RemoveTagHelperDirectiveDescriptor,
-        CSharpCodeParser.TagHelperPrefixDirectiveDescriptor,
-    };
+        var defaultDirectiveList = new List<Action<RazorCompletionItem>>(DirectiveCompletionItemProvider.DefaultDirectives.Count() * 2);
+
+        foreach (var directive in DirectiveCompletionItemProvider.DefaultDirectives)
+        {
+            defaultDirectiveList.Add(item => AssertRazorCompletionItem(directive, item, isSnippet: false));
+            defaultDirectiveList.Add(item => AssertRazorCompletionItem(directive, item, isSnippet: true));
+        }
+
+        s_defaultDirectiveCollectionVerifiers = defaultDirectiveList.ToArray();
+    }
 
     public DirectiveCompletionItemProviderTest(ITestOutputHelper testOutput)
         : base(testOutput)
@@ -42,12 +51,8 @@ public class DirectiveCompletionItemProviderTest : ToolingTestBase
         // Assert
         Assert.Collection(
             completionItems,
-            item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: false),
-            item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: true),
-            item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: false),
-            item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: true),
-            item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: false),
-            item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: true));
+            s_defaultDirectiveCollectionVerifiers
+        );
     }
 
     [Fact]
@@ -64,13 +69,11 @@ public class DirectiveCompletionItemProviderTest : ToolingTestBase
         // Assert
         Assert.Collection(
             completionItems,
-            item => AssertRazorCompletionItem(customDirective, item),
-            item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: false),
-            item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: true),
-            item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: false),
-            item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: true),
-            item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: false),
-            item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: true));
+            [
+                item => AssertRazorCompletionItem(customDirective, item), ..
+                s_defaultDirectiveCollectionVerifiers
+            ]
+        );
     }
 
     [Fact]
@@ -91,13 +94,11 @@ public class DirectiveCompletionItemProviderTest : ToolingTestBase
         // Assert
         Assert.Collection(
             completionItems,
-            item => AssertRazorCompletionItem("different", customDirective, item),
-            item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: false),
-            item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: true),
-            item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: false),
-            item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: true),
-            item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: false),
-            item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: true));
+            [
+                item => AssertRazorCompletionItem("different", customDirective, item), ..
+                s_defaultDirectiveCollectionVerifiers
+            ]
+        );
     }
 
     [Fact]
@@ -118,13 +119,11 @@ public class DirectiveCompletionItemProviderTest : ToolingTestBase
         // Assert
         Assert.Collection(
             completionItems,
-            item => AssertRazorCompletionItem("code", customDirective, item, DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters),
-            item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: false),
-            item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: true),
-            item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: false),
-            item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: true),
-            item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: false),
-            item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: true));
+            [
+                item => AssertRazorCompletionItem("code", customDirective, item, DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters), ..
+                s_defaultDirectiveCollectionVerifiers
+            ]
+        );
     }
 
     [Fact]
@@ -134,7 +133,7 @@ public class DirectiveCompletionItemProviderTest : ToolingTestBase
         var customDirective = DirectiveDescriptor.CreateRazorBlockDirective("custom", builder =>
         {
             builder.DisplayName = "section";
-            builder.Description = "My Custom Razozr Block Directive.";
+            builder.Description = "My Custom Razor Block Directive.";
         });
         var syntaxTree = CreateSyntaxTree("@sec", customDirective);
 
@@ -144,13 +143,11 @@ public class DirectiveCompletionItemProviderTest : ToolingTestBase
         // Assert
         Assert.Collection(
             completionItems,
-            item => AssertRazorCompletionItem("section", customDirective, item, DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters),
-            item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: false),
-            item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: true),
-            item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: false),
-            item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: true),
-            item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: false),
-            item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: true));
+            [
+                item => AssertRazorCompletionItem("section", customDirective, item, DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters), ..
+                s_defaultDirectiveCollectionVerifiers
+            ]
+        );
     }
 
     [Theory]
@@ -181,7 +178,7 @@ public class DirectiveCompletionItemProviderTest : ToolingTestBase
         Assert.Collection(
             completionItems,
             item => AssertRazorCompletionItem(knownDirective, customDirective, item, commitCharacters: DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters, isSnippet: false),
-            item => AssertRazorCompletionItem(knownDirective + " ...", customDirective, item, commitCharacters: DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters, isSnippet: true));
+            item => AssertRazorCompletionItem(knownDirective + " directive", customDirective, item, commitCharacters: DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters, isSnippet: true));
     }
 
     [Fact]
@@ -202,14 +199,12 @@ public class DirectiveCompletionItemProviderTest : ToolingTestBase
         // Assert
         Assert.Collection(
             completionItems,
-            item => AssertRazorCompletionItem("model", customDirective, item, commitCharacters: DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters, isSnippet: false),
-            item => AssertRazorCompletionItem("model ...", customDirective, item, commitCharacters: DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters, isSnippet: true),
-            item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: false),
-            item => AssertRazorCompletionItem(s_defaultDirectives[0], item, isSnippet: true),
-            item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: false),
-            item => AssertRazorCompletionItem(s_defaultDirectives[1], item, isSnippet: true),
-            item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: false),
-            item => AssertRazorCompletionItem(s_defaultDirectives[2], item, isSnippet: true));
+            [
+                item => AssertRazorCompletionItem("model", customDirective, item, commitCharacters: DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters, isSnippet: false),
+                item => AssertRazorCompletionItem("model directive", customDirective, item, commitCharacters: DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters, isSnippet: true), ..
+                s_defaultDirectiveCollectionVerifiers
+            ]
+        );
     }
 
     [Fact]
@@ -462,7 +457,7 @@ public class DirectiveCompletionItemProviderTest : ToolingTestBase
     }
 
     private static void AssertRazorCompletionItem(DirectiveDescriptor directive, RazorCompletionItem item, bool isSnippet = false) =>
-        AssertRazorCompletionItem(directive.Directive + (isSnippet ? " ..." : string.Empty), directive, item, isSnippet: isSnippet);
+        AssertRazorCompletionItem(directive.Directive + (isSnippet ? " directive" : string.Empty), directive, item, isSnippet: isSnippet);
 
     private static RazorSyntaxTree CreateSyntaxTree(string text, params DirectiveDescriptor[] directives)
     {

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
@@ -178,7 +178,7 @@ public class DirectiveCompletionItemProviderTest : ToolingTestBase
         Assert.Collection(
             completionItems,
             item => AssertRazorCompletionItem(knownDirective, customDirective, item, commitCharacters: DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters, isSnippet: false),
-            item => AssertRazorCompletionItem(knownDirective + " directive", customDirective, item, commitCharacters: DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters, isSnippet: true));
+            item => AssertRazorCompletionItem(knownDirective + " directive ...", customDirective, item, commitCharacters: DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters, isSnippet: true));
     }
 
     [Fact]
@@ -201,7 +201,7 @@ public class DirectiveCompletionItemProviderTest : ToolingTestBase
             completionItems,
             [
                 item => AssertRazorCompletionItem("model", customDirective, item, commitCharacters: DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters, isSnippet: false),
-                item => AssertRazorCompletionItem("model directive", customDirective, item, commitCharacters: DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters, isSnippet: true), ..
+                item => AssertRazorCompletionItem("model directive ...", customDirective, item, commitCharacters: DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters, isSnippet: true), ..
                 s_defaultDirectiveCollectionVerifiers
             ]
         );
@@ -457,7 +457,7 @@ public class DirectiveCompletionItemProviderTest : ToolingTestBase
     }
 
     private static void AssertRazorCompletionItem(DirectiveDescriptor directive, RazorCompletionItem item, bool isSnippet = false) =>
-        AssertRazorCompletionItem(directive.Directive + (isSnippet ? " directive" : string.Empty), directive, item, isSnippet: isSnippet);
+        AssertRazorCompletionItem(directive.Directive + (isSnippet ? " directive ..." : string.Empty), directive, item, isSnippet: isSnippet);
 
     private static RazorSyntaxTree CreateSyntaxTree(string text, params DirectiveDescriptor[] directives)
     {

--- a/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/Completion/RazorDirectiveCompletionSourceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/Completion/RazorDirectiveCompletionSourceTest.cs
@@ -30,7 +30,8 @@ public class RazorDirectiveCompletionSourceTest(ITestOutputHelper testOutput) : 
     [
         CSharpCodeParser.AddTagHelperDirectiveDescriptor,
         CSharpCodeParser.RemoveTagHelperDirectiveDescriptor,
-        CSharpCodeParser.TagHelperPrefixDirectiveDescriptor
+        CSharpCodeParser.TagHelperPrefixDirectiveDescriptor,
+        CSharpCodeParser.UsingDirectiveDescriptor
     ]);
 
     private readonly IRazorCompletionFactsService _completionFactsService = new RazorCompletionFactsService([new DirectiveCompletionItemProvider()]);
@@ -120,7 +121,9 @@ public class RazorDirectiveCompletionSourceTest(ITestOutputHelper testOutput) : 
             item => AssertRazorCompletionItem(s_defaultDirectives[1], item, completionSource, isSnippet: false),
             item => AssertRazorCompletionItem(s_defaultDirectives[1], item, completionSource, isSnippet: true),
             item => AssertRazorCompletionItem(s_defaultDirectives[2], item, completionSource, isSnippet: false),
-            item => AssertRazorCompletionItem(s_defaultDirectives[2], item, completionSource, isSnippet: true));
+            item => AssertRazorCompletionItem(s_defaultDirectives[2], item, completionSource, isSnippet: true),
+            item => AssertRazorCompletionItem(s_defaultDirectives[3], item, completionSource, isSnippet: false),
+            item => AssertRazorCompletionItem(s_defaultDirectives[3], item, completionSource, isSnippet: true));
     }
 
     [Fact]
@@ -184,7 +187,7 @@ public class RazorDirectiveCompletionSourceTest(ITestOutputHelper testOutput) : 
 
     private static void AssertRazorCompletionItem(DirectiveDescriptor directive, CompletionItem item, IAsyncCompletionSource source, bool isSnippet = false)
     {
-        var expectedDisplayText = isSnippet ? directive.Directive + " ..." : directive.Directive;
+        var expectedDisplayText = isSnippet ? directive.Directive + " directive" : directive.Directive;
         AssertRazorCompletionItem(expectedDisplayText, directive, item, source, isSnippet: isSnippet);
     }
 

--- a/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/Completion/RazorDirectiveCompletionSourceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/Completion/RazorDirectiveCompletionSourceTest.cs
@@ -187,7 +187,7 @@ public class RazorDirectiveCompletionSourceTest(ITestOutputHelper testOutput) : 
 
     private static void AssertRazorCompletionItem(DirectiveDescriptor directive, CompletionItem item, IAsyncCompletionSource source, bool isSnippet = false)
     {
-        var expectedDisplayText = isSnippet ? directive.Directive + " directive" : directive.Directive;
+        var expectedDisplayText = isSnippet ? directive.Directive + " directive ..." : directive.Directive;
         AssertRazorCompletionItem(expectedDisplayText, directive, item, source, isSnippet: isSnippet);
     }
 


### PR DESCRIPTION
﻿### Summary of the changes

- Adding "using" directive keyword
- Adding "using" directive snippet
- Changing directive snippet labels to say "<directive> directive", e.g. "using directive"
- Adding SnippetResponseRewriter to modify C# using snippet label to "using statement"
- Fixing up tests

Fixes:
https://github.com/dotnet/razor/issues/9330
https://github.com/dotnet/razor/issues/9331