### PR TITLE
Telemetry for mapCode - CorrelationId, duration

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Protocol/DelegatedTypes.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer.Protocol/DelegatedTypes.cs
@@ -63,6 +63,7 @@ internal record DelegatedCompletionParams(
 internal record DelegatedMapCodeParams(
     TextDocumentIdentifierAndVersion Identifier,
     RazorLanguageKind ProjectedKind,
+    Guid MapCodeCorrelationId,
     string[] Contents,
     Location[][] FocusLocations) : IDelegatedParams;
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MapCode/MapCodeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MapCode/MapCodeEndpoint.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.MapCode.Mappers;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.AspNetCore.Razor.PooledObjects;
+using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -37,11 +38,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.MapCode;
 internal sealed class MapCodeEndpoint(
     IRazorDocumentMappingService documentMappingService,
     IDocumentContextFactory documentContextFactory,
-    IClientConnection clientConnection) : IRazorDocumentlessRequestHandler<VSInternalMapCodeParams, WorkspaceEdit?>, ICapabilitiesProvider
+    IClientConnection clientConnection,
+    ITelemetryReporter telemetryReporter) : IRazorDocumentlessRequestHandler<VSInternalMapCodeParams, WorkspaceEdit?>, ICapabilitiesProvider
 {
     private readonly IRazorDocumentMappingService _documentMappingService = documentMappingService ?? throw new ArgumentNullException(nameof(documentMappingService));
     private readonly IDocumentContextFactory _documentContextFactory = documentContextFactory ?? throw new ArgumentNullException(nameof(documentContextFactory));
     private readonly IClientConnection _clientConnection = clientConnection ?? throw new ArgumentNullException(nameof(clientConnection));
+    private readonly ITelemetryReporter _telemetryReporter = telemetryReporter ?? throw new ArgumentNullException(nameof(telemetryReporter));
 
     public bool MutatesSolutionState => false;
 
@@ -51,22 +54,30 @@ internal sealed class MapCodeEndpoint(
     }
 
     public async Task<WorkspaceEdit?> HandleRequestAsync(
-        VSInternalMapCodeParams request,
+        VSInternalMapCodeParams mapperParams,
         RazorRequestContext context,
         CancellationToken cancellationToken)
     {
         // TO-DO: Apply updates to the workspace before doing mapping. This is currently
         // unimplemented by the client, so we won't bother doing anything for now until
         // we determine what kinds of updates the client will actually send us.
-        Debug.Assert(request.Updates is null);
+        Debug.Assert(mapperParams.Updates is null);
 
-        if (request.Updates is not null)
+        if (mapperParams.Updates is not null)
         {
             return null;
         }
 
+        using var ts = TelemetryScope.Create(_telemetryReporter, "mapcode", Severity.Normal,
+             new Property("mapCode.CorrelationId", mapperParams.MapCodeCorrelationId));
+
+        return await HandleMappingsAsync(mapperParams.Mappings, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<WorkspaceEdit?> HandleMappingsAsync(VSInternalMapCodeMapping[] mappings, CancellationToken cancellationToken)
+    { 
         using var _ = ArrayBuilderPool<TextDocumentEdit>.GetPooledObject(out var changes);
-        foreach (var mapping in request.Mappings)
+        foreach (var mapping in mappings)
         {
             if (mapping.TextDocument is null || mapping.FocusLocations is null)
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Endpoints/MapCode.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Endpoints/MapCode.cs
@@ -30,20 +30,24 @@ internal partial class RazorCustomMessageTarget
         {
             TextDocument = request.Identifier.TextDocumentIdentifier.WithUri(delegationDetails.Value.ProjectedUri),
             Contents = request.Contents,
-            FocusLocations = request.FocusLocations
+            FocusLocations = request.FocusLocations,
         };
 
         var mapCodeParams = new VSInternalMapCodeParams()
         {
-            Mappings = [mappings]
+            Mappings = [mappings],
+            MapCodeCorrelationId = request.MapCodeCorrelationId,
         };
 
         var textBuffer = delegationDetails.Value.TextBuffer;
+        var lspMethodName = VSInternalMethods.WorkspaceMapCodeName;
+        var languageServerName = delegationDetails.Value.LanguageServerName;
+        using var _ = _telemetryReporter.TrackLspRequest(lspMethodName, languageServerName, request.MapCodeCorrelationId);
 
         var response = await _requestInvoker.ReinvokeRequestOnServerAsync<VSInternalMapCodeParams, WorkspaceEdit?>(
             textBuffer,
-            VSInternalMethods.WorkspaceMapCodeName,
-            delegationDetails.Value.LanguageServerName,
+            lspMethodName,
+            languageServerName,
             SupportsMapCode,
             mapCodeParams,
             cancellationToken).ConfigureAwait(false);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/MapCode/MapCodeTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/MapCode/MapCodeTest.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.MapCode;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
+using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.AspNetCore.Razor.Test.Common.Mef;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
@@ -317,7 +318,7 @@ public class MapCodeTest(ITestOutputHelper testOutput) : LanguageServerTestBase(
         var languageServer = new MapCodeServer(csharpServer, csharpDocumentUri);
         var documentMappingService = new RazorDocumentMappingService(FilePathService, documentContextFactory, LoggerFactory);
 
-        var endpoint = new MapCodeEndpoint(documentMappingService, documentContextFactory, languageServer);
+        var endpoint = new MapCodeEndpoint(documentMappingService, documentContextFactory, languageServer, NoOpTelemetryReporter.Instance);
 
         var capabilitiesProvider = Assert.IsAssignableFrom<ICapabilitiesProvider>(endpoint);
 


### PR DESCRIPTION
Telemetry for mapCode - CorrelationId, duration

ISSUE:
When the mapCode method is called, it receives a correlationId; it should log that, so that we can stitch together which LSP servers did which work.

FIX:
Record in telemetry the correlationID and duration.