### PR TITLE
Cancelled tag helper discovery should report cancelled

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectWorkspaceStateGenerator.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectWorkspaceStateGenerator.cs
@@ -169,6 +169,9 @@ internal sealed class ProjectWorkspaceStateGenerator(
                     var tagHelpers = await _tagHelperResolver.GetTagHelpersAsync(workspaceProject, projectSnapshot, cancellationToken).ConfigureAwait(false);
                     watch.Stop();
 
+                    // don't report success if the work was cancelled
+                    cancellationToken.ThrowIfCancellationRequested();
+
                     _telemetryReporter.ReportEvent("taghelperresolve/end", Severity.Normal,
                         new Property("id", telemetryId),
                         new Property("ellapsedms", watch.ElapsedMilliseconds),


### PR DESCRIPTION
ISSUE:
There are cases (caught in debugger) where a cancelled tag helper discovery/update call reports success to the telemetry system.  We should report cancelled if cancelled.

FIX:
Check for cancellation.