### PR TITLE
Remove UsingToolNetFrameworkReferenceAssemblies

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,8 +4,6 @@
     <UsingToolVSSDK>true</UsingToolVSSDK>
     <MicrosoftVSSDKBuildToolsVersion>17.3.2094</MicrosoftVSSDKBuildToolsVersion>
     <MicroBuildPluginsSwixBuildVersion>1.1.33</MicroBuildPluginsSwixBuildVersion>
-    <!-- Use .NET Framework reference assemblies from a nuget package so machine-global targeting packs do not need to be installed. -->
-    <UsingToolNetFrameworkReferenceAssemblies>true</UsingToolNetFrameworkReferenceAssemblies>
     <UsingToolSymbolUploader>true</UsingToolSymbolUploader>
     <UsingToolMicrosoftNetCompilers>true</UsingToolMicrosoftNetCompilers>
   </PropertyGroup>


### PR DESCRIPTION
UsingToolNetFrameworkReferenceAssemblies got removed from Arcade a while ago as the SDK supports that natively.