### PR TITLE
Revert "Don't rebuild when doing rid-specific publishing, just publish (#9925)"

### DIFF
--- a/Razor.Slim.slnf
+++ b/Razor.Slim.slnf
@@ -26,8 +26,6 @@
       "src\\Razor\\src\\Microsoft.VisualStudio.LanguageServer.ContainedLanguage\\Microsoft.VisualStudio.LanguageServer.ContainedLanguage.csproj",
       "src\\Razor\\src\\Microsoft.VisualStudio.LanguageServices.Razor\\Microsoft.VisualStudio.LanguageServices.Razor.csproj",
       "src\\Razor\\src\\Microsoft.VisualStudio.RazorExtension\\Microsoft.VisualStudio.RazorExtension.csproj",
-      "src\\Razor\\src\\Microsoft.AspNetCore.Razor.LanguageServer\\Microsoft.AspNetCore.Razor.LanguageServer.csproj",
-      "src\\Razor\\src\\rzls\\rzls.csproj",
       "src\\Razor\\test\\Microsoft.AspNetCore.Razor.Test.Common.Tooling\\Microsoft.AspNetCore.Razor.Test.Common.Tooling.csproj",
       "src\\Razor\\test\\Microsoft.AspNetCore.Razor.Test.MvcShim.ClassLib\\Microsoft.AspNetCore.Razor.Test.MvcShim.ClassLib.csproj",
       "src\\Razor\\test\\Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X\\Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X.csproj",

--- a/eng/AfterSolutionBuild.targets
+++ b/eng/AfterSolutionBuild.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 
-  <Target Name="_PublishLanguageServerRids" AfterTargets="Pack" Condition="'$(DotNetBuildFromSource)' != 'true' and '$(ArcadeBuildFromSource)' != 'true'">
+  <Target Name="_PublishLanguageServerRids" AfterTargets="Pack" Condition="'$(DotNetBuildFromSource)' != 'true'">
     <PropertyGroup>
       <BuildAnalyzersSolutionPath>$(MSBuildThisFileDirectory)..\BuildAnalyzers.sln</BuildAnalyzersSolutionPath>
       <LanguageServerProject>$(MSBuildThisFileDirectory)..\src\Razor\src\rzls\rzls.csproj</LanguageServerProject>
@@ -15,7 +15,7 @@
              Targets="PublishAllRids" />
   </Target>
 
-  <Target Name="_PublishDevKitTelemetryRids" AfterTargets="Pack" Condition="'$(DotNetBuildFromSource)' != 'true' and '$(ArcadeBuildFromSource)' != 'true'">
+  <Target Name="_PublishDevKitTelemetryRids" AfterTargets="Pack" Condition="'$(DotNetBuildFromSource)' != 'true'">
     <PropertyGroup>
       <DevKitTelemetryProject>$(MSBuildThisFileDirectory)..\src\Razor\src\Microsoft.VisualStudio.DevKit.Razor\Microsoft.VisualStudio.DevKit.Razor.csproj</DevKitTelemetryProject>
       <RazorSolutionPath>$(MSBuildThisFileDirectory)..\Razor.sln</RazorSolutionPath>

--- a/src/Razor/src/Microsoft.VisualStudio.DevKit.Razor/Microsoft.VisualStudio.DevKit.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.DevKit.Razor/Microsoft.VisualStudio.DevKit.Razor.csproj
@@ -52,11 +52,11 @@
 
       <!-- Transform RuntimeIdentifierForPublish items to project items to pass to MSBuild task -->
       <ProjectToPublish Include="@(RuntimeIdentifierForPublish->'$(MSBuildProjectFullPath)')">
-        <AdditionalProperties>_IsPublishing=true;NoBuild=true;PublishRuntimeIdentifier=%(RuntimeIdentifierForPublish.Identity);PublishDir=$(RidsPublishDir)%(RuntimeIdentifierForPublish.Identity)\;TargetFramework=$(PublishTargetFramework);SelfContained=false;AppendRuntimeIdentifierToOutputPath=false</AdditionalProperties>
+        <AdditionalProperties>RuntimeIdentifier=%(RuntimeIdentifierForPublish.Identity);PublishDir=$(RidsPublishDir)%(RuntimeIdentifierForPublish.Identity)\;TargetFramework=$(PublishTargetFramework);SelfContained=false</AdditionalProperties>
       </ProjectToPublish>
 
       <ProjectToPublish_PlatformAgnostic Include="$(MSBuildProjectFullPath)">
-        <AdditionalProperties>_IsPublishing=true;NoBuild=true;PublishDir=$(RidsPublishDir)\PlatformAgnostic\;UseAppHost=false;TargetFramework=$(PublishTargetFramework);SelfContained=false;AppendRuntimeIdentifierToOutputPath=false</AdditionalProperties>
+        <AdditionalProperties>PublishDir=$(RidsPublishDir)\PlatformAgnostic\;UseAppHost=false;TargetFramework=$(PublishTargetFramework);SelfContained=false</AdditionalProperties>
       </ProjectToPublish_PlatformAgnostic>
     </ItemGroup>
 

--- a/src/Razor/src/rzls/rzls.csproj
+++ b/src/Razor/src/rzls/rzls.csproj
@@ -50,11 +50,11 @@
 
       <!-- Transform RuntimeIdentifierForPublish items to project items to pass to MSBuild task -->
       <ProjectToPublish Include="@(RuntimeIdentifierForPublish->'$(MSBuildProjectFullPath)')">
-        <AdditionalProperties>_IsPublishing=true;NoBuild=true;PublishRuntimeIdentifier=%(RuntimeIdentifierForPublish.Identity);PublishDir=$(RidsPublishDir)%(RuntimeIdentifierForPublish.Identity)\;TargetFramework=$(PublishTargetFramework);SelfContained=false;AppendRuntimeIdentifierToOutputPath=false</AdditionalProperties>
+        <AdditionalProperties>RuntimeIdentifier=%(RuntimeIdentifierForPublish.Identity);PublishDir=$(RidsPublishDir)%(RuntimeIdentifierForPublish.Identity)\;TargetFramework=$(PublishTargetFramework);SelfContained=false</AdditionalProperties>
       </ProjectToPublish>
 
       <ProjectToPublish_PlatformAgnostic Include="$(MSBuildProjectFullPath)">
-        <AdditionalProperties>_IsPublishing=true;NoBuild=true;PublishDir=$(RidsPublishDir)\PlatformAgnostic\;UseAppHost=false;TargetFramework=$(PublishTargetFramework);SelfContained=false;AppendRuntimeIdentifierToOutputPath=false</AdditionalProperties>
+        <AdditionalProperties>PublishDir=$(RidsPublishDir)\PlatformAgnostic\;UseAppHost=false;TargetFramework=$(PublishTargetFramework);SelfContained=false</AdditionalProperties>
       </ProjectToPublish_PlatformAgnostic>
     </ItemGroup>
 


### PR DESCRIPTION
This reverts commit e77dc86683ef07a9dd2ba4270003bda3b3886a5b which was causing arm64 mac images to incorrectly try to use the x64 runtime. Fixes [AB1977917](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1977817)
