### PR TITLE
In VMR builds only build the target RID and don't rebuild

### DIFF
--- a/Razor.Slim.slnf
+++ b/Razor.Slim.slnf
@@ -26,6 +26,8 @@
       "src\\Razor\\src\\Microsoft.VisualStudio.LanguageServer.ContainedLanguage\\Microsoft.VisualStudio.LanguageServer.ContainedLanguage.csproj",
       "src\\Razor\\src\\Microsoft.VisualStudio.LanguageServices.Razor\\Microsoft.VisualStudio.LanguageServices.Razor.csproj",
       "src\\Razor\\src\\Microsoft.VisualStudio.RazorExtension\\Microsoft.VisualStudio.RazorExtension.csproj",
+      "src\\Razor\\src\\Microsoft.AspNetCore.Razor.LanguageServer\\Microsoft.AspNetCore.Razor.LanguageServer.csproj",
+      "src\\Razor\\src\\rzls\\rzls.csproj",
       "src\\Razor\\test\\Microsoft.AspNetCore.Razor.Test.Common.Tooling\\Microsoft.AspNetCore.Razor.Test.Common.Tooling.csproj",
       "src\\Razor\\test\\Microsoft.AspNetCore.Razor.Test.MvcShim.ClassLib\\Microsoft.AspNetCore.Razor.Test.MvcShim.ClassLib.csproj",
       "src\\Razor\\test\\Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X\\Microsoft.AspNetCore.Razor.Test.MvcShim.Version1_X.csproj",

--- a/eng/AfterSolutionBuild.targets
+++ b/eng/AfterSolutionBuild.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 
-  <Target Name="_PublishLanguageServerRids" AfterTargets="Pack" Condition="'$(DotNetBuildFromSourceOnly)' != 'true' and '$(ArcadeBuildFromSourceOnly)' != 'true'">
+  <Target Name="_PublishLanguageServerRids" AfterTargets="Pack" Condition="'$(DotNetBuildFromSourceOnly)' != 'true' and '$(DotNetBuildFromSource)' != 'true'">
     <PropertyGroup>
       <BuildAnalyzersSolutionPath>$(MSBuildThisFileDirectory)..\BuildAnalyzers.sln</BuildAnalyzersSolutionPath>
       <LanguageServerProject>$(MSBuildThisFileDirectory)..\src\Razor\src\rzls\rzls.csproj</LanguageServerProject>
@@ -15,7 +15,7 @@
              Targets="PublishAllRids" />
   </Target>
 
-  <Target Name="_PublishDevKitTelemetryRids" AfterTargets="Pack" Condition="'$(DotNetBuildFromSourceOnly)' != 'true' and '$(ArcadeBuildFromSourceOnly)' != 'true'">
+  <Target Name="_PublishDevKitTelemetryRids" AfterTargets="Pack" Condition="'$(DotNetBuildFromSourceOnly)' != 'true' and '$(DotNetBuildFromSource)' != 'true'">
     <PropertyGroup>
       <DevKitTelemetryProject>$(MSBuildThisFileDirectory)..\src\Razor\src\Microsoft.VisualStudio.DevKit.Razor\Microsoft.VisualStudio.DevKit.Razor.csproj</DevKitTelemetryProject>
       <RazorSolutionPath>$(MSBuildThisFileDirectory)..\Razor.sln</RazorSolutionPath>

--- a/eng/AfterSolutionBuild.targets
+++ b/eng/AfterSolutionBuild.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 
-  <Target Name="_PublishLanguageServerRids" AfterTargets="Pack" Condition="'$(DotNetBuildFromSource)' != 'true' and '$(ArcadeBuildFromSource)' != 'true'">
+  <Target Name="_PublishLanguageServerRids" AfterTargets="Pack" Condition="'$(DotNetBuildFromSourceOnly)' != 'true' and '$(ArcadeBuildFromSourceOnly)' != 'true'">
     <PropertyGroup>
       <BuildAnalyzersSolutionPath>$(MSBuildThisFileDirectory)..\BuildAnalyzers.sln</BuildAnalyzersSolutionPath>
       <LanguageServerProject>$(MSBuildThisFileDirectory)..\src\Razor\src\rzls\rzls.csproj</LanguageServerProject>
@@ -15,7 +15,7 @@
              Targets="PublishAllRids" />
   </Target>
 
-  <Target Name="_PublishDevKitTelemetryRids" AfterTargets="Pack" Condition="'$(DotNetBuildFromSource)' != 'true' and '$(ArcadeBuildFromSource)' != 'true'">
+  <Target Name="_PublishDevKitTelemetryRids" AfterTargets="Pack" Condition="'$(DotNetBuildFromSourceOnly)' != 'true' and '$(ArcadeBuildFromSourceOnly)' != 'true'">
     <PropertyGroup>
       <DevKitTelemetryProject>$(MSBuildThisFileDirectory)..\src\Razor\src\Microsoft.VisualStudio.DevKit.Razor\Microsoft.VisualStudio.DevKit.Razor.csproj</DevKitTelemetryProject>
       <RazorSolutionPath>$(MSBuildThisFileDirectory)..\Razor.sln</RazorSolutionPath>

--- a/eng/AfterSolutionBuild.targets
+++ b/eng/AfterSolutionBuild.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 
-  <Target Name="_PublishLanguageServerRids" AfterTargets="Pack" Condition="'$(DotNetBuildFromSource)' != 'true'">
+  <Target Name="_PublishLanguageServerRids" AfterTargets="Pack" Condition="'$(DotNetBuildFromSource)' != 'true' and '$(ArcadeBuildFromSource)' != 'true'">
     <PropertyGroup>
       <BuildAnalyzersSolutionPath>$(MSBuildThisFileDirectory)..\BuildAnalyzers.sln</BuildAnalyzersSolutionPath>
       <LanguageServerProject>$(MSBuildThisFileDirectory)..\src\Razor\src\rzls\rzls.csproj</LanguageServerProject>
@@ -15,7 +15,7 @@
              Targets="PublishAllRids" />
   </Target>
 
-  <Target Name="_PublishDevKitTelemetryRids" AfterTargets="Pack" Condition="'$(DotNetBuildFromSource)' != 'true'">
+  <Target Name="_PublishDevKitTelemetryRids" AfterTargets="Pack" Condition="'$(DotNetBuildFromSource)' != 'true' and '$(ArcadeBuildFromSource)' != 'true'">
     <PropertyGroup>
       <DevKitTelemetryProject>$(MSBuildThisFileDirectory)..\src\Razor\src\Microsoft.VisualStudio.DevKit.Razor\Microsoft.VisualStudio.DevKit.Razor.csproj</DevKitTelemetryProject>
       <RazorSolutionPath>$(MSBuildThisFileDirectory)..\Razor.sln</RazorSolutionPath>

--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -16,10 +16,10 @@
           DependsOnTargets="PrepareInnerSourceBuildRepoRoot"
           BeforeTargets="RunInnerSourceBuildCommand">
     <Delete Files="$(InnerSourceBuildRepoRoot).globalconfig" />
-
-    <PropertyGroup>
-      <InnerBuildArgs>/p:TargetRid=$(TargetRid)</InnerBuildArgs>
-    </PropertyGroup>
   </Target>
+
+  <PropertyGroup>
+    <InnerBuildArgs>$(InnerBuildArgs) /p:TargetRid=$(TargetRid)</InnerBuildArgs>
+  </PropertyGroup>
 
 </Project>

--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -18,8 +18,4 @@
     <Delete Files="$(InnerSourceBuildRepoRoot).globalconfig" />
   </Target>
 
-  <PropertyGroup>
-    <InnerBuildArgs>$(InnerBuildArgs) /p:TargetRid=$(TargetRid)</InnerBuildArgs>
-  </PropertyGroup>
-
 </Project>

--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -16,6 +16,10 @@
           DependsOnTargets="PrepareInnerSourceBuildRepoRoot"
           BeforeTargets="RunInnerSourceBuildCommand">
     <Delete Files="$(InnerSourceBuildRepoRoot).globalconfig" />
+
+    <PropertyGroup>
+      <TargetRid>$(TargetRid)</TargetRid>
+    </PropertyGroup>
   </Target>
 
 </Project>

--- a/eng/SourceBuild.props
+++ b/eng/SourceBuild.props
@@ -18,7 +18,7 @@
     <Delete Files="$(InnerSourceBuildRepoRoot).globalconfig" />
 
     <PropertyGroup>
-      <TargetRid>$(TargetRid)</TargetRid>
+      <InnerBuildArgs>/p:TargetRid=$(TargetRid)</InnerBuildArgs>
     </PropertyGroup>
   </Target>
 

--- a/src/Razor/src/Microsoft.VisualStudio.DevKit.Razor/Microsoft.VisualStudio.DevKit.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.DevKit.Razor/Microsoft.VisualStudio.DevKit.Razor.csproj
@@ -25,7 +25,7 @@
   <PropertyGroup Condition="'$(DotNetBuild)' == 'true'">
     <RuntimeIdentifiers>$(TargetRid)</RuntimeIdentifiers>
     <RuntimeIdentifier>$(TargetRid)</RuntimeIdentifier>
-    <RidSpecificPublishNoBuildProperty>NoBuild=true</RidSpecificPublishNoBuildProperty>
+    <RidSpecificPublishNoBuildProperty>NoBuild=true;AppendRuntimeIdentifierToOutputPath=false</RidSpecificPublishNoBuildProperty>
   </PropertyGroup>
 
   <ItemGroup>
@@ -68,11 +68,11 @@
 
       <!-- Transform RuntimeIdentifierForPublish items to project items to pass to MSBuild task -->
       <ProjectToPublish Include="@(RuntimeIdentifierForPublish->'$(MSBuildProjectFullPath)')">
-        <AdditionalProperties>_IsPublishing=true;$(RidSpecificPublishNoBuildProperty);PublishRuntimeIdentifier=%(RuntimeIdentifierForPublish.Identity);PublishDir=$(RidsPublishDir)%(RuntimeIdentifierForPublish.Identity)\;TargetFramework=$(PublishTargetFramework);SelfContained=false;AppendRuntimeIdentifierToOutputPath=false</AdditionalProperties>
+        <AdditionalProperties>_IsPublishing=true;$(RidSpecificPublishNoBuildProperty);RuntimeIdentifier=%(RuntimeIdentifierForPublish.Identity);PublishDir=$(RidsPublishDir)%(RuntimeIdentifierForPublish.Identity)\;TargetFramework=$(PublishTargetFramework);SelfContained=false</AdditionalProperties>
       </ProjectToPublish>
 
       <ProjectToPublish_PlatformAgnostic Include="$(MSBuildProjectFullPath)">
-        <AdditionalProperties>_IsPublishing=true;NoBuild=true;PublishDir=$(RidsPublishDir)\PlatformAgnostic\;UseAppHost=false;TargetFramework=$(PublishTargetFramework);SelfContained=false;AppendRuntimeIdentifierToOutputPath=false</AdditionalProperties>
+        <AdditionalProperties>_IsPublishing=true;NoBuild=true;PublishDir=$(RidsPublishDir)\PlatformAgnostic\;UseAppHost=false;TargetFramework=$(PublishTargetFramework);SelfContained=false</AdditionalProperties>
       </ProjectToPublish_PlatformAgnostic>
     </ItemGroup>
 

--- a/src/Razor/src/Microsoft.VisualStudio.DevKit.Razor/Microsoft.VisualStudio.DevKit.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.DevKit.Razor/Microsoft.VisualStudio.DevKit.Razor.csproj
@@ -12,6 +12,22 @@
     <RemoveDevicePlatformSupport>true</RemoveDevicePlatformSupport>
   </PropertyGroup>
 
+  <!--
+    In a vertical build, we'll only publish for the RID of the vertical.
+    In a non-vertical build, we'll publish for alll RIDs of the OS we are building on (to reduce the number of CI jobs).
+  -->
+  <PropertyGroup Condition="'$(DotNetBuild)' != 'true'">
+    <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('Windows'))">win-x64;win-x86;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('Linux'))">linux-x64;linux-musl-x64;linux-arm64;linux-musl-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('OSX'))">osx-x64;osx-arm64</RuntimeIdentifiers>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(DotNetBuild)' == 'true'">
+    <RuntimeIdentifiers>$(TargetRid)</RuntimeIdentifiers>
+    <RuntimeIdentifier>$(TargetRid)</RuntimeIdentifier>
+    <RidSpecificPublishNoBuildProperty>NoBuild=true</RidSpecificPublishNoBuildProperty>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="..\Microsoft.VisualStudio.Editor.Razor\Telemetry\TelemetryReporter.cs" Link="Telemetry\TelemetryReporter.cs" />
   </ItemGroup>
@@ -52,7 +68,7 @@
 
       <!-- Transform RuntimeIdentifierForPublish items to project items to pass to MSBuild task -->
       <ProjectToPublish Include="@(RuntimeIdentifierForPublish->'$(MSBuildProjectFullPath)')">
-        <AdditionalProperties>_IsPublishing=true;NoBuild=true;PublishRuntimeIdentifier=%(RuntimeIdentifierForPublish.Identity);PublishDir=$(RidsPublishDir)%(RuntimeIdentifierForPublish.Identity)\;TargetFramework=$(PublishTargetFramework);SelfContained=false;AppendRuntimeIdentifierToOutputPath=false</AdditionalProperties>
+        <AdditionalProperties>_IsPublishing=true;$(RidSpecificPublishNoBuildProperty);PublishRuntimeIdentifier=%(RuntimeIdentifierForPublish.Identity);PublishDir=$(RidsPublishDir)%(RuntimeIdentifierForPublish.Identity)\;TargetFramework=$(PublishTargetFramework);SelfContained=false;AppendRuntimeIdentifierToOutputPath=false</AdditionalProperties>
       </ProjectToPublish>
 
       <ProjectToPublish_PlatformAgnostic Include="$(MSBuildProjectFullPath)">

--- a/src/Razor/src/Microsoft.VisualStudio.DevKit.Razor/Microsoft.VisualStudio.DevKit.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.DevKit.Razor/Microsoft.VisualStudio.DevKit.Razor.csproj
@@ -14,7 +14,7 @@
 
   <!--
     In a vertical build, we'll only publish for the RID of the vertical.
-    In a non-vertical build, we'll publish for alll RIDs of the OS we are building on (to reduce the number of CI jobs).
+    In a non-vertical build, we'll publish for all RIDs of the OS we are building on (to reduce the number of CI jobs).
   -->
   <PropertyGroup Condition="'$(DotNetBuild)' != 'true'">
     <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('Windows'))">win-x64;win-x86;win-arm64</RuntimeIdentifiers>

--- a/src/Razor/src/Microsoft.VisualStudio.DevKit.Razor/Microsoft.VisualStudio.DevKit.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.DevKit.Razor/Microsoft.VisualStudio.DevKit.Razor.csproj
@@ -52,11 +52,11 @@
 
       <!-- Transform RuntimeIdentifierForPublish items to project items to pass to MSBuild task -->
       <ProjectToPublish Include="@(RuntimeIdentifierForPublish->'$(MSBuildProjectFullPath)')">
-        <AdditionalProperties>RuntimeIdentifier=%(RuntimeIdentifierForPublish.Identity);PublishDir=$(RidsPublishDir)%(RuntimeIdentifierForPublish.Identity)\;TargetFramework=$(PublishTargetFramework);SelfContained=false</AdditionalProperties>
+        <AdditionalProperties>_IsPublishing=true;NoBuild=true;PublishRuntimeIdentifier=%(RuntimeIdentifierForPublish.Identity);PublishDir=$(RidsPublishDir)%(RuntimeIdentifierForPublish.Identity)\;TargetFramework=$(PublishTargetFramework);SelfContained=false;AppendRuntimeIdentifierToOutputPath=false</AdditionalProperties>
       </ProjectToPublish>
 
       <ProjectToPublish_PlatformAgnostic Include="$(MSBuildProjectFullPath)">
-        <AdditionalProperties>PublishDir=$(RidsPublishDir)\PlatformAgnostic\;UseAppHost=false;TargetFramework=$(PublishTargetFramework);SelfContained=false</AdditionalProperties>
+        <AdditionalProperties>_IsPublishing=true;NoBuild=true;PublishDir=$(RidsPublishDir)\PlatformAgnostic\;UseAppHost=false;TargetFramework=$(PublishTargetFramework);SelfContained=false;AppendRuntimeIdentifierToOutputPath=false</AdditionalProperties>
       </ProjectToPublish_PlatformAgnostic>
     </ItemGroup>
 

--- a/src/Razor/src/rzls/rzls.csproj
+++ b/src/Razor/src/rzls/rzls.csproj
@@ -10,7 +10,7 @@
 
   <!--
     In a vertical build, we'll only publish for the RID of the vertical.
-    In a non-vertical build, we'll publish for alll RIDs of the OS we are building on (to reduce the number of CI jobs).
+    In a non-vertical build, we'll publish for all RIDs of the OS we are building on (to reduce the number of CI jobs).
   -->
   <PropertyGroup Condition="'$(DotNetBuild)' != 'true'">
     <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('Windows'))">win-x64;win-x86;win-arm64</RuntimeIdentifiers>

--- a/src/Razor/src/rzls/rzls.csproj
+++ b/src/Razor/src/rzls/rzls.csproj
@@ -6,6 +6,8 @@
     <OutputType>Exe</OutputType>
     <Description>Razor is a markup syntax for adding server-side logic to web pages. This package contains a Razor language server.</Description>
     <EnableApiCheck>false</EnableApiCheck>
+    <IsShippingPackage>false</IsShippingPackage>
+    <RemoveDevicePlatformSupport>true</RemoveDevicePlatformSupport>
   </PropertyGroup>
 
   <!--

--- a/src/Razor/src/rzls/rzls.csproj
+++ b/src/Razor/src/rzls/rzls.csproj
@@ -50,11 +50,11 @@
 
       <!-- Transform RuntimeIdentifierForPublish items to project items to pass to MSBuild task -->
       <ProjectToPublish Include="@(RuntimeIdentifierForPublish->'$(MSBuildProjectFullPath)')">
-        <AdditionalProperties>RuntimeIdentifier=%(RuntimeIdentifierForPublish.Identity);PublishDir=$(RidsPublishDir)%(RuntimeIdentifierForPublish.Identity)\;TargetFramework=$(PublishTargetFramework);SelfContained=false</AdditionalProperties>
+        <AdditionalProperties>_IsPublishing=true;NoBuild=true;PublishRuntimeIdentifier=%(RuntimeIdentifierForPublish.Identity);PublishDir=$(RidsPublishDir)%(RuntimeIdentifierForPublish.Identity)\;TargetFramework=$(PublishTargetFramework);SelfContained=false;AppendRuntimeIdentifierToOutputPath=false</AdditionalProperties>
       </ProjectToPublish>
 
       <ProjectToPublish_PlatformAgnostic Include="$(MSBuildProjectFullPath)">
-        <AdditionalProperties>PublishDir=$(RidsPublishDir)\PlatformAgnostic\;UseAppHost=false;TargetFramework=$(PublishTargetFramework);SelfContained=false</AdditionalProperties>
+        <AdditionalProperties>_IsPublishing=true;NoBuild=true;PublishDir=$(RidsPublishDir)\PlatformAgnostic\;UseAppHost=false;TargetFramework=$(PublishTargetFramework);SelfContained=false;AppendRuntimeIdentifierToOutputPath=false</AdditionalProperties>
       </ProjectToPublish_PlatformAgnostic>
     </ItemGroup>
 

--- a/src/Razor/src/rzls/rzls.csproj
+++ b/src/Razor/src/rzls/rzls.csproj
@@ -6,8 +6,6 @@
     <OutputType>Exe</OutputType>
     <Description>Razor is a markup syntax for adding server-side logic to web pages. This package contains a Razor language server.</Description>
     <EnableApiCheck>false</EnableApiCheck>
-    <IsShippingPackage>false</IsShippingPackage>
-    <RemoveDevicePlatformSupport>true</RemoveDevicePlatformSupport>
   </PropertyGroup>
 
   <!--

--- a/src/Razor/src/rzls/rzls.csproj
+++ b/src/Razor/src/rzls/rzls.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup Condition="'$(DotNetBuild)' == 'true'">
     <RuntimeIdentifiers>$(TargetRid)</RuntimeIdentifiers>
     <RuntimeIdentifier>$(TargetRid)</RuntimeIdentifier>
-    <RidSpecificPublishNoBuildProperty>NoBuild=true</RidSpecificPublishNoBuildProperty>
+    <RidSpecificPublishNoBuildProperty>NoBuild=true;AppendRuntimeIdentifierToOutputPath=false</RidSpecificPublishNoBuildProperty>
   </PropertyGroup>
 
   <ItemGroup>
@@ -61,11 +61,11 @@
 
       <!-- Transform RuntimeIdentifierForPublish items to project items to pass to MSBuild task -->
       <ProjectToPublish Include="@(RuntimeIdentifierForPublish->'$(MSBuildProjectFullPath)')">
-        <AdditionalProperties>_IsPublishing=true;$(RidSpecificPublishNoBuildProperty);PublishRuntimeIdentifier=%(RuntimeIdentifierForPublish.Identity);PublishDir=$(RidsPublishDir)%(RuntimeIdentifierForPublish.Identity)\;TargetFramework=$(PublishTargetFramework);SelfContained=false;AppendRuntimeIdentifierToOutputPath=false</AdditionalProperties>
+        <AdditionalProperties>_IsPublishing=true;$(RidSpecificPublishNoBuildProperty);RuntimeIdentifier=%(RuntimeIdentifierForPublish.Identity);PublishDir=$(RidsPublishDir)%(RuntimeIdentifierForPublish.Identity)\;TargetFramework=$(PublishTargetFramework);SelfContained=false</AdditionalProperties>
       </ProjectToPublish>
 
       <ProjectToPublish_PlatformAgnostic Include="$(MSBuildProjectFullPath)">
-        <AdditionalProperties>_IsPublishing=true;NoBuild=true;PublishDir=$(RidsPublishDir)\PlatformAgnostic\;UseAppHost=false;TargetFramework=$(PublishTargetFramework);SelfContained=false;AppendRuntimeIdentifierToOutputPath=false</AdditionalProperties>
+        <AdditionalProperties>_IsPublishing=true;NoBuild=true;PublishDir=$(RidsPublishDir)\PlatformAgnostic\;UseAppHost=false;TargetFramework=$(PublishTargetFramework);SelfContained=false</AdditionalProperties>
       </ProjectToPublish_PlatformAgnostic>
     </ItemGroup>
 

--- a/src/Razor/src/rzls/rzls.csproj
+++ b/src/Razor/src/rzls/rzls.csproj
@@ -6,11 +6,24 @@
     <OutputType>Exe</OutputType>
     <Description>Razor is a markup syntax for adding server-side logic to web pages. This package contains a Razor language server.</Description>
     <EnableApiCheck>false</EnableApiCheck>
+    <IsShippingPackage>false</IsShippingPackage>
+    <RemoveDevicePlatformSupport>true</RemoveDevicePlatformSupport>
+  </PropertyGroup>
+
+  <!--
+    In a vertical build, we'll only publish for the RID of the vertical.
+    In a non-vertical build, we'll publish for alll RIDs of the OS we are building on (to reduce the number of CI jobs).
+  -->
+  <PropertyGroup Condition="'$(DotNetBuild)' != 'true'">
     <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('Windows'))">win-x64;win-x86;win-arm64</RuntimeIdentifiers>
     <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('Linux'))">linux-x64;linux-musl-x64;linux-arm64;linux-musl-arm64</RuntimeIdentifiers>
     <RuntimeIdentifiers Condition="$([MSBuild]::IsOSPlatform('OSX'))">osx-x64;osx-arm64</RuntimeIdentifiers>
-    <IsShippingPackage>false</IsShippingPackage>
-    <RemoveDevicePlatformSupport>true</RemoveDevicePlatformSupport>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(DotNetBuild)' == 'true'">
+    <RuntimeIdentifiers>$(TargetRid)</RuntimeIdentifiers>
+    <RuntimeIdentifier>$(TargetRid)</RuntimeIdentifier>
+    <RidSpecificPublishNoBuildProperty>NoBuild=true</RidSpecificPublishNoBuildProperty>
   </PropertyGroup>
 
   <ItemGroup>
@@ -50,7 +63,7 @@
 
       <!-- Transform RuntimeIdentifierForPublish items to project items to pass to MSBuild task -->
       <ProjectToPublish Include="@(RuntimeIdentifierForPublish->'$(MSBuildProjectFullPath)')">
-        <AdditionalProperties>_IsPublishing=true;NoBuild=true;PublishRuntimeIdentifier=%(RuntimeIdentifierForPublish.Identity);PublishDir=$(RidsPublishDir)%(RuntimeIdentifierForPublish.Identity)\;TargetFramework=$(PublishTargetFramework);SelfContained=false;AppendRuntimeIdentifierToOutputPath=false</AdditionalProperties>
+        <AdditionalProperties>_IsPublishing=true;$(RidSpecificPublishNoBuildProperty);PublishRuntimeIdentifier=%(RuntimeIdentifierForPublish.Identity);PublishDir=$(RidsPublishDir)%(RuntimeIdentifierForPublish.Identity)\;TargetFramework=$(PublishTargetFramework);SelfContained=false;AppendRuntimeIdentifierToOutputPath=false</AdditionalProperties>
       </ProjectToPublish>
 
       <ProjectToPublish_PlatformAgnostic Include="$(MSBuildProjectFullPath)">


### PR DESCRIPTION
Reapply #9925 but only do it in VMR builds. Additionally, only build the vertical's RID in a vertical build as we won't be able to restore the other apphost packs anyway.