### PR TITLE
Add formatting option to force open brace onto the next line after a `@code` or `@functions` block

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLSPOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLSPOptions.cs
@@ -18,21 +18,6 @@ internal record RazorLSPOptions(
     bool CodeBlockBraceOnNextLine,
     bool CommitElementsWithSpace)
 {
-    public RazorLSPOptions(bool enableFormatting, bool autoClosingTags, bool commitElementsWithSpace, ClientSettings settings)
-        : this(enableFormatting,
-              autoClosingTags,
-              !settings.ClientSpaceSettings.IndentWithTabs,
-              settings.ClientSpaceSettings.IndentSize,
-              settings.ClientCompletionSettings.AutoShowCompletion,
-              settings.ClientCompletionSettings.AutoListParams,
-              settings.AdvancedSettings.FormatOnType,
-              settings.AdvancedSettings.AutoInsertAttributeQuotes,
-              settings.AdvancedSettings.ColorBackground,
-              settings.AdvancedSettings.CodeBlockBraceOnNextLine,
-              commitElementsWithSpace)
-    {
-    }
-
     public readonly static RazorLSPOptions Default = new(EnableFormatting: true,
                                                          AutoClosingTags: true,
                                                          AutoListParams: true,
@@ -49,9 +34,16 @@ internal record RazorLSPOptions(
     /// Initializes the LSP options with the settings from the passed in client settings, and default values for anything
     /// not defined in client settings.
     /// </summary>
-    internal static RazorLSPOptions From(ClientSettings clientSettings)
+    internal static RazorLSPOptions From(ClientSettings settings)
         => new(Default.EnableFormatting,
-            clientSettings.AdvancedSettings.AutoClosingTags,
-            clientSettings.AdvancedSettings.CommitElementsWithSpace,
-            clientSettings);
+              settings.AdvancedSettings.AutoClosingTags,
+              !settings.ClientSpaceSettings.IndentWithTabs,
+              settings.ClientSpaceSettings.IndentSize,
+              settings.ClientCompletionSettings.AutoShowCompletion,
+              settings.ClientCompletionSettings.AutoListParams,
+              settings.AdvancedSettings.FormatOnType,
+              settings.AdvancedSettings.AutoInsertAttributeQuotes,
+              settings.AdvancedSettings.ColorBackground,
+              settings.AdvancedSettings.CodeBlockBraceOnNextLine,
+              settings.AdvancedSettings.CommitElementsWithSpace);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLSPOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLSPOptions.cs
@@ -15,6 +15,7 @@ internal record RazorLSPOptions(
     bool FormatOnType,
     bool AutoInsertAttributeQuotes,
     bool ColorBackground,
+    bool CodeBlockBraceOnNextLine,
     bool CommitElementsWithSpace)
 {
     public RazorLSPOptions(bool enableFormatting, bool autoClosingTags, bool commitElementsWithSpace, ClientSettings settings)
@@ -27,6 +28,7 @@ internal record RazorLSPOptions(
               settings.AdvancedSettings.FormatOnType,
               settings.AdvancedSettings.AutoInsertAttributeQuotes,
               settings.AdvancedSettings.ColorBackground,
+              settings.AdvancedSettings.CodeBlockBraceOnNextLine,
               commitElementsWithSpace)
     {
     }
@@ -40,6 +42,7 @@ internal record RazorLSPOptions(
                                                          FormatOnType: true,
                                                          AutoInsertAttributeQuotes: true,
                                                          ColorBackground: false,
+                                                         CodeBlockBraceOnNextLine: false,
                                                          CommitElementsWithSpace: true);
 
     /// <summary>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Settings/ClientSettings.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Settings/ClientSettings.cs
@@ -32,7 +32,7 @@ internal sealed record ClientSpaceSettings(bool IndentWithTabs, int IndentSize)
     public int IndentSize { get; } = IndentSize >= 0 ? IndentSize : throw new ArgumentOutOfRangeException(nameof(IndentSize));
 }
 
-internal sealed record ClientAdvancedSettings(bool FormatOnType, bool AutoClosingTags, bool AutoInsertAttributeQuotes, bool ColorBackground, bool CommitElementsWithSpace, SnippetSetting SnippetSetting, LogLevel LogLevel)
+internal sealed record ClientAdvancedSettings(bool FormatOnType, bool AutoClosingTags, bool AutoInsertAttributeQuotes, bool ColorBackground, bool CodeBlockBraceOnNextLine, bool CommitElementsWithSpace, SnippetSetting SnippetSetting, LogLevel LogLevel)
 {
-    public static readonly ClientAdvancedSettings Default = new(FormatOnType: true, AutoClosingTags: true, AutoInsertAttributeQuotes: true, ColorBackground: false, CommitElementsWithSpace: true, SnippetSetting.All, LogLevel.Warning);
+    public static readonly ClientAdvancedSettings Default = new(FormatOnType: true, AutoClosingTags: true, AutoInsertAttributeQuotes: true, ColorBackground: false, CodeBlockBraceOnNextLine: false, CommitElementsWithSpace: true, SnippetSetting.All, LogLevel.Warning);
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Options/OptionsStorage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Options/OptionsStorage.cs
@@ -53,6 +53,12 @@ internal class OptionsStorage : IAdvancedSettingsStorage, IDisposable
         set => SetBool(SettingsNames.ColorBackground.LegacyName, value);
     }
 
+    public bool CodeBlockBraceOnNextLine
+    {
+        get => GetBool(SettingsNames.CodeBlockBraceOnNextLine.LegacyName, defaultValue: false);
+        set => SetBool(SettingsNames.CodeBlockBraceOnNextLine.LegacyName, value);
+    }
+
     public bool CommitElementsWithSpace
     {
         get => GetBool(SettingsNames.CommitElementsWithSpace.LegacyName, defaultValue: true);
@@ -101,7 +107,7 @@ internal class OptionsStorage : IAdvancedSettingsStorage, IDisposable
 
     private EventHandler<ClientAdvancedSettingsChangedEventArgs>? _changed;
 
-    public ClientAdvancedSettings GetAdvancedSettings() => new(FormatOnType, AutoClosingTags, AutoInsertAttributeQuotes, ColorBackground, CommitElementsWithSpace, Snippets, LogLevel);
+    public ClientAdvancedSettings GetAdvancedSettings() => new(FormatOnType, AutoClosingTags, AutoInsertAttributeQuotes, ColorBackground, CodeBlockBraceOnNextLine, CommitElementsWithSpace, Snippets, LogLevel);
 
     public bool GetBool(string name, bool defaultValue)
     {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Options/SettingsNames.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Options/SettingsNames.cs
@@ -14,6 +14,7 @@ internal static class SettingsNames
     public static readonly Setting AutoClosingTags = new("AutoClosingTags", UnifiedCollection + ".autoClosingTags");
     public static readonly Setting AutoInsertAttributeQuotes = new("AutoInsertAttributeQuotes", UnifiedCollection + ".autoInsertAttributeQuotes");
     public static readonly Setting ColorBackground = new("ColorBackground", UnifiedCollection + ".colorBackground");
+    public static readonly Setting CodeBlockBraceOnNextLine = new("CodeBlockBraceOnNextLine", UnifiedCollection + ".codeBlockBraceOnNextLine");
     public static readonly Setting CommitElementsWithSpace = new("CommitElementsWithSpace", UnifiedCollection + ".commitCharactersWithSpace");
     public static readonly Setting Snippets = new("Snippets", UnifiedCollection + ".snippets");
     public static readonly Setting LogLevel = new("LogLevel", UnifiedCollection + ".logLevel");
@@ -24,6 +25,7 @@ internal static class SettingsNames
         AutoClosingTags,
         AutoInsertAttributeQuotes,
         ColorBackground,
+        CodeBlockBraceOnNextLine,
         CommitElementsWithSpace,
         Snippets,
         LogLevel,

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Options/AdvancedOptionPage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Options/AdvancedOptionPage.cs
@@ -21,6 +21,7 @@ internal class AdvancedOptionPage : DialogPage
     private bool? _autoClosingTags;
     private bool? _autoInsertAttributeQuotes;
     private bool? _colorBackground;
+    private bool? _codeBlockBraceOnNextLine;
     private bool? _commitElementsWithSpace;
     private SnippetSetting? _snippets;
     private LogLevel? _logLevel;
@@ -79,6 +80,15 @@ internal class AdvancedOptionPage : DialogPage
     {
         get => _colorBackground ?? _optionsStorage.Value.ColorBackground;
         set => _colorBackground = value;
+    }
+
+    [LocCategory(nameof(VSPackage.Formatting))]
+    [LocDescription(nameof(VSPackage.Setting_CodeBlockBraceOnNextLineDescription))]
+    [LocDisplayName(nameof(VSPackage.Setting_CodeBlockBraceOnNextLineDisplayName))]
+    public bool CodeBlockBraceOnNextLine
+    {
+        get => _codeBlockBraceOnNextLine ?? _optionsStorage.Value.CodeBlockBraceOnNextLine;
+        set => _codeBlockBraceOnNextLine = value;
     }
 
     [LocCategory(nameof(VSPackage.Completion))]

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/UnifiedSettings/razor.registration.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/UnifiedSettings/razor.registration.json
@@ -61,6 +61,20 @@
         }
       }
     },
+    "textEditor.razor.advanced.codeBlockBraceOnNextLine": {
+      "type": "boolean",
+      "default": false,
+      "title": "@Setting_CodeBlockBraceOnNextLinedDisplayName;{13b72f58-279e-49e0-a56d-296be02f0805}",
+      "description": "@Setting_CodeBlockBraceOnNextLinedDescription;{13b72f58-279e-49e0-a56d-296be02f0805}",
+      "migration": {
+        "pass": {
+          "input": {
+            "store": "VsUserSettingsRegistry",
+            "path": "Razor\\CodeBlockBraceOnNextLined"
+          }
+        }
+      }
+    },
     "textEditor.razor.advanced.commitElementsWithSpace": {
       "type": "boolean",
       "default": true,

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/VSPackage.resx
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/VSPackage.resx
@@ -162,6 +162,12 @@
   <data name="Setting_AutoInsertAttributeQuotesDisplayName" xml:space="preserve">
     <value>Auto Insert Attribute Quotes</value>
   </data>
+  <data name="Setting_CodeBlockBraceOnNextLineDescription" xml:space="preserve">
+    <value>Forces the open brace after an @code or @functions directive to be on the following line</value>
+  </data>
+  <data name="Setting_CodeBlockBraceOnNextLineDisplayName" xml:space="preserve">
+    <value>Code/Functions block open brace on next line</value>
+  </data>
   <data name="Setting_ColorBackgroundDescription" xml:space="preserve">
     <value>If true, gives C# code in Razor files a background color</value>
   </data>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.cs.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.cs.xlf
@@ -62,6 +62,16 @@
         <target state="translated">Automaticky vložit uvozovky atributů</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_CodeBlockBraceOnNextLineDescription">
+        <source>Forces the open brace after an @code or @functions directive to be on the following line</source>
+        <target state="new">Forces the open brace after an @code or @functions directive to be on the following line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_CodeBlockBraceOnNextLineDisplayName">
+        <source>Code/Functions block open brace on next line</source>
+        <target state="new">Code/Functions block open brace on next line</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_ColorBackgroundDescription">
         <source>If true, gives C# code in Razor files a background color</source>
         <target state="translated">Pokud je hodnota „true“, vrátí kód C# v souborech Razor barvu pozadí.</target>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.de.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.de.xlf
@@ -62,6 +62,16 @@
         <target state="translated">Anführungszeichen für Attribute automatisch einfügen</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_CodeBlockBraceOnNextLineDescription">
+        <source>Forces the open brace after an @code or @functions directive to be on the following line</source>
+        <target state="new">Forces the open brace after an @code or @functions directive to be on the following line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_CodeBlockBraceOnNextLineDisplayName">
+        <source>Code/Functions block open brace on next line</source>
+        <target state="new">Code/Functions block open brace on next line</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_ColorBackgroundDescription">
         <source>If true, gives C# code in Razor files a background color</source>
         <target state="translated">Bei „true“ erhält C#-Code in Razor-Dateien eine Hintergrundfarbe.</target>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.es.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.es.xlf
@@ -62,6 +62,16 @@
         <target state="translated">Insertar automáticamente comillas de atributo</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_CodeBlockBraceOnNextLineDescription">
+        <source>Forces the open brace after an @code or @functions directive to be on the following line</source>
+        <target state="new">Forces the open brace after an @code or @functions directive to be on the following line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_CodeBlockBraceOnNextLineDisplayName">
+        <source>Code/Functions block open brace on next line</source>
+        <target state="new">Code/Functions block open brace on next line</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_ColorBackgroundDescription">
         <source>If true, gives C# code in Razor files a background color</source>
         <target state="translated">Si es true, da un color de fondo al código de C# de los archivos de Razor.</target>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.fr.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.fr.xlf
@@ -62,6 +62,16 @@
         <target state="translated">Insérer automatiquement des guillemets d’attribut</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_CodeBlockBraceOnNextLineDescription">
+        <source>Forces the open brace after an @code or @functions directive to be on the following line</source>
+        <target state="new">Forces the open brace after an @code or @functions directive to be on the following line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_CodeBlockBraceOnNextLineDisplayName">
+        <source>Code/Functions block open brace on next line</source>
+        <target state="new">Code/Functions block open brace on next line</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_ColorBackgroundDescription">
         <source>If true, gives C# code in Razor files a background color</source>
         <target state="translated">Si la valeur est true, donne une couleur d’arrière-plan au code C# dans les fichiers Razor</target>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.it.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.it.xlf
@@ -62,6 +62,16 @@
         <target state="translated">Inserire automaticamente le virgolette degli attributi</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_CodeBlockBraceOnNextLineDescription">
+        <source>Forces the open brace after an @code or @functions directive to be on the following line</source>
+        <target state="new">Forces the open brace after an @code or @functions directive to be on the following line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_CodeBlockBraceOnNextLineDisplayName">
+        <source>Code/Functions block open brace on next line</source>
+        <target state="new">Code/Functions block open brace on next line</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_ColorBackgroundDescription">
         <source>If true, gives C# code in Razor files a background color</source>
         <target state="translated">Se true, assegna un colore di sfondo al codice C# nei file Razor</target>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.ja.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.ja.xlf
@@ -62,6 +62,16 @@
         <target state="translated">属性引用符の自動挿入</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_CodeBlockBraceOnNextLineDescription">
+        <source>Forces the open brace after an @code or @functions directive to be on the following line</source>
+        <target state="new">Forces the open brace after an @code or @functions directive to be on the following line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_CodeBlockBraceOnNextLineDisplayName">
+        <source>Code/Functions block open brace on next line</source>
+        <target state="new">Code/Functions block open brace on next line</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_ColorBackgroundDescription">
         <source>If true, gives C# code in Razor files a background color</source>
         <target state="translated">true の場合、Razor ファイルの C# コードに背景色を表示します</target>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.ko.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.ko.xlf
@@ -62,6 +62,16 @@
         <target state="translated">특성 따옴표 자동 삽입</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_CodeBlockBraceOnNextLineDescription">
+        <source>Forces the open brace after an @code or @functions directive to be on the following line</source>
+        <target state="new">Forces the open brace after an @code or @functions directive to be on the following line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_CodeBlockBraceOnNextLineDisplayName">
+        <source>Code/Functions block open brace on next line</source>
+        <target state="new">Code/Functions block open brace on next line</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_ColorBackgroundDescription">
         <source>If true, gives C# code in Razor files a background color</source>
         <target state="translated">true이면 Razor 파일의 C# 코드에 배경색을 지정합니다.</target>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.pl.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.pl.xlf
@@ -62,6 +62,16 @@
         <target state="translated">Automatyczne wstawianie cudzysłowów atrybutów</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_CodeBlockBraceOnNextLineDescription">
+        <source>Forces the open brace after an @code or @functions directive to be on the following line</source>
+        <target state="new">Forces the open brace after an @code or @functions directive to be on the following line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_CodeBlockBraceOnNextLineDisplayName">
+        <source>Code/Functions block open brace on next line</source>
+        <target state="new">Code/Functions block open brace on next line</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_ColorBackgroundDescription">
         <source>If true, gives C# code in Razor files a background color</source>
         <target state="translated">Jeśli ma wartość true, nadaje kolor tła dla kodu języka C# w plikach Razor</target>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.pt-BR.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.pt-BR.xlf
@@ -62,6 +62,16 @@
         <target state="translated">Inserir Aspas de Atributo Automaticamente</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_CodeBlockBraceOnNextLineDescription">
+        <source>Forces the open brace after an @code or @functions directive to be on the following line</source>
+        <target state="new">Forces the open brace after an @code or @functions directive to be on the following line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_CodeBlockBraceOnNextLineDisplayName">
+        <source>Code/Functions block open brace on next line</source>
+        <target state="new">Code/Functions block open brace on next line</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_ColorBackgroundDescription">
         <source>If true, gives C# code in Razor files a background color</source>
         <target state="translated">Se verdadeiro, dá ao código C# nos arquivos Razor uma cor de fundo</target>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.ru.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.ru.xlf
@@ -62,6 +62,16 @@
         <target state="translated">Автоматически вставлять кавычки атрибутов</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_CodeBlockBraceOnNextLineDescription">
+        <source>Forces the open brace after an @code or @functions directive to be on the following line</source>
+        <target state="new">Forces the open brace after an @code or @functions directive to be on the following line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_CodeBlockBraceOnNextLineDisplayName">
+        <source>Code/Functions block open brace on next line</source>
+        <target state="new">Code/Functions block open brace on next line</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_ColorBackgroundDescription">
         <source>If true, gives C# code in Razor files a background color</source>
         <target state="translated">Если ИСТИНА, коду C# в файлах Razor присваивается цвет фона.</target>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.tr.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.tr.xlf
@@ -62,6 +62,16 @@
         <target state="translated">Öznitelik Tırnaklarını Otomatik Ekle</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_CodeBlockBraceOnNextLineDescription">
+        <source>Forces the open brace after an @code or @functions directive to be on the following line</source>
+        <target state="new">Forces the open brace after an @code or @functions directive to be on the following line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_CodeBlockBraceOnNextLineDisplayName">
+        <source>Code/Functions block open brace on next line</source>
+        <target state="new">Code/Functions block open brace on next line</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_ColorBackgroundDescription">
         <source>If true, gives C# code in Razor files a background color</source>
         <target state="translated">True ise Razor dosyalarında C# kodu bir arka plan rengi verir</target>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.zh-Hans.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.zh-Hans.xlf
@@ -62,6 +62,16 @@
         <target state="translated">自动插入属性引号</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_CodeBlockBraceOnNextLineDescription">
+        <source>Forces the open brace after an @code or @functions directive to be on the following line</source>
+        <target state="new">Forces the open brace after an @code or @functions directive to be on the following line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_CodeBlockBraceOnNextLineDisplayName">
+        <source>Code/Functions block open brace on next line</source>
+        <target state="new">Code/Functions block open brace on next line</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_ColorBackgroundDescription">
         <source>If true, gives C# code in Razor files a background color</source>
         <target state="translated">如果为 true，则为 Razor 文件中的 C# 代码提供背景色</target>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.zh-Hant.xlf
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/xlf/VSPackage.zh-Hant.xlf
@@ -62,6 +62,16 @@
         <target state="translated">自動插入屬性引號</target>
         <note />
       </trans-unit>
+      <trans-unit id="Setting_CodeBlockBraceOnNextLineDescription">
+        <source>Forces the open brace after an @code or @functions directive to be on the following line</source>
+        <target state="new">Forces the open brace after an @code or @functions directive to be on the following line</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="Setting_CodeBlockBraceOnNextLineDisplayName">
+        <source>Code/Functions block open brace on next line</source>
+        <target state="new">Code/Functions block open brace on next line</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Setting_ColorBackgroundDescription">
         <source>If true, gives C# code in Razor files a background color</source>
         <target state="translated">若為 true，則給予 Razor 檔案中的 C# 程式碼背景色彩</target>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndToEndTest.NetFx.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndToEndTest.NetFx.cs
@@ -719,6 +719,7 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : SingleServer
             FormatOnType: true,
             AutoInsertAttributeQuotes: true,
             ColorBackground: false,
+            CodeBlockBraceOnNextLine: false,
             CommitElementsWithSpace: true);
         var optionsMonitor = TestRazorLSPOptionsMonitor.Create();
         await optionsMonitor.UpdateAsync(razorLSPOptions, CancellationToken.None);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorConfigurationServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorConfigurationServiceTest.cs
@@ -21,13 +21,14 @@ public class DefaultRazorConfigurationServiceTest(ITestOutputHelper testOutput) 
     {
         // Arrange
         var expectedOptions = new RazorLSPOptions(
-            EnableFormatting: false, AutoClosingTags: false, InsertSpaces: true, TabSize: 4, AutoShowCompletion: true, AutoListParams: true, FormatOnType: true, AutoInsertAttributeQuotes: true, ColorBackground: false, CodeBlockBraceOnNextLine: false, CommitElementsWithSpace: false);
+            EnableFormatting: false, AutoClosingTags: false, InsertSpaces: true, TabSize: 4, AutoShowCompletion: true, AutoListParams: true, FormatOnType: true, AutoInsertAttributeQuotes: true, ColorBackground: false, CodeBlockBraceOnNextLine: true, CommitElementsWithSpace: false);
         var razorJsonString =
             """
 
             {
               "format": {
-                "enable": "false"
+                "enable": "false",
+                "codeBlockBraceOnNextLine": "true"
               }
             }
 
@@ -92,11 +93,12 @@ public class DefaultRazorConfigurationServiceTest(ITestOutputHelper testOutput) 
     {
         // Arrange - purposely choosing options opposite of default
         var expectedOptions = new RazorLSPOptions(
-            EnableFormatting: false, AutoClosingTags: false, InsertSpaces: true, TabSize: 4, AutoShowCompletion: true, AutoListParams: true, FormatOnType: true, AutoInsertAttributeQuotes: true, ColorBackground: false, CodeBlockBraceOnNextLine: false, CommitElementsWithSpace: false);
+            EnableFormatting: false, AutoClosingTags: false, InsertSpaces: true, TabSize: 4, AutoShowCompletion: true, AutoListParams: true, FormatOnType: true, AutoInsertAttributeQuotes: true, ColorBackground: false, CodeBlockBraceOnNextLine: true, CommitElementsWithSpace: false);
         var razorJsonString = """
             {
               "format": {
-                "enable": "false"
+                "enable": "false",
+                "codeBlockBraceOnNextLine": "true"
               }
             }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorConfigurationServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorConfigurationServiceTest.cs
@@ -21,7 +21,7 @@ public class DefaultRazorConfigurationServiceTest(ITestOutputHelper testOutput) 
     {
         // Arrange
         var expectedOptions = new RazorLSPOptions(
-            EnableFormatting: false, AutoClosingTags: false, InsertSpaces: true, TabSize: 4, AutoShowCompletion: true, AutoListParams: true, FormatOnType: true, AutoInsertAttributeQuotes: true, ColorBackground: false, CommitElementsWithSpace: false);
+            EnableFormatting: false, AutoClosingTags: false, InsertSpaces: true, TabSize: 4, AutoShowCompletion: true, AutoListParams: true, FormatOnType: true, AutoInsertAttributeQuotes: true, ColorBackground: false, CodeBlockBraceOnNextLine: false, CommitElementsWithSpace: false);
         var razorJsonString =
             """
 
@@ -92,7 +92,7 @@ public class DefaultRazorConfigurationServiceTest(ITestOutputHelper testOutput) 
     {
         // Arrange - purposely choosing options opposite of default
         var expectedOptions = new RazorLSPOptions(
-            EnableFormatting: false, AutoClosingTags: false, InsertSpaces: true, TabSize: 4, AutoShowCompletion: true, AutoListParams: true, FormatOnType: true, AutoInsertAttributeQuotes: true, ColorBackground: false, CommitElementsWithSpace: false);
+            EnableFormatting: false, AutoClosingTags: false, InsertSpaces: true, TabSize: 4, AutoShowCompletion: true, AutoListParams: true, FormatOnType: true, AutoInsertAttributeQuotes: true, ColorBackground: false, CodeBlockBraceOnNextLine: false, CommitElementsWithSpace: false);
         var razorJsonString = """
             {
               "format": {
@@ -128,7 +128,7 @@ public class DefaultRazorConfigurationServiceTest(ITestOutputHelper testOutput) 
     {
         // Arrange - purposely choosing options opposite of default
         var expectedOptions = new RazorLSPOptions(
-            EnableFormatting: true, AutoClosingTags: false, InsertSpaces: false, TabSize: 8, AutoShowCompletion: true, AutoListParams: true, FormatOnType: false, AutoInsertAttributeQuotes: false, ColorBackground: false, CommitElementsWithSpace: false);
+            EnableFormatting: true, AutoClosingTags: false, InsertSpaces: false, TabSize: 8, AutoShowCompletion: true, AutoListParams: true, FormatOnType: false, AutoInsertAttributeQuotes: false, ColorBackground: false, CodeBlockBraceOnNextLine: false, CommitElementsWithSpace: false);
         var razorJsonString = """
             {
             }
@@ -171,7 +171,7 @@ public class DefaultRazorConfigurationServiceTest(ITestOutputHelper testOutput) 
 
         // Arrange
         // The Json blob is seen as a VS Code options set, so we have to use its default
-        var expectedOptions = RazorLSPOptions.Default with { CommitElementsWithSpace = false};
+        var expectedOptions = RazorLSPOptions.Default with { CommitElementsWithSpace = false };
         var razorJsonString = @"
 {
   ""format"": {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/RazorFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/RazorFormattingTest.cs
@@ -225,6 +225,61 @@ public class RazorFormattingTest(ITestOutputHelper testOutput) : FormattingTestB
     }
 
     [Fact]
+    public async Task CodeBlock_FixCloseBrace3()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                    @code        {
+                        private int currentCount = 0;
+
+                        private void IncrementCount()
+                        {
+                            currentCount++;
+                        }
+                        }
+                    """,
+            expected: """
+                    @code
+                    {
+                        private int currentCount = 0;
+
+                        private void IncrementCount()
+                        {
+                            currentCount++;
+                        }
+                    }
+                    """,
+            razorLSPOptions: RazorLSPOptions.Default with { CodeBlockBraceOnNextLine = true });
+    }
+
+    [Fact]
+    public async Task CodeBlock_FixCloseBrace4()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                    @code        {
+                        private int currentCount = 0;
+
+                        private void IncrementCount()
+                        {
+                            currentCount++;
+                        }                        }
+                    """,
+            expected: """
+                    @code
+                    {
+                        private int currentCount = 0;
+
+                        private void IncrementCount()
+                        {
+                            currentCount++;
+                        }
+                    }
+                    """,
+            razorLSPOptions: RazorLSPOptions.Default with { CodeBlockBraceOnNextLine = true });
+    }
+
+    [Fact]
     public async Task CodeBlock_TooMuchWhitespace()
     {
         await RunFormattingTestAsync(
@@ -277,6 +332,34 @@ public class RazorFormattingTest(ITestOutputHelper testOutput) : FormattingTestB
     }
 
     [Fact]
+    public async Task CodeBlock_NonSpaceWhitespace2()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                    @code	{
+                        private int currentCount = 0;
+
+                        private void IncrementCount()
+                        {
+                            currentCount++;
+                        }
+                    }
+                    """,
+            expected: """
+                    @code
+                    {
+                        private int currentCount = 0;
+
+                        private void IncrementCount()
+                        {
+                            currentCount++;
+                        }
+                    }
+                    """,
+            razorLSPOptions: RazorLSPOptions.Default with { CodeBlockBraceOnNextLine = true });
+    }
+
+    [Fact]
     public async Task CodeBlock_NoWhitespace()
     {
         await RunFormattingTestAsync(
@@ -300,6 +383,34 @@ public class RazorFormattingTest(ITestOutputHelper testOutput) : FormattingTestB
                         }
                     }
                     """);
+    }
+
+    [Fact]
+    public async Task CodeBlock_NoWhitespace2()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                    @code{
+                        private int currentCount = 0;
+
+                        private void IncrementCount()
+                        {
+                            currentCount++;
+                        }
+                    }
+                    """,
+            expected: """
+                    @code
+                    {
+                        private int currentCount = 0;
+
+                        private void IncrementCount()
+                        {
+                            currentCount++;
+                        }
+                    }
+                    """,
+            razorLSPOptions: RazorLSPOptions.Default with { CodeBlockBraceOnNextLine = true });
     }
 
     [Fact]
@@ -356,6 +467,35 @@ public class RazorFormattingTest(ITestOutputHelper testOutput) : FormattingTestB
                     }
                     """,
             fileKind: FileKinds.Legacy);
+    }
+
+    [Fact]
+    public async Task FunctionsBlock_TooManySpaces2()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                    @functions        {
+                        private int currentCount = 0;
+
+                        private void IncrementCount()
+                        {
+                            currentCount++;
+                        }
+                    }
+                    """,
+            expected: """
+                    @functions
+                    {
+                        private int currentCount = 0;
+
+                        private void IncrementCount()
+                        {
+                            currentCount++;
+                        }
+                    }
+                    """,
+            fileKind: FileKinds.Legacy,
+            razorLSPOptions: RazorLSPOptions.Default with { CodeBlockBraceOnNextLine = true });
     }
 
     [Fact]

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/TestRazorFormattingService.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/TestRazorFormattingService.cs
@@ -64,7 +64,7 @@ internal static class TestRazorFormattingService
             new HtmlFormattingPass(mappingService, client, versionCache, optionsMonitor, loggerFactory),
             new CSharpFormattingPass(mappingService, client, loggerFactory),
             new CSharpOnTypeFormattingPass(mappingService, client, optionsMonitor, loggerFactory),
-            new RazorFormattingPass(mappingService, client, loggerFactory),
+            new RazorFormattingPass(mappingService, client, optionsMonitor,  loggerFactory),
             new FormattingDiagnosticValidationPass(mappingService, client, loggerFactory),
             new FormattingContentValidationPass(mappingService, client, loggerFactory),
         };

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLSPOptionsMonitorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLSPOptionsMonitorTest.cs
@@ -28,7 +28,7 @@ public class RazorLSPOptionsMonitorTest : ToolingTestBase
     public async Task UpdateAsync_Invokes_OnChangeRegistration()
     {
         // Arrange
-        var expectedOptions = new RazorLSPOptions(EnableFormatting: false, AutoClosingTags: true, InsertSpaces: true, TabSize: 4, AutoShowCompletion: true, AutoListParams: true, FormatOnType: true, AutoInsertAttributeQuotes: true, ColorBackground: false, CommitElementsWithSpace: true);
+        var expectedOptions = new RazorLSPOptions(EnableFormatting: false, AutoClosingTags: true, InsertSpaces: true, TabSize: 4, AutoShowCompletion: true, AutoListParams: true, FormatOnType: true, AutoInsertAttributeQuotes: true, ColorBackground: false, CodeBlockBraceOnNextLine: false, CommitElementsWithSpace: true);
         var configService = Mock.Of<IConfigurationSyncService>(
             f => f.GetLatestOptionsAsync(DisposalToken) == Task.FromResult(expectedOptions),
             MockBehavior.Strict);
@@ -50,7 +50,7 @@ public class RazorLSPOptionsMonitorTest : ToolingTestBase
     public async Task UpdateAsync_DoesNotInvoke_OnChangeRegistration_AfterDispose()
     {
         // Arrange
-        var expectedOptions = new RazorLSPOptions(EnableFormatting: false, AutoClosingTags: true, InsertSpaces: true, TabSize: 4, AutoShowCompletion: true, AutoListParams: true, FormatOnType: true, AutoInsertAttributeQuotes: true, ColorBackground: false, CommitElementsWithSpace: true);
+        var expectedOptions = new RazorLSPOptions(EnableFormatting: false, AutoClosingTags: true, InsertSpaces: true, TabSize: 4, AutoShowCompletion: true, AutoListParams: true, FormatOnType: true, AutoInsertAttributeQuotes: true, ColorBackground: false, CodeBlockBraceOnNextLine: false, CommitElementsWithSpace: true);
         var configService = Mock.Of<IConfigurationSyncService>(
             f => f.GetLatestOptionsAsync(DisposalToken) == Task.FromResult(expectedOptions),
             MockBehavior.Strict);
@@ -96,7 +96,7 @@ public class RazorLSPOptionsMonitorTest : ToolingTestBase
     public void InitializedOptionsAreCurrent()
     {
         // Arrange
-        var expectedOptions = new RazorLSPOptions(EnableFormatting: false, AutoClosingTags: true, InsertSpaces: true, TabSize: 4, AutoShowCompletion: true, AutoListParams: true, FormatOnType: true, AutoInsertAttributeQuotes: true, ColorBackground: false, CommitElementsWithSpace: true);
+        var expectedOptions = new RazorLSPOptions(EnableFormatting: false, AutoClosingTags: true, InsertSpaces: true, TabSize: 4, AutoShowCompletion: true, AutoListParams: true, FormatOnType: true, AutoInsertAttributeQuotes: true, ColorBackground: false, CodeBlockBraceOnNextLine: false, CommitElementsWithSpace: true);
         var configService = Mock.Of<IConfigurationSyncService>(
             f => f.GetLatestOptionsAsync(DisposalToken) == Task.FromResult(expectedOptions),
             MockBehavior.Strict);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/LanguageServerTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/LanguageServerTestBase.cs
@@ -121,10 +121,10 @@ public abstract class LanguageServerTestBase : ToolingTestBase
         return new VersionedDocumentContext(uri, snapshot, projectContext: null, version: 0);
     }
 
-    internal static IOptionsMonitor<RazorLSPOptions> GetOptionsMonitor(bool enableFormatting = true, bool autoShowCompletion = true, bool autoListParams = true, bool formatOnType = true, bool autoInsertAttributeQuotes = true, bool colorBackground = false, bool commitElementsWithSpace = true)
+    internal static IOptionsMonitor<RazorLSPOptions> GetOptionsMonitor(bool enableFormatting = true, bool autoShowCompletion = true, bool autoListParams = true, bool formatOnType = true, bool autoInsertAttributeQuotes = true, bool colorBackground = false, bool codeBlockBraceOnNextLine = false, bool commitElementsWithSpace = true)
     {
         var monitor = new Mock<IOptionsMonitor<RazorLSPOptions>>(MockBehavior.Strict);
-        monitor.SetupGet(m => m.CurrentValue).Returns(new RazorLSPOptions(enableFormatting, true, InsertSpaces: true, TabSize: 4, autoShowCompletion, autoListParams, formatOnType, autoInsertAttributeQuotes, colorBackground, commitElementsWithSpace));
+        monitor.SetupGet(m => m.CurrentValue).Returns(new RazorLSPOptions(enableFormatting, true, InsertSpaces: true, TabSize: 4, autoShowCompletion, autoListParams, formatOnType, autoInsertAttributeQuotes, colorBackground, codeBlockBraceOnNextLine, commitElementsWithSpace));
         return monitor.Object;
     }
 

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Settings/ClientSettingsManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Settings/ClientSettingsManagerTest.cs
@@ -82,7 +82,7 @@ public class ClientSettingsManagerTest(ITestOutputHelper testOutput) : VisualStu
         var manager = new ClientSettingsManager(_clientSettingsChangeTriggers);
         var called = false;
         manager.ClientSettingsChanged += (caller, args) => called = true;
-        var settings = new ClientAdvancedSettings(FormatOnType: false, AutoClosingTags: true, AutoInsertAttributeQuotes: true, ColorBackground: true, CommitElementsWithSpace: false, SnippetSetting: default, LogLevel: default);
+        var settings = new ClientAdvancedSettings(FormatOnType: false, AutoClosingTags: true, AutoInsertAttributeQuotes: true, ColorBackground: true, CodeBlockBraceOnNextLine: false, CommitElementsWithSpace: false, SnippetSetting: default, LogLevel: default);
 
         // Act
         manager.Update(settings);


### PR DESCRIPTION
Fixes: Being nerdsniped by `u/featheredsnake` on Reddit: https://www.reddit.com/r/Blazor/comments/1b47odh/am_i_the_only_one_bothered_that_code_brackets/

![27c833c0-aa9c-4be6-9519-3b3ecb9f3f54](https://github.com/dotnet/razor/assets/754264/d3c16ea4-9b75-4972-a4bd-ad4bf986b54d)

VS Code option: https://github.com/dotnet/vscode-csharp/pull/6939