### PR TITLE
Avoid force-creating the project snapshot manager off the dispatcher

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LspProjectSnapshotManagerAccessor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LspProjectSnapshotManagerAccessor.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
@@ -38,5 +39,11 @@ internal sealed class LspProjectSnapshotManagerAccessor(
 
             return _instance;
         }
+    }
+
+    public bool TryGetInstance([NotNullWhen(true)] out ProjectSnapshotManagerBase? instance)
+    {
+        instance = _instance;
+        return instance is not null;
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/IProjectSnapshotManagerAccessor.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/IProjectSnapshotManagerAccessor.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.CodeAnalysis.Razor.Workspaces;
@@ -8,4 +9,10 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces;
 internal interface IProjectSnapshotManagerAccessor
 {
     ProjectSnapshotManagerBase Instance { get; }
+
+    /// <summary>
+    ///  Retrieves the <see cref="ProjectSnapshotManagerBase"/> instance. Returns <see langword="true"/>
+    ///  if the instance has been created; otherwise, <see langword="false"/>.
+    /// </summary>
+    bool TryGetInstance([NotNullWhen(true)] out ProjectSnapshotManagerBase? instance);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/FallbackProjectManager.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/FallbackProjectManager.cs
@@ -44,7 +44,8 @@ internal sealed class FallbackProjectManager(
     {
         try
         {
-            if (_projectManagerAccessor.Instance.TryGetLoadedProject(razorProjectKey, out var project))
+            if (_projectManagerAccessor.TryGetInstance(out var projectSnapshotManager) &&
+                projectSnapshotManager.TryGetLoadedProject(razorProjectKey, out var project))
             {
                 if (project is ProjectSnapshot { HostProject: FallbackHostProject })
                 {
@@ -76,7 +77,8 @@ internal sealed class FallbackProjectManager(
     {
         try
         {
-            if (_projectManagerAccessor.Instance.TryGetLoadedProject(razorProjectKey, out var project) &&
+            if (_projectManagerAccessor.TryGetInstance(out var projectSnapshotManager) &&
+                projectSnapshotManager.TryGetLoadedProject(razorProjectKey, out var project) &&
                 project is ProjectSnapshot { HostProject: FallbackHostProject })
             {
                 // If this is a fallback project, then Roslyn may not track documents in the project, so these dynamic file notifications

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocumentFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/CSharpVirtualDocumentFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -192,7 +193,9 @@ internal class CSharpVirtualDocumentFactory : VirtualDocumentFactoryBase
             yield break;
         }
 
-        var projects = _projectSnapshotManagerAccessor.Instance.GetProjects();
+        var projects = _projectSnapshotManagerAccessor.TryGetInstance(out var projectSnapshotManager)
+            ? projectSnapshotManager.GetProjects()
+            : ImmutableArray<IProjectSnapshot>.Empty;
 
         var inAny = false;
         var normalizedDocumentPath = FilePathService.GetProjectSystemFilePath(hostDocumentUri);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioProjectSnapshotManagerAccessor.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioProjectSnapshotManagerAccessor.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.ComponentModel.Composition;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -58,5 +59,11 @@ internal sealed class VisualStudioProjectSnapshotManagerAccessor(
                     .GetRequiredService<IProjectSnapshotManager>();
             }
         }
+    }
+
+    public bool TryGetInstance([NotNullWhen(true)] out ProjectSnapshotManagerBase? instance)
+    {
+        instance = _projectManager;
+        return instance is not null;
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorComponentSearchEngineTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorComponentSearchEngineTest.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X;
@@ -180,6 +181,14 @@ public class DefaultRazorComponentSearchEngineTest(ITestOutputHelper testOutput)
 
     internal class TestProjectSnapshotManagerAccessor(ProjectSnapshotManagerBase instance) : IProjectSnapshotManagerAccessor
     {
-        public ProjectSnapshotManagerBase Instance => instance;
+        private readonly ProjectSnapshotManagerBase _instance = instance;
+
+        public ProjectSnapshotManagerBase Instance => _instance;
+
+        public bool TryGetInstance([NotNullWhen(true)] out ProjectSnapshotManagerBase instance)
+        {
+            instance = _instance;
+            return instance is not null;
+        }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestProjectSnapshotManagerAccessor.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestProjectSnapshotManagerAccessor.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 
@@ -8,5 +9,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test;
 
 internal class TestProjectSnapshotManagerAccessor(ProjectSnapshotManagerBase instance) : IProjectSnapshotManagerAccessor
 {
-    public ProjectSnapshotManagerBase Instance => instance;
+    private readonly ProjectSnapshotManagerBase _instance = instance;
+
+    public ProjectSnapshotManagerBase Instance => _instance;
+
+    public bool TryGetInstance([NotNullWhen(true)] out ProjectSnapshotManagerBase? instance)
+    {
+        instance = _instance;
+        return instance is not null;
+    }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/FallbackProjectManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/FallbackProjectManagerTest.cs
@@ -34,13 +34,21 @@ public class FallbackProjectManagerTest : VisualStudioWorkspaceTestBase
 
         _projectManager = new TestProjectSnapshotManager(ProjectEngineFactoryProvider, Dispatcher);
 
-        var projectManagerAccessor = StrictMock.Of<IProjectSnapshotManagerAccessor>(a =>
-            a.Instance == _projectManager);
+        var projectManagerAccessorMock = new StrictMock<IProjectSnapshotManagerAccessor>();
+
+        projectManagerAccessorMock
+            .SetupGet(x => x.Instance)
+            .Returns(_projectManager);
+
+        ProjectSnapshotManagerBase? instanceResult = _projectManager;
+        projectManagerAccessorMock
+            .Setup(x => x.TryGetInstance(out instanceResult))
+            .Returns(true);
 
         _fallbackProjectManger = new FallbackProjectManager(
             _projectConfigurationFilePathStore,
             languageServerFeatureOptions,
-            projectManagerAccessor,
+            projectManagerAccessorMock.Object,
             Dispatcher,
             WorkspaceProvider,
             NoOpTelemetryReporter.Instance);


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1947624/
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1978114/
_Might_ fix https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1979185/

Recently, I made a change to `VisualStudioProjectSnapshotManagerAccessor.Instance` to use `JTF.Run(...)` as a last resort to ensure that the project snapshot manager is created on the dispatcher (commit 528f1e950190545b7dda2b20bd129975c71d4c2f). This is necessary because the project snapshot manager initializes change triggers when it is created, and change triggers can do significant work during initialization that should only run on the dispatcher. However, this has been problematic because it results in `JTF.Run(...)` occurring on thread pool threads, which can contribute to thread pool starvation.

To avoid `VisualStudioProjectSnapshotManagerAccessor.Instance` needing to use `JTF.Run(...)`, I've added an `IProjectSnapshotManagerAccessor.TryGetInstance(...)` method and fixed up a few call-sites to use it:

* `CSharpVirtualDocumentFactory` - Accesses the project snapshot manager to get the current list of projects. So, if the project snapshot manager hasn't been created yet, we can just assume that there aren't any projects.
* `FallbackProjectManager` - Access the project snapshot manager to try and get the loaded project for a particular project key. However, if the project snapshot manager hasn't been created yet, we can assume that there isn't a loaded project to retrieve.

Note that these are tactical fixes. Ultimately, `IProjectSnapshotManagerAccessor` will go away once #9950 is finished.