### PR TITLE
[release/dev17.10] Fix hang on solution close

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/FallbackProjectManager.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/FallbackProjectManager.cs
@@ -114,11 +114,18 @@ internal sealed class FallbackProjectManager(
         // the project will be updated, and it will no longer be a fallback project.
         var hostProject = new FallbackHostProject(project.FilePath, intermediateOutputPath, FallbackRazorConfiguration.Latest, rootNamespace, project.Name);
 
-        await _dispatcher
-            .RunOnDispatcherThreadAsync(
-                () => _projectManagerAccessor.Instance.ProjectAdded(hostProject),
-                cancellationToken)
-            .ConfigureAwait(false);
+        if (_dispatcher.IsDispatcherThread)
+        {
+            _projectManagerAccessor.Instance.ProjectAdded(hostProject);
+        }
+        else
+        {
+            await _dispatcher
+                .RunOnDispatcherThreadAsync(
+                    () => _projectManagerAccessor.Instance.ProjectAdded(hostProject),
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
 
         await AddFallbackDocumentAsync(hostProject.Key, filePath, project.FilePath, cancellationToken).ConfigureAwait(false);
 
@@ -137,11 +144,18 @@ internal sealed class FallbackProjectManager(
 
         var textLoader = new FileTextLoader(filePath, defaultEncoding: null);
 
-        await _dispatcher
-            .RunOnDispatcherThreadAsync(
-                () => _projectManagerAccessor.Instance.DocumentAdded(projectKey, hostDocument, textLoader),
-                cancellationToken)
-            .ConfigureAwait(false);
+        if (_dispatcher.IsDispatcherThread)
+        {
+            _projectManagerAccessor.Instance.DocumentAdded(projectKey, hostDocument, textLoader);
+        }
+        else
+        {
+            await _dispatcher
+                .RunOnDispatcherThreadAsync(
+                    () => _projectManagerAccessor.Instance.DocumentAdded(projectKey, hostDocument, textLoader),
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
     }
 
     private static HostDocument? CreateHostDocument(string filePath, string projectFilePath)
@@ -180,11 +194,18 @@ internal sealed class FallbackProjectManager(
             return;
         }
 
-        await _dispatcher
-            .RunOnDispatcherThreadAsync(
-                () => _projectManagerAccessor.Instance.DocumentRemoved(razorProjectKey, hostDocument),
-                cancellationToken)
-            .ConfigureAwait(false);
+        if (_dispatcher.IsDispatcherThread)
+        {
+            _projectManagerAccessor.Instance.DocumentRemoved(razorProjectKey, hostDocument);
+        }
+        else
+        {
+            await _dispatcher
+                .RunOnDispatcherThreadAsync(
+                    () => _projectManagerAccessor.Instance.DocumentRemoved(razorProjectKey, hostDocument),
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
     }
 
     private Project? TryFindProjectForProjectId(ProjectId projectId)


### PR DESCRIPTION
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1980614/

There are scenarios on 17.10p2 where my recent changes to make `FallbackProjectManager` use the dispatcher for project snapshot manager changes can cause a dead lock. The problem occurs when dynamic file info is updated on the dispatcher thread. Roslyn will then call `GetDynamicFileInfoAsync(...)` on the dispatcher thread and block on the result. `GetDynamicFileInfoAsync(...)` calls into `FallbackProjectManager.DynamicFileAddedAsync(...)`, which attempts to make changes to the project snapshot manager using the dispatcher. However, because the dispatcher thread is blocked, it can never make progress to newly queued task and hangs.

This is a small change to `FallbackProjectManager` to apply the project snapshot manager changes directly if it's running on the dispatcher thread. Otherwise, it runs the change on the dispatcher.