### PR TITLE
Update semantic tokens service to better support The Future™

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensRangeEndpointBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensRangeEndpointBenchmark.cs
@@ -18,6 +18,7 @@ using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -75,10 +76,9 @@ public class RazorSemanticTokensRangeEndpointBenchmark : RazorLanguageServerBenc
         DocumentContext = new VersionedDocumentContext(documentUri, documentSnapshot, projectContext: null, version);
 
         var razorOptionsMonitor = RazorLanguageServer.GetRequiredService<RazorLSPOptionsMonitor>();
-        var clientConnection = RazorLanguageServer.GetRequiredService<IClientConnection>();
         var clientCapabilitiesService = new BenchmarkClientCapabilitiesService(new VSInternalClientCapabilities() { SupportsVisualStudioExtensions = true });
         var razorSemanticTokensLegendService = new RazorSemanticTokensLegendService(clientCapabilitiesService);
-        SemanticTokensRangeEndpoint = new SemanticTokensRangeEndpoint(RazorSemanticTokenService, razorSemanticTokensLegendService, razorOptionsMonitor, clientConnection);
+        SemanticTokensRangeEndpoint = new SemanticTokensRangeEndpoint(RazorSemanticTokenService, razorSemanticTokensLegendService, razorOptionsMonitor, telemetryReporter: null);
 
         var text = await DocumentContext.GetSourceTextAsync(CancellationToken.None).ConfigureAwait(false);
         Range = new Range
@@ -158,21 +158,18 @@ public class RazorSemanticTokensRangeEndpointBenchmark : RazorLanguageServerBenc
             IRazorDocumentMappingService documentMappingService,
             RazorSemanticTokensLegendService razorSemanticTokensLegendService,
             IRazorLoggerFactory loggerFactory)
-            : base(documentMappingService, razorSemanticTokensLegendService, languageServerFeatureOptions, loggerFactory, telemetryReporter: null)
+            : base(documentMappingService, razorSemanticTokensLegendService, csharpSemanticTokensProvider: null!, languageServerFeatureOptions, loggerFactory)
         {
         }
 
         // We can't get C# responses without significant amounts of extra work, so let's just shim it for now, any non-Null result is fine.
-        internal override Task<ImmutableArray<SemanticRange>?> GetCSharpSemanticRangesAsync(
-            IClientConnection clientConnection,
+        protected override Task<ImmutableArray<SemanticRange>?> GetCSharpSemanticRangesAsync(
+            VersionedDocumentContext documentContext,
             RazorCodeDocument codeDocument,
-            TextDocumentIdentifier textDocumentIdentifier,
-            Range razorRange,
+            LinePositionSpan razorSpan,
             bool colorBackground,
-            long documentVersion,
             Guid correlationId,
-            CancellationToken cancellationToken,
-            string previousResultId = null)
+            CancellationToken cancellationToken)
         {
             return Task.FromResult<ImmutableArray<SemanticRange>?>(PregeneratedRandomSemanticRanges);
         }

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensScrollingBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensScrollingBenchmark.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer;
 using Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using static Microsoft.AspNetCore.Razor.Microbenchmarks.LanguageServer.RazorSemanticTokensBenchmark;
@@ -76,10 +77,6 @@ public class RazorSemanticTokensScrollingBenchmark : RazorLanguageServerBenchmar
     [Benchmark(Description = "Razor Semantic Tokens Range Scrolling")]
     public async Task RazorSemanticTokensRangeScrollingAsync()
     {
-        var textDocumentIdentifier = new TextDocumentIdentifier()
-        {
-            Uri = DocumentUri
-        };
         var cancellationToken = CancellationToken.None;
         var documentVersion = 1;
 
@@ -87,23 +84,16 @@ public class RazorSemanticTokensScrollingBenchmark : RazorLanguageServerBenchmar
 
         var documentLineCount = Range.End.Line;
 
-        var clientConnection = RazorLanguageServer.GetRequiredService<IClientConnection>();
-
         var lineCount = 0;
         while (lineCount != documentLineCount)
         {
             var newLineCount = Math.Min(lineCount + WindowSize, documentLineCount);
-            var range = new Range
-            {
-                Start = new Position(lineCount, 0),
-                End = new Position(newLineCount, 0)
-            };
+            var span = new LinePositionSpan(new LinePosition(lineCount, 0), new LinePosition(newLineCount, 0));
             await RazorSemanticTokenService!.GetSemanticTokensAsync(
-                clientConnection,
-                textDocumentIdentifier,
-                range,
                 DocumentContext,
+                span,
                 colorBackground: false,
+                Guid.Empty,
                 cancellationToken);
 
             lineCount = newLineCount;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
@@ -126,6 +126,7 @@ internal static class IServiceCollectionExtensions
         services.AddHandlerWithCapabilities<SemanticTokensRangeEndpoint>();
         // Ensure that we don't add the default service if something else has added one.
         services.TryAddSingleton<IRazorSemanticTokensInfoService, RazorSemanticTokensInfoService>();
+        services.AddSingleton<ICSharpSemanticTokensProvider, LSPCSharpSemanticTokensProvider>();
 
         services.AddSingleton<RazorSemanticTokensLegendService>();
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RazorCodeDocumentExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/RazorCodeDocumentExtensions.cs
@@ -2,11 +2,11 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Protocol;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 
@@ -20,7 +20,7 @@ internal static class RazorCodeDocumentExtensions
             _ => throw new System.InvalidOperationException(),
         };
 
-    public static bool TryGetMinimalCSharpRange(this RazorCodeDocument codeDocument, Range razorRange, [NotNullWhen(true)] out Range? csharpRange)
+    public static bool TryGetMinimalCSharpRange(this RazorCodeDocument codeDocument, LinePositionSpan razorRange, out LinePositionSpan csharpRange)
     {
         SourceSpan? minGeneratedSpan = null;
         SourceSpan? maxGeneratedSpan = null;
@@ -53,16 +53,16 @@ internal static class RazorCodeDocumentExtensions
         if (minGeneratedSpan is not null && maxGeneratedSpan is not null)
         {
             var csharpSourceText = codeDocument.GetCSharpSourceText();
-            var startRange = minGeneratedSpan.Value.ToRange(csharpSourceText);
-            var endRange = maxGeneratedSpan.Value.ToRange(csharpSourceText);
+            var startRange = minGeneratedSpan.Value.ToLinePositionSpan(csharpSourceText);
+            var endRange = maxGeneratedSpan.Value.ToLinePositionSpan(csharpSourceText);
 
-            csharpRange = new Range { Start = startRange.Start, End = endRange.End };
+            csharpRange = new LinePositionSpan(startRange.Start, endRange.End);
             Debug.Assert(csharpRange.Start.CompareTo(csharpRange.End) <= 0, "Range.Start should not be larger than Range.End");
 
             return true;
         }
 
-        csharpRange = null;
+        csharpRange = default;
         return false;
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/SemanticTokensRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/SemanticTokensRangeEndpoint.cs
@@ -1,10 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
+using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
+using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
@@ -14,13 +17,13 @@ internal sealed class SemanticTokensRangeEndpoint(
     IRazorSemanticTokensInfoService semanticTokensInfoService,
     RazorSemanticTokensLegendService razorSemanticTokensLegendService,
     RazorLSPOptionsMonitor razorLSPOptionsMonitor,
-    IClientConnection clientConnection)
+    ITelemetryReporter? telemetryReporter)
     : IRazorRequestHandler<SemanticTokensRangeParams, SemanticTokens?>, ICapabilitiesProvider
 {
     private readonly IRazorSemanticTokensInfoService _semanticTokensInfoService = semanticTokensInfoService;
     private readonly RazorSemanticTokensLegendService _razorSemanticTokensLegendService = razorSemanticTokensLegendService;
     private readonly RazorLSPOptionsMonitor _razorLSPOptionsMonitor = razorLSPOptionsMonitor;
-    private readonly IClientConnection _clientConnection = clientConnection;
+    private readonly ITelemetryReporter? _telemetryReporter = telemetryReporter;
 
     public bool MutatesSolutionState { get; } = false;
 
@@ -39,8 +42,19 @@ internal sealed class SemanticTokensRangeEndpoint(
         var documentContext = requestContext.GetRequiredDocumentContext();
         var colorBackground = _razorLSPOptionsMonitor.CurrentValue.ColorBackground;
 
-        var semanticTokens = await _semanticTokensInfoService.GetSemanticTokensAsync(_clientConnection, request.TextDocument, request.Range, documentContext, colorBackground, cancellationToken).ConfigureAwait(false);
+        var correlationId = Guid.NewGuid();
+        using var _ = _telemetryReporter?.TrackLspRequest(Methods.TextDocumentSemanticTokensRangeName, LanguageServerConstants.RazorLanguageServerName, correlationId);
 
-        return semanticTokens;
+        var data = await _semanticTokensInfoService.GetSemanticTokensAsync(documentContext, request.Range.ToLinePositionSpan(), colorBackground, correlationId, cancellationToken).ConfigureAwait(false);
+
+        if (data is null)
+        {
+            return null;
+        }
+
+        return new SemanticTokens
+        {
+            Data = data,
+        };
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/ICSharpSemanticTokensProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/ICSharpSemanticTokensProvider.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
+
+internal interface ICSharpSemanticTokensProvider
+{
+    Task<int[]?> GetCSharpSemanticTokensResponseAsync(
+        VersionedDocumentContext documentContext,
+        ImmutableArray<LinePositionSpan> csharpSpans,
+        bool usePreciseSemanticTokenRanges,
+        Guid correlationId,
+        CancellationToken cancellationToken);
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/IRazorSemanticTokenInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/IRazorSemanticTokenInfoService.cs
@@ -10,5 +10,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
 
 internal interface IRazorSemanticTokensInfoService
 {
+    /// <summary>
+    /// Gets the int array representing the semantic tokens for the given range.
+    /// </summary>
+    /// <remarks>See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_semanticTokens for details about the int array</remarks>
     Task<int[]?> GetSemanticTokensAsync(VersionedDocumentContext documentContext, LinePositionSpan range, bool colorBackground, Guid correlationId, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/IRazorSemanticTokenInfoService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/IRazorSemanticTokenInfoService.cs
@@ -1,13 +1,14 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
 
 internal interface IRazorSemanticTokensInfoService
 {
-    Task<SemanticTokens?> GetSemanticTokensAsync(IClientConnection clientConnection, TextDocumentIdentifier textDocumentIdentifier, Range range, VersionedDocumentContext documentContext, bool colorBackground, CancellationToken cancellationToken);
+    Task<int[]?> GetSemanticTokensAsync(VersionedDocumentContext documentContext, LinePositionSpan range, bool colorBackground, Guid correlationId, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/LSPCSharpSemanticTokensProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/LSPCSharpSemanticTokensProvider.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
+using Microsoft.AspNetCore.Razor.LanguageServer.Semantic.Models;
+using Microsoft.AspNetCore.Razor.PooledObjects;
+using Microsoft.CodeAnalysis.Razor.Logging;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
+
+internal class LSPCSharpSemanticTokensProvider(IClientConnection clientConnection, IRazorLoggerFactory loggerFactory) : ICSharpSemanticTokensProvider
+{
+    private readonly IClientConnection _clientConnection = clientConnection;
+    private readonly ILogger _logger = loggerFactory.CreateLogger<LSPCSharpSemanticTokensProvider>();
+
+    public async Task<int[]?> GetCSharpSemanticTokensResponseAsync(
+            VersionedDocumentContext documentContext,
+            ImmutableArray<LinePositionSpan> csharpSpans,
+            bool usePreciseSemanticTokenRanges,
+            Guid correlationId,
+            CancellationToken cancellationToken)
+    {
+        var documentVersion = documentContext.Version;
+
+        using var _ = ListPool<Range>.GetPooledObject(out var csharpRangeList);
+        foreach (var span in csharpSpans)
+        {
+            csharpRangeList.Add(span.ToRange());
+        }
+
+        var csharpRanges = csharpRangeList.ToArray();
+
+        var parameter = new ProvideSemanticTokensRangesParams(documentContext.Identifier.TextDocumentIdentifier, documentVersion, csharpRanges, correlationId);
+        ProvideSemanticTokensResponse? csharpResponse;
+        if (usePreciseSemanticTokenRanges)
+        {
+            csharpResponse = await GetCsharpResponseAsync(_clientConnection, parameter, CustomMessageNames.RazorProvidePreciseRangeSemanticTokensEndpoint, cancellationToken).ConfigureAwait(false);
+
+            // Likely the server doesn't support the new endpoint, fallback to the original one
+            if (csharpResponse?.Tokens is null && csharpRanges.Length > 1)
+            {
+                var minimalRange = new Range
+                {
+                    Start = csharpRanges[0].Start,
+                    End = csharpRanges[^1].End
+                };
+
+                var newParams = new ProvideSemanticTokensRangesParams(
+                    parameter.TextDocument,
+                    parameter.RequiredHostDocumentVersion,
+                    [minimalRange],
+                    parameter.CorrelationId);
+
+                csharpResponse = await GetCsharpResponseAsync(_clientConnection, newParams, CustomMessageNames.RazorProvideSemanticTokensRangeEndpoint, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        else
+        {
+            csharpResponse = await GetCsharpResponseAsync(_clientConnection, parameter, CustomMessageNames.RazorProvideSemanticTokensRangeEndpoint, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (csharpResponse is null)
+        {
+            // C# isn't ready yet, don't make Razor wait for it. Once C# is ready they'll send a refresh notification.
+            return [];
+        }
+
+        var csharpVersion = csharpResponse.HostDocumentSyncVersion;
+        if (csharpVersion != documentVersion)
+        {
+            // No C# response or C# is out of sync with us. Unrecoverable, return null to indicate no change.
+            // Once C# syncs up they'll send a refresh notification.
+            if (csharpVersion == -1)
+            {
+                _logger.LogWarning("Didn't get C# tokens because the virtual document wasn't found, or other problem. We were wanting {documentVersion} but C# could not get any version.", documentVersion);
+            }
+            else if (csharpVersion < documentVersion)
+            {
+                _logger.LogDebug("Didn't wait for Roslyn to get the C# version we were expecting. We are wanting {documentVersion} but C# is at {csharpVersion}.", documentVersion, csharpVersion);
+            }
+            else
+            {
+                _logger.LogWarning("We are behind the C# version which is surprising. Could be an old request that wasn't cancelled, but if not, expect most future requests to fail. We were wanting {documentVersion} but C# is at {csharpVersion}.", documentVersion, csharpVersion);
+            }
+
+            return null;
+        }
+
+        return csharpResponse.Tokens ?? [];
+    }
+
+    private static Task<ProvideSemanticTokensResponse?> GetCsharpResponseAsync(IClientConnection clientConnection, ProvideSemanticTokensRangesParams parameter, string lspMethodName, CancellationToken cancellationToken)
+    {
+        return clientConnection.SendRequestAsync<ProvideSemanticTokensRangesParams, ProvideSemanticTokensResponse?>(
+            lspMethodName,
+            parameter,
+            cancellationToken);
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/SemanticTokensVisitor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/SemanticTokensVisitor.cs
@@ -6,7 +6,6 @@ using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
-using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -31,14 +30,11 @@ internal sealed class SemanticTokensVisitor : SyntaxWalker
         _colorCodeBackground = colorCodeBackground;
     }
 
-    public static ImmutableArray<SemanticRange> GetSemanticRanges(RazorCodeDocument razorCodeDocument, Range range, RazorSemanticTokensLegendService razorSemanticTokensLegendService, bool colorCodeBackground)
+    public static ImmutableArray<SemanticRange> GetSemanticRanges(RazorCodeDocument razorCodeDocument, TextSpan textSpan, RazorSemanticTokensLegendService razorSemanticTokensLegendService, bool colorCodeBackground)
     {
-        var sourceText = razorCodeDocument.GetSourceText();
-        var rangeAsTextSpan = range.ToTextSpan(sourceText);
-
         using var _ = ArrayBuilderPool<SemanticRange>.GetPooledObject(out var builder);
 
-        var visitor = new SemanticTokensVisitor(builder, razorCodeDocument, rangeAsTextSpan, razorSemanticTokensLegendService, colorCodeBackground);
+        var visitor = new SemanticTokensVisitor(builder, razorCodeDocument, textSpan, razorSemanticTokensLegendService, colorCodeBackground);
 
         visitor.Visit(razorCodeDocument.GetSyntaxTree().Root);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/InlayHints/InlayHintEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/InlayHints/InlayHintEndpointTest.cs
@@ -7,7 +7,6 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
-using Microsoft.AspNetCore.Razor.LanguageServer.InlayHints;
 using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
@@ -16,7 +15,7 @@ using Roslyn.Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Microsoft.AspNetCore.Razor.LanguageServer.Test.InlayHints;
+namespace Microsoft.AspNetCore.Razor.LanguageServer.InlayHints;
 
 public class InlayHintEndpointTest(ITestOutputHelper testOutput) : SingleServerDelegatingEndpointTestBase(testOutput)
 {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokensTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokensTest.cs
@@ -874,7 +874,7 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
 
         var codeDocument = CreateCodeDocument(documentText, isRazorFile: true, DefaultTagHelpers);
         var csharpSourceText = codeDocument.GetCSharpSourceText();
-        var razorRange = GetRange(documentText);
+        var razorRange = GetSpan(documentText);
 
         if (precise)
         {
@@ -917,11 +917,11 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
 
         var service = await CreateServiceAsync(documentContext, csharpTokens, withCSharpBackground, serverSupportsPreciseRanges, precise);
 
-        var range = GetRange(documentText);
-        var tokens = await service.GetSemanticTokensAsync(_clientConnection.Object, new() { Uri = documentContext.Uri }, range, documentContext, withCSharpBackground, DisposalToken);
+        var range = GetSpan(documentText);
+        var tokens = await service.GetSemanticTokensAsync(documentContext, range, withCSharpBackground, Guid.Empty, DisposalToken);
 
         var sourceText = await documentContext.GetSourceTextAsync(DisposalToken);
-        AssertSemanticTokensMatchesBaseline(sourceText, tokens?.Data, testName.AssumeNotNull());
+        AssertSemanticTokensMatchesBaseline(sourceText, tokens, testName.AssumeNotNull());
     }
 
     private static VersionedDocumentContext CreateDocumentContext(
@@ -1006,12 +1006,14 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             options.HtmlVirtualDocumentSuffix == "__virtual.html",
             MockBehavior.Strict);
 
+        var cSharpSemanticTokensProvider = new LSPCSharpSemanticTokensProvider(_clientConnection.Object, LoggerFactory);
+
         var service = new RazorSemanticTokensInfoService(
             documentMappingService,
             TestRazorSemanticTokensLegendService.Instance,
+            cSharpSemanticTokensProvider,
             featureOptions,
-            LoggerFactory,
-            telemetryReporter: null);
+            LoggerFactory);
 
         return service;
     }
@@ -1029,7 +1031,7 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             SpanMappingService,
             DisposalToken);
 
-        var razorRange = GetRange(documentText);
+        var razorRange = GetSpan(documentText);
         var csharpRanges = GetMappedCSharpRanges(codeDocument, razorRange, precise);
         if (csharpRanges == null)
         {
@@ -1040,14 +1042,14 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
         {
             var result = await csharpServer.ExecuteRequestAsync<SemanticTokensRangesParams, SemanticTokens>(
                 "roslyn/semanticTokenRanges",
-                CreateVSSemanticTokensRangesParams(csharpRanges, csharpDocumentUri),
+                CreateVSSemanticTokensRangesParams(csharpRanges.Value, csharpDocumentUri),
                 DisposalToken);
 
             return new ProvideSemanticTokensResponse(tokens: result?.Data, hostDocumentSyncVersion: 0);
         }
         else
         {
-            var range = Assert.Single(csharpRanges);
+            var range = Assert.Single(csharpRanges.Value);
             var result = await csharpServer.ExecuteRequestAsync<SemanticTokensRangeParams, SemanticTokens>(
                 "textDocument/semanticTokens/range",
                 CreateVSSemanticTokensRangeParams(range, csharpDocumentUri),
@@ -1073,17 +1075,11 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
                     !precise || !serverSupportsPreciseRanges ? 1 : 0));
     }
 
-    private static Range GetRange(string text)
+    private static LinePositionSpan GetSpan(string text)
     {
         var lineCount = text.Count(c => c == '\n') + 1;
 
-        var range = new Range
-        {
-            Start = new Position { Line = 0, Character = 0 },
-            End = new Position { Line = lineCount, Character = 0 }
-        };
-
-        return range;
+        return new LinePositionSpan(new LinePosition(0, 0), new LinePosition(lineCount, 0));
     }
 
     private void AssertSemanticTokensMatchesBaseline(SourceText sourceText, int[]? actualSemanticTokens, string testName)
@@ -1122,7 +1118,7 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
         return baselineContents;
     }
 
-    private Range[]? GetMappedCSharpRanges(RazorCodeDocument codeDocument, Range razorRange, bool precise)
+    private ImmutableArray<LinePositionSpan>? GetMappedCSharpRanges(RazorCodeDocument codeDocument, LinePositionSpan razorRange, bool precise)
     {
         var documentMappingService = new RazorDocumentMappingService(FilePathService, new TestDocumentContextFactory(), LoggerFactory);
 
@@ -1147,18 +1143,18 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
         return [range];
     }
 
-    private static SemanticTokensRangesParams CreateVSSemanticTokensRangesParams(Range[] ranges, Uri uri)
+    private static SemanticTokensRangesParams CreateVSSemanticTokensRangesParams(ImmutableArray<LinePositionSpan> ranges, Uri uri)
         => new()
         {
             TextDocument = new TextDocumentIdentifier { Uri = uri },
-            Ranges = ranges
+            Ranges = ranges.Select(s => s.ToRange()).ToArray()
         };
 
-    private static SemanticTokensRangeParams CreateVSSemanticTokensRangeParams(Range range, Uri uri)
+    private static SemanticTokensRangeParams CreateVSSemanticTokensRangeParams(LinePositionSpan range, Uri uri)
         => new()
         {
             TextDocument = new TextDocumentIdentifier { Uri = uri },
-            Range = range
+            Range = range.ToRange()
         };
 
     private static void GenerateSemanticBaseline(string actualFileContents, string baselineFileName)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokensTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokensTest.cs
@@ -1006,12 +1006,12 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             options.HtmlVirtualDocumentSuffix == "__virtual.html",
             MockBehavior.Strict);
 
-        var cSharpSemanticTokensProvider = new LSPCSharpSemanticTokensProvider(_clientConnection.Object, LoggerFactory);
+        var csharpSemanticTokensProvider = new LSPCSharpSemanticTokensProvider(_clientConnection.Object, LoggerFactory);
 
         var service = new RazorSemanticTokensInfoService(
             documentMappingService,
             TestRazorSemanticTokensLegendService.Instance,
-            cSharpSemanticTokensProvider,
+            csharpSemanticTokensProvider,
             featureOptions,
             LoggerFactory);
 


### PR DESCRIPTION
In order to work in cohosting, and hence OOP, its a lot easier with a couple of relatively simple changes to the semantic tokens service:

1. Use MS.CA.Text types instead of LSP protocol types
2. Extract C# tokens requests to a separate service

This PR does both of those things, and also:

1. Move telemetry reporting out of the service, up into the endpoint

This is targeting the "regress cohosting" branch because it turns out this new design is impossible in cohosting right now 🤦‍♂️

Part of https://github.com/dotnet/razor/issues/9519