### PR TITLE
Restore automation task to remove the untriaged label

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -166,6 +166,18 @@ configuration:
       description: '[Issues] Tag all non-milestone issues as "untriaged"'
     - if:
       - payloadType: Issues
+      - or:
+        - isAction:
+            action: Closed
+        - isPartOfAnyMilestone
+      - hasLabel:
+          label: untriaged
+      then:
+      - removeLabel:
+          label: untriaged
+      description: '[Issues] Issues with milestone should be removed from "untriaged" tag'
+    - if:
+      - payloadType: Issues
       - isAction:
           action: Opened
       - or:


### PR DESCRIPTION
https://github.com/dotnet/razor/pull/9895 was missing the task that removes the untriaged label from issues that get closed or added to a milestone. This restores that automation in the Policy Service configuration.

/cc @phil-allen-msft @JohannesLampel 