### PR TITLE
Add razorencconfig to Microsoft.CodeAnalysis.Razor.Compiler

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Microsoft.CodeAnalysis.Razor.Compiler.csproj
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Microsoft.CodeAnalysis.Razor.Compiler.csproj
@@ -30,4 +30,8 @@
     <EmbeddedResource Update="SourceGenerators\Diagnostics\*.resx" Namespace="Microsoft.NET.Sdk.Razor.SourceGenerators.Diagnostics" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="RazorSourceGenerator.razorencconfig" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This was missed when we unified the dlls and causes failures when using .NET 9p2 in VS.
