### PR TITLE
Fix unified build failures in dependency flow

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.DevKit.Razor/Microsoft.VisualStudio.DevKit.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.DevKit.Razor/Microsoft.VisualStudio.DevKit.Razor.csproj
@@ -25,7 +25,9 @@
   <PropertyGroup Condition="'$(DotNetBuild)' == 'true'">
     <RuntimeIdentifiers>$(TargetRid)</RuntimeIdentifiers>
     <RuntimeIdentifier>$(TargetRid)</RuntimeIdentifier>
-    <RidSpecificPublishNoBuildProperty>NoBuild=true;AppendRuntimeIdentifierToOutputPath=false</RidSpecificPublishNoBuildProperty>
+    <SelfContained>false</SelfContained>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <RidSpecificPublishNoBuildProperty>NoBuild=true</RidSpecificPublishNoBuildProperty>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/src/rzls/rzls.csproj
+++ b/src/Razor/src/rzls/rzls.csproj
@@ -23,7 +23,9 @@
   <PropertyGroup Condition="'$(DotNetBuild)' == 'true'">
     <RuntimeIdentifiers>$(TargetRid)</RuntimeIdentifiers>
     <RuntimeIdentifier>$(TargetRid)</RuntimeIdentifier>
-    <RidSpecificPublishNoBuildProperty>NoBuild=true;AppendRuntimeIdentifierToOutputPath=false</RidSpecificPublishNoBuildProperty>
+    <SelfContained>false</SelfContained>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <RidSpecificPublishNoBuildProperty>NoBuild=true</RidSpecificPublishNoBuildProperty>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
﻿### Summary of the changes
Fix razor failures in https://github.com/dotnet/installer/pull/18916

- Explicitly set SelfContained to `false` to address warnings about how the default behavior with RuntimeIdentifier changed in the .NET 8 SDK
- Never append the RID to the output path, even in the build (which now was having it appended because we are specifying a RuntimeIdentifier.
