### PR TITLE
Fixing TagHelper attribute name completion at attribute name end

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
@@ -57,7 +57,7 @@ internal class TagHelperCompletionProvider : IRazorCompletionItemProvider
         {
             // This provider is trying to find the nearest Start or End tag. Most of the time, that's a level up, but if the index the user is typing at
             // is a token of a start or end tag directly, we already have the node we want.
-            MarkupStartTagSyntax or MarkupEndTagSyntax or MarkupTagHelperStartTagSyntax or MarkupTagHelperEndTagSyntax => owner,
+            MarkupStartTagSyntax or MarkupEndTagSyntax or MarkupTagHelperStartTagSyntax or MarkupTagHelperEndTagSyntax or MarkupTagHelperAttributeSyntax => owner,
             // Either the parent is a context we can handle, or it's not and we shouldn't show completions.
             _ => owner.Parent
         };

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
@@ -274,6 +274,12 @@ public class TagHelperCompletionProviderTest(ITestOutputHelper testOutput) : Tag
     <test1 int-val$$="1"/>
     """
     )]
+    [InlineData(
+    """
+    @addTagHelper*, TestAssembly
+    <test1 int-val$$/>
+    """
+    )]
     public void GetCompletionAt_AtAttributeEdge_IntAttribute_ReturnsCompletions(string documentText)
     {
         // Arrange

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
@@ -280,7 +280,25 @@ public class TagHelperCompletionProviderTest(ITestOutputHelper testOutput) : Tag
     <test1 int-val$$/>
     """
     )]
-    public void GetCompletionAt_AtAttributeEdge_IntAttribute_ReturnsCompletions(string documentText)
+    [InlineData(
+    """
+    @addTagHelper *, TestAssembly
+    <test1 bool-val$$="1"/>
+    """
+    )]
+    [InlineData(
+    """
+    @addTagHelper*, TestAssembly
+    <test1 bool-val$$/>
+    """
+    )]
+    [InlineData(
+    """
+    @addTagHelper*, TestAssembly
+    <test1 @bind-$$/>
+    """
+    )]
+    public void GetCompletionAt_AtAttributeEdge_BothAttribute_ReturnsCompletions(string documentText)
     {
         // Arrange
         var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, TestRazorLSPOptionsMonitor.Create());

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
@@ -261,16 +261,25 @@ public class TagHelperCompletionProviderTest(ITestOutputHelper testOutput) : Tag
         AssertTest1Test2Completions(completions);
     }
 
-    [Fact]
-    public void GetCompletionAt_AtAttributeEdge_IntAttribute_ReturnsCompletions()
+    [Theory]
+    [InlineData(
+    """
+    @addTagHelper *, TestAssembly
+    <test1 $$/>
+    """
+    )]
+    [InlineData(
+    """
+    @addTagHelper *, TestAssembly
+    <test1 int-val$$="1"/>
+    """
+    )]
+    public void GetCompletionAt_AtAttributeEdge_IntAttribute_ReturnsCompletions(string documentText)
     {
         // Arrange
         var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, TestRazorLSPOptionsMonitor.Create());
         var context = CreateRazorCompletionContext(
-            """
-                @addTagHelper *, TestAssembly
-                <test1 $$/>
-                """,
+            documentText,
             isRazorFile: false,
             tagHelpers: DefaultTagHelpers);
 


### PR DESCRIPTION
﻿### Summary of the changes

- Another case where we need to fixup owner returned by FindInnermostNode (that replaced previously used LocateOnwer) in RazorCompletionContext
- We were already fixing up cases for start/end element name, but we weren't for attributes
- Previously LocateOwner always gave us MarkupTextLiteral that was a child of the MarkupTagHelperAttribute, but now we get MarkupTagHelperAttribute itself from FindInnermostNode, so we need to add it to the list of exclusions where we don't need to get a parent of the owner
- Similar to what was done in #9455
- 
![image](https://github.com/dotnet/razor/assets/1863656/e1de874c-da1b-4918-b785-ca4758bc4405)

Fixes:
https://github.com/dotnet/razor/issues/9728