### PR TITLE
Add DisposableAction that takes in an arg to prevent a closure allocation

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/DisposableAction`1.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/DisposableAction`1.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.AspNetCore.Razor.Language.Legacy;
+
+internal ref struct DisposableAction<T>
+{
+    private readonly Action<T> _action;
+    private readonly T _arg;
+    private bool _invoked;
+
+    public DisposableAction(Action<T> action, T arg)
+    {
+        _action = action ?? throw new ArgumentNullException(nameof(action));
+        _arg = arg;
+    }
+
+    public void Dispose()
+    {
+        if (!_invoked)
+        {
+            _action(_arg);
+            _invoked = true;
+        }
+    }
+}

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/TokenizerBackedParser.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/TokenizerBackedParser.cs
@@ -647,21 +647,21 @@ internal abstract class TokenizerBackedParser<TTokenizer> : ParserBase
         return (TNode)node.SetAnnotations([annotation]);
     }
 
-    protected DisposableAction PushSpanContextConfig()
+    protected DisposableAction<(TokenizerBackedParser<TTokenizer>, SpanContextConfigAction?)> PushSpanContextConfig()
     {
         return PushSpanContextConfig(newConfig: (SpanContextConfigActionWithPreviousConfig?)null);
     }
 
-    protected DisposableAction PushSpanContextConfig(SpanContextConfigAction newConfig)
+    protected DisposableAction<(TokenizerBackedParser<TTokenizer>, SpanContextConfigAction?)> PushSpanContextConfig(SpanContextConfigAction newConfig)
     {
         return PushSpanContextConfig(newConfig == null ? null : (SpanEditHandlerBuilder? span, ref ISpanChunkGenerator? chunkGenerator, SpanContextConfigAction? _) => newConfig(span, ref chunkGenerator));
     }
 
-    protected DisposableAction PushSpanContextConfig(SpanContextConfigActionWithPreviousConfig? newConfig)
+    protected DisposableAction<(TokenizerBackedParser<TTokenizer>, SpanContextConfigAction?)> PushSpanContextConfig(SpanContextConfigActionWithPreviousConfig? newConfig)
     {
         var old = SpanContextConfig;
         ConfigureSpanContext(newConfig);
-        return new DisposableAction(() => SpanContextConfig = old);
+        return new DisposableAction<(TokenizerBackedParser<TTokenizer> Self, SpanContextConfigAction? Old)>(static arg => arg.Self.SpanContextConfig = arg.Old, arg: (this, old));
     }
 
     protected void ConfigureSpanContext(SpanContextConfigAction? config)


### PR DESCRIPTION
This closure allocation was showing up as 0.4% of allocations in devenv in the Completion speedometer test.

﻿*** prior allocations from completion speedometer test ***
![image](https://github.com/dotnet/razor/assets/6785178/6a8e9540-352d-4080-bb8c-7b6d62e1800a)