### PR TITLE
Use PooledArrayBuilder<SyntaxToken> throughout parsers and tokenizer

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -151,7 +151,7 @@
     <NuGetSolutionRestoreManagerInteropVersion>4.8.0</NuGetSolutionRestoreManagerInteropVersion>
     <StreamJsonRpcPackageVersion>2.17.11</StreamJsonRpcPackageVersion>
     <SystemRuntimeInteropServicesRuntimePackageVersion>4.3.0</SystemRuntimeInteropServicesRuntimePackageVersion>
-    <Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion>3.11.0-beta1.24128.1</Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion>
+    <Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion>3.11.0-beta1.24170.2</Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion>
     <Tooling_MicrosoftCodeAnalysisBannedApiAnalyzersPackageVersion>$(Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion)</Tooling_MicrosoftCodeAnalysisBannedApiAnalyzersPackageVersion>
     <Tooling_RoslynDiagnosticsAnalyzersPackageVersion>$(Tooling_MicrosoftCodeAnalysisAnalyzersPackageVersion)</Tooling_RoslynDiagnosticsAnalyzersPackageVersion>
     <Tooling_MicrosoftVisualStudioLanguageServicesPackageVersion>$(MicrosoftVisualStudioLanguageServicesPackageVersion)</Tooling_MicrosoftVisualStudioLanguageServicesPackageVersion>

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/TokenizerLookaheadTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/Legacy/TokenizerLookaheadTest.cs
@@ -67,15 +67,15 @@ public class TokenizerLookaheadTest : HtmlTokenizerTestBase
 
         // Act
         var i = 3;
-        IEnumerable<SyntaxToken> previousTokens = null;
+        SyntaxToken[] previousTokens = null;
         var tokenFound = tokenizer.LookaheadUntil((s, p) =>
         {
-            previousTokens = p;
+            previousTokens = p.ToArray();
             return --i == 0;
         });
 
         // Assert
-        Assert.Equal(4, previousTokens.Count());
+        Assert.Equal(4, previousTokens.Length);
 
         // For the very first element, there will be no previous items, so null is expected
         var orderIndex = 0;

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/CSharpCodeParser.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/CSharpCodeParser.cs
@@ -1013,7 +1013,7 @@ internal class CSharpCodeParser : TokenizerBackedParser<CSharpTokenizer>
 
     private bool TryParseDirective(
         in SyntaxListBuilder<RazorSyntaxNode> builder,
-        in PooledArrayBuilder<SyntaxToken> whitespace,
+        ref readonly PooledArrayBuilder<SyntaxToken> whitespace,
         CSharpTransitionSyntax transition,
         string directive)
     {
@@ -1911,7 +1911,7 @@ internal class CSharpCodeParser : TokenizerBackedParser<CSharpTokenizer>
 
     private bool TryParseKeyword(
         in SyntaxListBuilder<RazorSyntaxNode> builder,
-        in PooledArrayBuilder<SyntaxToken> whitespace,
+        ref readonly PooledArrayBuilder<SyntaxToken> whitespace,
         CSharpTransitionSyntax? transition)
     {
         var result = CSharpTokenizer.GetTokenKeyword(CurrentToken);

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/CSharpCodeParser.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/CSharpCodeParser.cs
@@ -2616,6 +2616,8 @@ internal class CSharpCodeParser : TokenizerBackedParser<CSharpTokenizer>
         in SyntaxListBuilder<RazorSyntaxNode> builder,
         ref PooledArrayBuilder<SyntaxToken> whitespace)
     {
+        Debug.Assert(whitespace.Count == 0, "Expected empty builder.");
+
         while (!EndOfFile)
         {
             ReadWhile(IsSpacingTokenIncludingNewLinesAndComments, ref whitespace);

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/HtmlMarkupParser.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/HtmlMarkupParser.cs
@@ -1782,6 +1782,8 @@ internal class HtmlMarkupParser : TokenizerBackedParser<HtmlTokenizer>
 
     private void FastReadWhitespaceAndNewLines(ref PooledArrayBuilder<SyntaxToken> whitespaceTokens)
     {
+        Debug.Assert(whitespaceTokens.Count == 0, "Expected empty builder.");
+
         if (EnsureCurrent() && (CurrentToken.Kind == SyntaxKind.Whitespace || CurrentToken.Kind == SyntaxKind.NewLine))
         {
             whitespaceTokens.Add(CurrentToken);

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/TokenizerBackedParser.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/TokenizerBackedParser.cs
@@ -302,6 +302,8 @@ internal abstract class TokenizerBackedParser<TTokenizer> : ParserBase
         TArg arg,
         ref PooledArrayBuilder<SyntaxToken> result)
     {
+        Debug.Assert(result.Count == 0, "Expected empty builder.");
+
         if (!EnsureCurrent() || !predicate(CurrentToken, arg))
         {
             return;
@@ -319,6 +321,8 @@ internal abstract class TokenizerBackedParser<TTokenizer> : ParserBase
         Func<SyntaxToken, bool> predicate,
         ref PooledArrayBuilder<SyntaxToken> result)
     {
+        Debug.Assert(result.Count == 0, "Expected empty builder.");
+
         if (!EnsureCurrent() || !predicate(CurrentToken))
         {
             return;

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/TokenizerBackedParser.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/TokenizerBackedParser.cs
@@ -207,7 +207,7 @@ internal abstract class TokenizerBackedParser<TTokenizer> : ParserBase
     /// that is the correct format for providing to this method. The caller of this method would,
     /// in that case, want to put c, b and a back into the stream, so "a, b, c" is the CORRECT order
     /// </remarks>
-    protected void PutBack(in PooledArrayBuilder<SyntaxToken> tokens)
+    protected void PutBack(ref readonly PooledArrayBuilder<SyntaxToken> tokens)
     {
         for (int i = tokens.Count - 1; i >= 0; i--)
         {
@@ -514,7 +514,7 @@ internal abstract class TokenizerBackedParser<TTokenizer> : ParserBase
         Accept(in tokens);
     }
 
-    protected void Accept(in PooledArrayBuilder<SyntaxToken> tokens)
+    protected void Accept(ref readonly PooledArrayBuilder<SyntaxToken> tokens)
     {
         foreach (var token in tokens)
         {

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/TokenizerBackedParser.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/TokenizerBackedParser.cs
@@ -101,17 +101,19 @@ internal abstract class TokenizerBackedParser<TTokenizer> : ParserBase
             return CurrentToken;
         }
 
+        using var _ = ListPool<SyntaxToken>.GetPooledObject(out var tokens);
+
         // We add 1 in order to store the current token.
-        var tokens = new SyntaxToken[count + 1];
+        tokens.SetCapacityIfLarger(count + 1);
         var currentToken = CurrentToken;
 
-        tokens[0] = currentToken;
+        tokens.Add(currentToken);
 
         // We need to look forward "count" many times.
         for (var i = 1; i <= count; i++)
         {
             NextToken();
-            tokens[i] = CurrentToken;
+            tokens.Add(CurrentToken);
         }
 
         // Restore Tokenizer's location to where it was pointing before the look-ahead.
@@ -142,7 +144,7 @@ internal abstract class TokenizerBackedParser<TTokenizer> : ParserBase
 
         var matchFound = false;
 
-        var tokens = new List<SyntaxToken>();
+        using var _ = ListPool<SyntaxToken>.GetPooledObject(out var tokens);
         tokens.Add(CurrentToken);
 
         while (true)

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ListExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ListExtensions.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.Razor;
@@ -30,5 +29,8 @@ internal static class ListExtensions
     public static T[] ToArrayOrEmpty<T>(this List<T>? list)
         => list?.Count > 0
             ? list.ToArray()
-            : Array.Empty<T>();
+            : [];
+
+    public static bool Any<T>(this List<T> list)
+        => list.Count > 0;
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledObjects/PooledArrayBuilder`1.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledObjects/PooledArrayBuilder`1.cs
@@ -434,6 +434,8 @@ internal partial struct PooledArrayBuilder<T> : IDisposable
         };
     }
 
+    public bool Any() => Count > 0;
+
     public void Push(T item)
     {
         Add(item);


### PR DESCRIPTION
@ToddGrun shared a couple PerfView stacks with me where the Razor compiler was allocating `List<SyntaxToken>` instances in the tokenizer. To remove those allocation, this change replaces `List<SyntaxToken>s` throughout the parsers and tokenizer, and uses `PooledArrayBuilder<SyntaxToken>` instead. In addition, I removed a couple of `Concat` calls and replaced them with pooled `StringBuilders`.