### PR TITLE
Port case-sensitivity fixes from main

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/CohostProjectSnapshot.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Cohost/CohostProjectSnapshot.cs
@@ -56,7 +56,7 @@ internal class CohostProjectSnapshot : IProjectSnapshot
 
         _importsToRelatedDocumentsLazy = new Lazy<ImmutableDictionary<string, ImmutableArray<string>>>(() =>
         {
-            var importsToRelatedDocuments = ImmutableDictionary.Create<string, ImmutableArray<string>>(FilePathNormalizer.Comparer);
+            var importsToRelatedDocuments = ImmutableDictionary.Create<string, ImmutableArray<string>>(FilePathNormalizingComparer.Instance);
             foreach (var document in DocumentFilePaths)
             {
                 var importTargetPaths = ProjectState.GetImportDocumentTargetPaths(document, FileKinds.GetFileKindFromFilePath(document), _lazyProjectEngine.Value);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/FilePathNormalizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/FilePathNormalizer.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Buffers;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis.Razor;
@@ -14,15 +12,9 @@ namespace Microsoft.AspNetCore.Razor.Utilities;
 
 internal static class FilePathNormalizer
 {
-    private static Lazy<IEqualityComparer<string>> _lazyComparer = new Lazy<IEqualityComparer<string>>(() => new FilePathNormalizingComparer());
-    public static IEqualityComparer<string> Comparer => _lazyComparer.Value;
-
-    private class FilePathNormalizingComparer : IEqualityComparer<string>
-    {
-        public bool Equals(string? x, string? y) => FilePathNormalizer.FilePathsEquivalent(x, y);
-
-        public int GetHashCode([DisallowNull] string obj) => FilePathNormalizer.GetHashCode(obj);
-    }
+    private static readonly Func<char, char> s_charConverter = RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+        ? c => c
+        : char.ToLowerInvariant;
 
     public static string NormalizeDirectory(string? directoryFilePath)
     {
@@ -147,7 +139,7 @@ internal static class FilePathNormalizer
 
         foreach (var ch in normalizedSpan)
         {
-            hashCombiner.Add(ch);
+            hashCombiner.Add(s_charConverter(ch));
         }
 
         return hashCombiner.CombinedHash;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/FilePathNormalizingComparer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/FilePathNormalizingComparer.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.Utilities;
+
+internal sealed class FilePathNormalizingComparer : IEqualityComparer<string>
+{
+    public static readonly FilePathNormalizingComparer Instance = new();
+
+    private FilePathNormalizingComparer()
+    {
+    }
+
+    public bool Equals(string? x, string? y) => FilePathNormalizer.FilePathsEquivalent(x, y);
+
+    public int GetHashCode(string obj) => FilePathNormalizer.GetHashCode(obj);
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshot.cs
@@ -26,7 +26,7 @@ internal class ProjectSnapshot : IProjectSnapshot
         State = state ?? throw new ArgumentNullException(nameof(state));
 
         _lock = new object();
-        _documents = new Dictionary<string, DocumentSnapshot>(FilePathNormalizer.Comparer);
+        _documents = new Dictionary<string, DocumentSnapshot>(FilePathNormalizingComparer.Instance);
     }
 
     public ProjectKey Key => State.HostProject.Key;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
@@ -31,8 +31,8 @@ internal class ProjectState
         ProjectDifference.DocumentAdded |
         ProjectDifference.DocumentRemoved;
 
-    private static readonly ImmutableDictionary<string, DocumentState> s_emptyDocuments = ImmutableDictionary.Create<string, DocumentState>(FilePathNormalizer.Comparer);
-    private static readonly ImmutableDictionary<string, ImmutableArray<string>> s_emptyImportsToRelatedDocuments = ImmutableDictionary.Create<string, ImmutableArray<string>>(FilePathNormalizer.Comparer);
+    private static readonly ImmutableDictionary<string, DocumentState> s_emptyDocuments = ImmutableDictionary.Create<string, DocumentState>(FilePathNormalizingComparer.Instance);
+    private static readonly ImmutableDictionary<string, ImmutableArray<string>> s_emptyImportsToRelatedDocuments = ImmutableDictionary.Create<string, ImmutableArray<string>>(FilePathNormalizingComparer.Instance);
     private readonly object _lock;
 
     private readonly IProjectEngineFactoryProvider _projectEngineFactoryProvider;
@@ -360,7 +360,7 @@ internal class ProjectState
             return this;
         }
 
-        var documents = Documents.ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.WithConfigurationChange(), FilePathNormalizer.Comparer);
+        var documents = Documents.ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.WithConfigurationChange(), FilePathNormalizingComparer.Instance);
 
         // If the host project has changed then we need to recompute the imports map
         var importsToRelatedDocuments = s_emptyImportsToRelatedDocuments;
@@ -388,7 +388,7 @@ internal class ProjectState
         }
 
         var difference = ProjectDifference.ProjectWorkspaceStateChanged;
-        var documents = Documents.ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.WithProjectWorkspaceStateChange(), FilePathNormalizer.Comparer);
+        var documents = Documents.ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.WithProjectWorkspaceStateChange(), FilePathNormalizingComparer.Instance);
         var state = new ProjectState(this, difference, HostProject, projectWorkspaceState, documents, ImportsToRelatedDocuments);
         return state;
     }
@@ -448,7 +448,7 @@ internal class ProjectState
         {
             var itemTargetPath = importItem.FilePath.Replace('/', '\\').TrimStart('\\');
 
-            if (FilePathNormalizer.Comparer.Equals(itemTargetPath, targetPath))
+            if (FilePathNormalizingComparer.Instance.Equals(itemTargetPath, targetPath))
             {
                 // We've normalized the original importItem.FilePath into the HostDocument.TargetPath. For instance, if the HostDocument.TargetPath
                 // was '/_Imports.razor' it'd be normalized down into '_Imports.razor'. The purpose of this method is to get the associated document

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/FilePathNormalizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/FilePathNormalizerTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Utilities;
 using Xunit;
@@ -239,5 +240,23 @@ public class FilePathNormalizerTest(ITestOutputHelper testOutput) : ToolingTestB
 
         // Assert
         Assert.Equal("C:/path/to/document.cshtml", normalized);
+    }
+
+    [OSSkipConditionTheory(["OSX", "Linux"])]
+    [InlineData(@"C:\path\to\document.cshtml")]
+    [InlineData(@"c:\path\to\document.cshtml")]
+    [InlineData("C:/path/to/document.cshtml")]
+    [InlineData("c:/path/to/document.cshtml")]
+    public void Comparer_CaseInsensitiveDictionary(string fileName)
+    {
+        var dictionary = new Dictionary<string, bool>(FilePathNormalizingComparer.Instance)
+        {
+            { "C:/path/to/document.cshtml", true },
+            { "C:/path/to/document1.cshtml", true },
+            { "C:/path/to/document2.cshtml", true }
+        };
+
+        Assert.True(dictionary.ContainsKey(fileName));
+        Assert.True(dictionary.TryGetValue(fileName, out _));
     }
 }


### PR DESCRIPTION
Port of https://github.com/dotnet/razor/pull/10050 to a new branch, which is at the point of https://github.com/dotnet/vscode-csharp/commit/bda22d3a7c0accdca813bc32f3afbd3ca35a5850, which is the current version of Razor bits in the `release` branch of the C# extension

@phil-allen-msft 