### PR TITLE
Ensure we assign 'force runtime code generation' to the correct param

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
@@ -153,7 +153,7 @@ internal class DefaultWindowsRazorProjectHost : WindowsRazorProjectHostBase
             return false;
         }
 
-        configuration = new(languageVersion, configurationItem.Key, extensions, forceRuntimeCodeGeneration);
+        configuration = new(languageVersion, configurationItem.Key, extensions, ForceRuntimeCodeGeneration: forceRuntimeCodeGeneration);
         return true;
     }
 


### PR DESCRIPTION
Actually, allow the IDE to turn on the ForceRuntimeCodeGeneration flag.