### PR TITLE
Don't show inlay hints for component attributes

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/InlayHints/InlayHintEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/InlayHints/InlayHintEndpointTest.cs
@@ -39,13 +39,13 @@ public class InlayHintEndpointTest(ITestOutputHelper testOutput) : SingleServerD
                 }
 
                 """,
-          toolTipMap: new Dictionary<string, string>
-              {
+            toolTipMap: new Dictionary<string, string>
+                {
                     { "int",            "struct System.Int32"            },
                     { "string",         "class System.String"            },
                     { "thisIsMyString", "(parameter) string thisIsMyStr" }
-              },
-          output: """
+                },
+            output: """
 
                 <div></div>
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/InlayHints/InlayHintEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/InlayHints/InlayHintEndpointTest.cs
@@ -22,8 +22,8 @@ public class InlayHintEndpointTest(ITestOutputHelper testOutput) : SingleServerD
 {
     [Fact]
     public Task InlayHints()
-      => VerifyInlayHintsAsync(
-          input: """
+        => VerifyInlayHintsAsync(
+            input: """
 
                 <div></div>
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/InlayHints/InlayHintEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/InlayHints/InlayHintEndpointTest.cs
@@ -22,8 +22,8 @@ public class InlayHintEndpointTest(ITestOutputHelper testOutput) : SingleServerD
 {
     [Fact]
     public Task InlayHints()
-        => VerifyInlayHintsAsync(
-            input: """
+      => VerifyInlayHintsAsync(
+          input: """
 
                 <div></div>
 
@@ -39,13 +39,13 @@ public class InlayHintEndpointTest(ITestOutputHelper testOutput) : SingleServerD
                 }
 
                 """,
-            toolTipMap: new Dictionary<string, string>
-                {
-                    { "int",           "struct System.Int32" },
-                    {"string",         "class System.String" },
-                    {"thisIsMyString", "(parameter) string thisIsMyStr" }
-                },
-            output: """
+          toolTipMap: new Dictionary<string, string>
+              {
+                    { "int",            "struct System.Int32"            },
+                    { "string",         "class System.String"            },
+                    { "thisIsMyString", "(parameter) string thisIsMyStr" }
+              },
+          output: """
 
                 <div></div>
 
@@ -62,11 +62,36 @@ public class InlayHintEndpointTest(ITestOutputHelper testOutput) : SingleServerD
 
                 """);
 
+    [Fact]
+    public Task InlayHints_ComponentAttributes()
+        => VerifyInlayHintsAsync(
+            input: """
+
+                <div>
+                    <InputText Value="_value" />
+                    <InputText Value="@_value" />
+                    <InputText Value="@(_value)" />
+                </div>
+
+                """,
+            toolTipMap: new Dictionary<string, string>
+                {
+                },
+            output: """
+
+                <div>
+                    <InputText Value="_value" />
+                    <InputText Value="@_value" />
+                    <InputText Value="@(_value)" />
+                </div>
+
+                """);
+
     private async Task VerifyInlayHintsAsync(string input, Dictionary<string, string> toolTipMap, string output)
     {
         TestFileMarkupParser.GetSpans(input, out input, out ImmutableDictionary<string, ImmutableArray<TextSpan>> spansDict);
-        var codeDocument = CreateCodeDocument(input);
         var razorFilePath = "C:/path/to/file.razor";
+        var codeDocument = CreateCodeDocument(input, filePath: razorFilePath);
 
         var languageServer = await CreateLanguageServerAsync(codeDocument, razorFilePath);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/CSharpTestLspServer.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/CSharpTestLspServer.cs
@@ -225,7 +225,17 @@ public sealed class CSharpTestLspServer : IAsyncDisposable
                 values.Add(item.Section switch
                 {
                     "csharp|inlay_hints.dotnet_enable_inlay_hints_for_parameters" => "true",
+                    "csharp|inlay_hints.dotnet_enable_inlay_hints_for_literal_parameters" => "true",
+                    "csharp|inlay_hints.dotnet_enable_inlay_hints_for_indexer_parameters" => "true",
+                    "csharp|inlay_hints.dotnet_enable_inlay_hints_for_object_creation_parameters" => "true",
+                    "csharp|inlay_hints.dotnet_enable_inlay_hints_for_other_parameters" => "true",
+                    "csharp|inlay_hints.dotnet_suppress_inlay_hints_for_parameters_that_differ_only_by_suffix" => "false",
+                    "csharp|inlay_hints.dotnet_suppress_inlay_hints_for_parameters_that_match_method_intent" => "false",
+                    "csharp|inlay_hints.dotnet_suppress_inlay_hints_for_parameters_that_match_argument_name" => "false",
                     "csharp|inlay_hints.csharp_enable_inlay_hints_for_types" => "true",
+                    "csharp|inlay_hints.csharp_enable_inlay_hints_for_implicit_variable_types" => "true",
+                    "csharp|inlay_hints.csharp_enable_inlay_hints_for_lambda_parameter_types" => "true",
+                    "csharp|inlay_hints.csharp_enable_inlay_hints_for_implicit_object_creation" => "true",
                     _ => ""
                 });
             }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/CSharpTestLspServerHelpers.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/CSharpTestLspServerHelpers.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Razor.Test.Common.Mef;
 using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 using Microsoft.CodeAnalysis;
@@ -54,7 +55,10 @@ internal static class CSharpTestLspServerHelpers
         var csharpFiles = files.Select(f => new CSharpFile(f.Uri, f.SourceText));
 
         var exportProvider = TestComposition.Roslyn.ExportProviderFactory.CreateExportProvider();
-        var metadataReferences = await ReferenceAssemblies.Default.ResolveAsync(language: LanguageNames.CSharp, cancellationToken);
+        var metadataReferences = (await ReferenceAssemblies.Default.ResolveAsync(language: LanguageNames.CSharp, cancellationToken))
+            // ComponentBase here comes from our ComponentShim project, not the real ASP.NET libraries. It's enough for the generated C#
+            // in tests to at least compile better.
+            .Add(MetadataReference.CreateFromFile(typeof(ComponentBase).Assembly.Location));
         var workspace = CreateCSharpTestWorkspace(csharpFiles, exportProvider, metadataReferences, razorSpanMappingService);
         var clientCapabilities = new VSInternalClientCapabilities
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/LanguageServerTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/LanguageServerTestBase.cs
@@ -92,6 +92,7 @@ public abstract class LanguageServerTestBase : ToolingTestBase
                 @using System;
                 @using Microsoft.AspNetCore.Components
                 @using Microsoft.AspNetCore.Components.Authorization
+                @using Microsoft.AspNetCore.Components.Forms
                 @using Microsoft.AspNetCore.Components.Routing
                 @using Microsoft.AspNetCore.Components.Web
                 """,


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/10088