### PR TITLE
Remove unnecessary parameter

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/LSPCSharpSemanticTokensProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/Services/LSPCSharpSemanticTokensProvider.cs
@@ -17,15 +17,15 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
 
-internal class LSPCSharpSemanticTokensProvider(IClientConnection clientConnection, IRazorLoggerFactory loggerFactory) : ICSharpSemanticTokensProvider
+internal class LSPCSharpSemanticTokensProvider(LanguageServerFeatureOptions languageServerFeatureOptions, IClientConnection clientConnection, IRazorLoggerFactory loggerFactory) : ICSharpSemanticTokensProvider
 {
+    private readonly LanguageServerFeatureOptions _languageServerFeatureOptions = languageServerFeatureOptions;
     private readonly IClientConnection _clientConnection = clientConnection;
     private readonly ILogger _logger = loggerFactory.CreateLogger<LSPCSharpSemanticTokensProvider>();
 
     public async Task<int[]?> GetCSharpSemanticTokensResponseAsync(
             VersionedDocumentContext documentContext,
             ImmutableArray<LinePositionSpan> csharpSpans,
-            bool usePreciseSemanticTokenRanges,
             Guid correlationId,
             CancellationToken cancellationToken)
     {
@@ -41,7 +41,7 @@ internal class LSPCSharpSemanticTokensProvider(IClientConnection clientConnectio
 
         var parameter = new ProvideSemanticTokensRangesParams(documentContext.Identifier.TextDocumentIdentifier, documentVersion, csharpRanges, correlationId);
         ProvideSemanticTokensResponse? csharpResponse;
-        if (usePreciseSemanticTokenRanges)
+        if (_languageServerFeatureOptions.UsePreciseSemanticTokenRanges)
         {
             csharpResponse = await GetCsharpResponseAsync(_clientConnection, parameter, CustomMessageNames.RazorProvidePreciseRangeSemanticTokensEndpoint, cancellationToken).ConfigureAwait(false);
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/IOutOfProcSemanticTokensService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/IOutOfProcSemanticTokensService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Text;
@@ -12,5 +13,6 @@ internal interface IOutOfProcSemanticTokensService
     ValueTask<int[]?> GetSemanticTokensDataAsync(
         TextDocument razorDocument,
         LinePositionSpan span,
+        Guid correlationId,
         CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/IRemoteSemanticTokensService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/IRemoteSemanticTokensService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
@@ -15,5 +16,6 @@ internal interface IRemoteSemanticTokensService
         DocumentId razorDocumentId,
         LinePositionSpan span,
         bool colorBackground,
+        Guid correlationId,
         CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/SemanticTokens/AbstractRazorSemanticTokensInfoService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/SemanticTokens/AbstractRazorSemanticTokensInfoService.cs
@@ -170,7 +170,7 @@ internal abstract class AbstractRazorSemanticTokensInfoService(
             csharpRanges = [csharpRange];
         }
 
-        var csharpResponse = await _csharpSemanticTokensProvider.GetCSharpSemanticTokensResponseAsync(documentContext, csharpRanges, _languageServerFeatureOptions.UsePreciseSemanticTokenRanges, correlationId, cancellationToken).ConfigureAwait(false);
+        var csharpResponse = await _csharpSemanticTokensProvider.GetCSharpSemanticTokensResponseAsync(documentContext, csharpRanges, correlationId, cancellationToken).ConfigureAwait(false);
 
         // Indicates an issue with retrieving the C# response (e.g. no response or C# is out of sync with us).
         // Unrecoverable, return default to indicate no change. We've already queued up a refresh request in

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/SemanticTokens/ICSharpSemanticTokensProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/SemanticTokens/ICSharpSemanticTokensProvider.cs
@@ -15,7 +15,6 @@ internal interface ICSharpSemanticTokensProvider
     Task<int[]?> GetCSharpSemanticTokensResponseAsync(
         VersionedDocumentContext documentContext,
         ImmutableArray<LinePositionSpan> csharpSpans,
-        bool usePreciseSemanticTokenRanges,
         Guid correlationId,
         CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Constants.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Constants.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Remote.Razor;
+
+internal static class Constants
+{
+    /// <summary>
+    /// The name we use for the "server" in cohosting, which is not really an LSP server, but we use it for telemetry to distinguish events
+    /// </summary>
+    public const string ExternalAccessServerName = "Razor.ExternalAccess";
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SemanticTokens/RemoteCSharpSemanticTokensProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SemanticTokens/RemoteCSharpSemanticTokensProvider.cs
@@ -18,14 +18,13 @@ using Microsoft.CodeAnalysis.Text;
 namespace Microsoft.CodeAnalysis.Remote.Razor.SemanticTokens;
 
 [Export(typeof(ICSharpSemanticTokensProvider)), Shared]
+[method: ImportingConstructor]
 internal class RemoteCSharpSemanticTokensProvider(IFilePathService filePathService) : ICSharpSemanticTokensProvider
 {
     private readonly IFilePathService _filePathService = filePathService;
 
-    public async Task<int[]?> GetCSharpSemanticTokensResponseAsync(VersionedDocumentContext documentContext, ImmutableArray<LinePositionSpan> csharpRanges, bool usePreciseSemanticTokenRanges, Guid correlationId, CancellationToken cancellationToken)
+    public async Task<int[]?> GetCSharpSemanticTokensResponseAsync(VersionedDocumentContext documentContext, ImmutableArray<LinePositionSpan> csharpRanges, Guid correlationId, CancellationToken cancellationToken)
     {
-        // TODO: Logic for usePreciseSemanticTokenRanges
-
         // We have a razor document, lets find the generated C# document
         var generatedDocument = GetGeneratedDocument(documentContext);
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SemanticTokens/RemoteSemanticTokensService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SemanticTokens/RemoteSemanticTokensService.cs
@@ -24,14 +24,14 @@ internal sealed class RemoteSemanticTokensService(
     private readonly IRazorSemanticTokensInfoService _razorSemanticTokensInfoService = razorSemanticTokensInfoService;
     private readonly DocumentSnapshotFactory _documentSnapshotFactory = documentSnapshotFactory;
 
-    public ValueTask<int[]?> GetSemanticTokensDataAsync(RazorPinnedSolutionInfoWrapper solutionInfo, DocumentId razorDocumentId, LinePositionSpan span, bool colorBackground, CancellationToken cancellationToken)
+    public ValueTask<int[]?> GetSemanticTokensDataAsync(RazorPinnedSolutionInfoWrapper solutionInfo, DocumentId razorDocumentId, LinePositionSpan span, bool colorBackground, Guid correlationId, CancellationToken cancellationToken)
         => RazorBrokeredServiceImplementation.RunServiceAsync(
             solutionInfo,
             ServiceBrokerClient,
-            solution => GetSemanticTokensDataAsync(solution, razorDocumentId, span, colorBackground, cancellationToken),
+            solution => GetSemanticTokensDataAsync(solution, razorDocumentId, span, colorBackground, correlationId, cancellationToken),
             cancellationToken);
 
-    private async ValueTask<int[]?> GetSemanticTokensDataAsync(Solution solution, DocumentId razorDocumentId, LinePositionSpan span, bool colorBackground, CancellationToken cancellationToken)
+    private async ValueTask<int[]?> GetSemanticTokensDataAsync(Solution solution, DocumentId razorDocumentId, LinePositionSpan span, bool colorBackground, Guid correlationId, CancellationToken cancellationToken)
     {
         var razorDocument = solution.GetAdditionalDocument(razorDocumentId);
         if (razorDocument is null)
@@ -42,7 +42,7 @@ internal sealed class RemoteSemanticTokensService(
         var documentContext = Create(razorDocument);
 
         // TODO: Telemetry?
-        return await _razorSemanticTokensInfoService.GetSemanticTokensAsync(documentContext, span, colorBackground, Guid.Empty, cancellationToken).ConfigureAwait(false);
+        return await _razorSemanticTokensInfoService.GetSemanticTokensAsync(documentContext, span, colorBackground, correlationId, cancellationToken).ConfigureAwait(false);
     }
 
     public VersionedDocumentContext Create(TextDocument textDocument)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/CohostSemanticTokensRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Cohost/CohostSemanticTokensRangeEndpoint.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.LanguageServer;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.SemanticTokens;
@@ -25,11 +27,13 @@ namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Cohost;
 internal sealed class CohostSemanticTokensRangeEndpoint(
     IOutOfProcSemanticTokensService semanticTokensInfoService,
     ISemanticTokensLegendService semanticTokensLegendService,
+    ITelemetryReporter telemetryReporter,
     IRazorLoggerFactory loggerFactory)
     : AbstractRazorCohostDocumentRequestHandler<SemanticTokensRangeParams, SemanticTokens?>, ICapabilitiesProvider
 {
     private readonly IOutOfProcSemanticTokensService _semanticTokensInfoService = semanticTokensInfoService;
     private readonly ISemanticTokensLegendService _semanticTokensLegendService = semanticTokensLegendService;
+    private readonly ITelemetryReporter _telemetryReporter = telemetryReporter;
     private readonly ILogger _logger = loggerFactory.CreateLogger<CohostSemanticTokensRangeEndpoint>();
 
     protected override bool MutatesSolutionState => false;
@@ -45,7 +49,10 @@ internal sealed class CohostSemanticTokensRangeEndpoint(
 
     protected override async Task<SemanticTokens?> HandleRequestAsync(SemanticTokensRangeParams request, RazorCohostRequestContext context, CancellationToken cancellationToken)
     {
-        var data = await _semanticTokensInfoService.GetSemanticTokensDataAsync(context.TextDocument.AssumeNotNull(), request.Range.ToLinePositionSpan(), cancellationToken);
+        var correlationId = Guid.NewGuid();
+        using var _ = _telemetryReporter.TrackLspRequest(Methods.TextDocumentSemanticTokensRangeName, RazorLSPConstants.CohostLanguageServerName, correlationId);
+
+        var data = await _semanticTokensInfoService.GetSemanticTokensDataAsync(context.TextDocument.AssumeNotNull(), request.Range.ToLinePositionSpan(), correlationId, cancellationToken);
 
         if (data is null)
         {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConstants.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLSPConstants.cs
@@ -9,6 +9,8 @@ internal static class RazorLSPConstants
 
     public const string RazorLanguageServerName = "Razor Language Server Client";
 
+    public const string CohostLanguageServerName = "Cohosted Razor Language Server Client";
+
     public const string HtmlLanguageServerName = "HtmlDelegationLanguageServerClient";
 
     public const string CSHTMLFileExtension = ".cshtml";

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/OutOfProcSemanticTokensService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/OutOfProcSemanticTokensService.cs
@@ -22,7 +22,7 @@ internal class OutOfProcSemanticTokensService(IRemoteClientProvider remoteClient
     private readonly IClientSettingsManager _clientSettingsManager = clientSettingsManager;
     private readonly ILogger _logger = loggerFactory.CreateLogger<OutOfProcSemanticTokensService>();
 
-    public async ValueTask<int[]?> GetSemanticTokensDataAsync(TextDocument razorDocument, LinePositionSpan span, CancellationToken cancellationToken)
+    public async ValueTask<int[]?> GetSemanticTokensDataAsync(TextDocument razorDocument, LinePositionSpan span, Guid correlationId, CancellationToken cancellationToken)
     {
         // We're being overly defensive here because the OOP host can return null for the client/session/operation
         // when it's disconnected (user stops the process).
@@ -43,7 +43,7 @@ internal class OutOfProcSemanticTokensService(IRemoteClientProvider remoteClient
 
             var data = await remoteClient.TryInvokeAsync<IRemoteSemanticTokensService, int[]?>(
                 razorDocument.Project.Solution,
-                (service, solutionInfo, cancellationToken) => service.GetSemanticTokensDataAsync(solutionInfo, razorDocument.Id, span, colorBackground, cancellationToken),
+                (service, solutionInfo, cancellationToken) => service.GetSemanticTokensDataAsync(solutionInfo, razorDocument.Id, span, colorBackground, correlationId, cancellationToken),
                 cancellationToken).ConfigureAwait(false);
 
             if (!data.HasValue)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokensTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokensTest.cs
@@ -1005,7 +1005,7 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             options.HtmlVirtualDocumentSuffix == "__virtual.html",
             MockBehavior.Strict);
 
-        var csharpSemanticTokensProvider = new LSPCSharpSemanticTokensProvider(_clientConnection.Object, LoggerFactory);
+        var csharpSemanticTokensProvider = new LSPCSharpSemanticTokensProvider(featureOptions, _clientConnection.Object, LoggerFactory);
 
         var service = new RazorSemanticTokensInfoService(
             documentMappingService,


### PR DESCRIPTION
Turns out the code path is the same for OOP, whether precise ranges is on or not :)

One of the items in https://github.com/dotnet/razor/issues/10103

Part of https://github.com/dotnet/razor/issues/9519
