### PR TITLE
Fix a couple of mistakes in the Razor VSIX manifest

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/source.extension.vsixmanifest
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/source.extension.vsixmanifest
@@ -51,7 +51,6 @@
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="System.Runtime.CompilerServices.Unsafe.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="System.Threading.Channels.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.AspNetCore.Razor.LanguageServer.dll" />
-    <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.AspNetCore.Razor.LanguageSupport.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.AspNetCore.Razor.LanguageServer.Protocol.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.CodeAnalysis.Razor.Workspaces.dll" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.CodeAnalysis.Razor.Workspaces.dll" />

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/source.extension.vsixmanifest
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/source.extension.vsixmanifest
@@ -53,7 +53,6 @@
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.AspNetCore.Razor.LanguageServer.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.AspNetCore.Razor.LanguageSupport.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.AspNetCore.Razor.LanguageServer.Protocol.dll" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.CodeAnalysis.Razor.Compiler.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.CodeAnalysis.Razor.Workspaces.dll" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Microsoft.CodeAnalysis.Razor.Workspaces.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly"  Path="Microsoft.VisualStudio.LanguageServices.Razor.dll" />


### PR DESCRIPTION
1. The Compiler should not be listed as a MEF component.
2. An old assembly was still listed: `Microsoft.AspNetCore.Razor.LanguageSupport`. This was renamed long ago to `Microsoft.AspNetCore.Razor.Utilities.Shared`