### PR TITLE
Remove MEF exports for completion from Workspaces

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DirectiveAttributeTransitionCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/DirectiveAttributeTransitionCompletionItemProvider.cs
@@ -32,7 +32,7 @@ internal class DirectiveAttributeTransitionCompletionItemProvider : DirectiveAtt
                     // In practice this happens in the `<button |` scenario where the "space" results in completions
                     // where this directive attribute transition character ("@...") gets provided and then typing
                     // `@` should re-trigger OR typing `/` should re-trigger.
-                    commitCharacters: RazorCommitCharacter.FromArray(new[] { "@", "/", ">" }));
+                    commitCharacters: RazorCommitCharacter.CreateArray(["@", "/", ">"]));
                 s_transitionCompletionItem.SetDirectiveCompletionDescription(new DirectiveCompletionDescription(SR.Blazor_directive_attributes));
             }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LegacyRazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LegacyRazorCompletionEndpoint.cs
@@ -91,7 +91,7 @@ internal class LegacyRazorCompletionEndpoint(
         };
         var completionOptions = new RazorCompletionOptions(SnippetsSupported: true);
         var owner = syntaxTree.Root.FindInnermostNode(hostDocumentIndex, includeWhitespace: true, walkMarkersBack: true);
-        owner = RazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, hostDocumentIndex);
+        owner = AbstractRazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, hostDocumentIndex);
         var completionContext = new RazorCompletionContext(hostDocumentIndex, owner, syntaxTree, tagHelperDocumentContext, reason, completionOptions);
 
         var razorCompletionItems = _completionFactsService.GetCompletionItems(completionContext);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LspRazorCompletionFactsService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/LspRazorCompletionFactsService.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Razor.Completion;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion;
+
+internal sealed class LspRazorCompletionFactsService(IEnumerable<IRazorCompletionItemProvider> providers)
+    : AbstractRazorCompletionFactsService(providers.ToImmutableArray())
+{
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/MarkupTransitionCompletionDescription.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/MarkupTransitionCompletionDescription.cs
@@ -2,8 +2,9 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.CodeAnalysis.Razor.Completion;
 
-namespace Microsoft.CodeAnalysis.Razor.Completion;
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion;
 
 internal class MarkupTransitionCompletionDescription : CompletionDescription
 {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/MarkupTransitionCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/MarkupTransitionCompletionItemProvider.cs
@@ -6,10 +6,12 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.Completion;
 using Microsoft.VisualStudio.Editor.Razor;
 using RazorSyntaxNode = Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxNode;
 
-namespace Microsoft.CodeAnalysis.Razor.Completion;
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion;
 
 internal class MarkupTransitionCompletionItemProvider : IRazorCompletionItemProvider
 {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionItemExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionItemExtensions.cs
@@ -9,7 +9,29 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion;
 
 internal static class RazorCompletionItemExtensions
 {
+    private readonly static string s_markupTransitionDescriptionKey = "Razor.MarkupTransitionDescription";
     private readonly static string s_tagHelperElementCompletionDescriptionKey = "Razor.TagHelperElementDescription";
+
+    public static void SetMarkupTransitionCompletionDescription(this RazorCompletionItem completionItem, MarkupTransitionCompletionDescription markupTransitionCompletionDescription)
+    {
+        if (completionItem is null)
+        {
+            throw new ArgumentNullException(nameof(completionItem));
+        }
+
+        completionItem.Items[s_markupTransitionDescriptionKey] = markupTransitionCompletionDescription;
+    }
+
+    public static MarkupTransitionCompletionDescription? GetMarkupTransitionCompletionDescription(this RazorCompletionItem completionItem)
+    {
+        if (completionItem is null)
+        {
+            throw new ArgumentNullException(nameof(completionItem));
+        }
+
+        var markupTransitionCompletionDescription = completionItem.Items[s_markupTransitionDescriptionKey] as MarkupTransitionCompletionDescription;
+        return markupTransitionCompletionDescription;
+    }
 
     public static void SetTagHelperElementDescriptionInfo(this RazorCompletionItem completionItem, AggregateBoundElementDescription elementDescriptionInfo)
     {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionListProvider.cs
@@ -62,7 +62,7 @@ internal class RazorCompletionListProvider(
         var syntaxTree = await documentContext.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
         var tagHelperContext = await documentContext.GetTagHelperContextAsync(cancellationToken).ConfigureAwait(false);
         var owner = syntaxTree.Root.FindInnermostNode(absoluteIndex, includeWhitespace: true, walkMarkersBack: true);
-        owner = RazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, absoluteIndex);
+        owner = AbstractRazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, absoluteIndex);
 
         var razorCompletionContext = new RazorCompletionContext(
             absoluteIndex,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
@@ -20,13 +20,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion;
 internal class TagHelperCompletionProvider : IRazorCompletionItemProvider
 {
     // Internal for testing
-    internal static readonly IReadOnlyList<RazorCommitCharacter> MinimizedAttributeCommitCharacters = RazorCommitCharacter.FromArray(new[] { "=", " " });
-    internal static readonly IReadOnlyList<RazorCommitCharacter> AttributeCommitCharacters = RazorCommitCharacter.FromArray(new[] { "=" });
-    internal static readonly IReadOnlyList<RazorCommitCharacter> AttributeSnippetCommitCharacters = RazorCommitCharacter.FromArray(new[] { "=" }, insert: false);
+    internal static readonly ImmutableArray<RazorCommitCharacter> MinimizedAttributeCommitCharacters = RazorCommitCharacter.CreateArray(["=", " "]);
+    internal static readonly ImmutableArray<RazorCommitCharacter> AttributeCommitCharacters = RazorCommitCharacter.CreateArray(["="]);
+    internal static readonly ImmutableArray<RazorCommitCharacter> AttributeSnippetCommitCharacters = RazorCommitCharacter.CreateArray(["="], insert: false);
 
-    private static readonly IReadOnlyList<RazorCommitCharacter> s_elementCommitCharacters = RazorCommitCharacter.FromArray(new[] { " ", ">" });
-    private static readonly IReadOnlyList<RazorCommitCharacter> s_elementCommitCharacters_WithoutSpace = RazorCommitCharacter.FromArray(new[] { ">" });
-    private static readonly IReadOnlyList<RazorCommitCharacter> s_noCommitCharacters = Array.Empty<RazorCommitCharacter>();
+    private static readonly ImmutableArray<RazorCommitCharacter> s_elementCommitCharacters = RazorCommitCharacter.CreateArray([" ", ">"]);
+    private static readonly ImmutableArray<RazorCommitCharacter> s_elementCommitCharacters_WithoutSpace = RazorCommitCharacter.CreateArray([">"]);
 
     private readonly ITagHelperCompletionService _tagHelperCompletionService;
     private readonly IOptionsMonitor<RazorLSPOptions> _optionsMonitor;
@@ -290,11 +289,11 @@ internal class TagHelperCompletionProvider : IRazorCompletionItemProvider
         return AttributeContext.Full;
     }
 
-    private static IReadOnlyList<RazorCommitCharacter> ResolveAttributeCommitCharacters(AttributeContext attributeContext)
+    private static ImmutableArray<RazorCommitCharacter> ResolveAttributeCommitCharacters(AttributeContext attributeContext)
     {
         return attributeContext switch
         {
-            AttributeContext.Indexer => s_noCommitCharacters,
+            AttributeContext.Indexer => [],
             AttributeContext.Minimized => MinimizedAttributeCommitCharacters,
             AttributeContext.Full => AttributeCommitCharacters,
             AttributeContext.FullSnippet => AttributeSnippetCommitCharacters,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
@@ -98,7 +98,7 @@ internal static class IServiceCollectionExtensions
         services.AddSingleton<CompletionItemResolver, RazorCompletionItemResolver>();
         services.AddSingleton<CompletionItemResolver, DelegatedCompletionItemResolver>();
         services.AddSingleton<ITagHelperCompletionService, LspTagHelperCompletionService>();
-        services.AddSingleton<IRazorCompletionFactsService, RazorCompletionFactsService>();
+        services.AddSingleton<IRazorCompletionFactsService, LspRazorCompletionFactsService>();
         services.AddSingleton<IRazorCompletionItemProvider, DirectiveCompletionItemProvider>();
         services.AddSingleton<IRazorCompletionItemProvider, DirectiveAttributeCompletionItemProvider>();
         services.AddSingleton<IRazorCompletionItemProvider, DirectiveAttributeParameterCompletionItemProvider>();

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/AbstractRazorCompletionFactsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/AbstractRazorCompletionFactsService.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Composition;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Razor.PooledObjects;
@@ -17,22 +15,9 @@ using SyntaxKind = AspNetCore.Razor.Language.SyntaxKind;
 using SyntaxNode = AspNetCore.Razor.Language.Syntax.SyntaxNode;
 #pragma warning restore IDE0065 // Misplaced using directive
 
-[Shared]
-[Export(typeof(IRazorCompletionFactsService))]
-internal class RazorCompletionFactsService : IRazorCompletionFactsService
+internal abstract class AbstractRazorCompletionFactsService(ImmutableArray<IRazorCompletionItemProvider> providers) : IRazorCompletionFactsService
 {
-    private readonly ImmutableArray<IRazorCompletionItemProvider> _providers;
-
-    [ImportingConstructor]
-    public RazorCompletionFactsService([ImportMany] IEnumerable<IRazorCompletionItemProvider> providers)
-    {
-        if (providers is null)
-        {
-            throw new ArgumentNullException(nameof(providers));
-        }
-
-        _providers = providers.ToImmutableArray();
-    }
+    private readonly ImmutableArray<IRazorCompletionItemProvider> _providers = providers;
 
     public ImmutableArray<RazorCompletionItem> GetCompletionItems(RazorCompletionContext context)
     {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Composition;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.PooledObjects;
@@ -13,8 +12,6 @@ using Microsoft.VisualStudio.Editor.Razor;
 
 namespace Microsoft.CodeAnalysis.Razor.Completion;
 
-[Shared]
-[Export(typeof(IRazorCompletionItemProvider))]
 internal class DirectiveAttributeCompletionItemProvider : DirectiveAttributeCompletionItemProviderBase
 {
     public override ImmutableArray<RazorCompletionItem> GetCompletionItems(RazorCompletionContext context)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeCompletionItemProvider.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -80,7 +78,7 @@ internal class DirectiveAttributeCompletionItemProvider : DirectiveAttributeComp
     internal ImmutableArray<RazorCompletionItem> GetAttributeCompletions(
         string selectedAttributeName,
         string containingTagName,
-        IEnumerable<string> attributes,
+        ImmutableArray<string> attributes,
         TagHelperDocumentContext tagHelperDocumentContext)
     {
         var descriptorsForTag = TagHelperFacts.GetTagHelpersGivenTag(tagHelperDocumentContext, containingTagName, parentTag: null);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeParameterCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeParameterCompletionItemProvider.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -67,9 +65,9 @@ internal class DirectiveAttributeParameterCompletionItemProvider : DirectiveAttr
     // Internal for testing
     internal ImmutableArray<RazorCompletionItem> GetAttributeParameterCompletions(
         string attributeName,
-        string parameterName,
+        string? parameterName,
         string containingTagName,
-        IEnumerable<string> attributes,
+        ImmutableArray<string> attributes,
         TagHelperDocumentContext tagHelperDocumentContext)
     {
         var descriptorsForTag = TagHelperFacts.GetTagHelpersGivenTag(tagHelperDocumentContext, containingTagName, parentTag: null);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeParameterCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeParameterCompletionItemProvider.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Composition;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.PooledObjects;
@@ -13,8 +12,6 @@ using Microsoft.VisualStudio.Editor.Razor;
 
 namespace Microsoft.CodeAnalysis.Razor.Completion;
 
-[Shared]
-[Export(typeof(IRazorCompletionItemProvider))]
 internal class DirectiveAttributeParameterCompletionItemProvider : DirectiveAttributeCompletionItemProviderBase
 {
     public override ImmutableArray<RazorCompletionItem> GetCompletionItems(RazorCompletionContext context)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Composition;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
@@ -14,8 +13,6 @@ using Microsoft.AspNetCore.Razor.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.Razor.Completion;
 
-[Shared]
-[Export(typeof(IRazorCompletionItemProvider))]
 internal class DirectiveCompletionItemProvider : IRazorCompletionItemProvider
 {
     internal static readonly ImmutableArray<RazorCommitCharacter> SingleLineDirectiveCommitCharacters = RazorCommitCharacter.CreateArray([" "]);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
@@ -18,8 +18,8 @@ namespace Microsoft.CodeAnalysis.Razor.Completion;
 [Export(typeof(IRazorCompletionItemProvider))]
 internal class DirectiveCompletionItemProvider : IRazorCompletionItemProvider
 {
-    internal static readonly IReadOnlyList<RazorCommitCharacter> SingleLineDirectiveCommitCharacters = RazorCommitCharacter.FromArray(new[] { " " });
-    internal static readonly IReadOnlyList<RazorCommitCharacter> BlockDirectiveCommitCharacters = RazorCommitCharacter.FromArray(new[] { " ", "{" });
+    internal static readonly ImmutableArray<RazorCommitCharacter> SingleLineDirectiveCommitCharacters = RazorCommitCharacter.CreateArray([" "]);
+    internal static readonly ImmutableArray<RazorCommitCharacter> BlockDirectiveCommitCharacters = RazorCommitCharacter.CreateArray([" ", "{"]);
 
     private static readonly IEnumerable<DirectiveDescriptor> s_defaultDirectives = new[]
     {
@@ -183,7 +183,7 @@ internal class DirectiveCompletionItemProvider : IRazorCompletionItemProvider
         return completionItems.DrainToImmutable();
     }
 
-    private static IReadOnlyList<RazorCommitCharacter> GetDirectiveCommitCharacters(DirectiveKind directiveKind)
+    private static ImmutableArray<RazorCommitCharacter> GetDirectiveCommitCharacters(DirectiveKind directiveKind)
     {
         return directiveKind switch
         {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Collections.Frozen;
 using System.Collections.Generic;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/MarkupTransitionCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/MarkupTransitionCompletionItemProvider.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
@@ -14,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Razor.Completion;
 
 internal class MarkupTransitionCompletionItemProvider : IRazorCompletionItemProvider
 {
-    private static readonly IReadOnlyList<RazorCommitCharacter> s_elementCommitCharacters = RazorCommitCharacter.FromArray(new[] { ">" });
+    private static readonly ImmutableArray<RazorCommitCharacter> s_elementCommitCharacters = RazorCommitCharacter.CreateArray([">"]);
 
     private static RazorCompletionItem? s_markupTransitionCompletionItem;
     public static RazorCompletionItem MarkupTransitionCompletionItem

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCommitCharacter.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCommitCharacter.cs
@@ -1,23 +1,22 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.AspNetCore.Razor.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.Razor.Completion;
 
-internal sealed record RazorCommitCharacter(string Character, bool Insert = true)
+internal readonly record struct RazorCommitCharacter(string Character, bool Insert = true)
 {
-    public static IReadOnlyList<RazorCommitCharacter> FromArray(IReadOnlyList<string> characters) => FromArray(characters, insert: true);
-
-    public static IReadOnlyList<RazorCommitCharacter> FromArray(IReadOnlyList<string> characters, bool insert)
+    public static ImmutableArray<RazorCommitCharacter> CreateArray(string[] characters, bool insert = true)
     {
-        var converted = new RazorCommitCharacter[characters.Count];
+        using var converted = new PooledArrayBuilder<RazorCommitCharacter>(capacity: characters.Length);
 
-        for (var i = 0; i < characters.Count; i++)
+        foreach (var ch in characters)
         {
-            converted[i] = new RazorCommitCharacter(characters[i], insert);
+            converted.Add(new(ch, insert));
         }
 
-        return converted;
+        return converted.DrainToImmutable();
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItem.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItem.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.Extensions.Internal;
@@ -28,7 +29,7 @@ internal sealed class RazorCompletionItem : IEquatable<RazorCompletionItem>
         string insertText,
         RazorCompletionItemKind kind,
         string? sortText = null,
-        IReadOnlyList<RazorCommitCharacter>? commitCharacters = null,
+        ImmutableArray<RazorCommitCharacter> commitCharacters = default,
         bool isSnippet = false)
     {
         if (displayText is null)
@@ -44,7 +45,7 @@ internal sealed class RazorCompletionItem : IEquatable<RazorCompletionItem>
         DisplayText = displayText;
         InsertText = insertText;
         Kind = kind;
-        CommitCharacters = commitCharacters;
+        CommitCharacters = commitCharacters.NullToEmpty();
         SortText = sortText ?? displayText;
         IsSnippet = isSnippet;
     }
@@ -62,7 +63,7 @@ internal sealed class RazorCompletionItem : IEquatable<RazorCompletionItem>
 
     public RazorCompletionItemKind Kind { get; }
 
-    public IReadOnlyCollection<RazorCommitCharacter>? CommitCharacters { get; }
+    public ImmutableArray<RazorCommitCharacter> CommitCharacters { get; }
 
     public ItemCollection Items
     {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItemExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItemExtensions.cs
@@ -11,7 +11,6 @@ internal static class RazorCompletionItemExtensions
 {
     private readonly static string s_attributeCompletionDescriptionKey = "Razor.AttributeDescription";
     private readonly static string s_directiveCompletionDescriptionKey = "Razor.DirectiveDescription";
-    private readonly static string s_markupTransitionDescriptionKey = "Razor.MarkupTransitionDescription";
 
     public static void SetAttributeCompletionDescription(this RazorCompletionItem completionItem, AggregateBoundAttributeDescription attributeCompletionDescription)
     {
@@ -53,27 +52,6 @@ internal static class RazorCompletionItemExtensions
 
         var attributeCompletionDescription = completionItem.Items[s_directiveCompletionDescriptionKey] as DirectiveCompletionDescription;
         return attributeCompletionDescription;
-    }
-
-    public static void SetMarkupTransitionCompletionDescription(this RazorCompletionItem completionItem, MarkupTransitionCompletionDescription markupTransitionCompletionDescription)
-    {
-        if (completionItem is null)
-        {
-            throw new ArgumentNullException(nameof(completionItem));
-        }
-
-        completionItem.Items[s_markupTransitionDescriptionKey] = markupTransitionCompletionDescription;
-    }
-
-    public static MarkupTransitionCompletionDescription? GetMarkupTransitionCompletionDescription(this RazorCompletionItem completionItem)
-    {
-        if (completionItem is null)
-        {
-            throw new ArgumentNullException(nameof(completionItem));
-        }
-
-        var markupTransitionCompletionDescription = completionItem.Items[s_markupTransitionDescriptionKey] as MarkupTransitionCompletionDescription;
-        return markupTransitionCompletionDescription;
     }
 
     public static IEnumerable<string> GetAttributeCompletionTypes(this RazorCompletionItem completionItem)

--- a/src/Razor/src/Microsoft.VisualStudio.LegacyEditor.Razor/Completion/LegacyRazorCompletionFactsService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LegacyEditor.Razor/Completion/LegacyRazorCompletionFactsService.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.Razor.Completion;
+
+namespace Microsoft.VisualStudio.LegacyEditor.Razor.Completion;
+
+[Export(typeof(IRazorCompletionFactsService))]
+internal sealed class LegacyRazorCompletionFactsService : AbstractRazorCompletionFactsService
+{
+    private static readonly ImmutableArray<IRazorCompletionItemProvider> s_providers =
+    [
+        new DirectiveAttributeCompletionItemProvider(),
+        new DirectiveAttributeParameterCompletionItemProvider(),
+        new DirectiveCompletionItemProvider()
+    ];
+
+    public LegacyRazorCompletionFactsService()
+        : base(s_providers)
+    {
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DirectiveAttributeTransitionCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DirectiveAttributeTransitionCompletionItemProviderTest.cs
@@ -322,7 +322,7 @@ public class DirectiveAttributeTransitionCompletionItemProviderTest : ToolingTes
     {
         var syntaxTree = GetSyntaxTree(documentContent, fileKind);
         var owner = syntaxTree.Root.FindInnermostNode(absoluteIndex, includeWhitespace: true, walkMarkersBack: true);
-        owner = RazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, absoluteIndex);
+        owner = AbstractRazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, absoluteIndex);
         var context = new RazorCompletionContext(absoluteIndex, owner, syntaxTree, _tagHelperDocumentContext);
         return context;
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/LegacyRazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/LegacyRazorCompletionEndpointTest.cs
@@ -51,7 +51,7 @@ public class LegacyRazorCompletionEndpointTest : LanguageServerTestBase
                 {
                     CompletionItemKind = new CompletionItemKindSetting()
                     {
-                        ValueSet = new[] { CompletionItemKind.TagHelper }
+                        ValueSet = [CompletionItemKind.TagHelper]
                     },
                     CompletionList = new VSInternalCompletionListSetting()
                     {
@@ -212,7 +212,11 @@ public class LegacyRazorCompletionEndpointTest : LanguageServerTestBase
     public void TryConvert_DirectiveAttribute_ReturnsTrue()
     {
         // Arrange
-        var completionItem = new RazorCompletionItem("@testDisplay", "testInsert", RazorCompletionItemKind.DirectiveAttribute, commitCharacters: RazorCommitCharacter.CreateArray(new[] { "=", ":" }));
+        var completionItem = new RazorCompletionItem(
+            "@testDisplay",
+            "testInsert",
+            RazorCompletionItemKind.DirectiveAttribute,
+            commitCharacters: RazorCommitCharacter.CreateArray(["=", ":"]));
 
         // Act
         var result = LegacyRazorCompletionEndpoint.TryConvert(completionItem, _clientCapabilities, out var converted);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/LegacyRazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/LegacyRazorCompletionEndpointTest.cs
@@ -41,7 +41,7 @@ public class LegacyRazorCompletionEndpointTest : LanguageServerTestBase
             new TagHelperCompletionProvider(tagHelperCompletionService, TestRazorLSPOptionsMonitor.Create())
         };
 
-        _completionFactsService = new RazorCompletionFactsService(completionProviders);
+        _completionFactsService = new LspRazorCompletionFactsService(completionProviders);
         _completionListCache = new CompletionListCache();
         _clientCapabilities = new VSInternalClientCapabilities()
         {
@@ -597,12 +597,5 @@ public class LegacyRazorCompletionEndpointTest : LanguageServerTestBase
         var tagHelperDocumentContext = TagHelperDocumentContext.Create(prefix: string.Empty, tagHelpers: []);
         codeDocument.SetTagHelperContext(tagHelperDocumentContext);
         return codeDocument;
-    }
-
-    private static void AssertDirectiveSnippet(CompletionItem completionItem, string directive)
-    {
-        Assert.StartsWith(directive, completionItem.InsertText);
-        Assert.Equal(DirectiveCompletionItemProvider.s_singleLineDirectiveSnippets[directive].InsertText, completionItem.InsertText);
-        Assert.Equal(CompletionItemKind.Snippet, completionItem.Kind);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/LegacyRazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/LegacyRazorCompletionEndpointTest.cs
@@ -212,7 +212,7 @@ public class LegacyRazorCompletionEndpointTest : LanguageServerTestBase
     public void TryConvert_DirectiveAttribute_ReturnsTrue()
     {
         // Arrange
-        var completionItem = new RazorCompletionItem("@testDisplay", "testInsert", RazorCompletionItemKind.DirectiveAttribute, commitCharacters: RazorCommitCharacter.FromArray(new[] { "=", ":" }));
+        var completionItem = new RazorCompletionItem("@testDisplay", "testInsert", RazorCompletionItemKind.DirectiveAttribute, commitCharacters: RazorCommitCharacter.CreateArray(new[] { "=", ":" }));
 
         // Act
         var result = LegacyRazorCompletionEndpoint.TryConvert(completionItem, _clientCapabilities, out var converted);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/MarkupTransitionCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/MarkupTransitionCompletionItemProviderTest.cs
@@ -8,11 +8,13 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.Completion;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Microsoft.CodeAnalysis.Razor.Completion;
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion;
 
 public class MarkupTransitionCompletionItemProviderTest(ITestOutputHelper testOutput) : ToolingTestBase(testOutput)
 {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionListProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionListProviderTest.cs
@@ -23,17 +23,17 @@ using static Microsoft.AspNetCore.Razor.Language.CommonMetadata;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion;
 
-public class RazorCompletionListProvierTest : LanguageServerTestBase
+public class RazorCompletionListProviderTest : LanguageServerTestBase
 {
     private readonly IRazorCompletionFactsService _completionFactsService;
     private readonly CompletionListCache _completionListCache;
     private readonly VSInternalClientCapabilities _clientCapabilities;
     private readonly VSInternalCompletionContext _defaultCompletionContext;
 
-    public RazorCompletionListProvierTest(ITestOutputHelper testOutput)
+    public RazorCompletionListProviderTest(ITestOutputHelper testOutput)
         : base(testOutput)
     {
-        _completionFactsService = new RazorCompletionFactsService(GetCompletionProviders());
+        _completionFactsService = new LspRazorCompletionFactsService(GetCompletionProviders());
         _completionListCache = new CompletionListCache();
         _clientCapabilities = new VSInternalClientCapabilities()
         {
@@ -571,7 +571,7 @@ public class RazorCompletionListProvierTest : LanguageServerTestBase
         var optionsMonitor = TestRazorLSPOptionsMonitor.Create();
         await optionsMonitor.UpdateAsync(optionsMonitor.CurrentValue with { AutoInsertAttributeQuotes = false }, DisposalToken);
 
-        var completionFactsService = new RazorCompletionFactsService(GetCompletionProviders(optionsMonitor));
+        var completionFactsService = new LspRazorCompletionFactsService(GetCompletionProviders(optionsMonitor));
         var provider = new RazorCompletionListProvider(completionFactsService, _completionListCache, LoggerFactory);
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionListProvierTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionListProvierTest.cs
@@ -224,7 +224,7 @@ public class RazorCompletionListProvierTest : LanguageServerTestBase
     public void TryConvert_DirectiveAttribute_ReturnsTrue()
     {
         // Arrange
-        var completionItem = new RazorCompletionItem("@testDisplay", "testInsert", RazorCompletionItemKind.DirectiveAttribute, commitCharacters: RazorCommitCharacter.FromArray(new[] { "=", ":" }));
+        var completionItem = new RazorCompletionItem("@testDisplay", "testInsert", RazorCompletionItemKind.DirectiveAttribute, commitCharacters: RazorCommitCharacter.CreateArray(new[] { "=", ":" }));
 
         // Act
         var result = RazorCompletionListProvider.TryConvert(completionItem, _clientCapabilities, out var converted);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
@@ -925,7 +925,7 @@ public class TagHelperCompletionProviderTest(ITestOutputHelper testOutput) : Tag
         var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
 
         var owner = syntaxTree.Root.FindInnermostNode(position, includeWhitespace: true, walkMarkersBack: true);
-        owner = RazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, position);
+        owner = AbstractRazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, position);
         return new RazorCompletionContext(position, owner, syntaxTree, tagHelperDocumentContext, Options: options);
     }
 }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DefaultRazorCompletionFactsServiceTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DefaultRazorCompletionFactsServiceTest.cs
@@ -25,7 +25,7 @@ public class DefaultRazorCompletionFactsServiceTest(ITestOutputHelper testOutput
         var provider1 = Mock.Of<IRazorCompletionItemProvider>(p => p.GetCompletionItems(context) == ImmutableArray.Create(completionItem1), MockBehavior.Strict);
         var completionItem2 = new RazorCompletionItem("displayText2", "insertText2", RazorCompletionItemKind.Directive);
         var provider2 = Mock.Of<IRazorCompletionItemProvider>(p => p.GetCompletionItems(context) == ImmutableArray.Create(completionItem2), MockBehavior.Strict);
-        var completionFactsService = new RazorCompletionFactsService(new[] { provider1, provider2 });
+        var completionFactsService = new TestRazorCompletionFactsProvider(provider1, provider2);
 
         // Act
         var completionItems = completionFactsService.GetCompletionItems(context);
@@ -33,4 +33,7 @@ public class DefaultRazorCompletionFactsServiceTest(ITestOutputHelper testOutput
         // Assert
         Assert.Equal(new[] { completionItem1, completionItem2 }, completionItems);
     }
+
+    private sealed class TestRazorCompletionFactsProvider(params IRazorCompletionItemProvider[] providers)
+        : AbstractRazorCompletionFactsService(providers.ToImmutableArray());
 }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderBaseTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderBaseTest.cs
@@ -235,7 +235,7 @@ public class DirectiveAttributeCompletionItemProviderBaseTest(ITestOutputHelper 
         var result = CompileToCSharp(content, throwOnFailure: false);
         var syntaxTree = result.CodeDocument.GetSyntaxTree();
         var owner = syntaxTree.Root.FindInnermostNode(index, includeWhitespace: true, walkMarkersBack: true);
-        owner = RazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, index);
+        owner = AbstractRazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, index);
 
         return owner;
     }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.cs
@@ -287,7 +287,7 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
         var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
 
         var owner = syntaxTree.Root.FindInnermostNode(absoluteIndex, includeWhitespace: true, walkMarkersBack: true);
-        owner = RazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, absoluteIndex);
+        owner = AbstractRazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, absoluteIndex);
         return new RazorCompletionContext(absoluteIndex, owner, syntaxTree, tagHelperDocumentContext);
     }
 }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeCompletionItemProviderTest.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.IntegrationTests;
@@ -18,7 +19,6 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
 {
     private readonly DirectiveAttributeCompletionItemProvider _provider;
     private readonly TagHelperDocumentContext _defaultTagHelperDocumentContext;
-    private readonly IEnumerable<string> _emptyAttributes;
 
     internal override string FileKind => FileKinds.Component;
     internal override bool UseTwoPhaseCompilation => true;
@@ -27,7 +27,6 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
         : base(testOutput)
     {
         _provider = new DirectiveAttributeCompletionItemProvider();
-        _emptyAttributes = [];
 
         // Most of these completions rely on stuff in the web namespace.
         ImportItems.Add(CreateProjectItem(
@@ -80,7 +79,7 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
         var completions = _provider.GetCompletionItems(context);
 
         // Assert
-        AssertContains(completions, "bind", "@bind", new[] { "=", ":" });
+        AssertContains(completions, "bind", "@bind", ["=", ":"]);
     }
 
     [Fact]
@@ -93,7 +92,7 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
         var completions = _provider.GetCompletionItems(context);
 
         // Assert
-        AssertContains(completions, "attributes", "@attributes", new[] { "=" });
+        AssertContains(completions, "attributes", "@attributes", ["="]);
     }
 
     [Fact]
@@ -168,7 +167,7 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
         var documentContext = TagHelperDocumentContext.Create(string.Empty, tagHelpers: []);
 
         // Act
-        var completions = _provider.GetAttributeCompletions("@bin", "foobarbaz", _emptyAttributes, documentContext);
+        var completions = _provider.GetAttributeCompletions("@bin", "foobarbaz", [], documentContext);
 
         // Assert
         Assert.Empty(completions);
@@ -184,7 +183,7 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
         var documentContext = TagHelperDocumentContext.Create(string.Empty, [descriptor.Build()]);
 
         // Act
-        var completions = _provider.GetAttributeCompletions("@bin", "input", _emptyAttributes, documentContext);
+        var completions = _provider.GetAttributeCompletions("@bin", "input", [], documentContext);
 
         // Assert
         Assert.Empty(completions);
@@ -194,13 +193,13 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
     public void GetAttributeCompletions_SelectedDirectiveAttribute_IsIncludedInCompletions()
     {
         // Arrange
-        var attributeNames = new string[] { "@bind" };
+        var attributeNames = ImmutableArray.Create("@bind");
 
         // Act
         var completions = _provider.GetAttributeCompletions("@bind", "input", attributeNames, _defaultTagHelperDocumentContext);
 
         // Assert
-        AssertContains(completions, "bind", "@bind", new[] { "=", ":" });
+        AssertContains(completions, "bind", "@bind", ["=", ":"]);
     }
 
     [Fact]
@@ -209,10 +208,10 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
         // Arrange
 
         // Act
-        var completions = _provider.GetAttributeCompletions("@", "input", _emptyAttributes, _defaultTagHelperDocumentContext);
+        var completions = _provider.GetAttributeCompletions("@", "input", [], _defaultTagHelperDocumentContext);
 
         // Assert
-        AssertContains(completions, "bind", "@bind", new[] { "=", ":" });
+        AssertContains(completions, "bind", "@bind", ["=", ":"]);
     }
 
     [Fact]
@@ -221,31 +220,30 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
         // Arrange
 
         // Act
-        var completions = _provider.GetAttributeCompletions("@", "input", _emptyAttributes, _defaultTagHelperDocumentContext);
+        var completions = _provider.GetAttributeCompletions("@", "input", [], _defaultTagHelperDocumentContext);
 
         // Assert
-        AssertContains(completions, "bind-", "@bind-...", Array.Empty<string>());
+        AssertContains(completions, "bind-", "@bind-...", []);
     }
 
     [Fact]
     public void GetAttributeCompletions_BaseDirectiveAttributeAlreadyExists_IncludesBaseAttribute()
     {
         // Arrange
-        var attributeNames = new[] { "@bind", "@" };
+        var attributeNames = ImmutableArray.Create("@bind", "@");
 
         // Act
         var completions = _provider.GetAttributeCompletions("@", "input", attributeNames, _defaultTagHelperDocumentContext);
 
         // Assert
-        AssertContains(completions, "bind", "@bind", new[] { "=", ":" });
+        AssertContains(completions, "bind", "@bind", ["=", ":"]);
     }
 
     [Fact]
     public void GetAttributeCompletions_BaseDirectiveAttributeAndParameterVariationsExist_ExcludesCompletion()
     {
         // Arrange
-        var attributeNames = new[]
-        {
+        var attributeNames = ImmutableArray.Create(
             "@bind",
             "@bind:format",
             "@bind:event",
@@ -253,8 +251,7 @@ public class DirectiveAttributeCompletionItemProviderTest : RazorToolingIntegrat
             "@bind:get",
             "@bind:set",
             "@bind:after",
-            "@",
-        };
+            "@");
 
         // Act
         var completions = _provider.GetAttributeCompletions("@", "input", attributeNames, _defaultTagHelperDocumentContext);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeParameterCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeParameterCompletionItemProviderTest.cs
@@ -179,7 +179,7 @@ public class DirectiveAttributeParameterCompletionItemProviderTest : RazorToolin
         var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
 
         var owner = syntaxTree.Root.FindInnermostNode(absoluteIndex);
-        owner = RazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, absoluteIndex);
+        owner = AbstractRazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, absoluteIndex);
         return new RazorCompletionContext(absoluteIndex, owner, syntaxTree, tagHelperDocumentContext);
     }
 }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeParameterCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeParameterCompletionItemProviderTest.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.IntegrationTests;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
@@ -16,7 +17,6 @@ public class DirectiveAttributeParameterCompletionItemProviderTest : RazorToolin
 {
     private readonly DirectiveAttributeParameterCompletionItemProvider _provider;
     private readonly TagHelperDocumentContext _defaultTagHelperDocumentContext;
-    private readonly IEnumerable<string> _emptyAttributes;
 
     internal override string FileKind => FileKinds.Component;
     internal override bool UseTwoPhaseCompilation => true;
@@ -25,7 +25,6 @@ public class DirectiveAttributeParameterCompletionItemProviderTest : RazorToolin
         : base(testOutput)
     {
         _provider = new DirectiveAttributeParameterCompletionItemProvider();
-        _emptyAttributes = [];
 
         // Most of these completions rely on stuff in the web namespace.
         ImportItems.Add(CreateProjectItem(
@@ -94,7 +93,7 @@ public class DirectiveAttributeParameterCompletionItemProviderTest : RazorToolin
         var documentContext = TagHelperDocumentContext.Create(string.Empty, tagHelpers: []);
 
         // Act
-        var completions = _provider.GetAttributeParameterCompletions("@bin", string.Empty, "foobarbaz", _emptyAttributes, documentContext);
+        var completions = _provider.GetAttributeParameterCompletions("@bin", string.Empty, "foobarbaz", [], documentContext);
 
         // Assert
         Assert.Empty(completions);
@@ -110,7 +109,7 @@ public class DirectiveAttributeParameterCompletionItemProviderTest : RazorToolin
         var documentContext = TagHelperDocumentContext.Create(string.Empty, [descriptor.Build()]);
 
         // Act
-        var completions = _provider.GetAttributeParameterCompletions("@bin", string.Empty, "input", _emptyAttributes, documentContext);
+        var completions = _provider.GetAttributeParameterCompletions("@bin", string.Empty, "input", [], documentContext);
 
         // Assert
         Assert.Empty(completions);
@@ -120,7 +119,7 @@ public class DirectiveAttributeParameterCompletionItemProviderTest : RazorToolin
     public void GetAttributeParameterCompletions_SelectedDirectiveAttributeParameter_IsExcludedInCompletions()
     {
         // Arrange
-        var attributeNames = new string[] { "@bind" };
+        var attributeNames = ImmutableArray.Create("@bind");
 
         // Act
         var completions = _provider.GetAttributeParameterCompletions("@bind", "format", "input", attributeNames, _defaultTagHelperDocumentContext);
@@ -135,7 +134,7 @@ public class DirectiveAttributeParameterCompletionItemProviderTest : RazorToolin
         // Arrange
 
         // Act
-        var completions = _provider.GetAttributeParameterCompletions("@bind", string.Empty, "input", _emptyAttributes, _defaultTagHelperDocumentContext);
+        var completions = _provider.GetAttributeParameterCompletions("@bind", string.Empty, "input", [], _defaultTagHelperDocumentContext);
 
         // Assert
         AssertContains(completions, "format");
@@ -145,13 +144,11 @@ public class DirectiveAttributeParameterCompletionItemProviderTest : RazorToolin
     public void GetAttributeParameterCompletions_BaseDirectiveAttributeAndParameterVariationsExist_ExcludesCompletion()
     {
         // Arrange
-        var attributeNames = new[]
-        {
+        var attributeNames = ImmutableArray.Create(
             "@bind",
             "@bind:format",
             "@bind:event",
-            "@",
-        };
+            "@");
 
         // Act
         var completions = _provider.GetAttributeParameterCompletions("@bind", string.Empty, "input", attributeNames, _defaultTagHelperDocumentContext);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
@@ -430,7 +430,7 @@ public class DirectiveCompletionItemProviderTest : ToolingTestBase
     {
         var tagHelperDocumentContext = TagHelperDocumentContext.Create(prefix: string.Empty, tagHelpers: []);
         var owner = syntaxTree.Root.FindInnermostNode(absoluteIndex);
-        owner = RazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, absoluteIndex);
+        owner = AbstractRazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, absoluteIndex);
         return new RazorCompletionContext(absoluteIndex, owner, syntaxTree, tagHelperDocumentContext, reason);
     }
 

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/MarkupTransitionCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/MarkupTransitionCompletionItemProviderTest.cs
@@ -331,7 +331,7 @@ public class MarkupTransitionCompletionItemProviderTest(ITestOutputHelper testOu
         var tagHelperDocumentContext = TagHelperDocumentContext.Create(prefix: string.Empty, tagHelpers: []);
 
         var owner = syntaxTree.Root.FindInnermostNode(absoluteIndex, includeWhitespace: true, walkMarkersBack: true);
-        owner = RazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, absoluteIndex);
+        owner = AbstractRazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, absoluteIndex);
         return new RazorCompletionContext(absoluteIndex, owner, syntaxTree, tagHelperDocumentContext);
     }
 

--- a/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/Completion/RazorDirectiveCompletionSourceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/Completion/RazorDirectiveCompletionSourceTest.cs
@@ -34,7 +34,7 @@ public class RazorDirectiveCompletionSourceTest(ITestOutputHelper testOutput) : 
         CSharpCodeParser.UsingDirectiveDescriptor
     ]);
 
-    private readonly IRazorCompletionFactsService _completionFactsService = new RazorCompletionFactsService([new DirectiveCompletionItemProvider()]);
+    private readonly IRazorCompletionFactsService _completionFactsService = new LegacyRazorCompletionFactsService();
 
     [UIFact]
     public async Task GetCompletionContextAsync_DoesNotProvideCompletionsPriorToParseResults()


### PR DESCRIPTION
Part of #10127

There are several completion types exported as MEF parts in service of the legacy editor. This change removes those MEF exports.