### PR TITLE
Remove logging MEF export from Workspaces

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
@@ -30,13 +30,19 @@ public class RazorLanguageServerBenchmarkBase : ProjectSnapshotManagerBenchmarkB
     {
         var (_, serverStream) = FullDuplexStream.CreatePair();
         Logger = new NoopLogger();
-        var razorLoggerFactory = new RazorLoggerFactory([new NoopLoggerProvider()]);
-        RazorLanguageServer = RazorLanguageServerWrapper.Create(serverStream, serverStream, razorLoggerFactory, NoOpTelemetryReporter.Instance, configure: (collection) =>
-        {
-            collection.AddSingleton<IOnInitialized, NoopClientNotifierService>();
-            collection.AddSingleton<IClientConnection, NoopClientNotifierService>();
-            Builder(collection);
-        }, featureOptions: BuildFeatureOptions());
+        var razorLoggerFactory = new NoopLoggerFactory();
+        RazorLanguageServer = RazorLanguageServerWrapper.Create(
+            serverStream,
+            serverStream,
+            razorLoggerFactory,
+            NoOpTelemetryReporter.Instance,
+            configure: (collection) =>
+            {
+                collection.AddSingleton<IOnInitialized, NoopClientNotifierService>();
+                collection.AddSingleton<IClientConnection, NoopClientNotifierService>();
+                Builder(collection);
+            },
+            featureOptions: BuildFeatureOptions());
     }
 
     protected internal virtual void Builder(IServiceCollection collection)
@@ -101,6 +107,8 @@ public class RazorLanguageServerBenchmarkBase : ProjectSnapshotManagerBenchmarkB
             throw new NotImplementedException();
         }
     }
+
+    internal class NoopLoggerFactory() : AbstractRazorLoggerFactory([new NoopLoggerProvider()]);
 
     internal class NoopLoggerProvider : IRazorLoggerProvider
     {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.LoggerFactoryWrapper.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.LoggerFactoryWrapper.cs
@@ -13,14 +13,9 @@ internal partial class RazorLanguageServer
     /// whether things are coming from the VS side, the LSP side, of our code. This is only temporary and will be removed when we move
     /// to cohosting as there will only be one side.
     /// </summary>
-    private class LoggerFactoryWrapper : IRazorLoggerFactory
+    private sealed class LoggerFactoryWrapper(IRazorLoggerFactory loggerFactory) : IRazorLoggerFactory
     {
-        private IRazorLoggerFactory _loggerFactory;
-
-        public LoggerFactoryWrapper(IRazorLoggerFactory loggerFactory)
-        {
-            _loggerFactory = loggerFactory;
-        }
+        private IRazorLoggerFactory _loggerFactory = loggerFactory;
 
         public void AddLoggerProvider(IRazorLoggerProvider provider)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -83,8 +83,8 @@ internal partial class RazorLanguageServer : AbstractLanguageServer<RazorRequest
         var handlerProvider = this.HandlerProvider;
         var queue = new RazorRequestExecutionQueue(this, _logger, handlerProvider);
         queue.Start();
-        return queue;
 
+        return queue;
     }
 
     protected override ILspServices ConstructLspServices()

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Logging/AbstractRazorLoggerFactory.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Logging/AbstractRazorLoggerFactory.cs
@@ -1,27 +1,23 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using System.Composition;
+using System.Collections.Immutable;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.CodeAnalysis.Razor.Logging;
 
-[Shared]
-[Export(typeof(IRazorLoggerFactory))]
-internal class RazorLoggerFactory : IRazorLoggerFactory
+internal abstract class AbstractRazorLoggerFactory : IRazorLoggerFactory
 {
     private readonly ILoggerFactory _loggerFactory;
 
-    [ImportingConstructor]
-    public RazorLoggerFactory([ImportMany] IEnumerable<IRazorLoggerProvider> razorLoggerProviders)
+    protected AbstractRazorLoggerFactory(ImmutableArray<IRazorLoggerProvider> providers)
     {
         _loggerFactory = LoggerFactory.Create(b =>
         {
             // We let everything through, and expect individual loggers to control their own levels
             b.AddFilter(level => true);
 
-            foreach (var provider in razorLoggerProviders)
+            foreach (var provider in providers)
             {
                 b.AddProvider(provider);
             }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Logging/RazorLogHubLoggerProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Logging/RazorLogHubLoggerProvider.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System.Composition;
+using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.Editor.Razor.Logging;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Logging;
 
-[Shared]
 [Export(typeof(IRazorLoggerProvider))]
 internal sealed class RazorLogHubLoggerProvider : IRazorLoggerProvider
 {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/VisualStudioRazorLoggerFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/VisualStudioRazorLoggerFactory.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.Razor.Logging;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor.Logging;
+
+[Export(typeof(IRazorLoggerFactory))]
+[method: ImportingConstructor]
+internal sealed class VisualStudioRazorLoggerFactory([ImportMany] IEnumerable<IRazorLoggerProvider> providers)
+    : AbstractRazorLoggerFactory(providers.ToImmutableArray())
+{
+}

--- a/src/Razor/src/rzls/LoggerFactory.cs
+++ b/src/Razor/src/rzls/LoggerFactory.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Razor.Logging;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer;
+
+internal sealed class LoggerFactory(ImmutableArray<IRazorLoggerProvider> providers)
+    : AbstractRazorLoggerFactory(providers)
+{
+}

--- a/src/Razor/src/rzls/Program.cs
+++ b/src/Razor/src/rzls/Program.cs
@@ -9,7 +9,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Exports;
 using Microsoft.AspNetCore.Razor.Telemetry;
-using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
@@ -79,7 +78,7 @@ public class Program
 
         // Have to create a logger factory to give to the server, but can't create any logger providers until we have
         // a server.
-        var loggerFactory = new RazorLoggerFactory([]);
+        var loggerFactory = new LoggerFactory([]);
 
         var server = RazorLanguageServerWrapper.Create(
             Console.OpenStandardInput(),

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Logging/TestOutputLoggerFactory.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Logging/TestOutputLoggerFactory.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Razor.Logging;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.Razor.Test.Common.Logging;
+
+internal sealed class TestOutputLoggerFactory(ITestOutputHelper output)
+    : AbstractRazorLoggerFactory([new TestOutputLoggerProvider(output)])
+{
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ToolingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ToolingTestBase.cs
@@ -94,7 +94,7 @@ public abstract partial class ToolingTestBase : IAsyncLifetime
         _disposalTokenSource = new();
         DisposalToken = _disposalTokenSource.Token;
 
-        LoggerFactory = new RazorLoggerFactory([new TestOutputLoggerProvider(testOutput)]);
+        LoggerFactory = new TestOutputLoggerFactory(testOutput);
 
         // Give this thread a name, so it's easier to find in the VS Threads window.
         Thread.CurrentThread.Name ??= "Main Thread";

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TelemetryReporterTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/TelemetryReporterTests.cs
@@ -4,20 +4,21 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Telemetry;
-using Microsoft.CodeAnalysis.Razor.Logging;
+using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.VisualStudio.Editor.Razor.Test.Shared;
 using Microsoft.VisualStudio.Telemetry;
 using StreamJsonRpc;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.VisualStudio.Editor.Razor.Test;
 
-public class TelemetryReporterTests
+public class TelemetryReporterTests(ITestOutputHelper testOutput) : ToolingTestBase(testOutput)
 {
     [Fact]
     public void NoArgument()
     {
-        var reporter = new TestTelemetryReporter(new RazorLoggerFactory([]));
+        var reporter = new TestTelemetryReporter(LoggerFactory);
         reporter.ReportEvent("EventName", Severity.Normal);
         Assert.Collection(reporter.Events,
             e1 =>
@@ -31,7 +32,7 @@ public class TelemetryReporterTests
     [Fact]
     public void OneArgument()
     {
-        var reporter = new TestTelemetryReporter(new RazorLoggerFactory([]));
+        var reporter = new TestTelemetryReporter(LoggerFactory);
         reporter.ReportEvent("EventName", Severity.Normal, new Property("P1", false));
         Assert.Collection(reporter.Events,
             e1 =>
@@ -48,7 +49,7 @@ public class TelemetryReporterTests
     [Fact]
     public void TwoArguments()
     {
-        var reporter = new TestTelemetryReporter(new RazorLoggerFactory([]));
+        var reporter = new TestTelemetryReporter(LoggerFactory);
         reporter.ReportEvent("EventName", Severity.Normal, new("P1", false), new("P2", "test"));
         Assert.Collection(reporter.Events,
             e1 =>
@@ -65,7 +66,7 @@ public class TelemetryReporterTests
     [Fact]
     public void ThreeArguments()
     {
-        var reporter = new TestTelemetryReporter(new RazorLoggerFactory([]));
+        var reporter = new TestTelemetryReporter(LoggerFactory);
         var p3Value = Guid.NewGuid();
         reporter.ReportEvent("EventName",
             Severity.Normal,
@@ -92,7 +93,7 @@ public class TelemetryReporterTests
     [Fact]
     public void FourArguments()
     {
-        var reporter = new TestTelemetryReporter(new RazorLoggerFactory([]));
+        var reporter = new TestTelemetryReporter(LoggerFactory);
         var p3Value = Guid.NewGuid();
         reporter.ReportEvent("EventName",
             Severity.Normal,
@@ -122,7 +123,7 @@ public class TelemetryReporterTests
     [Fact]
     public void Block_NoArguments()
     {
-        var reporter = new TestTelemetryReporter(new RazorLoggerFactory([]));
+        var reporter = new TestTelemetryReporter(LoggerFactory);
         using (var scope = reporter.BeginBlock("EventName", Severity.Normal))
         {
         }
@@ -141,7 +142,7 @@ public class TelemetryReporterTests
     [Fact]
     public void Block_OneArgument()
     {
-        var reporter = new TestTelemetryReporter(new RazorLoggerFactory([]));
+        var reporter = new TestTelemetryReporter(LoggerFactory);
         using (reporter.BeginBlock("EventName", Severity.Normal, new Property("P1", false)))
         {
         }
@@ -161,7 +162,7 @@ public class TelemetryReporterTests
     [Fact]
     public void Block_TwoArguments()
     {
-        var reporter = new TestTelemetryReporter(new RazorLoggerFactory([]));
+        var reporter = new TestTelemetryReporter(LoggerFactory);
         using (reporter.BeginBlock("EventName", Severity.Normal, new("P1", false), new("P2", "test")))
         {
         }
@@ -182,7 +183,7 @@ public class TelemetryReporterTests
     [Fact]
     public void Block_ThreeArguments()
     {
-        var reporter = new TestTelemetryReporter(new RazorLoggerFactory([]));
+        var reporter = new TestTelemetryReporter(LoggerFactory);
         var p3Value = Guid.NewGuid();
         using (reporter.BeginBlock("EventName",
             Severity.Normal,
@@ -212,7 +213,7 @@ public class TelemetryReporterTests
     [Fact]
     public void Block_FourArguments()
     {
-        var reporter = new TestTelemetryReporter(new RazorLoggerFactory([]));
+        var reporter = new TestTelemetryReporter(LoggerFactory);
         var p3Value = Guid.NewGuid();
         using (reporter.BeginBlock("EventName",
             Severity.Normal,
@@ -245,7 +246,7 @@ public class TelemetryReporterTests
     [Fact]
     public void HandleRIEWithInnerException()
     {
-        var reporter = new TestTelemetryReporter(new RazorLoggerFactory([]));
+        var reporter = new TestTelemetryReporter(LoggerFactory);
 
         var ae = new ApplicationException("expectedText");
         var rie = new RemoteInvocationException("a", 0, ae);
@@ -267,7 +268,7 @@ public class TelemetryReporterTests
     [Fact]
     public void HandleRIEWithNoInnerException()
     {
-        var reporter = new TestTelemetryReporter(new RazorLoggerFactory([]));
+        var reporter = new TestTelemetryReporter(LoggerFactory);
 
         var rie = new RemoteInvocationException("a", 0, errorData: null);
 
@@ -288,7 +289,7 @@ public class TelemetryReporterTests
     [Fact]
     public void TrackLspRequest()
     {
-        var reporter = new TestTelemetryReporter(new RazorLoggerFactory([]));
+        var reporter = new TestTelemetryReporter(LoggerFactory);
         var correlationId = Guid.NewGuid();
         using (reporter.TrackLspRequest("MethodName", "ServerName", correlationId))
         {
@@ -328,7 +329,7 @@ public class TelemetryReporterTests
     public void ReportFault_OperationCanceledExceptionWithoutInnerException_SkipsFaultReport()
     {
         // Arrange
-        var reporter = new TestTelemetryReporter(new RazorLoggerFactory([]));
+        var reporter = new TestTelemetryReporter(LoggerFactory);
         var exception = new OperationCanceledException("OCE", innerException: null);
 
         // Act
@@ -342,7 +343,7 @@ public class TelemetryReporterTests
     public void ReportFault_TaskCanceledExceptionWithoutInnerException_SkipsFaultReport()
     {
         // Arrange
-        var reporter = new TestTelemetryReporter(new RazorLoggerFactory([]));
+        var reporter = new TestTelemetryReporter(LoggerFactory);
         var exception = new TaskCanceledException("TCE", innerException: null);
 
         // Act
@@ -357,7 +358,7 @@ public class TelemetryReporterTests
     {
         // Arrange
         var depth = 3;
-        var reporter = new TestTelemetryReporter(new RazorLoggerFactory([]));
+        var reporter = new TestTelemetryReporter(LoggerFactory);
         var innerMostException = new Exception();
         var exception = new OperationCanceledException("Test", innerMostException);
         for (var i = 0; i < depth; i++)
@@ -377,7 +378,7 @@ public class TelemetryReporterTests
     {
         // Arrange
         var depth = 3;
-        var reporter = new TestTelemetryReporter(new RazorLoggerFactory([]));
+        var reporter = new TestTelemetryReporter(LoggerFactory);
         var innerMostException = new OperationCanceledException();
         var exception = new OperationCanceledException("Test", innerMostException);
         for (var i = 0; i < depth; i++)


### PR DESCRIPTION
Part of #10127

`RazorLoggerFactory` is exported as a MEF part. This change removes that MEF export and exports it from the VS Layer.