### PR TITLE
Disable latest runtime patch

### DIFF
--- a/src/Razor/src/rzls/rzls.csproj
+++ b/src/Razor/src/rzls/rzls.csproj
@@ -46,10 +46,6 @@
   -->
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
-
-    <!-- Enable roll-forward to latest patch.  This allows one restore operation
-        to apply to all of the self-contained publish operations. -->
-    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
     <RollForward>LatestMajor</RollForward>
     <RidsPublishDir>$(ArtifactsDir)LanguageServer\$(Configuration)\</RidsPublishDir>
   </PropertyGroup>


### PR DESCRIPTION
With this setting, the runtime config will require 8.0.1 to be set. This can cause issues for those without the latest patch installed. Fixes https://github.com/dotnet/razor/issues/10130 

Now the runsettings look like 

```json
{
  "runtimeOptions": {
    "tfm": "net8.0",
    "rollForward": "LatestMajor",
    "framework": {
      "name": "Microsoft.NETCore.App",
      "version": "8.0.0"
    },
    "configProperties": {
      "System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization": false
    }
  }
}
```