### PR TITLE
Fix hot path string allocations from ProjectKey

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/FilePathNormalizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/FilePathNormalizer.cs
@@ -84,13 +84,7 @@ internal static class FilePathNormalizer
         var filePathSpan = filePath.AsSpan();
 
         using var _1 = ArrayPool<char>.Shared.GetPooledArray(filePathSpan.Length, out var array);
-        var normalizedSpan = NormalizeCoreAndGetSpan(filePathSpan, array);
-
-        var lastSlashIndex = normalizedSpan.LastIndexOf('/');
-
-        var directoryNameSpan = lastSlashIndex >= 0
-            ? normalizedSpan[..(lastSlashIndex + 1)] // Include trailing slash
-            : normalizedSpan;
+        var directoryNameSpan = NormalizeDirectoryNameCore(filePathSpan, array);
 
         if (filePathSpan.Equals(directoryNameSpan, StringComparison.Ordinal))
         {
@@ -100,7 +94,30 @@ internal static class FilePathNormalizer
         return CreateString(directoryNameSpan);
     }
 
-    public static bool FilePathsEquivalent(string? filePath1, string? filePath2)
+    public static bool AreDirectoryPathsEquivalent(string? filePath1, string? filePath2)
+    {
+        var filePathSpan1 = filePath1.AsSpanOrDefault();
+        var filePathSpan2 = filePath2.AsSpanOrDefault();
+
+        if (filePathSpan1.IsEmpty)
+        {
+            return filePathSpan2.IsEmpty;
+        }
+        else if (filePathSpan2.IsEmpty)
+        {
+            return false;
+        }
+
+        using var _1 = ArrayPool<char>.Shared.GetPooledArray(filePathSpan1.Length, out var array1);
+        var normalizedSpan1 = NormalizeDirectoryNameCore(filePathSpan1, array1);
+
+        using var _2 = ArrayPool<char>.Shared.GetPooledArray(filePathSpan2.Length, out var array2);
+        var normalizedSpan2 = NormalizeDirectoryNameCore(filePathSpan2, array2);
+
+        return normalizedSpan1.Equals(normalizedSpan2, FilePathComparison.Instance);
+    }
+
+    public static bool AreFilePathsEquivalent(string? filePath1, string? filePath2)
     {
         var filePathSpan1 = filePath1.AsSpanOrDefault();
         var filePathSpan2 = filePath2.AsSpanOrDefault();
@@ -149,6 +166,17 @@ internal static class FilePathNormalizer
     {
         var (start, length) = NormalizeCore(source, destination);
         return destination.Slice(start, length);
+    }
+
+    private static ReadOnlySpan<char> NormalizeDirectoryNameCore(ReadOnlySpan<char> source, Span<char> destination)
+    {
+        var normalizedSpan = NormalizeCoreAndGetSpan(source, destination);
+
+        var lastSlashIndex = normalizedSpan.LastIndexOf('/');
+
+        return lastSlashIndex >= 0
+            ? normalizedSpan[..(lastSlashIndex + 1)] // Include trailing slash
+            : normalizedSpan;
     }
 
     /// <summary>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/FilePathNormalizingComparer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/FilePathNormalizingComparer.cs
@@ -13,7 +13,7 @@ internal sealed class FilePathNormalizingComparer : IEqualityComparer<string>
     {
     }
 
-    public bool Equals(string? x, string? y) => FilePathNormalizer.FilePathsEquivalent(x, y);
+    public bool Equals(string? x, string? y) => FilePathNormalizer.AreFilePathsEquivalent(x, y);
 
     public int GetHashCode(string obj) => FilePathNormalizer.GetHashCode(obj);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectKey.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectKey.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Utilities;
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -19,7 +18,7 @@ internal readonly record struct ProjectKey
     // end up. All creation logic is here in one place to ensure this is consistent.
     public static ProjectKey From(HostProject hostProject) => new(hostProject.IntermediateOutputPath);
     public static ProjectKey From(IProjectSnapshot project) => new(project.IntermediateOutputPath);
-    public static ProjectKey? From(Project project)
+    public static ProjectKey From(Project project)
     {
         var intermediateOutputPath = FilePathNormalizer.GetNormalizedDirectoryName(project.CompilationOutputInfo.AssemblyPath);
         return new(intermediateOutputPath);
@@ -33,8 +32,8 @@ internal readonly record struct ProjectKey
     {
         Debug.Assert(id is not null, "Cannot create a key for null Id. Did you call ProjectKey.From(this) in a constructor, before initializing a property?");
         Debug.Assert(!id!.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase), "We expect the intermediate output path, not the project file");
-        // The null check in the assert means the compiler thinks we're lying about id being non-nullable.. which is fair I suppose.
-        Id = FilePathNormalizer.NormalizeDirectory(id).AssumeNotNull();
+
+        Id = FilePathNormalizer.NormalizeDirectory(id);
     }
 
     public override int GetHashCode()
@@ -45,5 +44,14 @@ internal readonly record struct ProjectKey
     public bool Equals(ProjectKey other)
     {
         return FilePathComparer.Instance.Equals(Id, other.Id);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> if this <see cref="ProjectKey"/> matches the given
+    /// <see cref="Project"/>.
+    /// </summary>
+    public bool Matches(Project project)
+    {
+        return FilePathNormalizer.AreDirectoryPathsEquivalent(Id, project.CompilationOutputInfo.AssemblyPath);
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectKey.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectKey.cs
@@ -47,11 +47,18 @@ internal readonly record struct ProjectKey
     }
 
     /// <summary>
-    /// Returns <see langword="true"/> if this <see cref="ProjectKey"/> matches the given
-    /// <see cref="Project"/>.
+    /// Returns <see langword="true"/> if this <see cref="ProjectKey"/> matches the given <see cref="Project"/>.
     /// </summary>
     public bool Matches(Project project)
     {
+        // In order to perform this check, we are relying on the fact that Id will always end with a '/',
+        // because it is guaranteed to be normalized. However, CompilationOutputInfo.AssemblyPath will
+        // contain the assembly file name, which AreDirectoryPathsEquivalent will shave off before comparing.
+        // So, AreDirectoryPathsEquivalent will return true when Id is "C:/my/project/path/"
+        // and the assembly path is "C:\my\project\path\assembly.dll"
+
+        Debug.Assert(Id.EndsWith('/'), $"This method can't be called if {nameof(Id)} is not a normalized directory path.");
+
         return FilePathNormalizer.AreDirectoryPathsEquivalent(Id, project.CompilationOutputInfo.AssemblyPath);
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteProjectSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteProjectSnapshot.cs
@@ -39,7 +39,7 @@ internal class RemoteProjectSnapshot : IProjectSnapshot
         _project = project;
         _documentSnapshotFactory = documentSnapshotFactory;
         _telemetryReporter = telemetryReporter;
-        _projectKey = ProjectKey.From(_project).AssumeNotNull();
+        _projectKey = ProjectKey.From(_project);
 
         _lazyConfiguration = new Lazy<RazorConfiguration>(CreateRazorConfiguration);
         _lazyProjectEngine = new Lazy<RazorProjectEngine>(() =>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SemanticTokens/RemoteCSharpSemanticTokensProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SemanticTokens/RemoteCSharpSemanticTokensProvider.cs
@@ -49,7 +49,7 @@ internal class RemoteCSharpSemanticTokensProvider(IFilePathService filePathServi
 
         // TODO: A real implementation needs to get the SourceGeneratedDocument from the solution
 
-        var projectKey = ProjectKey.From(razorDocument.Project).AssumeNotNull();
+        var projectKey = ProjectKey.From(razorDocument.Project);
         var generatedFilePath = _filePathService.GetRazorCSharpFilePath(projectKey, razorDocument.FilePath.AssumeNotNull());
         var generatedDocumentId = solution.GetDocumentIdsWithFilePath(generatedFilePath).First(d => d.ProjectId == razorDocument.Project.Id);
         var generatedDocument = solution.GetDocument(generatedDocumentId).AssumeNotNull();

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DynamicFiles/RazorDynamicFileInfoProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/DynamicFiles/RazorDynamicFileInfoProvider.cs
@@ -354,7 +354,7 @@ internal class RazorDynamicFileInfoProvider : IRazorDynamicFileInfoProviderInter
 
         foreach (var project in workspace.CurrentSolution.Projects)
         {
-            if (key.Equals(ProjectKey.From(project)))
+            if (key.Matches(project))
             {
                 return project.Id;
             }
@@ -363,20 +363,13 @@ internal class RazorDynamicFileInfoProvider : IRazorDynamicFileInfoProviderInter
         return null;
     }
 
-    public ProjectKey? TryFindProjectKeyForProjectId(ProjectId projectId)
+    private ProjectKey? TryFindProjectKeyForProjectId(ProjectId projectId)
     {
         var workspace = _workspaceProvider.GetWorkspace();
 
-        var project = workspace.CurrentSolution.GetProject(projectId);
-        if (project is null ||
-            project.Language != LanguageNames.CSharp)
-        {
-            return null;
-        }
-
-        var projectKey = ProjectKey.From(project);
-
-        return projectKey;
+        return workspace.CurrentSolution.GetProject(projectId) is { Language: LanguageNames.CSharp } project
+            ? ProjectKey.From(project)
+            : null;
     }
 
     private RazorDynamicFileInfo CreateEmptyInfo(Key key)

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/ProjectSystem/FallbackProjectManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/ProjectSystem/FallbackProjectManager.cs
@@ -166,10 +166,6 @@ internal sealed class FallbackProjectManager(
         }
 
         var projectKey = ProjectKey.From(project);
-        if (projectKey is not { } razorProjectKey)
-        {
-            return;
-        }
 
         var hostDocument = CreateHostDocument(filePath, projectFilePath);
         if (hostDocument is null)
@@ -178,7 +174,7 @@ internal sealed class FallbackProjectManager(
         }
 
         await UpdateProjectManagerAsync(
-                updater => updater.DocumentRemoved(razorProjectKey, hostDocument),
+                updater => updater.DocumentRemoved(projectKey, hostDocument),
                 cancellationToken)
             .ConfigureAwait(false);
     }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/WorkspaceProjectStateChangeDetector.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/WorkspaceProjectStateChangeDetector.cs
@@ -496,12 +496,7 @@ internal class WorkspaceProjectStateChangeDetector : IRazorStartupService, IDisp
             return false;
         }
 
-        // ProjectKey could be null, if Roslyn doesn't know the IntermediateOutputPath for the project
-        if (ProjectKey.From(project) is not { } projectKey)
-        {
-            projectSnapshot = null;
-            return false;
-        }
+        var projectKey = ProjectKey.From(project);
 
         return _projectManager.TryGetLoadedProject(projectKey, out projectSnapshot);
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/FilePathNormalizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/FilePathNormalizerTest.cs
@@ -11,7 +11,7 @@ namespace Microsoft.AspNetCore.Razor.ProjectEngineHost.Test;
 
 public class FilePathNormalizerTest(ITestOutputHelper testOutput) : ToolingTestBase(testOutput)
 {
-    [OSSkipConditionFact(new[] { "OSX", "Linux" })]
+    [OSSkipConditionFact(["OSX", "Linux"])]
     public void Normalize_Windows_StripsPrecedingSlash()
     {
         // Arrange
@@ -102,7 +102,7 @@ public class FilePathNormalizerTest(ITestOutputHelper testOutput) : ToolingTestB
         Assert.Equal("C:/path/to/directory/", normalized);
     }
 
-    [OSSkipConditionFact(new[] { "OSX", "Linux" })]
+    [OSSkipConditionFact(["OSX", "Linux"])]
     public void NormalizeDirectory_Windows_HandlesSingleSlashDirectory()
     {
         // Arrange
@@ -115,29 +115,49 @@ public class FilePathNormalizerTest(ITestOutputHelper testOutput) : ToolingTestB
         Assert.Equal("/", normalized);
     }
 
+    [Theory]
+    [InlineData("path/to/", "path/to/", true)]
+    [InlineData("path/to1/", "path/to2/", false)]
+    [InlineData("path/to/", "path/to/file.cs", true)]
+    [InlineData("path/to/file.cs", "path/to/file.cs", true)]
+    [InlineData("path/to/file1.cs", "path/to/file2.cs", true)]
+    [InlineData("path/to1/file.cs", "path/to2/file.cs", false)]
+    [InlineData("path/to/", @"path\to\", true)]
+    [InlineData("path/to1/", @"path\to2\", false)]
+    [InlineData("path/to/", @"path\to\file.cs", true)]
+    [InlineData("path/to/file.cs", @"path\to\file.cs", true)]
+    [InlineData("path/to/file1.cs", @"path\to\file2.cs", true)]
+    [InlineData("path/to1/file.cs", @"path\to2\file.cs", false)]
+    public void AreDirectoryPathsEquivalent(string path1, string path2, bool expected)
+    {
+        var result = FilePathNormalizer.AreDirectoryPathsEquivalent(path1, path2);
+
+        Assert.Equal(expected, result);
+    }
+
     [Fact]
-    public void FilePathsEquivalent_NotEqualPaths_ReturnsFalse()
+    public void AreFilePathsEquivalent_NotEqualPaths_ReturnsFalse()
     {
         // Arrange
         var filePath1 = "path/to/document.cshtml";
         var filePath2 = "path\\to\\different\\document.cshtml";
 
         // Act
-        var result = FilePathNormalizer.FilePathsEquivalent(filePath1, filePath2);
+        var result = FilePathNormalizer.AreFilePathsEquivalent(filePath1, filePath2);
 
         // Assert
         Assert.False(result);
     }
 
     [Fact]
-    public void FilePathsEquivalent_NormalizesPathsBeforeComparison_ReturnsTrue()
+    public void AreFilePathsEquivalent_NormalizesPathsBeforeComparison_ReturnsTrue()
     {
         // Arrange
         var filePath1 = "path/to/document.cshtml";
         var filePath2 = "path\\to\\document.cshtml";
 
         // Act
-        var result = FilePathNormalizer.FilePathsEquivalent(filePath1, filePath2);
+        var result = FilePathNormalizer.AreFilePathsEquivalent(filePath1, filePath2);
 
         // Assert
         Assert.True(result);
@@ -189,7 +209,7 @@ public class FilePathNormalizerTest(ITestOutputHelper testOutput) : ToolingTestB
         Assert.Equal("/", normalized);
     }
 
-    [OSSkipConditionFact(new[] { "Windows" })]
+    [OSSkipConditionFact(["Windows"])]
     public void Normalize_NonWindows_AddsLeadingForwardSlash()
     {
         // Arrange

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/PathUtilities.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/PathUtilities.cs
@@ -32,6 +32,6 @@ public static class PathUtilities
 
     public static void AssertEquivalent(string? expectedFilePath, string? actualFilePath)
     {
-        Assert.True(FilePathNormalizer.FilePathsEquivalent(expectedFilePath, actualFilePath));
+        Assert.True(FilePathNormalizer.AreFilePathsEquivalent(expectedFilePath, actualFilePath));
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/FallbackProjectManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/FallbackProjectManagerTest.cs
@@ -190,7 +190,7 @@ public class FallbackProjectManagerTest : VisualStudioWorkspaceTestBase
         Assert.Equal(SomeProjectFile1.TargetPath, project.GetDocument(SomeProjectFile1.FilePath)!.TargetPath);
         Assert.Equal(SomeProjectFile2.TargetPath, project.GetDocument(SomeProjectFile2.FilePath)!.TargetPath);
         // The test data is created with a "\" so when the test runs on Linux, and direct string comparison wouldn't work
-        Assert.True(FilePathNormalizer.FilePathsEquivalent(SomeProjectNestedComponentFile3.TargetPath, project.GetDocument(SomeProjectNestedComponentFile3.FilePath)!.TargetPath));
+        Assert.True(FilePathNormalizer.AreFilePathsEquivalent(SomeProjectNestedComponentFile3.TargetPath, project.GetDocument(SomeProjectNestedComponentFile3.FilePath)!.TargetPath));
     }
 
     [UIFact]

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectStateChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/WorkspaceProjectStateChangeDetectorTest.cs
@@ -211,9 +211,9 @@ public class WorkspaceProjectStateChangeDetectorTest : VisualStudioWorkspaceTest
 
         // Assert
         Assert.Equal(3, _workQueueTestAccessor.Work.Count);
-        Assert.Contains(_workQueueTestAccessor.Work, u => u.Key == ProjectKey.From(_projectNumberOne).Value.Id);
-        Assert.Contains(_workQueueTestAccessor.Work, u => u.Key == ProjectKey.From(_projectNumberTwo).Value.Id);
-        Assert.Contains(_workQueueTestAccessor.Work, u => u.Key == ProjectKey.From(_projectNumberThree).Value.Id);
+        Assert.Contains(_workQueueTestAccessor.Work, u => u.Key == ProjectKey.From(_projectNumberOne).Id);
+        Assert.Contains(_workQueueTestAccessor.Work, u => u.Key == ProjectKey.From(_projectNumberTwo).Id);
+        Assert.Contains(_workQueueTestAccessor.Work, u => u.Key == ProjectKey.From(_projectNumberThree).Id);
 
         _workQueueTestAccessor.BlockBackgroundWorkStart.Set();
         _workQueueTestAccessor.NotifyBackgroundWorkCompleted.Wait();
@@ -261,9 +261,9 @@ public class WorkspaceProjectStateChangeDetectorTest : VisualStudioWorkspaceTest
 
         // Assert
         Assert.Equal(3, _workQueueTestAccessor.Work.Count);
-        Assert.Contains(_workQueueTestAccessor.Work, u => u.Key == ProjectKey.From(_projectNumberOne).Value.Id);
-        Assert.Contains(_workQueueTestAccessor.Work, u => u.Key == ProjectKey.From(_projectNumberTwo).Value.Id);
-        Assert.Contains(_workQueueTestAccessor.Work, u => u.Key == ProjectKey.From(_projectNumberThree).Value.Id);
+        Assert.Contains(_workQueueTestAccessor.Work, u => u.Key == ProjectKey.From(_projectNumberOne).Id);
+        Assert.Contains(_workQueueTestAccessor.Work, u => u.Key == ProjectKey.From(_projectNumberTwo).Id);
+        Assert.Contains(_workQueueTestAccessor.Work, u => u.Key == ProjectKey.From(_projectNumberThree).Id);
 
         _workQueueTestAccessor.BlockBackgroundWorkStart.Set();
         _workQueueTestAccessor.NotifyBackgroundWorkCompleted.Wait();

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/StringExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/StringExtensions.cs
@@ -22,4 +22,8 @@ internal static class StringExtensions
     // This method doesn't exist on .NET Framework, but it does on .NET Core.
     public static bool Contains(this string s, char ch)
         => s.IndexOf(ch) >= 0;
+
+    // This method doesn't exist on .NET Framework, but it does on .NET Core.
+    public static bool EndsWith(this string s, char ch)
+        => s.Length > 0 && s[^1] == ch;
 }


### PR DESCRIPTION
@toddgrun pointed me to a fair amount of string allocation due `ProjectKey.From(Project)` being called repeatedly on a hot path. To address this, I've added `ProjectKey.Matches(Project)`, which simply compares the current key's `Id` with the project's intermediate output path. This uses a new `FilePathNormalizer.AreDirectoryPathsEquivalent(...)` helper to avoid allocating a new string.

![image](https://github.com/dotnet/razor/assets/116161/0efd9ffd-0405-4b03-b2d1-f8b2ac9d0c6e)
