### PR TITLE
Switch Razor to using clasp as a source package

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,4 +13,5 @@ while [[ -h $source ]]; do
 done
 
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
+. "$scriptroot/eng/nuget-workaround.sh" $@
 "$scriptroot/eng/common/build.sh" --restore --build --pack $@

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -11,80 +11,80 @@
       <Sha>c0b5d69a1a1513528c77fffff708c7502d57c35c</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.10.0-3.24169.7">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.10.0-3.24170.4">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>98cd097bf122677378692ebe952b71ab6e5bb013</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CommonLanguageServerProtocol.Framework" Version="4.10.0-3.24169.7">
+    <Dependency Name="Microsoft.CommonLanguageServerProtocol.Framework" Version="4.10.0-3.24170.4">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>98cd097bf122677378692ebe952b71ab6e5bb013</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.ExternalAccess.Razor" Version="4.10.0-3.24169.7">
+    <Dependency Name="Microsoft.CodeAnalysis.ExternalAccess.Razor" Version="4.10.0-3.24170.4">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>98cd097bf122677378692ebe952b71ab6e5bb013</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Common" Version="4.10.0-3.24169.7">
+    <Dependency Name="Microsoft.CodeAnalysis.Common" Version="4.10.0-3.24170.4">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>98cd097bf122677378692ebe952b71ab6e5bb013</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.10.0-3.24169.7">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.10.0-3.24170.4">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>98cd097bf122677378692ebe952b71ab6e5bb013</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.EditorFeatures" Version="4.10.0-3.24169.7">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.EditorFeatures" Version="4.10.0-3.24170.4">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>98cd097bf122677378692ebe952b71ab6e5bb013</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="4.10.0-3.24169.7">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="4.10.0-3.24170.4">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>98cd097bf122677378692ebe952b71ab6e5bb013</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.10.0-3.24169.7">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.10.0-3.24170.4">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>98cd097bf122677378692ebe952b71ab6e5bb013</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures" Version="4.10.0-3.24169.7">
+    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures" Version="4.10.0-3.24170.4">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>98cd097bf122677378692ebe952b71ab6e5bb013</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Common" Version="4.10.0-3.24169.7">
+    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Common" Version="4.10.0-3.24170.4">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>98cd097bf122677378692ebe952b71ab6e5bb013</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Text" Version="4.10.0-3.24169.7">
+    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Text" Version="4.10.0-3.24170.4">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>98cd097bf122677378692ebe952b71ab6e5bb013</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Wpf" Version="4.10.0-3.24169.7">
+    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Wpf" Version="4.10.0-3.24170.4">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>98cd097bf122677378692ebe952b71ab6e5bb013</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Remote.ServiceHub" Version="4.10.0-3.24169.7">
+    <Dependency Name="Microsoft.CodeAnalysis.Remote.ServiceHub" Version="4.10.0-3.24170.4">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>98cd097bf122677378692ebe952b71ab6e5bb013</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.10.0-3.24169.7">
+    <Dependency Name="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.10.0-3.24170.4">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>98cd097bf122677378692ebe952b71ab6e5bb013</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.10.0-3.24169.7">
+    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.10.0-3.24170.4">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>98cd097bf122677378692ebe952b71ab6e5bb013</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.10.0-3.24169.7">
+    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.10.0-3.24170.4">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>98cd097bf122677378692ebe952b71ab6e5bb013</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.VisualStudio.LanguageServices" Version="4.10.0-3.24169.7">
+    <Dependency Name="Microsoft.VisualStudio.LanguageServices" Version="4.10.0-3.24170.4">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>98cd097bf122677378692ebe952b71ab6e5bb013</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Test.Utilities" Version="4.10.0-3.24169.7">
+    <Dependency Name="Microsoft.CodeAnalysis.Test.Utilities" Version="4.10.0-3.24170.4">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>98cd097bf122677378692ebe952b71ab6e5bb013</Sha>
     </Dependency>
     <!-- Intermediate is necessary for source build. -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.roslyn" Version="4.10.0-3.24169.7">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.roslyn" Version="4.10.0-3.24170.4">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>98cd097bf122677378692ebe952b71ab6e5bb013</Sha>
       <SourceBuild RepoName="roslyn" ManagedOnly="true" />

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -53,25 +53,25 @@
     <MicrosoftSourceBuildIntermediatearcadePackageVersion>8.0.0-beta.24165.4</MicrosoftSourceBuildIntermediatearcadePackageVersion>
     <MicrosoftDotNetXliffTasksPackageVersion>1.0.0-beta.23475.1</MicrosoftDotNetXliffTasksPackageVersion>
     <MicrosoftSourceBuildIntermediatexlifftasksPackageVersion>1.0.0-beta.23475.1</MicrosoftSourceBuildIntermediatexlifftasksPackageVersion>
-    <MicrosoftNetCompilersToolsetPackageVersion>4.10.0-3.24169.7</MicrosoftNetCompilersToolsetPackageVersion>
-    <MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>4.10.0-3.24169.7</MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>
-    <MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>4.10.0-3.24169.7</MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>
-    <MicrosoftCodeAnalysisCommonPackageVersion>4.10.0-3.24169.7</MicrosoftCodeAnalysisCommonPackageVersion>
-    <MicrosoftCodeAnalysisCSharpPackageVersion>4.10.0-3.24169.7</MicrosoftCodeAnalysisCSharpPackageVersion>
-    <MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion>4.10.0-3.24169.7</MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.10.0-3.24169.7</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>4.10.0-3.24169.7</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
-    <MicrosoftCodeAnalysisEditorFeaturesPackageVersion>4.10.0-3.24169.7</MicrosoftCodeAnalysisEditorFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisEditorFeaturesCommonPackageVersion>4.10.0-3.24169.7</MicrosoftCodeAnalysisEditorFeaturesCommonPackageVersion>
-    <MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>4.10.0-3.24169.7</MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>
-    <MicrosoftCodeAnalysisEditorFeaturesWpfPackageVersion>4.10.0-3.24169.7</MicrosoftCodeAnalysisEditorFeaturesWpfPackageVersion>
-    <MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>4.10.0-3.24169.7</MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>
-    <MicrosoftCodeAnalysisTestUtilitiesPackageVersion>4.10.0-3.24169.7</MicrosoftCodeAnalysisTestUtilitiesPackageVersion>
-    <MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>4.10.0-3.24169.7</MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>
-    <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>4.10.0-3.24169.7</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
-    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.10.0-3.24169.7</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
-    <MicrosoftSourceBuildIntermediateroslynPackageVersion>4.10.0-3.24169.7</MicrosoftSourceBuildIntermediateroslynPackageVersion>
-    <MicrosoftVisualStudioLanguageServicesPackageVersion>4.10.0-3.24169.7</MicrosoftVisualStudioLanguageServicesPackageVersion>
+    <MicrosoftNetCompilersToolsetPackageVersion>4.10.0-3.24170.4</MicrosoftNetCompilersToolsetPackageVersion>
+    <MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>4.10.0-3.24170.4</MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>
+    <MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>4.10.0-3.24170.4</MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>
+    <MicrosoftCodeAnalysisCommonPackageVersion>4.10.0-3.24170.4</MicrosoftCodeAnalysisCommonPackageVersion>
+    <MicrosoftCodeAnalysisCSharpPackageVersion>4.10.0-3.24170.4</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion>4.10.0-3.24170.4</MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.10.0-3.24170.4</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>4.10.0-3.24170.4</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisEditorFeaturesPackageVersion>4.10.0-3.24170.4</MicrosoftCodeAnalysisEditorFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisEditorFeaturesCommonPackageVersion>4.10.0-3.24170.4</MicrosoftCodeAnalysisEditorFeaturesCommonPackageVersion>
+    <MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>4.10.0-3.24170.4</MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>
+    <MicrosoftCodeAnalysisEditorFeaturesWpfPackageVersion>4.10.0-3.24170.4</MicrosoftCodeAnalysisEditorFeaturesWpfPackageVersion>
+    <MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>4.10.0-3.24170.4</MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>
+    <MicrosoftCodeAnalysisTestUtilitiesPackageVersion>4.10.0-3.24170.4</MicrosoftCodeAnalysisTestUtilitiesPackageVersion>
+    <MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>4.10.0-3.24170.4</MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>4.10.0-3.24170.4</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.10.0-3.24170.4</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
+    <MicrosoftSourceBuildIntermediateroslynPackageVersion>4.10.0-3.24170.4</MicrosoftSourceBuildIntermediateroslynPackageVersion>
+    <MicrosoftVisualStudioLanguageServicesPackageVersion>4.10.0-3.24170.4</MicrosoftVisualStudioLanguageServicesPackageVersion>
     <!--
       Exception - Microsoft.Extensions.ObjectPool and System.Collections.Immutable packages are not updated by automation,
       but are present in Version.Details.xml for source-build PVP flow. See the comment in Version.Details.xml for more information.

--- a/eng/cibuild.sh
+++ b/eng/cibuild.sh
@@ -13,4 +13,5 @@ while [[ -h $source ]]; do
 done
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 
+. "$scriptroot/nuget-workaround.sh" --ci $@
 . "$scriptroot/common/build.sh" --ci $@

--- a/eng/nuget-workaround.sh
+++ b/eng/nuget-workaround.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# This works around an issue where .editorconfigs in nuget packages are not respected if the NUGET_PACKAGES
+# environment variable does not end with a slash.  We copy the logic for setting the NUGET_PACKAGES variable from the eng/common/tools.sh
+# script as we cannot modify the script itself (its arcade managed).
+# This workaround is only required for non-windows builds as the powershell versions of the arcade scripts already ensure a trailing slash is present.
+# Tracking https://github.com/dotnet/roslyn/issues/72657
+ci=false
+while [[ $# > 0 ]]; do
+  opt="$(echo "${1/#--/-}" | tr "[:upper:]" "[:lower:]")"
+  case "$opt" in
+    -ci)
+      ci=true
+      break
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+if [[ "$ci" == true ]]; then
+  if [[ -z ${NUGET_PACKAGES:-} ]]; then
+    if [[ "$ci" == true ]]; then
+      export NUGET_PACKAGES="$HOME/.nuget/packages/"
+    else
+      export NUGET_PACKAGES="$repo_root/.packages/"
+      export RESTORENOCACHE=true
+    fi
+  fi
+fi

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Microsoft.AspNetCore.Razor.LanguageServer.csproj
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Microsoft.AspNetCore.Razor.LanguageServer.csproj
@@ -21,7 +21,7 @@
   <ItemGroup>
     <!-- Need this reference to avoid 'The C# language is not supported' error during formatting. -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)" />
-    <PackageReference Include="Microsoft.CommonLanguageServerProtocol.Framework" Version="$(MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion)" />
+    <PackageReference Include="Microsoft.CommonLanguageServerProtocol.Framework" Version="$(MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsPackageVersion)" />

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -219,12 +219,12 @@ internal partial class RazorLanguageServer : AbstractLanguageServer<RazorRequest
     }
 
     // Internal for testing
-    internal TestAccessor GetTestAccessor()
+    internal new TestAccessor GetTestAccessor()
     {
         return new TestAccessor(this);
     }
 
-    internal class TestAccessor
+    internal new class TestAccessor
     {
         private RazorLanguageServer _server;
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorRequestExecutionQueue.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorRequestExecutionQueue.cs
@@ -68,12 +68,12 @@ internal class RazorRequestExecutionQueue : RequestExecutionQueue<RazorRequestCo
     }
 
     // Internal for testing
-    internal TestAccessor GetTestAccessor()
+    internal new TestAccessor GetTestAccessor()
     {
         return new TestAccessor(this);
     }
 
-    internal class TestAccessor
+    internal new class TestAccessor
     {
         private RazorRequestExecutionQueue _queue;
 

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/AssemblyCodeBases.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/AssemblyCodeBases.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.VisualStudio.Shell;
 
-[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.CommonLanguageServerProtocol.Framework.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Extensions.ObjectPool.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Extensions.Options.dll")]
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Extensions.Primitives.dll")]

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
@@ -282,7 +282,6 @@
   <!-- Include our Razor package dependency dlls in our extension -->
   <ItemGroup>
     <RazorNgendVSIXSourceItem Include="$(OutputPath)Microsoft.CodeAnalysis.Razor.Compiler.dll" />
-    <RazorNgendVSIXSourceItem Include="$(OutputPath)Microsoft.CommonLanguageServerProtocol.Framework.dll" />
 
     <VSIXSourceItem Include="@(RazorNgendVSIXSourceItem)">
       <Ngen>$(Ngen)</Ngen>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/source.extension.vsixmanifest
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/source.extension.vsixmanifest
@@ -41,7 +41,6 @@
     <Asset Type="Microsoft.ServiceHub.Service" d:Source="File" Path="ServiceHubCore\Microsoft.VisualStudio.Razor.ClientInitializationCore64.servicehub.service.json" />
     <Asset Type="Microsoft.ServiceHub.Service" d:Source="File" Path="ServiceHubCore\Microsoft.VisualStudio.Razor.ClientInitializationCore64S.servicehub.service.json" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.CodeAnalysis.Razor.Compiler.dll" />
-    <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.CommonLanguageServerProtocol.Framework.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.ObjectPool.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.Options.dll" />
     <Asset Type="Microsoft.VisualStudio.Assembly" Path="Microsoft.Extensions.Primitives.dll" />

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/WebTools.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/WebTools.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+extern alias LegacyClasp;
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -240,8 +242,27 @@ internal static class WebTools
             BufferManager bufferManager,
             ILspLogger logger)
         {
-            var instance = CreateInstance(Type, textBufferFactoryService, bufferManager.Instance, logger);
+            var instance = CreateInstance(Type, textBufferFactoryService, bufferManager.Instance, new LegacyClaspILspLogger(logger));
             return new(instance);
+        }
+
+        /// <summary>
+        /// Wraps the razor logger (from the clasp source package) into the binary clasp logger that webtools uses.
+        /// </summary>
+        /// <param name="logger"></param>
+        private class LegacyClaspILspLogger(ILspLogger logger) : LegacyClasp.Microsoft.CommonLanguageServerProtocol.Framework.ILspLogger
+        {
+            public void LogEndContext(string message, params object[] @params) => logger.LogEndContext(message, @params);
+
+            public void LogError(string message, params object[] @params) => logger.LogError(message, @params);
+
+            public void LogException(Exception exception, string? message = null, params object[] @params) => logger.LogException(exception, message, @params);
+
+            public void LogInformation(string message, params object[] @params) => logger.LogInformation(message, @params);
+
+            public void LogStartContext(string message, params object[] @params) => logger.LogStartContext(message, @params);
+
+            public void LogWarning(string message, params object[] @params) => logger.LogWarning(message, @params);
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Microsoft.AspNetCore.Razor.LanguageServer.Test.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Microsoft.AspNetCore.Razor.LanguageServer.Test.csproj
@@ -6,6 +6,18 @@
     <!-- To generate baselines, run tests with /p:GenerateBaselines=true -->
     <DefineConstants Condition="'$(GenerateBaselines)'=='true'">$(DefineConstants);GENERATE_BASELINES</DefineConstants>
     <DefineConstants>$(DefineConstants);__RemoveThisBitTo__GENERATE_BASELINES</DefineConstants>
+
+    <!--
+      Some tests instantiate and run handlers from the webtools packages.
+      However, the webtools packages currently require the binary version of clasp (they haven't been updated yet).
+      In order to run them, we need to ensure that the clasp binary version is available.  Below we use the PackageDownload
+      feature to download the package and include it in the output (we can't use a package reference because it would conflict with the source package version).
+
+      We also reference the package in this project using an alias - some of the webtools types we instantiate take clasp binary types as parameter, which we have to create.
+
+      This should be removed once we can upgrade to new webtools package versions that use the source package version of clasp.
+    -->
+    <LegacyClaspVersion>4.7.0-1.23178.15</LegacyClaspVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -27,6 +39,17 @@
     <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" Version="$(MicrosoftVisualStudioShellPackagesVersion)" />
     <PackageReference Include="Microsoft.VisualStudio.Web" Version="$(MicrosoftVisualStudioWebPackageVersion)" />
     <PackageReference Include="Microsoft.WebTools.Shared" Version="$(MicrosoftWebToolsSharedPackageVersion)" />
+  </ItemGroup>
+
+  <!-- Ensure the legacy clasp binary package is available downloaded so we can drop it in the output folder. -->
+  <ItemGroup>
+    <PackageDownload Include="Microsoft.CommonLanguageServerProtocol.Framework" Version="[$(LegacyClaspVersion)]" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="$(NuGetPackageRoot)\microsoft.commonlanguageserverprotocol.framework\$(LegacyClaspVersion)\lib\netstandard2.0\Microsoft.CommonLanguageServerProtocol.Framework.dll">
+      <Private>true</Private>
+      <Aliases>LegacyClasp</Aliases>
+    </Reference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
﻿### Summary of the changes
Now that https://github.com/dotnet/roslyn/pull/72237 has merged on the Roslyn side, we need to update Razor to consume the source package version.  This will allow us to delete the nuget package version

-

Fixes:
