### PR TITLE
Simple logging in OOP to TraceSource

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentMapping/RemoteDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentMapping/RemoteDocumentMappingService.cs
@@ -3,9 +3,9 @@
 
 using System.Composition;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
+using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
-using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor.DocumentMapping;
 
@@ -13,10 +13,11 @@ namespace Microsoft.CodeAnalysis.Remote.Razor.DocumentMapping;
 [method: ImportingConstructor]
 internal sealed class RemoteDocumentMappingService(
     IFilePathService filePathService,
-    IDocumentContextFactory documentContextFactory)
+    IDocumentContextFactory documentContextFactory,
+    IRazorLoggerFactory loggerFactory)
     : AbstractRazorDocumentMappingService(
         filePathService,
         documentContextFactory,
-        NullLogger.Instance) // TODO: Logging
+        loggerFactory.CreateLogger<RemoteDocumentMappingService>())
 {
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Logging/RemoteLoggerFactory.Logger.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Logging/RemoteLoggerFactory.Logger.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.CodeAnalysis.Remote.Razor.Logging;
+
+internal partial class RemoteLoggerFactory
+{
+    private class Logger(string categoryName) : ILogger
+    {
+        public IDisposable BeginScope<TState>(TState state) => Scope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (s_traceSource is null)
+            {
+                // We can't log if there is no trace source to log to
+                return;
+            }
+
+            var formattedResult = formatter(state, exception);
+
+            switch (logLevel)
+            {
+                case LogLevel.Information:
+                    s_traceSource.TraceEvent(TraceEventType.Information, id: 0, "[{0}] {1}", categoryName, formattedResult);
+                    break;
+                case LogLevel.Trace:
+                case LogLevel.Debug:
+                    s_traceSource.TraceEvent(TraceEventType.Verbose, id: 0, "[{0}] {1}", categoryName, formattedResult);
+                    break;
+                case LogLevel.Warning:
+                    s_traceSource.TraceEvent(TraceEventType.Warning, id: 0, "[{0}] {1}", categoryName, formattedResult);
+                    break;
+                case LogLevel.Error:
+                case LogLevel.Critical:
+                    s_traceSource.TraceEvent(TraceEventType.Error, id: 0, "[{0}] {1} {2}", categoryName, formattedResult, exception!);
+                    break;
+            }
+        }
+
+        private class Scope : IDisposable
+        {
+            public static readonly Scope Instance = new();
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Logging/RemoteLoggerFactory.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Logging/RemoteLoggerFactory.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Composition;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.Razor.Logging;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.CodeAnalysis.Remote.Razor.Logging;
+
+[Export(typeof(IRazorLoggerFactory)), Shared]
+[method: ImportingConstructor]
+internal partial class RemoteLoggerFactory() : IRazorLoggerFactory
+{
+    private static TraceSource? s_traceSource;
+
+    internal static void Initialize(TraceSource traceSource)
+    {
+        s_traceSource ??= traceSource;
+    }
+
+    public void AddLoggerProvider(IRazorLoggerProvider provider)
+    {
+        throw new System.NotImplementedException();
+    }
+
+    public ILogger CreateLogger(string categoryName)
+    {
+        return new Logger(categoryName);
+    }
+
+    public void Dispose()
+    {
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorServiceFactoryBase.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorServiceFactoryBase.cs
@@ -2,10 +2,12 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.IO.Pipelines;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.Remote.Razor.Logging;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.ServiceHub.Framework.Services;
 using Microsoft.VisualStudio.Composition;
@@ -43,6 +45,9 @@ internal abstract partial class RazorServiceFactoryBase<TService> : IServiceHubS
     {
         // Dispose the AuthorizationServiceClient since we won't be using it
         authorizationServiceClient?.Dispose();
+
+        var traceSource = (TraceSource)hostProvidedServices.GetService(typeof(TraceSource));
+        RemoteLoggerFactory.Initialize(traceSource);
 
         return CreateAsync(stream.UsePipe(), serviceBroker);
     }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SemanticTokens/RazorSemanticTokensInfoService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SemanticTokens/RazorSemanticTokensInfoService.cs
@@ -3,9 +3,11 @@
 
 using System.Composition;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
+using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.SemanticTokens;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
-using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.CodeAnalysis.Remote.Razor.DocumentMapping;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor.SemanticTokens;
 
@@ -15,12 +17,13 @@ internal class RazorSemanticTokensInfoService(
     IRazorDocumentMappingService documentMappingService,
     ISemanticTokensLegendService semanticTokensLegendService,
     ICSharpSemanticTokensProvider csharpSemanticTokensProvider,
-    LanguageServerFeatureOptions languageServerFeatureOptions)
+    LanguageServerFeatureOptions languageServerFeatureOptions,
+    IRazorLoggerFactory loggerFactory)
     : AbstractRazorSemanticTokensInfoService(
         documentMappingService,
         semanticTokensLegendService,
-        csharpSemanticTokensProvider,
+csharpSemanticTokensProvider,
         languageServerFeatureOptions,
-        NullLogger.Instance) // TODO: Logging
+        loggerFactory.CreateLogger<RemoteDocumentMappingService>())
 {
 }


### PR DESCRIPTION
One of the follow up items in https://github.com/dotnet/razor/issues/10103

Part of https://github.com/dotnet/razor/issues/9519

I would like to improve this in future a bit, but for now just doing this simple logger will at least get us logs attached to feedback issues, and on our hard drives during development.