### PR TITLE
Add more logging when recording feedback

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Logging/IRazorLogHubTraceProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Logging/IRazorLogHubTraceProvider.cs
@@ -7,8 +7,8 @@ using System.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.Editor.Razor.Logging;
 
-internal abstract class RazorLogHubTraceProvider
+internal interface IRazorLogHubTraceProvider
 {
-    public abstract Task InitializeTraceAsync(string logIdentifier, int logHubSessionId, CancellationToken cancellationToken);
-    public abstract TraceSource? TryGetTraceSource();
+    Task InitializeTraceAsync(string logIdentifier, int logHubSessionId, CancellationToken cancellationToken);
+    TraceSource? TryGetTraceSource();
 }

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Settings/ClientSettingsManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Settings/ClientSettingsManager.cs
@@ -20,18 +20,13 @@ namespace Microsoft.VisualStudio.Editor.Razor.Settings;
 internal class ClientSettingsManager : IClientSettingsManager, IDisposable
 {
     public event EventHandler<ClientSettingsChangedEventArgs>? ClientSettingsChanged;
+    public event EventHandler<bool>? FeedbackRecordingChanged;
 
     private readonly object _settingsUpdateLock = new();
+
+    private readonly FeedbackRecordingWatcher _feedbackRecordingWatcher = new();
     private readonly IAdvancedSettingsStorage? _advancedSettingsStorage;
     private readonly RazorGlobalOptions? _globalOptions;
-    private readonly string _vsFeedbackSemaphoreFullPath;
-    private readonly int _vsProcessId;
-    private readonly DateTime _vsProcessStartTime;
-    private FileSystemWatcher? _vsFeedbackSemaphoreFileWatcher;
-    private int _isFeedbackBeingRecorded;
-
-    private const string VSFeedbackSemaphoreDir = @"Microsoft\VSFeedbackCollector";
-    private const string VSFeedbackSemaphoreFileName = "feedback.recording.json";
 
     [ImportingConstructor]
     public ClientSettingsManager(
@@ -61,45 +56,11 @@ internal class ClientSettingsManager : IClientSettingsManager, IDisposable
             Update(_advancedSettingsStorage.GetAdvancedSettings());
             _advancedSettingsStorage.OnChangedAsync(Update).Forget();
         }
-
-        // Set up logic to determine if a user is recording feedback.
-        // This is done by a few things:
-        // 1. VS uses a semaphore file on start/stop of recording. Make a file watcher for that file
-        // 2. Since multiple VS instances could be running, we want to make sure we're collecting only for the correct one. The file has the PID that we can compare against
-        // 3. Use the process start time as a simple check to avoid reading files that were created before this instance of VS was running
-        var vsProcess = Process.GetCurrentProcess();
-        _vsProcessId = vsProcess.Id;
-        _vsProcessStartTime = vsProcess.StartTime;
-
-        var tempDir = Path.GetTempPath();
-        var vsFeedbackTempDir = Path.Combine(tempDir, VSFeedbackSemaphoreDir);
-        _vsFeedbackSemaphoreFullPath = Path.Combine(vsFeedbackTempDir, VSFeedbackSemaphoreFileName);
-
-        // Directory may not exist in scenarios such as Razor integration tests
-        if (!Directory.Exists(vsFeedbackTempDir))
-        {
-            return;
-        }
-
-        _vsFeedbackSemaphoreFileWatcher = new FileSystemWatcher(vsFeedbackTempDir, VSFeedbackSemaphoreFileName);
-        _vsFeedbackSemaphoreFileWatcher.Created += (_, _) => OnFeedbackSemaphoreCreatedOrChanged();
-        _vsFeedbackSemaphoreFileWatcher.Changed += (_, _) => OnFeedbackSemaphoreCreatedOrChanged();
-        _vsFeedbackSemaphoreFileWatcher.Deleted += (_, _) => OnFeedbackSemaphoreDeleted();
-
-        // If the file exists on setup, check to see if it's actually the correct. It's possible a user started feedback before
-        // the razor package was loaded.
-        if (File.Exists(_vsFeedbackSemaphoreFullPath))
-        {
-            OnFeedbackSemaphoreCreatedOrChanged();
-        }
-
-        _vsFeedbackSemaphoreFileWatcher.EnableRaisingEvents = true;
     }
 
     public ClientSettings ClientSettings { get; private set; }
 
-    public bool IsFeedbackBeingRecorded => _isFeedbackBeingRecorded == 1;
-    public event EventHandler<bool>? FeedbackRecordingChanged;
+    public bool IsFeedbackBeingRecorded => _feedbackRecordingWatcher.IsFeedbackBeingRecorded;
 
     public bool ShouldLog(LogLevel logLevel)
         => IsFeedbackBeingRecorded
@@ -162,73 +123,8 @@ internal class ClientSettingsManager : IClientSettingsManager, IDisposable
         }
     }
 
-    private void OnFeedbackSemaphoreDeleted()
-    {
-        Interlocked.Exchange(ref _isFeedbackBeingRecorded, 0);
-        FeedbackRecordingChanged?.Invoke(this, false);
-    }
-
-    private void OnFeedbackSemaphoreCreatedOrChanged()
-    {
-        if (!IsLoggingEnabledForCurrentVisualStudioInstance(_vsFeedbackSemaphoreFullPath))
-        {
-            // The semaphore file was created for another VS instance.
-            return;
-        }
-
-        Interlocked.Exchange(ref _isFeedbackBeingRecorded, 1);
-        FeedbackRecordingChanged?.Invoke(this, true);
-        
-    }
-
-    private bool IsLoggingEnabledForCurrentVisualStudioInstance(string semaphoreFilePath)
-    {
-        try
-        {
-            if (_vsProcessStartTime > File.GetCreationTime(semaphoreFilePath))
-            {
-                // Semaphore file is older than the running instance of VS
-                return false;
-            }
-
-            // Check the contents of the semaphore file to see if it's for this instance of VS.
-            // Reading can hit contention so attempt a few times before bailing
-            string? content = null;
-            for (var i = 0; i < 5; i++)
-            {
-                try
-                {
-                    content = File.ReadAllText(semaphoreFilePath);
-                }
-                catch (IOException)
-                {
-                }
-
-                if (content is not null)
-                {
-                    break;
-                }
-            }
-
-            if (content is null)
-            {
-                return false;
-            }
-
-            var node = JsonNode.Parse(content);
-            return node?["processIds"] is JsonArray pids
-                && pids.Any(n => n?.GetValue<int>() == _vsProcessId);
-        }
-        catch
-        {
-            // Something went wrong opening or parsing the semaphore file - ignore it
-            return false;
-        }
-    }
-
     public void Dispose()
     {
-        (var fileWatcher, _vsFeedbackSemaphoreFileWatcher) = (_vsFeedbackSemaphoreFileWatcher, null);
-        fileWatcher?.Dispose();
+        _feedbackRecordingWatcher.Dispose();
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Settings/ClientSettingsManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Settings/ClientSettingsManager.cs
@@ -4,21 +4,34 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.Json.Nodes;
+using System.Threading;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Microsoft.CodeAnalysis.Razor.Settings;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.Threading;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.VisualStudio.Editor.Razor.Settings;
 
 [Export(typeof(IClientSettingsManager))]
-internal class ClientSettingsManager : IClientSettingsManager
+internal class ClientSettingsManager : IClientSettingsManager, IDisposable
 {
     public event EventHandler<ClientSettingsChangedEventArgs>? ClientSettingsChanged;
 
     private readonly object _settingsUpdateLock = new();
     private readonly IAdvancedSettingsStorage? _advancedSettingsStorage;
     private readonly RazorGlobalOptions? _globalOptions;
+    private readonly string _vsFeedbackSemaphoreFullPath;
+    private readonly int _vsProcessId;
+    private readonly DateTime _vsProcessStartTime;
+    private FileSystemWatcher? _vsFeedbackSemaphoreFileWatcher;
+    private int _isFeedbackBeingRecorded;
+    private const string VSFeedbackSemaphoreDir = @"Microsoft\VSFeedbackCollector";
+    private const string VSFeedbackSemaphoreFileName = "feedback.recording.json";
 
     [ImportingConstructor]
     public ClientSettingsManager(
@@ -48,12 +61,48 @@ internal class ClientSettingsManager : IClientSettingsManager
             Update(_advancedSettingsStorage.GetAdvancedSettings());
             _advancedSettingsStorage.OnChangedAsync(Update).Forget();
         }
+
+        // Set up logic to determine if a user is recording feedback.
+        // This is done by a few things:
+        // 1. VS uses a semaphore file on start/stop of recording. Make a file watcher for that file
+        // 2. Since multiple VS instances could be running, we want to make sure we're collecting only for the correct one. The file has the PID that we can compare against
+        // 3. Use the process start time as a simple check to avoid reading files that were created before this instance of VS was running
+        var vsProcess = Process.GetCurrentProcess();
+        _vsProcessId = vsProcess.Id;
+        _vsProcessStartTime = vsProcess.StartTime;
+
+        var tempDir = Path.GetTempPath();
+        var vsFeedbackTempDir = Path.Combine(tempDir, VSFeedbackSemaphoreDir);
+        _vsFeedbackSemaphoreFullPath = Path.Combine(vsFeedbackTempDir, VSFeedbackSemaphoreFileName);
+
+        // Directory may not exist in scenarios such as Razor integration tests
+        if (!Directory.Exists(vsFeedbackTempDir))
+        {
+            return;
+        }
+
+        _vsFeedbackSemaphoreFileWatcher = new FileSystemWatcher(vsFeedbackTempDir, VSFeedbackSemaphoreFileName);
+        _vsFeedbackSemaphoreFileWatcher.Created += (_, _) => OnFeedbackSemaphoreCreatedOrChanged();
+        _vsFeedbackSemaphoreFileWatcher.Changed += (_, _) => OnFeedbackSemaphoreCreatedOrChanged();
+        _vsFeedbackSemaphoreFileWatcher.Deleted += (_, _) => OnFeedbackSemaphoreDeleted();
+
+        // If the file exists on setup, check to see if it's actually the correct. It's possible a user started feedback before
+        // the razor package was loaded.
+        if (File.Exists(_vsFeedbackSemaphoreFullPath))
+        {
+            OnFeedbackSemaphoreCreatedOrChanged();
+        }
+
+        _vsFeedbackSemaphoreFileWatcher.EnableRaisingEvents = true;
     }
 
     public ClientSettings ClientSettings { get; private set; }
 
-    public bool IsLogLevelEnabled(LogLevel logLevel)
-        => logLevel >= ClientSettings.AdvancedSettings.LogLevel;
+    public bool IsFeedbackBeingRecorded => _isFeedbackBeingRecorded == 1;
+
+    public bool ShouldLog(LogLevel logLevel)
+        => IsFeedbackBeingRecorded
+        || logLevel >= ClientSettings.AdvancedSettings.LogLevel;
 
     public void Update(ClientSpaceSettings updatedSettings)
     {
@@ -110,5 +159,51 @@ internal class ClientSettingsManager : IClientSettingsManager
             var args = new ClientSettingsChangedEventArgs(ClientSettings);
             ClientSettingsChanged?.Invoke(this, args);
         }
+    }
+
+    private void OnFeedbackSemaphoreDeleted()
+    {
+        Interlocked.Exchange(ref _isFeedbackBeingRecorded, 0);
+    }
+
+    private void OnFeedbackSemaphoreCreatedOrChanged()
+    {
+        if (!IsLoggingEnabledForCurrentVisualStudioInstance(_vsFeedbackSemaphoreFullPath))
+        {
+            // The semaphore file was created for another VS instance.
+            return;
+        }
+
+        Interlocked.Exchange(ref _isFeedbackBeingRecorded, 1);
+    }
+
+    private bool IsLoggingEnabledForCurrentVisualStudioInstance(string semaphoreFilePath)
+    {
+        try
+        {
+            if (_vsProcessStartTime > File.GetCreationTime(semaphoreFilePath))
+            {
+                // Semaphore file is older than the running instance of VS
+                return false;
+            }
+
+            // Check the contents of the semaphore file to see if it's for this instance of VS
+            var content = File.ReadAllText(semaphoreFilePath);
+            var node = JsonNode.Parse(content);
+            return node?["processIds"] is JsonNode pidNode
+                && pidNode.GetValueKind() == System.Text.Json.JsonValueKind.Array
+                && pidNode.GetValue<int[]>().Contains(_vsProcessId);
+        }
+        catch
+        {
+            // Something went wrong opening or parsing the semaphore file - ignore it
+            return false;
+        }
+    }
+
+    public void Dispose()
+    {
+        (var fileWatcher, _vsFeedbackSemaphoreFileWatcher) = (_vsFeedbackSemaphoreFileWatcher, null);
+        fileWatcher?.Dispose();
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Settings/ClientSettingsManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Settings/ClientSettingsManager.cs
@@ -99,6 +99,7 @@ internal class ClientSettingsManager : IClientSettingsManager, IDisposable
     public ClientSettings ClientSettings { get; private set; }
 
     public bool IsFeedbackBeingRecorded => _isFeedbackBeingRecorded == 1;
+    public event EventHandler<bool>? FeedbackRecordingChanged;
 
     public bool ShouldLog(LogLevel logLevel)
         => IsFeedbackBeingRecorded
@@ -164,6 +165,7 @@ internal class ClientSettingsManager : IClientSettingsManager, IDisposable
     private void OnFeedbackSemaphoreDeleted()
     {
         Interlocked.Exchange(ref _isFeedbackBeingRecorded, 0);
+        FeedbackRecordingChanged?.Invoke(this, false);
     }
 
     private void OnFeedbackSemaphoreCreatedOrChanged()
@@ -175,6 +177,8 @@ internal class ClientSettingsManager : IClientSettingsManager, IDisposable
         }
 
         Interlocked.Exchange(ref _isFeedbackBeingRecorded, 1);
+        FeedbackRecordingChanged?.Invoke(this, true);
+        
     }
 
     private bool IsLoggingEnabledForCurrentVisualStudioInstance(string semaphoreFilePath)

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Settings/FeedbackRecordingWatcher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Settings/FeedbackRecordingWatcher.cs
@@ -1,0 +1,131 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.IO;
+using System;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Diagnostics;
+
+namespace Microsoft.VisualStudio.Editor.Razor.Settings;
+
+internal class FeedbackRecordingWatcher : IDisposable
+{
+    public event EventHandler<bool>? FeedbackRecordingChanged;
+    public bool IsFeedbackBeingRecorded => _isFeedbackBeingRecorded == 1;
+
+    private readonly string _vsFeedbackSemaphoreFullPath;
+    private readonly int _vsProcessId;
+    private readonly DateTime _vsProcessStartTime;
+    private FileSystemWatcher? _vsFeedbackSemaphoreFileWatcher;
+    private int _isFeedbackBeingRecorded;
+
+    private const string VSFeedbackSemaphoreDir = @"Microsoft\VSFeedbackCollector";
+    private const string VSFeedbackSemaphoreFileName = "feedback.recording.json";
+
+    public FeedbackRecordingWatcher()
+    {
+        // Set up logic to determine if a user is recording feedback.
+        // This is done by a few things:
+        // 1. VS uses a semaphore file on start/stop of recording. Make a file watcher for that file
+        // 2. Since multiple VS instances could be running, we want to make sure we're collecting only for the correct one. The file has the PID that we can compare against
+        // 3. Use the process start time as a simple check to avoid reading files that were created before this instance of VS was running
+        var vsProcess = Process.GetCurrentProcess();
+        _vsProcessId = vsProcess.Id;
+        _vsProcessStartTime = vsProcess.StartTime;
+
+        var tempDir = Path.GetTempPath();
+        var vsFeedbackTempDir = Path.Combine(tempDir, VSFeedbackSemaphoreDir);
+        _vsFeedbackSemaphoreFullPath = Path.Combine(vsFeedbackTempDir, VSFeedbackSemaphoreFileName);
+
+        // Directory may not exist in scenarios such as Razor integration tests
+        if (!Directory.Exists(vsFeedbackTempDir))
+        {
+            return;
+        }
+
+        _vsFeedbackSemaphoreFileWatcher = new FileSystemWatcher(vsFeedbackTempDir, VSFeedbackSemaphoreFileName);
+        _vsFeedbackSemaphoreFileWatcher.Created += (_, _) => OnFeedbackSemaphoreCreatedOrChanged();
+        _vsFeedbackSemaphoreFileWatcher.Changed += (_, _) => OnFeedbackSemaphoreCreatedOrChanged();
+        _vsFeedbackSemaphoreFileWatcher.Deleted += (_, _) => OnFeedbackSemaphoreDeleted();
+
+        // If the file exists on setup, check to see if it's actually the correct. It's possible a user started feedback before
+        // the razor package was loaded.
+        if (File.Exists(_vsFeedbackSemaphoreFullPath))
+        {
+            OnFeedbackSemaphoreCreatedOrChanged();
+        }
+
+        _vsFeedbackSemaphoreFileWatcher.EnableRaisingEvents = true;
+    }
+
+    public void Dispose()
+    {
+        (var fileWatcher, _vsFeedbackSemaphoreFileWatcher) = (_vsFeedbackSemaphoreFileWatcher, null);
+        fileWatcher?.Dispose();
+    }
+
+    private void OnFeedbackSemaphoreDeleted()
+    {
+        Interlocked.Exchange(ref _isFeedbackBeingRecorded, 0);
+        FeedbackRecordingChanged?.Invoke(this, false);
+    }
+
+    private void OnFeedbackSemaphoreCreatedOrChanged()
+    {
+        if (!IsLoggingEnabledForCurrentVisualStudioInstance(_vsFeedbackSemaphoreFullPath))
+        {
+            // The semaphore file was created for another VS instance.
+            return;
+        }
+
+        Interlocked.Exchange(ref _isFeedbackBeingRecorded, 1);
+        FeedbackRecordingChanged?.Invoke(this, true);
+
+    }
+
+    private bool IsLoggingEnabledForCurrentVisualStudioInstance(string semaphoreFilePath)
+    {
+        try
+        {
+            if (_vsProcessStartTime > File.GetCreationTime(semaphoreFilePath))
+            {
+                // Semaphore file is older than the running instance of VS
+                return false;
+            }
+
+            // Check the contents of the semaphore file to see if it's for this instance of VS.
+            // Reading can hit contention so attempt a few times before bailing
+            string? content = null;
+            for (var i = 0; i < 5; i++)
+            {
+                try
+                {
+                    content = File.ReadAllText(semaphoreFilePath);
+                }
+                catch (IOException)
+                {
+                }
+
+                if (content is not null)
+                {
+                    break;
+                }
+            }
+
+            if (content is null)
+            {
+                return false;
+            }
+
+            var node = JsonNode.Parse(content);
+            return node?["processIds"] is JsonArray pids
+                && pids.Any(n => n?.GetValue<int>() == _vsProcessId);
+        }
+        catch
+        {
+            // Something went wrong opening or parsing the semaphore file - ignore it
+            return false;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Settings/IClientSettingsManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Settings/IClientSettingsManager.cs
@@ -9,12 +9,16 @@ namespace Microsoft.VisualStudio.Editor.Razor.Settings;
 
 internal interface IClientSettingsManager
 {
+    bool IsFeedbackBeingRecorded { get; }
     ClientSettings ClientSettings { get; }
     event EventHandler<ClientSettingsChangedEventArgs> ClientSettingsChanged;
 
     void Update(ClientSpaceSettings updateSettings);
     void Update(ClientCompletionSettings updateSettings);
     void Update(ClientAdvancedSettings updateSettings);
-    bool IsLogLevelEnabled(LogLevel logLevel);
 
+    /// <summary>
+    /// Returns true if <see cref="IsFeedbackBeingRecorded"/> or if the level is >= <see cref="ClientAdvancedSettings.LogLevel"/>
+    /// </summary>
+    bool ShouldLog(LogLevel logLevel);
 }

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Settings/IClientSettingsManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Settings/IClientSettingsManager.cs
@@ -10,6 +10,8 @@ namespace Microsoft.VisualStudio.Editor.Razor.Settings;
 internal interface IClientSettingsManager
 {
     bool IsFeedbackBeingRecorded { get; }
+    event EventHandler<bool> FeedbackRecordingChanged;
+
     ClientSettings ClientSettings { get; }
     event EventHandler<ClientSettingsChangedEventArgs> ClientSettingsChanged;
 

--- a/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Settings/IClientSettingsManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.Editor.Razor/Settings/IClientSettingsManager.cs
@@ -3,16 +3,18 @@
 
 using System;
 using Microsoft.CodeAnalysis.Razor.Settings;
+using Microsoft.Extensions.Logging;
 
 namespace Microsoft.VisualStudio.Editor.Razor.Settings;
 
 internal interface IClientSettingsManager
 {
-    ClientSettings GetClientSettings();
+    ClientSettings ClientSettings { get; }
+    event EventHandler<ClientSettingsChangedEventArgs> ClientSettingsChanged;
 
     void Update(ClientSpaceSettings updateSettings);
     void Update(ClientCompletionSettings updateSettings);
     void Update(ClientAdvancedSettings updateSettings);
+    bool IsLogLevelEnabled(LogLevel logLevel);
 
-    event EventHandler<ClientSettingsChangedEventArgs> ClientSettingsChanged;
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Endpoints/WorkspaceConfiguration.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Endpoints/WorkspaceConfiguration.cs
@@ -30,7 +30,7 @@ internal partial class RazorCustomMessageTarget
             // we want to support Razor and HTML settings as well.
             var setting = item.Section switch
             {
-                "vs.editor.razor" => _editorSettingsManager.GetClientSettings(),
+                "vs.editor.razor" => _editorSettingsManager.ClientSettings,
                 _ => new object()
             };
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Logging/RazorLogHubLogger.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Logging/RazorLogHubLogger.cs
@@ -26,7 +26,7 @@ internal sealed class RazorLogHubLogger : ILogger
     public IDisposable BeginScope<TState>(TState state) => Scope.Instance;
 
     public bool IsEnabled(LogLevel logLevel)
-        => _clientSettingsManager.IsLogLevelEnabled(logLevel);
+        => _clientSettingsManager.ShouldLog(logLevel);
 
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
     {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Logging/RazorLogHubLogger.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Logging/RazorLogHubLogger.cs
@@ -6,26 +6,27 @@ using System.Diagnostics;
 using Microsoft.AspNetCore.Razor.LanguageServer;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.Editor.Razor.Logging;
+using Microsoft.VisualStudio.Editor.Razor.Settings;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Logging;
 
 internal sealed class RazorLogHubLogger : ILogger
 {
     private string _categoryName;
-    private RazorLogHubTraceProvider _traceProvider;
+    private IRazorLogHubTraceProvider _traceProvider;
+    private readonly IClientSettingsManager _clientSettingsManager;
 
-    public RazorLogHubLogger(string categoryName, RazorLogHubTraceProvider traceProvider)
+    public RazorLogHubLogger(string categoryName, IRazorLogHubTraceProvider traceProvider, IClientSettingsManager clientSettingsManager)
     {
         _categoryName = categoryName;
         _traceProvider = traceProvider;
+        _clientSettingsManager = clientSettingsManager;
     }
 
     public IDisposable BeginScope<TState>(TState state) => Scope.Instance;
 
     public bool IsEnabled(LogLevel logLevel)
-    {
-        return true;
-    }
+        => _clientSettingsManager.IsLogLevelEnabled(logLevel);
 
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
     {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Logging/RazorLogHubLoggerProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/Logging/RazorLogHubLoggerProvider.cs
@@ -5,23 +5,26 @@ using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.Editor.Razor.Logging;
+using Microsoft.VisualStudio.Editor.Razor.Settings;
 
 namespace Microsoft.VisualStudio.LanguageServerClient.Razor.Logging;
 
 [Export(typeof(IRazorLoggerProvider))]
 internal sealed class RazorLogHubLoggerProvider : IRazorLoggerProvider
 {
-    private readonly RazorLogHubTraceProvider _traceProvider;
+    private readonly IRazorLogHubTraceProvider _traceProvider;
+    private readonly IClientSettingsManager _clientSettingsManager;
 
     [ImportingConstructor]
-    public RazorLogHubLoggerProvider(RazorLogHubTraceProvider traceProvider)
+    public RazorLogHubLoggerProvider(IRazorLogHubTraceProvider traceProvider, IClientSettingsManager clientSettingsManager)
     {
         _traceProvider = traceProvider;
+        _clientSettingsManager = clientSettingsManager;
     }
 
     public ILogger CreateLogger(string categoryName)
     {
-        return new RazorLogHubLogger(categoryName, _traceProvider);
+        return new RazorLogHubLogger(categoryName, _traceProvider, _clientSettingsManager);
     }
 
     public void Dispose()

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorDocumentOptionsService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorDocumentOptionsService.cs
@@ -39,7 +39,7 @@ internal sealed class RazorDocumentOptionsService : IRazorDocumentOptionsService
         }
 
         // TO-DO: We should switch to a per-document implementation once Razor starts supporting .editorconfig.
-        var editorSettings = _editorSettingsManager.GetClientSettings().ClientSpaceSettings;
+        var editorSettings = _editorSettingsManager.ClientSettings.ClientSpaceSettings;
         return Task.FromResult<IRazorDocumentOptions>(new RazorDocumentOptions(document, editorSettings));
     }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServerClient.Razor/RazorLanguageServerClient.cs
@@ -38,7 +38,7 @@ internal class RazorLanguageServerClient(
     LSPRequestInvoker requestInvoker,
     ProjectConfigurationFilePathStore projectConfigurationFilePathStore,
     IRazorLoggerFactory razorLoggerFactory,
-    RazorLogHubTraceProvider traceProvider,
+    IRazorLogHubTraceProvider traceProvider,
     LanguageServerFeatureOptions languageServerFeatureOptions,
     ProjectSnapshotManagerDispatcher projectSnapshotManagerDispatcher,
     ILanguageClientBroker languageClientBroker,
@@ -62,7 +62,7 @@ internal class RazorLanguageServerClient(
     private readonly VisualStudioHostServicesProvider _vsHostWorkspaceServicesProvider = vsHostWorkspaceServicesProvider ?? throw new ArgumentNullException(nameof(vsHostWorkspaceServicesProvider));
     private readonly ProjectSnapshotManagerDispatcher _projectSnapshotManagerDispatcher = projectSnapshotManagerDispatcher ?? throw new ArgumentNullException(nameof(projectSnapshotManagerDispatcher));
     private readonly IRazorLoggerFactory _razorLoggerFactory = razorLoggerFactory ?? throw new ArgumentNullException(nameof(razorLoggerFactory));
-    private readonly RazorLogHubTraceProvider _traceProvider = traceProvider ?? throw new ArgumentNullException(nameof(traceProvider));
+    private readonly IRazorLogHubTraceProvider _traceProvider = traceProvider ?? throw new ArgumentNullException(nameof(traceProvider));
 
     private RazorLanguageServerWrapper? _server;
 
@@ -103,7 +103,7 @@ internal class RazorLanguageServerClient(
 
         var traceSource = _traceProvider.TryGetTraceSource();
 
-        var lspOptions = RazorLSPOptions.From(_clientSettingsManager.GetClientSettings());
+        var lspOptions = RazorLSPOptions.From(_clientSettingsManager.ClientSettings);
 
         _server = RazorLanguageServerWrapper.Create(
             serverStream,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/OutputWindowLoggerProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/OutputWindowLoggerProvider.cs
@@ -56,7 +56,7 @@ internal class OutputWindowLoggerProvider(
         }
 
         public bool IsEnabled(LogLevel logLevel)
-            => _clientSettingsManager.IsLogLevelEnabled(logLevel);
+            => _clientSettingsManager.ShouldLog(logLevel);
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
         {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/OutputWindowLoggerProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/OutputWindowLoggerProvider.cs
@@ -56,9 +56,7 @@ internal class OutputWindowLoggerProvider(
         }
 
         public bool IsEnabled(LogLevel logLevel)
-        {
-            return logLevel >= _clientSettingsManager.GetClientSettings().AdvancedSettings.LogLevel;
-        }
+            => _clientSettingsManager.IsLogLevelEnabled(logLevel);
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
         {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/VisualStudioFeedbackLoggerProvider.InMemoryBuffer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/VisualStudioFeedbackLoggerProvider.InMemoryBuffer.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+using System.Threading;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor.Logging;
+
+internal partial class VisualStudioFeedbackLoggerProvider
+{
+    /// <summary>
+    /// A circular in memory buffer to store logs in memory. The intent is
+    /// to lazily allocate the buffer as needed, provide a <see cref="ToString"/> method
+    /// for human readability of logs, and prepare the memory for garbage collection
+    /// on call to <see cref="Clear"/>
+    /// </summary>
+    private class InMemoryBuffer(int bufferSize)
+    {
+        private Lazy<string[]> _memory = new (() => new string[bufferSize]);
+
+        // Start at -1 because append always increments, so we want to start at value 0
+        private int _head = -1;
+
+        public void Append(string s)
+        {
+            var position = Interlocked.Increment(ref _head) % _memory.Value.Length;
+            _memory.Value[position] = s;
+        }
+
+        public void Clear()
+        {
+            Interlocked.Exchange(ref _memory, new Lazy<string[]>(() => new string[bufferSize]));
+        }
+
+        public override string ToString()
+        {
+            var (memory, position) = (_memory.Value, _head);
+            var sb = new StringBuilder(memory.Length);
+
+            for (var i = 0; i < memory.Length; i++)
+            {
+                sb.AppendLine(memory[position % memory.Length]);
+                position = (position + 1) % memory.Length;
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/VisualStudioFeedbackLoggerProvider.InMemoryLogger.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/VisualStudioFeedbackLoggerProvider.InMemoryLogger.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.Editor.Razor.Settings;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor.Logging;
+
+internal partial class VisualStudioFeedbackLoggerProvider
+{
+    private class InMemoryLogger(InMemoryBuffer buffer, string categoryName, IClientSettingsManager clientSettingsManager) : ILogger
+    {
+        private readonly InMemoryBuffer _buffer = buffer;
+        private readonly string _categoryName = categoryName;
+        private readonly IClientSettingsManager _clientSettingsManager = clientSettingsManager;
+
+        public IDisposable BeginScope<TState>(TState state)
+            => Scope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel)
+            => _clientSettingsManager.IsFeedbackBeingRecorded;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            if (IsEnabled(logLevel))
+            {
+                _buffer.Append($"{DateTime.Now:h:mm:ss.fff} [{_categoryName}] {formatter(state, exception)}");
+                if (exception is not null)
+                {
+                    _buffer.Append(exception.ToString());
+                }
+            }
+        }
+
+        private class Scope : IDisposable
+        {
+            public static Scope Instance = new();
+
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/VisualStudioFeedbackLoggerProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/VisualStudioFeedbackLoggerProvider.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
 using System.ComponentModel.Composition;
 using System.Threading;
 using Microsoft.CodeAnalysis.Razor.Logging;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/VisualStudioFeedbackLoggerProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/VisualStudioFeedbackLoggerProvider.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Threading;
+using Microsoft.CodeAnalysis.Razor.Logging;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.Editor.Razor.Settings;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor.Logging;
+
+[Export(typeof(IRazorLoggerProvider))]
+internal partial class VisualStudioFeedbackLoggerProvider : IRazorLoggerProvider
+{
+    private const int BufferSize = 5000;
+    private InMemoryBuffer _buffer = new(BufferSize);
+    private readonly IClientSettingsManager _clientSettingsManager;
+
+    [ImportingConstructor]
+    public VisualStudioFeedbackLoggerProvider(IClientSettingsManager clientSettingsManager)
+    {
+        _clientSettingsManager = clientSettingsManager;
+        _clientSettingsManager.FeedbackRecordingChanged += OnFeedbackRecordingChanged;
+    }
+
+    private void OnFeedbackRecordingChanged(object sender, bool isFeedbackRecording)
+    {
+        if (!isFeedbackRecording)
+        {
+            Interlocked.Exchange(ref _buffer, new(BufferSize));
+        }
+    }
+
+    public ILogger CreateLogger(string categoryName)
+    {
+        return new InMemoryLogger(_buffer, categoryName, _clientSettingsManager);
+    }
+
+    public void Dispose()
+    {
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/VisualStudioWindowsLogHubTraceProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/VisualStudioWindowsLogHubTraceProvider.cs
@@ -12,11 +12,11 @@ using VSShell = Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.LanguageServices.Razor.Logging;
 
-[Export(typeof(RazorLogHubTraceProvider))]
-internal class VisualStudioWindowsLogHubTraceProvider : RazorLogHubTraceProvider
+[Export(typeof(IRazorLogHubTraceProvider))]
+internal class VisualStudioWindowsLogHubTraceProvider : IRazorLogHubTraceProvider
 {
     private static readonly LoggerOptions s_logOptions = new(
-        requestedLoggingLevel: new LoggingLevelSettings(SourceLevels.Information | SourceLevels.ActivityTracing),
+        requestedLoggingLevel: new LoggingLevelSettings(SourceLevels.All),
         privacySetting: PrivacyFlags.MayContainPersonallyIdentifibleInformation | PrivacyFlags.MayContainPrivateInformation);
 
     private readonly SemaphoreSlim _initializationSemaphore;
@@ -28,7 +28,7 @@ internal class VisualStudioWindowsLogHubTraceProvider : RazorLogHubTraceProvider
         _initializationSemaphore = new SemaphoreSlim(initialCount: 1, maxCount: 1);
     }
 
-    public override async Task InitializeTraceAsync(string logIdentifier, int logHubSessionId, CancellationToken cancellationToken)
+    public async Task InitializeTraceAsync(string logIdentifier, int logHubSessionId, CancellationToken cancellationToken)
     {
         if ((await TryInitializeServiceBrokerAsync(cancellationToken).ConfigureAwait(false)) is false)
         {
@@ -43,7 +43,7 @@ internal class VisualStudioWindowsLogHubTraceProvider : RazorLogHubTraceProvider
         _traceSource = await traceConfig.RegisterLogSourceAsync(logId, s_logOptions, cancellationToken).ConfigureAwait(false);
     }
 
-    public override TraceSource? TryGetTraceSource()
+    public TraceSource? TryGetTraceSource()
     {
         return _traceSource;
     }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/OutOfProcSemanticTokensService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/OutOfProcSemanticTokensService.cs
@@ -39,7 +39,7 @@ internal class OutOfProcSemanticTokensService(IRemoteClientProvider remoteClient
 
         try
         {
-            var colorBackground = _clientSettingsManager.GetClientSettings().AdvancedSettings.ColorBackground;
+            var colorBackground = _clientSettingsManager.ClientSettings.AdvancedSettings.ColorBackground;
 
             var data = await remoteClient.TryInvokeAsync<IRemoteSemanticTokensService, int[]?>(
                 razorDocument.Project.Solution,

--- a/src/Razor/src/Microsoft.VisualStudio.LegacyEditor.Razor/Settings/WorkspaceEditorSettings.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LegacyEditor.Razor/Settings/WorkspaceEditorSettings.cs
@@ -24,7 +24,7 @@ internal sealed class WorkspaceEditorSettings : IWorkspaceEditorSettings
         _onClientSettingsChanged = OnClientSettingsChanged;
     }
 
-    public ClientSettings Current => _clientSettingsManager.GetClientSettings();
+    public ClientSettings Current => _clientSettingsManager.ClientSettings;
 
     private void OnClientSettingsChanged(object sender, ClientSettingsChangedEventArgs e)
     {

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
@@ -98,7 +98,7 @@ internal sealed class RazorPackage : AsyncPackage
         // LogHub can be initialized off the UI thread
         await TaskScheduler.Default;
 
-        var traceProvider = componentModel.GetService<RazorLogHubTraceProvider>();
+        var traceProvider = componentModel.GetService<IRazorLogHubTraceProvider>();
         await traceProvider.InitializeTraceAsync("Razor", 1, cancellationToken);
     }
 

--- a/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Settings/ClientSettingsManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Editor.Razor.Test/Settings/ClientSettingsManagerTest.cs
@@ -38,7 +38,7 @@ public class ClientSettingsManagerTest(ITestOutputHelper testOutput) : VisualStu
         var manager = new ClientSettingsManager(_clientSettingsChangeTriggers);
 
         // Assert
-        Assert.Equal(ClientSettings.Default, manager.GetClientSettings());
+        Assert.Equal(ClientSettings.Default, manager.ClientSettings);
     }
 
     [Fact]
@@ -55,7 +55,7 @@ public class ClientSettingsManagerTest(ITestOutputHelper testOutput) : VisualStu
 
         // Assert
         Assert.True(called);
-        Assert.Equal(settings, manager.GetClientSettings().ClientSpaceSettings);
+        Assert.Equal(settings, manager.ClientSettings.ClientSpaceSettings);
     }
 
     [Fact]
@@ -65,14 +65,14 @@ public class ClientSettingsManagerTest(ITestOutputHelper testOutput) : VisualStu
         var manager = new ClientSettingsManager(_clientSettingsChangeTriggers);
         var called = false;
         manager.ClientSettingsChanged += (caller, args) => called = true;
-        var originalSettings = manager.GetClientSettings();
+        var originalSettings = manager.ClientSettings;
 
         // Act
         manager.Update(ClientSpaceSettings.Default);
 
         // Assert
         Assert.False(called);
-        Assert.Same(originalSettings, manager.GetClientSettings());
+        Assert.Same(originalSettings, manager.ClientSettings);
     }
 
     [Fact]
@@ -89,7 +89,7 @@ public class ClientSettingsManagerTest(ITestOutputHelper testOutput) : VisualStu
 
         // Assert
         Assert.True(called);
-        Assert.Equal(settings, manager.GetClientSettings().AdvancedSettings);
+        Assert.Equal(settings, manager.ClientSettings.AdvancedSettings);
     }
 
     [Fact]
@@ -99,14 +99,14 @@ public class ClientSettingsManagerTest(ITestOutputHelper testOutput) : VisualStu
         var manager = new ClientSettingsManager(_clientSettingsChangeTriggers);
         var called = false;
         manager.ClientSettingsChanged += (caller, args) => called = true;
-        var originalSettings = manager.GetClientSettings();
+        var originalSettings = manager.ClientSettings;
 
         // Act
         manager.Update(ClientAdvancedSettings.Default);
 
         // Assert
         Assert.False(called);
-        Assert.Same(originalSettings, manager.GetClientSettings());
+        Assert.Same(originalSettings, manager.ClientSettings);
     }
 
     [Fact]
@@ -120,7 +120,7 @@ public class ClientSettingsManagerTest(ITestOutputHelper testOutput) : VisualStu
 
         var manager = new ClientSettingsManager(_clientSettingsChangeTriggers, new AdvancedSettingsStorage(expectedSettings));
 
-        Assert.Same(expectedSettings, manager.GetClientSettings().AdvancedSettings);
+        Assert.Same(expectedSettings, manager.ClientSettings.AdvancedSettings);
     }
 
     private class TestChangeTrigger : IClientSettingsChangedTrigger

--- a/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/Settings/WorkspaceEditorSettingsTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/Settings/WorkspaceEditorSettingsTest.cs
@@ -26,8 +26,7 @@ public class WorkspaceEditorSettingsTest(ITestOutputHelper testOutput) : VisualS
 
         var settingsManagerMock = new StrictMock<IClientSettingsManager>();
         settingsManagerMock
-            .Setup(x => x.GetClientSettings())
-            .Returns(expectedSettings);
+            .SetupGet(x => x.ClientSettings == expectedSettings);
 
         // Act
         var editorSettings = new WorkspaceEditorSettings(settingsManagerMock.Object);
@@ -42,8 +41,7 @@ public class WorkspaceEditorSettingsTest(ITestOutputHelper testOutput) : VisualS
         // Arrange
         var settingsManagerMock = new StrictMock<IClientSettingsManager>();
         settingsManagerMock
-            .Setup(x => x.GetClientSettings())
-            .Returns(ClientSettings.Default);
+            .SetupGet(x => x.ClientSettings == ClientSettings.Default);
 
         var editorSettings = new WorkspaceEditorSettings(settingsManagerMock.Object);
         var settingsAccessor = new TestAccessor(editorSettings);


### PR DESCRIPTION
Apologies in advance, the commits are chaos as I was figuring things out. This pr should do the following: 

1. Add a property and event on IClientSettings showing if feedback is being recording. 
2. Up logging on LogHub and OutputWindowLogger if IsFeedbackBeingCollected is true
3. Add a specific in memory logger that keeps up to 5k messages in memory while feedback is being collected 
4. Fix IClientSettings to have a ClientSettings as a property since it no longer allocates a new item. 
