### PR TITLE
Insert release/dev17.10 to VS main for now

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -60,7 +60,7 @@
         "Shipping",
         "NonShipping"
       ],
-      "vsBranch": "rel/d17.10",
+      "vsBranch": "main",
       "vsMajorVersion": 17,
       "insertionCreateDraftPR": false,
       "insertionTitlePrefix": "[17.10 P3]"


### PR DESCRIPTION
I always forget that when we snap a branch we want to insert it to main for a bit until VS also snaps on their side.