### PR TITLE
Minor OOP service cleanup

### DIFF
--- a/Razor.sln
+++ b/Razor.sln
@@ -62,6 +62,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{4CAC99E0
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		NuGet.config = NuGet.config
+		eng\targets\Services.props = eng\targets\Services.props
 		SpellingExclusions.dic = SpellingExclusions.dic
 		eng\Versions.props = eng\Versions.props
 	EndProjectSection

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Initialization/RemoteClientInitializationService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Initialization/RemoteClientInitializationService.cs
@@ -10,13 +10,10 @@ using Microsoft.ServiceHub.Framework;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor;
 
-internal sealed class RemoteClientInitializationService : RazorServiceBase, IRemoteClientInitializationService
+internal sealed class RemoteClientInitializationService(
+    IServiceBroker serviceBroker)
+    : RazorServiceBase(serviceBroker), IRemoteClientInitializationService
 {
-    internal RemoteClientInitializationService(IServiceBroker serviceBroker)
-        : base(serviceBroker)
-    {
-    }
-
     public ValueTask InitializeAsync(RemoteClientInitializationOptions options, CancellationToken cancellationToken)
         => RazorBrokeredServiceImplementation.RunServiceAsync(_ =>
             {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/TagHelpers/RemoteTagHelperProviderService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/TagHelpers/RemoteTagHelperProviderService.cs
@@ -4,7 +4,6 @@
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.AspNetCore.Razor.Serialization;
@@ -13,21 +12,17 @@ using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Api;
 using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.ServiceHub.Framework;
-using Microsoft.VisualStudio.Composition;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor;
 
-internal sealed class RemoteTagHelperProviderService : RazorServiceBase, IRemoteTagHelperProviderService
+internal sealed class RemoteTagHelperProviderService(
+    IServiceBroker serviceBroker,
+    RemoteTagHelperResolver tagHelperResolver,
+    RemoteTagHelperDeltaProvider tagHelperDeltaProvider)
+    : RazorServiceBase(serviceBroker), IRemoteTagHelperProviderService
 {
-    private readonly RemoteTagHelperResolver _tagHelperResolver;
-    private readonly RemoteTagHelperDeltaProvider _tagHelperDeltaProvider;
-
-    internal RemoteTagHelperProviderService(IServiceBroker serviceBroker, ExportProvider exportProvider)
-        : base(serviceBroker)
-    {
-        _tagHelperResolver = exportProvider.GetExportedValue<RemoteTagHelperResolver>().AssumeNotNull();
-        _tagHelperDeltaProvider = exportProvider.GetExportedValue<RemoteTagHelperDeltaProvider>().AssumeNotNull();
-    }
+    private readonly RemoteTagHelperResolver _tagHelperResolver = tagHelperResolver;
+    private readonly RemoteTagHelperDeltaProvider _tagHelperDeltaProvider = tagHelperDeltaProvider;
 
     public ValueTask<FetchTagHelpersResult> FetchTagHelpersAsync(
         RazorPinnedSolutionInfoWrapper solutionInfo,

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/TagHelpers/RemoteTagHelperProviderServiceFactory.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/TagHelpers/RemoteTagHelperProviderServiceFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using Microsoft.AspNetCore.Razor;
 using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio.Composition;
@@ -16,5 +17,9 @@ internal sealed class RemoteTagHelperProviderServiceFactory : RazorServiceFactor
     }
 
     protected override IRemoteTagHelperProviderService CreateService(IServiceBroker serviceBroker, ExportProvider exportProvider)
-        => new RemoteTagHelperProviderService(serviceBroker, exportProvider);
+    {
+        var tagHelperResolver = exportProvider.GetExportedValue<RemoteTagHelperResolver>().AssumeNotNull();
+        var tagHelperDeltaProvider = exportProvider.GetExportedValue<RemoteTagHelperDeltaProvider>().AssumeNotNull();
+        return new RemoteTagHelperProviderService(serviceBroker, tagHelperResolver, tagHelperDeltaProvider);
+    }
 }


### PR DESCRIPTION
Just a couple of tiny little inconsistencies in our OOP services. I think confining ExportProvider usage to the factories makes things much nicer in the services.

The other services already follow this pattern.