### PR TITLE
Make network paths be network paths

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/FilePathNormalizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/FilePathNormalizer.cs
@@ -252,11 +252,23 @@ internal static class FilePathNormalizer
             {
                 writeSlot = '/';
 
-                // if there are two slashes in a row, we skip over one of them, unless we're
-                // at the start of the span, in order to allow '\\network' paths
-                if (read > 0 && Unsafe.Add(ref readSlot, 1) is '/' or '\\')
+                if (Unsafe.Add(ref readSlot, 1) is '/' or '\\')
                 {
-                    read++;
+                    // We found two slashes in a row. If we are at the start of the path,
+                    // we we are at '\\network' paths, so want to leave them alone. Otherwise
+                    // we skip over one of them to de-dupe
+                    if (read == 0)
+                    {
+                        writeSlot = '\\';
+                        writeSlot = ref Unsafe.Add(ref writeSlot, 1);
+                        writeSlot = '\\';
+                        read++;
+                        write++;
+                    }
+                    else if (read > 0)
+                    {
+                        read++;
+                    }
                 }
             }
             else

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/FilePathNormalizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/FilePathNormalizerTest.cs
@@ -25,7 +25,20 @@ public class FilePathNormalizerTest(ITestOutputHelper testOutput) : ToolingTestB
     }
 
     [Fact]
-    public void Normalize_IgnoresUNCPaths()
+    public void Normalize_NormalizesPathsWithSlashAtPositionOne()
+    {
+        // Arrange
+        var path = @"d\ComputerName\path\to\something";
+
+        // Act
+        path = FilePathNormalizer.Normalize(path);
+
+        // Assert
+        Assert.Equal("d/ComputerName/path/to/something", path);
+    }
+
+    [Fact]
+    public void Normalize_FixesUNCPaths()
     {
         // Arrange
         var path = "//ComputerName/path/to/something";
@@ -34,7 +47,20 @@ public class FilePathNormalizerTest(ITestOutputHelper testOutput) : ToolingTestB
         path = FilePathNormalizer.Normalize(path);
 
         // Assert
-        Assert.Equal("//ComputerName/path/to/something", path);
+        Assert.Equal(@"\\ComputerName/path/to/something", path);
+    }
+
+    [Fact]
+    public void Normalize_IgnoresUNCPaths()
+    {
+        // Arrange
+        var path = @"\\ComputerName\path\to\something";
+
+        // Act
+        path = FilePathNormalizer.Normalize(path);
+
+        // Assert
+        Assert.Equal(@"\\ComputerName/path/to/something", path);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/10192

Seems we were normalizing `\\computername\path` to `//computername/path` which meant it wasn't a network path any more. Now we normalize to `\\computername/path` which seems to work fine 🤷‍♂️