### PR TITLE
Don't await FallbackProjectManager updates

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/FallbackProjectManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/FallbackProjectManagerTest.cs
@@ -71,12 +71,15 @@ public class FallbackProjectManagerTest : VisualStudioWorkspaceTestBase
                 new CompilationOutputInfo().WithAssemblyPath(Path.Combine(SomeProject.IntermediateOutputPath, "SomeProject.dll")));
         Workspace.TryApplyChanges(Workspace.CurrentSolution.AddProject(projectInfo));
 
-        await _fallbackProjectManger.DynamicFileAddedAsync(
-            projectId,
-            hostProject.Key,
-            SomeProject.FilePath,
-            SomeProjectFile1.FilePath,
-            DisposalToken);
+        await RunOnDispatcherAsync(() =>
+        {
+            _fallbackProjectManger.DynamicFileAdded(
+                projectId,
+                hostProject.Key,
+                SomeProject.FilePath,
+                SomeProjectFile1.FilePath,
+                DisposalToken);
+        });
 
         var project = Assert.Single(_projectManager.GetProjects());
         Assert.IsNotType<FallbackHostProject>(((ProjectSnapshot)project).HostProject);
@@ -93,12 +96,15 @@ public class FallbackProjectManagerTest : VisualStudioWorkspaceTestBase
 
         Workspace.TryApplyChanges(Workspace.CurrentSolution.AddProject(projectInfo));
 
-        await _fallbackProjectManger.DynamicFileAddedAsync(
-            projectId,
-            SomeProject.Key,
-            SomeProject.FilePath,
-            SomeProjectFile1.FilePath,
-            DisposalToken);
+        await RunOnDispatcherAsync(() =>
+        {
+            _fallbackProjectManger.DynamicFileAdded(
+                projectId,
+                SomeProject.Key,
+                SomeProject.FilePath,
+                SomeProjectFile1.FilePath,
+                DisposalToken);
+        });
 
         var project = Assert.Single(_projectManager.GetProjects());
         Assert.Equal("DisplayName", project.DisplayName);
@@ -122,12 +128,15 @@ public class FallbackProjectManagerTest : VisualStudioWorkspaceTestBase
 
         Workspace.TryApplyChanges(Workspace.CurrentSolution.AddProject(projectInfo));
 
-        await _fallbackProjectManger.DynamicFileAddedAsync(
+        await RunOnDispatcherAsync(() =>
+        {
+            _fallbackProjectManger.DynamicFileAdded(
             projectId,
             SomeProject.Key,
             SomeProject.FilePath,
             SomeProjectFile1.FilePath,
             DisposalToken);
+        });
 
         var project = Assert.Single(_projectManager.GetProjects());
         Assert.IsType<FallbackHostProject>(((ProjectSnapshot)project).HostProject);
@@ -159,26 +168,35 @@ public class FallbackProjectManagerTest : VisualStudioWorkspaceTestBase
 
         Workspace.TryApplyChanges(Workspace.CurrentSolution.AddProject(projectInfo));
 
-        await _fallbackProjectManger.DynamicFileAddedAsync(
-            projectId,
-            SomeProject.Key,
-            SomeProject.FilePath,
-            SomeProjectFile1.FilePath,
-            DisposalToken);
+        await RunOnDispatcherAsync(() =>
+        {
+            _fallbackProjectManger.DynamicFileAdded(
+                projectId,
+                SomeProject.Key,
+                SomeProject.FilePath,
+                SomeProjectFile1.FilePath,
+                DisposalToken);
+        });
 
-        await _fallbackProjectManger.DynamicFileAddedAsync(
-            projectId,
-            SomeProject.Key,
-            SomeProject.FilePath,
-            SomeProjectFile2.FilePath,
-            DisposalToken);
+        await RunOnDispatcherAsync(() =>
+        {
+            _fallbackProjectManger.DynamicFileAdded(
+                projectId,
+                SomeProject.Key,
+                SomeProject.FilePath,
+                SomeProjectFile2.FilePath,
+                DisposalToken);
+        });
 
-        await _fallbackProjectManger.DynamicFileAddedAsync(
-            projectId,
-            SomeProject.Key,
-            SomeProject.FilePath,
-            SomeProjectNestedComponentFile3.FilePath,
-            DisposalToken);
+        await RunOnDispatcherAsync(() =>
+        {
+            _fallbackProjectManger.DynamicFileAdded(
+                projectId,
+                SomeProject.Key,
+                SomeProject.FilePath,
+                SomeProjectNestedComponentFile3.FilePath,
+                DisposalToken);
+        });
 
         var project = Assert.Single(_projectManager.GetProjects());
 
@@ -204,27 +222,36 @@ public class FallbackProjectManagerTest : VisualStudioWorkspaceTestBase
 
         Workspace.TryApplyChanges(Workspace.CurrentSolution.AddProject(projectInfo));
 
-        await _fallbackProjectManger.DynamicFileAddedAsync(
-            projectId,
-            SomeProject.Key,
-            SomeProject.FilePath,
-            SomeProjectFile1.FilePath,
-            DisposalToken);
+        await RunOnDispatcherAsync(() =>
+        {
+            _fallbackProjectManger.DynamicFileAdded(
+                projectId,
+                SomeProject.Key,
+                SomeProject.FilePath,
+                SomeProjectFile1.FilePath,
+                DisposalToken);
+        });
 
         // These two represent linked files, or shared project items
-        await _fallbackProjectManger.DynamicFileAddedAsync(
-            projectId,
-            SomeProject.Key,
-            SomeProject.FilePath,
-            AnotherProjectFile2.FilePath,
-            DisposalToken);
+        await RunOnDispatcherAsync(() =>
+        {
+            _fallbackProjectManger.DynamicFileAdded(
+                projectId,
+                SomeProject.Key,
+                SomeProject.FilePath,
+                AnotherProjectFile2.FilePath,
+                DisposalToken);
+        });
 
-        await _fallbackProjectManger.DynamicFileAddedAsync(
-            projectId,
-            SomeProject.Key,
-            SomeProject.FilePath,
-            AnotherProjectComponentFile1.FilePath,
-            DisposalToken);
+        await RunOnDispatcherAsync(() =>
+        {
+            _fallbackProjectManger.DynamicFileAdded(
+                projectId,
+                SomeProject.Key,
+                SomeProject.FilePath,
+                AnotherProjectComponentFile1.FilePath,
+                DisposalToken);
+        });
 
         var project = Assert.Single(_projectManager.GetProjects());
 
@@ -245,12 +272,15 @@ public class FallbackProjectManagerTest : VisualStudioWorkspaceTestBase
 
         Workspace.TryApplyChanges(Workspace.CurrentSolution.AddProject(projectInfo));
 
-        await _fallbackProjectManger.DynamicFileAddedAsync(
-            projectId,
-            SomeProject.Key,
-            SomeProject.FilePath,
-            SomeProjectFile1.FilePath,
-            DisposalToken);
+        await RunOnDispatcherAsync(() =>
+        {
+            _fallbackProjectManger.DynamicFileAdded(
+                projectId,
+                SomeProject.Key,
+                SomeProject.FilePath,
+                SomeProjectFile1.FilePath,
+                DisposalToken);
+        });
 
         var kvp = Assert.Single(_projectConfigurationFilePathStore.GetMappings());
         Assert.Equal(SomeProject.Key, kvp.Key);


### PR DESCRIPTION
Back in 17.10p1, the FallbackProjectManager would apply changes to the project snapshot manager without scheduling the updates on the dispatcher. This had the potential to create correctness and reliability problems if those changes collided with other updates that *were* scheduled on the dispatcher.

To address the correctness problem, I made the FallbackProjectManager async and awaited any updates to the project snapshot manager. However, this created re-entrancy problems that resulted in deadlocks with Roslyn. I fixed a couple of those re-entrancy problems in 17.10p2, but hangs have persisted.

A recent Watson dump revealed another yet another re-entrancy issue with background document promotion in the IRazorDynamicFileInfoProvider. The hang occurs when waiting for the FallbackProjectManager to add the file, which causes the project snapshot manager to notify listeners of the update, which causes one of the listener to try and perform the background document promotion again, which causes the hang.

To address this, I've decided to just "fire-and-forget" the updates to the project snapshot manager. The updates will still happen on the dispatcher, but we won't wait for them and shouldn't hang.