### PR TITLE
Fix project load when intermediate output path isn't known

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/FilePathNormalizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/FilePathNormalizer.cs
@@ -225,6 +225,7 @@ internal static class FilePathNormalizer
         NormalizeAndDedupeSlashes(destination, ref charsWritten);
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
+            charsWritten > 1 &&
             destination is ['/', ..] and not ['/', '/', ..])
         {
             // We've been provided a path that probably looks something like /C:/path/to.

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/WorkspaceProjectStateChangeDetector.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/WorkspaceProjectStateChangeDetector.cs
@@ -394,7 +394,7 @@ internal partial class WorkspaceProjectStateChangeDetector : IRazorStartupServic
 
     private bool TryGetProjectSnapshot(Project? project, [NotNullWhen(true)] out IProjectSnapshot? projectSnapshot)
     {
-        if (project is null)
+        if (project?.CompilationOutputInfo.AssemblyPath is null)
         {
             projectSnapshot = null;
             return false;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/FilePathNormalizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/FilePathNormalizerTest.cs
@@ -24,6 +24,19 @@ public class FilePathNormalizerTest(ITestOutputHelper testOutput) : ToolingTestB
         Assert.Equal("c:/path/to/something", path);
     }
 
+    [OSSkipConditionFact(["OSX", "Linux"])]
+    public void Normalize_Windows_StripsPrecedingSlash_ShortPath()
+    {
+        // Arrange
+        var path = "/c";
+
+        // Act
+        path = FilePathNormalizer.Normalize(path);
+
+        // Assert
+        Assert.Equal("c", path);
+    }
+
     [Fact]
     public void Normalize_NormalizesPathsWithSlashAtPositionOne()
     {
@@ -133,6 +146,19 @@ public class FilePathNormalizerTest(ITestOutputHelper testOutput) : ToolingTestB
     {
         // Arrange
         var directory = @"\";
+
+        // Act
+        var normalized = FilePathNormalizer.NormalizeDirectory(directory);
+
+        // Assert
+        Assert.Equal("/", normalized);
+    }
+
+    [Fact]
+    public void NormalizeDirectory_HandlesSingleSlashDirectory()
+    {
+        // Arrange
+        var directory = "/";
 
         // Act
         var normalized = FilePathNormalizer.NormalizeDirectory(directory);


### PR DESCRIPTION
Not sure whether me or @DustinCampbell broke this, but hit this assert during debugging today. What was happening was:

* WorkspaceProjectStateChangeDetector tried to create a ProjectKey for a Project that had no compilation output assembly path
* `ProjectKey` calls `FilePathNormalizer.GetNormalizedDirectoryName`, passes in `null`, and gets back `/`
* `ProjectKey` then calls `FilePathNormalizer.NormalizeDirectory` on that `/`, which exploded

This fixes the first bullet point, by checking if Roslyn knows about the intermediate output path before continuing. Since this is only checking for project existence, we don't actually need to go further.
This fixes the third point by protecting against a single `/` being written for an input that is only a single `/`
This ignores the second point because it doesn't really matter, though it is slightly wasteful to get a normalized directory name, and then normalize it.