### PR TITLE
Add launch profiles that don't have native debugging enabled

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Properties/launchSettings.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Properties/launchSettings.json
@@ -1,15 +1,32 @@
 {
   "profiles": {
-    "Razor": {
+    "Razor (managed)": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "CPS_DiagnosticRuntime": "1",
+        "CPS_MetricsCollection": "1",
+        "ServiceHubTraceLevel": "All"
+      }
+    },
+    "Razor w/ ServiceHub (managed)": {
       "commandName": "Project",
       "environmentVariables": {
         "CPS_DiagnosticRuntime": "1",
         "CPS_MetricsCollection": "1",
         "ServiceHubTraceLevel": "All",
+        "SERVICEHUBDEBUGHOSTONSTARTUP": "ServiceHub.RoslynCodeAnalysisService.exe"
+      }
+    },
+    "Razor (managed + native)": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "CPS_DiagnosticRuntime": "1",
+        "CPS_MetricsCollection": "1",
+        "ServiceHubTraceLevel": "All"
       },
       "nativeDebugging": true
     },
-    "Razor (with ServiceHub debugging)": {
+    "Razor w/ ServiceHub (managed + native)": {
       "commandName": "Project",
       "environmentVariables": {
         "CPS_DiagnosticRuntime": "1",


### PR DESCRIPTION
Who wants to wait for the native debugger on F5 every time? Not me!