### PR TITLE
Avoid fault where misc files project is added off dispatcher

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/SnapshotResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/SnapshotResolver.cs
@@ -125,4 +125,16 @@ internal sealed class SnapshotResolver : ISnapshotResolver
         documentSnapshot = null;
         return false;
     }
+
+    internal TestAccessor GetTestAccessor() => new(this);
+
+    internal sealed class TestAccessor(SnapshotResolver instance)
+    {
+        public Task WaitForMiscFilesProjectAsync()
+        {
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
+            return instance._initializeTask;
+#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
+        }
+    }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
@@ -24,21 +24,25 @@ using Xunit.Sdk;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
-public class RazorProjectServiceTest : LanguageServerTestBase
+public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageServerTestBase(testOutput)
 {
     private static readonly SourceText s_emptyText = SourceText.From("");
 
-    private readonly TestProjectSnapshotManager _projectManager;
-    private readonly ISnapshotResolver _snapshotResolver;
-    private readonly DocumentVersionCache _documentVersionCache;
-    private readonly IRazorProjectService _projectService;
+#nullable disable
+    private TestProjectSnapshotManager _projectManager;
+    private SnapshotResolver _snapshotResolver;
+    private DocumentVersionCache _documentVersionCache;
+    private RazorProjectService _projectService;
+#nullable enable
 
-    public RazorProjectServiceTest(ITestOutputHelper testOutput)
-        : base(testOutput)
+    protected override async Task InitializeAsync()
     {
         _projectManager = CreateProjectSnapshotManager();
         _snapshotResolver = new SnapshotResolver(_projectManager, LoggerFactory);
         _documentVersionCache = new DocumentVersionCache(_projectManager);
+
+        var accessor = _snapshotResolver.GetTestAccessor();
+        await accessor.WaitForMiscFilesProjectAsync();
 
         var remoteTextLoaderFactoryMock = new StrictMock<RemoteTextLoaderFactory>();
         remoteTextLoaderFactoryMock


### PR DESCRIPTION
Telemetry recently indicated an assert is triggering in certain scenarios if the snapshot resolver adds the misc files project off of the dispatcher. To avoid this, I've updated the snapshot resolver to immediately start adding the misc files project when its created. Then, when the misc files project is requested, we'll wait for it to be added if it hasn't been yet. This is a temporary solution that will go away once project management is made more async.
