### PR TITLE
Warn on invalid NuGet configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,9 @@ x86/ !eng/common/cross/x86/
 msbuild.log
 msbuild.err
 msbuild.wrn
-msbuild.binlog
 msbuild.ProjectImports.zip
+*.binlog
+*.complog
 
 # Visual Studio 2015
 .vs/

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -41,7 +41,7 @@
   <Target Name="CheckNuPkgEnvEndsWithSlash"
           AfterTargets="AfterCompile">
     <Warning Condition="'$(NUGET_PACKAGES)' != '' AND !$(NUGET_PACKAGES.EndsWith('\'))"
-             Text="NUGET_PACKAGES should end with a slash or it will lead to editorconfig issues." />
+             Text="NUGET_PACKAGES should end with a slash or it will lead to editorconfig issues: $(NUGET_PACKAGES)" />
   </Target>
 
   <Target Name="GetCustomAssemblyAttributes"

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -40,7 +40,7 @@
   -->
   <Target Name="CheckNuPkgEnvEndsWithSlash"
           AfterTargets="AfterCompile">
-    <Warning Condition="'$(NUGET_PACKAGES)' != '' AND !$(NUGET_PACKAGES.EndsWith([System.IO.Path]::DirectorySeparatorChar))"
+    <Warning Condition="'$(NUGET_PACKAGES)' != '' AND !$(NUGET_PACKAGES.EndsWith($([System.IO.Path]::DirectorySeparatorChar)))"
              Text="NUGET_PACKAGES should end with a slash or it will lead to editorconfig issues: $(NUGET_PACKAGES)" />
   </Target>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -40,7 +40,7 @@
   -->
   <Target Name="CheckNuPkgEnvEndsWithSlash"
           AfterTargets="AfterCompile">
-    <Warning Condition="'$(NUGET_PACKAGES)' != '' AND !$(NUGET_PACKAGES.EndsWith($([System.IO.Path]::DirectorySeparatorChar)))"
+    <Warning Condition="'$(NUGET_PACKAGES)' != '' AND !$(NUGET_PACKAGES.EndsWith($([System.String]::new($([System.IO.Path]::DirectorySeparatorChar)))))"
              Text="NUGET_PACKAGES should end with a slash or it will lead to editorconfig issues: $(NUGET_PACKAGES)" />
   </Target>
 

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -34,6 +34,16 @@
     <SupportedPlatform Remove="iOS" />
   </ItemGroup>
 
+  <!--
+    Warn consumers until the underlying issue is fixed
+    https://github.com/dotnet/roslyn/issues/72657
+  -->
+  <Target Name="CheckNuPkgEnvEndsWithSlash"
+          AfterTargets="AfterCompile">
+    <Warning Condition="'$(NUGET_PACKAGES)' != '' AND !$(NUGET_PACKAGES.EndsWith('\'))"
+             Text="NUGET_PACKAGES should end with a slash or it will lead to editorconfig issues." />
+  </Target>
+
   <Target Name="GetCustomAssemblyAttributes"
           BeforeTargets="GetAssemblyAttributes"
           Condition=" '$(MSBuildProjectExtension)' == '.csproj' "

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -40,7 +40,7 @@
   -->
   <Target Name="CheckNuPkgEnvEndsWithSlash"
           AfterTargets="AfterCompile">
-    <Warning Condition="'$(NUGET_PACKAGES)' != '' AND !$(NUGET_PACKAGES.EndsWith('\'))"
+    <Warning Condition="'$(NUGET_PACKAGES)' != '' AND !$(NUGET_PACKAGES.EndsWith([System.IO.Path]::DirectorySeparatorChar))"
              Text="NUGET_PACKAGES should end with a slash or it will lead to editorconfig issues: $(NUGET_PACKAGES)" />
   </Target>
 

--- a/eng/cibuild.sh
+++ b/eng/cibuild.sh
@@ -13,7 +13,11 @@ while [[ -h $source ]]; do
 done
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 
-echo before nuget-workaround NUGET_PACKAGES=$NUGET_PACKAGES
+echo before nuget-workaround
+echo NUGET_PACKAGES=$NUGET_PACKAGES
+echo NuGetPackageRoot=$NuGetPackageRoot
 . "$scriptroot/nuget-workaround.sh" --ci $@
-echo after nuget-workaround NUGET_PACKAGES=$NUGET_PACKAGES
+echo after nuget-workaround
+echo NUGET_PACKAGES=$NUGET_PACKAGES
+echo NuGetPackageRoot=$NuGetPackageRoot
 . "$scriptroot/common/build.sh" --ci $@

--- a/eng/cibuild.sh
+++ b/eng/cibuild.sh
@@ -13,6 +13,7 @@ while [[ -h $source ]]; do
 done
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 
+env | sort
 echo before nuget-workaround
 echo NUGET_PACKAGES=$NUGET_PACKAGES
 echo NuGetPackageRoot=$NuGetPackageRoot

--- a/eng/cibuild.sh
+++ b/eng/cibuild.sh
@@ -13,5 +13,7 @@ while [[ -h $source ]]; do
 done
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 
+echo before nuget-workaround NUGET_PACKAGES=$NUGET_PACKAGES
 . "$scriptroot/nuget-workaround.sh" --ci $@
+echo after nuget-workaround NUGET_PACKAGES=$NUGET_PACKAGES
 . "$scriptroot/common/build.sh" --ci $@

--- a/eng/cibuild.sh
+++ b/eng/cibuild.sh
@@ -13,12 +13,5 @@ while [[ -h $source ]]; do
 done
 scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 
-env | sort
-echo before nuget-workaround
-echo NUGET_PACKAGES=$NUGET_PACKAGES
-echo NuGetPackageRoot=$NuGetPackageRoot
 . "$scriptroot/nuget-workaround.sh" --ci $@
-echo after nuget-workaround
-echo NUGET_PACKAGES=$NUGET_PACKAGES
-echo NuGetPackageRoot=$NuGetPackageRoot
 . "$scriptroot/common/build.sh" --ci $@


### PR DESCRIPTION
Issue a warning when `%NUGET_PACKAGES%` doesn't have a trailing slash until the associatede issue is fixed.

https://github.com/dotnet/roslyn/issues/72657
