### PR TITLE
update razor textmate grammar

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.json
@@ -5,6 +5,28 @@
     "razor",
     "cshtml"
   ],
+  "injections": {
+    "string.quoted.double.html": {
+      "patterns": [
+        {
+          "include": "#explicit-razor-expression"
+        },
+        {
+          "include": "#implicit-expression"
+        }
+      ]
+    },
+    "string.quoted.single.html": {
+      "patterns": [
+        {
+          "include": "#explicit-razor-expression"
+        },
+        {
+          "include": "#implicit-expression"
+        }
+      ]
+    }
+  },
   "patterns": [
     {
       "include": "#razor-control-structures"
@@ -58,16 +80,6 @@
         },
         {
           "include": "#optionally-transitioned-csharp-control-structures"
-        },
-        {
-          "include": "#implicit-expression"
-        }
-      ]
-    },
-    "implicit-or-explicit-expression": {
-      "patterns": [
-        {
-          "include": "#explicit-razor-expression"
         },
         {
           "include": "#implicit-expression"

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.json
@@ -64,6 +64,16 @@
         }
       ]
     },
+    "implicit-or-explicit-expression": {
+      "patterns": [
+        {
+          "include": "#explicit-razor-expression"
+        },
+        {
+          "include": "#implicit-expression"
+        }
+      ]
+    },
     "escaped-transition": {
       "name": "constant.character.escape.razor.transition",
       "match": "@@"

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/html.tmLanguage.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/html.tmLanguage.json
@@ -112,11 +112,11 @@
 												}
 											},
 											"name": "string.quoted.double.html",
-                      "patterns": [
-                        {
-                          "include": "#entities"
-                        }
-                      ]
+											"patterns": [
+												{
+													"include": "#entities"
+												}
+											]
 										},
 										{
 											"begin": "'",
@@ -136,11 +136,11 @@
 												}
 											},
 											"name": "string.quoted.single.html",
-                      "patterns": [
-                        {
-                          "include": "#entities"
-                        }
-                      ]
+											"patterns": [
+												{
+													"include": "#entities"
+												}
+											]
 										}
 									]
 								},
@@ -402,11 +402,11 @@
 								}
 							},
 							"name": "string.quoted.double.html",
-              "patterns": [
-                {
-                  "include": "#entities"
-                }
-              ]
+							"patterns": [
+								{
+									"include": "#entities"
+								}
+							]
 						},
 						{
 							"begin": "'",
@@ -422,11 +422,11 @@
 								}
 							},
 							"name": "string.quoted.single.html",
-              "patterns": [
-                {
-                  "include": "#entities"
-                }
-              ]
+							"patterns": [
+								{
+									"include": "#entities"
+								}
+							]
 						},
 						{
 							"match": "=",

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/html.tmLanguage.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/html.tmLanguage.json
@@ -114,9 +114,6 @@
 											"name": "string.quoted.double.html",
                       "patterns": [
                         {
-                          "include": "text.aspnetcorerazor#implicit-or-explicit-expression"
-                        },
-                        {
                           "include": "#entities"
                         }
                       ]
@@ -140,9 +137,6 @@
 											},
 											"name": "string.quoted.single.html",
                       "patterns": [
-                        {
-                          "include": "text.aspnetcorerazor#implicit-or-explicit-expression"
-                        },
                         {
                           "include": "#entities"
                         }
@@ -410,9 +404,6 @@
 							"name": "string.quoted.double.html",
               "patterns": [
                 {
-                  "include": "text.aspnetcorerazor#implicit-or-explicit-expression"
-                },
-                {
                   "include": "#entities"
                 }
               ]
@@ -432,9 +423,6 @@
 							},
 							"name": "string.quoted.single.html",
               "patterns": [
-                {
-                  "include": "text.aspnetcorerazor#implicit-or-explicit-expression"
-                },
                 {
                   "include": "#entities"
                 }

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/html.tmLanguage.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/html.tmLanguage.json
@@ -112,11 +112,14 @@
 												}
 											},
 											"name": "string.quoted.double.html",
-											"patterns": [
-												{
-													"include": "#entities"
-												}
-											]
+                      "patterns": [
+                        {
+                          "include": "text.aspnetcorerazor#implicit-or-explicit-expression"
+                        },
+                        {
+                          "include": "#entities"
+                        }
+                      ]
 										},
 										{
 											"begin": "'",
@@ -136,11 +139,14 @@
 												}
 											},
 											"name": "string.quoted.single.html",
-											"patterns": [
-												{
-													"include": "#entities"
-												}
-											]
+                      "patterns": [
+                        {
+                          "include": "text.aspnetcorerazor#implicit-or-explicit-expression"
+                        },
+                        {
+                          "include": "#entities"
+                        }
+                      ]
 										}
 									]
 								},
@@ -402,11 +408,14 @@
 								}
 							},
 							"name": "string.quoted.double.html",
-							"patterns": [
-								{
-									"include": "#entities"
-								}
-							]
+              "patterns": [
+                {
+                  "include": "text.aspnetcorerazor#implicit-or-explicit-expression"
+                },
+                {
+                  "include": "#entities"
+                }
+              ]
 						},
 						{
 							"begin": "'",
@@ -422,11 +431,14 @@
 								}
 							},
 							"name": "string.quoted.single.html",
-							"patterns": [
-								{
-									"include": "#entities"
-								}
-							]
+              "patterns": [
+                {
+                  "include": "text.aspnetcorerazor#implicit-or-explicit-expression"
+                },
+                {
+                  "include": "#entities"
+                }
+              ]
 						},
 						{
 							"match": "=",


### PR DESCRIPTION
Update razor textmate grammar so that razor expressions inside html tags are classified correctly

### Summary of the changes

- copied over the textmate grammar from the vscode-csharp repo. For testing and justification see dotnet/vscode-csharp#7051 and dotnet/vscode-csharp#7055
