### PR TITLE
Remove ProjectSnapshotManagerDispatcher from ProjectWorkspaceStateGenerator

### DIFF
--- a/SpellingExclusions.dic
+++ b/SpellingExclusions.dic
@@ -1,10 +1,8 @@
 csharp
-Blazor
-csproj
 cshtml
-microsoft
-Metacode
-hresult
 csproj
+hresult
+microsoft
 vsls
-csharp
+Blazor
+Metacode

--- a/SpellingExclusions.dic
+++ b/SpellingExclusions.dic
@@ -7,3 +7,4 @@ Metacode
 hresult
 csproj
 vsls
+csharp

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Logging/ILoggerExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Logging/ILoggerExtensions.cs
@@ -64,6 +64,14 @@ internal static class ILoggerExtensions
         }
     }
 
+    public static void LogError(this ILogger logger, Exception exception)
+    {
+        if (logger.IsEnabled(LogLevel.Error))
+        {
+            logger.Log(LogLevel.Error, exception.Message, exception);
+        }
+    }
+
     public static void LogError(this ILogger logger, Exception? exception, [InterpolatedStringHandlerArgument(nameof(logger))] ref ErrorLogMessageInterpolatedStringHandler message)
     {
         if (message.IsEnabled)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Logging/ILoggerExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Logging/ILoggerExtensions.cs
@@ -80,6 +80,14 @@ internal static class ILoggerExtensions
         }
     }
 
+    public static void LogCritical(this ILogger logger, Exception exception)
+    {
+        if (logger.IsEnabled(LogLevel.Critical))
+        {
+            logger.Log(LogLevel.Critical, exception.Message, exception);
+        }
+    }
+
     public static void LogCritical(this ILogger logger, Exception? exception, [InterpolatedStringHandlerArgument(nameof(logger))] ref CriticalLogMessageInterpolatedStringHandler message)
     {
         if (message.IsEnabled)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/IProjectWorkspaceStateGenerator.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/IProjectWorkspaceStateGenerator.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
@@ -10,5 +8,7 @@ namespace Microsoft.VisualStudio.Razor;
 
 internal interface IProjectWorkspaceStateGenerator
 {
-    Task UpdateAsync(Project? workspaceProject, IProjectSnapshot projectSnapshot, CancellationToken cancellationToken);
+    void EnqueueUpdate(Project? workspaceProject, IProjectSnapshot projectSnapshot);
+
+    void CancelUpdates();
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectWorkspaceStateGenerator.TestAccessor.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectWorkspaceStateGenerator.TestAccessor.cs
@@ -22,7 +22,7 @@ internal sealed partial class ProjectWorkspaceStateGenerator
 
         private sealed class UpdateItemWrapper(UpdateItem updateItem) : IUpdateItem
         {
-            public bool IsCompleted => updateItem.UpdateTask.IsCompleted;
+            public bool IsCompleted => updateItem.IsCompleted;
             public bool IsCancellationRequested => updateItem.IsCancellationRequested;
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectWorkspaceStateGenerator.TestAccessor.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectWorkspaceStateGenerator.TestAccessor.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading;
+using Microsoft.AspNetCore.Razor.PooledObjects;
+
+namespace Microsoft.VisualStudio.Razor;
+
+internal sealed partial class ProjectWorkspaceStateGenerator
+{
+    internal TestAccessor GetTestAccessor() => new(this);
+
+    internal sealed class TestAccessor(ProjectWorkspaceStateGenerator instance)
+    {
+        public interface IUpdateItem
+        {
+            bool IsCompleted { get; }
+            bool IsCancellationRequested { get; }
+        }
+
+        private sealed class UpdateItemWrapper(UpdateItem updateItem) : IUpdateItem
+        {
+            public bool IsCompleted => updateItem.UpdateTask.IsCompleted;
+            public bool IsCancellationRequested => updateItem.IsCancellationRequested;
+        }
+
+        public ImmutableArray<IUpdateItem> GetUpdates()
+        {
+            lock (instance._updates)
+            {
+                using var result = new PooledArrayBuilder<IUpdateItem>(capacity: instance._updates.Count);
+
+                foreach (var (_, updateItem) in instance._updates)
+                {
+                    result.Add(new UpdateItemWrapper(updateItem));
+                }
+
+                return result.ToImmutable();
+            }
+        }
+
+        /// <summary>
+        /// Used in unit tests to ensure we can control when background work starts.
+        /// </summary>
+        public ManualResetEventSlim? BlockBackgroundWorkStart
+        {
+            get => instance._blockBackgroundWorkStart;
+            set => instance._blockBackgroundWorkStart = value;
+        }
+
+        /// <summary>
+        /// Used in unit tests to ensure we can know when background work finishes.
+        /// </summary>
+        public ManualResetEventSlim? NotifyBackgroundWorkCompleted
+        {
+            get => instance._notifyBackgroundWorkCompleted;
+            set => instance._notifyBackgroundWorkCompleted = value;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectWorkspaceStateGenerator.UpdateItem.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectWorkspaceStateGenerator.UpdateItem.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.VisualStudio.Razor;
+
+internal sealed partial class ProjectWorkspaceStateGenerator
+{
+    // Internal for testing
+    internal class UpdateItem : IDisposable
+    {
+        public Task UpdateTask { get; }
+
+        private readonly CancellationTokenSource _tokenSource;
+
+        public bool IsCancellationRequested => _tokenSource.IsCancellationRequested;
+
+        public UpdateItem(Func<CancellationToken, Task> updater, CancellationToken token)
+        {
+            _tokenSource = CancellationTokenSource.CreateLinkedTokenSource(token);
+
+            UpdateTask = Task.Run(
+                () => updater(_tokenSource.Token),
+                _tokenSource.Token);
+        }
+
+        public void Dispose()
+        {
+            _tokenSource.Cancel();
+            _tokenSource.Dispose();
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectWorkspaceStateGenerator.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectWorkspaceStateGenerator.cs
@@ -106,11 +106,6 @@ internal sealed partial class ProjectWorkspaceStateGenerator(
 
     private async Task UpdateWorkspaceStateAsync(Project? workspaceProject, IProjectSnapshot projectSnapshot, CancellationToken cancellationToken)
     {
-        if (_disposeTokenSource.IsCancellationRequested)
-        {
-            return;
-        }
-
         try
         {
             // Only allow a single TagHelper resolver request to process at a time in order to reduce
@@ -174,7 +169,7 @@ internal sealed partial class ProjectWorkspaceStateGenerator(
             {
                 // Prevent ObjectDisposedException if we've disposed before we got here. The dispose method will release
                 // anyway, so we're all good.
-                if (!_disposeTokenSource.IsCancellationRequested)
+                if (!cancellationToken.IsCancellationRequested)
                 {
                     _semaphore.Release();
                 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectWorkspaceStateGenerator.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectWorkspaceStateGenerator.cs
@@ -76,7 +76,11 @@ internal sealed partial class ProjectWorkspaceStateGenerator(
         {
             if (_updates.TryGetValue(projectSnapshot.Key, out var updateItem))
             {
-                _logger.LogTrace($"Cancelling previously enqueued update for '{projectSnapshot.FilePath}'.");
+                if (!updateItem.UpdateTask.IsCompleted &&
+                    !updateItem.IsCancellationRequested)
+                {
+                    _logger.LogTrace($"Cancelling previously enqueued update for '{projectSnapshot.FilePath}'.");
+                }
 
                 updateItem.Dispose();
             }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectWorkspaceStateGenerator.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectWorkspaceStateGenerator.cs
@@ -48,9 +48,12 @@ internal sealed partial class ProjectWorkspaceStateGenerator(
         _disposeTokenSource.Cancel();
         _disposeTokenSource.Dispose();
 
-        foreach (var (_, updateItem) in _updates)
+        lock (_updates)
         {
-            updateItem.Dispose();
+            foreach (var (_, updateItem) in _updates)
+            {
+                updateItem.Dispose();
+            }
         }
 
         // Release before dispose to ensure we don't throw exceptions from the background thread trying to release

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/WorkspaceProjectStateChangeDetector.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/WorkspaceProjectStateChangeDetector.cs
@@ -70,17 +70,19 @@ internal partial class WorkspaceProjectStateChangeDetector : IRazorStartupServic
         _disposeTokenSource.Dispose();
     }
 
-    private async ValueTask ProcessBatchAsync(ImmutableArray<(Project? Project, IProjectSnapshot ProjectSnapshot)> items, CancellationToken token)
+    private ValueTask ProcessBatchAsync(ImmutableArray<(Project? Project, IProjectSnapshot ProjectSnapshot)> items, CancellationToken token)
     {
         foreach (var (project, projectSnapshot) in items.GetMostRecentUniqueItems(Comparer.Instance))
         {
             if (token.IsCancellationRequested)
             {
-                return;
+                return default;
             }
 
-            await _generator.UpdateAsync(project, projectSnapshot, token);
+            _generator.EnqueueUpdate(project, projectSnapshot);
         }
+
+        return default;
     }
 
     private void Workspace_WorkspaceChanged(object? sender, WorkspaceChangeEventArgs e)

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectWorkspaceStateGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectWorkspaceStateGeneratorTest.cs
@@ -80,7 +80,7 @@ public class ProjectWorkspaceStateGeneratorTest : VisualStudioWorkspaceTestBase
 
         // Assert
         var update = Assert.Single(stateGenerator.Updates);
-        Assert.False(update.Value.Task.IsCompleted);
+        Assert.False(update.Value.UpdateTask.IsCompleted);
     }
 
     [UIFact]
@@ -99,7 +99,7 @@ public class ProjectWorkspaceStateGeneratorTest : VisualStudioWorkspaceTestBase
         stateGenerator.EnqueueUpdate(_workspaceProject, _projectSnapshot);
 
         // Assert
-        Assert.True(initialUpdate.Cts.IsCancellationRequested);
+        Assert.True(initialUpdate.IsCancellationRequested);
     }
 
     [UIFact]

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectWorkspaceStateGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectWorkspaceStateGeneratorTest.cs
@@ -54,7 +54,7 @@ public class ProjectWorkspaceStateGeneratorTest : VisualStudioWorkspaceTestBase
     {
         // Arrange
         using var generator = new ProjectWorkspaceStateGenerator(
-            _projectManager, _tagHelperResolver, ErrorReporter, NoOpTelemetryReporter.Instance);
+            _projectManager, _tagHelperResolver, LoggerFactory, NoOpTelemetryReporter.Instance);
 
         var generatorAccessor = generator.GetTestAccessor();
         generatorAccessor.BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false);
@@ -73,7 +73,7 @@ public class ProjectWorkspaceStateGeneratorTest : VisualStudioWorkspaceTestBase
     {
         // Arrange
         using var generator = new ProjectWorkspaceStateGenerator(
-            _projectManager, _tagHelperResolver, ErrorReporter, NoOpTelemetryReporter.Instance);
+            _projectManager, _tagHelperResolver, LoggerFactory, NoOpTelemetryReporter.Instance);
 
         var generatorAccessor = generator.GetTestAccessor();
         generatorAccessor.BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false);
@@ -91,7 +91,7 @@ public class ProjectWorkspaceStateGeneratorTest : VisualStudioWorkspaceTestBase
     {
         // Arrange
         using var generator = new ProjectWorkspaceStateGenerator(
-            _projectManager, _tagHelperResolver, ErrorReporter, NoOpTelemetryReporter.Instance);
+            _projectManager, _tagHelperResolver, LoggerFactory, NoOpTelemetryReporter.Instance);
 
         var generatorAccessor = generator.GetTestAccessor();
         generatorAccessor.BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false);
@@ -112,7 +112,7 @@ public class ProjectWorkspaceStateGeneratorTest : VisualStudioWorkspaceTestBase
     {
         // Arrange
         using var generator = new ProjectWorkspaceStateGenerator(
-            _projectManager, _tagHelperResolver, ErrorReporter, NoOpTelemetryReporter.Instance);
+            _projectManager, _tagHelperResolver, LoggerFactory, NoOpTelemetryReporter.Instance);
 
         var generatorAccessor = generator.GetTestAccessor();
         generatorAccessor.NotifyBackgroundWorkCompleted = new ManualResetEventSlim(initialState: false);
@@ -140,7 +140,7 @@ public class ProjectWorkspaceStateGeneratorTest : VisualStudioWorkspaceTestBase
     {
         // Arrange
         using var generator = new ProjectWorkspaceStateGenerator(
-            _projectManager, _tagHelperResolver, ErrorReporter, NoOpTelemetryReporter.Instance);
+            _projectManager, _tagHelperResolver, LoggerFactory, NoOpTelemetryReporter.Instance);
 
         var generatorAccessor = generator.GetTestAccessor();
         generatorAccessor.NotifyBackgroundWorkCompleted = new ManualResetEventSlim(initialState: false);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/VsSolutionUpdatesProjectSnapshotChangeTriggerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/VsSolutionUpdatesProjectSnapshotChangeTriggerTest.cs
@@ -196,7 +196,7 @@ public class VsSolutionUpdatesProjectSnapshotChangeTriggerTest : VisualStudioTes
         Assert.NotNull(update.WorkspaceProject);
         Assert.Equal(update.WorkspaceProject.Id, _someWorkspaceProject.Id);
         Assert.Same(expectedProjectSnapshot, update.ProjectSnapshot);
-        Assert.True(update.CancellationToken.IsCancellationRequested);
+        Assert.True(update.IsCancelled);
     }
 
     [UIFact]


### PR DESCRIPTION
The primary goal of this change is to remove the `ProjectSnapshotManagerDispatcher` from `ProjectWorkspaceStateGenerator`, which was only used to synchronize access to the dictionary it uses to track updates. While doing this, I've significantly refactored the code with the following goals:

1. Don't create linked `CancellationTokenSources` to an external `CancellationToken`. This was used by `VsSolutionUpdatesProjectSnapshotChangeTrigger` to cancel all updates when the solution is closed. However, that's a pretty subtle mechanism and it's easy enough to just add a `CancelUpdates` method.
2. Ensure that the dictionary of updates is cleared when updates are cancelled. Otherwise, we risk holding onto Roslyn solution snapshots that are no longer valid.
3. Use the test accessor pattern to expose internals to tests.
4. Push task management code into the `UpdateItem` helper class.
5. Clean up the control flow in `UpdateWorkspaceStateAsync`.

Note: There is a `SemaphoreSlim` in this class that is used to throttle tag helper resolution to just a single project at a time. I'm not convinced this is necessary any longer and the comment surrounding it is likely no longer true. However, I've left it in place to avoid making a riskier change.