### PR TITLE
Add direct reference to xunit.runner.utility

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -121,6 +121,7 @@
     <PackageVersion Include="xunit" Version="$(_XunitPackageVersion)" />
     <PackageVersion Include="Xunit.Combinatorial" Version="1.5.25" />
     <PackageVersion Include="xunit.extensibility.execution" Version="$(_XunitPackageVersion)" />
+    <PackageVersion Include="xunit.runner.utility" Version="2.4.1" />
     <PackageVersion Include="Xunit.StaFact" Version="1.2.46-alpha" />
   </ItemGroup>
 </Project>

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Microsoft.VisualStudio.Razor.IntegrationTests.csproj
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Microsoft.VisualStudio.Razor.IntegrationTests.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="NuGet.SolutionRestoreManager.Interop" />
     <PackageReference Include="Microsoft.Internal.VisualStudio.Shell.Framework" />
     <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.utility" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Add direct reference to xunit.runner.utility

On at least some machines, it appears that running integration tests fails near startup because xunit.runner.utility.*.dll cannot be found.  Adding the direct reference fixes the issue.
