### PR TITLE
Extract component search engine method to extension

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorComponentSearchEngine.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorComponentSearchEngine.cs
@@ -51,7 +51,7 @@ internal class DefaultRazorComponentSearchEngine(
         {
             // Check the typename and namespace match
             if (IsPathCandidateForComponent(documentSnapshot, tagHelper.GetTypeNameIdentifier().AsMemory()) &&
-                ComponentNamespaceMatchesFullyQualifiedName(razorCodeDocument, tagHelper.GetTypeNamespace()))
+                razorCodeDocument.ComponentNamespaceMatches(tagHelper.GetTypeNamespace()))
             {
                 return tagHelper;
             }
@@ -112,7 +112,7 @@ internal class DefaultRazorComponentSearchEngine(
                 }
 
                 // Make sure we have the right namespace of the fully qualified name
-                if (!ComponentNamespaceMatchesFullyQualifiedName(razorCodeDocument, namespaceName))
+                if (!razorCodeDocument.ComponentNamespaceMatches(namespaceName))
                 {
                     continue;
                 }
@@ -142,15 +142,5 @@ internal class DefaultRazorComponentSearchEngine(
 
         var fileName = Path.GetFileNameWithoutExtension(documentSnapshot.FilePath);
         return fileName.AsSpan().Equals(path.Span, FilePathComparison.Instance);
-    }
-
-    private bool ComponentNamespaceMatchesFullyQualifiedName(RazorCodeDocument razorCodeDocument, string fullyQualifiedNamespace)
-    {
-        var namespaceNode = (NamespaceDeclarationIntermediateNode)razorCodeDocument
-            .GetDocumentIntermediateNode()
-            .FindDescendantNodes<IntermediateNode>()
-            .First(n => n is NamespaceDeclarationIntermediateNode);
-
-        return namespaceNode.Content == fullyQualifiedNamespace;
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorComponentSearchEngine.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorComponentSearchEngine.cs
@@ -23,43 +23,6 @@ internal class DefaultRazorComponentSearchEngine(
     private readonly IProjectSnapshotManager _projectManager = projectManager;
     private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<DefaultRazorComponentSearchEngine>();
 
-    public async override Task<TagHelperDescriptor?> TryGetTagHelperDescriptorAsync(IDocumentSnapshot documentSnapshot, CancellationToken cancellationToken)
-    {
-        // No point doing anything if its not a component
-        if (documentSnapshot.FileKind != FileKinds.Component)
-        {
-            return null;
-        }
-
-        var razorCodeDocument = await documentSnapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
-        if (razorCodeDocument is null)
-        {
-            return null;
-        }
-
-        var project = documentSnapshot.Project;
-
-        // If the document is an import document, then it can't be a component
-        if (project.IsImportDocument(documentSnapshot))
-        {
-            return null;
-        }
-
-        // If we got this far, we can check for tag helpers
-        var tagHelpers = await project.GetTagHelpersAsync(cancellationToken).ConfigureAwait(false);
-        foreach (var tagHelper in tagHelpers)
-        {
-            // Check the typename and namespace match
-            if (documentSnapshot.IsPathCandidateForComponent(tagHelper.GetTypeNameIdentifier().AsMemory()) &&
-                razorCodeDocument.ComponentNamespaceMatches(tagHelper.GetTypeNamespace()))
-            {
-                return tagHelper;
-            }
-        }
-
-        return null;
-    }
-
     /// <summary>Search for a component in a project based on its tag name and fully qualified name.</summary>
     /// <remarks>
     /// This method makes several assumptions about the nature of components. First, it assumes that a component

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorComponentSearchEngine.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorComponentSearchEngine.cs
@@ -50,7 +50,7 @@ internal class DefaultRazorComponentSearchEngine(
         foreach (var tagHelper in tagHelpers)
         {
             // Check the typename and namespace match
-            if (IsPathCandidateForComponent(documentSnapshot, tagHelper.GetTypeNameIdentifier().AsMemory()) &&
+            if (documentSnapshot.IsPathCandidateForComponent(tagHelper.GetTypeNameIdentifier().AsMemory()) &&
                 razorCodeDocument.ComponentNamespaceMatches(tagHelper.GetTypeNamespace()))
             {
                 return tagHelper;
@@ -100,7 +100,7 @@ internal class DefaultRazorComponentSearchEngine(
                 }
 
                 // Rule out if not Razor component with correct name
-                if (!IsPathCandidateForComponent(documentSnapshot, lookupSymbolName))
+                if (!documentSnapshot.IsPathCandidateForComponent(lookupSymbolName))
                 {
                     continue;
                 }
@@ -131,16 +131,5 @@ internal class DefaultRazorComponentSearchEngine(
         return genericSeparatorStart > 0
             ? typeName[..genericSeparatorStart]
             : typeName;
-    }
-
-    private static bool IsPathCandidateForComponent(IDocumentSnapshot documentSnapshot, ReadOnlyMemory<char> path)
-    {
-        if (documentSnapshot.FileKind != FileKinds.Component)
-        {
-            return false;
-        }
-
-        var fileName = Path.GetFileNameWithoutExtension(documentSnapshot.FilePath);
-        return fileName.AsSpan().Equals(path.Span, FilePathComparison.Instance);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorComponentSearchEngine.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultRazorComponentSearchEngine.cs
@@ -37,33 +37,23 @@ internal class DefaultRazorComponentSearchEngine(
             return null;
         }
 
-        var projects = _projectManager.GetProjects();
+        var project = documentSnapshot.Project;
 
-        foreach (var project in projects)
+        // If the document is an import document, then it can't be a component
+        if (project.IsImportDocument(documentSnapshot))
         {
-            // If the document is an import document, then it can't be a component
-            if (project.IsImportDocument(documentSnapshot))
-            {
-                return null;
-            }
+            return null;
+        }
 
-            // If the document isn't in this project, then no point searching for components
-            // This also avoids the issue of duplicate components
-            if (!project.DocumentFilePaths.Contains(documentSnapshot.FilePath))
+        // If we got this far, we can check for tag helpers
+        var tagHelpers = await project.GetTagHelpersAsync(cancellationToken).ConfigureAwait(false);
+        foreach (var tagHelper in tagHelpers)
+        {
+            // Check the typename and namespace match
+            if (IsPathCandidateForComponent(documentSnapshot, tagHelper.GetTypeNameIdentifier().AsMemory()) &&
+                ComponentNamespaceMatchesFullyQualifiedName(razorCodeDocument, tagHelper.GetTypeNamespace()))
             {
-                return null;
-            }
-
-            // If we got this far, we can check for tag helpers
-            var tagHelpers = await project.GetTagHelpersAsync(cancellationToken).ConfigureAwait(false);
-            foreach (var tagHelper in tagHelpers)
-            {
-                // Check the typename and namespace match
-                if (IsPathCandidateForComponent(documentSnapshot, tagHelper.GetTypeNameIdentifier().AsMemory()) &&
-                    ComponentNamespaceMatchesFullyQualifiedName(razorCodeDocument, tagHelper.GetTypeNamespace().AsSpan()))
-                {
-                    return tagHelper;
-                }
+                return tagHelper;
             }
         }
 
@@ -122,7 +112,7 @@ internal class DefaultRazorComponentSearchEngine(
                 }
 
                 // Make sure we have the right namespace of the fully qualified name
-                if (!ComponentNamespaceMatchesFullyQualifiedName(razorCodeDocument, namespaceName.AsSpan()))
+                if (!ComponentNamespaceMatchesFullyQualifiedName(razorCodeDocument, namespaceName))
                 {
                     continue;
                 }
@@ -154,19 +144,13 @@ internal class DefaultRazorComponentSearchEngine(
         return fileName.AsSpan().Equals(path.Span, FilePathComparison.Instance);
     }
 
-    private bool ComponentNamespaceMatchesFullyQualifiedName(RazorCodeDocument razorCodeDocument, ReadOnlySpan<char> namespaceName)
+    private bool ComponentNamespaceMatchesFullyQualifiedName(RazorCodeDocument razorCodeDocument, string fullyQualifiedNamespace)
     {
         var namespaceNode = (NamespaceDeclarationIntermediateNode)razorCodeDocument
             .GetDocumentIntermediateNode()
             .FindDescendantNodes<IntermediateNode>()
             .First(n => n is NamespaceDeclarationIntermediateNode);
 
-        var namespacesMatch = namespaceNode.Content.AsSpan().Equals(namespaceName, StringComparison.Ordinal);
-        if (!namespacesMatch)
-        {
-            _logger.LogInformation($"Namespace name {namespaceNode.Content} does not match namespace name {namespaceName.ToString()}.");
-        }
-
-        return namespacesMatch;
+        return namespaceNode.Content == fullyQualifiedNamespace;
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentPresentation/TextDocumentUriPresentationEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentPresentation/TextDocumentUriPresentationEndpoint.cs
@@ -127,10 +127,10 @@ internal class TextDocumentUriPresentationEndpoint(
 
         cancellationToken.ThrowIfCancellationRequested();
 
-        var descriptor = await _razorComponentSearchEngine.TryGetTagHelperDescriptorAsync(documentContext.Snapshot, cancellationToken).ConfigureAwait(false);
+        var descriptor = await documentContext.Snapshot.TryGetTagHelperDescriptorAsync(cancellationToken).ConfigureAwait(false);
         if (descriptor is null)
         {
-            Logger.LogInformation($"Failed to find tag helper descriptor.");
+            Logger.LogInformation($"Failed to find tag helper descriptor for {documentContext.Snapshot.FilePath}.");
             return null;
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentPresentation/TextDocumentUriPresentationEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentPresentation/TextDocumentUriPresentationEndpoint.cs
@@ -22,14 +22,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.DocumentPresentation;
 
 internal class TextDocumentUriPresentationEndpoint(
     IRazorDocumentMappingService razorDocumentMappingService,
-    RazorComponentSearchEngine razorComponentSearchEngine,
     IClientConnection clientConnection,
     IFilePathService filePathService,
     IDocumentContextFactory documentContextFactory,
     ILoggerFactory loggerFactory)
     : AbstractTextDocumentPresentationEndpointBase<UriPresentationParams>(razorDocumentMappingService, clientConnection, filePathService, loggerFactory.GetOrCreateLogger<TextDocumentUriPresentationEndpoint>()), ITextDocumentUriPresentationHandler
 {
-    private readonly RazorComponentSearchEngine _razorComponentSearchEngine = razorComponentSearchEngine ?? throw new ArgumentNullException(nameof(razorComponentSearchEngine));
     private readonly IDocumentContextFactory _documentContextFactory = documentContextFactory ?? throw new ArgumentNullException(nameof(documentContextFactory));
 
     public override string EndpointName => CustomMessageNames.RazorUriPresentationEndpoint;
@@ -101,14 +99,14 @@ internal class TextDocumentUriPresentationEndpoint(
                     {
                         Uri = request.TextDocument.Uri
                     },
-                    Edits = new[]
-                    {
+                    Edits =
+                    [
                         new TextEdit
                         {
                             NewText = componentTagText,
                             Range = request.Range
                         }
-                    }
+                    ]
                 }
             }
         };

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentPresentation/TextDocumentUriPresentationEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentPresentation/TextDocumentUriPresentationEndpoint.cs
@@ -134,38 +134,6 @@ internal class TextDocumentUriPresentationEndpoint(
             return null;
         }
 
-        var typeName = descriptor.GetTypeNameIdentifier();
-        if (string.IsNullOrWhiteSpace(typeName))
-        {
-            Logger.LogWarning($"Found a tag helper, {descriptor.Name}, but it has an empty TypeNameIdentifier.");
-            return null;
-        }
-
-        // TODO: Add @using statements if required, or fully qualify (GetTypeName())
-
-        using var _ = StringBuilderPool.GetPooledObject(out var sb);
-
-        sb.Append('<');
-        sb.Append(typeName);
-
-        foreach (var requiredAttribute in descriptor.EditorRequiredAttributes)
-        {
-            sb.Append(' ');
-            sb.Append(requiredAttribute.Name);
-            sb.Append("=\"\"");
-        }
-
-        if (descriptor.AllowedChildTags.Length > 0)
-        {
-            sb.Append("></");
-            sb.Append(typeName);
-            sb.Append('>');
-        }
-        else
-        {
-            sb.Append(" />");
-        }
-
-        return sb.ToString();
+        return descriptor.TryGetComponentTag();
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorComponentSearchEngine.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorComponentSearchEngine.cs
@@ -10,6 +10,4 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer;
 internal abstract class RazorComponentSearchEngine
 {
     public abstract Task<IDocumentSnapshot?> TryLocateComponentAsync(TagHelperDescriptor tagHelper);
-
-    public abstract Task<TagHelperDescriptor?> TryGetTagHelperDescriptorAsync(IDocumentSnapshot codeDocument, System.Threading.CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/IDocumentSnapshotExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/IDocumentSnapshotExtensions.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+namespace Microsoft.CodeAnalysis.Razor.Workspaces;
+
+internal static class IDocumentSnapshotExtensions
+{
+    public static bool IsPathCandidateForComponent(this IDocumentSnapshot documentSnapshot, ReadOnlyMemory<char> path)
+    {
+        if (documentSnapshot.FileKind != FileKinds.Component)
+        {
+            return false;
+        }
+
+        var fileName = Path.GetFileNameWithoutExtension(documentSnapshot.FilePath);
+        return fileName.AsSpan().Equals(path.Span, FilePathComparison.Instance);
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/IDocumentSnapshotExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/IDocumentSnapshotExtensions.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
@@ -10,6 +12,43 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces;
 
 internal static class IDocumentSnapshotExtensions
 {
+    public static async Task<TagHelperDescriptor?> TryGetTagHelperDescriptorAsync(this IDocumentSnapshot documentSnapshot, CancellationToken cancellationToken)
+    {
+        // No point doing anything if its not a component
+        if (documentSnapshot.FileKind != FileKinds.Component)
+        {
+            return null;
+        }
+
+        var razorCodeDocument = await documentSnapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
+        if (razorCodeDocument is null)
+        {
+            return null;
+        }
+
+        var project = documentSnapshot.Project;
+
+        // If the document is an import document, then it can't be a component
+        if (project.IsImportDocument(documentSnapshot))
+        {
+            return null;
+        }
+
+        // If we got this far, we can check for tag helpers
+        var tagHelpers = await project.GetTagHelpersAsync(cancellationToken).ConfigureAwait(false);
+        foreach (var tagHelper in tagHelpers)
+        {
+            // Check the typename and namespace match
+            if (documentSnapshot.IsPathCandidateForComponent(tagHelper.GetTypeNameIdentifier().AsMemory()) &&
+                razorCodeDocument.ComponentNamespaceMatches(tagHelper.GetTypeNamespace()))
+            {
+                return tagHelper;
+            }
+        }
+
+        return null;
+    }
+
     public static bool IsPathCandidateForComponent(this IDocumentSnapshot documentSnapshot, ReadOnlyMemory<char> path)
     {
         if (documentSnapshot.FileKind != FileKinds.Component)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/RazorCodeDocumentExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/RazorCodeDocumentExtensions.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Intermediate;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Text;
 
@@ -130,5 +132,15 @@ internal static class RazorCodeDocumentExtensions
 
         csharpRange = default;
         return false;
+    }
+
+    public static bool ComponentNamespaceMatches(this RazorCodeDocument razorCodeDocument, string fullyQualifiedNamespace)
+    {
+        var namespaceNode = (NamespaceDeclarationIntermediateNode)razorCodeDocument
+            .GetDocumentIntermediateNode()
+            .FindDescendantNodes<IntermediateNode>()
+            .First(n => n is NamespaceDeclarationIntermediateNode);
+
+        return namespaceNode.Content == fullyQualifiedNamespace;
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/TagHelperDescriptorExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/TagHelperDescriptorExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.Razor.Workspaces;
 
@@ -12,5 +13,41 @@ internal static class TagHelperDescriptorExtensions
     {
         return d.Metadata.TryGetValue(TagHelperMetadata.Common.ClassifyAttributesOnly, out var value) ||
             string.Equals(value, bool.TrueString, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static string? TryGetComponentTag(this TagHelperDescriptor descriptor)
+    {
+        var typeName = descriptor.GetTypeNameIdentifier();
+        if (string.IsNullOrWhiteSpace(typeName))
+        {
+            return null;
+        }
+
+        // TODO: Add @using statements if required, or fully qualify (GetTypeName())
+
+        using var _ = StringBuilderPool.GetPooledObject(out var sb);
+
+        sb.Append('<');
+        sb.Append(typeName);
+
+        foreach (var requiredAttribute in descriptor.EditorRequiredAttributes)
+        {
+            sb.Append(' ');
+            sb.Append(requiredAttribute.Name);
+            sb.Append("=\"\"");
+        }
+
+        if (descriptor.AllowedChildTags.Length > 0)
+        {
+            sb.Append("></");
+            sb.Append(typeName);
+            sb.Append('>');
+        }
+        else
+        {
+            sb.Append(" />");
+        }
+
+        return sb.ToString();
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentPresentation/TextDocumentUriPresentationEndpointTests.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentPresentation/TextDocumentUriPresentationEndpointTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.DocumentPresentation;
 
 public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutput) : LanguageServerTestBase(testOutput)
 {
-    [Fact]
+    [OSSkipConditionFact(["OSX", "Linux"])]
     public async Task Handle_SimpleComponent_ReturnsResult()
     {
         // Arrange
@@ -87,7 +87,7 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         Assert.Equal("<MyTagHelper />", result!.DocumentChanges!.Value.First[0].Edits[0].NewText);
     }
 
-    [Fact]
+    [OSSkipConditionFact(["OSX", "Linux"])]
     public async Task Handle_SimpleComponentWithChildFile_ReturnsResult()
     {
         // Arrange
@@ -154,7 +154,7 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         Assert.Equal("<MyTagHelper />", result!.DocumentChanges!.Value.First[0].Edits[0].NewText);
     }
 
-    [Fact]
+    [OSSkipConditionFact(["OSX", "Linux"])]
     public async Task Handle_ComponentWithRequiredAttribute_ReturnsResult()
     {
         // Arrange
@@ -383,7 +383,7 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         Assert.Null(result);
     }
 
-    [Fact]
+    [OSSkipConditionFact(["OSX", "Linux"])]
     public async Task Handle_ComponentWithNestedFiles_ReturnsResult()
     {
         // Arrange

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentPresentation/TextDocumentUriPresentationEndpointTests.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentPresentation/TextDocumentUriPresentationEndpointTests.cs
@@ -6,7 +6,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
+using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
+using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
+using Microsoft.AspNetCore.Razor.Test.Common.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol;
@@ -26,31 +29,36 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
     public async Task Handle_SimpleComponent_ReturnsResult()
     {
         // Arrange
-        var codeDocument = TestRazorCodeDocument.Create("<div></div>");
-        var documentMappingService = Mock.Of<IRazorDocumentMappingService>(
-            s => s.GetLanguageKind(codeDocument, It.IsAny<int>(), It.IsAny<bool>()) == RazorLanguageKind.Html, MockBehavior.Strict);
+        var manager = CreateProjectSnapshotManager();
+        var project = await manager.UpdateAsync(updater => updater.CreateAndAddProject("c:/path/project.csproj"));
+        await manager.CreateAndAddDocumentAsync(project, "c:/path/index.razor");
+        await manager.CreateAndAddDocumentAsync(project, "c:/path/MyTagHelper.razor");
 
-        var componentCodeDocument = TestRazorCodeDocument.Create("<div></div>");
+        var documentMappingService = Mock.Of<IRazorDocumentMappingService>(
+            s => s.GetLanguageKind(It.IsAny<RazorCodeDocument>(), It.IsAny<int>(), It.IsAny<bool>()) == RazorLanguageKind.Html, MockBehavior.Strict);
+
         var droppedUri = new Uri("file:///c:/path/MyTagHelper.razor");
         var builder = TagHelperDescriptorBuilder.Create("MyTagHelper", "MyAssembly");
-        builder.Metadata(TypeNameIdentifier("MyTagHelper"));
+        builder.SetMetadata(TypeNameIdentifier("MyTagHelper"), TypeNamespace("TestRootNamespace"));
         var tagHelperDescriptor = builder.Build();
 
-        var uri = new Uri("file://path/test.razor");
+        await manager.UpdateAsync(updater => updater.ProjectWorkspaceStateChanged(project.Key, ProjectWorkspaceState.Create([tagHelperDescriptor])));
 
-        var documentSnapshot = Mock.Of<IDocumentSnapshot>(s => s.GetGeneratedOutputAsync() == Task.FromResult(componentCodeDocument), MockBehavior.Strict);
-        var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
+        var razorFilePath = "c:/path/index.razor";
+        var uri = new Uri(razorFilePath);
 
-        var documentContext = CreateDocumentContext(uri, codeDocument);
-        var searchEngine = Mock.Of<RazorComponentSearchEngine>(
-            s => s.TryGetTagHelperDescriptorAsync(It.IsAny<IDocumentSnapshot>(), It.IsAny<CancellationToken>()) == Task.FromResult(tagHelperDescriptor),
-            MockBehavior.Strict);
+        var snapshotResolver = new SnapshotResolver(manager, LoggerFactory);
+        var documentVersionCache = new DocumentVersionCache(manager);
+        await manager.UpdateAsync(updater => updater.DocumentOpened(project.Key, razorFilePath, SourceText.From("<div></div>")));
+        var documentSnapshot = manager.GetLoadedProject(project.Key).GetDocument(razorFilePath).AssumeNotNull();
+        documentVersionCache.TrackDocumentVersion(documentSnapshot, 1);
+        var documentContextFactory = new DocumentContextFactory(manager, snapshotResolver, documentVersionCache, LoggerFactory);
+        var documentContext = await documentContextFactory.TryCreateForOpenDocumentAsync(uri, null, DisposalToken);
 
         var clientConnection = new Mock<IClientConnection>(MockBehavior.Strict);
 
         var endpoint = new TextDocumentUriPresentationEndpoint(
             documentMappingService,
-            searchEngine,
             clientConnection.Object,
             FilePathService,
             documentContextFactory,
@@ -67,10 +75,7 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
                 Start = new Position(0, 1),
                 End = new Position(0, 2)
             },
-            Uris = new[]
-            {
-                droppedUri
-            }
+            Uris = [droppedUri]
         };
         var requestContext = CreateRazorRequestContext(documentContext);
 
@@ -86,30 +91,36 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
     public async Task Handle_SimpleComponentWithChildFile_ReturnsResult()
     {
         // Arrange
-        var codeDocument = TestRazorCodeDocument.Create("<div></div>");
-        var documentMappingService = Mock.Of<IRazorDocumentMappingService>(
-            s => s.GetLanguageKind(codeDocument, It.IsAny<int>(), It.IsAny<bool>()) == RazorLanguageKind.Html, MockBehavior.Strict);
+        var manager = CreateProjectSnapshotManager();
+        var project = await manager.UpdateAsync(updater => updater.CreateAndAddProject("c:/path/project.csproj"));
+        await manager.CreateAndAddDocumentAsync(project, "c:/path/index.razor");
+        await manager.CreateAndAddDocumentAsync(project, "c:/path/MyTagHelper.razor");
 
-        var componentCodeDocument = TestRazorCodeDocument.Create("<div></div>");
+        var documentMappingService = Mock.Of<IRazorDocumentMappingService>(
+            s => s.GetLanguageKind(It.IsAny<RazorCodeDocument>(), It.IsAny<int>(), It.IsAny<bool>()) == RazorLanguageKind.Html, MockBehavior.Strict);
+
         var droppedUri = new Uri("file:///c:/path/MyTagHelper.razor");
         var builder = TagHelperDescriptorBuilder.Create("MyTagHelper", "MyAssembly");
-        builder.Metadata(TypeNameIdentifier("MyTagHelper"));
+        builder.SetMetadata(TypeNameIdentifier("MyTagHelper"), TypeNamespace("TestRootNamespace"));
         var tagHelperDescriptor = builder.Build();
 
-        var documentSnapshot = Mock.Of<IDocumentSnapshot>(s => s.GetGeneratedOutputAsync() == Task.FromResult(componentCodeDocument), MockBehavior.Strict);
+        await manager.UpdateAsync(updater => updater.ProjectWorkspaceStateChanged(project.Key, ProjectWorkspaceState.Create([tagHelperDescriptor])));
 
-        var uri = new Uri("file://path/test.razor");
-        var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
-        var documentContext = CreateDocumentContext(uri, codeDocument);
-        var searchEngine = Mock.Of<RazorComponentSearchEngine>(
-            s => s.TryGetTagHelperDescriptorAsync(It.IsAny<IDocumentSnapshot>(), It.IsAny<CancellationToken>()) == Task.FromResult(tagHelperDescriptor),
-            MockBehavior.Strict);
+        var razorFilePath = "c:/path/index.razor";
+        var uri = new Uri(razorFilePath);
+
+        var snapshotResolver = new SnapshotResolver(manager, LoggerFactory);
+        var documentVersionCache = new DocumentVersionCache(manager);
+        await manager.UpdateAsync(updater => updater.DocumentOpened(project.Key, razorFilePath, SourceText.From("<div></div>")));
+        var documentSnapshot = manager.GetLoadedProject(project.Key).GetDocument(razorFilePath).AssumeNotNull();
+        documentVersionCache.TrackDocumentVersion(documentSnapshot, 1);
+        var documentContextFactory = new DocumentContextFactory(manager, snapshotResolver, documentVersionCache, LoggerFactory);
+        var documentContext = await documentContextFactory.TryCreateForOpenDocumentAsync(uri, null, DisposalToken);
 
         var clientConnection = new Mock<IClientConnection>(MockBehavior.Strict);
 
         var endpoint = new TextDocumentUriPresentationEndpoint(
             documentMappingService,
-            searchEngine,
             clientConnection.Object,
             FilePathService,
             documentContextFactory,
@@ -126,12 +137,12 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
                 Start = new Position(0, 1),
                 End = new Position(0, 2)
             },
-            Uris = new[]
-            {
+            Uris =
+            [
                 new Uri("file:///c:/path/MyTagHelper.razor.cs"),
                 new Uri("file:///c:/path/MyTagHelper.razor.css"),
                 droppedUri,
-            }
+            ]
         };
         var requestContext = CreateRazorRequestContext(documentContext);
 
@@ -147,14 +158,17 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
     public async Task Handle_ComponentWithRequiredAttribute_ReturnsResult()
     {
         // Arrange
-        var codeDocument = TestRazorCodeDocument.Create("<div></div>");
-        var documentMappingService = Mock.Of<IRazorDocumentMappingService>(
-            s => s.GetLanguageKind(codeDocument, It.IsAny<int>(), It.IsAny<bool>()) == RazorLanguageKind.Html, MockBehavior.Strict);
+        var manager = CreateProjectSnapshotManager();
+        var project = await manager.UpdateAsync(updater => updater.CreateAndAddProject("c:/path/project.csproj"));
+        await manager.CreateAndAddDocumentAsync(project, "c:/path/index.razor");
+        await manager.CreateAndAddDocumentAsync(project, "c:/path/fetchdata.razor");
 
-        var componentCodeDocument = TestRazorCodeDocument.Create("<div></div>");
-        var droppedUri = new Uri("file:///c:/path/MyTagHelper.razor");
-        var builder = TagHelperDescriptorBuilder.Create("MyTagHelper", "MyAssembly");
-        builder.Metadata(TypeNameIdentifier("MyTagHelper"));
+        var documentMappingService = Mock.Of<IRazorDocumentMappingService>(
+            s => s.GetLanguageKind(It.IsAny<RazorCodeDocument>(), It.IsAny<int>(), It.IsAny<bool>()) == RazorLanguageKind.Html, MockBehavior.Strict);
+
+        var droppedUri = new Uri("file:///c:/path/fetchdata.razor");
+        var builder = TagHelperDescriptorBuilder.Create("FetchData", "MyAssembly");
+        builder.SetMetadata(TypeNameIdentifier("FetchData"), TypeNamespace("TestRootNamespace"));
         builder.BindAttribute(b =>
         {
             b.IsEditorRequired = true;
@@ -163,20 +177,23 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         builder.BindAttribute(b => b.Name = "MyNonRequiredAttribute");
         var tagHelperDescriptor = builder.Build();
 
-        var documentSnapshot = Mock.Of<IDocumentSnapshot>(s => s.GetGeneratedOutputAsync() == Task.FromResult(componentCodeDocument), MockBehavior.Strict);
+        await manager.UpdateAsync(updater => updater.ProjectWorkspaceStateChanged(project.Key, ProjectWorkspaceState.Create([tagHelperDescriptor])));
 
-        var uri = new Uri("file://path/test.razor");
-        var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
-        var documentContext = CreateDocumentContext(uri, codeDocument);
-        var searchEngine = Mock.Of<RazorComponentSearchEngine>(
-            s => s.TryGetTagHelperDescriptorAsync(It.IsAny<IDocumentSnapshot>(), It.IsAny<CancellationToken>()) == Task.FromResult(tagHelperDescriptor),
-            MockBehavior.Strict);
+        var razorFilePath = "c:/path/index.razor";
+        var uri = new Uri(razorFilePath);
+
+        var snapshotResolver = new SnapshotResolver(manager, LoggerFactory);
+        var documentVersionCache = new DocumentVersionCache(manager);
+        await manager.UpdateAsync(updater => updater.DocumentOpened(project.Key, razorFilePath, SourceText.From("<div></div>")));
+        var documentSnapshot = manager.GetLoadedProject(project.Key).GetDocument(razorFilePath).AssumeNotNull();
+        documentVersionCache.TrackDocumentVersion(documentSnapshot, 1);
+        var documentContextFactory = new DocumentContextFactory(manager, snapshotResolver, documentVersionCache, LoggerFactory);
+        var documentContext = await documentContextFactory.TryCreateForOpenDocumentAsync(uri, null, DisposalToken);
 
         var clientConnection = new Mock<IClientConnection>(MockBehavior.Strict);
 
         var endpoint = new TextDocumentUriPresentationEndpoint(
             documentMappingService,
-            searchEngine,
             clientConnection.Object,
             FilePathService,
             documentContextFactory,
@@ -193,10 +210,7 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
                 Start = new Position(0, 1),
                 End = new Position(0, 2)
             },
-            Uris = new[]
-            {
-                droppedUri
-            }
+            Uris = [droppedUri]
         };
         var requestContext = CreateRazorRequestContext(documentContext);
 
@@ -205,7 +219,7 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
 
         // Assert
         Assert.NotNull(result);
-        Assert.Equal("<MyTagHelper MyAttribute=\"\" />", result!.DocumentChanges!.Value.First[0].Edits[0].NewText);
+        Assert.Equal("<FetchData MyAttribute=\"\" />", result!.DocumentChanges!.Value.First[0].Edits[0].NewText);
     }
 
     [Fact]
@@ -226,9 +240,6 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         var uri = new Uri("file://path/test.razor");
         var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
         var documentContext = CreateDocumentContext(uri, codeDocument);
-        var searchEngine = Mock.Of<RazorComponentSearchEngine>(
-            s => s.TryGetTagHelperDescriptorAsync(It.IsAny<IDocumentSnapshot>(), It.IsAny<CancellationToken>()) == Task.FromResult(tagHelperDescriptor),
-            MockBehavior.Strict);
 
         var response = (WorkspaceEdit?)null;
 
@@ -239,7 +250,6 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
 
         var endpoint = new TextDocumentUriPresentationEndpoint(
             documentMappingService,
-            searchEngine,
             clientConnection.Object,
             FilePathService,
             documentContextFactory,
@@ -256,10 +266,7 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
                 Start = new Position(0, 1),
                 End = new Position(0, 2)
             },
-            Uris = new[]
-            {
-                droppedUri
-            }
+            Uris = [droppedUri]
         };
         var requestContext = CreateRazorRequestContext(documentContext);
 
@@ -283,7 +290,6 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         var uri = new Uri("file://path/test.razor");
         var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
         var documentContext = CreateDocumentContext(uri, codeDocument);
-        var searchEngine = Mock.Of<RazorComponentSearchEngine>(MockBehavior.Strict);
 
         var response = (WorkspaceEdit?)null;
 
@@ -294,7 +300,6 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
 
         var endpoint = new TextDocumentUriPresentationEndpoint(
             documentMappingService,
-            searchEngine,
             clientConnection.Object,
             FilePathService,
             documentContextFactory,
@@ -311,12 +316,12 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
                 Start = new Position(0, 1),
                 End = new Position(0, 2)
             },
-            Uris = new[]
-            {
+            Uris =
+            [
                 new Uri("file:///c:/path/SomeOtherFile.cs"),
                 new Uri("file:///c:/path/Bar.Foo"),
                 new Uri("file:///c:/path/MyTagHelper.razor"),
-            }
+            ]
         };
         var requestContext = CreateRazorRequestContext(documentContext);
 
@@ -341,7 +346,6 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         var uri = new Uri("file://path/test.razor");
         var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
         var documentContext = CreateDocumentContext(uri, codeDocument);
-        var searchEngine = Mock.Of<RazorComponentSearchEngine>(MockBehavior.Strict);
 
         var response = (WorkspaceEdit?)null;
 
@@ -352,7 +356,6 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
 
         var endpoint = new TextDocumentUriPresentationEndpoint(
             documentMappingService,
-            searchEngine,
             clientConnection.Object,
             FilePathService,
             documentContextFactory,
@@ -369,10 +372,7 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
                 Start = new Position(0, 1),
                 End = new Position(0, 2)
             },
-            Uris = new[]
-            {
-                droppedUri
-            }
+            Uris = [droppedUri]
         };
         var requestContext = CreateRazorRequestContext(documentContext);
 
@@ -387,35 +387,37 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
     public async Task Handle_ComponentWithNestedFiles_ReturnsResult()
     {
         // Arrange
-        var codeDocument = TestRazorCodeDocument.Create(@"<FetchData\>");
-        var documentMappingService = Mock.Of<IRazorDocumentMappingService>(
-            s => s.GetLanguageKind(codeDocument, It.IsAny<int>(), It.IsAny<bool>()) == RazorLanguageKind.Html, MockBehavior.Strict);
+        var manager = CreateProjectSnapshotManager();
+        var project = await manager.UpdateAsync(updater => updater.CreateAndAddProject("c:/path/project.csproj"));
+        await manager.CreateAndAddDocumentAsync(project, "c:/path/index.razor");
+        await manager.CreateAndAddDocumentAsync(project, "c:/path/fetchdata.razor");
 
-        var documentSnapshot = Mock.Of<IDocumentSnapshot>(s => s.GetGeneratedOutputAsync() == Task.FromResult(codeDocument), MockBehavior.Strict);
+        var documentMappingService = Mock.Of<IRazorDocumentMappingService>(
+            s => s.GetLanguageKind(It.IsAny<RazorCodeDocument>(), It.IsAny<int>(), It.IsAny<bool>()) == RazorLanguageKind.Html, MockBehavior.Strict);
 
         var droppedUri1 = new Uri("file:///c:/path/fetchdata.razor.cs");
         var droppedUri2 = new Uri("file:///c:/path/fetchdata.razor");
         var builder = TagHelperDescriptorBuilder.Create("FetchData", "MyAssembly");
-        builder.SetMetadata(TypeNameIdentifier("FetchData"));
+        builder.SetMetadata(TypeNameIdentifier("FetchData"), TypeNamespace("TestRootNamespace"));
         var tagHelperDescriptor = builder.Build();
 
-        var uri = new Uri("file://path/index.razor");
-        var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
-        var documentContext = CreateDocumentContext(uri, codeDocument);
-        var searchEngine = Mock.Of<RazorComponentSearchEngine>(
-            s => s.TryGetTagHelperDescriptorAsync(It.IsAny<IDocumentSnapshot>(), It.IsAny<CancellationToken>()) == Task.FromResult(tagHelperDescriptor),
-            MockBehavior.Strict);
+        await manager.UpdateAsync(updater => updater.ProjectWorkspaceStateChanged(project.Key, ProjectWorkspaceState.Create([tagHelperDescriptor])));
 
-        var response = (WorkspaceEdit?)null;
+        var razorFilePath = "c:/path/index.razor";
+        var uri = new Uri(razorFilePath);
+
+        var snapshotResolver = new SnapshotResolver(manager, LoggerFactory);
+        var documentVersionCache = new DocumentVersionCache(manager);
+        await manager.UpdateAsync(updater => updater.DocumentOpened(project.Key, razorFilePath, SourceText.From("<div></div>")));
+        var documentSnapshot = manager.GetLoadedProject(project.Key).GetDocument(razorFilePath).AssumeNotNull();
+        documentVersionCache.TrackDocumentVersion(documentSnapshot, 1);
+        var documentContextFactory = new DocumentContextFactory(manager, snapshotResolver, documentVersionCache, LoggerFactory);
+        var documentContext = await documentContextFactory.TryCreateForOpenDocumentAsync(uri, null, DisposalToken);
 
         var clientConnection = new Mock<IClientConnection>(MockBehavior.Strict);
-        clientConnection
-            .Setup(l => l.SendRequestAsync<IRazorPresentationParams, WorkspaceEdit?>(CustomMessageNames.RazorUriPresentationEndpoint, It.IsAny<IRazorPresentationParams>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(response);
 
         var endpoint = new TextDocumentUriPresentationEndpoint(
             documentMappingService,
-            searchEngine,
             clientConnection.Object,
             FilePathService,
             documentContextFactory,
@@ -432,11 +434,7 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
                 Start = new Position(0, 1),
                 End = new Position(0, 2)
             },
-            Uris = new[]
-            {
-                droppedUri1,
-                droppedUri2,
-            }
+            Uris = [droppedUri1, droppedUri2]
         };
         var requestContext = CreateRazorRequestContext(documentContext);
 
@@ -460,7 +458,6 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         var documentMappingService = Mock.Of<IRazorDocumentMappingService>(
             s => s.GetLanguageKind(codeDocument, It.IsAny<int>(), It.IsAny<bool>()) == RazorLanguageKind.CSharp &&
             s.TryMapToGeneratedDocumentRange(csharpDocument, It.IsAny<LinePositionSpan>(), out projectedRange) == true, MockBehavior.Strict);
-        var searchEngine = Mock.Of<RazorComponentSearchEngine>(MockBehavior.Strict);
 
         var documentSnapshot = Mock.Of<IDocumentSnapshot>(s => s.GetGeneratedOutputAsync() == Task.FromResult(codeDocument), MockBehavior.Strict);
         var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
@@ -474,7 +471,6 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
 
         var endpoint = new TextDocumentUriPresentationEndpoint(
             documentMappingService,
-            searchEngine,
             clientConnection.Object,
             FilePathService,
             documentContextFactory,
@@ -510,7 +506,6 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         var documentContext = CreateDocumentContext(uri, codeDocument);
         var documentMappingService = Mock.Of<IRazorDocumentMappingService>(
             s => s.GetLanguageKind(codeDocument, It.IsAny<int>(), It.IsAny<bool>()) == RazorLanguageKind.Html, MockBehavior.Strict);
-        var searchEngine = Mock.Of<RazorComponentSearchEngine>(MockBehavior.Strict);
 
         var documentSnapshot = Mock.Of<IDocumentSnapshot>(s => s.GetGeneratedOutputAsync() == Task.FromResult(codeDocument), MockBehavior.Strict);
         var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
@@ -524,7 +519,6 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
 
         var endpoint = new TextDocumentUriPresentationEndpoint(
             documentMappingService,
-            searchEngine,
             clientConnection.Object,
             FilePathService,
             documentContextFactory,
@@ -561,7 +555,6 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         var documentContext = CreateDocumentContext(uri, codeDocument);
         var documentMappingService = Mock.Of<IRazorDocumentMappingService>(
             s => s.GetLanguageKind(codeDocument, It.IsAny<int>(), It.IsAny<bool>()) == RazorLanguageKind.Html, MockBehavior.Strict);
-        var searchEngine = Mock.Of<RazorComponentSearchEngine>(MockBehavior.Strict);
 
         var documentSnapshot = Mock.Of<IDocumentSnapshot>(s => s.GetGeneratedOutputAsync() == Task.FromResult(codeDocument), MockBehavior.Strict);
         var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
@@ -575,7 +568,6 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
 
         var endpoint = new TextDocumentUriPresentationEndpoint(
             documentMappingService,
-            searchEngine,
             clientConnection.Object,
             FilePathService,
             documentContextFactory,
@@ -611,7 +603,6 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         var documentContext = CreateDocumentContext(uri, codeDocument);
         var documentMappingService = Mock.Of<IRazorDocumentMappingService>(
             s => s.GetLanguageKind(codeDocument, It.IsAny<int>(), It.IsAny<bool>()) == RazorLanguageKind.Html, MockBehavior.Strict);
-        var searchEngine = Mock.Of<RazorComponentSearchEngine>(MockBehavior.Strict);
 
         var documentSnapshot = Mock.Of<IDocumentSnapshot>(s => s.GetGeneratedOutputAsync() == Task.FromResult(codeDocument), MockBehavior.Strict);
         var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
@@ -625,7 +616,6 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
 
         var endpoint = new TextDocumentUriPresentationEndpoint(
             documentMappingService,
-            searchEngine,
             clientConnection.Object,
             FilePathService,
             documentContextFactory,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/LanguageServerTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/LanguageServerTestBase.cs
@@ -25,7 +25,6 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Moq;
 using Newtonsoft.Json;
 using Xunit.Abstractions;
-using static Nerdbank.Streams.MultiplexingStream;
 
 namespace Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 


### PR DESCRIPTION
As part of moving the Uri presentation endpoint to cohosting, I needed to do this, and thought it would be easier to review separately.

Part of https://github.com/dotnet/razor/issues/9519