### PR TITLE
Remove ProjectSnapshotManagerDispatcher from all "document processed listeners"

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeDocumentReferenceHolder.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeDocumentReferenceHolder.cs
@@ -35,10 +35,6 @@ internal class CodeDocumentReferenceHolder : IDocumentProcessedListener
         }
     }
 
-    public void Initialize(IProjectSnapshotManager projectManager)
-    {
-    }
-
     private void ProjectManager_Changed(object? sender, ProjectChangeEventArgs args)
     {
         // Goal here is to evict cache entries (really just references to code documents) of known documents when

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeDocumentReferenceHolder.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeDocumentReferenceHolder.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
-internal class CodeDocumentReferenceHolder : DocumentProcessedListener
+internal class CodeDocumentReferenceHolder : IDocumentProcessedListener
 {
     private Dictionary<DocumentKey, RazorCodeDocument> _codeDocumentCache;
     private IProjectSnapshotManager? _projectManager;
@@ -18,7 +18,7 @@ internal class CodeDocumentReferenceHolder : DocumentProcessedListener
         _codeDocumentCache = new();
     }
 
-    public override void DocumentProcessed(RazorCodeDocument codeDocument, IDocumentSnapshot documentSnapshot)
+    public void DocumentProcessed(RazorCodeDocument codeDocument, IDocumentSnapshot documentSnapshot)
     {
         // We capture a reference to the code document after a document has been processed in order to ensure that
         // latest document state information is readily available without re-computation. The DocumentState type
@@ -29,7 +29,7 @@ internal class CodeDocumentReferenceHolder : DocumentProcessedListener
         _codeDocumentCache[key] = codeDocument;
     }
 
-    public override void Initialize(IProjectSnapshotManager projectManager)
+    public void Initialize(IProjectSnapshotManager projectManager)
     {
         _projectManager = projectManager;
         _projectManager.Changed += ProjectManager_Changed;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.Comparer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.Comparer.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics;
+
+internal partial class RazorDiagnosticsPublisher
+{
+    private sealed class Comparer : IEqualityComparer<IDocumentSnapshot>
+    {
+        public static readonly Comparer Instance = new();
+
+        private Comparer()
+        {
+        }
+
+        public bool Equals(IDocumentSnapshot? x, IDocumentSnapshot? y)
+        {
+            var filePathX = x?.FilePath;
+            var filePathY = y?.FilePath;
+
+            return FilePathComparer.Instance.Equals(filePathX, filePathY);
+        }
+
+        public int GetHashCode(IDocumentSnapshot obj)
+        {
+            var filePath = obj.FilePath.AssumeNotNull();
+            return FilePathComparer.Instance.GetHashCode(filePath);
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.TestAccessor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.TestAccessor.cs
@@ -39,22 +39,9 @@ internal partial class RazorDiagnosticsPublisher
             await task.ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Used in tests to ensure we can control when background work completes.
-        /// </summary>
-        public ManualResetEventSlim? BlockBackgroundWorkCompleting
+        public Task WaitForDiagnosticsToPublishAsync()
         {
-            get => instance._blockBackgroundWorkCompleting;
-            set => instance._blockBackgroundWorkCompleting = value;
-        }
-
-        /// <summary>
-        /// Used in tests to ensure we can control when background work completes.
-        /// </summary>
-        public ManualResetEventSlim? NotifyBackgroundWorkCompleting
-        {
-            get => instance._notifyBackgroundWorkCompleting;
-            set => instance._notifyBackgroundWorkCompleting = value;
+            return instance._workQueue.WaitUntilCurrentBatchCompletesAsync();
         }
 
         public void SetPublishedCSharpDiagnostics(string filePath, ImmutableArray<Diagnostic> diagnostics)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.TestAccessor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.TestAccessor.cs
@@ -78,9 +78,9 @@ internal partial class RazorDiagnosticsPublisher
             instance.ClearClosedDocuments();
         }
 
-        public Task PublishDiagnosticsAsync(IDocumentSnapshot document)
+        public Task PublishDiagnosticsAsync(IDocumentSnapshot document, CancellationToken cancellationToken)
         {
-            return instance.PublishDiagnosticsAsync(document);
+            return instance.PublishDiagnosticsAsync(document, cancellationToken);
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.TestAccessor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.TestAccessor.cs
@@ -44,19 +44,11 @@ internal partial class RazorDiagnosticsPublisher
             return instance._workQueue.WaitUntilCurrentBatchCompletesAsync();
         }
 
-        public void SetPublishedCSharpDiagnostics(string filePath, ImmutableArray<Diagnostic> diagnostics)
+        public void SetPublishedDiagnostics(string filePath, RazorDiagnostic[] razorDiagnostics, Diagnostic[]? csharpDiagnostics)
         {
-            lock (instance._publishedDiagnosticsGate)
+            lock (instance._publishedDiagnostics)
             {
-                instance._publishedCSharpDiagnostics[filePath] = diagnostics;
-            }
-        }
-
-        public void SetPublishedRazorDiagnostics(string filePath, ImmutableArray<RazorDiagnostic> diagnostics)
-        {
-            lock (instance._publishedDiagnosticsGate)
-            {
-                instance._publishedRazorDiagnostics[filePath] = diagnostics;
+                instance._publishedDiagnostics[filePath] = new(razorDiagnostics, csharpDiagnostics);
             }
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.TestAccessor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.TestAccessor.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Collections.Immutable;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics;
 
 internal partial class RazorDiagnosticsPublisher
@@ -10,5 +14,21 @@ internal partial class RazorDiagnosticsPublisher
     internal sealed class TestAccessor(RazorDiagnosticsPublisher instance)
     {
         public bool IsWaitingToClearClosedDocuments => instance._documentClosedTimer is not null;
+
+        public void SetPublishedCSharpDiagnostics(string filePath, ImmutableArray<Diagnostic> diagnostics)
+        {
+            lock (instance._gate)
+            {
+                instance._publishedCSharpDiagnostics[filePath] = diagnostics;
+            }
+        }
+
+        public void SetPublishedRazorDiagnostics(string filePath, ImmutableArray<RazorDiagnostic> diagnostics)
+        {
+            lock (instance._gate)
+            {
+                instance._publishedRazorDiagnostics[filePath] = diagnostics;
+            }
+        }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.TestAccessor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.TestAccessor.cs
@@ -20,23 +20,15 @@ internal partial class RazorDiagnosticsPublisher
         {
             get
             {
-                lock (instance._documentClosedGate)
-                {
-                    return instance._waitingToClearClosedDocuments;
-                }
+                return !instance._clearClosedDocumentsTask.IsCompleted;
             }
         }
 
-        public async Task WaitForClearClosedDocumentsAsync()
+        public Task WaitForClearClosedDocumentsAsync()
         {
-            Task task;
-
-            lock (instance._documentClosedGate)
-            {
-                task = instance._clearClosedDocumentsTask;
-            }
-
-            await task.ConfigureAwait(false);
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
+            return instance._clearClosedDocumentsTask;
+#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
         }
 
         public Task WaitForDiagnosticsToPublishAsync()

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.TestAccessor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.TestAccessor.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics;
@@ -29,6 +31,16 @@ internal partial class RazorDiagnosticsPublisher
             {
                 instance._publishedRazorDiagnostics[filePath] = diagnostics;
             }
+        }
+
+        public void ClearClosedDocuments()
+        {
+            instance.ClearClosedDocuments();
+        }
+
+        public Task PublishDiagnosticsAsync(IDocumentSnapshot document)
+        {
+            return instance.PublishDiagnosticsAsync(document);
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.TestAccessor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.TestAccessor.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics;
+
+internal partial class RazorDiagnosticsPublisher
+{
+    internal TestAccessor GetTestAccessor() => new(this);
+
+    internal sealed class TestAccessor(RazorDiagnosticsPublisher instance)
+    {
+        public bool IsWaitingToClearClosedDocuments => instance._documentClosedTimer is not null;
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.TestAccessor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.TestAccessor.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -16,6 +17,24 @@ internal partial class RazorDiagnosticsPublisher
     internal sealed class TestAccessor(RazorDiagnosticsPublisher instance)
     {
         public bool IsWaitingToClearClosedDocuments => instance._documentClosedTimer is not null;
+
+        /// <summary>
+        /// Used in tests to ensure we can control when background work completes.
+        /// </summary>
+        public ManualResetEventSlim? BlockBackgroundWorkCompleting
+        {
+            get => instance._blockBackgroundWorkCompleting;
+            set => instance._blockBackgroundWorkCompleting = value;
+        }
+
+        /// <summary>
+        /// Used in tests to ensure we can control when background work completes.
+        /// </summary>
+        public ManualResetEventSlim? NotifyBackgroundWorkCompleting
+        {
+            get => instance._notifyBackgroundWorkCompleting;
+            set => instance._notifyBackgroundWorkCompleting = value;
+        }
 
         public void SetPublishedCSharpDiagnostics(string filePath, ImmutableArray<Diagnostic> diagnostics)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -14,6 +15,7 @@ using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol;
+using Microsoft.CodeAnalysis.Razor.Utilities;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Threading;
@@ -26,16 +28,14 @@ internal partial class RazorDiagnosticsPublisher : IDocumentProcessedListener, I
     private static readonly TimeSpan s_clearClosedDocumentsDelay = TimeSpan.FromSeconds(5);
 
     private readonly IProjectSnapshotManager _projectManager;
-    private readonly ProjectSnapshotManagerDispatcher _dispatcher;
     private readonly IClientConnection _clientConnection;
-    private readonly Dictionary<string, IDocumentSnapshot> _work;
     private readonly ILogger _logger;
     private readonly LanguageServerFeatureOptions _options;
     private readonly Lazy<RazorTranslateDiagnosticsService> _translateDiagnosticsService;
     private readonly Lazy<IDocumentContextFactory> _documentContextFactory;
-    private readonly TimeSpan _publishDelay;
 
     private readonly CancellationTokenSource _disposeTokenSource;
+    private readonly AsyncBatchingWorkQueue<IDocumentSnapshot> _workQueue;
 
     private readonly object _publishedDiagnosticsGate = new();
     private readonly Dictionary<string, IReadOnlyList<RazorDiagnostic>> _publishedRazorDiagnostics;
@@ -45,21 +45,18 @@ internal partial class RazorDiagnosticsPublisher : IDocumentProcessedListener, I
     private Task _clearClosedDocumentsTask = Task.CompletedTask;
     private bool _waitingToClearClosedDocuments;
 
-    private Timer? _workTimer;
-
     private ManualResetEventSlim? _blockBackgroundWorkCompleting;
     private ManualResetEventSlim? _notifyBackgroundWorkCompleting;
 
     public RazorDiagnosticsPublisher(
         IProjectSnapshotManager projectManager,
-        ProjectSnapshotManagerDispatcher dispatcher,
         IClientConnection clientConnection,
         LanguageServerFeatureOptions options,
         Lazy<RazorTranslateDiagnosticsService> translateDiagnosticsService,
         Lazy<IDocumentContextFactory> documentContextFactory,
         ILoggerFactory loggerFactory)
-        : this(projectManager, dispatcher, clientConnection,
-               options, translateDiagnosticsService, documentContextFactory,
+        : this(projectManager, clientConnection, options,
+              translateDiagnosticsService, documentContextFactory,
                loggerFactory, s_publishDelay)
     {
     }
@@ -67,60 +64,131 @@ internal partial class RazorDiagnosticsPublisher : IDocumentProcessedListener, I
     // Present for test to specify publish delay
     protected RazorDiagnosticsPublisher(
         IProjectSnapshotManager projectManager,
-        ProjectSnapshotManagerDispatcher dispatcher,
         IClientConnection clientConnection,
-        LanguageServerFeatureOptions languageServerFeatureOptions,
-        Lazy<RazorTranslateDiagnosticsService> razorTranslateDiagnosticsService,
+        LanguageServerFeatureOptions options,
+        Lazy<RazorTranslateDiagnosticsService> translateDiagnosticsService,
         Lazy<IDocumentContextFactory> documentContextFactory,
         ILoggerFactory loggerFactory,
         TimeSpan publishDelay)
     {
         _projectManager = projectManager;
-        _dispatcher = dispatcher;
         _clientConnection = clientConnection;
-        _options = languageServerFeatureOptions;
-        _translateDiagnosticsService = razorTranslateDiagnosticsService;
+        _options = options;
+        _translateDiagnosticsService = translateDiagnosticsService;
         _documentContextFactory = documentContextFactory;
 
         _disposeTokenSource = new();
+        _workQueue = new AsyncBatchingWorkQueue<IDocumentSnapshot>(publishDelay, ProcessBatchAsync, _disposeTokenSource.Token);
+
         _publishedRazorDiagnostics = new Dictionary<string, IReadOnlyList<RazorDiagnostic>>(FilePathComparer.Instance);
         _publishedCSharpDiagnostics = new Dictionary<string, IReadOnlyList<Diagnostic>>(FilePathComparer.Instance);
-        _work = new Dictionary<string, IDocumentSnapshot>(FilePathComparer.Instance);
         _logger = loggerFactory.GetOrCreateLogger<RazorDiagnosticsPublisher>();
-        _publishDelay = publishDelay;
     }
 
     public void Dispose()
     {
-        _workTimer?.Dispose();
-
         _disposeTokenSource.Cancel();
         _disposeTokenSource.Dispose();
     }
 
     public void DocumentProcessed(RazorCodeDocument codeDocument, IDocumentSnapshot document)
     {
-        if (document is null)
-        {
-            throw new ArgumentNullException(nameof(document));
-        }
+        _workQueue.AddWork(document);
 
-        _dispatcher.AssertRunningOnDispatcher();
-
-        lock (_work)
-        {
-            var filePath = document.FilePath.AssumeNotNull();
-            _work[filePath] = document;
-            StartWorkTimer();
-            StartDelayToClearDocuments();
-        }
+        StartDelayToClearDocuments();
     }
 
-    private void StartWorkTimer()
+    private async ValueTask ProcessBatchAsync(ImmutableArray<IDocumentSnapshot> items, CancellationToken token)
     {
-        // Access to the timer is protected by the lock in Synchronize and in Timer_Tick
-        // Timer will fire after a fixed delay, but only once.
-        _workTimer ??= new Timer(WorkTimer_Tick, state: null, dueTime: _publishDelay, period: Timeout.InfiniteTimeSpan);
+        foreach (var document in items.GetMostRecentUniqueItems(Comparer.Instance))
+        {
+            if (token.IsCancellationRequested)
+            {
+                return;
+            }
+
+            await PublishDiagnosticsAsync(document, token).ConfigureAwait(false);
+        }
+
+        OnCompletingBackgroundWork();
+    }
+
+    private async Task PublishDiagnosticsAsync(IDocumentSnapshot document, CancellationToken token)
+    {
+        var result = await document.GetGeneratedOutputAsync().ConfigureAwait(false);
+
+        Diagnostic[]? csharpDiagnostics = null;
+        if (_options.DelegateToCSharpOnDiagnosticPublish)
+        {
+            var uriBuilder = new UriBuilder()
+            {
+                Scheme = Uri.UriSchemeFile,
+                Path = document.FilePath,
+                Host = string.Empty,
+            };
+
+            var delegatedParams = new DocumentDiagnosticParams
+            {
+                TextDocument = new TextDocumentIdentifier { Uri = uriBuilder.Uri },
+            };
+
+            var delegatedResponse = await _clientConnection.SendRequestAsync<DocumentDiagnosticParams, SumType<FullDocumentDiagnosticReport, UnchangedDocumentDiagnosticReport>?>(
+                CustomMessageNames.RazorCSharpPullDiagnosticsEndpointName,
+                delegatedParams,
+                token).ConfigureAwait(false);
+
+            if (delegatedResponse.HasValue &&
+                delegatedResponse.Value.TryGetFirst(out var fullDiagnostics) &&
+                fullDiagnostics.Items is not null)
+            {
+                var documentContext = await _documentContextFactory.Value
+                    .TryCreateAsync(delegatedParams.TextDocument.Uri, projectContext: null, token)
+                    .ConfigureAwait(false);
+
+                if (documentContext is not null)
+                {
+                    csharpDiagnostics = await _translateDiagnosticsService.Value
+                        .TranslateAsync(RazorLanguageKind.CSharp, fullDiagnostics.Items, documentContext, token)
+                        .ConfigureAwait(false);
+                }
+            }
+        }
+
+        var razorDiagnostics = result.GetCSharpDocument().Diagnostics;
+
+        lock (_publishedDiagnosticsGate)
+        {
+            var filePath = document.FilePath.AssumeNotNull();
+
+            if (_publishedRazorDiagnostics.TryGetValue(filePath, out var previousRazorDiagnostics) && razorDiagnostics.SequenceEqual(previousRazorDiagnostics)
+                && (csharpDiagnostics == null || (_publishedCSharpDiagnostics.TryGetValue(filePath, out var previousCsharpDiagnostics) && csharpDiagnostics.SequenceEqual(previousCsharpDiagnostics))))
+            {
+                // Diagnostics are the same as last publish
+                return;
+            }
+
+            _publishedRazorDiagnostics[filePath] = razorDiagnostics;
+            if (csharpDiagnostics != null)
+            {
+                _publishedCSharpDiagnostics[filePath] = csharpDiagnostics;
+            }
+        }
+
+        if (!document.TryGetText(out var sourceText))
+        {
+            Debug.Fail("Document source text should already be available.");
+            return;
+        }
+
+        var convertedDiagnostics = razorDiagnostics.Select(razorDiagnostic => RazorDiagnosticConverter.Convert(razorDiagnostic, sourceText, document));
+        var combinedDiagnostics = csharpDiagnostics == null ? convertedDiagnostics : convertedDiagnostics.Concat(csharpDiagnostics);
+        PublishDiagnosticsForFilePath(document.FilePath, combinedDiagnostics);
+
+        if (_logger.IsEnabled(LogLevel.Trace))
+        {
+            var diagnosticString = string.Join(", ", razorDiagnostics.Select(diagnostic => diagnostic.Id));
+            _logger.LogTrace($"Publishing diagnostics for document '{document.FilePath}': {diagnosticString}");
+        }
     }
 
     private void StartDelayToClearDocuments()
@@ -192,145 +260,6 @@ internal partial class RazorDiagnosticsPublisher : IDocumentProcessedListener, I
                     }
                 }
             }
-        }
-    }
-
-    private async Task PublishDiagnosticsAsync(IDocumentSnapshot document)
-    {
-        var result = await document.GetGeneratedOutputAsync().ConfigureAwait(false);
-
-        Diagnostic[]? csharpDiagnostics = null;
-        if (_options.DelegateToCSharpOnDiagnosticPublish)
-        {
-            var uriBuilder = new UriBuilder()
-            {
-                Scheme = Uri.UriSchemeFile,
-                Path = document.FilePath,
-                Host = string.Empty,
-            };
-
-            var delegatedParams = new DocumentDiagnosticParams
-            {
-                TextDocument = new TextDocumentIdentifier { Uri = uriBuilder.Uri },
-            };
-
-            var delegatedResponse = await _clientConnection.SendRequestAsync<DocumentDiagnosticParams, SumType<FullDocumentDiagnosticReport, UnchangedDocumentDiagnosticReport>?>(
-                CustomMessageNames.RazorCSharpPullDiagnosticsEndpointName,
-                delegatedParams,
-                _disposeTokenSource.Token).ConfigureAwait(false);
-
-            if (delegatedResponse.HasValue &&
-                delegatedResponse.Value.TryGetFirst(out var fullDiagnostics) &&
-                fullDiagnostics.Items is not null)
-            {
-                var documentContext = await _documentContextFactory.Value
-                    .TryCreateAsync(delegatedParams.TextDocument.Uri, projectContext: null, _disposeTokenSource.Token)
-                    .ConfigureAwait(false);
-
-                if (documentContext is not null)
-                {
-                    csharpDiagnostics = await _translateDiagnosticsService.Value
-                        .TranslateAsync(RazorLanguageKind.CSharp, fullDiagnostics.Items, documentContext, _disposeTokenSource.Token)
-                        .ConfigureAwait(false);
-                }
-            }
-        }
-
-        var razorDiagnostics = result.GetCSharpDocument().Diagnostics;
-
-        lock (_publishedDiagnosticsGate)
-        {
-            var filePath = document.FilePath.AssumeNotNull();
-
-            if (_publishedRazorDiagnostics.TryGetValue(filePath, out var previousRazorDiagnostics) && razorDiagnostics.SequenceEqual(previousRazorDiagnostics)
-                && (csharpDiagnostics == null || (_publishedCSharpDiagnostics.TryGetValue(filePath, out var previousCsharpDiagnostics) && csharpDiagnostics.SequenceEqual(previousCsharpDiagnostics))))
-            {
-                // Diagnostics are the same as last publish
-                return;
-            }
-
-            _publishedRazorDiagnostics[filePath] = razorDiagnostics;
-            if (csharpDiagnostics != null)
-            {
-                _publishedCSharpDiagnostics[filePath] = csharpDiagnostics;
-            }
-        }
-
-        if (!document.TryGetText(out var sourceText))
-        {
-            Debug.Fail("Document source text should already be available.");
-            return;
-        }
-
-        var convertedDiagnostics = razorDiagnostics.Select(razorDiagnostic => RazorDiagnosticConverter.Convert(razorDiagnostic, sourceText, document));
-        var combinedDiagnostics = csharpDiagnostics == null ? convertedDiagnostics : convertedDiagnostics.Concat(csharpDiagnostics);
-        PublishDiagnosticsForFilePath(document.FilePath, combinedDiagnostics);
-
-        if (_logger.IsEnabled(LogLevel.Trace))
-        {
-            var diagnosticString = string.Join(", ", razorDiagnostics.Select(diagnostic => diagnostic.Id));
-            _logger.LogTrace($"Publishing diagnostics for document '{document.FilePath}': {diagnosticString}");
-        }
-    }
-
-    private void WorkTimer_Tick(object? state)
-    {
-        WorkTimer_TickAsync().Forget();
-    }
-
-    private async Task WorkTimer_TickAsync()
-    {
-        try
-        {
-            IDocumentSnapshot[] documents;
-            lock (_work)
-            {
-                documents = _work.Values.ToArray();
-                _work.Clear();
-            }
-
-            for (var i = 0; i < documents.Length; i++)
-            {
-                var document = documents[i];
-                await PublishDiagnosticsAsync(document).ConfigureAwait(false);
-            }
-
-            OnCompletingBackgroundWork();
-
-            lock (_work)
-            {
-                // Suppress analyzer that suggests using DisposeAsync().
-#pragma warning disable VSTHRD103 // Call async methods when in an async method
-
-                // Resetting the timer allows another batch of work to start.
-                _workTimer?.Dispose();
-                _workTimer = null;
-
-#pragma warning restore VSTHRD103 // Call async methods when in an async method
-
-                // If more work came in while we were running start the timer again.
-                if (_work.Count > 0)
-                {
-                    StartWorkTimer();
-                }
-            }
-        }
-        catch
-        {
-            lock (_work)
-            {
-                // Suppress analyzer that suggests using DisposeAsync().
-
-#pragma warning disable VSTHRD103 // Call async methods when in an async method
-
-                // Resetting the timer allows another batch of work to start.
-                _workTimer?.Dispose();
-                _workTimer = null;
-
-#pragma warning restore VSTHRD103 // Call async methods when in an async method
-            }
-
-            throw;
         }
     }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.cs
@@ -19,7 +19,7 @@ using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics;
 
-internal class RazorDiagnosticsPublisher : DocumentProcessedListener
+internal class RazorDiagnosticsPublisher : IDocumentProcessedListener
 {
     // Internal for testing
     internal TimeSpan _publishDelay = TimeSpan.FromSeconds(2);
@@ -93,7 +93,7 @@ internal class RazorDiagnosticsPublisher : DocumentProcessedListener
     // Used in tests to ensure we can control when background work completes.
     public ManualResetEventSlim? NotifyBackgroundWorkCompleting { get; set; }
 
-    public override void Initialize(IProjectSnapshotManager projectManager)
+    public void Initialize(IProjectSnapshotManager projectManager)
     {
         if (projectManager is null)
         {
@@ -103,7 +103,7 @@ internal class RazorDiagnosticsPublisher : DocumentProcessedListener
         _projectManager = projectManager;
     }
 
-    public override void DocumentProcessed(RazorCodeDocument codeDocument, IDocumentSnapshot document)
+    public void DocumentProcessed(RazorCodeDocument codeDocument, IDocumentSnapshot document)
     {
         if (document is null)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.cs
@@ -45,9 +45,6 @@ internal partial class RazorDiagnosticsPublisher : IDocumentProcessedListener, I
     private Task _clearClosedDocumentsTask = Task.CompletedTask;
     private bool _waitingToClearClosedDocuments;
 
-    private ManualResetEventSlim? _blockBackgroundWorkCompleting;
-    private ManualResetEventSlim? _notifyBackgroundWorkCompleting;
-
     public RazorDiagnosticsPublisher(
         IProjectSnapshotManager projectManager,
         IClientConnection clientConnection,
@@ -109,8 +106,6 @@ internal partial class RazorDiagnosticsPublisher : IDocumentProcessedListener, I
 
             await PublishDiagnosticsAsync(document, token).ConfigureAwait(false);
         }
-
-        OnCompletingBackgroundWork();
     }
 
     private async Task PublishDiagnosticsAsync(IDocumentSnapshot document, CancellationToken token)
@@ -260,20 +255,6 @@ internal partial class RazorDiagnosticsPublisher : IDocumentProcessedListener, I
                     }
                 }
             }
-        }
-    }
-
-    private void OnCompletingBackgroundWork()
-    {
-        if (_notifyBackgroundWorkCompleting is { } notifyResetEvent)
-        {
-            notifyResetEvent.Set();
-        }
-
-        if (_blockBackgroundWorkCompleting is { } blockResetEvent)
-        {
-            blockResetEvent.Wait();
-            blockResetEvent.Reset();
         }
     }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.cs
@@ -133,8 +133,7 @@ internal partial class RazorDiagnosticsPublisher : IDocumentProcessedListener, I
             cancellationToken).ConfigureAwait(false);
     }
 
-    // Internal for testing
-    internal void ClearClosedDocuments()
+    private void ClearClosedDocuments()
     {
         try
         {
@@ -189,8 +188,7 @@ internal partial class RazorDiagnosticsPublisher : IDocumentProcessedListener, I
         }
     }
 
-    // Internal for testing
-    internal async Task PublishDiagnosticsAsync(IDocumentSnapshot document)
+    private async Task PublishDiagnosticsAsync(IDocumentSnapshot document)
     {
         var result = await document.GetGeneratedOutputAsync().ConfigureAwait(false);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.cs
@@ -228,7 +228,7 @@ internal partial class RazorDiagnosticsPublisher : IDocumentProcessedListener, I
 
             void ClearClosedDocumentsPublishedDiagnostics<T>(Dictionary<string, IReadOnlyList<T>> publishedDiagnostics) where T : class
             {
-                using var documentsToRemove = new PooledArrayBuilder<(string key, bool publicEmptyDiagnostics)>(capacity: publishedDiagnostics.Count);
+                using var documentsToRemove = new PooledArrayBuilder<(string key, bool publishEmptyDiagnostics)>(capacity: publishedDiagnostics.Count);
 
                 foreach (var (key, value) in publishedDiagnostics)
                 {
@@ -236,7 +236,7 @@ internal partial class RazorDiagnosticsPublisher : IDocumentProcessedListener, I
                     {
                         // If there were previously published diagnostics for this document, take note so
                         // we can publish an empty set of diagnostics.
-                        documentsToRemove.Add((key, publicEmptyDiagnostics: value.Count > 0));
+                        documentsToRemove.Add((key, publishEmptyDiagnostics: value.Count > 0));
                     }
                 }
 
@@ -245,11 +245,11 @@ internal partial class RazorDiagnosticsPublisher : IDocumentProcessedListener, I
                     return;
                 }
 
-                foreach (var (key, publicEmptyDiagnostics) in documentsToRemove)
+                foreach (var (key, publishEmptyDiagnostics) in documentsToRemove)
                 {
                     publishedDiagnostics.Remove(key);
 
-                    if (publicEmptyDiagnostics)
+                    if (publishEmptyDiagnostics)
                     {
                         PublishDiagnosticsForFilePath(key, []);
                     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
@@ -238,11 +238,11 @@ internal static class IServiceCollectionExtensions
         {
             // If single server is on, then we don't want to publish diagnostics, so best to just not hook up to any
             // events etc.
-            services.AddSingleton<DocumentProcessedListener, RazorDiagnosticsPublisher>();
+            services.AddSingleton<IDocumentProcessedListener, RazorDiagnosticsPublisher>();
         }
 
-        services.AddSingleton<DocumentProcessedListener, GeneratedDocumentSynchronizer>();
-        services.AddSingleton<DocumentProcessedListener, CodeDocumentReferenceHolder>();
+        services.AddSingleton<IDocumentProcessedListener, GeneratedDocumentSynchronizer>();
+        services.AddSingleton<IDocumentProcessedListener, CodeDocumentReferenceHolder>();
 
         services.AddSingleton<LSPTagHelperTooltipFactory, DefaultLSPTagHelperTooltipFactory>();
         services.AddSingleton<VSLSPTagHelperTooltipFactory, DefaultVSLSPTagHelperTooltipFactory>();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/GeneratedDocumentPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/GeneratedDocumentPublisher.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
@@ -22,24 +23,21 @@ internal sealed class GeneratedDocumentPublisher : IGeneratedDocumentPublisher, 
     private readonly Dictionary<DocumentKey, PublishData> _publishedCSharpData;
     private readonly Dictionary<string, PublishData> _publishedHtmlData;
     private readonly IProjectSnapshotManager _projectManager;
-    private readonly ProjectSnapshotManagerDispatcher _dispatcher;
     private readonly IClientConnection _clientConnection;
     private readonly LanguageServerFeatureOptions _options;
     private readonly ILogger _logger;
 
     public GeneratedDocumentPublisher(
         IProjectSnapshotManager projectManager,
-        ProjectSnapshotManagerDispatcher dispatcher,
         IClientConnection clientConnection,
         LanguageServerFeatureOptions options,
         ILoggerFactory loggerFactory)
     {
         _projectManager = projectManager;
-        _dispatcher = dispatcher;
         _clientConnection = clientConnection;
         _options = options;
         _logger = loggerFactory.GetOrCreateLogger<GeneratedDocumentPublisher>();
-        _publishedCSharpData = new Dictionary<DocumentKey, PublishData>();
+        _publishedCSharpData = [];
 
         // We don't generate individual Html documents per-project, so in order to ensure diffs are calculated correctly
         // we don't use the project key for the key for this dictionary. This matches when we send edits to the client,
@@ -52,18 +50,6 @@ internal sealed class GeneratedDocumentPublisher : IGeneratedDocumentPublisher, 
 
     public void PublishCSharp(ProjectKey projectKey, string filePath, SourceText sourceText, int hostDocumentVersion)
     {
-        if (filePath is null)
-        {
-            throw new ArgumentNullException(nameof(filePath));
-        }
-
-        if (sourceText is null)
-        {
-            throw new ArgumentNullException(nameof(sourceText));
-        }
-
-        _dispatcher.AssertRunningOnDispatcher();
-
         // If our generated documents don't have unique file paths, then using project key information is problematic for the client.
         // For example, when a document moves from the Misc Project to a real project, we will update it here, and each version would
         // have a different project key. On the receiving end however, there is only one file path, therefore one version of the contents,
@@ -73,30 +59,36 @@ internal sealed class GeneratedDocumentPublisher : IGeneratedDocumentPublisher, 
             projectKey = default;
         }
 
-        var key = new DocumentKey(projectKey, filePath);
-        if (!_publishedCSharpData.TryGetValue(key, out var previouslyPublishedData))
-        {
-            _logger.LogDebug($"New publish data created for {projectKey} and {filePath}");
-            previouslyPublishedData = PublishData.Default;
-        }
+        PublishData? previouslyPublishedData;
+        IReadOnlyList<TextChange> textChanges;
 
-        var textChanges = SourceTextDiffer.GetMinimalTextChanges(previouslyPublishedData.SourceText, sourceText);
-        if (textChanges.Count == 0 && hostDocumentVersion == previouslyPublishedData.HostDocumentVersion)
+        lock (_publishedCSharpData)
         {
-            // Source texts match along with host document versions. We've already published something that looks like this. No-op.
-            return;
-        }
+            var key = new DocumentKey(projectKey, filePath);
+            if (!_publishedCSharpData.TryGetValue(key, out previouslyPublishedData))
+            {
+                _logger.LogDebug($"New publish data created for {projectKey} and {filePath}");
+                previouslyPublishedData = PublishData.Default;
+            }
 
-        if (_logger.IsEnabled(LogLevel.Trace))
-        {
-            var previousDocumentLength = previouslyPublishedData.SourceText.Length;
-            var currentDocumentLength = sourceText.Length;
-            var documentLengthDelta = sourceText.Length - previousDocumentLength;
-            _logger.LogTrace(
-                $"Updating C# buffer of {filePath} for project {projectKey} to correspond with host document version {hostDocumentVersion}. {previousDocumentLength} -> {currentDocumentLength} = Change delta of {documentLengthDelta} via {textChanges.Count} text changes.");
-        }
+            textChanges = SourceTextDiffer.GetMinimalTextChanges(previouslyPublishedData.SourceText, sourceText);
+            if (textChanges.Count == 0 && hostDocumentVersion == previouslyPublishedData.HostDocumentVersion)
+            {
+                // Source texts match along with host document versions. We've already published something that looks like this. No-op.
+                return;
+            }
 
-        _publishedCSharpData[key] = new PublishData(sourceText, hostDocumentVersion);
+            if (_logger.IsEnabled(LogLevel.Trace))
+            {
+                var previousDocumentLength = previouslyPublishedData.SourceText.Length;
+                var currentDocumentLength = sourceText.Length;
+                var documentLengthDelta = sourceText.Length - previousDocumentLength;
+                _logger.LogTrace(
+                    $"Updating C# buffer of {filePath} for project {projectKey} to correspond with host document version {hostDocumentVersion}. {previousDocumentLength} -> {currentDocumentLength} = Change delta of {documentLengthDelta} via {textChanges.Count} text changes.");
+            }
+
+            _publishedCSharpData[key] = new PublishData(sourceText, hostDocumentVersion);
+        }
 
         var request = new UpdateBufferRequest()
         {
@@ -107,45 +99,39 @@ internal sealed class GeneratedDocumentPublisher : IGeneratedDocumentPublisher, 
             PreviousWasEmpty = previouslyPublishedData.SourceText.Length == 0
         };
 
-        _ = _clientConnection.SendNotificationAsync(CustomMessageNames.RazorUpdateCSharpBufferEndpoint, request, CancellationToken.None);
+        _clientConnection.SendNotificationAsync(CustomMessageNames.RazorUpdateCSharpBufferEndpoint, request, CancellationToken.None).Forget();
     }
 
     public void PublishHtml(ProjectKey projectKey, string filePath, SourceText sourceText, int hostDocumentVersion)
     {
-        if (filePath is null)
+        PublishData? previouslyPublishedData;
+        IReadOnlyList<TextChange> textChanges;
+
+        lock (_publishedHtmlData)
         {
-            throw new ArgumentNullException(nameof(filePath));
+            if (!_publishedHtmlData.TryGetValue(filePath, out previouslyPublishedData))
+            {
+                previouslyPublishedData = PublishData.Default;
+            }
+
+            textChanges = SourceTextDiffer.GetMinimalTextChanges(previouslyPublishedData.SourceText, sourceText);
+            if (textChanges.Count == 0 && hostDocumentVersion == previouslyPublishedData.HostDocumentVersion)
+            {
+                // Source texts match along with host document versions. We've already published something that looks like this. No-op.
+                return;
+            }
+
+            if (_logger.IsEnabled(LogLevel.Trace))
+            {
+                var previousDocumentLength = previouslyPublishedData.SourceText.Length;
+                var currentDocumentLength = sourceText.Length;
+                var documentLengthDelta = sourceText.Length - previousDocumentLength;
+                _logger.LogTrace(
+                    $"Updating HTML buffer of {filePath} to correspond with host document version {hostDocumentVersion}. {previousDocumentLength} -> {currentDocumentLength} = Change delta of {documentLengthDelta} via {textChanges.Count} text changes.");
+            }
+
+            _publishedHtmlData[filePath] = new PublishData(sourceText, hostDocumentVersion);
         }
-
-        if (sourceText is null)
-        {
-            throw new ArgumentNullException(nameof(sourceText));
-        }
-
-        _dispatcher.AssertRunningOnDispatcher();
-
-        if (!_publishedHtmlData.TryGetValue(filePath, out var previouslyPublishedData))
-        {
-            previouslyPublishedData = PublishData.Default;
-        }
-
-        var textChanges = SourceTextDiffer.GetMinimalTextChanges(previouslyPublishedData.SourceText, sourceText);
-        if (textChanges.Count == 0 && hostDocumentVersion == previouslyPublishedData.HostDocumentVersion)
-        {
-            // Source texts match along with host document versions. We've already published something that looks like this. No-op.
-            return;
-        }
-
-        if (_logger.IsEnabled(LogLevel.Trace))
-        {
-            var previousDocumentLength = previouslyPublishedData.SourceText.Length;
-            var currentDocumentLength = sourceText.Length;
-            var documentLengthDelta = sourceText.Length - previousDocumentLength;
-            _logger.LogTrace(
-                $"Updating HTML buffer of {filePath} to correspond with host document version {hostDocumentVersion}. {previousDocumentLength} -> {currentDocumentLength} = Change delta of {documentLengthDelta} via {textChanges.Count} text changes.");
-        }
-
-        _publishedHtmlData[filePath] = new PublishData(sourceText, hostDocumentVersion);
 
         var request = new UpdateBufferRequest()
         {
@@ -156,7 +142,7 @@ internal sealed class GeneratedDocumentPublisher : IGeneratedDocumentPublisher, 
             PreviousWasEmpty = previouslyPublishedData.SourceText.Length == 0
         };
 
-        _ = _clientConnection.SendNotificationAsync(CustomMessageNames.RazorUpdateHtmlBufferEndpoint, request, CancellationToken.None);
+        _clientConnection.SendNotificationAsync(CustomMessageNames.RazorUpdateHtmlBufferEndpoint, request, CancellationToken.None).Forget();
     }
 
     private void ProjectManager_Changed(object? sender, ProjectChangeEventArgs args)
@@ -167,13 +153,12 @@ internal sealed class GeneratedDocumentPublisher : IGeneratedDocumentPublisher, 
             return;
         }
 
-        _dispatcher.AssertRunningOnDispatcher();
-
         switch (args.Kind)
         {
             case ProjectChangeKind.DocumentChanged:
-                Assumes.NotNull(args.DocumentFilePath);
-                if (!_projectManager.IsDocumentOpen(args.DocumentFilePath))
+                var documentFilePath = args.DocumentFilePath.AssumeNotNull();
+
+                if (!_projectManager.IsDocumentOpen(documentFilePath))
                 {
                     // Document closed, evict published source text, unless the server doesn't want us to.
                     if (_options.UpdateBuffersForClosedDocuments)
@@ -189,24 +174,31 @@ internal sealed class GeneratedDocumentPublisher : IGeneratedDocumentPublisher, 
                         projectKey = default;
                     }
 
-                    var key = new DocumentKey(projectKey, args.DocumentFilePath);
-                    if (_publishedCSharpData.ContainsKey(key))
+                    var key = new DocumentKey(projectKey, documentFilePath);
+
+                    lock (_publishedCSharpData)
                     {
-                        var removed = _publishedCSharpData.Remove(key);
-                        if (!removed)
+                        if (_publishedCSharpData.ContainsKey(key))
                         {
-                            _logger.LogError($"Published data should be protected by the project snapshot manager's thread and should never fail to remove.");
-                            Debug.Fail("Published data should be protected by the project snapshot manager's thread and should never fail to remove.");
+                            var removed = _publishedCSharpData.Remove(key);
+                            if (!removed)
+                            {
+                                _logger.LogError($"Published data should be protected by the project snapshot manager's thread and should never fail to remove.");
+                                Debug.Fail("Published data should be protected by the project snapshot manager's thread and should never fail to remove.");
+                            }
                         }
                     }
 
-                    if (_publishedHtmlData.ContainsKey(args.DocumentFilePath))
+                    lock (_publishedHtmlData)
                     {
-                        var removed = _publishedHtmlData.Remove(args.DocumentFilePath);
-                        if (!removed)
+                        if (_publishedHtmlData.ContainsKey(documentFilePath))
                         {
-                            _logger.LogError($"Published data should be protected by the project snapshot manager's thread and should never fail to remove.");
-                            Debug.Fail("Published data should be protected by the project snapshot manager's thread and should never fail to remove.");
+                            var removed = _publishedHtmlData.Remove(documentFilePath);
+                            if (!removed)
+                            {
+                                _logger.LogError($"Published data should be protected by the project snapshot manager's thread and should never fail to remove.");
+                                Debug.Fail("Published data should be protected by the project snapshot manager's thread and should never fail to remove.");
+                            }
                         }
                     }
                 }
@@ -223,18 +215,22 @@ internal sealed class GeneratedDocumentPublisher : IGeneratedDocumentPublisher, 
                         break;
                     }
 
-                    using var _ = ListPool<DocumentKey>.GetPooledObject(out var keysToRemove);
-                    foreach (var keyValuePair in _publishedCSharpData)
+                    lock (_publishedCSharpData)
                     {
-                        if (keyValuePair.Key.ProjectKey.Equals(args.ProjectKey))
-                        {
-                            keysToRemove.Add(keyValuePair.Key);
-                        }
-                    }
+                        using var keysToRemove = new PooledArrayBuilder<DocumentKey>();
 
-                    foreach (var key in keysToRemove)
-                    {
-                        _publishedCSharpData.Remove(key);
+                        foreach (var keyValuePair in _publishedCSharpData)
+                        {
+                            if (keyValuePair.Key.ProjectKey.Equals(args.ProjectKey))
+                            {
+                                keysToRemove.Add(keyValuePair.Key);
+                            }
+                        }
+
+                        foreach (var key in keysToRemove)
+                        {
+                            _publishedCSharpData.Remove(key);
+                        }
                     }
 
                     break;
@@ -242,19 +238,9 @@ internal sealed class GeneratedDocumentPublisher : IGeneratedDocumentPublisher, 
         }
     }
 
-    private sealed class PublishData
+    private sealed record PublishData(SourceText SourceText, int? HostDocumentVersion)
     {
-        public static readonly PublishData Default = new PublishData(SourceText.From(string.Empty), null);
-
-        public PublishData(SourceText sourceText, int? hostDocumentVersion)
-        {
-            SourceText = sourceText;
-            HostDocumentVersion = hostDocumentVersion;
-        }
-
-        public SourceText SourceText { get; }
-
-        public int? HostDocumentVersion { get; }
+        public static readonly PublishData Default = new(SourceText.From(string.Empty), null);
     }
 
     internal TestAccessor GetTestAccessor()

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/GeneratedDocumentSynchronizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/GeneratedDocumentSynchronizer.cs
@@ -12,18 +12,18 @@ internal class GeneratedDocumentSynchronizer(
     IGeneratedDocumentPublisher publisher,
     IDocumentVersionCache documentVersionCache,
     ProjectSnapshotManagerDispatcher dispatcher,
-    LanguageServerFeatureOptions languageServerFeatureOptions) : DocumentProcessedListener
+    LanguageServerFeatureOptions languageServerFeatureOptions) : IDocumentProcessedListener
 {
     private readonly IGeneratedDocumentPublisher _publisher = publisher;
     private readonly IDocumentVersionCache _documentVersionCache = documentVersionCache;
     private readonly ProjectSnapshotManagerDispatcher _dispatcher = dispatcher;
     private readonly LanguageServerFeatureOptions _languageServerFeatureOptions = languageServerFeatureOptions;
 
-    public override void Initialize(IProjectSnapshotManager projectManager)
+    public void Initialize(IProjectSnapshotManager projectManager)
     {
     }
 
-    public override void DocumentProcessed(RazorCodeDocument codeDocument, IDocumentSnapshot document)
+    public void DocumentProcessed(RazorCodeDocument codeDocument, IDocumentSnapshot document)
     {
         _dispatcher.AssertRunningOnDispatcher();
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/GeneratedDocumentSynchronizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/GeneratedDocumentSynchronizer.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 
@@ -11,12 +10,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer;
 internal class GeneratedDocumentSynchronizer(
     IGeneratedDocumentPublisher publisher,
     IDocumentVersionCache documentVersionCache,
-    ProjectSnapshotManagerDispatcher dispatcher,
     LanguageServerFeatureOptions languageServerFeatureOptions) : IDocumentProcessedListener
 {
     private readonly IGeneratedDocumentPublisher _publisher = publisher;
     private readonly IDocumentVersionCache _documentVersionCache = documentVersionCache;
-    private readonly ProjectSnapshotManagerDispatcher _dispatcher = dispatcher;
     private readonly LanguageServerFeatureOptions _languageServerFeatureOptions = languageServerFeatureOptions;
 
     public void Initialize(IProjectSnapshotManager projectManager)
@@ -25,8 +22,6 @@ internal class GeneratedDocumentSynchronizer(
 
     public void DocumentProcessed(RazorCodeDocument codeDocument, IDocumentSnapshot document)
     {
-        _dispatcher.AssertRunningOnDispatcher();
-
         if (!_documentVersionCache.TryGetDocumentVersion(document, out var hostDocumentVersion))
         {
             // Could not resolve document version

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/GeneratedDocumentSynchronizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/GeneratedDocumentSynchronizer.cs
@@ -16,10 +16,6 @@ internal class GeneratedDocumentSynchronizer(
     private readonly IDocumentVersionCache _documentVersionCache = documentVersionCache;
     private readonly LanguageServerFeatureOptions _languageServerFeatureOptions = languageServerFeatureOptions;
 
-    public void Initialize(IProjectSnapshotManager projectManager)
-    {
-    }
-
     public void DocumentProcessed(RazorCodeDocument codeDocument, IDocumentSnapshot document)
     {
         if (!_documentVersionCache.TryGetDocumentVersion(document, out var hostDocumentVersion))

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IDocumentProcessedListener.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IDocumentProcessedListener.cs
@@ -8,7 +8,5 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
 internal interface IDocumentProcessedListener
 {
-    void Initialize(IProjectSnapshotManager projectManager);
-
     void DocumentProcessed(RazorCodeDocument codeDocument, IDocumentSnapshot documentSnapshot);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IDocumentProcessedListener.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IDocumentProcessedListener.cs
@@ -6,9 +6,9 @@ using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
-internal abstract class DocumentProcessedListener
+internal interface IDocumentProcessedListener
 {
-    public abstract void Initialize(IProjectSnapshotManager projectManager);
+    void Initialize(IProjectSnapshotManager projectManager);
 
-    public abstract void DocumentProcessed(RazorCodeDocument codeDocument, IDocumentSnapshot documentSnapshot);
+    void DocumentProcessed(RazorCodeDocument codeDocument, IDocumentSnapshot documentSnapshot);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/OpenDocumentGenerator.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/OpenDocumentGenerator.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Utilities;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
@@ -29,7 +28,6 @@ internal partial class OpenDocumentGenerator : IRazorStartupService, IDisposable
 
     private readonly ImmutableArray<IDocumentProcessedListener> _listeners;
     private readonly IProjectSnapshotManager _projectManager;
-    private readonly ProjectSnapshotManagerDispatcher _dispatcher;
     private readonly LanguageServerFeatureOptions _options;
 
     private readonly AsyncBatchingWorkQueue<IDocumentSnapshot> _workQueue;
@@ -38,12 +36,10 @@ internal partial class OpenDocumentGenerator : IRazorStartupService, IDisposable
     public OpenDocumentGenerator(
         IEnumerable<IDocumentProcessedListener> listeners,
         IProjectSnapshotManager projectManager,
-        ProjectSnapshotManagerDispatcher dispatcher,
         LanguageServerFeatureOptions options)
     {
         _listeners = listeners.ToImmutableArray();
         _projectManager = projectManager;
-        _dispatcher = dispatcher;
         _options = options;
 
         _disposeTokenSource = new();
@@ -72,25 +68,15 @@ internal partial class OpenDocumentGenerator : IRazorStartupService, IDisposable
 
             var codeDocument = await document.GetGeneratedOutputAsync().ConfigureAwait(false);
 
-            await _dispatcher
-                .RunAsync(
-                    static state =>
-                    {
-                        var (codeDocument, document, listeners, token) = state;
+            foreach (var listener in _listeners)
+            {
+                if (token.IsCancellationRequested)
+                {
+                    return;
+                }
 
-                        foreach (var listener in listeners)
-                        {
-                            if (token.IsCancellationRequested)
-                            {
-                                return;
-                            }
-
-                            listener.DocumentProcessed(codeDocument, document);
-                        }
-                    },
-                    state: (codeDocument, document, _listeners, token),
-                    token)
-                .ConfigureAwait(false);
+                listener.DocumentProcessed(codeDocument, document);
+            }
         }
     }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/OpenDocumentGenerator.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/OpenDocumentGenerator.cs
@@ -27,7 +27,7 @@ internal partial class OpenDocumentGenerator : IRazorStartupService, IDisposable
     // a document for each keystroke.
     private static readonly TimeSpan s_delay = TimeSpan.FromMilliseconds(10);
 
-    private readonly ImmutableArray<DocumentProcessedListener> _listeners;
+    private readonly ImmutableArray<IDocumentProcessedListener> _listeners;
     private readonly IProjectSnapshotManager _projectManager;
     private readonly ProjectSnapshotManagerDispatcher _dispatcher;
     private readonly LanguageServerFeatureOptions _options;
@@ -36,7 +36,7 @@ internal partial class OpenDocumentGenerator : IRazorStartupService, IDisposable
     private readonly CancellationTokenSource _disposeTokenSource;
 
     public OpenDocumentGenerator(
-        IEnumerable<DocumentProcessedListener> listeners,
+        IEnumerable<IDocumentProcessedListener> listeners,
         IProjectSnapshotManager projectManager,
         ProjectSnapshotManagerDispatcher dispatcher,
         LanguageServerFeatureOptions options)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/OpenDocumentGenerator.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/OpenDocumentGenerator.cs
@@ -53,11 +53,6 @@ internal partial class OpenDocumentGenerator : IRazorStartupService, IDisposable
             _disposeTokenSource.Token);
 
         _projectManager.Changed += ProjectManager_Changed;
-
-        foreach (var listener in _listeners)
-        {
-            listener.Initialize(_projectManager);
-        }
     }
 
     public void Dispose()

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeDocumentReferenceHolderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeDocumentReferenceHolderTest.cs
@@ -34,8 +34,7 @@ public class CodeDocumentReferenceHolderTest(ITestOutputHelper testOutput) : Lan
     protected override Task InitializeAsync()
     {
         _projectManager = CreateProjectSnapshotManager();
-        _referenceHolder = new CodeDocumentReferenceHolder();
-        _referenceHolder.Initialize(_projectManager);
+        _referenceHolder = new CodeDocumentReferenceHolder(_projectManager);
 
         return Task.CompletedTask;
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeDocumentReferenceHolderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeDocumentReferenceHolderTest.cs
@@ -180,10 +180,7 @@ public class CodeDocumentReferenceHolderTest(ITestOutputHelper testOutput) : Lan
     {
         var codeDocument = await documentSnapshot.GetGeneratedOutputAsync();
 
-        await RunOnDispatcherAsync(() =>
-        {
-            _referenceHolder.DocumentProcessed(codeDocument, documentSnapshot);
-        });
+        _referenceHolder.DocumentProcessed(codeDocument, documentSnapshot);
 
         return new(codeDocument);
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsPublisherTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsPublisherTest.cs
@@ -119,13 +119,12 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
         var documentContextFactory = new TestDocumentContextFactory(_openedDocument.FilePath, codeDocument);
         var translateDiagnosticsService = new RazorTranslateDiagnosticsService(Mock.Of<IRazorDocumentMappingService>(MockBehavior.Strict), LoggerFactory);
 
-        using var publisher = new TestRazorDiagnosticsPublisher(Dispatcher, clientConnection, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory)
+        using var publisher = new TestRazorDiagnosticsPublisher(_projectManager, Dispatcher, clientConnection, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory)
         {
             BlockBackgroundWorkCompleting = new ManualResetEventSlim(initialState: true),
             NotifyBackgroundWorkCompleting = new ManualResetEventSlim(initialState: false),
         };
 
-        publisher.Initialize(_projectManager);
         await RunOnDispatcherAsync(() =>
             publisher.DocumentProcessed(_testCodeDocument, processedOpenDocument));
         Assert.True(publisher.NotifyBackgroundWorkCompleting.Wait(TimeSpan.FromSeconds(2)));
@@ -224,8 +223,7 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
         var documentMappingService = new RazorDocumentMappingService(filePathService, documentContextFactory, LoggerFactory);
         var translateDiagnosticsService = new RazorTranslateDiagnosticsService(documentMappingService, LoggerFactory);
 
-        using var publisher = new TestRazorDiagnosticsPublisher(Dispatcher, clientConnection.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
-        publisher.Initialize(_projectManager);
+        using var publisher = new TestRazorDiagnosticsPublisher(_projectManager, Dispatcher, clientConnection.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
 
         // Act
         await publisher.PublishDiagnosticsAsync(processedOpenDocument);
@@ -280,9 +278,8 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
         var documentContextFactory = new TestDocumentContextFactory(_openedDocument.FilePath, codeDocument);
         var translateDiagnosticsService = new RazorTranslateDiagnosticsService(Mock.Of<IRazorDocumentMappingService>(MockBehavior.Strict), LoggerFactory);
 
-        using var publisher = new TestRazorDiagnosticsPublisher(Dispatcher, clientConnection.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
+        using var publisher = new TestRazorDiagnosticsPublisher(_projectManager, Dispatcher, clientConnection.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
         publisher.PublishedRazorDiagnostics[processedOpenDocument.FilePath] = s_emptyRazorDiagnostics;
-        publisher.Initialize(_projectManager);
 
         // Act
         await publisher.PublishDiagnosticsAsync(processedOpenDocument);
@@ -338,8 +335,8 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
         var documentContextFactory = new TestDocumentContextFactory(_openedDocument.FilePath, codeDocument);
         var translateDiagnosticsService = new RazorTranslateDiagnosticsService(Mock.Of<IRazorDocumentMappingService>(MockBehavior.Strict), LoggerFactory);
 
-        using var publisher = new TestRazorDiagnosticsPublisher(Dispatcher, clientConnection.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
-        publisher.Initialize(_projectManager);
+        using var publisher = new TestRazorDiagnosticsPublisher(_projectManager, Dispatcher, clientConnection.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
+
         await publisher.PublishDiagnosticsAsync(processedOpenDocument);
         arranging = false;
 
@@ -375,9 +372,8 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
         var documentMappingService = new RazorDocumentMappingService(filePathService, documentContextFactory, LoggerFactory);
         var translateDiagnosticsService = new RazorTranslateDiagnosticsService(documentMappingService, LoggerFactory);
 
-        using var publisher = new TestRazorDiagnosticsPublisher(Dispatcher, clientConnection.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
+        using var publisher = new TestRazorDiagnosticsPublisher(_projectManager, Dispatcher, clientConnection.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
         publisher.PublishedRazorDiagnostics[processedOpenDocument.FilePath] = s_singleRazorDiagnostic;
-        publisher.Initialize(_projectManager);
 
         // Act & Assert
         await publisher.PublishDiagnosticsAsync(processedOpenDocument);
@@ -426,8 +422,8 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
         var documentContextFactory = new TestDocumentContextFactory(_openedDocument.FilePath, codeDocument);
         var translateDiagnosticsService = new RazorTranslateDiagnosticsService(Mock.Of<IRazorDocumentMappingService>(MockBehavior.Strict), LoggerFactory);
 
-        using var publisher = new TestRazorDiagnosticsPublisher(Dispatcher, clientConnection.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
-        publisher.Initialize(_projectManager);
+        using var publisher = new TestRazorDiagnosticsPublisher(_projectManager, Dispatcher, clientConnection.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
+
         await publisher.PublishDiagnosticsAsync(processedOpenDocument);
         arranging = false;
 
@@ -456,11 +452,10 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
         var documentContextFactory = new TestDocumentContextFactory();
         var translateDiagnosticsService = new RazorTranslateDiagnosticsService(Mock.Of<IRazorDocumentMappingService>(MockBehavior.Strict), LoggerFactory);
 
-        using var publisher = new TestRazorDiagnosticsPublisher(Dispatcher, clientConnection.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
+        using var publisher = new TestRazorDiagnosticsPublisher(_projectManager, Dispatcher, clientConnection.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
         Assert.NotNull(_closedDocument.FilePath);
         publisher.PublishedRazorDiagnostics[_closedDocument.FilePath] = s_singleRazorDiagnostic;
         publisher.PublishedCSharpDiagnostics[_closedDocument.FilePath] = s_singleCSharpDiagnostic;
-        publisher.Initialize(_projectManager);
 
         // Act
         publisher.ClearClosedDocuments();
@@ -477,11 +472,10 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
         var documentContextFactory = new TestDocumentContextFactory();
         var translateDiagnosticsService = new RazorTranslateDiagnosticsService(Mock.Of<IRazorDocumentMappingService>(MockBehavior.Strict), LoggerFactory);
 
-        using var publisher = new TestRazorDiagnosticsPublisher(Dispatcher, clientConnection.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
+        using var publisher = new TestRazorDiagnosticsPublisher(_projectManager, Dispatcher, clientConnection.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
         Assert.NotNull(_openedDocument.FilePath);
         publisher.PublishedRazorDiagnostics[_openedDocument.FilePath] = s_singleRazorDiagnostic;
         publisher.PublishedCSharpDiagnostics[_openedDocument.FilePath] = s_singleCSharpDiagnostic;
-        publisher.Initialize(_projectManager);
 
         // Act & Assert
         publisher.ClearClosedDocuments();
@@ -495,11 +489,10 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
         var documentContextFactory = new TestDocumentContextFactory();
         var translateDiagnosticsService = new RazorTranslateDiagnosticsService(Mock.Of<IRazorDocumentMappingService>(MockBehavior.Strict), LoggerFactory);
 
-        using var publisher = new TestRazorDiagnosticsPublisher(Dispatcher, clientConnection.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
+        using var publisher = new TestRazorDiagnosticsPublisher(_projectManager, Dispatcher, clientConnection.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
         Assert.NotNull(_closedDocument.FilePath);
         publisher.PublishedRazorDiagnostics[_closedDocument.FilePath] = s_emptyRazorDiagnostics;
         publisher.PublishedCSharpDiagnostics[_closedDocument.FilePath] = s_emptyCSharpDiagnostics;
-        publisher.Initialize(_projectManager);
 
         // Act & Assert
         publisher.ClearClosedDocuments();
@@ -513,14 +506,13 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
         var documentContextFactory = new TestDocumentContextFactory();
         var translateDiagnosticsService = new RazorTranslateDiagnosticsService(Mock.Of<IRazorDocumentMappingService>(MockBehavior.Strict), LoggerFactory);
 
-        using var publisher = new TestRazorDiagnosticsPublisher(Dispatcher, clientConnection.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
+        using var publisher = new TestRazorDiagnosticsPublisher(_projectManager, Dispatcher, clientConnection.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
         Assert.NotNull(_closedDocument.FilePath);
         Assert.NotNull(_openedDocument.FilePath);
         publisher.PublishedRazorDiagnostics[_closedDocument.FilePath] = s_emptyRazorDiagnostics;
         publisher.PublishedCSharpDiagnostics[_closedDocument.FilePath] = s_emptyCSharpDiagnostics;
         publisher.PublishedRazorDiagnostics[_openedDocument.FilePath] = s_emptyRazorDiagnostics;
         publisher.PublishedCSharpDiagnostics[_openedDocument.FilePath] = s_emptyCSharpDiagnostics;
-        publisher.Initialize(_projectManager);
 
         // Act
         publisher.ClearClosedDocuments();
@@ -541,13 +533,14 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
     private class TestRazorDiagnosticsPublisher : RazorDiagnosticsPublisher, IDisposable
     {
         public TestRazorDiagnosticsPublisher(
+            IProjectSnapshotManager projectManager,
             ProjectSnapshotManagerDispatcher dispatcher,
             IClientConnection clientConnection,
             LanguageServerFeatureOptions options,
             RazorTranslateDiagnosticsService razorTranslateDiagnosticsService,
             IDocumentContextFactory documentContextFactory,
             ILoggerFactory loggerFactory)
-            : base(dispatcher, clientConnection, options,
+            : base(projectManager, dispatcher, clientConnection, options,
                   new Lazy<RazorTranslateDiagnosticsService>(() => razorTranslateDiagnosticsService),
                   new Lazy<IDocumentContextFactory>(() => documentContextFactory),
                   loggerFactory)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsPublisherTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsPublisherTest.cs
@@ -225,9 +225,10 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
         var translateDiagnosticsService = new RazorTranslateDiagnosticsService(documentMappingService, LoggerFactory);
 
         using var publisher = new TestRazorDiagnosticsPublisher(_projectManager, Dispatcher, clientConnection.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
+        var publisherAccessor = publisher.GetTestAccessor();
 
         // Act
-        await publisher.PublishDiagnosticsAsync(processedOpenDocument);
+        await publisherAccessor.PublishDiagnosticsAsync(processedOpenDocument);
 
         // Assert
         clientConnection.VerifyAll();
@@ -284,7 +285,7 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
         publisherAccessor.SetPublishedRazorDiagnostics(processedOpenDocument.FilePath, s_emptyRazorDiagnostics);
 
         // Act
-        await publisher.PublishDiagnosticsAsync(processedOpenDocument);
+        await publisherAccessor.PublishDiagnosticsAsync(processedOpenDocument);
 
         // Assert
         clientConnection.VerifyAll();
@@ -338,12 +339,13 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
         var translateDiagnosticsService = new RazorTranslateDiagnosticsService(Mock.Of<IRazorDocumentMappingService>(MockBehavior.Strict), LoggerFactory);
 
         using var publisher = new TestRazorDiagnosticsPublisher(_projectManager, Dispatcher, clientConnection.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
+        var publisherAccessor = publisher.GetTestAccessor();
 
-        await publisher.PublishDiagnosticsAsync(processedOpenDocument);
+        await publisherAccessor.PublishDiagnosticsAsync(processedOpenDocument);
         arranging = false;
 
         // Act
-        await publisher.PublishDiagnosticsAsync(processedOpenDocument);
+        await publisherAccessor.PublishDiagnosticsAsync(processedOpenDocument);
 
         // Assert
         clientConnection.VerifyAll();
@@ -379,7 +381,7 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
         publisherAccessor.SetPublishedRazorDiagnostics(processedOpenDocument.FilePath, s_singleRazorDiagnostic);
 
         // Act & Assert
-        await publisher.PublishDiagnosticsAsync(processedOpenDocument);
+        await publisherAccessor.PublishDiagnosticsAsync(processedOpenDocument);
     }
 
     [Fact]
@@ -426,12 +428,13 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
         var translateDiagnosticsService = new RazorTranslateDiagnosticsService(Mock.Of<IRazorDocumentMappingService>(MockBehavior.Strict), LoggerFactory);
 
         using var publisher = new TestRazorDiagnosticsPublisher(_projectManager, Dispatcher, clientConnection.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
+        var publisherAccessor = publisher.GetTestAccessor();
 
-        await publisher.PublishDiagnosticsAsync(processedOpenDocument);
+        await publisherAccessor.PublishDiagnosticsAsync(processedOpenDocument);
         arranging = false;
 
         // Act & Assert
-        await publisher.PublishDiagnosticsAsync(processedOpenDocument);
+        await publisherAccessor.PublishDiagnosticsAsync(processedOpenDocument);
     }
 
     [Fact]
@@ -462,7 +465,7 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
         publisherAccessor.SetPublishedCSharpDiagnostics(_closedDocument.FilePath, s_singleCSharpDiagnostic);
 
         // Act
-        publisher.ClearClosedDocuments();
+        publisherAccessor.ClearClosedDocuments();
 
         // Assert
         clientConnection.VerifyAll();
@@ -483,7 +486,7 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
         publisherAccessor.SetPublishedCSharpDiagnostics(_openedDocument.FilePath, s_singleCSharpDiagnostic);
 
         // Act & Assert
-        publisher.ClearClosedDocuments();
+        publisherAccessor.ClearClosedDocuments();
     }
 
     [Fact]
@@ -501,7 +504,7 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
         publisherAccessor.SetPublishedCSharpDiagnostics(_closedDocument.FilePath, s_emptyCSharpDiagnostics);
 
         // Act & Assert
-        publisher.ClearClosedDocuments();
+        publisherAccessor.ClearClosedDocuments();
     }
 
     [Fact]
@@ -522,7 +525,7 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
         publisherAccessor.SetPublishedCSharpDiagnostics(_openedDocument.FilePath, s_emptyCSharpDiagnostics);
 
         // Act
-        publisher.ClearClosedDocuments();
+        publisherAccessor.ClearClosedDocuments();
 
         // Assert
         Assert.True(publisherAccessor.IsWaitingToClearClosedDocuments);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsPublisherTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsPublisherTest.cs
@@ -543,11 +543,9 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
             : base(projectManager, dispatcher, clientConnection, options,
                   new Lazy<RazorTranslateDiagnosticsService>(() => razorTranslateDiagnosticsService),
                   new Lazy<IDocumentContextFactory>(() => documentContextFactory),
-                  loggerFactory)
+                  loggerFactory,
+                  publishDelay: TimeSpan.FromMilliseconds(1))
         {
-            // The diagnostics publisher by default will wait 2 seconds until publishing diagnostics. For testing purposes we reduce
-            // the amount of time we wait for diagnostic publishing because we have more concrete control of the timer and its lifecycle.
-            _publishDelay = TimeSpan.FromMilliseconds(1);
         }
 
         public void Dispose()

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsPublisherTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsPublisherTest.cs
@@ -31,12 +31,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics;
 
 public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : LanguageServerTestBase(testOutput)
 {
-    private static readonly ImmutableArray<RazorDiagnostic> s_singleRazorDiagnostic =
+    private static readonly RazorDiagnostic[] s_singleRazorDiagnostic =
     [
         RazorDiagnosticFactory.CreateDirective_BlockDirectiveCannotBeImported("test")
     ];
 
-    private static readonly ImmutableArray<Diagnostic> s_singleCSharpDiagnostic =
+    private static readonly Diagnostic[] s_singleCSharpDiagnostic =
     [
         new Diagnostic()
         {
@@ -288,7 +288,7 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
 
         using var publisher = new TestRazorDiagnosticsPublisher(_projectManager, clientConnectionMock.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
         var publisherAccessor = publisher.GetTestAccessor();
-        publisherAccessor.SetPublishedRazorDiagnostics(processedOpenDocument.FilePath, []);
+        publisherAccessor.SetPublishedDiagnostics(processedOpenDocument.FilePath, razorDiagnostics: [], csharpDiagnostics: null);
 
         // Act
         await publisherAccessor.PublishDiagnosticsAsync(processedOpenDocument, DisposalToken);
@@ -384,7 +384,7 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
 
         using var publisher = new TestRazorDiagnosticsPublisher(_projectManager, clientConnectionMock.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
         var publisherAccessor = publisher.GetTestAccessor();
-        publisherAccessor.SetPublishedRazorDiagnostics(processedOpenDocument.FilePath, s_singleRazorDiagnostic);
+        publisherAccessor.SetPublishedDiagnostics(processedOpenDocument.FilePath, s_singleRazorDiagnostic, csharpDiagnostics: null);
 
         // Act & Assert
         await publisherAccessor.PublishDiagnosticsAsync(processedOpenDocument, DisposalToken);
@@ -467,8 +467,7 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
         using var publisher = new TestRazorDiagnosticsPublisher(_projectManager, clientConnectionMock.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
         var publisherAccessor = publisher.GetTestAccessor();
         Assert.NotNull(_closedDocument.FilePath);
-        publisherAccessor.SetPublishedRazorDiagnostics(_closedDocument.FilePath, s_singleRazorDiagnostic);
-        publisherAccessor.SetPublishedCSharpDiagnostics(_closedDocument.FilePath, s_singleCSharpDiagnostic);
+        publisherAccessor.SetPublishedDiagnostics(_closedDocument.FilePath, s_singleRazorDiagnostic, s_singleCSharpDiagnostic);
 
         // Act
         publisherAccessor.ClearClosedDocuments();
@@ -488,8 +487,7 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
         using var publisher = new TestRazorDiagnosticsPublisher(_projectManager, clientConnectionMock.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
         var publisherAccessor = publisher.GetTestAccessor();
         Assert.NotNull(_openedDocument.FilePath);
-        publisherAccessor.SetPublishedRazorDiagnostics(_openedDocument.FilePath, s_singleRazorDiagnostic);
-        publisherAccessor.SetPublishedCSharpDiagnostics(_openedDocument.FilePath, s_singleCSharpDiagnostic);
+        publisherAccessor.SetPublishedDiagnostics(_openedDocument.FilePath, s_singleRazorDiagnostic, s_singleCSharpDiagnostic);
 
         // Act & Assert
         publisherAccessor.ClearClosedDocuments();
@@ -506,8 +504,7 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
         using var publisher = new TestRazorDiagnosticsPublisher(_projectManager, clientConnectionMock.Object, TestLanguageServerFeatureOptions.Instance, translateDiagnosticsService, documentContextFactory, LoggerFactory);
         var publisherAccessor = publisher.GetTestAccessor();
         Assert.NotNull(_closedDocument.FilePath);
-        publisherAccessor.SetPublishedRazorDiagnostics(_closedDocument.FilePath, []);
-        publisherAccessor.SetPublishedCSharpDiagnostics(_closedDocument.FilePath, []);
+        publisherAccessor.SetPublishedDiagnostics(_closedDocument.FilePath, razorDiagnostics: [], csharpDiagnostics: []);
 
         // Act & Assert
         publisherAccessor.ClearClosedDocuments();
@@ -525,10 +522,8 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
         var publisherAccessor = publisher.GetTestAccessor();
         Assert.NotNull(_closedDocument.FilePath);
         Assert.NotNull(_openedDocument.FilePath);
-        publisherAccessor.SetPublishedRazorDiagnostics(_closedDocument.FilePath, []);
-        publisherAccessor.SetPublishedCSharpDiagnostics(_closedDocument.FilePath, []);
-        publisherAccessor.SetPublishedRazorDiagnostics(_openedDocument.FilePath, []);
-        publisherAccessor.SetPublishedCSharpDiagnostics(_openedDocument.FilePath, []);
+        publisherAccessor.SetPublishedDiagnostics(_closedDocument.FilePath, razorDiagnostics: [], csharpDiagnostics: []);
+        publisherAccessor.SetPublishedDiagnostics(_openedDocument.FilePath, razorDiagnostics: [], csharpDiagnostics: []);
 
         // Act
         publisherAccessor.ClearClosedDocuments();
@@ -537,7 +532,7 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
         Assert.True(publisherAccessor.IsWaitingToClearClosedDocuments);
     }
 
-    private static RazorCodeDocument CreateCodeDocument(ImmutableArray<RazorDiagnostic> diagnostics)
+    private static RazorCodeDocument CreateCodeDocument(RazorDiagnostic[] diagnostics)
     {
         var codeDocument = TestRazorCodeDocument.Create("hello");
         var razorCSharpDocument = RazorCSharpDocument.Create(codeDocument, "hello", RazorCodeGenerationOptions.CreateDefault(), diagnostics);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/GeneratedDocumentPublisherTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/GeneratedDocumentPublisherTest.cs
@@ -39,18 +39,15 @@ public class GeneratedDocumentPublisherTest : LanguageServerTestBase
     }
 
     [Fact]
-    public async Task PublishCSharp_FirstTime_PublishesEntireSourceText()
+    public void PublishCSharp_FirstTime_PublishesEntireSourceText()
     {
         // Arrange
-        var publisher = new GeneratedDocumentPublisher(_projectManager, Dispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
+        var publisher = new GeneratedDocumentPublisher(_projectManager, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         var content = "// C# content";
         var sourceText = SourceText.From(content);
 
         // Act
-        await RunOnDispatcherAsync(() =>
-        {
-            publisher.PublishCSharp(s_hostProject.Key, "/path/to/file.razor", sourceText, 123);
-        });
+        publisher.PublishCSharp(s_hostProject.Key, "/path/to/file.razor", sourceText, 123);
 
         // Assert
         var updateRequest = Assert.Single(_serverClient.UpdateRequests);
@@ -61,16 +58,15 @@ public class GeneratedDocumentPublisherTest : LanguageServerTestBase
     }
 
     [Fact]
-    public async Task PublishHtml_FirstTime_PublishesEntireSourceText()
+    public void PublishHtml_FirstTime_PublishesEntireSourceText()
     {
         // Arrange
-        var publisher = new GeneratedDocumentPublisher(_projectManager, Dispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
+        var publisher = new GeneratedDocumentPublisher(_projectManager, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         var content = "HTML content";
         var sourceText = SourceText.From(content);
 
         // Act
-        await RunOnDispatcherAsync(() =>
-            publisher.PublishHtml(s_hostProject.Key, "/path/to/file.razor", sourceText, 123));
+        publisher.PublishHtml(s_hostProject.Key, "/path/to/file.razor", sourceText, 123);
 
         // Assert
         var updateRequest = Assert.Single(_serverClient.UpdateRequests);
@@ -81,21 +77,19 @@ public class GeneratedDocumentPublisherTest : LanguageServerTestBase
     }
 
     [Fact]
-    public async Task PublishCSharp_SecondTime_PublishesSourceTextDifferences()
+    public void PublishCSharp_SecondTime_PublishesSourceTextDifferences()
     {
         // Arrange
-        var publisher = new GeneratedDocumentPublisher(_projectManager, Dispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
+        var publisher = new GeneratedDocumentPublisher(_projectManager, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         var initialSourceText = SourceText.From("// Initial content\n");
-        await RunOnDispatcherAsync(() =>
-            publisher.PublishCSharp(s_hostProject.Key, "/path/to/file.razor", initialSourceText, 123));
+        publisher.PublishCSharp(s_hostProject.Key, "/path/to/file.razor", initialSourceText, 123);
         var change = new TextChange(
             new TextSpan(initialSourceText.Length, 0),
             "// Another line");
         var changedSourceText = initialSourceText.WithChanges(change);
 
         // Act
-        await RunOnDispatcherAsync(() =>
-            publisher.PublishCSharp(s_hostProject.Key, "/path/to/file.razor", changedSourceText, 124));
+        publisher.PublishCSharp(s_hostProject.Key, "/path/to/file.razor", changedSourceText, 124);
 
         // Assert
         Assert.Equal(2, _serverClient.UpdateRequests.Count);
@@ -107,21 +101,19 @@ public class GeneratedDocumentPublisherTest : LanguageServerTestBase
     }
 
     [Fact]
-    public async Task PublishHtml_SecondTime_PublishesSourceTextDifferences()
+    public void PublishHtml_SecondTime_PublishesSourceTextDifferences()
     {
         // Arrange
-        var publisher = new GeneratedDocumentPublisher(_projectManager, Dispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
+        var publisher = new GeneratedDocumentPublisher(_projectManager, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         var initialSourceText = SourceText.From("HTML content\n");
-        await RunOnDispatcherAsync(() =>
-            publisher.PublishHtml(s_hostProject.Key, "/path/to/file.razor", initialSourceText, 123));
+        publisher.PublishHtml(s_hostProject.Key, "/path/to/file.razor", initialSourceText, 123);
         var change = new TextChange(
             new TextSpan(initialSourceText.Length, 0),
             "More content!!");
         var changedSourceText = initialSourceText.WithChanges(change);
 
         // Act
-        await RunOnDispatcherAsync(() =>
-            publisher.PublishHtml(s_hostProject.Key, "/path/to/file.razor", changedSourceText, 124));
+        publisher.PublishHtml(s_hostProject.Key, "/path/to/file.razor", changedSourceText, 124);
 
         // Assert
         Assert.Equal(2, _serverClient.UpdateRequests.Count);
@@ -133,19 +125,17 @@ public class GeneratedDocumentPublisherTest : LanguageServerTestBase
     }
 
     [Fact]
-    public async Task PublishCSharp_SecondTime_IdenticalContent_NoTextChanges()
+    public void PublishCSharp_SecondTime_IdenticalContent_NoTextChanges()
     {
         // Arrange
-        var publisher = new GeneratedDocumentPublisher(_projectManager, Dispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
+        var publisher = new GeneratedDocumentPublisher(_projectManager, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         var sourceTextContent = "// The content";
         var initialSourceText = SourceText.From(sourceTextContent);
-        await RunOnDispatcherAsync(() =>
-            publisher.PublishCSharp(s_hostProject.Key, "/path/to/file.razor", initialSourceText, 123));
+        publisher.PublishCSharp(s_hostProject.Key, "/path/to/file.razor", initialSourceText, 123);
         var identicalSourceText = SourceText.From(sourceTextContent);
 
         // Act
-        await RunOnDispatcherAsync(() =>
-            publisher.PublishCSharp(s_hostProject.Key, "/path/to/file.razor", identicalSourceText, 124));
+        publisher.PublishCSharp(s_hostProject.Key, "/path/to/file.razor", identicalSourceText, 124);
 
         // Assert
         Assert.Equal(2, _serverClient.UpdateRequests.Count);
@@ -156,19 +146,17 @@ public class GeneratedDocumentPublisherTest : LanguageServerTestBase
     }
 
     [Fact]
-    public async Task PublishHtml_SecondTime_IdenticalContent_NoTextChanges()
+    public void PublishHtml_SecondTime_IdenticalContent_NoTextChanges()
     {
         // Arrange
-        var publisher = new GeneratedDocumentPublisher(_projectManager, Dispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
+        var publisher = new GeneratedDocumentPublisher(_projectManager, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         var sourceTextContent = "HTMl content";
         var initialSourceText = SourceText.From(sourceTextContent);
-        await RunOnDispatcherAsync(() =>
-            publisher.PublishHtml(s_hostProject.Key, "/path/to/file.razor", initialSourceText, 123));
+        publisher.PublishHtml(s_hostProject.Key, "/path/to/file.razor", initialSourceText, 123);
         var identicalSourceText = SourceText.From(sourceTextContent);
 
         // Act
-        await RunOnDispatcherAsync(() =>
-            publisher.PublishHtml(s_hostProject.Key, "/path/to/file.razor", identicalSourceText, 124));
+        publisher.PublishHtml(s_hostProject.Key, "/path/to/file.razor", identicalSourceText, 124);
 
         // Assert
         Assert.Equal(2, _serverClient.UpdateRequests.Count);
@@ -179,19 +167,17 @@ public class GeneratedDocumentPublisherTest : LanguageServerTestBase
     }
 
     [Fact]
-    public async Task PublishCSharp_DifferentFileSameContent_PublishesEverything()
+    public void PublishCSharp_DifferentFileSameContent_PublishesEverything()
     {
         // Arrange
-        var publisher = new GeneratedDocumentPublisher(_projectManager, Dispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
+        var publisher = new GeneratedDocumentPublisher(_projectManager, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         var sourceTextContent = "// The content";
         var initialSourceText = SourceText.From(sourceTextContent);
-        await RunOnDispatcherAsync(() =>
-            publisher.PublishCSharp(s_hostProject.Key, "/path/to/file1.razor", initialSourceText, 123));
+        publisher.PublishCSharp(s_hostProject.Key, "/path/to/file1.razor", initialSourceText, 123);
         var identicalSourceText = SourceText.From(sourceTextContent);
 
         // Act
-        await RunOnDispatcherAsync(() =>
-            publisher.PublishCSharp(s_hostProject.Key, "/path/to/file2.razor", identicalSourceText, 123));
+        publisher.PublishCSharp(s_hostProject.Key, "/path/to/file2.razor", identicalSourceText, 123);
 
         // Assert
         Assert.Equal(2, _serverClient.UpdateRequests.Count);
@@ -203,19 +189,17 @@ public class GeneratedDocumentPublisherTest : LanguageServerTestBase
     }
 
     [Fact]
-    public async Task PublishHtml_DifferentFileSameContent_PublishesEverything()
+    public void PublishHtml_DifferentFileSameContent_PublishesEverything()
     {
         // Arrange
-        var publisher = new GeneratedDocumentPublisher(_projectManager, Dispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
+        var publisher = new GeneratedDocumentPublisher(_projectManager, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         var sourceTextContent = "HTML content";
         var initialSourceText = SourceText.From(sourceTextContent);
-        await RunOnDispatcherAsync(() =>
-            publisher.PublishHtml(s_hostProject.Key, "/path/to/file1.razor", initialSourceText, 123));
+        publisher.PublishHtml(s_hostProject.Key, "/path/to/file1.razor", initialSourceText, 123);
         var identicalSourceText = SourceText.From(sourceTextContent);
 
         // Act
-        await RunOnDispatcherAsync(() =>
-            publisher.PublishHtml(s_hostProject.Key, "/path/to/file2.razor", identicalSourceText, 123));
+        publisher.PublishHtml(s_hostProject.Key, "/path/to/file2.razor", identicalSourceText, 123);
 
         // Assert
         Assert.Equal(2, _serverClient.UpdateRequests.Count);
@@ -230,14 +214,11 @@ public class GeneratedDocumentPublisherTest : LanguageServerTestBase
     public async Task ProjectSnapshotManager_DocumentChanged_OpenDocument_PublishesEmptyTextChanges_CSharp()
     {
         // Arrange
-        var publisher = new GeneratedDocumentPublisher(_projectManager, Dispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
+        var publisher = new GeneratedDocumentPublisher(_projectManager, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         var sourceTextContent = "// The content";
         var initialSourceText = SourceText.From(sourceTextContent);
 
-        await RunOnDispatcherAsync(() =>
-        {
-            publisher.PublishCSharp(s_hostProject.Key, s_hostDocument.FilePath, initialSourceText, 123);
-        });
+        publisher.PublishCSharp(s_hostProject.Key, s_hostDocument.FilePath, initialSourceText, 123);
 
         // Act
         await _projectManager.UpdateAsync(updater =>
@@ -245,10 +226,7 @@ public class GeneratedDocumentPublisherTest : LanguageServerTestBase
             updater.DocumentOpened(s_hostProject.Key, s_hostDocument.FilePath, initialSourceText);
         });
 
-        await RunOnDispatcherAsync(() =>
-        {
-            publisher.PublishCSharp(s_hostProject.Key, s_hostDocument.FilePath, initialSourceText, 124);
-        });
+        publisher.PublishCSharp(s_hostProject.Key, s_hostDocument.FilePath, initialSourceText, 124);
 
         // Assert
         Assert.Equal(2, _serverClient.UpdateRequests.Count);
@@ -262,14 +240,11 @@ public class GeneratedDocumentPublisherTest : LanguageServerTestBase
     public async Task ProjectSnapshotManager_DocumentChanged_OpenDocument_VersionEquivalent_Noops_CSharp()
     {
         // Arrange
-        var publisher = new GeneratedDocumentPublisher(_projectManager, Dispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
+        var publisher = new GeneratedDocumentPublisher(_projectManager, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         var sourceTextContent = "// The content";
         var initialSourceText = SourceText.From(sourceTextContent);
 
-        await RunOnDispatcherAsync(() =>
-        {
-            publisher.PublishCSharp(s_hostProject.Key, s_hostDocument.FilePath, initialSourceText, 123);
-        });
+        publisher.PublishCSharp(s_hostProject.Key, s_hostDocument.FilePath, initialSourceText, 123);
 
         // Act
         await _projectManager.UpdateAsync(updater =>
@@ -277,10 +252,7 @@ public class GeneratedDocumentPublisherTest : LanguageServerTestBase
             updater.DocumentOpened(s_hostProject.Key, s_hostDocument.FilePath, initialSourceText);
         });
 
-        await RunOnDispatcherAsync(() =>
-        {
-            publisher.PublishCSharp(s_hostProject.Key, s_hostDocument.FilePath, initialSourceText, 123);
-        });
+        publisher.PublishCSharp(s_hostProject.Key, s_hostDocument.FilePath, initialSourceText, 123);
 
         // Assert
         var updateRequest = Assert.Single(_serverClient.UpdateRequests);
@@ -292,14 +264,11 @@ public class GeneratedDocumentPublisherTest : LanguageServerTestBase
     public async Task ProjectSnapshotManager_DocumentChanged_OpenDocument_PublishesEmptyTextChanges_Html()
     {
         // Arrange
-        var publisher = new GeneratedDocumentPublisher(_projectManager, Dispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
+        var publisher = new GeneratedDocumentPublisher(_projectManager, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         var sourceTextContent = "<!-- The content -->";
         var initialSourceText = SourceText.From(sourceTextContent);
 
-        await RunOnDispatcherAsync(() =>
-        {
-            publisher.PublishHtml(s_hostProject.Key, s_hostDocument.FilePath, initialSourceText, 123);
-        });
+        publisher.PublishHtml(s_hostProject.Key, s_hostDocument.FilePath, initialSourceText, 123);
 
         // Act
         await _projectManager.UpdateAsync(updater =>
@@ -307,10 +276,7 @@ public class GeneratedDocumentPublisherTest : LanguageServerTestBase
             updater.DocumentOpened(s_hostProject.Key, s_hostDocument.FilePath, initialSourceText);
         });
 
-        await RunOnDispatcherAsync(() =>
-        {
-            publisher.PublishHtml(s_hostProject.Key, s_hostDocument.FilePath, initialSourceText, 124);
-        });
+        publisher.PublishHtml(s_hostProject.Key, s_hostDocument.FilePath, initialSourceText, 124);
 
         // Assert
         Assert.Equal(2, _serverClient.UpdateRequests.Count);
@@ -324,14 +290,11 @@ public class GeneratedDocumentPublisherTest : LanguageServerTestBase
     public async Task ProjectSnapshotManager_DocumentChanged_OpenDocument_VersionEquivalent_Noops_Html()
     {
         // Arrange
-        var publisher = new GeneratedDocumentPublisher(_projectManager, Dispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
+        var publisher = new GeneratedDocumentPublisher(_projectManager, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         var sourceTextContent = "<!-- The content -->";
         var initialSourceText = SourceText.From(sourceTextContent);
 
-        await RunOnDispatcherAsync(() =>
-        {
-            publisher.PublishHtml(s_hostProject.Key, s_hostDocument.FilePath, initialSourceText, 123);
-        });
+        publisher.PublishHtml(s_hostProject.Key, s_hostDocument.FilePath, initialSourceText, 123);
 
         // Act
         await _projectManager.UpdateAsync(updater =>
@@ -339,10 +302,7 @@ public class GeneratedDocumentPublisherTest : LanguageServerTestBase
             updater.DocumentOpened(s_hostProject.Key, s_hostDocument.FilePath, initialSourceText);
         });
 
-        await RunOnDispatcherAsync(() =>
-        {
-            publisher.PublishHtml(s_hostProject.Key, s_hostDocument.FilePath, initialSourceText, 123);
-        });
+        publisher.PublishHtml(s_hostProject.Key, s_hostDocument.FilePath, initialSourceText, 123);
 
         // Assert
         var updateRequest = Assert.Single(_serverClient.UpdateRequests);
@@ -354,14 +314,11 @@ public class GeneratedDocumentPublisherTest : LanguageServerTestBase
     public async Task ProjectSnapshotManager_DocumentChanged_ClosedDocument_RepublishesTextChanges()
     {
         // Arrange
-        var publisher = new GeneratedDocumentPublisher(_projectManager, Dispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
+        var publisher = new GeneratedDocumentPublisher(_projectManager, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         var sourceTextContent = "// The content";
         var initialSourceText = SourceText.From(sourceTextContent);
 
-        await RunOnDispatcherAsync(() =>
-        {
-            publisher.PublishCSharp(s_hostProject.Key, s_hostDocument.FilePath, initialSourceText, 123);
-        });
+        publisher.PublishCSharp(s_hostProject.Key, s_hostDocument.FilePath, initialSourceText, 123);
 
         await _projectManager.UpdateAsync(updater =>
         {
@@ -374,10 +331,7 @@ public class GeneratedDocumentPublisherTest : LanguageServerTestBase
             updater.DocumentClosed(s_hostProject.Key, s_hostDocument.FilePath, new EmptyTextLoader(s_hostDocument.FilePath));
         });
 
-        await RunOnDispatcherAsync(() =>
-        {
-            publisher.PublishCSharp(s_hostProject.Key, s_hostDocument.FilePath, initialSourceText, 123);
-        });
+        publisher.PublishCSharp(s_hostProject.Key, s_hostDocument.FilePath, initialSourceText, 123);
 
         // Assert
         Assert.Equal(2, _serverClient.UpdateRequests.Count);
@@ -392,7 +346,7 @@ public class GeneratedDocumentPublisherTest : LanguageServerTestBase
     public async Task ProjectSnapshotManager_DocumentMoved_DoesntRepublishWholeDocument()
     {
         // Arrange
-        var publisher = new GeneratedDocumentPublisher(_projectManager, Dispatcher, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
+        var publisher = new GeneratedDocumentPublisher(_projectManager, _serverClient, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
         var sourceTextContent = """
             public void Method()
             {
@@ -407,10 +361,7 @@ public class GeneratedDocumentPublisherTest : LanguageServerTestBase
             """;
         var changedSourceText = SourceText.From(changedTextContent);
 
-        await RunOnDispatcherAsync(() =>
-        {
-            publisher.PublishCSharp(s_hostProject.Key, s_hostDocument.FilePath, initialSourceText, 123);
-        });
+        publisher.PublishCSharp(s_hostProject.Key, s_hostDocument.FilePath, initialSourceText, 123);
 
         await _projectManager.UpdateAsync(updater =>
         {
@@ -424,10 +375,7 @@ public class GeneratedDocumentPublisherTest : LanguageServerTestBase
             updater.DocumentAdded(s_hostProject2.Key, s_hostDocument, new EmptyTextLoader(s_hostDocument.FilePath));
         });
 
-        await RunOnDispatcherAsync(() =>
-        {
-            publisher.PublishCSharp(s_hostProject2.Key, s_hostDocument.FilePath, changedSourceText, 124);
-        });
+        publisher.PublishCSharp(s_hostProject2.Key, s_hostDocument.FilePath, changedSourceText, 124);
 
         // Assert
         Assert.Equal(2, _serverClient.UpdateRequests.Count);
@@ -443,14 +391,11 @@ public class GeneratedDocumentPublisherTest : LanguageServerTestBase
     {
         // Arrange
         var options = new TestLanguageServerFeatureOptions(includeProjectKeyInGeneratedFilePath: true);
-        var publisher = new GeneratedDocumentPublisher(_projectManager, Dispatcher, _serverClient, options, LoggerFactory);
+        var publisher = new GeneratedDocumentPublisher(_projectManager, _serverClient, options, LoggerFactory);
         var sourceTextContent = "// The content";
         var initialSourceText = SourceText.From(sourceTextContent);
 
-        await RunOnDispatcherAsync(() =>
-        {
-            publisher.PublishCSharp(s_hostProject.Key, s_hostDocument.FilePath, initialSourceText, 123);
-        });
+        publisher.PublishCSharp(s_hostProject.Key, s_hostDocument.FilePath, initialSourceText, 123);
 
         await _projectManager.UpdateAsync(updater =>
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/GeneratedDocumentSynchronizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/GeneratedDocumentSynchronizerTest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
@@ -28,19 +27,18 @@ public class GeneratedDocumentSynchronizerTest : LanguageServerTestBase
         var projectManager = StrictMock.Of<IProjectSnapshotManager>();
         _cache = new DocumentVersionCache(projectManager);
         _publisher = new TestGeneratedDocumentPublisher();
-        _synchronizer = new GeneratedDocumentSynchronizer(_publisher, _cache, Dispatcher, TestLanguageServerFeatureOptions.Instance);
+        _synchronizer = new GeneratedDocumentSynchronizer(_publisher, _cache, TestLanguageServerFeatureOptions.Instance);
         _document = TestDocumentSnapshot.Create("C:/path/to/file.razor");
         _codeDocument = CreateCodeDocument("<p>Hello World</p>");
     }
 
     [Fact]
-    public async Task DocumentProcessed_UnknownVersion_Noops()
+    public void DocumentProcessed_UnknownVersion_Noops()
     {
         // Arrange
 
         // Act
-        await Dispatcher.RunAsync(
-            () => _synchronizer.DocumentProcessed(_codeDocument, _document), DisposalToken);
+        _synchronizer.DocumentProcessed(_codeDocument, _document);
 
         // Assert
         Assert.False(_publisher.PublishedCSharp);
@@ -48,16 +46,13 @@ public class GeneratedDocumentSynchronizerTest : LanguageServerTestBase
     }
 
     [Fact]
-    public async Task DocumentProcessed_KnownVersion_Publishes()
+    public void DocumentProcessed_KnownVersion_Publishes()
     {
         // Arrange
-        await Dispatcher.RunAsync(() =>
-        {
-            _cache.TrackDocumentVersion(_document, version: 1337);
+        _cache.TrackDocumentVersion(_document, version: 1337);
 
-            // Act
-            _synchronizer.DocumentProcessed(_codeDocument, _document);
-        }, DisposalToken);
+        // Act
+        _synchronizer.DocumentProcessed(_codeDocument, _document);
 
         // Assert
         Assert.True(_publisher.PublishedCSharp);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/OpenDocumentGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/OpenDocumentGeneratorTest.cs
@@ -178,9 +178,5 @@ public class OpenDocumentGeneratorTest(ITestOutputHelper testOutput) : LanguageS
         {
             _tcs.SetResult(document);
         }
-
-        public void Initialize(IProjectSnapshotManager projectManager)
-        {
-        }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/OpenDocumentGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/OpenDocumentGeneratorTest.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
 using Xunit;
@@ -34,7 +33,7 @@ public class OpenDocumentGeneratorTest(ITestOutputHelper testOutput) : LanguageS
         // Arrange
         var projectManager = CreateProjectSnapshotManager();
         var listener = new TestDocumentProcessedListener();
-        using var generator = new TestOpenDocumentGenerator(projectManager, Dispatcher, listener);
+        using var generator = new TestOpenDocumentGenerator(projectManager, listener);
 
         await projectManager.UpdateAsync(updater =>
         {
@@ -55,7 +54,7 @@ public class OpenDocumentGeneratorTest(ITestOutputHelper testOutput) : LanguageS
         // Arrange
         var projectManager = CreateProjectSnapshotManager();
         var listener = new TestDocumentProcessedListener();
-        using var generator = new TestOpenDocumentGenerator(projectManager, Dispatcher, listener);
+        using var generator = new TestOpenDocumentGenerator(projectManager, listener);
 
         await projectManager.UpdateAsync(updater =>
         {
@@ -77,7 +76,7 @@ public class OpenDocumentGeneratorTest(ITestOutputHelper testOutput) : LanguageS
         // Arrange
         var projectManager = CreateProjectSnapshotManager();
         var listener = new TestDocumentProcessedListener();
-        using var generator = new TestOpenDocumentGenerator(projectManager, Dispatcher, listener);
+        using var generator = new TestOpenDocumentGenerator(projectManager, listener);
 
         await projectManager.UpdateAsync(updater =>
         {
@@ -102,7 +101,7 @@ public class OpenDocumentGeneratorTest(ITestOutputHelper testOutput) : LanguageS
         // Arrange
         var projectManager = CreateProjectSnapshotManager();
         var listener = new TestDocumentProcessedListener();
-        using var generator = new TestOpenDocumentGenerator(projectManager, Dispatcher, listener);
+        using var generator = new TestOpenDocumentGenerator(projectManager, listener);
 
         await projectManager.UpdateAsync(updater =>
         {
@@ -125,7 +124,7 @@ public class OpenDocumentGeneratorTest(ITestOutputHelper testOutput) : LanguageS
         // Arrange
         var projectManager = CreateProjectSnapshotManager();
         var listener = new TestDocumentProcessedListener();
-        using var generator = new TestOpenDocumentGenerator(projectManager, Dispatcher, listener);
+        using var generator = new TestOpenDocumentGenerator(projectManager, listener);
 
         await projectManager.UpdateAsync(updater =>
         {
@@ -146,9 +145,8 @@ public class OpenDocumentGeneratorTest(ITestOutputHelper testOutput) : LanguageS
 
     private class TestOpenDocumentGenerator(
         IProjectSnapshotManager projectManager,
-        ProjectSnapshotManagerDispatcher dispatcher,
         params IDocumentProcessedListener[] listeners)
-        : OpenDocumentGenerator(listeners, projectManager, dispatcher, TestLanguageServerFeatureOptions.Instance);
+        : OpenDocumentGenerator(listeners, projectManager, TestLanguageServerFeatureOptions.Instance);
 
     private class TestDocumentProcessedListener : IDocumentProcessedListener
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/OpenDocumentGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/OpenDocumentGeneratorTest.cs
@@ -147,10 +147,10 @@ public class OpenDocumentGeneratorTest(ITestOutputHelper testOutput) : LanguageS
     private class TestOpenDocumentGenerator(
         IProjectSnapshotManager projectManager,
         ProjectSnapshotManagerDispatcher dispatcher,
-        params DocumentProcessedListener[] listeners)
+        params IDocumentProcessedListener[] listeners)
         : OpenDocumentGenerator(listeners, projectManager, dispatcher, TestLanguageServerFeatureOptions.Instance);
 
-    private class TestDocumentProcessedListener : DocumentProcessedListener
+    private class TestDocumentProcessedListener : IDocumentProcessedListener
     {
         private readonly TaskCompletionSource<IDocumentSnapshot> _tcs;
 
@@ -174,12 +174,12 @@ public class OpenDocumentGeneratorTest(ITestOutputHelper testOutput) : LanguageS
             return _tcs.Task;
         }
 
-        public override void DocumentProcessed(RazorCodeDocument codeDocument, IDocumentSnapshot document)
+        public void DocumentProcessed(RazorCodeDocument codeDocument, IDocumentSnapshot document)
         {
             _tcs.SetResult(document);
         }
 
-        public override void Initialize(IProjectSnapshotManager projectManager)
+        public void Initialize(IProjectSnapshotManager projectManager)
         {
         }
     }


### PR DESCRIPTION
This is a more significant change that removes usage of `ProjectSnapshotManagerDispatcher` from all "document processed listeners". As part of this work, I've re-worked the `RazorDiagnosticsPublisher` to use an `AsyncBatchingWorkQueue` and `Task.Delay` rather than a pair of timers. The result is a much simpler for implementation of `RazorDiagnosticsPublisher`.