### PR TITLE
Remove ProjectSnapshotManagerDispatcher from RenameEndpoint

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Refactoring/RenameEndpoint.cs
@@ -26,7 +26,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Refactoring;
 
 [RazorLanguageServerEndpoint(Methods.TextDocumentRenameName)]
 internal sealed class RenameEndpoint(
-    ProjectSnapshotManagerDispatcher dispatcher,
     RazorComponentSearchEngine componentSearchEngine,
     IProjectSnapshotManager projectManager,
     LanguageServerFeatureOptions languageServerFeatureOptions,
@@ -39,7 +38,6 @@ internal sealed class RenameEndpoint(
         clientConnection,
         loggerFactory.GetOrCreateLogger<RenameEndpoint>()), ICapabilitiesProvider
 {
-    private readonly ProjectSnapshotManagerDispatcher _dispatcher = dispatcher;
     private readonly IProjectSnapshotManager _projectManager = projectManager;
     private readonly RazorComponentSearchEngine _componentSearchEngine = componentSearchEngine;
     private readonly LanguageServerFeatureOptions _languageServerFeatureOptions = languageServerFeatureOptions;
@@ -126,7 +124,7 @@ internal sealed class RenameEndpoint(
         documentChanges.Add(fileRename);
         AddEditsForCodeDocument(documentChanges, originTagHelpers, request.NewName, request.TextDocument.Uri, codeDocument);
 
-        var documentSnapshots = await GetAllDocumentSnapshotsAsync(documentContext, cancellationToken).ConfigureAwait(false);
+        var documentSnapshots = GetAllDocumentSnapshots(documentContext);
 
         foreach (var documentSnapshot in documentSnapshots)
         {
@@ -148,14 +146,12 @@ internal sealed class RenameEndpoint(
         };
     }
 
-    private async Task<ImmutableArray<IDocumentSnapshot?>> GetAllDocumentSnapshotsAsync(DocumentContext skipDocumentContext, CancellationToken cancellationToken)
+    private ImmutableArray<IDocumentSnapshot?> GetAllDocumentSnapshots(DocumentContext skipDocumentContext)
     {
         using var documentSnapshots = new PooledArrayBuilder<IDocumentSnapshot?>();
         using var _ = StringHashSetPool.GetPooledObject(out var documentPaths);
 
-        var projects = await _dispatcher
-            .RunAsync(() => _projectManager.GetProjects(), cancellationToken)
-            .ConfigureAwait(false);
+        var projects = _projectManager.GetProjects();
 
         foreach (var project in projects)
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointDelegationTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointDelegationTest.cs
@@ -66,7 +66,6 @@ public class RenameEndpointDelegationTest(ITestOutputHelper testOutput) : Single
         var searchEngine = new DefaultRazorComponentSearchEngine(projectManager, LoggerFactory);
 
         var endpoint = new RenameEndpoint(
-            Dispatcher,
             searchEngine,
             projectManager,
             LanguageServerFeatureOptions,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
@@ -694,7 +694,6 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
         clientConnection ??= StrictMock.Of<IClientConnection>();
 
         var endpoint = new RenameEndpoint(
-            Dispatcher,
             searchEngine,
             projectManager,
             options,


### PR DESCRIPTION
RenameEndpoint takes a `ProjectSnapshotManagerDispatcher` in order to call `IProjectSnapshotManager.GetProjects()`. However, that method is thread-safe, thanks to @ryzngard's work in #8943. So, this use of `ProjectSnapshotManagerDispatcher` can be removed.