### PR TITLE
Remove ProjectSnapshotManagerDispatcher from RazorFileChangeDetector

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IRazorFileChangeListener.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IRazorFileChangeListener.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
 internal interface IRazorFileChangeListener
 {
-    void RazorFileChanged(string filePath, RazorFileChangeKind kind);
+    Task RazorFileChangedAsync(string filePath, RazorFileChangeKind kind, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.TestAccessor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.TestAccessor.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using System.Threading.Tasks;
+using System;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer;
+
+internal partial class RazorFileChangeDetector
+{
+    internal TestAccessor GetTestAccessor() => new(this);
+
+    internal sealed class TestAccessor(RazorFileChangeDetector instance)
+    {
+        public void AddWork(string filePath, RazorFileChangeKind kind)
+        {
+            if (kind is not (RazorFileChangeKind.Added or RazorFileChangeKind.Removed))
+            {
+                throw new ArgumentException("Only adds and removes are allowed", nameof(kind));
+            }
+
+            instance._workQueue.AddWork((filePath, kind));
+        }
+
+        public void AddWork(params (string filePath, RazorFileChangeKind kind)[] items)
+        {
+            foreach (var (filePath, kind) in items)
+            {
+                if (kind is not (RazorFileChangeKind.Added or RazorFileChangeKind.Removed))
+                {
+                    throw new ArgumentException("Only adds and removes are allowed", nameof(items));
+                }
+            }
+
+            instance._workQueue.AddWork(items);
+        }
+
+        public Task WaitUntilCurrentBatchCompletesAsync()
+        {
+            return instance._workQueue.WaitUntilCurrentBatchCompletesAsync();
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetector.cs
@@ -146,8 +146,10 @@ internal partial class RazorFileChangeDetector : IFileChangeDetector, IDisposabl
             }
         }
 
-        // This is an entry point for testing
-        OnInitializationFinished();
+        if (!InitializeFileWatchers)
+        {
+            return;
+        }
 
         if (cancellationToken.IsCancellationRequested)
         {
@@ -203,9 +205,7 @@ internal partial class RazorFileChangeDetector : IFileChangeDetector, IDisposabl
     }
 
     // Protected virtual for testing
-    protected virtual void OnInitializationFinished()
-    {
-    }
+    protected virtual bool InitializeFileWatchers => true;
 
     // Protected virtual for testing
     protected virtual ImmutableArray<string> GetExistingRazorFiles(string workspaceDirectory)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetectorManager.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetectorManager.cs
@@ -3,38 +3,23 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
-internal class RazorFileChangeDetectorManager : IDisposable
+internal class RazorFileChangeDetectorManager(
+    WorkspaceDirectoryPathResolver workspaceDirectoryPathResolver,
+    IEnumerable<IFileChangeDetector> fileChangeDetectors) : IDisposable
 {
-    private readonly WorkspaceDirectoryPathResolver _workspaceDirectoryPathResolver;
-    private readonly IReadOnlyList<IFileChangeDetector> _fileChangeDetectors;
-    private readonly object _disposeLock = new object();
+    private readonly WorkspaceDirectoryPathResolver _workspaceDirectoryPathResolver = workspaceDirectoryPathResolver;
+    private readonly ImmutableArray<IFileChangeDetector> _fileChangeDetectors = fileChangeDetectors.ToImmutableArray();
+    private readonly object _disposeLock = new();
     private bool _disposed;
 
-    public RazorFileChangeDetectorManager(
-        WorkspaceDirectoryPathResolver workspaceDirectoryPathResolver,
-        IEnumerable<IFileChangeDetector> fileChangeDetectors)
-    {
-        if (workspaceDirectoryPathResolver is null)
-        {
-            throw new ArgumentNullException(nameof(workspaceDirectoryPathResolver));
-        }
-
-        if (fileChangeDetectors is null)
-        {
-            throw new ArgumentNullException(nameof(fileChangeDetectors));
-        }
-
-        _workspaceDirectoryPathResolver = workspaceDirectoryPathResolver;
-        _fileChangeDetectors = fileChangeDetectors.ToArray();
-    }
-
-    public async Task InitializedAsync()
+    public async Task InitializedAsync(CancellationToken cancellationToken)
     {
         // Initialized request, this occurs once the server and client have agreed on what sort of features they both support. It only happens once.
 
@@ -42,8 +27,6 @@ internal class RazorFileChangeDetectorManager : IDisposable
 
         foreach (var fileChangeDetector in _fileChangeDetectors)
         {
-            // We create a dummy cancellation token for now. Have an issue to pass through the cancellation token in the O# lib: https://github.com/OmniSharp/csharp-language-server-protocol/issues/200
-            var cancellationToken = CancellationToken.None;
             await fileChangeDetector.StartAsync(workspaceDirectoryPath, cancellationToken).ConfigureAwait(false);
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileSynchronizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileSynchronizer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.VisualStudio.Threading;
@@ -13,21 +14,11 @@ internal class RazorFileSynchronizer(IRazorProjectService projectService) : IRaz
 {
     private readonly IRazorProjectService _projectService = projectService;
 
-    public void RazorFileChanged(string filePath, RazorFileChangeKind kind)
-    {
-        if (filePath is null)
+    public Task RazorFileChangedAsync(string filePath, RazorFileChangeKind kind, CancellationToken cancellationToken)
+        => kind switch
         {
-            throw new ArgumentNullException(nameof(filePath));
-        }
-
-        switch (kind)
-        {
-            case RazorFileChangeKind.Added:
-                _projectService.AddDocumentAsync(filePath, CancellationToken.None).Forget();
-                break;
-            case RazorFileChangeKind.Removed:
-                _projectService.RemoveDocumentAsync(filePath, CancellationToken.None).Forget();
-                break;
-        }
-    }
+            RazorFileChangeKind.Added => _projectService.AddDocumentAsync(filePath, cancellationToken),
+            RazorFileChangeKind.Removed => _projectService.RemoveDocumentAsync(filePath, cancellationToken),
+            _ => Task.CompletedTask
+        };
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorInitializedEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorInitializedEndpoint.cs
@@ -21,7 +21,7 @@ internal class RazorInitializedEndpoint : INotificationHandler<InitializedParams
         var capabilitiesService = requestContext.GetRequiredService<IClientCapabilitiesService>();
 
         var fileChangeDetectorManager = requestContext.LspServices.GetRequiredService<RazorFileChangeDetectorManager>();
-        await fileChangeDetectorManager.InitializedAsync().ConfigureAwait(false);
+        await fileChangeDetectorManager.InitializedAsync(cancellationToken).ConfigureAwait(false);
 
         foreach (var onStartedItem in onStartedItems)
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorFileChangeDetectorManagerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorFileChangeDetectorManagerTest.cs
@@ -1,19 +1,19 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Moq;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
-public class RazorFileChangeDetectorManagerTest
+public class RazorFileChangeDetectorManagerTest(ITestOutputHelper testOutput) : ToolingTestBase(testOutput)
 {
     [Fact]
     public async Task InitializedAsync_StartsFileChangeDetectors()
@@ -32,30 +32,41 @@ public class RazorFileChangeDetectorManagerTest
         {
             RootUri = uriBuilder.Uri,
         };
-        var languageServer = new Mock<IInitializeManager<InitializeParams, InitializeResult>>(MockBehavior.Strict);
-        languageServer.Setup(s => s.GetInitializeParams())
-            .Returns(clientSettings);
-        var detector1 = new Mock<IFileChangeDetector>(MockBehavior.Strict);
-        var expectedWorkspaceDirectory = $"\\\\{initialWorkspaceDirectory}";
-        detector1
-            .Setup(detector => detector.StartAsync(expectedWorkspaceDirectory, It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask)
-            .Verifiable();
-        var detector2 = new Mock<IFileChangeDetector>(MockBehavior.Strict);
-        detector2
-            .Setup(detector => detector.StartAsync(expectedWorkspaceDirectory, It.IsAny<CancellationToken>()))
-            .Returns(Task.CompletedTask)
-            .Verifiable();
-        var workspaceDirectoryPathResolver = new DefaultWorkspaceDirectoryPathResolver(languageServer.Object);
-        var detectorManager = new RazorFileChangeDetectorManager(workspaceDirectoryPathResolver, new[] { detector1.Object, detector2.Object });
 
-        // Act
-        await detectorManager.InitializedAsync();
+        var languageServerMock = new StrictMock<IInitializeManager<InitializeParams, InitializeResult>>();
+        languageServerMock
+            .Setup(s => s.GetInitializeParams())
+            .Returns(clientSettings);
+
+        var expectedWorkspaceDirectory = $"\\\\{initialWorkspaceDirectory}";
+
+        var detectorMock1 = new StrictMock<IFileChangeDetector>();
+        detectorMock1
+            .Setup(detector => detector.StartAsync(expectedWorkspaceDirectory, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .Verifiable();
+
+        detectorMock1.Setup(x => x.Stop());
+
+        var detectorMock2 = new StrictMock<IFileChangeDetector>();
+        detectorMock2
+            .Setup(detector => detector.StartAsync(expectedWorkspaceDirectory, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .Verifiable();
+
+        detectorMock2.Setup(x => x.Stop());
+
+        var workspaceDirectoryPathResolver = new DefaultWorkspaceDirectoryPathResolver(languageServerMock.Object);
+        using (var detectorManager = new RazorFileChangeDetectorManager(workspaceDirectoryPathResolver, [detectorMock1.Object, detectorMock2.Object]))
+        {
+            // Act
+            await detectorManager.InitializedAsync(DisposalToken);
+        }
 
         // Assert
-        detector1.VerifyAll();
-        detector2.VerifyAll();
-        languageServer.VerifyAll();
+        detectorMock1.VerifyAll();
+        detectorMock2.VerifyAll();
+        languageServerMock.VerifyAll();
     }
 
     [Fact]
@@ -67,22 +78,27 @@ public class RazorFileChangeDetectorManagerTest
         {
             RootUri = new Uri(expectedWorkspaceDirectory),
         };
-        var languageServer = new Mock<IInitializeManager<InitializeParams, InitializeResult>>(MockBehavior.Strict);
-        languageServer
+
+        var languageServerMock = new StrictMock<IInitializeManager<InitializeParams, InitializeResult>>();
+        languageServerMock
             .Setup(s => s.GetInitializeParams())
             .Returns(clientSettings);
 
-        var detector = new Mock<IFileChangeDetector>(MockBehavior.Strict);
+        var detectorMock = new StrictMock<IFileChangeDetector>();
         var cts = new TaskCompletionSource<bool>();
-        detector.Setup(d => d.StartAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        detectorMock
+            .Setup(d => d.StartAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .Returns(cts.Task);
         var stopCount = 0;
-        detector.Setup(d => d.Stop()).Callback(() => stopCount++);
-        var workspaceDirectoryPathResolver = new DefaultWorkspaceDirectoryPathResolver(languageServer.Object);
-        var detectorManager = new RazorFileChangeDetectorManager(workspaceDirectoryPathResolver, new[] { detector.Object });
+        detectorMock
+            .Setup(d => d.Stop())
+            .Callback(() => stopCount++);
+
+        var workspaceDirectoryPathResolver = new DefaultWorkspaceDirectoryPathResolver(languageServerMock.Object);
+        using var detectorManager = new RazorFileChangeDetectorManager(workspaceDirectoryPathResolver, [detectorMock.Object]);
 
         // Act
-        var initializeTask = detectorManager.InitializedAsync();
+        var initializeTask = detectorManager.InitializedAsync(DisposalToken);
         detectorManager.Dispose();
 
         // Unblock the detector start
@@ -92,6 +108,6 @@ public class RazorFileChangeDetectorManagerTest
         // Assert
         Assert.Equal(2, stopCount);
 
-        languageServer.VerifyAll();
+        languageServerMock.VerifyAll();
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorFileSynchronizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorFileSynchronizerTest.cs
@@ -28,8 +28,7 @@ public class RazorFileSynchronizerTest(ITestOutputHelper testOutput) : LanguageS
         var synchronizer = new RazorFileSynchronizer(projectService.Object);
 
         // Act
-        await RunOnDispatcherAsync(() =>
-            synchronizer.RazorFileChanged(filePath, RazorFileChangeKind.Added));
+        await synchronizer.RazorFileChangedAsync(filePath, RazorFileChangeKind.Added, DisposalToken);
 
         // Assert
         projectService.VerifyAll();
@@ -48,8 +47,7 @@ public class RazorFileSynchronizerTest(ITestOutputHelper testOutput) : LanguageS
         var synchronizer = new RazorFileSynchronizer(projectService.Object);
 
         // Act
-        await RunOnDispatcherAsync(() =>
-            synchronizer.RazorFileChanged(filePath, RazorFileChangeKind.Added));
+        await synchronizer.RazorFileChangedAsync(filePath, RazorFileChangeKind.Added, DisposalToken);
 
         // Assert
         projectService.VerifyAll();
@@ -68,8 +66,7 @@ public class RazorFileSynchronizerTest(ITestOutputHelper testOutput) : LanguageS
         var synchronizer = new RazorFileSynchronizer(projectService.Object);
 
         // Act
-        await RunOnDispatcherAsync(() =>
-            synchronizer.RazorFileChanged(filePath, RazorFileChangeKind.Removed));
+        await synchronizer.RazorFileChangedAsync(filePath, RazorFileChangeKind.Removed, DisposalToken);
 
         // Assert
         projectService.VerifyAll();
@@ -88,8 +85,7 @@ public class RazorFileSynchronizerTest(ITestOutputHelper testOutput) : LanguageS
         var synchronizer = new RazorFileSynchronizer(projectService.Object);
 
         // Act
-        await RunOnDispatcherAsync(() =>
-            synchronizer.RazorFileChanged(filePath, RazorFileChangeKind.Removed));
+        await synchronizer.RazorFileChangedAsync(filePath, RazorFileChangeKind.Removed, DisposalToken);
 
         // Assert
         projectService.VerifyAll();


### PR DESCRIPTION
This change removes usage of `ProjectSnapshotManagerDispatcher` from `RazorFileChangeDetector`. In order to achieve that, I've refactored `RazorFileChangeDetector` to use an `AsyncBatchingWorkQueue` rather than the existing complex strategy of tracking a dictionary of "pending notifications" with delayed tasks. However, the `ProcessBatchAsync` is a bit trickier than others I've implemented.

To reduce churn on the `RazorProjectService`, `RazorFileChangeDetector` does extra work to try and avoid elide adds/remove pairs for the same file. This makes the `ProcessBatchAsync` more complex because we need to pass through the items in the batch once to find add/remove pairs and make note of the changes we should skip. Then, we make a second pass and notify the listeners of changes, taking care to step over skipped changes we noted in the first pass. I hope the comments there clarify the new strategy. The behavior should be approximately the same.