### PR TITLE
Unit tests for RazorProjectInfoEndpointPublisher

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/ProjectInfoEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/ProjectInfoEndpoint.cs
@@ -30,15 +30,8 @@ internal class ProjectInfoEndpoint : IRazorNotificationHandler<ProjectInfoParams
 
     public Task HandleNotificationAsync(ProjectInfoParams request, RazorRequestContext requestContext, CancellationToken cancellationToken)
     {
-        RazorProjectInfo? razorProjectInfo = null;
-
-        // ProjectInfo will be null if project is being deleted and should be removed
-        if (request.ProjectInfo is string projectInfoBase64)
-        {
-            var projectInfoBytes = Convert.FromBase64String(projectInfoBase64);
-            using var stream = new MemoryStream(projectInfoBytes);
-            razorProjectInfo = RazorProjectInfoDeserializer.Instance.DeserializeFromStream(stream);
-        }
+        var razorProjectInfo =
+            RazorProjectInfoDeserializer.Instance.DeserializeFromString(request.ProjectInfo);
 
         var projectKey = ProjectKey.FromString(request.ProjectKeyId);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Serialization/IRazorProjectInfoDeserializer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Serialization/IRazorProjectInfoDeserializer.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Serialization;
 
 internal interface IRazorProjectInfoDeserializer
 {
-    RazorProjectInfo? DeserializeFromString(string? projectInfoBase64String);
+    RazorProjectInfo? DeserializeFromString(string? base64String);
     RazorProjectInfo? DeserializeFromFile(string filePath);
     RazorProjectInfo? DeserializeFromStream(Stream stream);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Serialization/IRazorProjectInfoDeserializer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Serialization/IRazorProjectInfoDeserializer.cs
@@ -8,6 +8,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Serialization;
 
 internal interface IRazorProjectInfoDeserializer
 {
+    RazorProjectInfo? DeserializeFromString(string? projectInfoString);
     RazorProjectInfo? DeserializeFromFile(string filePath);
     RazorProjectInfo? DeserializeFromStream(Stream stream);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Serialization/IRazorProjectInfoDeserializer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Serialization/IRazorProjectInfoDeserializer.cs
@@ -8,7 +8,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Serialization;
 
 internal interface IRazorProjectInfoDeserializer
 {
-    RazorProjectInfo? DeserializeFromString(string? projectInfoString);
+    RazorProjectInfo? DeserializeFromString(string? projectInfoBase64String);
     RazorProjectInfo? DeserializeFromFile(string filePath);
     RazorProjectInfo? DeserializeFromStream(Stream stream);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Serialization/RazorProjectInfoDeserializer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Serialization/RazorProjectInfoDeserializer.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.IO;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
+using StreamJsonRpc;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Serialization;
 
@@ -12,6 +14,21 @@ internal sealed class RazorProjectInfoDeserializer : IRazorProjectInfoDeserializ
 
     private RazorProjectInfoDeserializer()
     {
+    }
+
+    public RazorProjectInfo? DeserializeFromString(string? projectInfoBase64)
+    {
+        RazorProjectInfo? razorProjectInfo = null;
+
+        // ProjectInfo will be null if project is being deleted and should be removed
+        if (projectInfoBase64 is not null)
+        {
+            var projectInfoBytes = Convert.FromBase64String(projectInfoBase64);
+            using var stream = new MemoryStream(projectInfoBytes);
+            razorProjectInfo = DeserializeFromStream(stream);
+        }
+
+        return razorProjectInfo;
     }
 
     public RazorProjectInfo? DeserializeFromFile(string filePath)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Serialization/RazorProjectInfoDeserializer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Serialization/RazorProjectInfoDeserializer.cs
@@ -15,14 +15,14 @@ internal sealed class RazorProjectInfoDeserializer : IRazorProjectInfoDeserializ
     {
     }
 
-    public RazorProjectInfo? DeserializeFromString(string? projectInfoBase64String)
+    public RazorProjectInfo? DeserializeFromString(string? base64String)
     {
         RazorProjectInfo? razorProjectInfo = null;
 
         // ProjectInfo will be null if project is being deleted and should be removed
-        if (projectInfoBase64String is not null)
+        if (base64String is not null)
         {
-            var projectInfoBytes = Convert.FromBase64String(projectInfoBase64String);
+            var projectInfoBytes = Convert.FromBase64String(base64String);
             using var stream = new MemoryStream(projectInfoBytes);
             razorProjectInfo = DeserializeFromStream(stream);
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Serialization/RazorProjectInfoDeserializer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Serialization/RazorProjectInfoDeserializer.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
-using StreamJsonRpc;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Serialization;
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Serialization/RazorProjectInfoDeserializer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Serialization/RazorProjectInfoDeserializer.cs
@@ -15,14 +15,14 @@ internal sealed class RazorProjectInfoDeserializer : IRazorProjectInfoDeserializ
     {
     }
 
-    public RazorProjectInfo? DeserializeFromString(string? projectInfoBase64)
+    public RazorProjectInfo? DeserializeFromString(string? projectInfoBase64String)
     {
         RazorProjectInfo? razorProjectInfo = null;
 
         // ProjectInfo will be null if project is being deleted and should be removed
-        if (projectInfoBase64 is not null)
+        if (projectInfoBase64String is not null)
         {
-            var projectInfoBytes = Convert.FromBase64String(projectInfoBase64);
+            var projectInfoBytes = Convert.FromBase64String(projectInfoBase64String);
             using var stream = new MemoryStream(projectInfoBytes);
             razorProjectInfo = DeserializeFromStream(stream);
         }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshotExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshotExtensions.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.IO;
 using System.Threading;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.PooledObjects;
@@ -35,6 +37,17 @@ internal static class IProjectSnapshotExtensions
             displayName: project.DisplayName,
             projectWorkspaceState: project.ProjectWorkspaceState,
             documents: documents.DrainToImmutable());
+    }
+
+    public static string ToRazorProjectInfoString(this IProjectSnapshot project, string serializedFilePath)
+    {
+        var projectInfo = project.ToRazorProjectInfo(serializedFilePath);
+
+        using var stream = new MemoryStream();
+        projectInfo.SerializeTo(stream);
+        var base64ProjectInfo = Convert.ToBase64String(stream.ToArray());
+
+        return base64ProjectInfo;
     }
 
     public static ImmutableArray<TagHelperDescriptor> GetTagHelpersSynchronously(this IProjectSnapshot projectSnapshot)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshotExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshotExtensions.cs
@@ -39,7 +39,7 @@ internal static class IProjectSnapshotExtensions
             documents: documents.DrainToImmutable());
     }
 
-    public static string ToRazorProjectInfoString(this IProjectSnapshot project, string serializedFilePath)
+    public static string ToBase64EncodedProjectInfo(this IProjectSnapshot project, string serializedFilePath)
     {
         var projectInfo = project.ToRazorProjectInfo(serializedFilePath);
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/ProjectSystem/RazorProjectInfoEndpointPublisher.TestAccessor.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/ProjectSystem/RazorProjectInfoEndpointPublisher.TestAccessor.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
@@ -11,10 +10,7 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.ProjectSystem;
 
 internal partial class RazorProjectInfoEndpointPublisher
 {
-    internal TestAccessor GetTestAccessor() => new(this);
-
-    [SuppressMessage("RoslynDiagnosticsMaintainability", "RS0043:Do not call 'GetTestAccessor()'", Justification = "Used by test code only")]
-    internal static TestAccessor CreateTestInstanceAccessor(LSPRequestInvoker requestInvoker, IProjectSnapshotManager projectSnapshotManager)
+    internal static TestAccessor GetTestAccessor(LSPRequestInvoker requestInvoker, IProjectSnapshotManager projectSnapshotManager)
         => new(new RazorProjectInfoEndpointPublisher(requestInvoker, projectSnapshotManager, TimeSpan.FromMilliseconds(1)));
 
     internal sealed class TestAccessor(RazorProjectInfoEndpointPublisher instance)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/ProjectSystem/RazorProjectInfoEndpointPublisher.TestAccessor.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/ProjectSystem/RazorProjectInfoEndpointPublisher.TestAccessor.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.ProjectSystem;
+
+internal partial class RazorProjectInfoEndpointPublisher
+{
+    internal TestAccessor GetTestAccessor() => new(this);
+
+    [SuppressMessage("RoslynDiagnosticsMaintainability", "RS0043:Do not call 'GetTestAccessor()'", Justification = "Used by test code only")]
+    internal static TestAccessor CreateTestInstanceAccessor(LSPRequestInvoker requestInvoker, IProjectSnapshotManager projectSnapshotManager)
+        => new(new RazorProjectInfoEndpointPublisher(requestInvoker, projectSnapshotManager, TimeSpan.FromMilliseconds(1)));
+
+    internal sealed class TestAccessor(RazorProjectInfoEndpointPublisher instance)
+    {
+        /// <summary>
+        /// Allows unit tests to imitate ProjectManager.Changed event firing
+        /// </summary>
+        public void ProjectManager_Changed(object sender, ProjectChangeEventArgs args)
+            => instance.ProjectManager_Changed(sender, args);
+
+        /// <summary>
+        /// Allows unit tests to enqueue project update directly.
+        /// </summary>
+        public void EnqueuePublish(IProjectSnapshot projectSnapshot)
+             => instance.EnqueuePublish(projectSnapshot);
+
+        /// <summary>
+        /// Delegates StartSending() call to wrapped instance for unit tests
+        /// </summary>
+        public void StartSending() => instance.StartSending();
+
+        /// <summary>
+        /// Allows unit tests to wait for all work queue items to be processed.
+        /// </summary>
+        public Task WaitUntilCurrentBatchCompletesAsync()
+            => instance._workQueue.WaitUntilCurrentBatchCompletesAsync();
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/ProjectSystem/RazorProjectInfoEndpointPublisher.TestAccessor.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/ProjectSystem/RazorProjectInfoEndpointPublisher.TestAccessor.cs
@@ -1,17 +1,15 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
-using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 
 namespace Microsoft.VisualStudio.Razor.LanguageClient.ProjectSystem;
 
 internal partial class RazorProjectInfoEndpointPublisher
 {
-    internal static TestAccessor GetTestAccessor(LSPRequestInvoker requestInvoker, IProjectSnapshotManager projectSnapshotManager)
-        => new(new RazorProjectInfoEndpointPublisher(requestInvoker, projectSnapshotManager, TimeSpan.FromMilliseconds(1)));
+    internal TestAccessor GetTestAccessor()
+        => new(this);
 
     internal sealed class TestAccessor(RazorProjectInfoEndpointPublisher instance)
     {
@@ -26,11 +24,6 @@ internal partial class RazorProjectInfoEndpointPublisher
         /// </summary>
         public void EnqueuePublish(IProjectSnapshot projectSnapshot)
              => instance.EnqueuePublish(projectSnapshot);
-
-        /// <summary>
-        /// Delegates StartSending() call to wrapped instance for unit tests
-        /// </summary>
-        public void StartSending() => instance.StartSending();
 
         /// <summary>
         /// Allows unit tests to wait for all work queue items to be processed.

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/ProjectSystem/RazorProjectInfoEndpointPublisher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/ProjectSystem/RazorProjectInfoEndpointPublisher.cs
@@ -162,7 +162,7 @@ internal partial class RazorProjectInfoEndpointPublisher : IDisposable
 
     private void ImmediatePublish(IProjectSnapshot projectSnapshot, CancellationToken cancellationToken)
     {
-        var base64ProjectInfo = projectSnapshot.ToRazorProjectInfoString(projectSnapshot.IntermediateOutputPath);
+        var base64ProjectInfo = projectSnapshot.ToBase64EncodedProjectInfo(projectSnapshot.IntermediateOutputPath);
 
         ImmediatePublish(projectSnapshot.Key, base64ProjectInfo, cancellationToken);
     }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/ProjectSystem/RazorProjectInfoEndpointPublisher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/ProjectSystem/RazorProjectInfoEndpointPublisher.cs
@@ -76,8 +76,7 @@ internal partial class RazorProjectInfoEndpointPublisher : IDisposable
         }
     }
 
-    // internal for testing
-    internal void ProjectManager_Changed(object sender, ProjectChangeEventArgs args)
+    private void ProjectManager_Changed(object sender, ProjectChangeEventArgs args)
     {
         // Don't do any work if the solution is closing
         if (args.SolutionIsClosing)
@@ -124,8 +123,7 @@ internal partial class RazorProjectInfoEndpointPublisher : IDisposable
         }
     }
 
-    // protected for tests
-    protected void EnqueuePublish(IProjectSnapshot projectSnapshot)
+    private void EnqueuePublish(IProjectSnapshot projectSnapshot)
     {
         _workQueue.AddWork((Project: projectSnapshot, Removal: false));
     }
@@ -190,8 +188,4 @@ internal partial class RazorProjectInfoEndpointPublisher : IDisposable
                 parameter,
                 cancellationToken).Forget();
     }
-
-    // Used by tests
-    protected Task WaitUntilCurrentBatchCompletesAsync()
-        => _workQueue.WaitUntilCurrentBatchCompletesAsync();
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/ProjectSystem/RazorProjectInfoEndpointPublisher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/ProjectSystem/RazorProjectInfoEndpointPublisher.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Diagnostics;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor;

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/ProjectSystem/RazorProjectInfoEndpointPublisherTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/ProjectSystem/RazorProjectInfoEndpointPublisherTest.cs
@@ -69,7 +69,6 @@ public class RazorProjectInfoEndpointPublisherTest(ITestOutputHelper testOutput)
         Assert.Equal(1, callCount);
     }
 
-
     [Fact]
     public async Task ProjectManager_Changed_NotActive_Noops()
     {
@@ -156,7 +155,6 @@ public class RazorProjectInfoEndpointPublisherTest(ITestOutputHelper testOutput)
     [InlineData(ProjectChangeKind.ProjectChanged, true, false)]
     [InlineData(ProjectChangeKind.ProjectRemoved, true, true)]
     [InlineData(ProjectChangeKind.ProjectAdded, false, false)]
-
     internal async Task ProjectManager_Changed_EnqueuesPublishAsync(ProjectChangeKind changeKind, bool waitForQueueEmpty, bool expectNullProjectInfo)
     {
         // Arrange

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/ProjectSystem/RazorProjectInfoEndpointPublisherTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/ProjectSystem/RazorProjectInfoEndpointPublisherTest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
@@ -51,7 +50,7 @@ public class RazorProjectInfoEndpointPublisherTest(ITestOutputHelper testOutput)
             .Callback<string, string, ProjectInfoParams, CancellationToken>((s1, s2, param, ct) => callCount++)
             .ReturnsAsync(new ReinvokeResponse<object>());
 
-        var publisher = new TestRazorProjectInfoEndpointPublisher(
+        var publisher = RazorProjectInfoEndpointPublisher.CreateTestInstanceAccessor(
             requestInvoker.Object,
             projectManager);
 
@@ -94,7 +93,7 @@ public class RazorProjectInfoEndpointPublisherTest(ITestOutputHelper testOutput)
             .Callback<string, string, ProjectInfoParams, CancellationToken>((s1, s2, param, ct) => callCount++)
             .ReturnsAsync(new ReinvokeResponse<object>());
 
-        var publisher = new TestRazorProjectInfoEndpointPublisher(
+        var publisher = RazorProjectInfoEndpointPublisher.CreateTestInstanceAccessor(
             requestInvoker.Object,
             projectManager);
 
@@ -138,7 +137,7 @@ public class RazorProjectInfoEndpointPublisherTest(ITestOutputHelper testOutput)
             .Callback<string, string, ProjectInfoParams, CancellationToken>((s1, s2, param, ct) => callCount++)
             .ReturnsAsync(new ReinvokeResponse<object>());
 
-        var publisher = new TestRazorProjectInfoEndpointPublisher(
+        var publisher = RazorProjectInfoEndpointPublisher.CreateTestInstanceAccessor(
             requestInvoker.Object,
             projectManager);
 
@@ -179,7 +178,7 @@ public class RazorProjectInfoEndpointPublisherTest(ITestOutputHelper testOutput)
                 })
             .ReturnsAsync(new ReinvokeResponse<object>());
 
-        var publisher = new TestRazorProjectInfoEndpointPublisher(
+        var publisher = RazorProjectInfoEndpointPublisher.CreateTestInstanceAccessor(
             requestInvoker.Object,
             projectManager);
 
@@ -233,7 +232,7 @@ public class RazorProjectInfoEndpointPublisherTest(ITestOutputHelper testOutput)
             })
             .ReturnsAsync(new ReinvokeResponse<object>());
 
-        var publisher = new TestRazorProjectInfoEndpointPublisher(
+        var publisher = RazorProjectInfoEndpointPublisher.CreateTestInstanceAccessor(
             requestInvoker.Object,
             projectManager);
 
@@ -259,21 +258,5 @@ public class RazorProjectInfoEndpointPublisherTest(ITestOutputHelper testOutput)
     internal static IProjectSnapshot CreateProjectSnapshot(string projectFilePath, string[] documentFilePaths)
     {
         return TestProjectSnapshot.Create(projectFilePath, documentFilePaths);
-    }
-
-    private class TestRazorProjectInfoEndpointPublisher(
-        LSPRequestInvoker lspRequestInvoker,
-        IProjectSnapshotManager projectSnapshotManager)
-        : RazorProjectInfoEndpointPublisher(
-            lspRequestInvoker,
-            projectSnapshotManager,
-            TimeSpan.FromMilliseconds(1))
-
-    {
-        public new Task WaitUntilCurrentBatchCompletesAsync()
-            => base.WaitUntilCurrentBatchCompletesAsync();
-
-        public new void EnqueuePublish(IProjectSnapshot project)
-            => base.EnqueuePublish(project);
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/ProjectSystem/RazorProjectInfoEndpointPublisherTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/ProjectSystem/RazorProjectInfoEndpointPublisherTest.cs
@@ -50,7 +50,7 @@ public class RazorProjectInfoEndpointPublisherTest(ITestOutputHelper testOutput)
             .Callback<string, string, ProjectInfoParams, CancellationToken>((s1, s2, param, ct) => callCount++)
             .ReturnsAsync(new ReinvokeResponse<object>());
 
-        var publisher = RazorProjectInfoEndpointPublisher.CreateTestInstanceAccessor(
+        var publisher = RazorProjectInfoEndpointPublisher.GetTestAccessor(
             requestInvoker.Object,
             projectManager);
 
@@ -93,7 +93,7 @@ public class RazorProjectInfoEndpointPublisherTest(ITestOutputHelper testOutput)
             .Callback<string, string, ProjectInfoParams, CancellationToken>((s1, s2, param, ct) => callCount++)
             .ReturnsAsync(new ReinvokeResponse<object>());
 
-        var publisher = RazorProjectInfoEndpointPublisher.CreateTestInstanceAccessor(
+        var publisher = RazorProjectInfoEndpointPublisher.GetTestAccessor(
             requestInvoker.Object,
             projectManager);
 
@@ -137,7 +137,7 @@ public class RazorProjectInfoEndpointPublisherTest(ITestOutputHelper testOutput)
             .Callback<string, string, ProjectInfoParams, CancellationToken>((s1, s2, param, ct) => callCount++)
             .ReturnsAsync(new ReinvokeResponse<object>());
 
-        var publisher = RazorProjectInfoEndpointPublisher.CreateTestInstanceAccessor(
+        var publisher = RazorProjectInfoEndpointPublisher.GetTestAccessor(
             requestInvoker.Object,
             projectManager);
 
@@ -178,7 +178,7 @@ public class RazorProjectInfoEndpointPublisherTest(ITestOutputHelper testOutput)
                 })
             .ReturnsAsync(new ReinvokeResponse<object>());
 
-        var publisher = RazorProjectInfoEndpointPublisher.CreateTestInstanceAccessor(
+        var publisher = RazorProjectInfoEndpointPublisher.GetTestAccessor(
             requestInvoker.Object,
             projectManager);
 
@@ -214,7 +214,7 @@ public class RazorProjectInfoEndpointPublisherTest(ITestOutputHelper testOutput)
 
         var firstSnapshot = CreateProjectSnapshot(@"C:\path\to\project.csproj");
         var secondSnapshot = CreateProjectSnapshot(@"C:\path\to\project.csproj", [@"C:\path\to\file.cshtml"]);
-        var expectedProjectInfoString = secondSnapshot.ToRazorProjectInfoString(secondSnapshot.IntermediateOutputPath);
+        var expectedProjectInfoString = secondSnapshot.ToBase64EncodedProjectInfo(secondSnapshot.IntermediateOutputPath);
 
         var projectInfoParams = (ProjectInfoParams?)null;
         var callCount = 0;
@@ -232,7 +232,7 @@ public class RazorProjectInfoEndpointPublisherTest(ITestOutputHelper testOutput)
             })
             .ReturnsAsync(new ReinvokeResponse<object>());
 
-        var publisher = RazorProjectInfoEndpointPublisher.CreateTestInstanceAccessor(
+        var publisher = RazorProjectInfoEndpointPublisher.GetTestAccessor(
             requestInvoker.Object,
             projectManager);
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/ProjectSystem/RazorProjectInfoEndpointPublisherTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/ProjectSystem/RazorProjectInfoEndpointPublisherTest.cs
@@ -1,0 +1,281 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.Serialization;
+using Microsoft.AspNetCore.Razor.ProjectSystem;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
+using Microsoft.AspNetCore.Razor.Test.Common.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Protocol;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Protocol.ProjectSystem;
+using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
+using Microsoft.VisualStudio.Razor.LanguageClient;
+using Microsoft.VisualStudio.Razor.LanguageClient.ProjectSystem;
+using Moq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor.Test.LanguageClient.ProjectSystem;
+
+public class RazorProjectInfoEndpointPublisherTest(ITestOutputHelper testOutput) : LanguageServerTestBase(testOutput)
+{
+    [Fact]
+    [WorkItem("https://github.com/dotnet/aspnetcore/issues/35945")]
+    public async Task ProjectManager_Changed_Remove_Change_NoopsOnDelayedPublish()
+    {
+        // Arrange
+        var projectManager = CreateProjectSnapshotManager();
+
+        var callCount = 0;
+        var tagHelpers = ImmutableArray.Create(
+            new TagHelperDescriptor(FileKinds.Component, "Namespace.FileNameOther", "Assembly", "FileName", "FileName document", "FileName hint",
+                caseSensitive: false, tagMatchingRules: default, attributeDescriptors: default, allowedChildTags: default, metadata: null!, diagnostics: default));
+
+        var initialProjectSnapshot = CreateProjectSnapshot(
+            @"C:\path\to\project.csproj", ProjectWorkspaceState.Create(tagHelpers, CodeAnalysis.CSharp.LanguageVersion.Preview));
+        var expectedProjectSnapshot = CreateProjectSnapshot(
+            @"C:\path\to\project.csproj", ProjectWorkspaceState.Create(CodeAnalysis.CSharp.LanguageVersion.Preview));
+        var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
+        requestInvoker
+            .Setup(r => r.ReinvokeRequestOnServerAsync<ProjectInfoParams, object>(
+                LanguageServerConstants.RazorProjectInfoEndpoint,
+                RazorLSPConstants.RazorLanguageServerName,
+                It.IsAny<ProjectInfoParams>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, string, ProjectInfoParams, CancellationToken>((s1, s2, param, ct) => callCount++)
+            .ReturnsAsync(new ReinvokeResponse<object>());
+
+        var publisher = new TestRazorProjectInfoEndpointPublisher(
+            requestInvoker.Object,
+            projectManager);
+
+        var documentRemovedArgs = ProjectChangeEventArgs.CreateTestInstance(
+            initialProjectSnapshot, initialProjectSnapshot, documentFilePath: @"C:\path\to\file.razor", ProjectChangeKind.DocumentRemoved);
+        var projectChangedArgs = ProjectChangeEventArgs.CreateTestInstance(
+            initialProjectSnapshot, expectedProjectSnapshot, documentFilePath: null!, ProjectChangeKind.ProjectChanged);
+
+        // Act
+        publisher.ProjectManager_Changed(null!, documentRemovedArgs);
+        publisher.ProjectManager_Changed(null!, projectChangedArgs);
+        await publisher.WaitUntilCurrentBatchCompletesAsync();
+
+        // Assert
+        Assert.Equal(1, callCount);
+    }
+
+
+    [Fact]
+    public async Task ProjectManager_Changed_NotActive_Noops()
+    {
+        // Arrange
+        var projectManager = CreateProjectSnapshotManager();
+
+        var hostProject = new HostProject(@"C:\path\to\project.csproj", @"C:\path\to\obj", RazorConfiguration.Default, rootNamespace: "TestRootNamespace");
+        var hostDocument = new HostDocument(@"C:\path\to\file.razor", "file.razor");
+
+        await projectManager.UpdateAsync(updater =>
+        {
+            updater.ProjectAdded(hostProject);
+        });
+
+        var callCount = 0;
+        var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
+        requestInvoker
+            .Setup(r => r.ReinvokeRequestOnServerAsync<ProjectInfoParams, object>(
+                LanguageServerConstants.RazorProjectInfoEndpoint,
+                RazorLSPConstants.RazorLanguageServerName,
+                It.IsAny<ProjectInfoParams>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, string, ProjectInfoParams, CancellationToken>((s1, s2, param, ct) => callCount++)
+            .ReturnsAsync(new ReinvokeResponse<object>());
+
+        var publisher = new TestRazorProjectInfoEndpointPublisher(
+            requestInvoker.Object,
+            projectManager);
+
+        // Act
+        await projectManager.UpdateAsync(updater =>
+        {
+            updater.DocumentAdded(hostProject.Key, hostDocument, new EmptyTextLoader(hostDocument.FilePath));
+        });
+        await publisher.WaitUntilCurrentBatchCompletesAsync();
+
+        // Assert
+        Assert.Equal(0, callCount);
+    }
+
+    [Fact]
+    public async Task ProjectManager_Changed_ServerStarted_InitializedProject_Publishes()
+    {
+        // Arrange
+        var projectManager = CreateProjectSnapshotManager();
+
+        var hostProject = new HostProject(@"C:\path\to\project.csproj", @"C:\path\to\obj", RazorConfiguration.Default, rootNamespace: "TestRootNamespace");
+        var hostDocument = new HostDocument(@"C:\path\to\file.razor", "file.razor");
+
+        await projectManager.UpdateAsync(updater =>
+        {
+            updater.ProjectAdded(hostProject);
+            updater.ProjectWorkspaceStateChanged(hostProject.Key, ProjectWorkspaceState.Default);
+            updater.DocumentAdded(hostProject.Key, hostDocument, new EmptyTextLoader(hostDocument.FilePath));
+        });
+
+        var projectSnapshot = projectManager.GetProjects()[0];
+
+        var callCount = 0;
+        var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
+        requestInvoker
+            .Setup(r => r.ReinvokeRequestOnServerAsync<ProjectInfoParams, object>(
+                LanguageServerConstants.RazorProjectInfoEndpoint,
+                RazorLSPConstants.RazorLanguageServerName,
+                It.IsAny<ProjectInfoParams>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, string, ProjectInfoParams, CancellationToken>((s1, s2, param, ct) => callCount++)
+            .ReturnsAsync(new ReinvokeResponse<object>());
+
+        var publisher = new TestRazorProjectInfoEndpointPublisher(
+            requestInvoker.Object,
+            projectManager);
+
+        // Act
+        publisher.StartSending();
+
+        // Assert
+        Assert.Equal(1, callCount);
+    }
+
+    [Theory]
+    [InlineData(ProjectChangeKind.DocumentAdded, true, false)]
+    [InlineData(ProjectChangeKind.DocumentRemoved, true, false)]
+    [InlineData(ProjectChangeKind.ProjectChanged, true, false)]
+    [InlineData(ProjectChangeKind.ProjectRemoved, true, true)]
+    [InlineData(ProjectChangeKind.ProjectAdded, false, false)]
+
+    internal async Task ProjectManager_Changed_EnqueuesPublishAsync(ProjectChangeKind changeKind, bool waitForQueueEmpty, bool expectNullProjectInfo)
+    {
+        // Arrange
+        var projectManager = CreateProjectSnapshotManager();
+        var projectConfigurationFilePathStore = new DefaultProjectConfigurationFilePathStore();
+
+        var projectSnapshot = CreateProjectSnapshot(@"C:\path\to\project.csproj", ProjectWorkspaceState.Create(CodeAnalysis.CSharp.LanguageVersion.CSharp7_3));
+        var expectedProjectInfo = projectSnapshot.ToRazorProjectInfo(projectSnapshot.IntermediateOutputPath);
+        var callCount = 0;
+        var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
+        var projectInfoParams = (ProjectInfoParams?)null;
+        requestInvoker
+            .Setup(r => r.ReinvokeRequestOnServerAsync<ProjectInfoParams, object>(
+                LanguageServerConstants.RazorProjectInfoEndpoint,
+                RazorLSPConstants.RazorLanguageServerName,
+                It.IsAny<ProjectInfoParams>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, string, ProjectInfoParams, CancellationToken>((s1, s2, param, ct) =>
+                {
+                    callCount++;
+                    projectInfoParams = param;
+                })
+            .ReturnsAsync(new ReinvokeResponse<object>());
+
+        var publisher = new TestRazorProjectInfoEndpointPublisher(
+            requestInvoker.Object,
+            projectManager);
+
+        var args = ProjectChangeEventArgs.CreateTestInstance(projectSnapshot, projectSnapshot, documentFilePath: null!, changeKind);
+
+        // Act
+        publisher.ProjectManager_Changed(null!, args);
+        if (waitForQueueEmpty)
+        {
+            await publisher.WaitUntilCurrentBatchCompletesAsync();
+        }
+
+        // Assert
+        Assert.Equal(1, callCount);
+        var projectInfo =
+            RazorProjectInfoDeserializer.Instance.DeserializeFromString(projectInfoParams!.ProjectInfo);
+        if (expectNullProjectInfo)
+        {
+            Assert.Null(projectInfo);
+        }
+        else
+        {
+            Assert.NotNull(projectInfo);
+            Assert.Equal(expectedProjectInfo, projectInfo);
+        }
+    }
+
+    [Fact]
+    public async Task EnqueuePublish_BatchesPublishRequestsAsync()
+    {
+        // Arrange
+        var projectManager = CreateProjectSnapshotManager();
+
+        var firstSnapshot = CreateProjectSnapshot(@"C:\path\to\project.csproj");
+        var secondSnapshot = CreateProjectSnapshot(@"C:\path\to\project.csproj", [@"C:\path\to\file.cshtml"]);
+        var expectedProjectInfoString = secondSnapshot.ToRazorProjectInfoString(secondSnapshot.IntermediateOutputPath);
+
+        var projectInfoParams = (ProjectInfoParams?)null;
+        var callCount = 0;
+        var requestInvoker = new Mock<LSPRequestInvoker>(MockBehavior.Strict);
+        requestInvoker
+            .Setup(r => r.ReinvokeRequestOnServerAsync<ProjectInfoParams, object>(
+                LanguageServerConstants.RazorProjectInfoEndpoint,
+                RazorLSPConstants.RazorLanguageServerName,
+                It.IsAny<ProjectInfoParams>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<string, string, ProjectInfoParams, CancellationToken>((s1, s2, param, ct) =>
+            {
+                callCount++;
+                projectInfoParams = param;
+            })
+            .ReturnsAsync(new ReinvokeResponse<object>());
+
+        var publisher = new TestRazorProjectInfoEndpointPublisher(
+            requestInvoker.Object,
+            projectManager);
+
+        // Act
+        publisher.EnqueuePublish(firstSnapshot);
+        publisher.EnqueuePublish(secondSnapshot);
+        await publisher.WaitUntilCurrentBatchCompletesAsync();
+
+        // Assert
+        Assert.Equal(1, callCount);
+        Assert.NotNull(projectInfoParams);
+        Assert.Equal(expectedProjectInfoString, projectInfoParams.ProjectInfo);
+    }
+
+    internal static IProjectSnapshot CreateProjectSnapshot(
+        string projectFilePath,
+        ProjectWorkspaceState? projectWorkspaceState = null,
+        string[]? documentFilePaths = null)
+    {
+        return TestProjectSnapshot.Create(projectFilePath, documentFilePaths ?? [], projectWorkspaceState);
+    }
+
+    internal static IProjectSnapshot CreateProjectSnapshot(string projectFilePath, string[] documentFilePaths)
+    {
+        return TestProjectSnapshot.Create(projectFilePath, documentFilePaths);
+    }
+
+    private class TestRazorProjectInfoEndpointPublisher(
+        LSPRequestInvoker lspRequestInvoker,
+        IProjectSnapshotManager projectSnapshotManager)
+        : RazorProjectInfoEndpointPublisher(
+            lspRequestInvoker,
+            projectSnapshotManager,
+            TimeSpan.FromMilliseconds(1))
+
+    {
+        public new Task WaitUntilCurrentBatchCompletesAsync()
+            => base.WaitUntilCurrentBatchCompletesAsync();
+
+        public new void EnqueuePublish(IProjectSnapshot project)
+            => base.EnqueuePublish(project);
+    }
+}


### PR DESCRIPTION
﻿### Summary of the changes

Unit tests for RazorProjectInfoEndpointPublisher
- Based on tests for RazorProjectInfoPublisher
- Excludes tests that didn't make sense for the endpoint-based code (e.g. filename scenarios, etc.)

