### PR TITLE
Remove ProjectSnapshotManagerDispatcher from ProjectConfigurationStateSynchronizer

### DIFF
--- a/SpellingExclusions.dic
+++ b/SpellingExclusions.dic
@@ -1,6 +1,7 @@
 csharp
 cshtml
 csproj
+deserializer
 hresult
 microsoft
 vsls

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeEventArgs.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeEventArgs.cs
@@ -12,28 +12,20 @@ using Microsoft.CodeAnalysis.Razor.Workspaces;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
-internal sealed class ProjectConfigurationFileChangeEventArgs : EventArgs
+internal sealed class ProjectConfigurationFileChangeEventArgs(
+    string configurationFilePath,
+    RazorFileChangeKind kind,
+    IRazorProjectInfoDeserializer? projectInfoDeserializer = null) : EventArgs
 {
-    public string ConfigurationFilePath { get; }
-    public RazorFileChangeKind Kind { get; }
+    public string ConfigurationFilePath { get; } = configurationFilePath;
+    public RazorFileChangeKind Kind { get; } = kind;
 
-    private readonly IRazorProjectInfoDeserializer _deserializer;
+    private readonly IRazorProjectInfoDeserializer _deserializer = projectInfoDeserializer ?? RazorProjectInfoDeserializer.Instance;
     private RazorProjectInfo? _projectInfo;
-    private readonly object _gate;
+    private readonly object _gate = new();
     private bool _deserialized;
 
-    public ProjectConfigurationFileChangeEventArgs(
-        string configurationFilePath,
-        RazorFileChangeKind kind,
-        IRazorProjectInfoDeserializer? projectInfoDeserializer = null)
-    {
-        ConfigurationFilePath = configurationFilePath ?? throw new ArgumentNullException(nameof(configurationFilePath));
-        Kind = kind;
-        _deserializer = projectInfoDeserializer ?? RazorProjectInfoDeserializer.Instance;
-        _gate = new object();
-    }
-
-    public bool TryDeserialize(LanguageServerFeatureOptions languageServerFeatureOptions, [NotNullWhen(true)] out RazorProjectInfo? projectInfo)
+    public bool TryDeserialize(LanguageServerFeatureOptions options, [NotNullWhen(true)] out RazorProjectInfo? projectInfo)
     {
         if (Kind == RazorFileChangeKind.Removed)
         {
@@ -65,7 +57,7 @@ internal sealed class ProjectConfigurationFileChangeEventArgs : EventArgs
                     {
                         Configuration = deserializedProjectInfo.Configuration with
                         {
-                            LanguageServerFlags = languageServerFeatureOptions.ToLanguageServerFlags()
+                            LanguageServerFlags = options.ToLanguageServerFlags()
                         }
                     };
 
@@ -79,15 +71,10 @@ internal sealed class ProjectConfigurationFileChangeEventArgs : EventArgs
                     return false;
                 }
             }
+
+            projectInfo = _projectInfo;
         }
 
-        projectInfo = _projectInfo;
-        if (projectInfo is null)
-        {
-            // Deserialization failed
-            return false;
-        }
-
-        return true;
+        return projectInfo is not null;
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeEventArgs.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeEventArgs.cs
@@ -15,12 +15,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer;
 internal sealed class ProjectConfigurationFileChangeEventArgs(
     string configurationFilePath,
     RazorFileChangeKind kind,
-    IRazorProjectInfoDeserializer? projectInfoDeserializer = null) : EventArgs
+    IRazorProjectInfoDeserializer? deserializer = null) : EventArgs
 {
     public string ConfigurationFilePath { get; } = configurationFilePath;
     public RazorFileChangeKind Kind { get; } = kind;
 
-    private readonly IRazorProjectInfoDeserializer _deserializer = projectInfoDeserializer ?? RazorProjectInfoDeserializer.Instance;
+    private readonly IRazorProjectInfoDeserializer _deserializer = deserializer ?? RazorProjectInfoDeserializer.Instance;
     private RazorProjectInfo? _projectInfo;
     private readonly object _gate = new();
     private bool _deserialized;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.Comparer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.Comparer.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Razor;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer;
+
+internal partial class ProjectConfigurationStateSynchronizer
+{
+    private sealed class Comparer : IEqualityComparer<Work>
+    {
+        public static readonly Comparer Instance = new();
+
+        private Comparer()
+        {
+        }
+
+        public bool Equals(Work? x, Work? y)
+        {
+            if (x is null)
+            {
+                return y is null;
+            }
+            else if (y is null)
+            {
+                return x is null;
+            }
+
+            // For purposes of removing duplicates from batches, two Work instances
+            // are equal only if their identifying properties are equal. So, only
+            // configuration file paths and project keys.
+
+            if (!FilePathComparer.Instance.Equals(x.ConfigurationFilePath, y.ConfigurationFilePath))
+            {
+                return false;
+            }
+
+            return (x, y) switch
+            {
+                (AddProject, AddProject) => true,
+
+                (ResetProject { ProjectKey: var keyX },
+                 ResetProject { ProjectKey: var keyY })
+                    => keyX == keyY,
+
+                (UpdateProject { ProjectKey: var keyX },
+                 UpdateProject { ProjectKey: var keyY })
+                    => keyX == keyY,
+
+                _ => false,
+            };
+        }
+
+        public int GetHashCode(Work obj)
+            => obj.GetHashCode();
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.TestAccessor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.TestAccessor.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer;
+
+internal partial class ProjectConfigurationStateSynchronizer
+{
+    internal TestAccessor GetTestAccessor() => new(this);
+
+    internal sealed class TestAccessor(ProjectConfigurationStateSynchronizer instance)
+    {
+        public Task WaitUntilCurrentBatchCompletesAsync()
+            => instance._workQueue.WaitUntilCurrentBatchCompletesAsync();
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.cs
@@ -75,7 +75,7 @@ internal partial class ProjectConfigurationStateSynchronizer : IProjectConfigura
                 AddProject(var configurationFilePath, var projectInfo) => AddProjectAsync(configurationFilePath, projectInfo, token),
                 ResetProject(_, var projectKey) => ResetProjectAsync(projectKey, token),
                 UpdateProject(_, var projectKey, var projectInfo) => UpdateProjectAsync(projectKey, projectInfo, token),
-                _ => Task.CompletedTask
+                _ => Assumed.Unreachable<Task>()
             };
 
             await itemTask.ConfigureAwait(false);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.cs
@@ -11,55 +11,54 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Utilities;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Utilities;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
-internal class ProjectConfigurationStateSynchronizer : IProjectConfigurationFileChangeListener, IDisposable
+internal partial class ProjectConfigurationStateSynchronizer : IProjectConfigurationFileChangeListener, IDisposable
 {
+    private abstract record Work(string ConfigurationFilePath);
+    private sealed record AddProject(string ConfigurationFilePath, RazorProjectInfo ProjectInfo) : Work(ConfigurationFilePath);
+    private sealed record ResetProject(string ConfigurationFilePath, ProjectKey ProjectKey) : Work(ConfigurationFilePath);
+    private sealed record UpdateProject(string ConfigurationFilePath, ProjectKey ProjectKey, RazorProjectInfo ProjectInfo) : Work(ConfigurationFilePath);
+
     private static readonly TimeSpan s_delay = TimeSpan.FromMilliseconds(250);
 
-    private readonly ProjectSnapshotManagerDispatcher _dispatcher;
     private readonly IRazorProjectService _projectService;
     private readonly LanguageServerFeatureOptions _options;
     private readonly ILogger _logger;
-    private readonly TimeSpan _delay;
 
-    internal readonly Dictionary<ProjectKey, DelayedProjectInfo> ProjectInfoMap;
+    private readonly CancellationTokenSource _disposeTokenSource;
+    private readonly AsyncBatchingWorkQueue<Work> _workQueue;
 
     private ImmutableDictionary<string, ProjectKey> _filePathToProjectKeyMap = ImmutableDictionary<string, ProjectKey>.Empty;
 
-    private readonly CancellationTokenSource _disposeTokenSource;
-
     public ProjectConfigurationStateSynchronizer(
-        ProjectSnapshotManagerDispatcher dispatcher,
         IRazorProjectService projectService,
         ILoggerFactory loggerFactory,
         LanguageServerFeatureOptions options)
-        : this(dispatcher, projectService, loggerFactory, options, s_delay)
+        : this(projectService, loggerFactory, options, s_delay)
     {
     }
 
     protected ProjectConfigurationStateSynchronizer(
-        ProjectSnapshotManagerDispatcher dispatcher,
         IRazorProjectService projectService,
         ILoggerFactory loggerFactory,
         LanguageServerFeatureOptions options,
         TimeSpan delay)
     {
-        _dispatcher = dispatcher;
         _projectService = projectService;
         _options = options;
         _logger = loggerFactory.GetOrCreateLogger<ProjectConfigurationStateSynchronizer>();
-        _delay = delay;
-
-        ProjectInfoMap = new Dictionary<ProjectKey, DelayedProjectInfo>();
 
         _disposeTokenSource = new();
+        _workQueue = new(delay, ProcessBatchAsync, _disposeTokenSource.Token);
     }
 
     public void Dispose()
@@ -67,179 +66,171 @@ internal class ProjectConfigurationStateSynchronizer : IProjectConfigurationFile
         _disposeTokenSource.Cancel();
         _disposeTokenSource.Dispose();
     }
+    private async ValueTask ProcessBatchAsync(ImmutableArray<Work> items, CancellationToken token)
+    {
+        foreach (var item in items.GetMostRecentUniqueItems(Comparer.Instance))
+        {
+            var itemTask = item switch
+            {
+                AddProject(var configurationFilePath, var projectInfo) => AddProjectAsync(configurationFilePath, projectInfo, token),
+                ResetProject(_, var projectKey) => ResetProjectAsync(projectKey, token),
+                UpdateProject(_, var projectKey, var projectInfo) => UpdateProjectAsync(projectKey, projectInfo, token),
+                _ => Task.CompletedTask
+            };
+
+            await itemTask.ConfigureAwait(false);
+        }
+
+        async Task AddProjectAsync(string configurationFilePath, RazorProjectInfo projectInfo, CancellationToken token)
+        {
+            var projectFilePath = FilePathNormalizer.Normalize(projectInfo.FilePath);
+            var intermediateOutputPath = FilePathNormalizer.GetNormalizedDirectoryName(configurationFilePath);
+
+            var projectKey = await _projectService
+                .AddProjectAsync(
+                    projectFilePath,
+                    intermediateOutputPath,
+                    projectInfo.Configuration,
+                    projectInfo.RootNamespace,
+                    projectInfo.DisplayName,
+                    token)
+                .ConfigureAwait(false);
+
+            _logger.LogInformation($"Added {projectKey.Id}.");
+
+            ImmutableInterlocked.AddOrUpdate(ref _filePathToProjectKeyMap, configurationFilePath, projectKey, static (k, v) => v);
+            _logger.LogInformation($"Project configuration file added for project '{projectFilePath}': '{configurationFilePath}'");
+
+            await UpdateProjectAsync(projectKey, projectInfo, token).ConfigureAwait(false);
+        }
+
+        Task ResetProjectAsync(ProjectKey projectKey, CancellationToken token)
+        {
+            _logger.LogInformation($"Resetting {projectKey.Id}.");
+
+            return _projectService
+                .UpdateProjectAsync(
+                    projectKey,
+                    configuration: null,
+                    rootNamespace: null,
+                    displayName: "",
+                    ProjectWorkspaceState.Default,
+                    documents: [],
+                    token);
+        }
+
+        Task UpdateProjectAsync(ProjectKey projectKey, RazorProjectInfo projectInfo, CancellationToken token)
+        {
+            _logger.LogInformation($"Updating {projectKey.Id}.");
+
+            return _projectService
+                .UpdateProjectAsync(
+                    projectKey,
+                    projectInfo.Configuration,
+                    projectInfo.RootNamespace,
+                    projectInfo.DisplayName,
+                    projectInfo.ProjectWorkspaceState,
+                    projectInfo.Documents,
+                    token);
+        }
+    }
 
     public void ProjectConfigurationFileChanged(ProjectConfigurationFileChangeEventArgs args)
     {
-        if (args is null)
-        {
-            throw new ArgumentNullException(nameof(args));
-        }
-
-        _dispatcher.AssertRunningOnDispatcher();
+        var configurationFilePath = FilePathNormalizer.Normalize(args.ConfigurationFilePath);
 
         switch (args.Kind)
         {
             case RazorFileChangeKind.Changed:
                 {
-                    var configurationFilePath = FilePathNormalizer.Normalize(args.ConfigurationFilePath);
-                    if (!args.TryDeserialize(_options, out var projectInfo))
+                    if (args.TryDeserialize(_options, out var projectInfo))
                     {
-                        if (!_filePathToProjectKeyMap.TryGetValue(configurationFilePath, out var lastAssociatedProjectKey))
+                        if (_filePathToProjectKeyMap.TryGetValue(configurationFilePath, out var projectKey))
                         {
-                            // Could not resolve an associated project file, noop.
-                            _logger.LogWarning($"Failed to deserialize configuration file after change for an unknown project. Configuration file path: '{configurationFilePath}'");
-                            return;
+                            _logger.LogInformation($"""
+                                Configuration file changed for project '{projectKey.Id}'.
+                                Configuration file path: '{configurationFilePath}'
+                                """);
+
+                            _workQueue.AddWork(new UpdateProject(configurationFilePath, projectKey, projectInfo));
                         }
                         else
                         {
-                            _logger.LogWarning($"Failed to deserialize configuration file after change for project '{lastAssociatedProjectKey.Id}': '{configurationFilePath}'");
+                            _logger.LogWarning($"""
+                                Adding project for previously unseen configuration file.
+                                Configuration file path: '{configurationFilePath}'
+                                """);
+
+                            _workQueue.AddWork(new AddProject(configurationFilePath, projectInfo));
                         }
-
-                        // We found the last associated project file for the configuration file. Reset the project since we can't
-                        // accurately determine its configurations.
-
-                        EnqueueUpdateProject(lastAssociatedProjectKey, projectInfo: null, _disposeTokenSource.Token);
-                        return;
                     }
-
-                    if (!_filePathToProjectKeyMap.TryGetValue(configurationFilePath, out var associatedProjectKey))
+                    else
                     {
-                        _logger.LogWarning($"Found no project key for configuration file. Assuming new project. Configuration file path: '{configurationFilePath}'");
+                        if (_filePathToProjectKeyMap.TryGetValue(configurationFilePath, out var projectKey))
+                        {
+                            _logger.LogWarning($"""
+                                Failed to deserialize after change to configuration file for project '{projectKey.Id}'.
+                                Configuration file path: '{configurationFilePath}'
+                                """);
 
-                        AddProjectAsync(configurationFilePath, projectInfo, _disposeTokenSource.Token).Forget();
-                        return;
+                            // We found the last associated project file for the configuration file. Reset the project since we can't
+                            // accurately determine its configurations.
+
+                            _workQueue.AddWork(new ResetProject(configurationFilePath, projectKey));
+                        }
+                        else
+                        {
+                            // Could not resolve an associated project file.
+                            _logger.LogWarning($"""
+                                Failed to deserialize after change to previously unseen configuration file.
+                                Configuration file path: '{configurationFilePath}'
+                                """);
+                        }
                     }
-
-                    _logger.LogInformation($"Project configuration file changed for project '{associatedProjectKey.Id}': '{configurationFilePath}'");
-
-                    EnqueueUpdateProject(associatedProjectKey, projectInfo, _disposeTokenSource.Token);
-                    break;
                 }
+
+                break;
+
             case RazorFileChangeKind.Added:
                 {
-                    var configurationFilePath = FilePathNormalizer.Normalize(args.ConfigurationFilePath);
-                    if (!args.TryDeserialize(_options, out var projectInfo))
+                    if (args.TryDeserialize(_options, out var projectInfo))
                     {
-                        // Given that this is the first time we're seeing this configuration file if we can't deserialize it
-                        // then we have to noop.
-                        _logger.LogWarning($"Failed to deserialize configuration file on configuration added event. Configuration file path: '{configurationFilePath}'");
-                        return;
+                        _workQueue.AddWork(new AddProject(configurationFilePath, projectInfo));
                     }
-
-                    AddProjectAsync(configurationFilePath, projectInfo, _disposeTokenSource.Token).Forget();
-                    break;
+                    else
+                    {
+                        // This is the first time we've seen this configuration file, but we can't deserialize it.
+                        // The only thing we can really do is issue a warning.
+                        _logger.LogWarning($"""
+                            Failed to deserialize previously unseen configuration file.
+                            Configuration file path: '{configurationFilePath}'
+                            """);
+                    }
                 }
+
+                break;
+
             case RazorFileChangeKind.Removed:
                 {
-                    var configurationFilePath = FilePathNormalizer.Normalize(args.ConfigurationFilePath);
-                    if (!ImmutableInterlocked.TryRemove(ref _filePathToProjectKeyMap, configurationFilePath, out var projectKey))
+                    if (ImmutableInterlocked.TryRemove(ref _filePathToProjectKeyMap, configurationFilePath, out var projectKey))
                     {
-                        // Failed to deserialize the initial project configuration file on add so we can't remove the configuration file because it doesn't exist in the list.
-                        _logger.LogWarning($"Failed to resolve associated project on configuration removed event. Configuration file path: '{configurationFilePath}'");
-                        return;
+                        _logger.LogInformation($"""
+                            Configuration file removed for project '{projectKey}'.
+                            Configuration file path: '{configurationFilePath}'
+                            """);
+
+                        _workQueue.AddWork(new ResetProject(configurationFilePath, projectKey));
                     }
-
-                    _logger.LogInformation($"Project configuration file removed for project '{projectKey}': '{configurationFilePath}'");
-
-                    EnqueueUpdateProject(projectKey, projectInfo: null, _disposeTokenSource.Token);
-                    break;
+                    else
+                    {
+                        _logger.LogWarning($"""
+                            Failed to resolve associated project on configuration removed event.
+                            Configuration file path: '{configurationFilePath}'
+                            """);
+                    }
                 }
+
+                break;
         }
-
-        async Task AddProjectAsync(string configurationFilePath, RazorProjectInfo projectInfo, CancellationToken cancellationToken)
-        {
-            try
-            {
-                var projectFilePath = FilePathNormalizer.Normalize(projectInfo.FilePath);
-                var intermediateOutputPath = Path.GetDirectoryName(configurationFilePath).AssumeNotNull();
-                var rootNamespace = projectInfo.RootNamespace;
-
-                var projectKey = await _projectService
-                    .AddProjectAsync(
-                        projectFilePath,
-                        intermediateOutputPath,
-                        projectInfo.Configuration,
-                        rootNamespace,
-                        projectInfo.DisplayName,
-                        cancellationToken)
-                    .ConfigureAwait(false);
-
-                ImmutableInterlocked.AddOrUpdate(ref _filePathToProjectKeyMap, configurationFilePath, projectKey, static (k, v) => v);
-
-                _logger.LogInformation($"Project configuration file added for project '{projectFilePath}': '{configurationFilePath}'");
-                EnqueueUpdateProject(projectKey, projectInfo, cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, $"Error occurred while adding project: {projectInfo.FilePath}");
-            }
-        }
-
-        Task UpdateProjectAsync(ProjectKey projectKey, RazorProjectInfo? projectInfo, CancellationToken cancellationToken)
-        {
-            if (projectInfo is null)
-            {
-                return ResetProjectAsync(projectKey, cancellationToken);
-            }
-
-            _logger.LogInformation($"Actually updating {projectKey} with a real projectInfo");
-
-            var projectWorkspaceState = projectInfo.ProjectWorkspaceState ?? ProjectWorkspaceState.Default;
-            var documents = projectInfo.Documents;
-            return _projectService.UpdateProjectAsync(
-                projectKey,
-                projectInfo.Configuration,
-                projectInfo.RootNamespace,
-                projectInfo.DisplayName,
-                projectWorkspaceState,
-                documents,
-                cancellationToken);
-        }
-
-        async Task UpdateAfterDelayAsync(ProjectKey projectKey, CancellationToken cancellationToken)
-        {
-            // ConfigureAwait(true) to make sure we are still running in ProjectSnapshotManagerDispatcher context
-            await Task.Delay(_delay).ConfigureAwait(true);
-
-            _dispatcher.AssertRunningOnDispatcher();
-
-            var delayedProjectInfo = ProjectInfoMap[projectKey];
-            await UpdateProjectAsync(projectKey, delayedProjectInfo.ProjectInfo, cancellationToken).ConfigureAwait(false);
-        }
-
-        void EnqueueUpdateProject(ProjectKey projectKey, RazorProjectInfo? projectInfo, CancellationToken cancellationToken)
-        {
-            if (!ProjectInfoMap.ContainsKey(projectKey))
-            {
-                ProjectInfoMap[projectKey] = new DelayedProjectInfo();
-            }
-
-            var delayedProjectInfo = ProjectInfoMap[projectKey];
-            delayedProjectInfo.ProjectInfo = projectInfo;
-
-            if (delayedProjectInfo.ProjectUpdateTask is null || delayedProjectInfo.ProjectUpdateTask.IsCompleted)
-            {
-                delayedProjectInfo.ProjectUpdateTask = UpdateAfterDelayAsync(projectKey, cancellationToken);
-            }
-        }
-
-        Task ResetProjectAsync(ProjectKey projectKey, CancellationToken cancellationToken)
-        {
-            return _projectService.UpdateProjectAsync(
-                projectKey,
-                configuration: null,
-                rootNamespace: null,
-                displayName: "",
-                ProjectWorkspaceState.Default,
-                documents: [],
-                cancellationToken);
-        }
-    }
-
-    internal class DelayedProjectInfo
-    {
-        public Task? ProjectUpdateTask { get; set; }
-
-        public RazorProjectInfo? ProjectInfo { get; set; }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.cs
@@ -37,7 +37,8 @@ internal partial class ProjectConfigurationStateSynchronizer : IProjectConfigura
     private readonly CancellationTokenSource _disposeTokenSource;
     private readonly AsyncBatchingWorkQueue<Work> _workQueue;
 
-    private ImmutableDictionary<string, ProjectKey> _filePathToProjectKeyMap = ImmutableDictionary<string, ProjectKey>.Empty;
+    private ImmutableDictionary<string, ProjectKey> _filePathToProjectKeyMap =
+        ImmutableDictionary<string, ProjectKey>.Empty.WithComparers(keyComparer: FilePathComparer.Instance);
 
     public ProjectConfigurationStateSynchronizer(
         IRazorProjectService projectService,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/MonitorProjectConfigurationFilePathEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/MonitorProjectConfigurationFilePathEndpoint.cs
@@ -21,7 +21,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 internal class MonitorProjectConfigurationFilePathEndpoint : IRazorNotificationHandler<MonitorProjectConfigurationFilePathParams>, IDisposable
 {
     private readonly IProjectSnapshotManager _projectManager;
-    private readonly ProjectSnapshotManagerDispatcher _dispatcher;
     private readonly WorkspaceDirectoryPathResolver _workspaceDirectoryPathResolver;
     private readonly IEnumerable<IProjectConfigurationFileChangeListener> _listeners;
     private readonly LanguageServerFeatureOptions _options;
@@ -35,14 +34,12 @@ internal class MonitorProjectConfigurationFilePathEndpoint : IRazorNotificationH
 
     public MonitorProjectConfigurationFilePathEndpoint(
         IProjectSnapshotManager projectManager,
-        ProjectSnapshotManagerDispatcher dispatcher,
         WorkspaceDirectoryPathResolver workspaceDirectoryPathResolver,
         IEnumerable<IProjectConfigurationFileChangeListener> listeners,
         LanguageServerFeatureOptions options,
         ILoggerFactory loggerFactory)
     {
         _projectManager = projectManager;
-        _dispatcher = dispatcher;
         _workspaceDirectoryPathResolver = workspaceDirectoryPathResolver;
         _listeners = listeners;
         _options = options;
@@ -211,7 +208,6 @@ internal class MonitorProjectConfigurationFilePathEndpoint : IRazorNotificationH
     // Protected virtual for testing
     protected virtual IFileChangeDetector CreateFileChangeDetector()
         => new ProjectConfigurationFileChangeDetector(
-            _dispatcher,
             _listeners,
             _options,
             _loggerFactory);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/MonitorProjectConfigurationFilePathEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/MonitorProjectConfigurationFilePathEndpointTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
@@ -12,7 +11,6 @@ using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.AspNetCore.Razor.Test.Common.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
-using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
@@ -45,7 +43,6 @@ public class MonitorProjectConfigurationFilePathEndpointTest : LanguageServerTes
             .Throws<Exception>();
         var configurationFileEndpoint = new MonitorProjectConfigurationFilePathEndpoint(
             projectManager,
-            Dispatcher,
             directoryPathResolver.Object,
             listeners: [],
             TestLanguageServerFeatureOptions.Instance,
@@ -77,7 +74,6 @@ public class MonitorProjectConfigurationFilePathEndpointTest : LanguageServerTes
             .Throws<Exception>();
         var configurationFileEndpoint = new MonitorProjectConfigurationFilePathEndpoint(
             projectManager,
-            Dispatcher,
             directoryPathResolver.Object,
             listeners: [],
             TestLanguageServerFeatureOptions.Instance,
@@ -105,7 +101,6 @@ public class MonitorProjectConfigurationFilePathEndpointTest : LanguageServerTes
         var detector = new TestFileChangeDetector();
         var configurationFileEndpoint = new TestMonitorProjectConfigurationFilePathEndpoint(
             () => detector,
-            Dispatcher,
             _directoryPathResolver,
             listeners: [],
             LoggerFactory,
@@ -144,7 +139,6 @@ public class MonitorProjectConfigurationFilePathEndpointTest : LanguageServerTes
         var detector = new TestFileChangeDetector();
         var configurationFileEndpoint = new TestMonitorProjectConfigurationFilePathEndpoint(
             () => detector,
-            Dispatcher,
             _directoryPathResolver,
             listeners: [],
             LoggerFactory,
@@ -176,7 +170,6 @@ public class MonitorProjectConfigurationFilePathEndpointTest : LanguageServerTes
         var detector = new TestFileChangeDetector();
         var configurationFileEndpoint = new TestMonitorProjectConfigurationFilePathEndpoint(
             () => detector,
-            Dispatcher,
             _directoryPathResolver,
             listeners: [],
             LoggerFactory,
@@ -209,7 +202,6 @@ public class MonitorProjectConfigurationFilePathEndpointTest : LanguageServerTes
         var detector = new TestFileChangeDetector();
         var configurationFileEndpoint = new TestMonitorProjectConfigurationFilePathEndpoint(
             () => detector,
-            Dispatcher,
             _directoryPathResolver,
             listeners: [],
             LoggerFactory,
@@ -243,7 +235,6 @@ public class MonitorProjectConfigurationFilePathEndpointTest : LanguageServerTes
         var detector = new TestFileChangeDetector();
         var configurationFileEndpoint = new TestMonitorProjectConfigurationFilePathEndpoint(
             () => detector,
-            Dispatcher,
             _directoryPathResolver,
             listeners: [],
             LoggerFactory,
@@ -285,7 +276,6 @@ public class MonitorProjectConfigurationFilePathEndpointTest : LanguageServerTes
         var detector = new TestFileChangeDetector();
         var configurationFileEndpoint = new TestMonitorProjectConfigurationFilePathEndpoint(
             () => detector,
-            Dispatcher,
             _directoryPathResolver,
             listeners: [],
             LoggerFactory,
@@ -331,7 +321,6 @@ public class MonitorProjectConfigurationFilePathEndpointTest : LanguageServerTes
         var detectors = new[] { projectOpenDebugDetector, releaseDetector, postPublishDebugDetector };
         var configurationFileEndpoint = new TestMonitorProjectConfigurationFilePathEndpoint(
             () => detectors[callCount++],
-            Dispatcher,
             _directoryPathResolver,
             listeners: [],
             LoggerFactory,
@@ -388,7 +377,6 @@ public class MonitorProjectConfigurationFilePathEndpointTest : LanguageServerTes
         var detectors = new[] { debug1Detector, debug2Detector, release1Detector };
         var configurationFileEndpoint = new TestMonitorProjectConfigurationFilePathEndpoint(
             () => detectors[callCount++],
-            Dispatcher,
             _directoryPathResolver,
             listeners: [],
             LoggerFactory,
@@ -445,9 +433,8 @@ public class MonitorProjectConfigurationFilePathEndpointTest : LanguageServerTes
         var detector = new TestFileChangeDetector();
         var configurationFileEndpoint = new TestMonitorProjectConfigurationFilePathEndpoint(
             () => detector,
-            Dispatcher,
             _directoryPathResolver,
-            Enumerable.Empty<IProjectConfigurationFileChangeListener>(),
+            listeners: [],
             LoggerFactory,
             projectManager,
             options: new TestLanguageServerFeatureOptions(monitorWorkspaceFolderForConfigurationFiles: false));
@@ -483,14 +470,13 @@ public class MonitorProjectConfigurationFilePathEndpointTest : LanguageServerTes
 
     private class TestMonitorProjectConfigurationFilePathEndpoint(
         Func<IFileChangeDetector> fileChangeDetectorFactory,
-        ProjectSnapshotManagerDispatcher dispatcher,
         WorkspaceDirectoryPathResolver workspaceDirectoryPathResolver,
         IEnumerable<IProjectConfigurationFileChangeListener> listeners,
         ILoggerFactory loggerFactory,
         IProjectSnapshotManager projectManager,
-        LanguageServerFeatureOptions? options = null) : MonitorProjectConfigurationFilePathEndpoint(
+        LanguageServerFeatureOptions? options = null)
+        : MonitorProjectConfigurationFilePathEndpoint(
             projectManager,
-            dispatcher,
             workspaceDirectoryPathResolver,
             listeners,
             options ?? TestLanguageServerFeatureOptions.Instance,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationFileChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationFileChangeDetectorTest.cs
@@ -1,12 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 using Microsoft.CodeAnalysis.Razor.Logging;
@@ -16,28 +15,28 @@ using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
-public class ProjectConfigurationFileChangeDetectorTest : LanguageServerTestBase
+public class ProjectConfigurationFileChangeDetectorTest(ITestOutputHelper testOutput) : LanguageServerTestBase(testOutput)
 {
-    public ProjectConfigurationFileChangeDetectorTest(ITestOutputHelper testOutput)
-        : base(testOutput)
-    {
-    }
-
     [Fact]
     public async Task StartAsync_NotifiesListenersOfExistingConfigurationFiles()
     {
         // Arrange
         var eventArgs1 = new List<ProjectConfigurationFileChangeEventArgs>();
-        var listener1 = new Mock<IProjectConfigurationFileChangeListener>(MockBehavior.Strict);
-        listener1.Setup(l => l.ProjectConfigurationFileChanged(It.IsAny<ProjectConfigurationFileChangeEventArgs>()))
-            .Callback<ProjectConfigurationFileChangeEventArgs>(args => eventArgs1.Add(args));
+        var listenerMock1 = new StrictMock<IProjectConfigurationFileChangeListener>();
+        listenerMock1
+            .Setup(l => l.ProjectConfigurationFileChanged(It.IsAny<ProjectConfigurationFileChangeEventArgs>()))
+            .Callback<ProjectConfigurationFileChangeEventArgs>(eventArgs1.Add);
+
         var eventArgs2 = new List<ProjectConfigurationFileChangeEventArgs>();
-        var listener2 = new Mock<IProjectConfigurationFileChangeListener>(MockBehavior.Strict);
-        listener2.Setup(l => l.ProjectConfigurationFileChanged(It.IsAny<ProjectConfigurationFileChangeEventArgs>()))
-            .Callback<ProjectConfigurationFileChangeEventArgs>(args => eventArgs2.Add(args));
+        var listenerMock2 = new StrictMock<IProjectConfigurationFileChangeListener>();
+        listenerMock2
+            .Setup(l => l.ProjectConfigurationFileChanged(It.IsAny<ProjectConfigurationFileChangeEventArgs>()))
+            .Callback<ProjectConfigurationFileChangeEventArgs>(eventArgs2.Add);
+
         ImmutableArray<string> existingConfigurationFiles = ["c:/path/to/project.razor.json", "c:/other/path/project.razor.bin"];
+
         var detector = new TestProjectConfigurationFileChangeDetector(
-            new[] { listener1.Object, listener2.Object },
+            [listenerMock1.Object, listenerMock2.Object],
             existingConfigurationFiles,
             LoggerFactory);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationFileChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationFileChangeDetectorTest.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
@@ -36,7 +37,7 @@ public class ProjectConfigurationFileChangeDetectorTest : LanguageServerTestBase
         var listener2 = new Mock<IProjectConfigurationFileChangeListener>(MockBehavior.Strict);
         listener2.Setup(l => l.ProjectConfigurationFileChanged(It.IsAny<ProjectConfigurationFileChangeEventArgs>()))
             .Callback<ProjectConfigurationFileChangeEventArgs>(args => eventArgs2.Add(args));
-        var existingConfigurationFiles = new[] { "c:/path/to/project.razor.json", "c:/other/path/project.razor.bin" };
+        ImmutableArray<string> existingConfigurationFiles = ["c:/path/to/project.razor.json", "c:/other/path/project.razor.bin"];
         var cts = new CancellationTokenSource();
         var detector = new TestProjectConfigurationFileChangeDetector(
             cts,
@@ -76,13 +77,13 @@ public class ProjectConfigurationFileChangeDetectorTest : LanguageServerTestBase
     private class TestProjectConfigurationFileChangeDetector : ProjectConfigurationFileChangeDetector
     {
         private readonly CancellationTokenSource _cancellationTokenSource;
-        private readonly IReadOnlyList<string> _existingConfigurationFiles;
+        private readonly ImmutableArray<string> _existingConfigurationFiles;
 
         public TestProjectConfigurationFileChangeDetector(
             CancellationTokenSource cancellationTokenSource,
             ProjectSnapshotManagerDispatcher dispatcher,
             IEnumerable<IProjectConfigurationFileChangeListener> listeners,
-            IReadOnlyList<string> existingConfigurationFiles,
+            ImmutableArray<string> existingConfigurationFiles,
             ILoggerFactory loggerFactory)
             : base(dispatcher, listeners, TestLanguageServerFeatureOptions.Instance, loggerFactory)
         {
@@ -96,7 +97,7 @@ public class ProjectConfigurationFileChangeDetectorTest : LanguageServerTestBase
             _cancellationTokenSource.Cancel();
         }
 
-        protected override IEnumerable<string> GetExistingConfigurationFiles(string workspaceDirectory)
+        protected override ImmutableArray<string> GetExistingConfigurationFiles(string workspaceDirectory)
         {
             return _existingConfigurationFiles;
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationFileChangeEventArgsTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationFileChangeEventArgsTest.cs
@@ -36,7 +36,7 @@ public class ProjectConfigurationFileChangeEventArgsTest(ITestOutputHelper testO
         var args = new ProjectConfigurationFileChangeEventArgs(
             configurationFilePath: "/path/to/obj/project.razor.bin",
             kind: RazorFileChangeKind.Removed,
-            projectInfoDeserializer: deserializerMock.Object);
+            deserializer: deserializerMock.Object);
 
         // Act
         var result = args.TryDeserialize(TestLanguageServerFeatureOptions.Instance, out var handle);
@@ -68,7 +68,7 @@ public class ProjectConfigurationFileChangeEventArgsTest(ITestOutputHelper testO
         var args = new ProjectConfigurationFileChangeEventArgs(
             configurationFilePath: "/path/to/DIFFERENT/obj/project.razor.bin",
             kind: RazorFileChangeKind.Added,
-            projectInfoDeserializer: deserializerMock.Object);
+            deserializer: deserializerMock.Object);
 
         // Act
         var result = args.TryDeserialize(TestLanguageServerFeatureOptions.Instance, out var deserializedProjectInfo);
@@ -99,7 +99,7 @@ public class ProjectConfigurationFileChangeEventArgsTest(ITestOutputHelper testO
         var args = new ProjectConfigurationFileChangeEventArgs(
             configurationFilePath: "/path/to/obj/project.razor.bin",
             kind: RazorFileChangeKind.Added,
-            projectInfoDeserializer: deserializerMock.Object);
+            deserializer: deserializerMock.Object);
 
         // Act
         var result1 = args.TryDeserialize(TestLanguageServerFeatureOptions.Instance, out var projectInfo1);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationFileChangeEventArgsTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationFileChangeEventArgsTest.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System.Collections.Immutable;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.Serialization;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
-using Microsoft.AspNetCore.Razor.Serialization;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 using Moq;
@@ -21,7 +19,7 @@ public class ProjectConfigurationFileChangeEventArgsTest(ITestOutputHelper testO
     public void TryDeserialize_RemovedKind_ReturnsFalse()
     {
         // Arrange
-        var deserializerMock = new Mock<IRazorProjectInfoDeserializer>(MockBehavior.Strict);
+        var deserializerMock = new StrictMock<IRazorProjectInfoDeserializer>();
         deserializerMock
             .Setup(x => x.DeserializeFromFile(It.IsAny<string>()))
             .Returns(new RazorProjectInfo(
@@ -31,7 +29,7 @@ public class ProjectConfigurationFileChangeEventArgsTest(ITestOutputHelper testO
                 rootNamespace: null,
                 displayName: "project",
                 projectWorkspaceState: ProjectWorkspaceState.Default,
-                documents: ImmutableArray<DocumentSnapshotHandle>.Empty));
+                documents: []));
 
         var args = new ProjectConfigurationFileChangeEventArgs(
             configurationFilePath: "/path/to/obj/project.razor.bin",
@@ -51,7 +49,7 @@ public class ProjectConfigurationFileChangeEventArgsTest(ITestOutputHelper testO
     public void TryDeserialize_DifferingSerializationPaths_ReturnsFalse()
     {
         // Arrange
-        var deserializerMock = new Mock<IRazorProjectInfoDeserializer>(MockBehavior.Strict);
+        var deserializerMock = new StrictMock<IRazorProjectInfoDeserializer>();
         var projectInfo = new RazorProjectInfo(
             "/path/to/ORIGINAL/obj/project.razor.bin",
             "c:/path/to/project.csproj",
@@ -59,7 +57,7 @@ public class ProjectConfigurationFileChangeEventArgsTest(ITestOutputHelper testO
             rootNamespace: null,
             displayName: "project",
             projectWorkspaceState: ProjectWorkspaceState.Default,
-            documents: ImmutableArray<DocumentSnapshotHandle>.Empty);
+            documents: []);
 
         deserializerMock
             .Setup(x => x.DeserializeFromFile(It.IsAny<string>()))
@@ -82,7 +80,7 @@ public class ProjectConfigurationFileChangeEventArgsTest(ITestOutputHelper testO
     public void TryDeserialize_MemoizesResults()
     {
         // Arrange
-        var deserializerMock = new Mock<IRazorProjectInfoDeserializer>(MockBehavior.Strict);
+        var deserializerMock = new StrictMock<IRazorProjectInfoDeserializer>();
         var projectInfo = new RazorProjectInfo(
             "/path/to/obj/project.razor.bin",
             "c:/path/to/project.csproj",
@@ -90,7 +88,7 @@ public class ProjectConfigurationFileChangeEventArgsTest(ITestOutputHelper testO
             rootNamespace: null,
             displayName: "project",
             projectWorkspaceState: ProjectWorkspaceState.Default,
-            documents: ImmutableArray<DocumentSnapshotHandle>.Empty);
+            documents: []);
 
         deserializerMock
             .Setup(x => x.DeserializeFromFile(It.IsAny<string>()))
@@ -119,14 +117,17 @@ public class ProjectConfigurationFileChangeEventArgsTest(ITestOutputHelper testO
     public void TryDeserialize_NullFileDeserialization_MemoizesResults_ReturnsFalse()
     {
         // Arrange
-        var deserializerMock = new Mock<IRazorProjectInfoDeserializer>(MockBehavior.Strict);
+        var deserializerMock = new StrictMock<IRazorProjectInfoDeserializer>();
         var callCount = 0;
         deserializerMock
             .Setup(x => x.DeserializeFromFile(It.IsAny<string>()))
             .Callback(() => callCount++)
             .Returns<RazorProjectInfo>(null);
 
-        var args = new ProjectConfigurationFileChangeEventArgs("/path/to/obj/project.razor.bin", RazorFileChangeKind.Changed, deserializerMock.Object);
+        var args = new ProjectConfigurationFileChangeEventArgs(
+            configurationFilePath: "/path/to/obj/project.razor.bin",
+            kind: RazorFileChangeKind.Changed,
+            deserializer: deserializerMock.Object);
 
         // Act
         var result1 = args.TryDeserialize(TestLanguageServerFeatureOptions.Instance, out var handle1);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationStateSynchronizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationStateSynchronizerTest.cs
@@ -3,6 +3,7 @@
 
 #nullable disable
 
+using System;
 using System.Collections.Immutable;
 using System.IO;
 using System.Threading;
@@ -19,6 +20,9 @@ using Microsoft.AspNetCore.Razor.Test.Common.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 using Microsoft.AspNetCore.Razor.Utilities;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.Logging;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Moq;
 using Xunit;
 using Xunit.Abstractions;
@@ -554,10 +558,8 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
 
     private ProjectConfigurationStateSynchronizer GetSynchronizer(IRazorProjectService razorProjectService)
     {
-        var synchronizer = new ProjectConfigurationStateSynchronizer(Dispatcher, razorProjectService, LoggerFactory, new TestLanguageServerFeatureOptions());
-        synchronizer.EnqueueDelay = 5;
-
-        return synchronizer;
+        return new TestProjectConfigurationStateSynchronizer(
+            Dispatcher, razorProjectService, LoggerFactory, TestLanguageServerFeatureOptions.Instance, TimeSpan.FromMilliseconds(5));
     }
 
     private static IRazorProjectInfoDeserializer CreateDeserializer(RazorProjectInfo projectInfo)
@@ -569,4 +571,12 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
 
         return deserializer.Object;
     }
+
+    private sealed class TestProjectConfigurationStateSynchronizer(
+        ProjectSnapshotManagerDispatcher dispatcher,
+        IRazorProjectService projectService,
+        ILoggerFactory loggerFactory,
+        LanguageServerFeatureOptions options,
+        TimeSpan delay)
+        : ProjectConfigurationStateSynchronizer(dispatcher, projectService, loggerFactory, options, delay);
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationStateSynchronizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationStateSynchronizerTest.cs
@@ -36,7 +36,7 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
     {
         // Arrange
         var projectService = new Mock<IRazorProjectService>(MockBehavior.Strict);
-        var synchronizer = GetSynchronizer(projectService.Object);
+        using var synchronizer = GetSynchronizer(projectService.Object);
         var deserializerMock = new Mock<IRazorProjectInfoDeserializer>(MockBehavior.Strict);
         var args = new ProjectConfigurationFileChangeEventArgs(
             configurationFilePath: "/path/to/project.razor.bin",
@@ -94,10 +94,10 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
                 "",
                 ProjectWorkspaceState.Default,
                 ImmutableArray<DocumentSnapshotHandle>.Empty,
-                CancellationToken.None))
+                It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask)
             .Verifiable();
-        var synchronizer = GetSynchronizer(projectService.Object);
+        using var synchronizer = GetSynchronizer(projectService.Object);
         var jsonFileDeserializer = CreateDeserializer(projectInfo);
         var addArgs = new ProjectConfigurationFileChangeEventArgs("/path/to\\obj/project.razor.bin", RazorFileChangeKind.Added, jsonFileDeserializer);
         var enqueueTask = await Dispatcher.RunAsync(async () =>
@@ -129,7 +129,7 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
     {
         // Arrange
         var projectService = new Mock<IRazorProjectService>(MockBehavior.Strict);
-        var synchronizer = GetSynchronizer(projectService.Object);
+        using var synchronizer = GetSynchronizer(projectService.Object);
 
         var deserializerMock = new Mock<IRazorProjectInfoDeserializer>(MockBehavior.Strict);
         deserializerMock
@@ -183,7 +183,7 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
                 projectInfo.Documents, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask)
             .Verifiable();
-        var synchronizer = GetSynchronizer(projectService.Object);
+        using var synchronizer = GetSynchronizer(projectService.Object);
         var jsonFileDeserializer = CreateDeserializer(projectInfo);
         var args = new ProjectConfigurationFileChangeEventArgs("/path/to/obj/project.razor.bin", RazorFileChangeKind.Added, jsonFileDeserializer);
 
@@ -242,10 +242,10 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
                 "",
                 ProjectWorkspaceState.Default,
                 ImmutableArray<DocumentSnapshotHandle>.Empty,
-                CancellationToken.None))
+                It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask)
             .Verifiable();
-        var synchronizer = GetSynchronizer(projectService.Object);
+        using var synchronizer = GetSynchronizer(projectService.Object);
         var deserializer = CreateDeserializer(projectInfo);
         var addArgs = new ProjectConfigurationFileChangeEventArgs("/path/to/obj/project.razor.bin", RazorFileChangeKind.Added, deserializer);
         var enqueueTask = await Dispatcher.RunAsync(async () =>
@@ -328,7 +328,7 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
                 It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask)
             .Verifiable();
-        var synchronizer = GetSynchronizer(projectService.Object);
+        using var synchronizer = GetSynchronizer(projectService.Object);
         var addDeserializer = CreateDeserializer(initialProjectInfo);
         var addArgs = new ProjectConfigurationFileChangeEventArgs(
             "/path/to/obj/project.razor.bin",
@@ -415,10 +415,10 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
                 "",
                 ProjectWorkspaceState.Default,
                 ImmutableArray<DocumentSnapshotHandle>.Empty,
-                CancellationToken.None))
+                It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask)
             .Verifiable();
-        var synchronizer = GetSynchronizer(projectService.Object);
+        using var synchronizer = GetSynchronizer(projectService.Object);
         var addDeserializer = CreateDeserializer(initialProjectInfo);
         var addArgs = new ProjectConfigurationFileChangeEventArgs("/path/to/obj/project.razor.bin", RazorFileChangeKind.Added, addDeserializer);
         var enqueueTask = await Dispatcher.RunAsync(async () =>
@@ -455,7 +455,7 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
     {
         // Arrange
         var projectService = new Mock<IRazorProjectService>(MockBehavior.Strict);
-        var synchronizer = GetSynchronizer(projectService.Object);
+        using var synchronizer = GetSynchronizer(projectService.Object);
 
         var changedDeserializerMock = new Mock<IRazorProjectInfoDeserializer>(MockBehavior.Strict);
         changedDeserializerMock
@@ -514,7 +514,7 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
                 It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
-        var synchronizer = GetSynchronizer(projectService.Object);
+        using var synchronizer = GetSynchronizer(projectService.Object);
         var changedDeserializer = CreateDeserializer(projectInfo);
         var removedArgs = new ProjectConfigurationFileChangeEventArgs(projectInfo.SerializedFilePath, RazorFileChangeKind.Removed, changedDeserializer);
         var addedArgs = new ProjectConfigurationFileChangeEventArgs(projectInfo.SerializedFilePath, RazorFileChangeKind.Added, changedDeserializer);
@@ -556,11 +556,8 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
         }
     }
 
-    private ProjectConfigurationStateSynchronizer GetSynchronizer(IRazorProjectService razorProjectService)
-    {
-        return new TestProjectConfigurationStateSynchronizer(
-            Dispatcher, razorProjectService, LoggerFactory, TestLanguageServerFeatureOptions.Instance, TimeSpan.FromMilliseconds(5));
-    }
+    private TestProjectConfigurationStateSynchronizer GetSynchronizer(IRazorProjectService razorProjectService)
+        => new(Dispatcher, razorProjectService, LoggerFactory, TestLanguageServerFeatureOptions.Instance, TimeSpan.FromMilliseconds(5));
 
     private static IRazorProjectInfoDeserializer CreateDeserializer(RazorProjectInfo projectInfo)
     {


### PR DESCRIPTION
This change removes `ProjectSnapshotManagerDispatcher` usage from `ProjectConfigurationStateSynchronizer` and `ProjectConfigurationFileChangeDetector`. Ultimately, a lot of this code will go away once #10173 is the default behavior.

As part of this change, I updated `ProjectConfigurationStateSynchronizer` to use an `AsyncBatchingWorkQueue`. In my opinion, this is a huge improvement over the previous implementation.