### PR TITLE
Include arm64 for source gen test

### DIFF
--- a/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Test.csproj
+++ b/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/Microsoft.NET.Sdk.Razor.SourceGenerators.Test.csproj
@@ -57,6 +57,11 @@
         <Reference Include="$(PkgMicrosoft_AspNetCore_App_Runtime_osx-x64)\runtimes\osx-x64\lib\net8.0\*.dll" />
       </ItemGroup>
     </When>
+    <When Condition="$(NetCoreSDKRuntimeIdentifier) == 'osx-arm64'">
+      <ItemGroup>
+        <Reference Include="$(PkgMicrosoft_AspNetCore_App_Runtime_osx-arm64)\runtimes\osx-arm64\lib\net8.0\*.dll" />
+      </ItemGroup>
+    </When>
   </Choose>
 
 </Project>


### PR DESCRIPTION
This made it so devkit in vscode at least had no errors. Command line builds are still failing but this unblocks me