### PR TITLE
Get integration tests running again

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -122,6 +122,7 @@
     <PackageVersion Include="Xunit.Combinatorial" Version="1.5.25" />
     <PackageVersion Include="xunit.extensibility.execution" Version="$(_XunitPackageVersion)" />
     <PackageVersion Include="xunit.runner.utility" Version="2.4.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="$(_XunitPackageVersion)" />
     <PackageVersion Include="Xunit.StaFact" Version="1.2.46-alpha" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -122,7 +122,6 @@
     <PackageVersion Include="Xunit.Combinatorial" Version="1.5.25" />
     <PackageVersion Include="xunit.extensibility.execution" Version="$(_XunitPackageVersion)" />
     <PackageVersion Include="xunit.runner.utility" Version="2.4.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="$(_XunitPackageVersion)" />
     <PackageVersion Include="Xunit.StaFact" Version="1.2.46-alpha" />
   </ItemGroup>
 </Project>

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Microsoft.VisualStudio.Razor.IntegrationTests.csproj
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Microsoft.VisualStudio.Razor.IntegrationTests.csproj
@@ -36,6 +36,7 @@
     <PackageReference Include="Microsoft.Internal.VisualStudio.Shell.Framework" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.utility" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Microsoft.VisualStudio.Razor.IntegrationTests.csproj
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Microsoft.VisualStudio.Razor.IntegrationTests.csproj
@@ -45,6 +45,7 @@
       import the package ourselves, but as an implicit definition to stop Nuget complaining.
       TL;DR: MSBuild was designed to cause pain.
     -->
+    <PackageReference Include="xunit.runner.console" Version="$(XUnitRunnerConsoleVersion)" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioVersion)" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true"/>
   </ItemGroup>
 

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Microsoft.VisualStudio.Razor.IntegrationTests.csproj
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Microsoft.VisualStudio.Razor.IntegrationTests.csproj
@@ -36,7 +36,16 @@
     <PackageReference Include="Microsoft.Internal.VisualStudio.Shell.Framework" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.utility" />
-    <PackageReference Include="xunit.runner.visualstudio" />
+
+    <!--
+      We need to reference XUnit, but Arcade won't import it because the test runner above is MSTest,
+      and we can't just reference the package we need because they are implicit references in Arcade
+      for other projects, and CPM doesn't play nicely with those. We could try to manually import
+      the Arcade XUnit.targets file, but finding that file is a pain, so instead we can just manually
+      import the package ourselves, but as an implicit definition to stop Nuget complaining.
+      TL;DR: MSBuild was designed to cause pain.
+    -->
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioVersion)" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Restores the reference to `xunit.runners.visualstudio` that was inadvertently lost when moving to CPM.

Run is happening now, but signs are positive:
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9450237