### PR TITLE
Register UI context for cohost activation

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorConstants.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorConstants.cs
@@ -15,6 +15,8 @@ internal static class RazorConstants
 
     public const string RazorLanguageServiceString = "4513FA64-5B72-4B58-9D4C-1D3C81996C2C";
 
+    public const string RazorCohostingUIContext = "6d5b86dc-6b8a-483b-ae30-098a3c7d6774";
+
     public static readonly Guid RazorLanguageServiceGuid = new(RazorLanguageServiceString);
 
     public const string VSProjectItemsIdentifier = "CF_VSSTGPROJECTITEMS";

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
@@ -35,6 +35,14 @@ namespace Microsoft.VisualStudio.RazorExtension;
 [ProvideToolWindow(typeof(SyntaxVisualizerToolWindow))]
 [ProvideLanguageEditorOptionPage(typeof(AdvancedOptionPage), RazorConstants.RazorLSPContentTypeName, category: null, "Advanced", pageNameResourceId: "#1050", keywordListResourceId: 1060)]
 [Guid(PackageGuidString)]
+// We activate cohosting when the first Razor file is opened. This matches the previous behavior where the
+// LSP client MEF export had the Razor content type metadata.
+[ProvideUIContextRule(
+        contextGuid: RazorConstants.RazorCohostingUIContext,
+        name: "Razor Cohosting Activation",
+        expression: "RazorContentType",
+        termNames: ["RazorContentType"],
+        termValues: [$"ActiveEditorContentType:{RazorConstants.RazorLSPContentTypeName}"])]
 internal sealed class RazorPackage : AsyncPackage
 {
     public const string PackageGuidString = "13b72f58-279e-49e0-a56d-296be02f0805";


### PR DESCRIPTION
Register the UI context for Razor, so it can be used in Roslyn (see https://github.com/dotnet/roslyn/pull/73172)

Will eventual fix https://github.com/dotnet/razor/issues/10279 once the Roslyn side is in
Part of https://github.com/dotnet/razor/issues/9519