### PR TITLE
Lower drop retention from 10 years to 3 months

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -286,6 +286,7 @@ extends:
                 dropName: $(VisualStudio.DropName)
                 dropFolder: 'artifacts\VSSetup\$(_BuildConfig)\Insertion'
                 accessToken: $(_DevDivDropAccessToken)
+                dropRetentionDays: 90
               continueOnError: true
               condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
 


### PR DESCRIPTION
Fixes a warning in official builds:

<samp>
##[warning]DropRetentionDays not set. Defaulting to 10 years (3650 days). Please reduce drop retention period to 30 days if possible.
</samp>
<p>

I'm not sure what value to replace 10 years with - the drop is inserted into VS (and if it ends up in VS release branch I presume it's still used for releasing) so probably shouldn't live too shortly. I chose 90 days as that's the example in https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/outputs/microbuild-vsts-drop?tabs=inlinetask.

Official build run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2435732&view=results