### PR TITLE
Add some helper utilities

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/ProjectSystem/RazorProjectInfo.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/ProjectSystem/RazorProjectInfo.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
+using System.Buffers;
 using System.Collections.Immutable;
 using System.IO;
 using MessagePack;
@@ -45,8 +47,14 @@ internal sealed record class RazorProjectInfo
         Documents = documents.NullToEmpty();
     }
 
+    public void SerializeTo(IBufferWriter<byte> bufferWriter)
+        => MessagePackSerializer.Serialize(bufferWriter, this, s_options);
+
     public void SerializeTo(Stream stream)
         => MessagePackSerializer.Serialize(stream, this, s_options);
+
+    public static RazorProjectInfo? DeserializeFrom(ReadOnlyMemory<byte> buffer)
+        => MessagePackSerializer.Deserialize<RazorProjectInfo>(buffer, s_options);
 
     public static RazorProjectInfo? DeserializeFrom(Stream stream)
         => MessagePackSerializer.Deserialize<RazorProjectInfo>(stream, s_options);

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ArgHelperTests.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ArgHelperTests.cs
@@ -1,0 +1,155 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Utilities.Shared.Test;
+
+public class ArgHelperTests
+{
+    [Theory]
+    [InlineData(null, typeof(ArgumentNullException))]
+    [InlineData("test")]
+    public void ThrowIfNull(string? s, Type? exceptionType = null)
+    {
+        Verify(() => ArgHelper.ThrowIfNull(s), exceptionType);
+    }
+
+    [Fact]
+    public unsafe void ThrowIfNull_NullPtr_Throws()
+    {
+        byte* ptr = null;
+
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            ArgHelper.ThrowIfNull(ptr);
+        });
+    }
+
+    [Fact]
+    public unsafe void ThrowIfNull_Ptr_DoesNotThrow()
+    {
+        fixed (byte* ptr = new byte[8])
+        {
+            ArgHelper.ThrowIfNull(ptr);
+        }
+    }
+
+    [Theory]
+    [InlineData(null, typeof(ArgumentNullException))]
+    [InlineData("", typeof(ArgumentException))]
+    [InlineData("    ")]
+    [InlineData("test")]
+    public void ThrowIfNullOrEmpty(string? s, Type? exceptionType = null)
+    {
+        Verify(() => ArgHelper.ThrowIfNullOrEmpty(s), exceptionType);
+    }
+
+    [Theory]
+    [InlineData(null, typeof(ArgumentNullException))]
+    [InlineData("", typeof(ArgumentException))]
+    [InlineData("    ", typeof(ArgumentException))]
+    [InlineData("test")]
+    public void ThrowIfNullOrWhiteSpace(string? s, Type? exceptionType = null)
+    {
+        Verify(() => ArgHelper.ThrowIfNullOrWhiteSpace(s), exceptionType);
+    }
+
+    [Theory]
+    [InlineData(null, null, typeof(ArgumentOutOfRangeException))]
+    [InlineData(null, "test")]
+    [InlineData("test", null)]
+    [InlineData("test", "test", typeof(ArgumentOutOfRangeException))]
+    [InlineData("test", "TeSt")]
+    public void ThrowIfEqual(string? s1, string? s2, Type? exceptionType = null)
+    {
+        Verify(() => ArgHelper.ThrowIfEqual(s1, s2), exceptionType);
+    }
+
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(null, "test", typeof(ArgumentOutOfRangeException))]
+    [InlineData("test", null, typeof(ArgumentOutOfRangeException))]
+    [InlineData("test", "test")]
+    [InlineData("test", "TeSt", typeof(ArgumentOutOfRangeException))]
+    public void ThrowIfNotEqual(string? s1, string? s2, Type? exceptionType = null)
+    {
+        Verify(() => ArgHelper.ThrowIfNotEqual(s1, s2), exceptionType);
+    }
+
+    [Theory]
+    [InlineData(0, typeof(ArgumentOutOfRangeException))]
+    [InlineData(-1)]
+    [InlineData(1)]
+    public void ThrowIfZero(int v, Type? exceptionType = null)
+    {
+        Verify(() => ArgHelper.ThrowIfZero(v), exceptionType);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1, typeof(ArgumentOutOfRangeException))]
+    [InlineData(1)]
+    public void ThrowIfNegative(int v, Type? exceptionType = null)
+    {
+        Verify(() => ArgHelper.ThrowIfNegative(v), exceptionType);
+    }
+
+    [Theory]
+    [InlineData(0, typeof(ArgumentOutOfRangeException))]
+    [InlineData(-1, typeof(ArgumentOutOfRangeException))]
+    [InlineData(1)]
+    public void ThrowIfNegativeOrZero(int v, Type? exceptionType = null)
+    {
+        Verify(() => ArgHelper.ThrowIfNegativeOrZero(v), exceptionType);
+    }
+
+    [Theory]
+    [InlineData(42, 42)]
+    [InlineData(41, 42)]
+    [InlineData(43, 42, typeof(ArgumentOutOfRangeException))]
+    public void ThrowIfGreaterThan(int v1, int v2, Type? exceptionType = null)
+    {
+        Verify(() => ArgHelper.ThrowIfGreaterThan(v1, v2), exceptionType);
+    }
+
+    [Theory]
+    [InlineData(42, 42, typeof(ArgumentOutOfRangeException))]
+    [InlineData(41, 42)]
+    [InlineData(43, 42, typeof(ArgumentOutOfRangeException))]
+    public void ThrowIfGreaterThanOrEqual(int v1, int v2, Type? exceptionType = null)
+    {
+        Verify(() => ArgHelper.ThrowIfGreaterThanOrEqual(v1, v2), exceptionType);
+    }
+
+    [Theory]
+    [InlineData(42, 42)]
+    [InlineData(41, 42, typeof(ArgumentOutOfRangeException))]
+    [InlineData(43, 42)]
+    public void ThrowIfLessThan(int v1, int v2, Type? exceptionType = null)
+    {
+        Verify(() => ArgHelper.ThrowIfLessThan(v1, v2), exceptionType);
+    }
+
+    [Theory]
+    [InlineData(42, 42, typeof(ArgumentOutOfRangeException))]
+    [InlineData(41, 42, typeof(ArgumentOutOfRangeException))]
+    [InlineData(43, 42)]
+    public void ThrowIfLessThanOrEqual(int v1, int v2, Type? exceptionType = null)
+    {
+        Verify(() => ArgHelper.ThrowIfLessThanOrEqual(v1, v2), exceptionType);
+    }
+
+    private static void Verify(Action a, Type? exceptionType = null)
+    {
+        if (exceptionType is not null)
+        {
+            Assert.Throws(exceptionType, a);
+        }
+        else
+        {
+            a();
+        }
+    }
+}

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/Microsoft.AspNetCore.Razor.Utilities.Shared.Test.csproj
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/Microsoft.AspNetCore.Razor.Utilities.Shared.Test.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(DefaultNetCoreTargetFrameworks)</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);$(DefaultNetFxTargetFramework)</TargetFrameworks>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/PooledArrayBufferWriterTests.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/PooledArrayBufferWriterTests.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Buffers;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.Utilities.Shared.Test;
+
+public class PooledArrayBufferWriterTests
+{
+    [Theory]
+    [InlineData(42)]
+    [InlineData(256)]
+    [InlineData(400)]
+    [InlineData(1024)]
+    [InlineData(8 * 1024)]
+    public void FillBufferWriter(int arraySize)
+    {
+        // Create an array filled with byte data.
+        Span<byte> span = new byte[arraySize];
+
+        for (var i = 0; i < arraySize; i++)
+        {
+            span[i] = (byte)(i % 255);
+        }
+
+        using var bufferWriter = new PooledArrayBufferWriter<byte>();
+
+        bufferWriter.Write(span);
+
+        Assert.True(span.SequenceEqual(bufferWriter.WrittenMemory.Span));
+    }
+}

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ArgHelper.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ArgHelper.cs
@@ -1,0 +1,272 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+#if !NET8_0_OR_GREATER
+using System.Collections.Generic;
+#endif
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.AspNetCore.Razor;
+
+internal static class ArgHelper
+{
+    public static void ThrowIfNull([NotNull] object? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+    {
+#if NET8_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(argument, paramName);
+#else
+        if (argument is null)
+        {
+            ThrowException(paramName);
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ThrowException(string? paramName)
+        {
+            throw new ArgumentNullException(paramName);
+        }
+#endif
+    }
+
+    public static unsafe void ThrowIfNull([NotNull] void* argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+    {
+#if NET8_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(argument, paramName);
+#else
+        if (argument is null)
+        {
+            ThrowArgumentNullException(paramName);
+        }
+#endif
+    }
+
+#if !NET8_0_OR_GREATER
+    [DoesNotReturn]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void ThrowArgumentNullException(string? paramName)
+    {
+        throw new ArgumentNullException(paramName);
+    }
+#endif
+
+    public static void ThrowIfNullOrEmpty([NotNull] string? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+    {
+#if NET8_0_OR_GREATER
+        ArgumentException.ThrowIfNullOrEmpty(argument, paramName);
+#else
+        if (argument.IsNullOrEmpty())
+        {
+            ThrowException(argument, paramName);
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ThrowException(string? argument, string? paramName)
+        {
+            ThrowIfNull(argument, paramName);
+            throw new ArgumentException(SR.The_value_cannot_be_an_empty_string, paramName);
+        }
+#endif
+    }
+
+    public static void ThrowIfNullOrWhiteSpace([NotNull] string? argument, [CallerArgumentExpression(nameof(argument))] string? paramName = null)
+    {
+#if NET8_0_OR_GREATER
+        ArgumentException.ThrowIfNullOrWhiteSpace(argument, paramName);
+#else
+
+        if (argument.IsNullOrWhiteSpace())
+        {
+            ThrowException(argument, paramName);
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ThrowException(string? argument, string? paramName)
+        {
+            ThrowIfNull(argument, paramName);
+            throw new ArgumentException(SR.The_value_cannot_be_an_empty_string_composed_entirely_of_whitespace, paramName);
+        }
+#endif
+    }
+
+    public static void ThrowIfZero(int value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+    {
+#if NET8_0_OR_GREATER
+        ArgumentOutOfRangeException.ThrowIfZero(value, paramName);
+#else
+        if (value == 0)
+        {
+            ThrowException(value, paramName);
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ThrowException(int value, string? paramName)
+        {
+            throw new ArgumentOutOfRangeException(paramName, value, SR.Format0_1_must_be_a_non_zero_value(paramName, value));
+        }
+#endif
+    }
+
+    public static void ThrowIfNegative(int value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+    {
+#if NET8_0_OR_GREATER
+        ArgumentOutOfRangeException.ThrowIfNegative(value, paramName);
+#else
+        if (value < 0)
+        {
+            ThrowException(value, paramName);
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ThrowException(int value, string? paramName)
+        {
+            throw new ArgumentOutOfRangeException(paramName, value, SR.Format0_1_must_be_a_non_negative_value(paramName, value));
+        }
+#endif
+    }
+
+    public static void ThrowIfNegativeOrZero(int value, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+    {
+#if NET8_0_OR_GREATER
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(value, paramName);
+#else
+        if (value <= 0)
+        {
+            ThrowException(value, paramName);
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ThrowException(int value, string? paramName)
+        {
+            throw new ArgumentOutOfRangeException(paramName, value, SR.Format0_1_must_be_a_non_negative_and_non_zero_value(paramName, value));
+        }
+#endif
+    }
+
+    public static void ThrowIfEqual<T>(T value, T other, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        where T : IEquatable<T>?
+    {
+#if NET8_0_OR_GREATER
+        ArgumentOutOfRangeException.ThrowIfEqual(value, other, paramName);
+#else
+        if (EqualityComparer<T>.Default.Equals(value, other))
+        {
+            ThrowException(value, other, paramName);
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ThrowException(T value, T other, string? paramName)
+        {
+            throw new ArgumentOutOfRangeException(paramName, value, SR.Format0_1_must_not_be_equal_to_2(paramName, (object?)value ?? "null", (object?)other ?? "null"));
+        }
+#endif
+    }
+
+    public static void ThrowIfNotEqual<T>(T value, T other, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        where T : IEquatable<T>?
+    {
+#if NET8_0_OR_GREATER
+        ArgumentOutOfRangeException.ThrowIfNotEqual(value, other, paramName);
+#else
+        if (!EqualityComparer<T>.Default.Equals(value, other))
+        {
+            ThrowException(value, other, paramName);
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ThrowException(T value, T other, string? paramName)
+        {
+            throw new ArgumentOutOfRangeException(paramName, value, SR.Format0_1_must_be_equal_to_2(paramName, (object?)value ?? "null", (object?)other ?? "null"));
+        }
+#endif
+    }
+
+    public static void ThrowIfGreaterThan<T>(T value, T other, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        where T : IComparable<T>
+    {
+#if NET8_0_OR_GREATER
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(value, other, paramName);
+#else
+        if (value.CompareTo(other) > 0)
+        {
+            ThrowException(value, other, paramName);
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ThrowException(T value, T other, string? paramName)
+        {
+            throw new ArgumentOutOfRangeException(paramName, value, SR.Format0_1_must_be_less_than_or_equal_to_2(paramName, value, other));
+        }
+#endif
+    }
+
+    public static void ThrowIfGreaterThanOrEqual<T>(T value, T other, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        where T : IComparable<T>
+    {
+#if NET8_0_OR_GREATER
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(value, other, paramName);
+#else
+        if (value.CompareTo(other) >= 0)
+        {
+            ThrowException(value, other, paramName);
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ThrowException(T value, T other, string? paramName)
+        {
+            throw new ArgumentOutOfRangeException(paramName, value, SR.Format0_1_must_be_less_than_2(paramName, value, other));
+        }
+#endif
+    }
+
+    public static void ThrowIfLessThan<T>(T value, T other, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        where T : IComparable<T>
+    {
+#if NET8_0_OR_GREATER
+        ArgumentOutOfRangeException.ThrowIfLessThan(value, other, paramName);
+#else
+        if (value.CompareTo(other) < 0)
+        {
+            ThrowException(value, other, paramName);
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ThrowException(T value, T other, string? paramName)
+        {
+            throw new ArgumentOutOfRangeException(paramName, value, SR.Format0_1_must_be_greater_than_or_equal_to_2(paramName, value, other));
+        }
+#endif
+    }
+
+    public static void ThrowIfLessThanOrEqual<T>(T value, T other, [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        where T : IComparable<T>
+    {
+#if NET8_0_OR_GREATER
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(value, other, paramName);
+#else
+        if (value.CompareTo(other) <= 0)
+        {
+            ThrowException(value, other, paramName);
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ThrowException(T value, T other, string? paramName)
+        {
+            throw new ArgumentOutOfRangeException(paramName, value, SR.Format0_1_must_be_greater_than_2(paramName, value, other));
+        }
+#endif
+    }
+}

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ArgHelper.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ArgHelper.cs
@@ -39,7 +39,7 @@ internal static class ArgHelper
 #if !NET8_0_OR_GREATER
     [DoesNotReturn]
     [MethodImpl(MethodImplOptions.NoInlining)]
-    static void ThrowArgumentNullException(string? paramName)
+    private static void ThrowArgumentNullException(string? paramName)
     {
         throw new ArgumentNullException(paramName);
     }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ArgHelper.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ArgHelper.cs
@@ -19,14 +19,7 @@ internal static class ArgHelper
 #else
         if (argument is null)
         {
-            ThrowException(paramName);
-        }
-
-        [DoesNotReturn]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static void ThrowException(string? paramName)
-        {
-            throw new ArgumentNullException(paramName);
+            ThrowArgumentNullException(paramName);
         }
 #endif
     }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledArrayBufferWriter`1.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledArrayBufferWriter`1.cs
@@ -1,0 +1,193 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+// Copied from https://github.com/dotnet/runtime
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using Microsoft.AspNetCore.Razor;
+
+namespace System.Buffers;
+
+/// <summary>
+///  <see cref="IBufferWriter{T}"/> that uses <see cref="ArrayPool{T}"/>.
+/// </summary>
+internal sealed class PooledArrayBufferWriter<T> : IBufferWriter<T>, IDisposable
+{
+    private T[]? _rentedBuffer;
+    private int _index;
+
+    private const int MinimumBufferSize = 256;
+
+    public PooledArrayBufferWriter()
+    {
+        _rentedBuffer = ArrayPool<T>.Shared.Rent(MinimumBufferSize);
+        _index = 0;
+    }
+
+    public PooledArrayBufferWriter(int initialCapacity)
+    {
+        ArgHelper.ThrowIfNegativeOrZero(initialCapacity);
+
+        _rentedBuffer = ArrayPool<T>.Shared.Rent(initialCapacity);
+        _index = 0;
+    }
+
+    public ReadOnlyMemory<T> WrittenMemory
+    {
+        get
+        {
+            CheckIfDisposed();
+
+            return _rentedBuffer.AsMemory(0, _index);
+        }
+    }
+
+    public int WrittenCount
+    {
+        get
+        {
+            CheckIfDisposed();
+
+            return _index;
+        }
+    }
+
+    public int Capacity
+    {
+        get
+        {
+            CheckIfDisposed();
+
+            return _rentedBuffer.Length;
+        }
+    }
+
+    public int FreeCapacity
+    {
+        get
+        {
+            CheckIfDisposed();
+
+            return _rentedBuffer.Length - _index;
+        }
+    }
+
+    public void Clear()
+    {
+        CheckIfDisposed();
+
+        ClearHelper();
+    }
+
+    private void ClearHelper()
+    {
+        Debug.Assert(_rentedBuffer != null);
+
+        _rentedBuffer.AsSpan(0, _index).Clear();
+        _index = 0;
+    }
+
+    // Returns the rented buffer back to the pool
+    public void Dispose()
+    {
+        if (_rentedBuffer == null)
+        {
+            return;
+        }
+
+        ClearHelper();
+        ArrayPool<T>.Shared.Return(_rentedBuffer);
+        _rentedBuffer = null;
+    }
+
+    [MemberNotNull(nameof(_rentedBuffer))]
+    private void CheckIfDisposed()
+    {
+        if (_rentedBuffer == null)
+        {
+            ThrowObjectDisposed();
+        }
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ThrowObjectDisposed()
+        {
+            throw new ObjectDisposedException(nameof(ArrayBufferWriter<T>));
+        }
+    }
+
+    public void Advance(int count)
+    {
+        CheckIfDisposed();
+
+        ArgHelper.ThrowIfNegative(count);
+
+        if (_index > _rentedBuffer.Length - count)
+        {
+            ThrowCannotAdvance(_rentedBuffer.Length);
+        }
+
+        _index += count;
+
+        [DoesNotReturn]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static void ThrowCannotAdvance(int capacity)
+        {
+            throw new InvalidOperationException(SR.FormatCannot_advance_past_end_of_the_buffer_which_has_a_size_of_0(capacity));
+        }
+    }
+
+    public Memory<T> GetMemory(int sizeHint = 0)
+    {
+        CheckIfDisposed();
+
+        CheckAndResizeBuffer(sizeHint);
+        return _rentedBuffer.AsMemory(_index);
+    }
+
+    public Span<T> GetSpan(int sizeHint = 0)
+    {
+        CheckIfDisposed();
+
+        CheckAndResizeBuffer(sizeHint);
+        return _rentedBuffer.AsSpan(_index);
+    }
+
+    private void CheckAndResizeBuffer(int sizeHint)
+    {
+        Debug.Assert(_rentedBuffer != null);
+
+        ArgHelper.ThrowIfNegative(sizeHint);
+
+        if (sizeHint == 0)
+        {
+            sizeHint = MinimumBufferSize;
+        }
+
+        var availableSpace = _rentedBuffer!.Length - _index;
+
+        if (sizeHint > availableSpace)
+        {
+            var growBy = Math.Max(sizeHint, _rentedBuffer.Length);
+
+            var newSize = checked(_rentedBuffer.Length + growBy);
+
+            var oldBuffer = _rentedBuffer;
+
+            _rentedBuffer = ArrayPool<T>.Shared.Rent(newSize);
+
+            Debug.Assert(oldBuffer.Length >= _index);
+            Debug.Assert(_rentedBuffer.Length >= _index);
+
+            var previousBuffer = oldBuffer.AsSpan(0, _index);
+            previousBuffer.CopyTo(_rentedBuffer);
+            previousBuffer.Clear();
+            ArrayPool<T>.Shared.Return(oldBuffer);
+        }
+
+        Debug.Assert(_rentedBuffer.Length - _index > 0);
+        Debug.Assert(_rentedBuffer.Length - _index >= sizeHint);
+    }
+}

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledArrayBufferWriter`1.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledArrayBufferWriter`1.cs
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-// Copied from https://github.com/dotnet/runtime
+// Copied from https://github.com/dotnet/aspnetcore/blob/207bc7d00c00bf454dc83789d6824609b1d8b02a/src/Shared/PooledArrayBufferWriter.cs,
+// which is derived from https://github.com/dotnet/runtime/blob/abb5c348f242e546b5768ad70ebe4051f08f7d24/src/libraries/Common/src/System/Text/Json/PooledByteBufferWriter.cs
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/SR.resx
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/SR.resx
@@ -117,6 +117,33 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="0_1_must_be_a_non_negative_and_non_zero_value" xml:space="preserve">
+    <value>{0} ('{1}') must be a non-negative and non-zero value.</value>
+  </data>
+  <data name="0_1_must_be_a_non_negative_value" xml:space="preserve">
+    <value>{0} ('{1}') must be a non-negative value.</value>
+  </data>
+  <data name="0_1_must_be_a_non_zero_value" xml:space="preserve">
+    <value>{0} ('{1}') must be a non-zero value.</value>
+  </data>
+  <data name="0_1_must_be_equal_to_2" xml:space="preserve">
+    <value>{0} ('{1}') must be equal to '{2}'.</value>
+  </data>
+  <data name="0_1_must_be_greater_than_2" xml:space="preserve">
+    <value>{0} ('{1}') must be greater than '{2}'.</value>
+  </data>
+  <data name="0_1_must_be_greater_than_or_equal_to_2" xml:space="preserve">
+    <value>{0} ('{1}') must be greater than or equal to '{2}'.</value>
+  </data>
+  <data name="0_1_must_be_less_than_2" xml:space="preserve">
+    <value>{0} ('{1}') must be less than '{2}'.</value>
+  </data>
+  <data name="0_1_must_be_less_than_or_equal_to_2" xml:space="preserve">
+    <value>{0} ('{1}') must be less than or equal to '{2}'.</value>
+  </data>
+  <data name="0_1_must_not_be_equal_to_2" xml:space="preserve">
+    <value>{0} ('{1}') must not be equal to '{2}'.</value>
+  </data>
   <data name="Cannot_advance_past_end_of_the_buffer_which_has_a_size_of_0" xml:space="preserve">
     <value>Cannot advance past the end of the buffer, which has a size of {0}.</value>
   </data>
@@ -137,6 +164,12 @@
   </data>
   <data name="Non_negative_number_required" xml:space="preserve">
     <value>Non-negative number required.</value>
+  </data>
+  <data name="The_value_cannot_be_an_empty_string" xml:space="preserve">
+    <value>The value cannot be an empty string.</value>
+  </data>
+  <data name="The_value_cannot_be_an_empty_string_composed_entirely_of_whitespace" xml:space="preserve">
+    <value>The value cannot be an empty string or composed entirely of whitespace.</value>
   </data>
   <data name="This_program_location_is_thought_to_be_unreachable" xml:space="preserve">
     <value>This program location is thought to be unreachable.</value>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.cs.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.cs.xlf
@@ -2,6 +2,51 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../SR.resx">
     <body>
+      <trans-unit id="0_1_must_be_a_non_negative_and_non_zero_value">
+        <source>{0} ('{1}') must be a non-negative and non-zero value.</source>
+        <target state="new">{0} ('{1}') must be a non-negative and non-zero value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_a_non_negative_value">
+        <source>{0} ('{1}') must be a non-negative value.</source>
+        <target state="new">{0} ('{1}') must be a non-negative value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_a_non_zero_value">
+        <source>{0} ('{1}') must be a non-zero value.</source>
+        <target state="new">{0} ('{1}') must be a non-zero value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_equal_to_2">
+        <source>{0} ('{1}') must be equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_greater_than_2">
+        <source>{0} ('{1}') must be greater than '{2}'.</source>
+        <target state="new">{0} ('{1}') must be greater than '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_greater_than_or_equal_to_2">
+        <source>{0} ('{1}') must be greater than or equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be greater than or equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_less_than_2">
+        <source>{0} ('{1}') must be less than '{2}'.</source>
+        <target state="new">{0} ('{1}') must be less than '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_less_than_or_equal_to_2">
+        <source>{0} ('{1}') must be less than or equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be less than or equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_not_be_equal_to_2">
+        <source>{0} ('{1}') must not be equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must not be equal to '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_advance_past_end_of_the_buffer_which_has_a_size_of_0">
         <source>Cannot advance past the end of the buffer, which has a size of {0}.</source>
         <target state="translated">Nelze přejít za konec vyrovnávací paměti, která má velikost {0}.</target>
@@ -35,6 +80,16 @@
       <trans-unit id="Non_negative_number_required">
         <source>Non-negative number required.</source>
         <target state="translated">Vyžaduje se nezáporné číslo.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_value_cannot_be_an_empty_string">
+        <source>The value cannot be an empty string.</source>
+        <target state="new">The value cannot be an empty string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_value_cannot_be_an_empty_string_composed_entirely_of_whitespace">
+        <source>The value cannot be an empty string or composed entirely of whitespace.</source>
+        <target state="new">The value cannot be an empty string or composed entirely of whitespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="This_program_location_is_thought_to_be_unreachable">

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.de.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.de.xlf
@@ -2,6 +2,51 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../SR.resx">
     <body>
+      <trans-unit id="0_1_must_be_a_non_negative_and_non_zero_value">
+        <source>{0} ('{1}') must be a non-negative and non-zero value.</source>
+        <target state="new">{0} ('{1}') must be a non-negative and non-zero value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_a_non_negative_value">
+        <source>{0} ('{1}') must be a non-negative value.</source>
+        <target state="new">{0} ('{1}') must be a non-negative value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_a_non_zero_value">
+        <source>{0} ('{1}') must be a non-zero value.</source>
+        <target state="new">{0} ('{1}') must be a non-zero value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_equal_to_2">
+        <source>{0} ('{1}') must be equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_greater_than_2">
+        <source>{0} ('{1}') must be greater than '{2}'.</source>
+        <target state="new">{0} ('{1}') must be greater than '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_greater_than_or_equal_to_2">
+        <source>{0} ('{1}') must be greater than or equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be greater than or equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_less_than_2">
+        <source>{0} ('{1}') must be less than '{2}'.</source>
+        <target state="new">{0} ('{1}') must be less than '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_less_than_or_equal_to_2">
+        <source>{0} ('{1}') must be less than or equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be less than or equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_not_be_equal_to_2">
+        <source>{0} ('{1}') must not be equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must not be equal to '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_advance_past_end_of_the_buffer_which_has_a_size_of_0">
         <source>Cannot advance past the end of the buffer, which has a size of {0}.</source>
         <target state="translated">Das Ende des Puffers mit einer Größe von {0} kann nicht über das Ende des Puffers hinaus erreicht werden.</target>
@@ -35,6 +80,16 @@
       <trans-unit id="Non_negative_number_required">
         <source>Non-negative number required.</source>
         <target state="translated">Nicht negative Zahl erforderlich.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_value_cannot_be_an_empty_string">
+        <source>The value cannot be an empty string.</source>
+        <target state="new">The value cannot be an empty string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_value_cannot_be_an_empty_string_composed_entirely_of_whitespace">
+        <source>The value cannot be an empty string or composed entirely of whitespace.</source>
+        <target state="new">The value cannot be an empty string or composed entirely of whitespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="This_program_location_is_thought_to_be_unreachable">

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.es.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.es.xlf
@@ -2,6 +2,51 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../SR.resx">
     <body>
+      <trans-unit id="0_1_must_be_a_non_negative_and_non_zero_value">
+        <source>{0} ('{1}') must be a non-negative and non-zero value.</source>
+        <target state="new">{0} ('{1}') must be a non-negative and non-zero value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_a_non_negative_value">
+        <source>{0} ('{1}') must be a non-negative value.</source>
+        <target state="new">{0} ('{1}') must be a non-negative value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_a_non_zero_value">
+        <source>{0} ('{1}') must be a non-zero value.</source>
+        <target state="new">{0} ('{1}') must be a non-zero value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_equal_to_2">
+        <source>{0} ('{1}') must be equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_greater_than_2">
+        <source>{0} ('{1}') must be greater than '{2}'.</source>
+        <target state="new">{0} ('{1}') must be greater than '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_greater_than_or_equal_to_2">
+        <source>{0} ('{1}') must be greater than or equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be greater than or equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_less_than_2">
+        <source>{0} ('{1}') must be less than '{2}'.</source>
+        <target state="new">{0} ('{1}') must be less than '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_less_than_or_equal_to_2">
+        <source>{0} ('{1}') must be less than or equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be less than or equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_not_be_equal_to_2">
+        <source>{0} ('{1}') must not be equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must not be equal to '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_advance_past_end_of_the_buffer_which_has_a_size_of_0">
         <source>Cannot advance past the end of the buffer, which has a size of {0}.</source>
         <target state="translated">No se puede avanzar más allá del final del búfer, que tiene un tamaño de {0}.</target>
@@ -35,6 +80,16 @@
       <trans-unit id="Non_negative_number_required">
         <source>Non-negative number required.</source>
         <target state="translated">Se requiere un número no negativo.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_value_cannot_be_an_empty_string">
+        <source>The value cannot be an empty string.</source>
+        <target state="new">The value cannot be an empty string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_value_cannot_be_an_empty_string_composed_entirely_of_whitespace">
+        <source>The value cannot be an empty string or composed entirely of whitespace.</source>
+        <target state="new">The value cannot be an empty string or composed entirely of whitespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="This_program_location_is_thought_to_be_unreachable">

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.fr.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.fr.xlf
@@ -2,6 +2,51 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../SR.resx">
     <body>
+      <trans-unit id="0_1_must_be_a_non_negative_and_non_zero_value">
+        <source>{0} ('{1}') must be a non-negative and non-zero value.</source>
+        <target state="new">{0} ('{1}') must be a non-negative and non-zero value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_a_non_negative_value">
+        <source>{0} ('{1}') must be a non-negative value.</source>
+        <target state="new">{0} ('{1}') must be a non-negative value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_a_non_zero_value">
+        <source>{0} ('{1}') must be a non-zero value.</source>
+        <target state="new">{0} ('{1}') must be a non-zero value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_equal_to_2">
+        <source>{0} ('{1}') must be equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_greater_than_2">
+        <source>{0} ('{1}') must be greater than '{2}'.</source>
+        <target state="new">{0} ('{1}') must be greater than '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_greater_than_or_equal_to_2">
+        <source>{0} ('{1}') must be greater than or equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be greater than or equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_less_than_2">
+        <source>{0} ('{1}') must be less than '{2}'.</source>
+        <target state="new">{0} ('{1}') must be less than '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_less_than_or_equal_to_2">
+        <source>{0} ('{1}') must be less than or equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be less than or equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_not_be_equal_to_2">
+        <source>{0} ('{1}') must not be equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must not be equal to '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_advance_past_end_of_the_buffer_which_has_a_size_of_0">
         <source>Cannot advance past the end of the buffer, which has a size of {0}.</source>
         <target state="translated">Impossible d’avancer au-delà de la fin de la mémoire tampon, qui a une taille de {0}.</target>
@@ -35,6 +80,16 @@
       <trans-unit id="Non_negative_number_required">
         <source>Non-negative number required.</source>
         <target state="translated">Nombre non négatif obligatoire.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_value_cannot_be_an_empty_string">
+        <source>The value cannot be an empty string.</source>
+        <target state="new">The value cannot be an empty string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_value_cannot_be_an_empty_string_composed_entirely_of_whitespace">
+        <source>The value cannot be an empty string or composed entirely of whitespace.</source>
+        <target state="new">The value cannot be an empty string or composed entirely of whitespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="This_program_location_is_thought_to_be_unreachable">

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.it.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.it.xlf
@@ -2,6 +2,51 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../SR.resx">
     <body>
+      <trans-unit id="0_1_must_be_a_non_negative_and_non_zero_value">
+        <source>{0} ('{1}') must be a non-negative and non-zero value.</source>
+        <target state="new">{0} ('{1}') must be a non-negative and non-zero value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_a_non_negative_value">
+        <source>{0} ('{1}') must be a non-negative value.</source>
+        <target state="new">{0} ('{1}') must be a non-negative value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_a_non_zero_value">
+        <source>{0} ('{1}') must be a non-zero value.</source>
+        <target state="new">{0} ('{1}') must be a non-zero value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_equal_to_2">
+        <source>{0} ('{1}') must be equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_greater_than_2">
+        <source>{0} ('{1}') must be greater than '{2}'.</source>
+        <target state="new">{0} ('{1}') must be greater than '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_greater_than_or_equal_to_2">
+        <source>{0} ('{1}') must be greater than or equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be greater than or equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_less_than_2">
+        <source>{0} ('{1}') must be less than '{2}'.</source>
+        <target state="new">{0} ('{1}') must be less than '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_less_than_or_equal_to_2">
+        <source>{0} ('{1}') must be less than or equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be less than or equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_not_be_equal_to_2">
+        <source>{0} ('{1}') must not be equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must not be equal to '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_advance_past_end_of_the_buffer_which_has_a_size_of_0">
         <source>Cannot advance past the end of the buffer, which has a size of {0}.</source>
         <target state="translated">Impossibile avanzare oltre la fine del buffer, che dimensioni di {0}.</target>
@@ -35,6 +80,16 @@
       <trans-unit id="Non_negative_number_required">
         <source>Non-negative number required.</source>
         <target state="translated">Numero non negativo obbligatorio.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_value_cannot_be_an_empty_string">
+        <source>The value cannot be an empty string.</source>
+        <target state="new">The value cannot be an empty string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_value_cannot_be_an_empty_string_composed_entirely_of_whitespace">
+        <source>The value cannot be an empty string or composed entirely of whitespace.</source>
+        <target state="new">The value cannot be an empty string or composed entirely of whitespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="This_program_location_is_thought_to_be_unreachable">

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.ja.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.ja.xlf
@@ -2,6 +2,51 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../SR.resx">
     <body>
+      <trans-unit id="0_1_must_be_a_non_negative_and_non_zero_value">
+        <source>{0} ('{1}') must be a non-negative and non-zero value.</source>
+        <target state="new">{0} ('{1}') must be a non-negative and non-zero value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_a_non_negative_value">
+        <source>{0} ('{1}') must be a non-negative value.</source>
+        <target state="new">{0} ('{1}') must be a non-negative value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_a_non_zero_value">
+        <source>{0} ('{1}') must be a non-zero value.</source>
+        <target state="new">{0} ('{1}') must be a non-zero value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_equal_to_2">
+        <source>{0} ('{1}') must be equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_greater_than_2">
+        <source>{0} ('{1}') must be greater than '{2}'.</source>
+        <target state="new">{0} ('{1}') must be greater than '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_greater_than_or_equal_to_2">
+        <source>{0} ('{1}') must be greater than or equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be greater than or equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_less_than_2">
+        <source>{0} ('{1}') must be less than '{2}'.</source>
+        <target state="new">{0} ('{1}') must be less than '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_less_than_or_equal_to_2">
+        <source>{0} ('{1}') must be less than or equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be less than or equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_not_be_equal_to_2">
+        <source>{0} ('{1}') must not be equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must not be equal to '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_advance_past_end_of_the_buffer_which_has_a_size_of_0">
         <source>Cannot advance past the end of the buffer, which has a size of {0}.</source>
         <target state="translated">バッファーの末尾 (サイズが {0}) を超えて進むことはできません。</target>
@@ -35,6 +80,16 @@
       <trans-unit id="Non_negative_number_required">
         <source>Non-negative number required.</source>
         <target state="translated">負でない数値が必要です。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_value_cannot_be_an_empty_string">
+        <source>The value cannot be an empty string.</source>
+        <target state="new">The value cannot be an empty string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_value_cannot_be_an_empty_string_composed_entirely_of_whitespace">
+        <source>The value cannot be an empty string or composed entirely of whitespace.</source>
+        <target state="new">The value cannot be an empty string or composed entirely of whitespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="This_program_location_is_thought_to_be_unreachable">

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.ko.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.ko.xlf
@@ -2,6 +2,51 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../SR.resx">
     <body>
+      <trans-unit id="0_1_must_be_a_non_negative_and_non_zero_value">
+        <source>{0} ('{1}') must be a non-negative and non-zero value.</source>
+        <target state="new">{0} ('{1}') must be a non-negative and non-zero value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_a_non_negative_value">
+        <source>{0} ('{1}') must be a non-negative value.</source>
+        <target state="new">{0} ('{1}') must be a non-negative value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_a_non_zero_value">
+        <source>{0} ('{1}') must be a non-zero value.</source>
+        <target state="new">{0} ('{1}') must be a non-zero value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_equal_to_2">
+        <source>{0} ('{1}') must be equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_greater_than_2">
+        <source>{0} ('{1}') must be greater than '{2}'.</source>
+        <target state="new">{0} ('{1}') must be greater than '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_greater_than_or_equal_to_2">
+        <source>{0} ('{1}') must be greater than or equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be greater than or equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_less_than_2">
+        <source>{0} ('{1}') must be less than '{2}'.</source>
+        <target state="new">{0} ('{1}') must be less than '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_less_than_or_equal_to_2">
+        <source>{0} ('{1}') must be less than or equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be less than or equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_not_be_equal_to_2">
+        <source>{0} ('{1}') must not be equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must not be equal to '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_advance_past_end_of_the_buffer_which_has_a_size_of_0">
         <source>Cannot advance past the end of the buffer, which has a size of {0}.</source>
         <target state="translated">크기가 {0}인 버퍼의 끝을 지나서 진행할 수 없습니다.</target>
@@ -35,6 +80,16 @@
       <trans-unit id="Non_negative_number_required">
         <source>Non-negative number required.</source>
         <target state="translated">음수가 아닌 수가 필요합니다.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_value_cannot_be_an_empty_string">
+        <source>The value cannot be an empty string.</source>
+        <target state="new">The value cannot be an empty string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_value_cannot_be_an_empty_string_composed_entirely_of_whitespace">
+        <source>The value cannot be an empty string or composed entirely of whitespace.</source>
+        <target state="new">The value cannot be an empty string or composed entirely of whitespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="This_program_location_is_thought_to_be_unreachable">

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.pl.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.pl.xlf
@@ -2,6 +2,51 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../SR.resx">
     <body>
+      <trans-unit id="0_1_must_be_a_non_negative_and_non_zero_value">
+        <source>{0} ('{1}') must be a non-negative and non-zero value.</source>
+        <target state="new">{0} ('{1}') must be a non-negative and non-zero value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_a_non_negative_value">
+        <source>{0} ('{1}') must be a non-negative value.</source>
+        <target state="new">{0} ('{1}') must be a non-negative value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_a_non_zero_value">
+        <source>{0} ('{1}') must be a non-zero value.</source>
+        <target state="new">{0} ('{1}') must be a non-zero value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_equal_to_2">
+        <source>{0} ('{1}') must be equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_greater_than_2">
+        <source>{0} ('{1}') must be greater than '{2}'.</source>
+        <target state="new">{0} ('{1}') must be greater than '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_greater_than_or_equal_to_2">
+        <source>{0} ('{1}') must be greater than or equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be greater than or equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_less_than_2">
+        <source>{0} ('{1}') must be less than '{2}'.</source>
+        <target state="new">{0} ('{1}') must be less than '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_less_than_or_equal_to_2">
+        <source>{0} ('{1}') must be less than or equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be less than or equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_not_be_equal_to_2">
+        <source>{0} ('{1}') must not be equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must not be equal to '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_advance_past_end_of_the_buffer_which_has_a_size_of_0">
         <source>Cannot advance past the end of the buffer, which has a size of {0}.</source>
         <target state="translated">Nie można przejść poza koniec buforu o rozmiarze {0}.</target>
@@ -35,6 +80,16 @@
       <trans-unit id="Non_negative_number_required">
         <source>Non-negative number required.</source>
         <target state="translated">Wymagana jest liczba nieujemna.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_value_cannot_be_an_empty_string">
+        <source>The value cannot be an empty string.</source>
+        <target state="new">The value cannot be an empty string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_value_cannot_be_an_empty_string_composed_entirely_of_whitespace">
+        <source>The value cannot be an empty string or composed entirely of whitespace.</source>
+        <target state="new">The value cannot be an empty string or composed entirely of whitespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="This_program_location_is_thought_to_be_unreachable">

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.pt-BR.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.pt-BR.xlf
@@ -2,6 +2,51 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../SR.resx">
     <body>
+      <trans-unit id="0_1_must_be_a_non_negative_and_non_zero_value">
+        <source>{0} ('{1}') must be a non-negative and non-zero value.</source>
+        <target state="new">{0} ('{1}') must be a non-negative and non-zero value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_a_non_negative_value">
+        <source>{0} ('{1}') must be a non-negative value.</source>
+        <target state="new">{0} ('{1}') must be a non-negative value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_a_non_zero_value">
+        <source>{0} ('{1}') must be a non-zero value.</source>
+        <target state="new">{0} ('{1}') must be a non-zero value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_equal_to_2">
+        <source>{0} ('{1}') must be equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_greater_than_2">
+        <source>{0} ('{1}') must be greater than '{2}'.</source>
+        <target state="new">{0} ('{1}') must be greater than '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_greater_than_or_equal_to_2">
+        <source>{0} ('{1}') must be greater than or equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be greater than or equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_less_than_2">
+        <source>{0} ('{1}') must be less than '{2}'.</source>
+        <target state="new">{0} ('{1}') must be less than '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_less_than_or_equal_to_2">
+        <source>{0} ('{1}') must be less than or equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be less than or equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_not_be_equal_to_2">
+        <source>{0} ('{1}') must not be equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must not be equal to '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_advance_past_end_of_the_buffer_which_has_a_size_of_0">
         <source>Cannot advance past the end of the buffer, which has a size of {0}.</source>
         <target state="translated">Não é possível avançar após o final do buffer, que tem um tamanho de {0}.</target>
@@ -35,6 +80,16 @@
       <trans-unit id="Non_negative_number_required">
         <source>Non-negative number required.</source>
         <target state="translated">É necessário um número não negativo.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_value_cannot_be_an_empty_string">
+        <source>The value cannot be an empty string.</source>
+        <target state="new">The value cannot be an empty string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_value_cannot_be_an_empty_string_composed_entirely_of_whitespace">
+        <source>The value cannot be an empty string or composed entirely of whitespace.</source>
+        <target state="new">The value cannot be an empty string or composed entirely of whitespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="This_program_location_is_thought_to_be_unreachable">

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.ru.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.ru.xlf
@@ -2,6 +2,51 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../SR.resx">
     <body>
+      <trans-unit id="0_1_must_be_a_non_negative_and_non_zero_value">
+        <source>{0} ('{1}') must be a non-negative and non-zero value.</source>
+        <target state="new">{0} ('{1}') must be a non-negative and non-zero value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_a_non_negative_value">
+        <source>{0} ('{1}') must be a non-negative value.</source>
+        <target state="new">{0} ('{1}') must be a non-negative value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_a_non_zero_value">
+        <source>{0} ('{1}') must be a non-zero value.</source>
+        <target state="new">{0} ('{1}') must be a non-zero value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_equal_to_2">
+        <source>{0} ('{1}') must be equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_greater_than_2">
+        <source>{0} ('{1}') must be greater than '{2}'.</source>
+        <target state="new">{0} ('{1}') must be greater than '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_greater_than_or_equal_to_2">
+        <source>{0} ('{1}') must be greater than or equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be greater than or equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_less_than_2">
+        <source>{0} ('{1}') must be less than '{2}'.</source>
+        <target state="new">{0} ('{1}') must be less than '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_less_than_or_equal_to_2">
+        <source>{0} ('{1}') must be less than or equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be less than or equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_not_be_equal_to_2">
+        <source>{0} ('{1}') must not be equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must not be equal to '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_advance_past_end_of_the_buffer_which_has_a_size_of_0">
         <source>Cannot advance past the end of the buffer, which has a size of {0}.</source>
         <target state="translated">Невозможно выйти за пределы буфера размером {0}.</target>
@@ -35,6 +80,16 @@
       <trans-unit id="Non_negative_number_required">
         <source>Non-negative number required.</source>
         <target state="translated">Требуется неотрицательное число.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_value_cannot_be_an_empty_string">
+        <source>The value cannot be an empty string.</source>
+        <target state="new">The value cannot be an empty string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_value_cannot_be_an_empty_string_composed_entirely_of_whitespace">
+        <source>The value cannot be an empty string or composed entirely of whitespace.</source>
+        <target state="new">The value cannot be an empty string or composed entirely of whitespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="This_program_location_is_thought_to_be_unreachable">

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.tr.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.tr.xlf
@@ -2,6 +2,51 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../SR.resx">
     <body>
+      <trans-unit id="0_1_must_be_a_non_negative_and_non_zero_value">
+        <source>{0} ('{1}') must be a non-negative and non-zero value.</source>
+        <target state="new">{0} ('{1}') must be a non-negative and non-zero value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_a_non_negative_value">
+        <source>{0} ('{1}') must be a non-negative value.</source>
+        <target state="new">{0} ('{1}') must be a non-negative value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_a_non_zero_value">
+        <source>{0} ('{1}') must be a non-zero value.</source>
+        <target state="new">{0} ('{1}') must be a non-zero value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_equal_to_2">
+        <source>{0} ('{1}') must be equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_greater_than_2">
+        <source>{0} ('{1}') must be greater than '{2}'.</source>
+        <target state="new">{0} ('{1}') must be greater than '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_greater_than_or_equal_to_2">
+        <source>{0} ('{1}') must be greater than or equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be greater than or equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_less_than_2">
+        <source>{0} ('{1}') must be less than '{2}'.</source>
+        <target state="new">{0} ('{1}') must be less than '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_less_than_or_equal_to_2">
+        <source>{0} ('{1}') must be less than or equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be less than or equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_not_be_equal_to_2">
+        <source>{0} ('{1}') must not be equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must not be equal to '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_advance_past_end_of_the_buffer_which_has_a_size_of_0">
         <source>Cannot advance past the end of the buffer, which has a size of {0}.</source>
         <target state="translated">Boyutu {0} olan arabelleğin sonuna ilerlenemiyor.</target>
@@ -35,6 +80,16 @@
       <trans-unit id="Non_negative_number_required">
         <source>Non-negative number required.</source>
         <target state="translated">Negatif olmayan sayı gerekiyor.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_value_cannot_be_an_empty_string">
+        <source>The value cannot be an empty string.</source>
+        <target state="new">The value cannot be an empty string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_value_cannot_be_an_empty_string_composed_entirely_of_whitespace">
+        <source>The value cannot be an empty string or composed entirely of whitespace.</source>
+        <target state="new">The value cannot be an empty string or composed entirely of whitespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="This_program_location_is_thought_to_be_unreachable">

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.zh-Hans.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.zh-Hans.xlf
@@ -2,6 +2,51 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../SR.resx">
     <body>
+      <trans-unit id="0_1_must_be_a_non_negative_and_non_zero_value">
+        <source>{0} ('{1}') must be a non-negative and non-zero value.</source>
+        <target state="new">{0} ('{1}') must be a non-negative and non-zero value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_a_non_negative_value">
+        <source>{0} ('{1}') must be a non-negative value.</source>
+        <target state="new">{0} ('{1}') must be a non-negative value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_a_non_zero_value">
+        <source>{0} ('{1}') must be a non-zero value.</source>
+        <target state="new">{0} ('{1}') must be a non-zero value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_equal_to_2">
+        <source>{0} ('{1}') must be equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_greater_than_2">
+        <source>{0} ('{1}') must be greater than '{2}'.</source>
+        <target state="new">{0} ('{1}') must be greater than '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_greater_than_or_equal_to_2">
+        <source>{0} ('{1}') must be greater than or equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be greater than or equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_less_than_2">
+        <source>{0} ('{1}') must be less than '{2}'.</source>
+        <target state="new">{0} ('{1}') must be less than '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_less_than_or_equal_to_2">
+        <source>{0} ('{1}') must be less than or equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be less than or equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_not_be_equal_to_2">
+        <source>{0} ('{1}') must not be equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must not be equal to '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_advance_past_end_of_the_buffer_which_has_a_size_of_0">
         <source>Cannot advance past the end of the buffer, which has a size of {0}.</source>
         <target state="translated">无法前进到缓冲区的末尾，该缓冲区的大小为 {0}。</target>
@@ -35,6 +80,16 @@
       <trans-unit id="Non_negative_number_required">
         <source>Non-negative number required.</source>
         <target state="translated">需要提供非负数。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_value_cannot_be_an_empty_string">
+        <source>The value cannot be an empty string.</source>
+        <target state="new">The value cannot be an empty string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_value_cannot_be_an_empty_string_composed_entirely_of_whitespace">
+        <source>The value cannot be an empty string or composed entirely of whitespace.</source>
+        <target state="new">The value cannot be an empty string or composed entirely of whitespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="This_program_location_is_thought_to_be_unreachable">

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.zh-Hant.xlf
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Resources/xlf/SR.zh-Hant.xlf
@@ -2,6 +2,51 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../SR.resx">
     <body>
+      <trans-unit id="0_1_must_be_a_non_negative_and_non_zero_value">
+        <source>{0} ('{1}') must be a non-negative and non-zero value.</source>
+        <target state="new">{0} ('{1}') must be a non-negative and non-zero value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_a_non_negative_value">
+        <source>{0} ('{1}') must be a non-negative value.</source>
+        <target state="new">{0} ('{1}') must be a non-negative value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_a_non_zero_value">
+        <source>{0} ('{1}') must be a non-zero value.</source>
+        <target state="new">{0} ('{1}') must be a non-zero value.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_equal_to_2">
+        <source>{0} ('{1}') must be equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_greater_than_2">
+        <source>{0} ('{1}') must be greater than '{2}'.</source>
+        <target state="new">{0} ('{1}') must be greater than '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_greater_than_or_equal_to_2">
+        <source>{0} ('{1}') must be greater than or equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be greater than or equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_less_than_2">
+        <source>{0} ('{1}') must be less than '{2}'.</source>
+        <target state="new">{0} ('{1}') must be less than '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_be_less_than_or_equal_to_2">
+        <source>{0} ('{1}') must be less than or equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must be less than or equal to '{2}'.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="0_1_must_not_be_equal_to_2">
+        <source>{0} ('{1}') must not be equal to '{2}'.</source>
+        <target state="new">{0} ('{1}') must not be equal to '{2}'.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="Cannot_advance_past_end_of_the_buffer_which_has_a_size_of_0">
         <source>Cannot advance past the end of the buffer, which has a size of {0}.</source>
         <target state="translated">無法超過緩衝區的結尾，緩衝區大小為 {0}。</target>
@@ -35,6 +80,16 @@
       <trans-unit id="Non_negative_number_required">
         <source>Non-negative number required.</source>
         <target state="translated">需要非負數。</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_value_cannot_be_an_empty_string">
+        <source>The value cannot be an empty string.</source>
+        <target state="new">The value cannot be an empty string.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="The_value_cannot_be_an_empty_string_composed_entirely_of_whitespace">
+        <source>The value cannot be an empty string or composed entirely of whitespace.</source>
+        <target state="new">The value cannot be an empty string or composed entirely of whitespace.</target>
         <note />
       </trans-unit>
       <trans-unit id="This_program_location_is_thought_to_be_unreachable">


### PR DESCRIPTION
This change introduces a couple of helper utilities into MS.ANC.Razor.Utilities.Shared. Most notably, I've introduced an `ArgHelper` type that can be used for argument validation. This is analogous to the various `ArgumentNullException.Throw*`, `ArgumentException.Throw*`, and `ArgumentOutOfRangeException.Throw*` APIs that were added in .NET 8+. In addition, I've included `PooledArrayBufferWriter<T>`, which is a use implementation of `IBufferWriter<T>` that uses shared array pools.