### PR TITLE
Fixes broken mapcode LSP flow from razor to c#

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_MapCode.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_MapCode.cs
@@ -83,8 +83,8 @@ internal partial class RazorCustomMessageTarget
 
     private static bool SupportsMapCode(JToken token)
     {
-        return token is JObject obj
-            && obj.TryGetValue(VSInternalMethods.WorkspaceMapCodeName, out var supportsMapCode)
-            && supportsMapCode.ToObject<bool>();
+        var serverCapabilities = token.ToObject<VSInternalServerCapabilities>();
+
+        return serverCapabilities?.MapCodeProvider ?? false;
     }
 }


### PR DESCRIPTION
This causes the mapcode edits returned from C# and Razor to no longer be empty.
But still the resulting edit is wrong.
So there is more work to do.

Contributes to #10040