### PR TITLE
Fix integration tests, and razor, by using the correct cancellation token

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectWorkspaceStateGenerator.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectWorkspaceStateGenerator.cs
@@ -109,6 +109,11 @@ internal sealed partial class ProjectWorkspaceStateGenerator(
 
     private async Task UpdateWorkspaceStateAsync(Project? workspaceProject, IProjectSnapshot projectSnapshot, CancellationToken cancellationToken)
     {
+        if (_disposeTokenSource.IsCancellationRequested)
+        {
+            return;
+        }
+
         try
         {
             // Only allow a single TagHelper resolver request to process at a time in order to reduce
@@ -172,7 +177,7 @@ internal sealed partial class ProjectWorkspaceStateGenerator(
             {
                 // Prevent ObjectDisposedException if we've disposed before we got here. The dispose method will release
                 // anyway, so we're all good.
-                if (!cancellationToken.IsCancellationRequested)
+                if (!_disposeTokenSource.IsCancellationRequested)
                 {
                     _semaphore.Release();
                 }


### PR DESCRIPTION
This reverts commit d76f5c59d9892b4c05e8291bb72578a869ecdf5d, humorously entitled "Check correct CancellationToken". Sorry @DustinCampbell 😁

What was happening was that when a project change was queued up, we cancelled any previous work that was in play. This used to check the disposal cancellation token, so we didn't try to release a semaphore that was disposed. The change to use the passed in cancellation token meant we never released the semaphore.