### PR TITLE
Allow multiple forms for the featureflag script

### DIFF
--- a/eng/scripts/featureflag.ps1
+++ b/eng/scripts/featureflag.ps1
@@ -1,4 +1,4 @@
-[CmdletBinding(PositionalBinding=$false)]
+[CmdletBinding(PositionalBinding = $false)]
 param(
   [string]$flag = $null,
   [switch]$enable,
@@ -9,46 +9,22 @@ param(
 )
 
 if ($null -eq $flag -or '' -eq $flag) {
-    throw "Specify a -flag to set"
+  throw "Specify a -flag to set"
 }
 
 if ($flag.EndsWith("\")) {
   throw "Provided flag '$flag' ends with '\', which is not valid"
 }
 
-$value = 0
-
-if ($enable)
-{
-  $value = 1
-}
-
-# If the flag contains \ assume that the intention was to provide a full path, otherwise use the default for razor lsp feature flags
-if (-not $flag.Contains("\"))
-{
-  $flag = "FeatureFlags\Razor\LSP\" + $flag
-}
-
-Write-Host "Attempting to modify '$flag' to '$value'"
-
-
-$slashIndex = $flag.LastIndexOf("\")
-
-if ($slashIndex -ge 0) {
-    $flagBase = $flag.Substring(0, $slashIndex)
-    $flag = $flag.Substring($slashIndex + 1) #+1 to trim the \
-}
-
 if ($set -and $get) {
-    throw "Use only one of set or get"
+  throw "Use only one of set or get"
 }
 
 if (-not ($set -or $get)) {
-    throw "Specify one of -set or -get"
+  throw "Specify one of -set or -get"
 }
 
-if ($set)
-{
+if ($set) {
   if ($enable -and $disable) {
     throw "Use only one of -enable or -disable"
   }
@@ -56,6 +32,36 @@ if ($set)
   if (-not ($enable -or $disable)) {
     throw "Specify one of -enable or -disable"
   }
+}
+
+$value = 0
+
+if ($enable) {
+  $value = 1
+}
+
+$slashIndex = $flag.LastIndexOf("\")
+
+if ($slashIndex -ge 0) {
+  $flagBase = $flag.Substring(0, $slashIndex)
+  $flag = $flag.Substring($slashIndex + 1) #+1 to trim the \
+}
+
+if ($flag.IndexOf('.') -ge 0) {
+  Write-Host "Replacing . in $flag with \"
+  $flag = $flag.Replace(".", "\")
+  Write-Host "New value for flag: $flag"
+}
+
+if (-not ($flag -like "FeatureFlags*"))
+{
+  Write-Host "FeatureFlags was not present, modifying $flag"
+  $flag = "FeatureFlags\" + $flag
+  Write-Host "New value for flag: $flag"
+}
+
+if ($set) {
+  Write-Host "Attempting to modify '$flag' to '$value'"
 }
 
 $engPath = Join-Path $PSScriptRoot ".."
@@ -74,9 +80,10 @@ Write-Host "Running VsRegEdit"
 $vsDir = $vsInfo.installationPath.TrimEnd("\")
 $vsRegEdit = Join-Path (Join-Path (Join-Path $vsDir 'Common7') 'IDE') 'VsRegEdit.exe'
 
+Write-Host "Current value:"
+&$vsRegEdit read "$vsDir" $hive HKCU $flag VALUE dword
+
 if ($set) {
+  Write-Host "Running $vsRegEdit set `"$vsDir`" $hive HKCU $flag VALUE dword $value"
   &$vsRegEdit set "$vsDir" $hive HKCU $flag VALUE dword $value
-}
-else {
-  &$vsRegEdit read "$vsDir" $hive HKCU $flag VALUE dword
 }


### PR DESCRIPTION
It was tedious to get the actual argument right, so this checks for multiple forms and tries to correct them. 

The following should be supported now: 

`eng\scripts\featureflag.ps1 -set -flag Razor.LSP.ForceRuntimeCodeGeneration -enable`
`eng\scripts\featureflag.ps1 -set -flag Razor\LSP\ForceRuntimeCodeGeneration -enable`
`eng\scripts\featureflag.ps1 -set -flag FeatureFlags.Razor.LSP.ForceRuntimeCodeGeneration -enable`
`eng\scripts\featureflag.ps1 -set -flag FeatureFlags\Razor\LSP\ForceRuntimeCodeGeneration -enable`

This should make copying the value from code easier to figure out. We could also just assume feature flags start with `FeatureFlags\LSP\Razor\<flagname>` but that's not inherantly true, just happens to be for now. 