### PR TITLE
Fix source mappings not appearing in fuse:

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/CodeGeneration/DesignTimeNodeWriterTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/CodeGeneration/DesignTimeNodeWriterTest.cs
@@ -553,7 +553,7 @@ Render Children
     public void LinePragma_Enhanced_Is_Adjusted_On_Windows(string fileName, string expectedFileName)
     {
         var writer = new RuntimeNodeWriter();
-        var context = TestCodeRenderingContext.CreateDesignTime();
+        var context = TestCodeRenderingContext.CreateDesignTime(source: RazorSourceDocument.Create("", fileName));
 
         Assert.True(context.Options.RemapLinePragmaPathsOnWindows);
         Assert.True(context.Options.UseEnhancedLinePragma);
@@ -586,6 +586,8 @@ Render Children
             """,
             csharp,
             ignoreLineEndingDifferences: true);
+
+        Assert.Single(((DefaultCodeRenderingContext)context).SourceMappings);
     }
 
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriterExtensions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriterExtensions.cs
@@ -592,8 +592,7 @@ internal static class CodeWriterExtensions
             return NullDisposable.Default;
         }
 
-        var sourceSpan = RemapFilePathIfNecessary(span.Value, context);
-        return new LinePragmaWriter(writer, sourceSpan, context, 0, useEnhancedLinePragma: false, suppressLineDefaultAndHidden);
+        return new LinePragmaWriter(writer, span.Value, context, 0, useEnhancedLinePragma: false, suppressLineDefaultAndHidden);
     }
 
     public static IDisposable BuildEnhancedLinePragma(this CodeWriter writer, SourceSpan? span, CodeRenderingContext context, int characterOffset = 0, bool suppressLineDefaultAndHidden = false)
@@ -604,8 +603,7 @@ internal static class CodeWriterExtensions
             return NullDisposable.Default;
         }
 
-        var sourceSpan = RemapFilePathIfNecessary(span.Value, context);
-        return new LinePragmaWriter(writer, sourceSpan, context, characterOffset, useEnhancedLinePragma: true, suppressLineDefaultAndHidden);
+        return new LinePragmaWriter(writer, span.Value, context, characterOffset, useEnhancedLinePragma: true, suppressLineDefaultAndHidden);
     }
 
     private static SourceSpan RemapFilePathIfNecessary(SourceSpan sourceSpan, CodeRenderingContext context)
@@ -804,13 +802,14 @@ internal static class CodeWriterExtensions
                 _writer.WriteLine("#nullable restore");
             }
 
+            var sourceSpan = RemapFilePathIfNecessary(span, context);
             if (useEnhancedLinePragma && _context.Options.UseEnhancedLinePragma)
             {
-                WriteEnhancedLineNumberDirective(writer, span, characterOffset);
+                WriteEnhancedLineNumberDirective(writer, sourceSpan, characterOffset);
             }
             else
             {
-                WriteLineNumberDirective(writer, span);
+                WriteLineNumberDirective(writer, sourceSpan);
             }
 
             // Capture the line index after writing the #line directive.


### PR DESCRIPTION
Move windows path remapping later in the process so that path comparisons for source mappings are unaffected

Fixes https://github.com/dotnet/razor/issues/10263