### PR TITLE
Minor improvements to integration tests

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractIntegrationTest.cs
@@ -33,6 +33,9 @@ public abstract class AbstractIntegrationTest : AbstractIdeIntegrationTest
 
     public override async Task InitializeAsync()
     {
+        // Not sure why the module initializer doesn't seem to work for integration tests
+        ThrowingTraceListener.Initialize();
+
         await base.InitializeAsync();
     }
 

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/OutputInProcess.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/OutputInProcess.cs
@@ -33,7 +33,7 @@ internal partial class OutputInProcess
         // We can't remove logging providers, so we just keep track of ours so we can make sure it points to the right test output helper
         if (_testLoggerProvider is null)
         {
-            _testLoggerProvider = new TestOutputLoggerProvider(testOutputHelper, LogLevel.Warning);
+            _testLoggerProvider = new TestOutputLoggerProvider(testOutputHelper);
             logger.AddLoggerProvider(_testLoggerProvider);
         }
         else

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Microsoft.VisualStudio.Razor.IntegrationTests.csproj
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Microsoft.VisualStudio.Razor.IntegrationTests.csproj
@@ -20,6 +20,11 @@
       <PrivateAssets>All</PrivateAssets>
       <CopyLocalSatelliteAssemblies>False</CopyLocalSatelliteAssemblies>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\Microsoft.VisualStudio.RazorExtension\Microsoft.VisualStudio.RazorExtension.csproj">
+      <PrivateAssets>All</PrivateAssets>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <CopyLocalSatelliteAssemblies>False</CopyLocalSatelliteAssemblies>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\RazorDeployment\RazorDeployment.csproj" Private="False" Condition="'$(BuildDependencyVsix)' == 'true'">
       <PrivateAssets>All</PrivateAssets>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
@@ -45,8 +50,8 @@
       import the package ourselves, but as an implicit definition to stop Nuget complaining.
       TL;DR: MSBuild was designed to cause pain.
     -->
-    <PackageReference Include="xunit.runner.console" Version="$(XUnitRunnerConsoleVersion)" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true"/>
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioVersion)" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true"/>
+    <PackageReference Include="xunit.runner.console" Version="$(XUnitRunnerConsoleVersion)" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioVersion)" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Reference the razor extension from the integration test project, so that making a code change and running a test from Test Explorer actually causes the new code to be tested
* Manually initialize the `ThrowingTraceListener` because it seems the module initializer doesn't work with our wacky test infra (and I choose not to try to understand the latter :P)
* Up the log level of the test logger, so the Text Explorer output includes the full logs of the test run