### PR TITLE
Bump major version to 9

### DIFF
--- a/eng/AfterSigning.targets
+++ b/eng/AfterSigning.targets
@@ -10,6 +10,35 @@
       Condition="!Exists('$(VSSetupDir)$(Configuration)\$(RazorExtensionVSIXName)')" />
   </Target>
 
+  <!--
+    Write a list of assembly names and versions that the insertion tool uses to update assembly versions in DevDiv.
+    We want to update these lines in VS's /src/ProductData/AssemblyVersions.tt:
+      const string RazorRuntimeAssemblyVersion = "7.0.0.0";
+      const string RazorToolingAssemblyVersion = "7.0.0.0";
+    Hence we write into VSSetup/DevDivPackages/DependentAssemblyVersions.csv:
+      RazorRuntimeAssembly,8.0.0.0
+      RazorToolingAssembly,8.0.0.0
+  -->
+  <PropertyGroup>
+    <_DependentAssemblyVersionsFile>$(VisualStudioBuildPackagesDir)DependentAssemblyVersions.csv</_DependentAssemblyVersionsFile>
+    <_RazorAssemblyVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion).0</_RazorAssemblyVersion>
+  </PropertyGroup>
+  <Target Name="_GenerateDependentAssemblyVersions"
+          AfterTargets="GenerateVisualStudioInsertionManifests"
+          Inputs="$(_RazorAssemblyVersion)"
+          Outputs="$(_DependentAssemblyVersionsFile)"
+          Condition="'$(OS)'=='WINDOWS_NT' AND '$(ArcadeBuildFromSource)' != 'true'">
+    <ItemGroup>
+      <_AssemblyVersionEntry Include="RazorRuntimeAssembly" />
+      <_AssemblyVersionEntry Include="RazorToolingAssembly" />
+    </ItemGroup>
+    <MakeDir Directories="$(VisualStudioBuildPackagesDir)"/>
+    <WriteLinesToFile Lines="@(_AssemblyVersionEntry->'%(Identity),$(_RazorAssemblyVersion)')" File="$(_DependentAssemblyVersionsFile)" Overwrite="true"/>
+    <ItemGroup>
+      <FileWrites Include="$(_DependentAssemblyVersionsFile)"/>
+    </ItemGroup>
+  </Target>
+
   <Target Name="_ZipLanguageServerBinaries" AfterTargets="Pack" Condition="'$(ArcadeBuildFromSource)' != 'true'">
     <!-- This target is defined in eng/targets/Packaging.targets and included in every project. -->
     <MSBuild Projects="$(RepoRoot)src\Razor\src\Microsoft.AspNetCore.Razor.LanguageServer\Microsoft.AspNetCore.Razor.LanguageServer.csproj"

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <!-- Versioning for assemblies/packages -->
   <PropertyGroup>
-    <MajorVersion>7</MajorVersion>
+    <MajorVersion>9</MajorVersion>
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <PreReleaseVersionLabel>preview</PreReleaseVersionLabel>

--- a/eng/pipelines/insert.yml
+++ b/eng/pipelines/insert.yml
@@ -189,7 +189,7 @@ steps:
         -requiredValueSentinel "REQUIRED" `
         -reviewerGUID "6c25b447-1d90-4840-8fde-d8b22cb8733e" `
         -specificBuild "$(Build.BuildNumber)" `
-        -updateAssemblyVersions "false" `
+        -updateAssemblyVersions "true" `
         -updateCoreXTLibraries "false" `
         -visualStudioBranchName "$(Template.VSBranchName)" `
         -writePullRequest "prid.txt" `


### PR DESCRIPTION
Follow up on https://github.com/dotnet/razor/pull/9303.
Official build run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2439107&view=results
VS insertion will need to have a binding redirect added like this (once, then future insertions should work even when major version changes again): https://dev.azure.com/devdiv/DevDiv/_git/VS/commit/a4d1b034e47c7aa3c04d7aa6cb13b49f66e1a00e?refName=refs/heads/dev/dn-bot/insertions/main.20240422141608