### PR TITLE
Make RazorProjectService operations atomic

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
@@ -87,7 +87,7 @@ public class RazorLanguageServerBenchmarkBase : ProjectSnapshotManagerBenchmarkB
 
     private class NoopClientNotifierService : IClientConnection, IOnInitialized
     {
-        public Task InitializeAsync(ILspServices services, CancellationToken cancellationToken)
+        public Task OnInitializedAsync(ILspServices services, CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
@@ -87,7 +87,7 @@ public class RazorLanguageServerBenchmarkBase : ProjectSnapshotManagerBenchmarkB
 
     private class NoopClientNotifierService : IClientConnection, IOnInitialized
     {
-        public Task OnInitializedAsync(VSInternalClientCapabilities clientCapabilities, CancellationToken cancellationToken)
+        public Task OnInitializedAsync(ILspServices services, CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
@@ -87,7 +87,7 @@ public class RazorLanguageServerBenchmarkBase : ProjectSnapshotManagerBenchmarkB
 
     private class NoopClientNotifierService : IClientConnection, IOnInitialized
     {
-        public Task OnInitializedAsync(ILspServices services, CancellationToken cancellationToken)
+        public Task InitializeAsync(ILspServices services, CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ClientConnection.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ClientConnection.cs
@@ -48,7 +48,7 @@ internal sealed class ClientConnection(JsonRpc jsonRpc) : IClientConnection, IOn
     /// <summary>
     /// Fires when the language server is set to "Started".
     /// </summary>
-    public Task InitializeAsync(ILspServices services, CancellationToken cancellationToken)
+    public Task OnInitializedAsync(ILspServices services, CancellationToken cancellationToken)
     {
         _initializedCompletionSource.TrySetResult(true);
         return Task.CompletedTask;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ClientConnection.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ClientConnection.cs
@@ -48,7 +48,7 @@ internal sealed class ClientConnection(JsonRpc jsonRpc) : IClientConnection, IOn
     /// <summary>
     /// Fires when the language server is set to "Started".
     /// </summary>
-    public Task OnInitializedAsync(ILspServices services, CancellationToken cancellationToken)
+    public Task InitializeAsync(ILspServices services, CancellationToken cancellationToken)
     {
         _initializedCompletionSource.TrySetResult(true);
         return Task.CompletedTask;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ClientConnection.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ClientConnection.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
+using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using StreamJsonRpc;
 
@@ -47,7 +48,7 @@ internal sealed class ClientConnection(JsonRpc jsonRpc) : IClientConnection, IOn
     /// <summary>
     /// Fires when the language server is set to "Started".
     /// </summary>
-    public Task OnInitializedAsync(VSInternalClientCapabilities clientCapabilities, CancellationToken cancellationToken)
+    public Task OnInitializedAsync(ILspServices services, CancellationToken cancellationToken)
     {
         _initializedCompletionSource.TrySetResult(true);
         return Task.CompletedTask;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/DefaultCSharpCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/DefaultCSharpCodeActionResolver.cs
@@ -73,7 +73,7 @@ internal sealed class DefaultCSharpCodeActionResolver : CSharpCodeActionResolver
             throw new ArgumentNullException(nameof(codeAction));
         }
 
-        var documentContext = await _documentContextFactory.TryCreateForOpenDocumentAsync(csharpParams.RazorFileIdentifier, cancellationToken).ConfigureAwait(false);
+        var documentContext = _documentContextFactory.TryCreateForOpenDocument(csharpParams.RazorFileIdentifier);
         if (documentContext is null)
         {
             return codeAction;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/DefaultCSharpCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/DefaultCSharpCodeActionResolver.cs
@@ -73,8 +73,7 @@ internal sealed class DefaultCSharpCodeActionResolver : CSharpCodeActionResolver
             throw new ArgumentNullException(nameof(codeAction));
         }
 
-        var documentContext = _documentContextFactory.TryCreateForOpenDocument(csharpParams.RazorFileIdentifier);
-        if (documentContext is null)
+        if (!_documentContextFactory.TryCreateForOpenDocument(csharpParams.RazorFileIdentifier, out var documentContext))
         {
             return codeAction;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/UnformattedRemappingCSharpCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/UnformattedRemappingCSharpCodeActionResolver.cs
@@ -54,8 +54,7 @@ internal sealed class UnformattedRemappingCSharpCodeActionResolver : CSharpCodeA
 
         cancellationToken.ThrowIfCancellationRequested();
 
-        var documentContext = _documentContextFactory.TryCreateForOpenDocument(csharpParams.RazorFileIdentifier);
-        if (documentContext is null)
+        if (!_documentContextFactory.TryCreateForOpenDocument(csharpParams.RazorFileIdentifier, out var documentContext))
         {
             return codeAction;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/UnformattedRemappingCSharpCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/UnformattedRemappingCSharpCodeActionResolver.cs
@@ -54,7 +54,7 @@ internal sealed class UnformattedRemappingCSharpCodeActionResolver : CSharpCodeA
 
         cancellationToken.ThrowIfCancellationRequested();
 
-        var documentContext = await _documentContextFactory.TryCreateForOpenDocumentAsync(csharpParams.RazorFileIdentifier, cancellationToken).ConfigureAwait(false);
+        var documentContext = _documentContextFactory.TryCreateForOpenDocument(csharpParams.RazorFileIdentifier);
         if (documentContext is null)
         {
             return codeAction;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Html/DefaultHtmlCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Html/DefaultHtmlCodeActionResolver.cs
@@ -55,8 +55,7 @@ internal sealed class DefaultHtmlCodeActionResolver : HtmlCodeActionResolver
             throw new ArgumentNullException(nameof(codeAction));
         }
 
-        var documentContext = _documentContextFactory.TryCreateForOpenDocument(resolveParams.RazorFileIdentifier);
-        if (documentContext is null)
+        if (!_documentContextFactory.TryCreateForOpenDocument(resolveParams.RazorFileIdentifier, out var documentContext))
         {
             return codeAction;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Html/DefaultHtmlCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Html/DefaultHtmlCodeActionResolver.cs
@@ -55,7 +55,7 @@ internal sealed class DefaultHtmlCodeActionResolver : HtmlCodeActionResolver
             throw new ArgumentNullException(nameof(codeAction));
         }
 
-        var documentContext = await _documentContextFactory.TryCreateForOpenDocumentAsync(resolveParams.RazorFileIdentifier, cancellationToken).ConfigureAwait(false);
+        var documentContext = _documentContextFactory.TryCreateForOpenDocument(resolveParams.RazorFileIdentifier);
         if (documentContext is null)
         {
             return codeAction;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/AddUsingsCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/AddUsingsCodeActionResolver.cs
@@ -45,7 +45,7 @@ internal sealed class AddUsingsCodeActionResolver : IRazorCodeActionResolver
             return null;
         }
 
-        var documentContext = await _documentContextFactory.TryCreateAsync(actionParams.Uri, cancellationToken).ConfigureAwait(false);
+        var documentContext = _documentContextFactory.TryCreate(actionParams.Uri);
         if (documentContext is null)
         {
             return null;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/AddUsingsCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/AddUsingsCodeActionResolver.cs
@@ -45,8 +45,7 @@ internal sealed class AddUsingsCodeActionResolver : IRazorCodeActionResolver
             return null;
         }
 
-        var documentContext = _documentContextFactory.TryCreate(actionParams.Uri);
-        if (documentContext is null)
+        if (!_documentContextFactory.TryCreate(actionParams.Uri, out var documentContext))
         {
             return null;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/CreateComponentCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/CreateComponentCodeActionResolver.cs
@@ -43,7 +43,7 @@ internal sealed class CreateComponentCodeActionResolver : IRazorCodeActionResolv
             return null;
         }
 
-        var documentContext = await _documentContextFactory.TryCreateAsync(actionParams.Uri, cancellationToken).ConfigureAwait(false);
+        var documentContext = _documentContextFactory.TryCreate(actionParams.Uri);
         if (documentContext is null)
         {
             return null;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/CreateComponentCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/CreateComponentCodeActionResolver.cs
@@ -43,8 +43,7 @@ internal sealed class CreateComponentCodeActionResolver : IRazorCodeActionResolv
             return null;
         }
 
-        var documentContext = _documentContextFactory.TryCreate(actionParams.Uri);
-        if (documentContext is null)
+        if (!_documentContextFactory.TryCreate(actionParams.Uri, out var documentContext))
         {
             return null;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
@@ -60,8 +60,7 @@ internal sealed class ExtractToCodeBehindCodeActionResolver : IRazorCodeActionRe
 
         var path = FilePathNormalizer.Normalize(actionParams.Uri.GetAbsoluteOrUNCPath());
 
-        var documentContext = _documentContextFactory.TryCreate(actionParams.Uri);
-        if (documentContext is null)
+        if (!_documentContextFactory.TryCreate(actionParams.Uri, out var documentContext))
         {
             return null;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
@@ -60,7 +60,7 @@ internal sealed class ExtractToCodeBehindCodeActionResolver : IRazorCodeActionRe
 
         var path = FilePathNormalizer.Normalize(actionParams.Uri.GetAbsoluteOrUNCPath());
 
-        var documentContext = await _documentContextFactory.TryCreateAsync(actionParams.Uri, cancellationToken).ConfigureAwait(false);
+        var documentContext = _documentContextFactory.TryCreate(actionParams.Uri);
         if (documentContext is null)
         {
             return null;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/GenerateMethodCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/GenerateMethodCodeActionResolver.cs
@@ -72,7 +72,7 @@ internal class GenerateMethodCodeActionResolver : IRazorCodeActionResolver
             return null;
         }
 
-        var documentContext = await _documentContextFactory.TryCreateForOpenDocumentAsync(actionParams.Uri, cancellationToken).ConfigureAwait(false);
+        var documentContext = _documentContextFactory.TryCreateForOpenDocument(actionParams.Uri);
         if (documentContext is null)
         {
             return null;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/GenerateMethodCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/GenerateMethodCodeActionResolver.cs
@@ -72,8 +72,7 @@ internal class GenerateMethodCodeActionResolver : IRazorCodeActionResolver
             return null;
         }
 
-        var documentContext = _documentContextFactory.TryCreateForOpenDocument(actionParams.Uri);
-        if (documentContext is null)
+        if (!_documentContextFactory.TryCreateForOpenDocument(actionParams.Uri, out var documentContext))
         {
             return null;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionItemResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionItemResolver.cs
@@ -100,7 +100,7 @@ internal class DelegatedCompletionItemResolver : CompletionItemResolver
         }
 
         var identifier = context.OriginalRequestParams.Identifier.TextDocumentIdentifier;
-        var documentContext = await _documentContextFactory.TryCreateForOpenDocumentAsync(identifier, cancellationToken).ConfigureAwait(false);
+        var documentContext = _documentContextFactory.TryCreateForOpenDocument(identifier);
         if (documentContext is null)
         {
             return resolvedCompletionItem;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionItemResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionItemResolver.cs
@@ -100,8 +100,7 @@ internal class DelegatedCompletionItemResolver : CompletionItemResolver
         }
 
         var identifier = context.OriginalRequestParams.Identifier.TextDocumentIdentifier;
-        var documentContext = _documentContextFactory.TryCreateForOpenDocument(identifier);
-        if (documentContext is null)
+        if (!_documentContextFactory.TryCreateForOpenDocument(identifier, out var documentContext))
         {
             return resolvedCompletionItem;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.cs
@@ -183,9 +183,8 @@ internal partial class RazorDiagnosticsPublisher : IDocumentProcessedListener, I
                     delegatedResponse.Value.TryGetFirst(out var fullDiagnostics) &&
                     fullDiagnostics.Items is not null)
                 {
-                    var documentContext = await _documentContextFactory.Value
-                        .TryCreateAsync(delegatedParams.TextDocument.Uri, projectContext: null, token)
-                        .ConfigureAwait(false);
+                    var documentContext = _documentContextFactory.Value
+                        .TryCreate(delegatedParams.TextDocument.Uri, projectContext: null);
 
                     if (documentContext is not null)
                     {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.cs
@@ -183,10 +183,7 @@ internal partial class RazorDiagnosticsPublisher : IDocumentProcessedListener, I
                     delegatedResponse.Value.TryGetFirst(out var fullDiagnostics) &&
                     fullDiagnostics.Items is not null)
                 {
-                    var documentContext = _documentContextFactory.Value
-                        .TryCreate(delegatedParams.TextDocument.Uri, projectContext: null);
-
-                    if (documentContext is not null)
+                    if (_documentContextFactory.Value.TryCreate(delegatedParams.TextDocument.Uri, projectContext: null, out var documentContext))
                     {
                         return await _translateDiagnosticsService.Value
                             .TranslateAsync(RazorLanguageKind.CSharp, fullDiagnostics.Items, documentContext, token)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentContextFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentContextFactory.cs
@@ -106,7 +106,7 @@ internal sealed class DocumentContextFactory(
         // Couldn't find the document in a real project. Maybe the language server doesn't yet know about the project
         // that the IDE is asking us about. In that case, we might have the document in our misc files project, and we'll
         // move it to the real project when/if we find out about it.
-        var miscellaneousProject = await _snapshotResolver.GetMiscellaneousProjectAsync(cancellationToken).ConfigureAwait(false);
+        var miscellaneousProject = _snapshotResolver.GetMiscellaneousProject();
         var normalizedDocumentPath = FilePathNormalizer.Normalize(filePath);
         if (miscellaneousProject.GetDocument(normalizedDocumentPath) is { } miscDocument)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentContextFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentContextFactory.cs
@@ -100,8 +100,7 @@ internal sealed class DocumentContextFactory(
     {
         if (projectContext is null)
         {
-            documentSnapshot = _snapshotResolver.ResolveDocumentInAnyProject(filePath);
-            return documentSnapshot is not null;
+            return _snapshotResolver.TryResolveDocumentInAnyProject(filePath, out documentSnapshot);
         }
 
         if (_projectManager.TryGetLoadedProject(projectContext.ToProjectKey(), out var project) &&

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentContextFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentContextFactory.cs
@@ -92,9 +92,7 @@ internal sealed class DocumentContextFactory(
     {
         if (projectContext is null)
         {
-            return await _snapshotResolver
-                .ResolveDocumentInAnyProjectAsync(filePath, cancellationToken)
-                .ConfigureAwait(false);
+            return _snapshotResolver.ResolveDocumentInAnyProject(filePath);
         }
 
         if (_projectManager.TryGetLoadedProject(projectContext.ToProjectKey(), out var project) &&

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentPresentation/TextDocumentUriPresentationEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentPresentation/TextDocumentUriPresentationEndpoint.cs
@@ -116,7 +116,7 @@ internal class TextDocumentUriPresentationEndpoint(
     {
         Logger.LogInformation($"Trying to find document info for dropped uri {uri}.");
 
-        var documentContext = await _documentContextFactory.TryCreateAsync(uri, cancellationToken).ConfigureAwait(false);
+        var documentContext = _documentContextFactory.TryCreate(uri);
         if (documentContext is null)
         {
             Logger.LogInformation($"Failed to find document for component {uri}.");

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentPresentation/TextDocumentUriPresentationEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentPresentation/TextDocumentUriPresentationEndpoint.cs
@@ -116,8 +116,7 @@ internal class TextDocumentUriPresentationEndpoint(
     {
         Logger.LogInformation($"Trying to find document info for dropped uri {uri}.");
 
-        var documentContext = _documentContextFactory.TryCreate(uri);
-        if (documentContext is null)
+        if (!_documentContextFactory.TryCreate(uri, out var documentContext))
         {
             Logger.LogInformation($"Failed to find document for component {uri}.");
             return null;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 
 internal static class IServiceCollectionExtensions
 {
-    public static void AddLifeCycleServices(this IServiceCollection services, RazorLanguageServer razorLanguageServer, ClientConnection serverManager, ILspServerActivationTracker? lspServerActivationTracker)
+    public static void AddLifeCycleServices(this IServiceCollection services, RazorLanguageServer razorLanguageServer, ClientConnection clientConnection, ILspServerActivationTracker? lspServerActivationTracker)
     {
         services.AddHandler<RazorInitializeEndpoint>();
         services.AddHandler<RazorInitializedEndpoint>();
@@ -51,7 +51,7 @@ internal static class IServiceCollectionExtensions
 
         services.AddSingleton<ICapabilitiesProvider, RazorLanguageServerCapability>();
 
-        services.AddSingleton<IOnInitialized>(serverManager);
+        services.AddSingleton<IOnInitialized>(clientConnection);
     }
 
     public static void AddFormattingServices(this IServiceCollection services)
@@ -207,6 +207,7 @@ internal static class IServiceCollectionExtensions
 
         services.AddSingleton<RemoteTextLoaderFactory, DefaultRemoteTextLoaderFactory>();
         services.AddSingleton<ISnapshotResolver, SnapshotResolver>();
+        services.AddSingleton<IOnInitialized>(sp => (SnapshotResolver)sp.GetRequiredService<ISnapshotResolver>());
         services.AddSingleton<IRazorProjectService, RazorProjectService>();
         services.AddSingleton<IRazorStartupService, OpenDocumentGenerator>();
         services.AddSingleton<IRazorDocumentMappingService, RazorDocumentMappingService>();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
@@ -212,6 +212,7 @@ internal static class IServiceCollectionExtensions
         services.AddSingleton<IRazorStartupService, OpenDocumentGenerator>();
         services.AddSingleton<IRazorDocumentMappingService, RazorDocumentMappingService>();
         services.AddSingleton<RazorFileChangeDetectorManager>();
+        services.AddSingleton<IOnInitialized>(sp => sp.GetRequiredService<RazorFileChangeDetectorManager>());
 
         if (featureOptions.UseProjectConfigurationEndpoint)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/HoverService.TestAccessor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/HoverService.TestAccessor.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover;
+
+internal sealed partial class HoverService
+{
+    internal TestAccessor GetTestAccessor() => new(this);
+
+    internal sealed class TestAccessor(HoverService instance)
+    {
+        public Task<VSInternalHover?> GetHoverInfoAsync(
+            string documentFilePath,
+            RazorCodeDocument codeDocument,
+            SourceLocation location,
+            VSInternalClientCapabilities clientCapabilities,
+            CancellationToken cancellationToken)
+            => instance.GetHoverInfoAsync(documentFilePath, codeDocument, location, clientCapabilities, cancellationToken);
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/HoverService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/HoverService.cs
@@ -24,7 +24,7 @@ using VisualStudioMarkupKind = Microsoft.VisualStudio.LanguageServer.Protocol.Ma
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover;
 
-internal sealed class HoverService(
+internal sealed partial class HoverService(
     LSPTagHelperTooltipFactory lspTagHelperTooltipFactory,
     VSLSPTagHelperTooltipFactory vsLspTagHelperTooltipFactory,
     IRazorDocumentMappingService mappingService,
@@ -94,15 +94,13 @@ internal sealed class HoverService(
         return response;
     }
 
-    public TestAccessor GetTestAccessor() => new(this);
-
-    public async Task<VSInternalHover?> GetHoverInfoAsync(string documentFilePath, RazorCodeDocument codeDocument, SourceLocation location, VSInternalClientCapabilities clientCapabilities, CancellationToken cancellationToken)
+    private async Task<VSInternalHover?> GetHoverInfoAsync(
+        string documentFilePath,
+        RazorCodeDocument codeDocument,
+        SourceLocation location,
+        VSInternalClientCapabilities clientCapabilities,
+        CancellationToken cancellationToken)
     {
-        if (codeDocument is null)
-        {
-            throw new ArgumentNullException(nameof(codeDocument));
-        }
-
         var syntaxTree = codeDocument.GetSyntaxTree();
 
         var owner = syntaxTree.Root.FindInnermostNode(location.AbsoluteIndex);
@@ -349,11 +347,5 @@ internal sealed class HoverService(
         var hoverContentFormat = clientCapabilities.TextDocument?.Hover?.ContentFormat;
         var hoverKind = hoverContentFormat?.Contains(VisualStudioMarkupKind.Markdown) == true ? VisualStudioMarkupKind.Markdown : VisualStudioMarkupKind.PlainText;
         return hoverKind;
-    }
-
-    public class TestAccessor(HoverService service)
-    {
-        public Task<VSInternalHover?> GetHoverInfoAsync(string documentFilePath, RazorCodeDocument codeDocument, SourceLocation location, VSInternalClientCapabilities clientCapabilities, CancellationToken cancellationToken)
-            => service.GetHoverInfoAsync(documentFilePath, codeDocument, location, clientCapabilities, cancellationToken);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IOnInitialized.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IOnInitialized.cs
@@ -3,11 +3,12 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
 internal interface IOnInitialized
 {
-    Task OnInitializedAsync(VSInternalClientCapabilities clientCapabilities, CancellationToken cancellationToken);
+    Task OnInitializedAsync(ILspServices services, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IOnInitialized.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IOnInitialized.cs
@@ -10,5 +10,5 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
 internal interface IOnInitialized
 {
-    Task InitializeAsync(ILspServices services, CancellationToken cancellationToken);
+    Task OnInitializedAsync(ILspServices services, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IOnInitialized.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IOnInitialized.cs
@@ -10,5 +10,5 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
 internal interface IOnInitialized
 {
-    Task OnInitializedAsync(ILspServices services, CancellationToken cancellationToken);
+    Task InitializeAsync(ILspServices services, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MapCode/MapCodeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MapCode/MapCodeEndpoint.cs
@@ -85,8 +85,7 @@ internal sealed class MapCodeEndpoint(
                 continue;
             }
 
-            var documentContext = _documentContextFactory.TryCreateForOpenDocument(mapping.TextDocument.Uri);
-            if (documentContext is null)
+            if (!_documentContextFactory.TryCreateForOpenDocument(mapping.TextDocument.Uri, out var documentContext))
             {
                 continue;
             }
@@ -356,8 +355,7 @@ internal sealed class MapCodeEndpoint(
                     continue;
                 }
 
-                var documentContext = _documentContextFactory.TryCreateForOpenDocument(potentialLocation.Uri);
-                if (documentContext is null)
+                if (!_documentContextFactory.TryCreateForOpenDocument(potentialLocation.Uri, out var documentContext))
                 {
                     continue;
                 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MapCode/MapCodeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MapCode/MapCodeEndpoint.cs
@@ -85,7 +85,7 @@ internal sealed class MapCodeEndpoint(
                 continue;
             }
 
-            var documentContext = await _documentContextFactory.TryCreateForOpenDocumentAsync(mapping.TextDocument.Uri, cancellationToken).ConfigureAwait(false);
+            var documentContext = _documentContextFactory.TryCreateForOpenDocument(mapping.TextDocument.Uri);
             if (documentContext is null)
             {
                 continue;
@@ -356,7 +356,7 @@ internal sealed class MapCodeEndpoint(
                     continue;
                 }
 
-                var documentContext = await _documentContextFactory.TryCreateForOpenDocumentAsync(potentialLocation.Uri, cancellationToken).ConfigureAwait(false);
+                var documentContext = _documentContextFactory.TryCreateForOpenDocument(potentialLocation.Uri);
                 if (documentContext is null)
                 {
                     continue;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/ISnapshotResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/ISnapshotResolver.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -23,5 +24,5 @@ internal interface ISnapshotResolver
     /// Finds a <see cref="IDocumentSnapshot"/> for the given document path that is contained within any project, and returns the first
     /// one found if it does. This method should be avoided where possible, and the overload that takes a <see cref="ProjectKey"/> should be used instead
     /// </summary>
-    IDocumentSnapshot? ResolveDocumentInAnyProject(string documentFilePath);
+    bool TryResolveDocumentInAnyProject(string documentFilePath, [NotNullWhen(true)] out IDocumentSnapshot? document);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/ISnapshotResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/ISnapshotResolver.cs
@@ -10,6 +10,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 
 internal interface ISnapshotResolver
 {
+    Task InitializeAsync(CancellationToken cancellationToken);
+
     /// <summary>
     /// Finds all the projects where the document path starts with the path of the folder that contains the project file.
     /// </summary>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/ISnapshotResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/ISnapshotResolver.cs
@@ -11,8 +11,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 
 internal interface ISnapshotResolver
 {
-    Task InitializeAsync(CancellationToken cancellationToken);
-
     /// <summary>
     /// Finds all the projects where the document path starts with the path of the folder that contains the project file.
     /// </summary>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/ISnapshotResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/ISnapshotResolver.cs
@@ -17,7 +17,7 @@ internal interface ISnapshotResolver
     /// </summary>
     ImmutableArray<IProjectSnapshot> FindPotentialProjects(string documentFilePath);
 
-    Task<IProjectSnapshot> GetMiscellaneousProjectAsync(CancellationToken cancellationToken);
+    IProjectSnapshot GetMiscellaneousProject();
 
     /// <summary>
     /// Finds a <see cref="IDocumentSnapshot"/> for the given document path that is contained within any project, and returns the first

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/ISnapshotResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/ISnapshotResolver.cs
@@ -23,5 +23,5 @@ internal interface ISnapshotResolver
     /// Finds a <see cref="IDocumentSnapshot"/> for the given document path that is contained within any project, and returns the first
     /// one found if it does. This method should be avoided where possible, and the overload that takes a <see cref="ProjectKey"/> should be used instead
     /// </summary>
-    Task<IDocumentSnapshot?> ResolveDocumentInAnyProjectAsync(string documentFilePath, CancellationToken cancellationToken);
+    IDocumentSnapshot? ResolveDocumentInAnyProject(string documentFilePath);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/ISnapshotResolverExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/ISnapshotResolverExtensions.cs
@@ -30,7 +30,7 @@ internal static class ISnapshotResolverExtensions
         }
 
         var normalizedDocumentPath = FilePathNormalizer.Normalize(documentFilePath);
-        var miscProject = await snapshotResolver.GetMiscellaneousProjectAsync(cancellationToken).ConfigureAwait(false);
+        var miscProject = snapshotResolver.GetMiscellaneousProject();
         if (miscProject.GetDocument(normalizedDocumentPath) is not null)
         {
             projects.Add(miscProject);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/ISnapshotResolverExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/ISnapshotResolverExtensions.cs
@@ -12,19 +12,20 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 
 internal static class ISnapshotResolverExtensions
 {
-    public static ImmutableArray<IProjectSnapshot> TryResolveAllProjects(
+    public static bool TryResolveAllProjects(
         this ISnapshotResolver snapshotResolver,
-        string documentFilePath)
+        string documentFilePath,
+        out ImmutableArray<IProjectSnapshot> projects)
     {
         var potentialProjects = snapshotResolver.FindPotentialProjects(documentFilePath);
 
-        using var projects = new PooledArrayBuilder<IProjectSnapshot>(capacity: potentialProjects.Length);
+        using var builder = new PooledArrayBuilder<IProjectSnapshot>(capacity: potentialProjects.Length);
 
         foreach (var project in potentialProjects)
         {
             if (project.GetDocument(documentFilePath) is not null)
             {
-                projects.Add(project);
+                builder.Add(project);
             }
         }
 
@@ -32,9 +33,10 @@ internal static class ISnapshotResolverExtensions
         var miscProject = snapshotResolver.GetMiscellaneousProject();
         if (miscProject.GetDocument(normalizedDocumentPath) is not null)
         {
-            projects.Add(miscProject);
+            builder.Add(miscProject);
         }
 
-        return projects.DrainToImmutable();
+        projects = builder.DrainToImmutable();
+        return projects.Length > 0;
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/ISnapshotResolverExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/ISnapshotResolverExtensions.cs
@@ -12,10 +12,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 
 internal static class ISnapshotResolverExtensions
 {
-    public static async Task<ImmutableArray<IProjectSnapshot>> TryResolveAllProjectsAsync(
+    public static ImmutableArray<IProjectSnapshot> TryResolveAllProjects(
         this ISnapshotResolver snapshotResolver,
-        string documentFilePath,
-        CancellationToken cancellationToken)
+        string documentFilePath)
     {
         var potentialProjects = snapshotResolver.FindPotentialProjects(documentFilePath);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
@@ -111,9 +111,7 @@ internal class RazorProjectService(
                 // We are okay to use the non-project-key overload of TryResolveDocument here because we really are just checking if the document
                 // has been added to _any_ project. AddDocument will take care of adding to all of the necessary ones, and then below we ensure
                 // we process them all too
-                var document = _snapshotResolver.ResolveDocumentInAnyProject(textDocumentPath);
-
-                if (document is null)
+                if (!_snapshotResolver.TryResolveDocumentInAnyProject(textDocumentPath, out var document))
                 {
                     // Document hasn't been added. This usually occurs when VSCode trumps all other initialization
                     // processes and pre-initializes already open documents.

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
@@ -66,7 +66,7 @@ internal class RazorProjectService(
 
         if (!added)
         {
-            var miscFilesProject = await _snapshotResolver.GetMiscellaneousProjectAsync(cancellationToken).ConfigureAwait(false);
+            var miscFilesProject = _snapshotResolver.GetMiscellaneousProject();
             await AddDocumentToProjectAsync(miscFilesProject, textDocumentPath, cancellationToken).ConfigureAwait(false);
         }
 
@@ -203,7 +203,7 @@ internal class RazorProjectService(
             if (_projectManager.IsDocumentOpen(textDocumentPath))
             {
                 _logger.LogInformation($"Moving document '{textDocumentPath}' from project '{projectSnapshot.Key}' to misc files because it is open.");
-                var miscellaneousProject = await _snapshotResolver.GetMiscellaneousProjectAsync(cancellationToken).ConfigureAwait(false);
+                var miscellaneousProject = _snapshotResolver.GetMiscellaneousProject();
                 if (projectSnapshot != miscellaneousProject)
                 {
                     await MoveDocumentAsync(textDocumentPath, projectSnapshot, miscellaneousProject, cancellationToken).ConfigureAwait(false);
@@ -261,7 +261,7 @@ internal class RazorProjectService(
         var projects = await _snapshotResolver.TryResolveAllProjectsAsync(textDocumentPath, cancellationToken).ConfigureAwait(false);
         if (projects.IsEmpty)
         {
-            var miscFilesProject = await _snapshotResolver.GetMiscellaneousProjectAsync(cancellationToken).ConfigureAwait(false);
+            var miscFilesProject = _snapshotResolver.GetMiscellaneousProject();
             projects = [miscFilesProject];
         }
 
@@ -373,7 +373,7 @@ internal class RazorProjectService(
         var currentProjectKey = project.Key;
         var projectDirectory = FilePathNormalizer.GetNormalizedDirectoryName(project.FilePath);
         var documentMap = documents.ToDictionary(document => EnsureFullPath(document.FilePath, projectDirectory), FilePathComparer.Instance);
-        var miscellaneousProject = await _snapshotResolver.GetMiscellaneousProjectAsync(cancellationToken).ConfigureAwait(false);
+        var miscellaneousProject = _snapshotResolver.GetMiscellaneousProject();
 
         // "Remove" any unnecessary documents by putting them into the misc project
         foreach (var documentFilePath in project.DocumentFilePaths)
@@ -433,7 +433,7 @@ internal class RazorProjectService(
         }
 
         project = _projectManager.GetLoadedProject(project.Key);
-        miscellaneousProject = await _snapshotResolver.GetMiscellaneousProjectAsync(cancellationToken).ConfigureAwait(false);
+        miscellaneousProject = _snapshotResolver.GetMiscellaneousProject();
 
         // Add (or migrate from misc) any new documents
         foreach (var documentKvp in documentMap)
@@ -508,7 +508,7 @@ internal class RazorProjectService(
 
     private async Task TryMigrateMiscellaneousDocumentsToProjectAsync(CancellationToken cancellationToken)
     {
-        var miscellaneousProject = await _snapshotResolver.GetMiscellaneousProjectAsync(cancellationToken).ConfigureAwait(false);
+        var miscellaneousProject = _snapshotResolver.GetMiscellaneousProject();
 
         foreach (var documentFilePath in miscellaneousProject.DocumentFilePaths)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
@@ -258,7 +258,7 @@ internal class RazorProjectService(
         CancellationToken cancellationToken)
     {
         var textDocumentPath = FilePathNormalizer.Normalize(filePath);
-        var projects = await _snapshotResolver.TryResolveAllProjectsAsync(textDocumentPath, cancellationToken).ConfigureAwait(false);
+        var projects = _snapshotResolver.TryResolveAllProjects(textDocumentPath);
         if (projects.IsEmpty)
         {
             var miscFilesProject = _snapshotResolver.GetMiscellaneousProject();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
@@ -123,9 +123,7 @@ internal class RazorProjectService(
         // We are okay to use the non-project-key overload of TryResolveDocument here because we really are just checking if the document
         // has been added to _any_ project. AddDocument will take care of adding to all of the necessary ones, and then below we ensure
         // we process them all too
-        var document = await _snapshotResolver
-            .ResolveDocumentInAnyProjectAsync(textDocumentPath, cancellationToken)
-            .ConfigureAwait(false);
+        var document = _snapshotResolver.ResolveDocumentInAnyProject(textDocumentPath);
 
         if (document is null)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
@@ -29,7 +29,7 @@ internal class RazorProjectService(
     IDocumentVersionCache documentVersionCache,
     IProjectSnapshotManager projectManager,
     ILoggerFactory loggerFactory)
-    : IRazorProjectService, IDisposable
+    : IRazorProjectService
 {
     private readonly IProjectSnapshotManager _projectManager = projectManager;
     private readonly RemoteTextLoaderFactory _remoteTextLoaderFactory = remoteTextLoaderFactory;
@@ -37,23 +37,15 @@ internal class RazorProjectService(
     private readonly IDocumentVersionCache _documentVersionCache = documentVersionCache;
     private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<RazorProjectService>();
 
-    // This lock is used to ensure that the public entry points to the project service,
-    // i.e. AddDocumentAsync, OpenDocumentAsync, etc., cannot interleave.
-    private readonly AsyncSemaphore _gate = new(initialCount: 1);
-
-    public void Dispose()
+    public Task AddDocumentAsync(string filePath, CancellationToken cancellationToken)
     {
-        _gate.Dispose();
+        return _projectManager.UpdateAsync(
+            updater: AddDocumentCore,
+            state: filePath,
+            cancellationToken);
     }
 
-    public async Task AddDocumentAsync(string filePath, CancellationToken cancellationToken)
-    {
-        using var _ = await _gate.EnterAsync(cancellationToken).ConfigureAwait(false);
-
-        await AddDocumentNeedsLocksAsync(filePath, cancellationToken).ConfigureAwait(false);
-    }
-
-    private async Task AddDocumentNeedsLocksAsync(string filePath, CancellationToken cancellationToken)
+    private void AddDocumentCore(ProjectSnapshotManager.Updater updater, string filePath)
     {
         var textDocumentPath = FilePathNormalizer.Normalize(filePath);
 
@@ -61,16 +53,16 @@ internal class RazorProjectService(
         foreach (var projectSnapshot in _snapshotResolver.FindPotentialProjects(textDocumentPath))
         {
             added = true;
-            await AddDocumentToProjectAsync(projectSnapshot, textDocumentPath, cancellationToken).ConfigureAwait(false);
+            AddDocumentToProject(updater, projectSnapshot, textDocumentPath);
         }
 
         if (!added)
         {
             var miscFilesProject = _snapshotResolver.GetMiscellaneousProject();
-            await AddDocumentToProjectAsync(miscFilesProject, textDocumentPath, cancellationToken).ConfigureAwait(false);
+            AddDocumentToProject(updater, miscFilesProject, textDocumentPath);
         }
 
-        async Task AddDocumentToProjectAsync(IProjectSnapshot projectSnapshot, string textDocumentPath, CancellationToken cancellationToken)
+        void AddDocumentToProject(ProjectSnapshotManager.Updater updater, IProjectSnapshot projectSnapshot, string textDocumentPath)
         {
             if (projectSnapshot.GetDocument(FilePathNormalizer.Normalize(textDocumentPath)) is not null)
             {
@@ -95,12 +87,7 @@ internal class RazorProjectService(
 
             _logger.LogInformation($"Adding document '{filePath}' to project '{projectSnapshot.Key}'.");
 
-            await _projectManager
-                .UpdateAsync(
-                    static (updater, state) => updater.DocumentAdded(state.key, state.hostDocument, state.textLoader),
-                    state: (key: projectSnapshot.Key, hostDocument, textLoader),
-                    cancellationToken)
-                .ConfigureAwait(false);
+            updater.DocumentAdded(projectSnapshot.Key, hostDocument, textLoader);
 
             // Adding a document to a project could also happen because a target was added to a project, or we're moving a document
             // from Misc Project to a real one, and means the newly added document could actually already be open.
@@ -109,151 +96,137 @@ internal class RazorProjectService(
                 _projectManager.TryGetLoadedProject(projectSnapshot.Key, out var project) &&
                 project.GetDocument(textDocumentPath) is { } document)
             {
-                _ = document.GetGeneratedOutputAsync();
+                document.GetGeneratedOutputAsync().Forget();
             }
         }
     }
 
-    public async Task OpenDocumentAsync(string filePath, SourceText sourceText, int version, CancellationToken cancellationToken)
+    public Task OpenDocumentAsync(string filePath, SourceText sourceText, int version, CancellationToken cancellationToken)
     {
-        using var _ = await _gate.EnterAsync(cancellationToken).ConfigureAwait(false);
-
-        var textDocumentPath = FilePathNormalizer.Normalize(filePath);
-
-        // We are okay to use the non-project-key overload of TryResolveDocument here because we really are just checking if the document
-        // has been added to _any_ project. AddDocument will take care of adding to all of the necessary ones, and then below we ensure
-        // we process them all too
-        var document = _snapshotResolver.ResolveDocumentInAnyProject(textDocumentPath);
-
-        if (document is null)
-        {
-            // Document hasn't been added. This usually occurs when VSCode trumps all other initialization
-            // processes and pre-initializes already open documents.
-            await AddDocumentNeedsLocksAsync(filePath, cancellationToken).ConfigureAwait(false);
-        }
-
-        await ActOnDocumentInMultipleProjectsAsync(
-            filePath,
-            async (projectSnapshot, textDocumentPath, cancellationToken) =>
+        return _projectManager.UpdateAsync(
+            updater =>
             {
-                _logger.LogInformation($"Opening document '{textDocumentPath}' in project '{projectSnapshot.Key}'.");
+                var textDocumentPath = FilePathNormalizer.Normalize(filePath);
 
-                await _projectManager
-                    .UpdateAsync(
-                        static (updater, state) => updater.DocumentOpened(state.key, state.textDocumentPath, state.sourceText),
-                        state: (key: projectSnapshot.Key, textDocumentPath, sourceText),
-                        cancellationToken)
-                    .ConfigureAwait(false);
-            },
-            cancellationToken).ConfigureAwait(false);
+                // We are okay to use the non-project-key overload of TryResolveDocument here because we really are just checking if the document
+                // has been added to _any_ project. AddDocument will take care of adding to all of the necessary ones, and then below we ensure
+                // we process them all too
+                var document = _snapshotResolver.ResolveDocumentInAnyProject(textDocumentPath);
 
-        // Use a separate loop, as the above call modified out projects, so we have to make sure we're operating on the latest snapshot
-        await ActOnDocumentInMultipleProjectsAsync(
-            filePath,
-            (projectSnapshot, textDocumentPath, cancellationToken) =>
-            {
-                TrackDocumentVersion(projectSnapshot, textDocumentPath, version, startGenerating: true);
-                return Task.CompletedTask;
-            },
-            cancellationToken).ConfigureAwait(false);
-    }
-
-    public async Task CloseDocumentAsync(string filePath, CancellationToken cancellationToken)
-    {
-        using var _ = await _gate.EnterAsync(cancellationToken).ConfigureAwait(false);
-
-        await ActOnDocumentInMultipleProjectsAsync(
-            filePath,
-            (projectSnapshot, textDocumentPath, cancellationToken) =>
-            {
-                var textLoader = _remoteTextLoaderFactory.Create(filePath);
-                _logger.LogInformation($"Closing document '{textDocumentPath}' in project '{projectSnapshot.Key}'.");
-
-                return _projectManager.UpdateAsync(
-                    static (updater, state) => updater.DocumentClosed(state.key, state.textDocumentPath, state.textLoader),
-                    state: (key: projectSnapshot.Key, textDocumentPath, textLoader),
-                    cancellationToken);
-            },
-            cancellationToken).ConfigureAwait(false);
-    }
-
-    public async Task RemoveDocumentAsync(string filePath, CancellationToken cancellationToken)
-    {
-        using var _ = await _gate.EnterAsync(cancellationToken).ConfigureAwait(false);
-
-        await ActOnDocumentInMultipleProjectsAsync(filePath, async (projectSnapshot, textDocumentPath, cancellationToken) =>
-        {
-            if (!projectSnapshot.DocumentFilePaths.Contains(textDocumentPath, FilePathComparer.Instance))
-            {
-                _logger.LogInformation($"Containing project is not tracking document '{textDocumentPath}'");
-                return;
-            }
-
-            if (projectSnapshot.GetDocument(textDocumentPath) is not DocumentSnapshot documentSnapshot)
-            {
-                _logger.LogError($"Containing project does not contain document '{textDocumentPath}'");
-                return;
-            }
-
-            // If the document is open, we can't remove it, because we could still get a request for it, and that
-            // request would fail. Instead we move it to the miscellaneous project, just like if we got notified of
-            // a remove via the project.razor.bin
-            if (_projectManager.IsDocumentOpen(textDocumentPath))
-            {
-                _logger.LogInformation($"Moving document '{textDocumentPath}' from project '{projectSnapshot.Key}' to misc files because it is open.");
-                var miscellaneousProject = _snapshotResolver.GetMiscellaneousProject();
-                if (projectSnapshot != miscellaneousProject)
+                if (document is null)
                 {
-                    await MoveDocumentAsync(textDocumentPath, projectSnapshot, miscellaneousProject, cancellationToken).ConfigureAwait(false);
+                    // Document hasn't been added. This usually occurs when VSCode trumps all other initialization
+                    // processes and pre-initializes already open documents.
+                    AddDocumentCore(updater, filePath);
                 }
-            }
-            else
-            {
-                _logger.LogInformation($"Removing document '{textDocumentPath}' from project '{projectSnapshot.Key}'.");
 
-                await _projectManager
-                    .UpdateAsync(
-                        static (updater, state) => updater.DocumentRemoved(state.Key, state.HostDocument),
-                        state: (projectSnapshot.Key, documentSnapshot.State.HostDocument),
-                        cancellationToken)
-                    .ConfigureAwait(false);
-            }
-        },
-        cancellationToken).ConfigureAwait(false);
+                ActOnDocumentInMultipleProjects(
+                    filePath,
+                    (projectSnapshot, textDocumentPath) =>
+                    {
+                        _logger.LogInformation($"Opening document '{textDocumentPath}' in project '{projectSnapshot.Key}'.");
+                        updater.DocumentOpened(projectSnapshot.Key, textDocumentPath, sourceText);
+                    });
+
+                // Use a separate loop, as the above call modified out projects, so we have to make sure we're operating on the latest snapshot
+                ActOnDocumentInMultipleProjects(
+                    filePath,
+                    (projectSnapshot, textDocumentPath) =>
+                    {
+                        TrackDocumentVersion(projectSnapshot, textDocumentPath, version, startGenerating: true);
+                    });
+            },
+            cancellationToken);
     }
 
-    public async Task UpdateDocumentAsync(string filePath, SourceText sourceText, int version, CancellationToken cancellationToken)
+    public Task CloseDocumentAsync(string filePath, CancellationToken cancellationToken)
     {
-        using var _ = await _gate.EnterAsync(cancellationToken).ConfigureAwait(false);
-
-        await ActOnDocumentInMultipleProjectsAsync(
-            filePath,
-            (project, textDocumentPath, cancellationToken) =>
+        return _projectManager.UpdateAsync(
+            updater =>
             {
-                _logger.LogTrace($"Updating document '{textDocumentPath}' in {project.Key}.");
+                ActOnDocumentInMultipleProjects(
+                    filePath,
+                    (projectSnapshot, textDocumentPath) =>
+                    {
+                        var textLoader = _remoteTextLoaderFactory.Create(filePath);
+                        _logger.LogInformation($"Closing document '{textDocumentPath}' in project '{projectSnapshot.Key}'.");
 
-                return _projectManager.UpdateAsync(
-                    static (updater, state) => updater.DocumentChanged(state.key, state.textDocumentPath, state.sourceText),
-                    state: (key: project.Key, textDocumentPath, sourceText),
-                    cancellationToken);
+                        updater.DocumentClosed(projectSnapshot.Key, textDocumentPath, textLoader);
+                    });
             },
-            cancellationToken).ConfigureAwait(false);
-
-        // Use a separate loop, as the above call modified out projects, so we have to make sure we're operating on the latest snapshot
-        await ActOnDocumentInMultipleProjectsAsync(
-            filePath,
-            (projectSnapshot, textDocumentPath, cancellationToken) =>
-            {
-                TrackDocumentVersion(projectSnapshot, textDocumentPath, version, startGenerating: false);
-                return Task.CompletedTask;
-            },
-            cancellationToken).ConfigureAwait(false);
+            cancellationToken);
     }
 
-    private async Task ActOnDocumentInMultipleProjectsAsync(
-        string filePath,
-        Func<IProjectSnapshot, string, CancellationToken, Task> func,
-        CancellationToken cancellationToken)
+    public Task RemoveDocumentAsync(string filePath, CancellationToken cancellationToken)
+    {
+        return _projectManager.UpdateAsync(
+            updater =>
+            {
+                ActOnDocumentInMultipleProjects(
+                    filePath,
+                    (projectSnapshot, textDocumentPath) =>
+                    {
+                        if (!projectSnapshot.DocumentFilePaths.Contains(textDocumentPath, FilePathComparer.Instance))
+                        {
+                            _logger.LogInformation($"Containing project is not tracking document '{textDocumentPath}'");
+                            return;
+                        }
+
+                        if (projectSnapshot.GetDocument(textDocumentPath) is not DocumentSnapshot documentSnapshot)
+                        {
+                            _logger.LogError($"Containing project does not contain document '{textDocumentPath}'");
+                            return;
+                        }
+
+                        // If the document is open, we can't remove it, because we could still get a request for it, and that
+                        // request would fail. Instead we move it to the miscellaneous project, just like if we got notified of
+                        // a remove via the project.razor.bin
+                        if (_projectManager.IsDocumentOpen(textDocumentPath))
+                        {
+                            _logger.LogInformation($"Moving document '{textDocumentPath}' from project '{projectSnapshot.Key}' to misc files because it is open.");
+                            var miscellaneousProject = _snapshotResolver.GetMiscellaneousProject();
+                            if (projectSnapshot != miscellaneousProject)
+                            {
+                                MoveDocument(updater, textDocumentPath, fromProject: projectSnapshot, toProject: miscellaneousProject);
+                            }
+                        }
+                        else
+                        {
+                            _logger.LogInformation($"Removing document '{textDocumentPath}' from project '{projectSnapshot.Key}'.");
+
+                            updater.DocumentRemoved(projectSnapshot.Key, documentSnapshot.State.HostDocument);
+                        }
+                    });
+            },
+            cancellationToken);
+    }
+
+    public Task UpdateDocumentAsync(string filePath, SourceText sourceText, int version, CancellationToken cancellationToken)
+    {
+        return _projectManager.UpdateAsync(
+            updater =>
+            {
+                ActOnDocumentInMultipleProjects(
+                    filePath,
+                    (project, textDocumentPath) =>
+                    {
+                        _logger.LogTrace($"Updating document '{textDocumentPath}' in {project.Key}.");
+
+                        updater.DocumentChanged(project.Key, textDocumentPath, sourceText);
+                    });
+
+                // Use a separate loop, as the above call modified out projects, so we have to make sure we're operating on the latest snapshot
+                ActOnDocumentInMultipleProjects(
+                    filePath,
+                    (projectSnapshot, textDocumentPath) =>
+                    {
+                        TrackDocumentVersion(projectSnapshot, textDocumentPath, version, startGenerating: false);
+                    });
+            },
+            cancellationToken);
+    }
+
+    private void ActOnDocumentInMultipleProjects(string filePath, Action<IProjectSnapshot, string> action)
     {
         var textDocumentPath = FilePathNormalizer.Normalize(filePath);
         var projects = _snapshotResolver.TryResolveAllProjects(textDocumentPath);
@@ -265,11 +238,11 @@ internal class RazorProjectService(
 
         foreach (var project in projects)
         {
-            await func(project, textDocumentPath, cancellationToken).ConfigureAwait(false);
+            action(project, textDocumentPath);
         }
     }
 
-    public async Task<ProjectKey> AddProjectAsync(
+    public Task<ProjectKey> AddProjectAsync(
         string filePath,
         string intermediateOutputPath,
         RazorConfiguration? configuration,
@@ -277,28 +250,26 @@ internal class RazorProjectService(
         string? displayName,
         CancellationToken cancellationToken)
     {
-        using var _ = await _gate.EnterAsync(cancellationToken).ConfigureAwait(false);
+        return _projectManager.UpdateAsync(
+            updater =>
+            {
+                var normalizedPath = FilePathNormalizer.Normalize(filePath);
+                var hostProject = new HostProject(
+                    normalizedPath, intermediateOutputPath, configuration ?? FallbackRazorConfiguration.Latest, rootNamespace, displayName);
 
-        var normalizedPath = FilePathNormalizer.Normalize(filePath);
-        var hostProject = new HostProject(
-            normalizedPath, intermediateOutputPath, configuration ?? FallbackRazorConfiguration.Latest, rootNamespace, displayName);
+                // ProjectAdded will no-op if the project already exists
+                updater.ProjectAdded(hostProject);
 
-        // ProjectAdded will no-op if the project already exists
-        await _projectManager
-            .UpdateAsync(
-                static (updater, hostProject) => updater.ProjectAdded(hostProject),
-                state: hostProject,
-                cancellationToken)
-            .ConfigureAwait(false);
+                _logger.LogInformation($"Added project '{filePath}' with key {hostProject.Key} to project system.");
 
-        _logger.LogInformation($"Added project '{filePath}' with key {hostProject.Key} to project system.");
+                TryMigrateMiscellaneousDocumentsToProject(updater);
 
-        await TryMigrateMiscellaneousDocumentsToProjectAsync(cancellationToken).ConfigureAwait(false);
-
-        return hostProject.Key;
+                return hostProject.Key;
+            },
+            cancellationToken);
     }
 
-    public async Task UpdateProjectAsync(
+    public Task UpdateProjectAsync(
         ProjectKey projectKey,
         RazorConfiguration? configuration,
         string? rootNamespace,
@@ -307,63 +278,59 @@ internal class RazorProjectService(
         ImmutableArray<DocumentSnapshotHandle> documents,
         CancellationToken cancellationToken)
     {
-        using var _ = await _gate.EnterAsync(cancellationToken).ConfigureAwait(false);
+        return _projectManager.UpdateAsync(
+            updater =>
+            {
+                if (!_projectManager.TryGetLoadedProject(projectKey, out var project))
+                {
+                    // Never tracked the project to begin with, noop.
+                    _logger.LogInformation($"Failed to update untracked project '{projectKey}'.");
+                    return;
+                }
 
-        if (!_projectManager.TryGetLoadedProject(projectKey, out var project))
-        {
-            // Never tracked the project to begin with, noop.
-            _logger.LogInformation($"Failed to update untracked project '{projectKey}'.");
-            return;
-        }
+                UpdateProjectDocuments(updater, documents, project.Key);
 
-        await UpdateProjectDocumentsAsync(documents, project.Key, cancellationToken).ConfigureAwait(false);
+                if (!projectWorkspaceState.Equals(ProjectWorkspaceState.Default))
+                {
+                    _logger.LogInformation($"Updating project '{project.Key}' TagHelpers ({projectWorkspaceState.TagHelpers.Length}) and C# Language Version ({projectWorkspaceState.CSharpLanguageVersion}).");
+                }
 
-        if (!projectWorkspaceState.Equals(ProjectWorkspaceState.Default))
-        {
-            _logger.LogInformation($"Updating project '{project.Key}' TagHelpers ({projectWorkspaceState.TagHelpers.Length}) and C# Language Version ({projectWorkspaceState.CSharpLanguageVersion}).");
-        }
+                updater.ProjectWorkspaceStateChanged(project.Key, projectWorkspaceState);
 
-        await _projectManager
-            .UpdateAsync(
-                static (updater, state) => updater.ProjectWorkspaceStateChanged(state.key, state.projectWorkspaceState),
-                state: (key: project.Key, projectWorkspaceState),
-                cancellationToken)
-            .ConfigureAwait(false);
+                var currentConfiguration = project.Configuration;
+                var currentRootNamespace = project.RootNamespace;
+                if (currentConfiguration.ConfigurationName == configuration?.ConfigurationName &&
+                    currentRootNamespace == rootNamespace)
+                {
+                    _logger.LogTrace($"Updating project '{project.Key}'. The project is already using configuration '{configuration.ConfigurationName}' and root namespace '{rootNamespace}'.");
+                    return;
+                }
 
-        var currentConfiguration = project.Configuration;
-        var currentRootNamespace = project.RootNamespace;
-        if (currentConfiguration.ConfigurationName == configuration?.ConfigurationName &&
-            currentRootNamespace == rootNamespace)
-        {
-            _logger.LogTrace($"Updating project '{project.Key}'. The project is already using configuration '{configuration.ConfigurationName}' and root namespace '{rootNamespace}'.");
-            return;
-        }
+                if (configuration is null)
+                {
+                    configuration = FallbackRazorConfiguration.Latest;
+                    _logger.LogInformation($"Updating project '{project.Key}' to use the latest configuration ('{configuration.ConfigurationName}')'.");
+                }
+                else if (currentConfiguration.ConfigurationName != configuration.ConfigurationName)
+                {
+                    _logger.LogInformation($"Updating project '{project.Key}' to Razor configuration '{configuration.ConfigurationName}' with language version '{configuration.LanguageVersion}'.");
+                }
 
-        if (configuration is null)
-        {
-            configuration = FallbackRazorConfiguration.Latest;
-            _logger.LogInformation($"Updating project '{project.Key}' to use the latest configuration ('{configuration.ConfigurationName}')'.");
-        }
-        else if (currentConfiguration.ConfigurationName != configuration.ConfigurationName)
-        {
-            _logger.LogInformation($"Updating project '{project.Key}' to Razor configuration '{configuration.ConfigurationName}' with language version '{configuration.LanguageVersion}'.");
-        }
+                if (currentRootNamespace != rootNamespace)
+                {
+                    _logger.LogInformation($"Updating project '{project.Key}''s root namespace to '{rootNamespace}'.");
+                }
 
-        if (currentRootNamespace != rootNamespace)
-        {
-            _logger.LogInformation($"Updating project '{project.Key}''s root namespace to '{rootNamespace}'.");
-        }
-
-        var hostProject = new HostProject(project.FilePath, project.IntermediateOutputPath, configuration, rootNamespace, displayName);
-        await _projectManager
-            .UpdateAsync(
-                static (updater, hostProject) => updater.ProjectConfigurationChanged(hostProject),
-                state: hostProject,
-                cancellationToken)
-            .ConfigureAwait(false);
+                var hostProject = new HostProject(project.FilePath, project.IntermediateOutputPath, configuration, rootNamespace, displayName);
+                updater.ProjectConfigurationChanged(hostProject);
+            },
+            cancellationToken);
     }
 
-    private async Task UpdateProjectDocumentsAsync(ImmutableArray<DocumentSnapshotHandle> documents, ProjectKey projectKey, CancellationToken cancellationToken)
+    private void UpdateProjectDocuments(
+        ProjectSnapshotManager.Updater updater,
+        ImmutableArray<DocumentSnapshotHandle> documents,
+        ProjectKey projectKey)
     {
         _logger.LogDebug($"UpdateProjectDocuments for {projectKey} with {documents.Length} documents: {string.Join(", ", documents.Select(d => d.FilePath))}");
 
@@ -384,7 +351,7 @@ internal class RazorProjectService(
 
             _logger.LogDebug($"Document '{documentFilePath}' no longer exists in project '{projectKey}'. Moving to miscellaneous project.");
 
-            await MoveDocumentAsync(documentFilePath, project, miscellaneousProject, cancellationToken).ConfigureAwait(false);
+            MoveDocument(updater, documentFilePath, fromProject: project, toProject: miscellaneousProject);
         }
 
         project = _projectManager.GetLoadedProject(projectKey);
@@ -418,16 +385,8 @@ internal class RazorProjectService(
 
             var remoteTextLoader = _remoteTextLoaderFactory.Create(newFilePath);
 
-            await _projectManager
-                .UpdateAsync(
-                    static (updater, state) =>
-                    {
-                        updater.DocumentRemoved(state.currentProjectKey, state.currentHostDocument);
-                        updater.DocumentAdded(state.currentProjectKey, state.newHostDocument, state.remoteTextLoader);
-                    },
-                    state: (currentProjectKey, currentHostDocument, newHostDocument, remoteTextLoader),
-                    cancellationToken)
-                .ConfigureAwait(false);
+            updater.DocumentRemoved(currentProjectKey, currentHostDocument);
+            updater.DocumentAdded(currentProjectKey, newHostDocument, remoteTextLoader);
         }
 
         project = _projectManager.GetLoadedProject(project.Key);
@@ -445,7 +404,7 @@ internal class RazorProjectService(
 
             if (miscellaneousProject.DocumentFilePaths.Contains(documentFilePath, FilePathComparer.Instance))
             {
-                await MoveDocumentAsync(documentFilePath, miscellaneousProject, project, cancellationToken).ConfigureAwait(false);
+                MoveDocument(updater, documentFilePath, fromProject: miscellaneousProject, toProject: project);
             }
             else
             {
@@ -455,24 +414,23 @@ internal class RazorProjectService(
 
                 _logger.LogInformation($"Adding new document '{documentFilePath}' to project '{currentProjectKey}'.");
 
-                await _projectManager
-                    .UpdateAsync(
-                        static (updater, state) => updater.DocumentAdded(state.currentProjectKey, state.newHostDocument, state.remoteTextLoader),
-                        state: (currentProjectKey, newHostDocument, remoteTextLoader),
-                        cancellationToken)
-                    .ConfigureAwait(false);
+                updater.DocumentAdded(currentProjectKey, newHostDocument, remoteTextLoader);
             }
         }
     }
 
-    private Task MoveDocumentAsync(string documentFilePath, IProjectSnapshot fromProject, IProjectSnapshot toProject, CancellationToken cancellationToken)
+    private void MoveDocument(
+        ProjectSnapshotManager.Updater updater,
+        string documentFilePath,
+        IProjectSnapshot fromProject,
+        IProjectSnapshot toProject)
     {
         Debug.Assert(fromProject.DocumentFilePaths.Contains(documentFilePath, FilePathComparer.Instance));
         Debug.Assert(!toProject.DocumentFilePaths.Contains(documentFilePath, FilePathComparer.Instance));
 
         if (fromProject.GetDocument(documentFilePath) is not DocumentSnapshot documentSnapshot)
         {
-            return Task.CompletedTask;
+            return;
         }
 
         var currentHostDocument = documentSnapshot.State.HostDocument;
@@ -482,14 +440,8 @@ internal class RazorProjectService(
 
         _logger.LogInformation($"Moving '{documentFilePath}' from the '{fromProject.Key}' project to '{toProject.Key}' project.");
 
-        return _projectManager.UpdateAsync(
-            static (updater, state) =>
-            {
-                updater.DocumentRemoved(state.fromProject.Key, state.currentHostDocument);
-                updater.DocumentAdded(state.toProject.Key, state.newHostDocument, state.textLoader);
-            },
-            state: (fromProject, currentHostDocument, toProject, newHostDocument, textLoader),
-            cancellationToken);
+        updater.DocumentRemoved(fromProject.Key, currentHostDocument);
+        updater.DocumentAdded(toProject.Key, newHostDocument, textLoader);
     }
 
     private static string EnsureFullPath(string filePath, string projectDirectory)
@@ -504,7 +456,7 @@ internal class RazorProjectService(
         return normalizedFilePath;
     }
 
-    private async Task TryMigrateMiscellaneousDocumentsToProjectAsync(CancellationToken cancellationToken)
+    private void TryMigrateMiscellaneousDocumentsToProject(ProjectSnapshotManager.Updater updater)
     {
         var miscellaneousProject = _snapshotResolver.GetMiscellaneousProject();
 
@@ -524,12 +476,7 @@ internal class RazorProjectService(
             // Remove from miscellaneous project
             var defaultMiscProject = miscellaneousProject;
 
-            await _projectManager
-                .UpdateAsync(
-                    static (updater, state) => updater.DocumentRemoved(state.Key, state.HostDocument),
-                    state: (defaultMiscProject.Key, documentSnapshot.State.HostDocument),
-                    cancellationToken)
-                .ConfigureAwait(false);
+            updater.DocumentRemoved(defaultMiscProject.Key, documentSnapshot.State.HostDocument);
 
             // Add to new project
 
@@ -538,12 +485,7 @@ internal class RazorProjectService(
             var newHostDocument = new HostDocument(documentSnapshot.FilePath, documentSnapshot.TargetPath);
             _logger.LogInformation($"Migrating '{documentFilePath}' from the '{miscellaneousProject.Key}' project to '{projectSnapshot.Key}' project.");
 
-            await _projectManager
-                .UpdateAsync(
-                    static (updater, state) => updater.DocumentAdded(state.key, state.newHostDocument, state.textLoader),
-                    state: (key: defaultProject.Key, newHostDocument, textLoader),
-                    cancellationToken)
-                .ConfigureAwait(false);
+            updater.DocumentAdded(defaultProject.Key, newHostDocument, textLoader);
         }
     }
 
@@ -559,25 +501,7 @@ internal class RazorProjectService(
         if (startGenerating)
         {
             // Start generating the C# for the document so it can immediately be ready for incoming requests.
-            _ = documentSnapshot.GetGeneratedOutputAsync();
-        }
-    }
-
-    private class DelegatingTextLoader : TextLoader
-    {
-        private readonly IDocumentSnapshot _fromDocument;
-        public DelegatingTextLoader(IDocumentSnapshot fromDocument)
-        {
-            _fromDocument = fromDocument ?? throw new ArgumentNullException(nameof(fromDocument));
-        }
-        public override async Task<TextAndVersion> LoadTextAndVersionAsync(
-           LoadTextOptions options,
-           CancellationToken cancellationToken)
-        {
-            var sourceText = await _fromDocument.GetTextAsync().ConfigureAwait(false);
-            var version = await _fromDocument.GetTextVersionAsync().ConfigureAwait(false);
-            var textAndVersion = TextAndVersion.Create(sourceText, version.GetNewerVersion());
-            return textAndVersion;
+            documentSnapshot.GetGeneratedOutputAsync().Forget();
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
@@ -227,8 +227,7 @@ internal class RazorProjectService(
     private void ActOnDocumentInMultipleProjects(string filePath, Action<IProjectSnapshot, string> action)
     {
         var textDocumentPath = FilePathNormalizer.Normalize(filePath);
-        var projects = _snapshotResolver.TryResolveAllProjects(textDocumentPath);
-        if (projects.IsEmpty)
+        if (!_snapshotResolver.TryResolveAllProjects(textDocumentPath, out var projects))
         {
             var miscFilesProject = _snapshotResolver.GetMiscellaneousProject();
             projects = [miscFilesProject];

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/SnapshotResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/SnapshotResolver.cs
@@ -13,10 +13,11 @@ using Microsoft.AspNetCore.Razor.Utilities;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CommonLanguageServerProtocol.Framework;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 
-internal sealed class SnapshotResolver : ISnapshotResolver
+internal sealed class SnapshotResolver : ISnapshotResolver, IOnInitialized
 {
     private readonly IProjectSnapshotManager _projectManager;
     private readonly ILogger _logger;
@@ -34,7 +35,7 @@ internal sealed class SnapshotResolver : ISnapshotResolver
         MiscellaneousHostProject = new HostProject(normalizedPath, normalizedPath, FallbackRazorConfiguration.Latest, rootNamespace: null, "Miscellaneous Files");
     }
 
-    public Task InitializeAsync(CancellationToken cancellationToken)
+    public Task OnInitializedAsync(ILspServices services, CancellationToken cancellationToken)
     {
         // This is called when the language server is initialized.
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/SnapshotResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/SnapshotResolver.cs
@@ -35,7 +35,7 @@ internal sealed class SnapshotResolver : ISnapshotResolver, IOnInitialized
         MiscellaneousHostProject = new HostProject(normalizedPath, normalizedPath, FallbackRazorConfiguration.Latest, rootNamespace: null, "Miscellaneous Files");
     }
 
-    public Task OnInitializedAsync(ILspServices services, CancellationToken cancellationToken)
+    public Task InitializeAsync(ILspServices services, CancellationToken cancellationToken)
     {
         // This is called when the language server is initialized.
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/SnapshotResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/SnapshotResolver.cs
@@ -33,6 +33,16 @@ internal sealed class SnapshotResolver : ISnapshotResolver
         MiscellaneousHostProject = new HostProject(normalizedPath, normalizedPath, FallbackRazorConfiguration.Latest, rootNamespace: null, "Miscellaneous Files");
     }
 
+    public Task InitializeAsync(CancellationToken cancellationToken)
+    {
+        // This is called when the language server is initialized.
+
+        return _projectManager.UpdateAsync(
+            (updater, miscHostProject) => updater.ProjectAdded(miscHostProject),
+            state: MiscellaneousHostProject,
+            cancellationToken);
+    }
+
     /// <inheritdoc/>
     public ImmutableArray<IProjectSnapshot> FindPotentialProjects(string documentFilePath)
     {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/SnapshotResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/SnapshotResolver.cs
@@ -73,21 +73,9 @@ internal sealed class SnapshotResolver : ISnapshotResolver
         return projects.DrainToImmutable();
     }
 
-    public async Task<IProjectSnapshot> GetMiscellaneousProjectAsync(CancellationToken cancellationToken)
+    public IProjectSnapshot GetMiscellaneousProject()
     {
-        if (!_projectManager.TryGetLoadedProject(MiscellaneousHostProject.Key, out var miscellaneousProject))
-        {
-            await _projectManager
-                .UpdateAsync(
-                    static (updater, miscHostProject) => updater.ProjectAdded(miscHostProject),
-                    state: MiscellaneousHostProject,
-                    cancellationToken)
-                .ConfigureAwait(false);
-
-            miscellaneousProject = _projectManager.GetLoadedProject(MiscellaneousHostProject.Key);
-        }
-
-        return miscellaneousProject;
+        return _projectManager.GetLoadedProject(MiscellaneousHostProject.Key);
     }
 
     public async Task<IDocumentSnapshot?> ResolveDocumentInAnyProjectAsync(string documentFilePath, CancellationToken cancellationToken)
@@ -112,7 +100,7 @@ internal sealed class SnapshotResolver : ISnapshotResolver
         }
 
         _logger.LogTrace($"Looking for {documentFilePath} in miscellaneous project.");
-        var miscellaneousProject = await GetMiscellaneousProjectAsync(cancellationToken).ConfigureAwait(false);
+        var miscellaneousProject = GetMiscellaneousProject();
 
         if (miscellaneousProject.GetDocument(normalizedDocumentPath) is { } miscDocument)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/SnapshotResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/SnapshotResolver.cs
@@ -78,7 +78,7 @@ internal sealed class SnapshotResolver : ISnapshotResolver
         return _projectManager.GetLoadedProject(MiscellaneousHostProject.Key);
     }
 
-    public async Task<IDocumentSnapshot?> ResolveDocumentInAnyProjectAsync(string documentFilePath, CancellationToken cancellationToken)
+    public IDocumentSnapshot? ResolveDocumentInAnyProject(string documentFilePath)
     {
         _logger.LogTrace($"Looking for {documentFilePath}.");
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/SnapshotResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/SnapshotResolver.cs
@@ -35,7 +35,7 @@ internal sealed class SnapshotResolver : ISnapshotResolver, IOnInitialized
         MiscellaneousHostProject = new HostProject(normalizedPath, normalizedPath, FallbackRazorConfiguration.Latest, rootNamespace: null, "Miscellaneous Files");
     }
 
-    public Task InitializeAsync(ILspServices services, CancellationToken cancellationToken)
+    public Task OnInitializedAsync(ILspServices services, CancellationToken cancellationToken)
     {
         // This is called when the language server is initialized.
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/SnapshotResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/SnapshotResolver.cs
@@ -47,11 +47,6 @@ internal sealed class SnapshotResolver : ISnapshotResolver
     /// <inheritdoc/>
     public ImmutableArray<IProjectSnapshot> FindPotentialProjects(string documentFilePath)
     {
-        if (documentFilePath is null)
-        {
-            throw new ArgumentNullException(nameof(documentFilePath));
-        }
-
         var normalizedDocumentPath = FilePathNormalizer.Normalize(documentFilePath);
 
         using var projects = new PooledArrayBuilder<IProjectSnapshot>();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorConfigurationEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorConfigurationEndpoint.cs
@@ -6,6 +6,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.CodeAnalysis.Razor.Logging;
+using Microsoft.CodeAnalysis.Razor.Protocol;
+using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
@@ -25,8 +27,11 @@ internal class RazorConfigurationEndpoint(RazorLSPOptionsMonitor optionsMonitor,
         await _optionsMonitor.UpdateAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task OnInitializedAsync(VSInternalClientCapabilities clientCapabilities, CancellationToken cancellationToken)
+    public async Task OnInitializedAsync(ILspServices services, CancellationToken cancellationToken)
     {
+        var capabilitiesService = services.GetRequiredService<IClientCapabilitiesService>();
+        var clientCapabilities = capabilitiesService.ClientCapabilities;
+
         if (clientCapabilities.Workspace?.Configuration == true)
         {
             await _optionsMonitor.UpdateAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorConfigurationEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorConfigurationEndpoint.cs
@@ -27,7 +27,7 @@ internal class RazorConfigurationEndpoint(RazorLSPOptionsMonitor optionsMonitor,
         await _optionsMonitor.UpdateAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task InitializeAsync(ILspServices services, CancellationToken cancellationToken)
+    public async Task OnInitializedAsync(ILspServices services, CancellationToken cancellationToken)
     {
         var capabilitiesService = services.GetRequiredService<IClientCapabilitiesService>();
         var clientCapabilities = capabilitiesService.ClientCapabilities;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorConfigurationEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorConfigurationEndpoint.cs
@@ -27,7 +27,7 @@ internal class RazorConfigurationEndpoint(RazorLSPOptionsMonitor optionsMonitor,
         await _optionsMonitor.UpdateAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task OnInitializedAsync(ILspServices services, CancellationToken cancellationToken)
+    public async Task InitializeAsync(ILspServices services, CancellationToken cancellationToken)
     {
         var capabilitiesService = services.GetRequiredService<IClientCapabilitiesService>();
         var clientCapabilities = capabilitiesService.ClientCapabilities;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetectorManager.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetectorManager.cs
@@ -20,7 +20,7 @@ internal class RazorFileChangeDetectorManager(
     private readonly object _disposeLock = new();
     private bool _disposed;
 
-    public async Task InitializeAsync(ILspServices services, CancellationToken cancellationToken)
+    public async Task OnInitializedAsync(ILspServices services, CancellationToken cancellationToken)
     {
         // Initialized request, this occurs once the server and client have agreed on what sort of features they both support. It only happens once.
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetectorManager.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetectorManager.cs
@@ -7,19 +7,20 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CommonLanguageServerProtocol.Framework;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
 internal class RazorFileChangeDetectorManager(
     WorkspaceDirectoryPathResolver workspaceDirectoryPathResolver,
-    IEnumerable<IFileChangeDetector> fileChangeDetectors) : IDisposable
+    IEnumerable<IFileChangeDetector> fileChangeDetectors) : IOnInitialized, IDisposable
 {
     private readonly WorkspaceDirectoryPathResolver _workspaceDirectoryPathResolver = workspaceDirectoryPathResolver;
     private readonly ImmutableArray<IFileChangeDetector> _fileChangeDetectors = fileChangeDetectors.ToImmutableArray();
     private readonly object _disposeLock = new();
     private bool _disposed;
 
-    public async Task InitializedAsync(CancellationToken cancellationToken)
+    public async Task OnInitializedAsync(ILspServices services, CancellationToken cancellationToken)
     {
         // Initialized request, this occurs once the server and client have agreed on what sort of features they both support. It only happens once.
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetectorManager.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileChangeDetectorManager.cs
@@ -20,7 +20,7 @@ internal class RazorFileChangeDetectorManager(
     private readonly object _disposeLock = new();
     private bool _disposed;
 
-    public async Task OnInitializedAsync(ILspServices services, CancellationToken cancellationToken)
+    public async Task InitializeAsync(ILspServices services, CancellationToken cancellationToken)
     {
         // Initialized request, this occurs once the server and client have agreed on what sort of features they both support. It only happens once.
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorInitializedEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorInitializedEndpoint.cs
@@ -22,7 +22,7 @@ internal class RazorInitializedEndpoint : INotificationHandler<InitializedParams
 
         foreach (var onStartedItem in onStartedItems)
         {
-            await onStartedItem.InitializeAsync(requestContext.LspServices, cancellationToken).ConfigureAwait(false);
+            await onStartedItem.OnInitializedAsync(requestContext.LspServices, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorInitializedEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorInitializedEndpoint.cs
@@ -20,9 +20,6 @@ internal class RazorInitializedEndpoint : INotificationHandler<InitializedParams
     {
         var onStartedItems = requestContext.LspServices.GetRequiredServices<IOnInitialized>();
 
-        var fileChangeDetectorManager = requestContext.LspServices.GetRequiredService<RazorFileChangeDetectorManager>();
-        await fileChangeDetectorManager.InitializedAsync(cancellationToken).ConfigureAwait(false);
-
         foreach (var onStartedItem in onStartedItems)
         {
             await onStartedItem.OnInitializedAsync(requestContext.LspServices, cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorInitializedEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorInitializedEndpoint.cs
@@ -4,6 +4,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
+using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -19,6 +20,9 @@ internal class RazorInitializedEndpoint : INotificationHandler<InitializedParams
     {
         var onStartedItems = requestContext.LspServices.GetRequiredServices<IOnInitialized>();
         var capabilitiesService = requestContext.GetRequiredService<IClientCapabilitiesService>();
+
+        var snapshotResolver = requestContext.LspServices.GetRequiredService<ISnapshotResolver>();
+        await snapshotResolver.InitializeAsync(cancellationToken).ConfigureAwait(false);
 
         var fileChangeDetectorManager = requestContext.LspServices.GetRequiredService<RazorFileChangeDetectorManager>();
         await fileChangeDetectorManager.InitializedAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorInitializedEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorInitializedEndpoint.cs
@@ -20,9 +20,6 @@ internal class RazorInitializedEndpoint : INotificationHandler<InitializedParams
     {
         var onStartedItems = requestContext.LspServices.GetRequiredServices<IOnInitialized>();
 
-        var snapshotResolver = requestContext.LspServices.GetRequiredService<ISnapshotResolver>();
-        await snapshotResolver.InitializeAsync(cancellationToken).ConfigureAwait(false);
-
         var fileChangeDetectorManager = requestContext.LspServices.GetRequiredService<RazorFileChangeDetectorManager>();
         await fileChangeDetectorManager.InitializedAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorInitializedEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorInitializedEndpoint.cs
@@ -19,7 +19,6 @@ internal class RazorInitializedEndpoint : INotificationHandler<InitializedParams
     public async Task HandleNotificationAsync(InitializedParams request, RazorRequestContext requestContext, CancellationToken cancellationToken)
     {
         var onStartedItems = requestContext.LspServices.GetRequiredServices<IOnInitialized>();
-        var capabilitiesService = requestContext.GetRequiredService<IClientCapabilitiesService>();
 
         var snapshotResolver = requestContext.LspServices.GetRequiredService<ISnapshotResolver>();
         await snapshotResolver.InitializeAsync(cancellationToken).ConfigureAwait(false);
@@ -29,7 +28,7 @@ internal class RazorInitializedEndpoint : INotificationHandler<InitializedParams
 
         foreach (var onStartedItem in onStartedItems)
         {
-            await onStartedItem.OnInitializedAsync(capabilitiesService.ClientCapabilities, cancellationToken).ConfigureAwait(false);
+            await onStartedItem.OnInitializedAsync(requestContext.LspServices, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorInitializedEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorInitializedEndpoint.cs
@@ -22,7 +22,7 @@ internal class RazorInitializedEndpoint : INotificationHandler<InitializedParams
 
         foreach (var onStartedItem in onStartedItems)
         {
-            await onStartedItem.OnInitializedAsync(requestContext.LspServices, cancellationToken).ConfigureAwait(false);
+            await onStartedItem.InitializeAsync(requestContext.LspServices, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorRequestContextFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorRequestContextFactory.cs
@@ -35,7 +35,7 @@ internal class RazorRequestContextFactory(ILspServices lspServices) : AbstractRe
 
                 logger.LogDebug($"Trying to create DocumentContext for {queueItem.MethodName} for {textDocumentIdentifier.GetProjectContext()?.Id ?? "(no project context)"} for {uri}");
 
-                documentContext = documentContextFactory.TryCreateForOpenDocument(textDocumentIdentifier);
+                documentContextFactory.TryCreateForOpenDocument(textDocumentIdentifier, out documentContext);
             }
             else if (textDocumentHandler is ITextDocumentIdentifierHandler<TRequestParams, Uri> uriHandler)
             {
@@ -43,7 +43,7 @@ internal class RazorRequestContextFactory(ILspServices lspServices) : AbstractRe
 
                 logger.LogDebug($"Trying to create DocumentContext for {queueItem.MethodName}, with no project context, for {uri}");
 
-                documentContext = documentContextFactory.TryCreateForOpenDocument(uri);
+                documentContextFactory.TryCreateForOpenDocument(uri, out documentContext);
             }
             else
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorRequestContextFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorRequestContextFactory.cs
@@ -17,7 +17,7 @@ internal class RazorRequestContextFactory(ILspServices lspServices) : AbstractRe
 {
     private readonly ILspServices _lspServices = lspServices;
 
-    public override async Task<RazorRequestContext> CreateRequestContextAsync<TRequestParams>(IQueueItem<RazorRequestContext> queueItem, IMethodHandler methodHandler, TRequestParams @params, CancellationToken cancellationToken)
+    public override Task<RazorRequestContext> CreateRequestContextAsync<TRequestParams>(IQueueItem<RazorRequestContext> queueItem, IMethodHandler methodHandler, TRequestParams @params, CancellationToken cancellationToken)
     {
         var logger = _lspServices.GetRequiredService<ILoggerFactory>().GetOrCreateLogger<RazorRequestContextFactory>();
 
@@ -58,6 +58,6 @@ internal class RazorRequestContextFactory(ILspServices lspServices) : AbstractRe
 
         var requestContext = new RazorRequestContext(documentContext, _lspServices, queueItem.MethodName, uri);
 
-        return requestContext;
+        return Task.FromResult(requestContext);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorRequestContextFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorRequestContextFactory.cs
@@ -35,7 +35,7 @@ internal class RazorRequestContextFactory(ILspServices lspServices) : AbstractRe
 
                 logger.LogDebug($"Trying to create DocumentContext for {queueItem.MethodName} for {textDocumentIdentifier.GetProjectContext()?.Id ?? "(no project context)"} for {uri}");
 
-                documentContext = await documentContextFactory.TryCreateForOpenDocumentAsync(textDocumentIdentifier, cancellationToken).ConfigureAwait(false);
+                documentContext = documentContextFactory.TryCreateForOpenDocument(textDocumentIdentifier);
             }
             else if (textDocumentHandler is ITextDocumentIdentifierHandler<TRequestParams, Uri> uriHandler)
             {
@@ -43,7 +43,7 @@ internal class RazorRequestContextFactory(ILspServices lspServices) : AbstractRe
 
                 logger.LogDebug($"Trying to create DocumentContext for {queueItem.MethodName}, with no project context, for {uri}");
 
-                documentContext = await documentContextFactory.TryCreateForOpenDocumentAsync(uri, cancellationToken).ConfigureAwait(false);
+                documentContext = documentContextFactory.TryCreateForOpenDocument(uri);
             }
             else
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/TagHelperTooltipFactoryBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/TagHelperTooltipFactoryBase.cs
@@ -31,8 +31,7 @@ internal abstract class TagHelperTooltipFactoryBase
 
     internal async Task<string?> GetProjectAvailabilityAsync(string documentFilePath, string tagHelperTypeName, CancellationToken cancellationToken)
     {
-        var projectSnapshots = _snapshotResolver.TryResolveAllProjects(documentFilePath);
-        if (projectSnapshots.IsEmpty)
+        if (!_snapshotResolver.TryResolveAllProjects(documentFilePath, out var projectSnapshots))
         {
             return null;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/TagHelperTooltipFactoryBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/TagHelperTooltipFactoryBase.cs
@@ -31,7 +31,7 @@ internal abstract class TagHelperTooltipFactoryBase
 
     internal async Task<string?> GetProjectAvailabilityAsync(string documentFilePath, string tagHelperTypeName, CancellationToken cancellationToken)
     {
-        var projectSnapshots = await _snapshotResolver.TryResolveAllProjectsAsync(documentFilePath, cancellationToken).ConfigureAwait(false);
+        var projectSnapshots = _snapshotResolver.TryResolveAllProjects(documentFilePath);
         if (projectSnapshots.IsEmpty)
         {
             return null;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/AbstractRazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/AbstractRazorDocumentMappingService.cs
@@ -449,7 +449,7 @@ internal abstract class AbstractRazorDocumentMappingService(
             return (generatedDocumentUri, generatedDocumentRange);
         }
 
-        var documentContext = await _documentContextFactory.TryCreateAsync(razorDocumentUri, cancellationToken).ConfigureAwait(false);
+        var documentContext = _documentContextFactory.TryCreate(razorDocumentUri);
         if (documentContext is null)
         {
             return (generatedDocumentUri, generatedDocumentRange);
@@ -809,7 +809,7 @@ internal abstract class AbstractRazorDocumentMappingService(
             }
 
             var razorDocumentUri = _documentFilePathService.GetRazorDocumentUri(generatedDocumentUri);
-            var documentContext = await _documentContextFactory.TryCreateForOpenDocumentAsync(razorDocumentUri, entry.TextDocument.GetProjectContext(), cancellationToken).ConfigureAwait(false);
+            var documentContext = _documentContextFactory.TryCreateForOpenDocument(razorDocumentUri, entry.TextDocument.GetProjectContext());
             if (documentContext is null)
             {
                 continue;
@@ -853,7 +853,7 @@ internal abstract class AbstractRazorDocumentMappingService(
                 continue;
             }
 
-            var documentContext = await _documentContextFactory.TryCreateAsync(uri, cancellationToken).ConfigureAwait(false);
+            var documentContext = _documentContextFactory.TryCreate(uri);
             if (documentContext is null)
             {
                 continue;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/AbstractRazorDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/AbstractRazorDocumentMappingService.cs
@@ -449,8 +449,7 @@ internal abstract class AbstractRazorDocumentMappingService(
             return (generatedDocumentUri, generatedDocumentRange);
         }
 
-        var documentContext = _documentContextFactory.TryCreate(razorDocumentUri);
-        if (documentContext is null)
+        if (!_documentContextFactory.TryCreate(razorDocumentUri, out var documentContext))
         {
             return (generatedDocumentUri, generatedDocumentRange);
         }
@@ -809,8 +808,8 @@ internal abstract class AbstractRazorDocumentMappingService(
             }
 
             var razorDocumentUri = _documentFilePathService.GetRazorDocumentUri(generatedDocumentUri);
-            var documentContext = _documentContextFactory.TryCreateForOpenDocument(razorDocumentUri, entry.TextDocument.GetProjectContext());
-            if (documentContext is null)
+
+            if (!_documentContextFactory.TryCreateForOpenDocument(razorDocumentUri, entry.TextDocument.GetProjectContext(), out var documentContext))
             {
                 continue;
             }
@@ -853,8 +852,7 @@ internal abstract class AbstractRazorDocumentMappingService(
                 continue;
             }
 
-            var documentContext = _documentContextFactory.TryCreate(uri);
-            if (documentContext is null)
+            if (!_documentContextFactory.TryCreate(uri, out var documentContext))
             {
                 continue;
             }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentContextFactory.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentContextFactory.cs
@@ -2,13 +2,11 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 internal interface IDocumentContextFactory
 {
-    Task<DocumentContext?> TryCreateAsync(Uri documentUri, VSProjectContext? projectContext, bool versioned, CancellationToken cancellationToken);
+    DocumentContext? TryCreate(Uri documentUri, VSProjectContext? projectContext, bool versioned);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentContextFactory.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentContextFactory.cs
@@ -2,11 +2,16 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 internal interface IDocumentContextFactory
 {
-    DocumentContext? TryCreate(Uri documentUri, VSProjectContext? projectContext, bool versioned);
+    bool TryCreate(
+        Uri documentUri,
+        VSProjectContext? projectContext,
+        bool versioned,
+        [NotNullWhen(true)] out DocumentContext? context);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentContextFactoryExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentContextFactoryExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -9,21 +10,68 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 internal static class IDocumentContextFactoryExtensions
 {
-    public static DocumentContext? TryCreate(this IDocumentContextFactory service, TextDocumentIdentifier documentIdentifier)
-        => service.TryCreate(documentIdentifier.Uri, documentIdentifier.GetProjectContext(), versioned: false);
+    public static bool TryCreate(
+        this IDocumentContextFactory service,
+        TextDocumentIdentifier documentIdentifier,
+        [NotNullWhen(true)] out DocumentContext? context)
+        => service.TryCreate(documentIdentifier.Uri, documentIdentifier.GetProjectContext(), versioned: false, out context);
 
-    public static DocumentContext? TryCreate(this IDocumentContextFactory service, Uri documentUri)
-        => service.TryCreate(documentUri, projectContext: null, versioned: false);
+    public static bool TryCreate(
+        this IDocumentContextFactory service,
+        Uri documentUri,
+        [NotNullWhen(true)] out DocumentContext? context)
+        => service.TryCreate(documentUri, projectContext: null, versioned: false, out context);
 
-    public static DocumentContext? TryCreate(this IDocumentContextFactory service, Uri documentUri, VSProjectContext? projectContext)
-        => service.TryCreate(documentUri, projectContext, versioned: false);
+    public static bool TryCreate(
+        this IDocumentContextFactory service,
+        Uri documentUri,
+        VSProjectContext? projectContext,
+        [NotNullWhen(true)] out DocumentContext? context)
+        => service.TryCreate(documentUri, projectContext, versioned: false, out context);
 
-    public static VersionedDocumentContext? TryCreateForOpenDocument(this IDocumentContextFactory service, Uri documentUri)
-        => (VersionedDocumentContext?)service.TryCreate(documentUri, projectContext: null, versioned: true);
+    public static bool TryCreateForOpenDocument(
+        this IDocumentContextFactory service,
+        Uri documentUri,
+        [NotNullWhen(true)] out VersionedDocumentContext? context)
+    {
+        if (service.TryCreate(documentUri, projectContext: null, versioned: true, out var documentContext))
+        {
+            context = (VersionedDocumentContext)documentContext;
+            return true;
+        }
 
-    public static VersionedDocumentContext? TryCreateForOpenDocument(this IDocumentContextFactory service, TextDocumentIdentifier documentIdentifier)
-        => (VersionedDocumentContext?)service.TryCreate(documentIdentifier.Uri, documentIdentifier.GetProjectContext(), versioned: true);
+        context = null;
+        return false;
+    }
 
-    public static VersionedDocumentContext? TryCreateForOpenDocument(this IDocumentContextFactory service, Uri documentUri, VSProjectContext? projectContext)
-        => (VersionedDocumentContext?)service.TryCreate(documentUri, projectContext, versioned: true);
+    public static bool TryCreateForOpenDocument(
+        this IDocumentContextFactory service,
+        TextDocumentIdentifier documentIdentifier,
+        [NotNullWhen(true)] out VersionedDocumentContext? context)
+    {
+        if (service.TryCreate(documentIdentifier.Uri, documentIdentifier.GetProjectContext(), versioned: true, out var documentContext))
+        {
+            context = (VersionedDocumentContext)documentContext;
+            return true;
+        }
+
+        context = null;
+        return false;
+    }
+
+    public static bool TryCreateForOpenDocument(
+        this IDocumentContextFactory service,
+        Uri documentUri,
+        VSProjectContext? projectContext,
+        [NotNullWhen(true)] out VersionedDocumentContext? context)
+    {
+        if (service.TryCreate(documentUri, projectContext, versioned: true, out var documentContext))
+        {
+            context = (VersionedDocumentContext)documentContext;
+            return true;
+        }
+
+        context = null;
+        return false;
+    }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentContextFactoryExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentContextFactoryExtensions.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -11,21 +9,21 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 internal static class IDocumentContextFactoryExtensions
 {
-    public static Task<DocumentContext?> TryCreateAsync(this IDocumentContextFactory service, TextDocumentIdentifier documentIdentifier, CancellationToken cancellationToken)
-        => service.TryCreateAsync(documentIdentifier.Uri, documentIdentifier.GetProjectContext(), versioned: false, cancellationToken);
+    public static DocumentContext? TryCreate(this IDocumentContextFactory service, TextDocumentIdentifier documentIdentifier)
+        => service.TryCreate(documentIdentifier.Uri, documentIdentifier.GetProjectContext(), versioned: false);
 
-    public static Task<DocumentContext?> TryCreateAsync(this IDocumentContextFactory service, Uri documentUri, CancellationToken cancellationToken)
-        => service.TryCreateAsync(documentUri, projectContext: null, versioned: false, cancellationToken);
+    public static DocumentContext? TryCreate(this IDocumentContextFactory service, Uri documentUri)
+        => service.TryCreate(documentUri, projectContext: null, versioned: false);
 
-    public static Task<DocumentContext?> TryCreateAsync(this IDocumentContextFactory service, Uri documentUri, VSProjectContext? projectContext, CancellationToken cancellationToken)
-        => service.TryCreateAsync(documentUri, projectContext, versioned: false, cancellationToken);
+    public static DocumentContext? TryCreate(this IDocumentContextFactory service, Uri documentUri, VSProjectContext? projectContext)
+        => service.TryCreate(documentUri, projectContext, versioned: false);
 
-    public static async Task<VersionedDocumentContext?> TryCreateForOpenDocumentAsync(this IDocumentContextFactory service, Uri documentUri, CancellationToken cancellationToken)
-        => (VersionedDocumentContext?)await service.TryCreateAsync(documentUri, projectContext: null, versioned: true, cancellationToken).ConfigureAwait(false);
+    public static VersionedDocumentContext? TryCreateForOpenDocument(this IDocumentContextFactory service, Uri documentUri)
+        => (VersionedDocumentContext?)service.TryCreate(documentUri, projectContext: null, versioned: true);
 
-    public static async Task<VersionedDocumentContext?> TryCreateForOpenDocumentAsync(this IDocumentContextFactory service, TextDocumentIdentifier documentIdentifier, CancellationToken cancellationToken)
-        => (VersionedDocumentContext?)await service.TryCreateAsync(documentIdentifier.Uri, documentIdentifier.GetProjectContext(), versioned: true, cancellationToken).ConfigureAwait(false);
+    public static VersionedDocumentContext? TryCreateForOpenDocument(this IDocumentContextFactory service, TextDocumentIdentifier documentIdentifier)
+        => (VersionedDocumentContext?)service.TryCreate(documentIdentifier.Uri, documentIdentifier.GetProjectContext(), versioned: true);
 
-    public static async Task<VersionedDocumentContext?> TryCreateForOpenDocumentAsync(this IDocumentContextFactory service, Uri documentUri, VSProjectContext? projectContext, CancellationToken cancellationToken)
-        => (VersionedDocumentContext?)await service.TryCreateAsync(documentUri, projectContext, versioned: true, cancellationToken).ConfigureAwait(false);
+    public static VersionedDocumentContext? TryCreateForOpenDocument(this IDocumentContextFactory service, Uri documentUri, VSProjectContext? projectContext)
+        => (VersionedDocumentContext?)service.TryCreate(documentUri, projectContext, versioned: true);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/DocumentContextFactory.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/DocumentContextFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Composition;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -11,7 +12,11 @@ namespace Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
 [Export(typeof(IDocumentContextFactory)), Shared]
 internal class DocumentContextFactory : IDocumentContextFactory
 {
-    public DocumentContext? TryCreate(Uri documentUri, VSProjectContext? projectContext, bool versioned)
+    public bool TryCreate(
+        Uri documentUri,
+        VSProjectContext? projectContext,
+        bool versioned,
+        [NotNullWhen(true)] out DocumentContext? context)
     {
         throw new NotSupportedException("OOP doesn't support this yet, because we don't have a way to pass in the right solution snapshot to use");
     }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/DocumentContextFactory.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/DocumentContextFactory.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Composition;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -13,7 +11,7 @@ namespace Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
 [Export(typeof(IDocumentContextFactory)), Shared]
 internal class DocumentContextFactory : IDocumentContextFactory
 {
-    public Task<DocumentContext?> TryCreateAsync(Uri documentUri, VSProjectContext? projectContext, bool versioned, CancellationToken cancellationToken)
+    public DocumentContext? TryCreate(Uri documentUri, VSProjectContext? projectContext, bool versioned)
     {
         throw new NotSupportedException("OOP doesn't support this yet, because we don't have a way to pass in the right solution snapshot to use");
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/OnAutoInsertEndpointTest.NetFx.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/OnAutoInsertEndpointTest.NetFx.cs
@@ -383,7 +383,7 @@ public partial class OnAutoInsertEndpointTest
                 InsertSpaces = true
             },
         };
-        var documentContext = await DocumentContextFactory.TryCreateForOpenDocumentAsync(@params.TextDocument, DisposalToken);
+        var documentContext = DocumentContextFactory.TryCreateForOpenDocument(@params.TextDocument);
 
         var requestContext = await CreateOnAutoInsertRequestContextAsync(documentContext);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/OnAutoInsertEndpointTest.NetFx.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/OnAutoInsertEndpointTest.NetFx.cs
@@ -383,7 +383,7 @@ public partial class OnAutoInsertEndpointTest
                 InsertSpaces = true
             },
         };
-        var documentContext = DocumentContextFactory.TryCreateForOpenDocument(@params.TextDocument);
+        Assert.True(DocumentContextFactory.TryCreateForOpenDocument(@params.TextDocument, out var documentContext));
 
         var requestContext = await CreateOnAutoInsertRequestContextAsync(documentContext);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndToEndTest.NetFx.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndToEndTest.NetFx.cs
@@ -1255,18 +1255,18 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : SingleServer
             }
         }
 
-        public override Task<DocumentContext?> TryCreateAsync(Uri documentUri, VSProjectContext? projectContext, bool versioned, CancellationToken cancellationToken)
+        public override DocumentContext? TryCreate(Uri documentUri, VSProjectContext? projectContext, bool versioned)
         {
             if (FilePath is null || CodeDocument is null)
             {
-                return Task.FromResult<DocumentContext?>(null);
+                return null;
             }
 
             var projectWorkspaceState = ProjectWorkspaceState.Create(_tagHelperDescriptors.ToImmutableArray());
             var testDocumentSnapshot = TestDocumentSnapshot.Create(FilePath, CodeDocument.GetSourceText().ToString(), CodeAnalysis.VersionStamp.Default, projectWorkspaceState);
             testDocumentSnapshot.With(CodeDocument);
 
-            return Task.FromResult<DocumentContext?>(CreateDocumentContext(new Uri(FilePath), testDocumentSnapshot));
+            return CreateDocumentContext(new Uri(FilePath), testDocumentSnapshot);
         }
 
         private static List<TagHelperDescriptor> CreateTagHelperDescriptors()

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndToEndTest.NetFx.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndToEndTest.NetFx.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -1247,7 +1248,6 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : SingleServer
             int? version = null)
             : base(filePath, codeDocument, version)
         {
-
             _tagHelperDescriptors = CreateTagHelperDescriptors();
             if (tagHelpers is not null)
             {
@@ -1255,18 +1255,24 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : SingleServer
             }
         }
 
-        public override DocumentContext? TryCreate(Uri documentUri, VSProjectContext? projectContext, bool versioned)
+        public override bool TryCreate(
+            Uri documentUri,
+            VSProjectContext? projectContext,
+            bool versioned,
+            [NotNullWhen(true)] out DocumentContext? context)
         {
             if (FilePath is null || CodeDocument is null)
             {
-                return null;
+                context = null;
+                return false;
             }
 
             var projectWorkspaceState = ProjectWorkspaceState.Create(_tagHelperDescriptors.ToImmutableArray());
             var testDocumentSnapshot = TestDocumentSnapshot.Create(FilePath, CodeDocument.GetSourceText().ToString(), CodeAnalysis.VersionStamp.Default, projectWorkspaceState);
             testDocumentSnapshot.With(CodeDocument);
 
-            return CreateDocumentContext(new Uri(FilePath), testDocumentSnapshot);
+            context = CreateDocumentContext(new Uri(FilePath), testDocumentSnapshot);
+            return true;
         }
 
         private static List<TagHelperDescriptor> CreateTagHelperDescriptors()

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Html/DefaultHtmlCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Html/DefaultHtmlCodeActionResolverTest.cs
@@ -33,8 +33,7 @@ public class DefaultHtmlCodeActionResolverTest(ITestOutputHelper testOutput) : L
         var documentPath = "c:/Test.razor";
         var documentUri = new Uri(documentPath);
         var documentContextFactory = CreateDocumentContextFactory(documentUri, contents);
-        var context = documentContextFactory.TryCreate(documentUri);
-        Assert.NotNull(context);
+        Assert.True(documentContextFactory.TryCreate(documentUri, out var context));
         var sourceText = await context.GetSourceTextAsync(DisposalToken);
         var remappedEdit = new WorkspaceEdit
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Html/DefaultHtmlCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Html/DefaultHtmlCodeActionResolverTest.cs
@@ -33,7 +33,7 @@ public class DefaultHtmlCodeActionResolverTest(ITestOutputHelper testOutput) : L
         var documentPath = "c:/Test.razor";
         var documentUri = new Uri(documentPath);
         var documentContextFactory = CreateDocumentContextFactory(documentUri, contents);
-        var context = await documentContextFactory.TryCreateAsync(documentUri, DisposalToken);
+        var context = documentContextFactory.TryCreate(documentUri);
         Assert.NotNull(context);
         var sourceText = await context.GetSourceTextAsync(DisposalToken);
         var remappedEdit = new WorkspaceEdit

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultLSPTagHelperTooltipFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultLSPTagHelperTooltipFactoryTest.cs
@@ -67,7 +67,6 @@ World", cleanedSummary);
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultLSPTagHelperTooltipFactory(snapshotResolver);
         var elementDescription = AggregateBoundElementDescription.Empty;
 
@@ -83,7 +82,6 @@ World", cleanedSummary);
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedTagHelperInfos = new[]
         {
@@ -106,7 +104,6 @@ Uses `List<System.String>`s", markdown.Value);
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedTagHelperInfos = new[]
         {
@@ -126,11 +123,10 @@ Uses `List<System.String>`s", markdown.Value);
     }
 
     [Fact]
-    public async Task TryCreateTooltip_Markup_Attribute_PlainText_NoBold()
+    public void TryCreateTooltip_Markup_Attribute_PlainText_NoBold()
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedAttributeDescriptions = new[]
         {
@@ -158,7 +154,6 @@ Uses `List<System.String>`s", markdown.Value);
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedTagHelperInfos = new[]
         {
@@ -183,11 +178,10 @@ Also uses `List<System.String>`s", markdown.Value);
     }
 
     [Fact]
-    public async Task TryCreateTooltip_Markup_Attribute_SingleAssociatedAttribute_ReturnsTrue()
+    public void TryCreateTooltip_Markup_Attribute_SingleAssociatedAttribute_ReturnsTrue()
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedAttributeDescriptions = new[]
         {
@@ -211,11 +205,10 @@ Uses `List<System.String>`s", markdown.Value);
     }
 
     [Fact]
-    public async Task TryCreateTooltip_Markup_Attribute_MultipleAssociatedAttributes_ReturnsTrue()
+    public void TryCreateTooltip_Markup_Attribute_MultipleAssociatedAttributes_ReturnsTrue()
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedAttributeDescriptions = new[]
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultLSPTagHelperTooltipFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultLSPTagHelperTooltipFactoryTest.cs
@@ -67,6 +67,7 @@ World", cleanedSummary);
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
+        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultLSPTagHelperTooltipFactory(snapshotResolver);
         var elementDescription = AggregateBoundElementDescription.Empty;
 
@@ -82,6 +83,7 @@ World", cleanedSummary);
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
+        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedTagHelperInfos = new[]
         {
@@ -104,6 +106,7 @@ Uses `List<System.String>`s", markdown.Value);
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
+        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedTagHelperInfos = new[]
         {
@@ -123,10 +126,11 @@ Uses `List<System.String>`s", markdown.Value);
     }
 
     [Fact]
-    public void TryCreateTooltip_Markup_Attribute_PlainText_NoBold()
+    public async Task TryCreateTooltip_Markup_Attribute_PlainText_NoBold()
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
+        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedAttributeDescriptions = new[]
         {
@@ -154,6 +158,7 @@ Uses `List<System.String>`s", markdown.Value);
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
+        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedTagHelperInfos = new[]
         {
@@ -178,10 +183,11 @@ Also uses `List<System.String>`s", markdown.Value);
     }
 
     [Fact]
-    public void TryCreateTooltip_Markup_Attribute_SingleAssociatedAttribute_ReturnsTrue()
+    public async Task TryCreateTooltip_Markup_Attribute_SingleAssociatedAttribute_ReturnsTrue()
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
+        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedAttributeDescriptions = new[]
         {
@@ -205,10 +211,11 @@ Uses `List<System.String>`s", markdown.Value);
     }
 
     [Fact]
-    public void TryCreateTooltip_Markup_Attribute_MultipleAssociatedAttributes_ReturnsTrue()
+    public async Task TryCreateTooltip_Markup_Attribute_MultipleAssociatedAttributes_ReturnsTrue()
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
+        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedAttributeDescriptions = new[]
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultVSLSPTagHelperTooltipFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultVSLSPTagHelperTooltipFactoryTest.cs
@@ -171,6 +171,7 @@ End summary description.";
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
+        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var elementDescription = AggregateBoundElementDescription.Empty;
 
@@ -186,6 +187,7 @@ End summary description.";
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
+        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedTagHelperInfos = new[]
         {
@@ -227,6 +229,7 @@ End summary description.";
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
+        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedTagHelperInfos = new[]
         {
@@ -267,6 +270,7 @@ End summary description.";
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
+        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedTagHelperInfos = new[]
         {
@@ -317,10 +321,11 @@ End summary description.";
     }
 
     [Fact]
-    public void TryCreateTooltip_ClassifiedTextElement_NoAssociatedAttributeDescriptions_ReturnsFalse()
+    public async Task TryCreateTooltip_ClassifiedTextElement_NoAssociatedAttributeDescriptions_ReturnsFalse()
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
+        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var elementDescription = AggregateBoundAttributeDescription.Empty;
 
@@ -333,10 +338,11 @@ End summary description.";
     }
 
     [Fact]
-    public void TryCreateTooltip_ClassifiedTextElement_Attribute_SingleAssociatedAttribute_ReturnsTrue_NestedTypes()
+    public async Task TryCreateTooltip_ClassifiedTextElement_Attribute_SingleAssociatedAttribute_ReturnsTrue_NestedTypes()
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
+        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedAttributeDescriptions = new[]
         {
@@ -382,10 +388,11 @@ End summary description.";
     }
 
     [Fact]
-    public void TryCreateTooltip_ClassifiedTextElement_Attribute_MultipleAssociatedAttributes_ReturnsTrue()
+    public async Task TryCreateTooltip_ClassifiedTextElement_Attribute_MultipleAssociatedAttributes_ReturnsTrue()
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
+        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedAttributeDescriptions = new[]
         {
@@ -461,6 +468,7 @@ End summary description.";
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
+        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var elementDescription = AggregateBoundElementDescription.Empty;
 
@@ -476,6 +484,7 @@ End summary description.";
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
+        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedTagHelperInfos = new[]
         {
@@ -556,10 +565,11 @@ End summary description.";
     }
 
     [Fact]
-    public void TryCreateTooltip_ContainerElement_NoAssociatedAttributeDescriptions_ReturnsFalse()
+    public async Task TryCreateTooltip_ContainerElement_NoAssociatedAttributeDescriptions_ReturnsFalse()
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
+        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var elementDescription = AggregateBoundAttributeDescription.Empty;
 
@@ -572,10 +582,11 @@ End summary description.";
     }
 
     [Fact]
-    public void TryCreateTooltip_ContainerElement_Attribute_MultipleAssociatedAttributes_ReturnsTrue()
+    public async Task TryCreateTooltip_ContainerElement_Attribute_MultipleAssociatedAttributes_ReturnsTrue()
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
+        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedAttributeDescriptions = new[]
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultVSLSPTagHelperTooltipFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DefaultVSLSPTagHelperTooltipFactoryTest.cs
@@ -171,7 +171,6 @@ End summary description.";
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var elementDescription = AggregateBoundElementDescription.Empty;
 
@@ -187,7 +186,6 @@ End summary description.";
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedTagHelperInfos = new[]
         {
@@ -229,7 +227,6 @@ End summary description.";
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedTagHelperInfos = new[]
         {
@@ -270,7 +267,6 @@ End summary description.";
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedTagHelperInfos = new[]
         {
@@ -321,11 +317,10 @@ End summary description.";
     }
 
     [Fact]
-    public async Task TryCreateTooltip_ClassifiedTextElement_NoAssociatedAttributeDescriptions_ReturnsFalse()
+    public void TryCreateTooltip_ClassifiedTextElement_NoAssociatedAttributeDescriptions_ReturnsFalse()
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var elementDescription = AggregateBoundAttributeDescription.Empty;
 
@@ -338,11 +333,10 @@ End summary description.";
     }
 
     [Fact]
-    public async Task TryCreateTooltip_ClassifiedTextElement_Attribute_SingleAssociatedAttribute_ReturnsTrue_NestedTypes()
+    public void TryCreateTooltip_ClassifiedTextElement_Attribute_SingleAssociatedAttribute_ReturnsTrue_NestedTypes()
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedAttributeDescriptions = new[]
         {
@@ -388,11 +382,10 @@ End summary description.";
     }
 
     [Fact]
-    public async Task TryCreateTooltip_ClassifiedTextElement_Attribute_MultipleAssociatedAttributes_ReturnsTrue()
+    public void TryCreateTooltip_ClassifiedTextElement_Attribute_MultipleAssociatedAttributes_ReturnsTrue()
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedAttributeDescriptions = new[]
         {
@@ -468,7 +461,6 @@ End summary description.";
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var elementDescription = AggregateBoundElementDescription.Empty;
 
@@ -484,7 +476,6 @@ End summary description.";
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedTagHelperInfos = new[]
         {
@@ -565,11 +556,10 @@ End summary description.";
     }
 
     [Fact]
-    public async Task TryCreateTooltip_ContainerElement_NoAssociatedAttributeDescriptions_ReturnsFalse()
+    public void TryCreateTooltip_ContainerElement_NoAssociatedAttributeDescriptions_ReturnsFalse()
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var elementDescription = AggregateBoundAttributeDescription.Empty;
 
@@ -582,11 +572,10 @@ End summary description.";
     }
 
     [Fact]
-    public async Task TryCreateTooltip_ContainerElement_Attribute_MultipleAssociatedAttributes_ReturnsTrue()
+    public void TryCreateTooltip_ContainerElement_Attribute_MultipleAssociatedAttributes_ReturnsTrue()
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         var associatedAttributeDescriptions = new[]
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/LegacyRazorCompletionResolveEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/LegacyRazorCompletionResolveEndpointTest.cs
@@ -20,18 +20,18 @@ using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion;
 
-public class LegacyRazorCompletionResolveEndpointTest : LanguageServerTestBase
+public class LegacyRazorCompletionResolveEndpointTest(ITestOutputHelper testOutput) : LanguageServerTestBase(testOutput)
 {
-    private readonly LSPTagHelperTooltipFactory _lspTagHelperTooltipFactory;
-    private readonly VSLSPTagHelperTooltipFactory _vsLspTagHelperTooltipFactory;
-    private readonly CompletionListCache _completionListCache;
-    private readonly VSInternalCompletionSetting _completionCapability;
-    private readonly VSInternalClientCapabilities _defaultClientCapability;
+    private LSPTagHelperTooltipFactory _lspTagHelperTooltipFactory;
+    private VSLSPTagHelperTooltipFactory _vsLspTagHelperTooltipFactory;
+    private CompletionListCache _completionListCache;
+    private VSInternalCompletionSetting _completionCapability;
+    private VSInternalClientCapabilities _defaultClientCapability;
 
-    public LegacyRazorCompletionResolveEndpointTest(ITestOutputHelper testOutput)
-        : base(testOutput)
+    protected async override Task InitializeAsync()
     {
         var snapshotResolver = new TestSnapshotResolver();
+        await snapshotResolver.InitializeAsync(DisposalToken);
         _lspTagHelperTooltipFactory = new Mock<LSPTagHelperTooltipFactory>(MockBehavior.Strict, snapshotResolver).Object;
         _vsLspTagHelperTooltipFactory = new Mock<VSLSPTagHelperTooltipFactory>(MockBehavior.Strict, snapshotResolver).Object;
         _completionListCache = new CompletionListCache();
@@ -97,6 +97,7 @@ public class LegacyRazorCompletionResolveEndpointTest : LanguageServerTestBase
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
+        await snapshotResolver.InitializeAsync(DisposalToken);
         var lspDescriptionFactory = new Mock<LSPTagHelperTooltipFactory>(MockBehavior.Strict, snapshotResolver);
         var markdown = new MarkupContent
         {
@@ -126,6 +127,7 @@ public class LegacyRazorCompletionResolveEndpointTest : LanguageServerTestBase
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
+        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new Mock<LSPTagHelperTooltipFactory>(MockBehavior.Strict, snapshotResolver);
         var markdown = new MarkupContent
         {
@@ -155,6 +157,7 @@ public class LegacyRazorCompletionResolveEndpointTest : LanguageServerTestBase
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
+        await snapshotResolver.InitializeAsync(DisposalToken);
         var lspDescriptionFactory = new Mock<LSPTagHelperTooltipFactory>(MockBehavior.Strict, snapshotResolver);
         var markdown = new MarkupContent
         {
@@ -184,6 +187,7 @@ public class LegacyRazorCompletionResolveEndpointTest : LanguageServerTestBase
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
+        await snapshotResolver.InitializeAsync(DisposalToken);
         var lspDescriptionFactory = new Mock<LSPTagHelperTooltipFactory>(MockBehavior.Strict, snapshotResolver);
         var markdown = new MarkupContent
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/LegacyRazorCompletionResolveEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/LegacyRazorCompletionResolveEndpointTest.cs
@@ -20,18 +20,18 @@ using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion;
 
-public class LegacyRazorCompletionResolveEndpointTest(ITestOutputHelper testOutput) : LanguageServerTestBase(testOutput)
+public class LegacyRazorCompletionResolveEndpointTest : LanguageServerTestBase
 {
-    private LSPTagHelperTooltipFactory _lspTagHelperTooltipFactory;
-    private VSLSPTagHelperTooltipFactory _vsLspTagHelperTooltipFactory;
-    private CompletionListCache _completionListCache;
-    private VSInternalCompletionSetting _completionCapability;
-    private VSInternalClientCapabilities _defaultClientCapability;
+    private readonly LSPTagHelperTooltipFactory _lspTagHelperTooltipFactory;
+    private readonly VSLSPTagHelperTooltipFactory _vsLspTagHelperTooltipFactory;
+    private readonly CompletionListCache _completionListCache;
+    private readonly VSInternalCompletionSetting _completionCapability;
+    private readonly VSInternalClientCapabilities _defaultClientCapability;
 
-    protected async override Task InitializeAsync()
+    public LegacyRazorCompletionResolveEndpointTest(ITestOutputHelper testOutput)
+        : base(testOutput)
     {
         var snapshotResolver = new TestSnapshotResolver();
-        await snapshotResolver.InitializeAsync(DisposalToken);
         _lspTagHelperTooltipFactory = new Mock<LSPTagHelperTooltipFactory>(MockBehavior.Strict, snapshotResolver).Object;
         _vsLspTagHelperTooltipFactory = new Mock<VSLSPTagHelperTooltipFactory>(MockBehavior.Strict, snapshotResolver).Object;
         _completionListCache = new CompletionListCache();
@@ -39,7 +39,7 @@ public class LegacyRazorCompletionResolveEndpointTest(ITestOutputHelper testOutp
         {
             CompletionItem = new CompletionItemSetting()
             {
-                DocumentationFormat = new[] { MarkupKind.PlainText, MarkupKind.Markdown },
+                DocumentationFormat = [MarkupKind.PlainText, MarkupKind.Markdown],
             }
         };
 
@@ -97,7 +97,6 @@ public class LegacyRazorCompletionResolveEndpointTest(ITestOutputHelper testOutp
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var lspDescriptionFactory = new Mock<LSPTagHelperTooltipFactory>(MockBehavior.Strict, snapshotResolver);
         var markdown = new MarkupContent
         {
@@ -127,7 +126,6 @@ public class LegacyRazorCompletionResolveEndpointTest(ITestOutputHelper testOutp
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var descriptionFactory = new Mock<LSPTagHelperTooltipFactory>(MockBehavior.Strict, snapshotResolver);
         var markdown = new MarkupContent
         {
@@ -157,7 +155,6 @@ public class LegacyRazorCompletionResolveEndpointTest(ITestOutputHelper testOutp
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var lspDescriptionFactory = new Mock<LSPTagHelperTooltipFactory>(MockBehavior.Strict, snapshotResolver);
         var markdown = new MarkupContent
         {
@@ -187,7 +184,6 @@ public class LegacyRazorCompletionResolveEndpointTest(ITestOutputHelper testOutp
     {
         // Arrange
         var snapshotResolver = new TestSnapshotResolver();
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var lspDescriptionFactory = new Mock<LSPTagHelperTooltipFactory>(MockBehavior.Strict, snapshotResolver);
         var markdown = new MarkupContent
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionItemResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionItemResolverTest.cs
@@ -17,20 +17,20 @@ using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion;
 
-public class RazorCompletionItemResolverTest(ITestOutputHelper testOutput) : LanguageServerTestBase(testOutput)
+public class RazorCompletionItemResolverTest : LanguageServerTestBase
 {
-    private LSPTagHelperTooltipFactory _lspTagHelperTooltipFactory;
-    private VSLSPTagHelperTooltipFactory _vsLspTagHelperTooltipFactory;
-    private VSInternalCompletionSetting _completionCapability;
-    private VSInternalClientCapabilities _defaultClientCapability;
-    private VSInternalClientCapabilities _vsClientCapability;
-    private AggregateBoundAttributeDescription _attributeDescription;
-    private AggregateBoundElementDescription _elementDescription;
+    private readonly LSPTagHelperTooltipFactory _lspTagHelperTooltipFactory;
+    private readonly VSLSPTagHelperTooltipFactory _vsLspTagHelperTooltipFactory;
+    private readonly VSInternalCompletionSetting _completionCapability;
+    private readonly VSInternalClientCapabilities _defaultClientCapability;
+    private readonly VSInternalClientCapabilities _vsClientCapability;
+    private readonly AggregateBoundAttributeDescription _attributeDescription;
+    private readonly AggregateBoundElementDescription _elementDescription;
 
-    protected async override Task InitializeAsync()
+    public RazorCompletionItemResolverTest(ITestOutputHelper testOutput)
+        : base(testOutput)
     {
         var snapshotResolver = new TestSnapshotResolver();
-        await snapshotResolver.InitializeAsync(DisposalToken);
 
         _lspTagHelperTooltipFactory = new DefaultLSPTagHelperTooltipFactory(snapshotResolver);
         _vsLspTagHelperTooltipFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
@@ -38,7 +38,7 @@ public class RazorCompletionItemResolverTest(ITestOutputHelper testOutput) : Lan
         {
             CompletionItem = new CompletionItemSetting()
             {
-                DocumentationFormat = new[] { MarkupKind.PlainText, MarkupKind.Markdown },
+                DocumentationFormat = [MarkupKind.PlainText, MarkupKind.Markdown],
             }
         };
 
@@ -60,9 +60,9 @@ public class RazorCompletionItemResolverTest(ITestOutputHelper testOutput) : Lan
         };
 
         var attributeDescriptionInfo = new BoundAttributeDescriptionInfo("System.DateTime", "System.DateTime", "DateTime", "Returns the time.");
-        _attributeDescription = new AggregateBoundAttributeDescription(ImmutableArray.Create(attributeDescriptionInfo));
+        _attributeDescription = new AggregateBoundAttributeDescription([attributeDescriptionInfo]);
         var elementDescriptionInfo = new BoundElementDescriptionInfo("System.SomeTagHelper", "This is some TagHelper.");
-        _elementDescription = new AggregateBoundElementDescription(ImmutableArray.Create(elementDescriptionInfo));
+        _elementDescription = new AggregateBoundElementDescription([elementDescriptionInfo]);
     }
 
     [Fact]

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionItemResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionItemResolverTest.cs
@@ -17,20 +17,21 @@ using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion;
 
-public class RazorCompletionItemResolverTest : LanguageServerTestBase
+public class RazorCompletionItemResolverTest(ITestOutputHelper testOutput) : LanguageServerTestBase(testOutput)
 {
-    private readonly LSPTagHelperTooltipFactory _lspTagHelperTooltipFactory;
-    private readonly VSLSPTagHelperTooltipFactory _vsLspTagHelperTooltipFactory;
-    private readonly VSInternalCompletionSetting _completionCapability;
-    private readonly VSInternalClientCapabilities _defaultClientCapability;
-    private readonly VSInternalClientCapabilities _vsClientCapability;
-    private readonly AggregateBoundAttributeDescription _attributeDescription;
-    private readonly AggregateBoundElementDescription _elementDescription;
+    private LSPTagHelperTooltipFactory _lspTagHelperTooltipFactory;
+    private VSLSPTagHelperTooltipFactory _vsLspTagHelperTooltipFactory;
+    private VSInternalCompletionSetting _completionCapability;
+    private VSInternalClientCapabilities _defaultClientCapability;
+    private VSInternalClientCapabilities _vsClientCapability;
+    private AggregateBoundAttributeDescription _attributeDescription;
+    private AggregateBoundElementDescription _elementDescription;
 
-    public RazorCompletionItemResolverTest(ITestOutputHelper testOutput)
-        : base(testOutput)
+    protected async override Task InitializeAsync()
     {
         var snapshotResolver = new TestSnapshotResolver();
+        await snapshotResolver.InitializeAsync(DisposalToken);
+
         _lspTagHelperTooltipFactory = new DefaultLSPTagHelperTooltipFactory(snapshotResolver);
         _vsLspTagHelperTooltipFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
         _completionCapability = new VSInternalCompletionSetting()

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperTooltipFactoryBaseTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperTooltipFactoryBaseTest.cs
@@ -346,7 +346,6 @@ There is no xml, but I got you this < and the >.
     public async Task GetAvailableProjects_NoProjects_ReturnsNull()
     {
         var snapshotResolver = new TestSnapshotResolver();
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var service = new TestTagHelperToolTipFactory(snapshotResolver);
 
         var availability = await service.GetProjectAvailabilityAsync("file.razor", "MyTagHelper", CancellationToken.None);
@@ -371,7 +370,6 @@ There is no xml, but I got you this < and the >.
         var project = TestProjectSnapshot.Create(projectFilePath, documentFilePaths: [razorFilePath], projectWorkspaceState);
 
         var snapshotResolver = new TestSnapshotResolver(razorFilePath, project);
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var service = new TestTagHelperToolTipFactory(snapshotResolver);
 
         var availability = await service.GetProjectAvailabilityAsync(razorFilePath, tagHelperTypeName, CancellationToken.None);
@@ -409,7 +407,6 @@ There is no xml, but I got you this < and the >.
            projectWorkspaceState);
 
         var snapshotResolver = new TestSnapshotResolver(razorFilePath, project1, project2);
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var service = new TestTagHelperToolTipFactory(snapshotResolver);
 
         var availability = await service.GetProjectAvailabilityAsync(razorFilePath, tagHelperTypeName, CancellationToken.None);
@@ -449,7 +446,6 @@ There is no xml, but I got you this < and the >.
             displayName: "project2");
 
         var snapshotResolver = new TestSnapshotResolver(razorFilePath, project1, project2);
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var service = new TestTagHelperToolTipFactory(snapshotResolver);
 
         var availability = await service.GetProjectAvailabilityAsync(razorFilePath, tagHelperTypeName, CancellationToken.None);
@@ -486,7 +482,6 @@ There is no xml, but I got you this < and the >.
            displayName: "project2");
 
         var snapshotResolver = new TestSnapshotResolver(razorFilePath, project1, project2);
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var service = new TestTagHelperToolTipFactory(snapshotResolver);
 
         var availability = await service.GetProjectAvailabilityAsync(razorFilePath, "MyTagHelper", CancellationToken.None);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperTooltipFactoryBaseTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperTooltipFactoryBaseTest.cs
@@ -346,6 +346,7 @@ There is no xml, but I got you this < and the >.
     public async Task GetAvailableProjects_NoProjects_ReturnsNull()
     {
         var snapshotResolver = new TestSnapshotResolver();
+        await snapshotResolver.InitializeAsync(DisposalToken);
         var service = new TestTagHelperToolTipFactory(snapshotResolver);
 
         var availability = await service.GetProjectAvailabilityAsync("file.razor", "MyTagHelper", CancellationToken.None);
@@ -370,6 +371,7 @@ There is no xml, but I got you this < and the >.
         var project = TestProjectSnapshot.Create(projectFilePath, documentFilePaths: [razorFilePath], projectWorkspaceState);
 
         var snapshotResolver = new TestSnapshotResolver(razorFilePath, project);
+        await snapshotResolver.InitializeAsync(DisposalToken);
         var service = new TestTagHelperToolTipFactory(snapshotResolver);
 
         var availability = await service.GetProjectAvailabilityAsync(razorFilePath, tagHelperTypeName, CancellationToken.None);
@@ -407,6 +409,7 @@ There is no xml, but I got you this < and the >.
            projectWorkspaceState);
 
         var snapshotResolver = new TestSnapshotResolver(razorFilePath, project1, project2);
+        await snapshotResolver.InitializeAsync(DisposalToken);
         var service = new TestTagHelperToolTipFactory(snapshotResolver);
 
         var availability = await service.GetProjectAvailabilityAsync(razorFilePath, tagHelperTypeName, CancellationToken.None);
@@ -446,6 +449,7 @@ There is no xml, but I got you this < and the >.
             displayName: "project2");
 
         var snapshotResolver = new TestSnapshotResolver(razorFilePath, project1, project2);
+        await snapshotResolver.InitializeAsync(DisposalToken);
         var service = new TestTagHelperToolTipFactory(snapshotResolver);
 
         var availability = await service.GetProjectAvailabilityAsync(razorFilePath, tagHelperTypeName, CancellationToken.None);
@@ -482,6 +486,7 @@ There is no xml, but I got you this < and the >.
            displayName: "project2");
 
         var snapshotResolver = new TestSnapshotResolver(razorFilePath, project1, project2);
+        await snapshotResolver.InitializeAsync(DisposalToken);
         var service = new TestTagHelperToolTipFactory(snapshotResolver);
 
         var availability = await service.GetProjectAvailabilityAsync(razorFilePath, "MyTagHelper", CancellationToken.None);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Debugging/ValidateBreakpointRangeEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Debugging/ValidateBreakpointRangeEndpointTest.cs
@@ -152,7 +152,7 @@ public class ValidateBreakpointRangeEndpointTest(ITestOutputHelper testOutput) :
             Range = breakpointSpan.ToRange(codeDocument.GetSourceText())
         };
 
-        var documentContext = await DocumentContextFactory.TryCreateForOpenDocumentAsync(request.TextDocument, DisposalToken);
+        var documentContext = DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument);
         Assert.NotNull(documentContext);
         var requestContext = CreateValidateBreakpointRangeRequestContext(documentContext);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Debugging/ValidateBreakpointRangeEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Debugging/ValidateBreakpointRangeEndpointTest.cs
@@ -152,8 +152,7 @@ public class ValidateBreakpointRangeEndpointTest(ITestOutputHelper testOutput) :
             Range = breakpointSpan.ToRange(codeDocument.GetSourceText())
         };
 
-        var documentContext = DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument);
-        Assert.NotNull(documentContext);
+        Assert.True(DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument, out var documentContext));
         var requestContext = CreateValidateBreakpointRangeRequestContext(documentContext);
 
         return await endpoint.HandleRequestAsync(request, requestContext, DisposalToken);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorComponentSearchEngineTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorComponentSearchEngineTest.cs
@@ -47,6 +47,7 @@ public class DefaultRazorComponentSearchEngineTest(ITestOutputHelper testOutput)
         _projectManager = CreateProjectSnapshotManager();
 
         var snapshotResolver = new SnapshotResolver(_projectManager, LoggerFactory);
+        await snapshotResolver.InitializeAsync(DisposalToken);
         var documentVersionCache = new DocumentVersionCache(_projectManager);
 
         var remoteTextLoaderFactoryMock = new StrictMock<RemoteTextLoaderFactory>();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorComponentSearchEngineTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorComponentSearchEngineTest.cs
@@ -48,7 +48,7 @@ public class DefaultRazorComponentSearchEngineTest(ITestOutputHelper testOutput)
         _projectManager = CreateProjectSnapshotManager();
 
         var snapshotResolver = new SnapshotResolver(_projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
         var documentVersionCache = new DocumentVersionCache(_projectManager);
 
         var remoteTextLoaderFactoryMock = new StrictMock<RemoteTextLoaderFactory>();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorComponentSearchEngineTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorComponentSearchEngineTest.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.AspNetCore.Razor.Test.Common.ProjectSystem;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CommonLanguageServerProtocol.Framework;
 using Moq;
 using Xunit;
 using Xunit.Abstractions;
@@ -47,7 +48,7 @@ public class DefaultRazorComponentSearchEngineTest(ITestOutputHelper testOutput)
         _projectManager = CreateProjectSnapshotManager();
 
         var snapshotResolver = new SnapshotResolver(_projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
         var documentVersionCache = new DocumentVersionCache(_projectManager);
 
         var remoteTextLoaderFactoryMock = new StrictMock<RemoteTextLoaderFactory>();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorComponentSearchEngineTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorComponentSearchEngineTest.cs
@@ -48,7 +48,7 @@ public class DefaultRazorComponentSearchEngineTest(ITestOutputHelper testOutput)
         _projectManager = CreateProjectSnapshotManager();
 
         var snapshotResolver = new SnapshotResolver(_projectManager, LoggerFactory);
-        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
         var documentVersionCache = new DocumentVersionCache(_projectManager);
 
         var remoteTextLoaderFactoryMock = new StrictMock<RemoteTextLoaderFactory>();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/DefinitionEndpointDelegationTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/DefinitionEndpointDelegationTest.cs
@@ -239,7 +239,7 @@ public class DefinitionEndpointDelegationTest(ITestOutputHelper testOutput) : Si
         var searchEngine = new DefaultRazorComponentSearchEngine(projectManager, LoggerFactory);
 
         var razorUri = new Uri(razorFilePath);
-        var documentContext = await DocumentContextFactory.TryCreateForOpenDocumentAsync(razorUri, DisposalToken);
+        var documentContext = DocumentContextFactory.TryCreateForOpenDocument(razorUri);
         var requestContext = CreateRazorRequestContext(documentContext);
 
         var endpoint = new DefinitionEndpoint(searchEngine, DocumentMappingService, LanguageServerFeatureOptions, languageServer, LoggerFactory);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/DefinitionEndpointDelegationTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/DefinitionEndpointDelegationTest.cs
@@ -239,7 +239,7 @@ public class DefinitionEndpointDelegationTest(ITestOutputHelper testOutput) : Si
         var searchEngine = new DefaultRazorComponentSearchEngine(projectManager, LoggerFactory);
 
         var razorUri = new Uri(razorFilePath);
-        var documentContext = DocumentContextFactory.TryCreateForOpenDocument(razorUri);
+        Assert.True(DocumentContextFactory.TryCreateForOpenDocument(razorUri, out var documentContext));
         var requestContext = CreateRazorRequestContext(documentContext);
 
         var endpoint = new DefinitionEndpoint(searchEngine, DocumentMappingService, LanguageServerFeatureOptions, languageServer, LoggerFactory);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentContextFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentContextFactoryTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -217,9 +218,16 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
         public IProjectSnapshot GetMiscellaneousProject()
             => throw new NotImplementedException();
 
-        public IDocumentSnapshot? ResolveDocumentInAnyProject(string documentFilePath)
-            => documentFilePath == _documentSnapshot?.FilePath
-                ? _documentSnapshot
-                : null;
+        public bool TryResolveDocumentInAnyProject(string documentFilePath, [NotNullWhen(true)] out IDocumentSnapshot? document)
+        {
+            if (documentFilePath == _documentSnapshot?.FilePath)
+            {
+                document = _documentSnapshot;
+                return true;
+            }
+
+            document = null;
+            return false;
+        }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentContextFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentContextFactoryTest.cs
@@ -214,7 +214,7 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
         public ImmutableArray<IProjectSnapshot> FindPotentialProjects(string documentFilePath)
             => throw new NotImplementedException();
 
-        public Task<IProjectSnapshot> GetMiscellaneousProjectAsync(CancellationToken cancellationToken)
+        public IProjectSnapshot GetMiscellaneousProject()
             => throw new NotImplementedException();
 
         public Task<IDocumentSnapshot?> ResolveDocumentInAnyProjectAsync(string documentFilePath, CancellationToken cancellationToken)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentContextFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentContextFactoryTest.cs
@@ -46,7 +46,7 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
         var factory = new DocumentContextFactory(_projectManager, snapshotResolver, _documentVersionCache, LoggerFactory);
 
         // Act
-        var documentContext = await factory.TryCreateAsync(uri, DisposalToken);
+        var documentContext = factory.TryCreate(uri);
 
         // Assert
         Assert.Null(documentContext);
@@ -65,7 +65,7 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
         var factory = new DocumentContextFactory(_projectManager, snapshotResolver, _documentVersionCache, LoggerFactory);
 
         // Act
-        var documentContext = await factory.TryCreateForOpenDocumentAsync(uri, DisposalToken);
+        var documentContext = factory.TryCreateForOpenDocument(uri);
 
         // Assert
         Assert.Null(documentContext);
@@ -84,7 +84,7 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
         var factory = new DocumentContextFactory(_projectManager, snapshotResolver, _documentVersionCache, LoggerFactory);
 
         // Act
-        var documentContext = await factory.TryCreateForOpenDocumentAsync(uri, DisposalToken);
+        var documentContext = factory.TryCreateForOpenDocument(uri);
 
         // Assert
         Assert.Null(documentContext);
@@ -105,7 +105,7 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
         var factory = new DocumentContextFactory(_projectManager, snapshotResolver, _documentVersionCache, LoggerFactory);
 
         // Act
-        var documentContext = await factory.TryCreateAsync(uri, DisposalToken);
+        var documentContext = factory.TryCreate(uri);
 
         // Assert
         Assert.NotNull(documentContext);
@@ -139,7 +139,7 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
         });
 
         // Act
-        var documentContext = await factory.TryCreateAsync(uri, new VisualStudio.LanguageServer.Protocol.VSProjectContext { Id = hostProject.Key.Id }, DisposalToken);
+        var documentContext = factory.TryCreate(uri, new VisualStudio.LanguageServer.Protocol.VSProjectContext { Id = hostProject.Key.Id });
 
         // Assert
         Assert.NotNull(documentContext);
@@ -171,7 +171,7 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
         });
 
         // Act
-        var documentContext = await factory.TryCreateAsync(uri, new VisualStudio.LanguageServer.Protocol.VSProjectContext { Id = hostProject.Key.Id }, DisposalToken);
+        var documentContext = factory.TryCreate(uri, new VisualStudio.LanguageServer.Protocol.VSProjectContext { Id = hostProject.Key.Id });
 
         // Assert
         Assert.NotNull(documentContext);
@@ -195,7 +195,7 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
         var factory = new DocumentContextFactory(_projectManager, snapshotResolver, _documentVersionCache, LoggerFactory);
 
         // Act
-        var documentContext = await factory.TryCreateForOpenDocumentAsync(uri, DisposalToken);
+        var documentContext = factory.TryCreateForOpenDocument(uri);
 
         // Assert
         Assert.NotNull(documentContext);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentContextFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentContextFactoryTest.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
@@ -35,14 +34,13 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
     }
 
     [Fact]
-    public async Task TryCreateAsync_CanNotResolveDocument_ReturnsNull()
+    public void TryCreateAsync_CanNotResolveDocument_ReturnsNull()
     {
         // Arrange
         var filePath = FilePathNormalizer.Normalize(Path.Combine(s_baseDirectory, "file.cshtml"));
         var uri = new Uri(filePath);
 
         var snapshotResolver = new TestSnapshotResolver();
-        await snapshotResolver.InitializeAsync(DisposalToken);
 
         var factory = new DocumentContextFactory(_projectManager, snapshotResolver, _documentVersionCache, LoggerFactory);
 
@@ -54,14 +52,13 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
     }
 
     [Fact]
-    public async Task TryCreateForOpenDocumentAsync_CanNotResolveDocument_ReturnsNull()
+    public void TryCreateForOpenDocumentAsync_CanNotResolveDocument_ReturnsNull()
     {
         // Arrange
         var filePath = FilePathNormalizer.Normalize(Path.Combine(s_baseDirectory, "file.cshtml"));
         var uri = new Uri(filePath);
 
         var snapshotResolver = new TestSnapshotResolver();
-        await snapshotResolver.InitializeAsync(DisposalToken);
 
         var factory = new DocumentContextFactory(_projectManager, snapshotResolver, _documentVersionCache, LoggerFactory);
 
@@ -73,7 +70,7 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
     }
 
     [Fact]
-    public async Task TryCreateForOpenDocumentAsync_CanNotResolveVersion_ReturnsNull()
+    public void TryCreateForOpenDocumentAsync_CanNotResolveVersion_ReturnsNull()
     {
         // Arrange
         var filePath = FilePathNormalizer.Normalize(Path.Combine(s_baseDirectory, "file.cshtml"));
@@ -81,7 +78,6 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
 
         var documentSnapshot = TestDocumentSnapshot.Create(filePath);
         var snapshotResolver = new TestSnapshotResolver(documentSnapshot);
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var factory = new DocumentContextFactory(_projectManager, snapshotResolver, _documentVersionCache, LoggerFactory);
 
         // Act
@@ -92,7 +88,7 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
     }
 
     [Fact]
-    public async Task TryCreateAsync_ResolvesContent()
+    public void TryCreateAsync_ResolvesContent()
     {
         // Arrange
         var filePath = FilePathNormalizer.Normalize(Path.Combine(s_baseDirectory, "file.cshtml"));
@@ -102,7 +98,6 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
         var codeDocument = RazorCodeDocument.Create(RazorSourceDocument.Create(string.Empty, documentSnapshot.FilePath));
         documentSnapshot.With(codeDocument);
         var snapshotResolver = new TestSnapshotResolver(documentSnapshot);
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var factory = new DocumentContextFactory(_projectManager, snapshotResolver, _documentVersionCache, LoggerFactory);
 
         // Act
@@ -127,7 +122,6 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
         var codeDocument = RazorCodeDocument.Create(RazorSourceDocument.Create(string.Empty, documentSnapshot.FilePath));
         documentSnapshot.With(codeDocument);
         var snapshotResolver = new TestSnapshotResolver(documentSnapshot);
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var factory = new DocumentContextFactory(_projectManager, snapshotResolver, _documentVersionCache, LoggerFactory);
 
         var hostProject = new HostProject(projectFilePath, intermediateOutputPath, RazorConfiguration.Default, rootNamespace: null);
@@ -181,7 +175,7 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
     }
 
     [Fact]
-    public async Task TryCreateForOpenDocumentAsync_ResolvesContent()
+    public void TryCreateForOpenDocumentAsync_ResolvesContent()
     {
         // Arrange
         var filePath = FilePathNormalizer.Normalize(Path.Combine(s_baseDirectory, "file.cshtml"));
@@ -191,7 +185,6 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
         var codeDocument = RazorCodeDocument.Create(RazorSourceDocument.Create(string.Empty, documentSnapshot.FilePath));
         documentSnapshot.With(codeDocument);
         var snapshotResolver = new TestSnapshotResolver(documentSnapshot);
-        await snapshotResolver.InitializeAsync(DisposalToken);
         _documentVersionCache.TrackDocumentVersion(documentSnapshot, version: 1337);
         var factory = new DocumentContextFactory(_projectManager, snapshotResolver, _documentVersionCache, LoggerFactory);
 
@@ -208,9 +201,6 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
     private sealed class TestSnapshotResolver(IDocumentSnapshot? documentSnapshot = null) : ISnapshotResolver
     {
         private readonly IDocumentSnapshot? _documentSnapshot = documentSnapshot;
-
-        public Task InitializeAsync(CancellationToken cancellationToken)
-            => Task.CompletedTask;
 
         public ImmutableArray<IProjectSnapshot> FindPotentialProjects(string documentFilePath)
             => throw new NotImplementedException();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentContextFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentContextFactoryTest.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.AspNetCore.Razor.Test.Common.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Utilities;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.VisualStudio.Copilot;
 using Moq;
 using Xunit;
 using Xunit.Abstractions;
@@ -45,10 +46,7 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
         var factory = new DocumentContextFactory(_projectManager, snapshotResolver, _documentVersionCache, LoggerFactory);
 
         // Act
-        var documentContext = factory.TryCreate(uri);
-
-        // Assert
-        Assert.Null(documentContext);
+        Assert.False(factory.TryCreate(uri, out _));
     }
 
     [Fact]
@@ -63,10 +61,7 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
         var factory = new DocumentContextFactory(_projectManager, snapshotResolver, _documentVersionCache, LoggerFactory);
 
         // Act
-        var documentContext = factory.TryCreateForOpenDocument(uri);
-
-        // Assert
-        Assert.Null(documentContext);
+        Assert.False(factory.TryCreateForOpenDocument(uri, out _));
     }
 
     [Fact]
@@ -81,10 +76,7 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
         var factory = new DocumentContextFactory(_projectManager, snapshotResolver, _documentVersionCache, LoggerFactory);
 
         // Act
-        var documentContext = factory.TryCreateForOpenDocument(uri);
-
-        // Assert
-        Assert.Null(documentContext);
+        Assert.False(factory.TryCreateForOpenDocument(uri, out _));
     }
 
     [Fact]
@@ -101,10 +93,9 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
         var factory = new DocumentContextFactory(_projectManager, snapshotResolver, _documentVersionCache, LoggerFactory);
 
         // Act
-        var documentContext = factory.TryCreate(uri);
+        Assert.True(factory.TryCreate(uri, out var documentContext));
 
         // Assert
-        Assert.NotNull(documentContext);
         Assert.Equal(uri, documentContext.Uri);
         Assert.Same(documentSnapshot, documentContext.Snapshot);
     }
@@ -134,10 +125,9 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
         });
 
         // Act
-        var documentContext = factory.TryCreate(uri, new VisualStudio.LanguageServer.Protocol.VSProjectContext { Id = hostProject.Key.Id });
+        Assert.True(factory.TryCreate(uri, new VisualStudio.LanguageServer.Protocol.VSProjectContext { Id = hostProject.Key.Id }, out var documentContext));
 
         // Assert
-        Assert.NotNull(documentContext);
         Assert.Equal(uri, documentContext.Uri);
     }
 
@@ -166,10 +156,9 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
         });
 
         // Act
-        var documentContext = factory.TryCreate(uri, new VisualStudio.LanguageServer.Protocol.VSProjectContext { Id = hostProject.Key.Id });
+        Assert.True(factory.TryCreate(uri, new VisualStudio.LanguageServer.Protocol.VSProjectContext { Id = hostProject.Key.Id }, out var documentContext));
 
         // Assert
-        Assert.NotNull(documentContext);
         Assert.Equal(uri, documentContext.Uri);
         documentResolverMock.Verify();
     }
@@ -189,10 +178,9 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
         var factory = new DocumentContextFactory(_projectManager, snapshotResolver, _documentVersionCache, LoggerFactory);
 
         // Act
-        var documentContext = factory.TryCreateForOpenDocument(uri);
+        Assert.True(factory.TryCreateForOpenDocument(uri, out var documentContext));
 
         // Assert
-        Assert.NotNull(documentContext);
         Assert.Equal(1337, documentContext.Version);
         Assert.Equal(uri, documentContext.Uri);
         Assert.Same(documentSnapshot, documentContext.Snapshot);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentContextFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentContextFactoryTest.cs
@@ -217,9 +217,9 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
         public IProjectSnapshot GetMiscellaneousProject()
             => throw new NotImplementedException();
 
-        public Task<IDocumentSnapshot?> ResolveDocumentInAnyProjectAsync(string documentFilePath, CancellationToken cancellationToken)
+        public IDocumentSnapshot? ResolveDocumentInAnyProject(string documentFilePath)
             => documentFilePath == _documentSnapshot?.FilePath
-                ? Task.FromResult<IDocumentSnapshot?>(_documentSnapshot)
-                : Task.FromResult<IDocumentSnapshot?>(null);
+                ? _documentSnapshot
+                : null;
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentPresentation/TextDocumentUriPresentationEndpointTests.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentPresentation/TextDocumentUriPresentationEndpointTests.cs
@@ -29,10 +29,14 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
     public async Task Handle_SimpleComponent_ReturnsResult()
     {
         // Arrange
-        var manager = CreateProjectSnapshotManager();
-        var project = await manager.UpdateAsync(updater => updater.CreateAndAddProject("c:/path/project.csproj"));
-        await manager.CreateAndAddDocumentAsync(project, "c:/path/index.razor");
-        await manager.CreateAndAddDocumentAsync(project, "c:/path/MyTagHelper.razor");
+        var projectManager = CreateProjectSnapshotManager();
+
+        var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
+        await snapshotResolver.InitializeAsync(DisposalToken);
+
+        var project = await projectManager.UpdateAsync(updater => updater.CreateAndAddProject("c:/path/project.csproj"));
+        await projectManager.CreateAndAddDocumentAsync(project, "c:/path/index.razor");
+        await projectManager.CreateAndAddDocumentAsync(project, "c:/path/MyTagHelper.razor");
 
         var documentMappingService = Mock.Of<IRazorDocumentMappingService>(
             s => s.GetLanguageKind(It.IsAny<RazorCodeDocument>(), It.IsAny<int>(), It.IsAny<bool>()) == RazorLanguageKind.Html, MockBehavior.Strict);
@@ -42,17 +46,16 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         builder.SetMetadata(TypeNameIdentifier("MyTagHelper"), TypeNamespace("TestRootNamespace"));
         var tagHelperDescriptor = builder.Build();
 
-        await manager.UpdateAsync(updater => updater.ProjectWorkspaceStateChanged(project.Key, ProjectWorkspaceState.Create([tagHelperDescriptor])));
+        await projectManager.UpdateAsync(updater => updater.ProjectWorkspaceStateChanged(project.Key, ProjectWorkspaceState.Create([tagHelperDescriptor])));
 
         var razorFilePath = "c:/path/index.razor";
         var uri = new Uri(razorFilePath);
 
-        var snapshotResolver = new SnapshotResolver(manager, LoggerFactory);
-        var documentVersionCache = new DocumentVersionCache(manager);
-        await manager.UpdateAsync(updater => updater.DocumentOpened(project.Key, razorFilePath, SourceText.From("<div></div>")));
-        var documentSnapshot = manager.GetLoadedProject(project.Key).GetDocument(razorFilePath).AssumeNotNull();
+        var documentVersionCache = new DocumentVersionCache(projectManager);
+        await projectManager.UpdateAsync(updater => updater.DocumentOpened(project.Key, razorFilePath, SourceText.From("<div></div>")));
+        var documentSnapshot = projectManager.GetLoadedProject(project.Key).GetDocument(razorFilePath).AssumeNotNull();
         documentVersionCache.TrackDocumentVersion(documentSnapshot, 1);
-        var documentContextFactory = new DocumentContextFactory(manager, snapshotResolver, documentVersionCache, LoggerFactory);
+        var documentContextFactory = new DocumentContextFactory(projectManager, snapshotResolver, documentVersionCache, LoggerFactory);
         var documentContext = await documentContextFactory.TryCreateForOpenDocumentAsync(uri, null, DisposalToken);
 
         var clientConnection = new Mock<IClientConnection>(MockBehavior.Strict);
@@ -91,10 +94,14 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
     public async Task Handle_SimpleComponentWithChildFile_ReturnsResult()
     {
         // Arrange
-        var manager = CreateProjectSnapshotManager();
-        var project = await manager.UpdateAsync(updater => updater.CreateAndAddProject("c:/path/project.csproj"));
-        await manager.CreateAndAddDocumentAsync(project, "c:/path/index.razor");
-        await manager.CreateAndAddDocumentAsync(project, "c:/path/MyTagHelper.razor");
+        var projectManager = CreateProjectSnapshotManager();
+
+        var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
+        await snapshotResolver.InitializeAsync(DisposalToken);
+
+        var project = await projectManager.UpdateAsync(updater => updater.CreateAndAddProject("c:/path/project.csproj"));
+        await projectManager.CreateAndAddDocumentAsync(project, "c:/path/index.razor");
+        await projectManager.CreateAndAddDocumentAsync(project, "c:/path/MyTagHelper.razor");
 
         var documentMappingService = Mock.Of<IRazorDocumentMappingService>(
             s => s.GetLanguageKind(It.IsAny<RazorCodeDocument>(), It.IsAny<int>(), It.IsAny<bool>()) == RazorLanguageKind.Html, MockBehavior.Strict);
@@ -104,17 +111,16 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         builder.SetMetadata(TypeNameIdentifier("MyTagHelper"), TypeNamespace("TestRootNamespace"));
         var tagHelperDescriptor = builder.Build();
 
-        await manager.UpdateAsync(updater => updater.ProjectWorkspaceStateChanged(project.Key, ProjectWorkspaceState.Create([tagHelperDescriptor])));
+        await projectManager.UpdateAsync(updater => updater.ProjectWorkspaceStateChanged(project.Key, ProjectWorkspaceState.Create([tagHelperDescriptor])));
 
         var razorFilePath = "c:/path/index.razor";
         var uri = new Uri(razorFilePath);
 
-        var snapshotResolver = new SnapshotResolver(manager, LoggerFactory);
-        var documentVersionCache = new DocumentVersionCache(manager);
-        await manager.UpdateAsync(updater => updater.DocumentOpened(project.Key, razorFilePath, SourceText.From("<div></div>")));
-        var documentSnapshot = manager.GetLoadedProject(project.Key).GetDocument(razorFilePath).AssumeNotNull();
+        var documentVersionCache = new DocumentVersionCache(projectManager);
+        await projectManager.UpdateAsync(updater => updater.DocumentOpened(project.Key, razorFilePath, SourceText.From("<div></div>")));
+        var documentSnapshot = projectManager.GetLoadedProject(project.Key).GetDocument(razorFilePath).AssumeNotNull();
         documentVersionCache.TrackDocumentVersion(documentSnapshot, 1);
-        var documentContextFactory = new DocumentContextFactory(manager, snapshotResolver, documentVersionCache, LoggerFactory);
+        var documentContextFactory = new DocumentContextFactory(projectManager, snapshotResolver, documentVersionCache, LoggerFactory);
         var documentContext = await documentContextFactory.TryCreateForOpenDocumentAsync(uri, null, DisposalToken);
 
         var clientConnection = new Mock<IClientConnection>(MockBehavior.Strict);
@@ -158,10 +164,14 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
     public async Task Handle_ComponentWithRequiredAttribute_ReturnsResult()
     {
         // Arrange
-        var manager = CreateProjectSnapshotManager();
-        var project = await manager.UpdateAsync(updater => updater.CreateAndAddProject("c:/path/project.csproj"));
-        await manager.CreateAndAddDocumentAsync(project, "c:/path/index.razor");
-        await manager.CreateAndAddDocumentAsync(project, "c:/path/fetchdata.razor");
+        var projectManager = CreateProjectSnapshotManager();
+
+        var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
+        await snapshotResolver.InitializeAsync(DisposalToken);
+
+        var project = await projectManager.UpdateAsync(updater => updater.CreateAndAddProject("c:/path/project.csproj"));
+        await projectManager.CreateAndAddDocumentAsync(project, "c:/path/index.razor");
+        await projectManager.CreateAndAddDocumentAsync(project, "c:/path/fetchdata.razor");
 
         var documentMappingService = Mock.Of<IRazorDocumentMappingService>(
             s => s.GetLanguageKind(It.IsAny<RazorCodeDocument>(), It.IsAny<int>(), It.IsAny<bool>()) == RazorLanguageKind.Html, MockBehavior.Strict);
@@ -177,17 +187,16 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         builder.BindAttribute(b => b.Name = "MyNonRequiredAttribute");
         var tagHelperDescriptor = builder.Build();
 
-        await manager.UpdateAsync(updater => updater.ProjectWorkspaceStateChanged(project.Key, ProjectWorkspaceState.Create([tagHelperDescriptor])));
+        await projectManager.UpdateAsync(updater => updater.ProjectWorkspaceStateChanged(project.Key, ProjectWorkspaceState.Create([tagHelperDescriptor])));
 
         var razorFilePath = "c:/path/index.razor";
         var uri = new Uri(razorFilePath);
 
-        var snapshotResolver = new SnapshotResolver(manager, LoggerFactory);
-        var documentVersionCache = new DocumentVersionCache(manager);
-        await manager.UpdateAsync(updater => updater.DocumentOpened(project.Key, razorFilePath, SourceText.From("<div></div>")));
-        var documentSnapshot = manager.GetLoadedProject(project.Key).GetDocument(razorFilePath).AssumeNotNull();
+        var documentVersionCache = new DocumentVersionCache(projectManager);
+        await projectManager.UpdateAsync(updater => updater.DocumentOpened(project.Key, razorFilePath, SourceText.From("<div></div>")));
+        var documentSnapshot = projectManager.GetLoadedProject(project.Key).GetDocument(razorFilePath).AssumeNotNull();
         documentVersionCache.TrackDocumentVersion(documentSnapshot, 1);
-        var documentContextFactory = new DocumentContextFactory(manager, snapshotResolver, documentVersionCache, LoggerFactory);
+        var documentContextFactory = new DocumentContextFactory(projectManager, snapshotResolver, documentVersionCache, LoggerFactory);
         var documentContext = await documentContextFactory.TryCreateForOpenDocumentAsync(uri, null, DisposalToken);
 
         var clientConnection = new Mock<IClientConnection>(MockBehavior.Strict);
@@ -387,10 +396,14 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
     public async Task Handle_ComponentWithNestedFiles_ReturnsResult()
     {
         // Arrange
-        var manager = CreateProjectSnapshotManager();
-        var project = await manager.UpdateAsync(updater => updater.CreateAndAddProject("c:/path/project.csproj"));
-        await manager.CreateAndAddDocumentAsync(project, "c:/path/index.razor");
-        await manager.CreateAndAddDocumentAsync(project, "c:/path/fetchdata.razor");
+        var projectManager = CreateProjectSnapshotManager();
+
+        var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
+        await snapshotResolver.InitializeAsync(DisposalToken);
+
+        var project = await projectManager.UpdateAsync(updater => updater.CreateAndAddProject("c:/path/project.csproj"));
+        await projectManager.CreateAndAddDocumentAsync(project, "c:/path/index.razor");
+        await projectManager.CreateAndAddDocumentAsync(project, "c:/path/fetchdata.razor");
 
         var documentMappingService = Mock.Of<IRazorDocumentMappingService>(
             s => s.GetLanguageKind(It.IsAny<RazorCodeDocument>(), It.IsAny<int>(), It.IsAny<bool>()) == RazorLanguageKind.Html, MockBehavior.Strict);
@@ -401,17 +414,16 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         builder.SetMetadata(TypeNameIdentifier("FetchData"), TypeNamespace("TestRootNamespace"));
         var tagHelperDescriptor = builder.Build();
 
-        await manager.UpdateAsync(updater => updater.ProjectWorkspaceStateChanged(project.Key, ProjectWorkspaceState.Create([tagHelperDescriptor])));
+        await projectManager.UpdateAsync(updater => updater.ProjectWorkspaceStateChanged(project.Key, ProjectWorkspaceState.Create([tagHelperDescriptor])));
 
         var razorFilePath = "c:/path/index.razor";
         var uri = new Uri(razorFilePath);
 
-        var snapshotResolver = new SnapshotResolver(manager, LoggerFactory);
-        var documentVersionCache = new DocumentVersionCache(manager);
-        await manager.UpdateAsync(updater => updater.DocumentOpened(project.Key, razorFilePath, SourceText.From("<div></div>")));
-        var documentSnapshot = manager.GetLoadedProject(project.Key).GetDocument(razorFilePath).AssumeNotNull();
+        var documentVersionCache = new DocumentVersionCache(projectManager);
+        await projectManager.UpdateAsync(updater => updater.DocumentOpened(project.Key, razorFilePath, SourceText.From("<div></div>")));
+        var documentSnapshot = projectManager.GetLoadedProject(project.Key).GetDocument(razorFilePath).AssumeNotNull();
         documentVersionCache.TrackDocumentVersion(documentSnapshot, 1);
-        var documentContextFactory = new DocumentContextFactory(manager, snapshotResolver, documentVersionCache, LoggerFactory);
+        var documentContextFactory = new DocumentContextFactory(projectManager, snapshotResolver, documentVersionCache, LoggerFactory);
         var documentContext = await documentContextFactory.TryCreateForOpenDocumentAsync(uri, null, DisposalToken);
 
         var clientConnection = new Mock<IClientConnection>(MockBehavior.Strict);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentPresentation/TextDocumentUriPresentationEndpointTests.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentPresentation/TextDocumentUriPresentationEndpointTests.cs
@@ -35,7 +35,7 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         var projectManager = CreateProjectSnapshotManager();
 
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         var project = await projectManager.UpdateAsync(updater => updater.CreateAndAddProject("c:/path/project.csproj"));
         await projectManager.CreateAndAddDocumentAsync(project, "c:/path/index.razor");
@@ -100,7 +100,7 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         var projectManager = CreateProjectSnapshotManager();
 
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         var project = await projectManager.UpdateAsync(updater => updater.CreateAndAddProject("c:/path/project.csproj"));
         await projectManager.CreateAndAddDocumentAsync(project, "c:/path/index.razor");
@@ -170,7 +170,7 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         var projectManager = CreateProjectSnapshotManager();
 
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         var project = await projectManager.UpdateAsync(updater => updater.CreateAndAddProject("c:/path/project.csproj"));
         await projectManager.CreateAndAddDocumentAsync(project, "c:/path/index.razor");
@@ -402,7 +402,7 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         var projectManager = CreateProjectSnapshotManager();
 
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         var project = await projectManager.UpdateAsync(updater => updater.CreateAndAddProject("c:/path/project.csproj"));
         await projectManager.CreateAndAddDocumentAsync(project, "c:/path/index.razor");

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentPresentation/TextDocumentUriPresentationEndpointTests.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentPresentation/TextDocumentUriPresentationEndpointTests.cs
@@ -56,7 +56,7 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         var documentSnapshot = projectManager.GetLoadedProject(project.Key).GetDocument(razorFilePath).AssumeNotNull();
         documentVersionCache.TrackDocumentVersion(documentSnapshot, 1);
         var documentContextFactory = new DocumentContextFactory(projectManager, snapshotResolver, documentVersionCache, LoggerFactory);
-        var documentContext = await documentContextFactory.TryCreateForOpenDocumentAsync(uri, null, DisposalToken);
+        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri, null);
 
         var clientConnection = new Mock<IClientConnection>(MockBehavior.Strict);
 
@@ -121,7 +121,7 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         var documentSnapshot = projectManager.GetLoadedProject(project.Key).GetDocument(razorFilePath).AssumeNotNull();
         documentVersionCache.TrackDocumentVersion(documentSnapshot, 1);
         var documentContextFactory = new DocumentContextFactory(projectManager, snapshotResolver, documentVersionCache, LoggerFactory);
-        var documentContext = await documentContextFactory.TryCreateForOpenDocumentAsync(uri, null, DisposalToken);
+        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri, null);
 
         var clientConnection = new Mock<IClientConnection>(MockBehavior.Strict);
 
@@ -197,7 +197,7 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         var documentSnapshot = projectManager.GetLoadedProject(project.Key).GetDocument(razorFilePath).AssumeNotNull();
         documentVersionCache.TrackDocumentVersion(documentSnapshot, 1);
         var documentContextFactory = new DocumentContextFactory(projectManager, snapshotResolver, documentVersionCache, LoggerFactory);
-        var documentContext = await documentContextFactory.TryCreateForOpenDocumentAsync(uri, null, DisposalToken);
+        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri, null);
 
         var clientConnection = new Mock<IClientConnection>(MockBehavior.Strict);
 
@@ -424,7 +424,7 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         var documentSnapshot = projectManager.GetLoadedProject(project.Key).GetDocument(razorFilePath).AssumeNotNull();
         documentVersionCache.TrackDocumentVersion(documentSnapshot, 1);
         var documentContextFactory = new DocumentContextFactory(projectManager, snapshotResolver, documentVersionCache, LoggerFactory);
-        var documentContext = await documentContextFactory.TryCreateForOpenDocumentAsync(uri, null, DisposalToken);
+        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri, null);
 
         var clientConnection = new Mock<IClientConnection>(MockBehavior.Strict);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentPresentation/TextDocumentUriPresentationEndpointTests.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentPresentation/TextDocumentUriPresentationEndpointTests.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
+using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.AspNetCore.Razor.Test.Common.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
@@ -15,6 +16,7 @@ using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Protocol.DocumentPresentation;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Moq;
 using Xunit;
@@ -32,7 +34,7 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         var projectManager = CreateProjectSnapshotManager();
 
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         var project = await projectManager.UpdateAsync(updater => updater.CreateAndAddProject("c:/path/project.csproj"));
         await projectManager.CreateAndAddDocumentAsync(project, "c:/path/index.razor");
@@ -97,7 +99,7 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         var projectManager = CreateProjectSnapshotManager();
 
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         var project = await projectManager.UpdateAsync(updater => updater.CreateAndAddProject("c:/path/project.csproj"));
         await projectManager.CreateAndAddDocumentAsync(project, "c:/path/index.razor");
@@ -167,7 +169,7 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         var projectManager = CreateProjectSnapshotManager();
 
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         var project = await projectManager.UpdateAsync(updater => updater.CreateAndAddProject("c:/path/project.csproj"));
         await projectManager.CreateAndAddDocumentAsync(project, "c:/path/index.razor");
@@ -399,7 +401,7 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         var projectManager = CreateProjectSnapshotManager();
 
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         var project = await projectManager.UpdateAsync(updater => updater.CreateAndAddProject("c:/path/project.csproj"));
         await projectManager.CreateAndAddDocumentAsync(project, "c:/path/index.razor");

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentPresentation/TextDocumentUriPresentationEndpointTests.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentPresentation/TextDocumentUriPresentationEndpointTests.cs
@@ -17,6 +17,7 @@ using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Protocol.DocumentPresentation;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CommonLanguageServerProtocol.Framework;
+using Microsoft.VisualStudio.Copilot;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Moq;
 using Xunit;
@@ -58,7 +59,7 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         var documentSnapshot = projectManager.GetLoadedProject(project.Key).GetDocument(razorFilePath).AssumeNotNull();
         documentVersionCache.TrackDocumentVersion(documentSnapshot, 1);
         var documentContextFactory = new DocumentContextFactory(projectManager, snapshotResolver, documentVersionCache, LoggerFactory);
-        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri, null);
+        Assert.True(documentContextFactory.TryCreateForOpenDocument(uri, null, out var documentContext));
 
         var clientConnection = new Mock<IClientConnection>(MockBehavior.Strict);
 
@@ -123,7 +124,7 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         var documentSnapshot = projectManager.GetLoadedProject(project.Key).GetDocument(razorFilePath).AssumeNotNull();
         documentVersionCache.TrackDocumentVersion(documentSnapshot, 1);
         var documentContextFactory = new DocumentContextFactory(projectManager, snapshotResolver, documentVersionCache, LoggerFactory);
-        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri, null);
+        Assert.True(documentContextFactory.TryCreateForOpenDocument(uri, null, out var documentContext));
 
         var clientConnection = new Mock<IClientConnection>(MockBehavior.Strict);
 
@@ -199,7 +200,7 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         var documentSnapshot = projectManager.GetLoadedProject(project.Key).GetDocument(razorFilePath).AssumeNotNull();
         documentVersionCache.TrackDocumentVersion(documentSnapshot, 1);
         var documentContextFactory = new DocumentContextFactory(projectManager, snapshotResolver, documentVersionCache, LoggerFactory);
-        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri, null);
+        Assert.True(documentContextFactory.TryCreateForOpenDocument(uri, null, out var documentContext));
 
         var clientConnection = new Mock<IClientConnection>(MockBehavior.Strict);
 
@@ -426,7 +427,7 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         var documentSnapshot = projectManager.GetLoadedProject(project.Key).GetDocument(razorFilePath).AssumeNotNull();
         documentVersionCache.TrackDocumentVersion(documentSnapshot, 1);
         var documentContextFactory = new DocumentContextFactory(projectManager, snapshotResolver, documentVersionCache, LoggerFactory);
-        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri, null);
+        Assert.True(documentContextFactory.TryCreateForOpenDocument(uri, null, out var documentContext));
 
         var clientConnection = new Mock<IClientConnection>(MockBehavior.Strict);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentPresentation/TextDocumentUriPresentationEndpointTests.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentPresentation/TextDocumentUriPresentationEndpointTests.cs
@@ -34,7 +34,7 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         var projectManager = CreateProjectSnapshotManager();
 
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         var project = await projectManager.UpdateAsync(updater => updater.CreateAndAddProject("c:/path/project.csproj"));
         await projectManager.CreateAndAddDocumentAsync(project, "c:/path/index.razor");
@@ -99,7 +99,7 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         var projectManager = CreateProjectSnapshotManager();
 
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         var project = await projectManager.UpdateAsync(updater => updater.CreateAndAddProject("c:/path/project.csproj"));
         await projectManager.CreateAndAddDocumentAsync(project, "c:/path/index.razor");
@@ -169,7 +169,7 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         var projectManager = CreateProjectSnapshotManager();
 
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         var project = await projectManager.UpdateAsync(updater => updater.CreateAndAddProject("c:/path/project.csproj"));
         await projectManager.CreateAndAddDocumentAsync(project, "c:/path/index.razor");
@@ -401,7 +401,7 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
         var projectManager = CreateProjectSnapshotManager();
 
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         var project = await projectManager.UpdateAsync(updater => updater.CreateAndAddProject("c:/path/project.csproj"));
         await projectManager.CreateAndAddDocumentAsync(project, "c:/path/index.razor");

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentSymbols/DocumentSymbolEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentSymbols/DocumentSymbolEndpointTest.cs
@@ -89,7 +89,7 @@ public class DocumentSymbolEndpointTest(ITestOutputHelper testOutput) : SingleSe
                 }
             }
         };
-        var documentContext = DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument);
+        Assert.True(DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument, out var documentContext));
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentSymbols/DocumentSymbolEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentSymbols/DocumentSymbolEndpointTest.cs
@@ -89,7 +89,7 @@ public class DocumentSymbolEndpointTest(ITestOutputHelper testOutput) : SingleSe
                 }
             }
         };
-        var documentContext = await DocumentContextFactory.TryCreateForOpenDocumentAsync(request.TextDocument, DisposalToken);
+        var documentContext = DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument);
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/FindReferences/FindAllReferencesEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/FindReferences/FindAllReferencesEndpointTest.cs
@@ -76,7 +76,7 @@ public class FindAllReferencesEndpointTest(ITestOutputHelper testOutput) : Singl
             },
             Position = new Position(line, offset)
         };
-        var documentContext = await DocumentContextFactory.TryCreateForOpenDocumentAsync(request.TextDocument, DisposalToken);
+        var documentContext = DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument);
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/FindReferences/FindAllReferencesEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/FindReferences/FindAllReferencesEndpointTest.cs
@@ -76,7 +76,7 @@ public class FindAllReferencesEndpointTest(ITestOutputHelper testOutput) : Singl
             },
             Position = new Position(line, offset)
         };
-        var documentContext = DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument);
+        Assert.True(DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument, out var documentContext));
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Folding/FoldingEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Folding/FoldingEndpointTest.cs
@@ -117,7 +117,7 @@ public class FoldingEndpointTest(ITestOutputHelper testOutput) : SingleServerDel
                 }
             }
         };
-        var documentContext = DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument);
+        Assert.True(DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument, out var documentContext));
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Folding/FoldingEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Folding/FoldingEndpointTest.cs
@@ -117,7 +117,7 @@ public class FoldingEndpointTest(ITestOutputHelper testOutput) : SingleServerDel
                 }
             }
         };
-        var documentContext = await DocumentContextFactory.TryCreateForOpenDocumentAsync(request.TextDocument, DisposalToken);
+        var documentContext = DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument);
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/DocumentOnTypeFormattingEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/DocumentOnTypeFormattingEndpointTest.cs
@@ -193,9 +193,9 @@ public class DocumentOnTypeFormattingEndpointTest(ITestOutputHelper testOutput) 
         var codeDocument = CreateCodeDocument(content, sourceMappings);
         var uri = new Uri("file://path/test.razor");
 
-        var documentResolver = CreateDocumentContextFactory(uri, codeDocument);
+        var documentContextFactory = CreateDocumentContextFactory(uri, codeDocument);
         var formattingService = new DummyRazorFormattingService();
-        var documentMappingService = new RazorDocumentMappingService(FilePathService, documentResolver, LoggerFactory);
+        var documentMappingService = new RazorDocumentMappingService(FilePathService, documentContextFactory, LoggerFactory);
 
         var optionsMonitor = GetOptionsMonitor(enableFormatting: true);
         var endpoint = new DocumentOnTypeFormattingEndpoint(
@@ -207,8 +207,8 @@ public class DocumentOnTypeFormattingEndpointTest(ITestOutputHelper testOutput) 
             Position = new Position(2, 11),
             Options = new FormattingOptions { InsertSpaces = true, TabSize = 4 }
         };
-        var documentContext = documentResolver.TryCreateForOpenDocument(uri);
-        var requestContext = CreateRazorRequestContext(documentContext!);
+        Assert.True(documentContextFactory.TryCreateForOpenDocument(uri, out var documentContext));
+        var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act
         var result = await endpoint.HandleRequestAsync(@params, requestContext, DisposalToken);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/DocumentOnTypeFormattingEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/DocumentOnTypeFormattingEndpointTest.cs
@@ -207,7 +207,7 @@ public class DocumentOnTypeFormattingEndpointTest(ITestOutputHelper testOutput) 
             Position = new Position(2, 11),
             Options = new FormattingOptions { InsertSpaces = true, TabSize = 4 }
         };
-        var documentContext = await documentResolver.TryCreateForOpenDocumentAsync(uri, DisposalToken);
+        var documentContext = documentResolver.TryCreateForOpenDocument(uri);
         var requestContext = CreateRazorRequestContext(documentContext!);
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverServiceTest.cs
@@ -48,7 +48,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
             {
                 Hover = new()
                 {
-                    ContentFormat = new[] { markupKind },
+                    ContentFormat = [markupKind],
                 }
             }
         };
@@ -64,7 +64,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
-        var service = await GetHoverServiceAsync();
+        var service = GetHoverService();
         var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
@@ -94,7 +94,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
-        var service = await GetHoverServiceAsync();
+        var service = GetHoverService();
         var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
@@ -124,7 +124,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPositionAndSpan(txt, out txt, out var cursorPosition, out var span);
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
-        var service = await GetHoverServiceAsync();
+        var service = GetHoverService();
         var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
@@ -148,7 +148,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
-        var service = await GetHoverServiceAsync();
+        var service = GetHoverService();
         var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
@@ -176,7 +176,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
-        var service = await GetHoverServiceAsync();
+        var service = GetHoverService();
         var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
@@ -205,7 +205,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
-        var service = await GetHoverServiceAsync();
+        var service = GetHoverService();
         var serviceAccessor = service.GetTestAccessor();
         var edgeLocation = cursorPosition;
         var location = new SourceLocation(edgeLocation, 0, edgeLocation);
@@ -235,7 +235,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
-        var service = await GetHoverServiceAsync();
+        var service = GetHoverService();
         var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
@@ -257,7 +257,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
-        var service = await GetHoverServiceAsync();
+        var service = GetHoverService();
         var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
@@ -279,7 +279,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
-        var service = await GetHoverServiceAsync();
+        var service = GetHoverService();
         var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
@@ -301,7 +301,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
-        var service = await GetHoverServiceAsync();
+        var service = GetHoverService();
         var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
@@ -334,7 +334,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
 
         var codeDocument = CreateCodeDocument(txt, "text.razor", DefaultTagHelpers);
-        var service = await GetHoverServiceAsync();
+        var service = GetHoverService();
         var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
@@ -363,7 +363,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
-        var service = await GetHoverServiceAsync();
+        var service = GetHoverService();
         var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
@@ -391,7 +391,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
-        var service = await GetHoverServiceAsync();
+        var service = GetHoverService();
         var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
@@ -420,7 +420,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false);
-        var service = await GetHoverServiceAsync();
+        var service = GetHoverService();
         var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
@@ -443,7 +443,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
 
-        var service = await GetHoverServiceAsync();
+        var service =  GetHoverService();
         var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
@@ -473,7 +473,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
 
-        var service = await GetHoverServiceAsync();
+        var service = GetHoverService();
         var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
@@ -502,7 +502,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: true, DefaultTagHelpers);
 
-        var service = await GetHoverServiceAsync();
+        var service = GetHoverService();
         var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
@@ -533,7 +533,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: true, DefaultTagHelpers);
 
-        var service = await GetHoverServiceAsync();
+        var service = GetHoverService();
         var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
@@ -565,7 +565,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: true, DefaultTagHelpers);
 
-        var service = await GetHoverServiceAsync();
+        var service = GetHoverService();
         var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
@@ -592,7 +592,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: true, DefaultTagHelpers);
 
-        var service = await GetHoverServiceAsync();
+        var service = GetHoverService();
         var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
@@ -622,7 +622,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
 
-        var service = await GetHoverServiceAsync();
+        var service = GetHoverService();
         var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
@@ -653,7 +653,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false);
 
-        var service = await GetHoverServiceAsync();
+        var service = GetHoverService();
         var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
@@ -676,7 +676,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false);
 
-        var service = await GetHoverServiceAsync();
+        var service = GetHoverService();
         var serviceAccessor = service.GetTestAccessor();
 
         var location = new SourceLocation(cursorPosition, -1, -1);
@@ -699,7 +699,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
-        var service = await GetHoverServiceAsync();
+        var service = GetHoverService();
         var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
         var clientCapabilities = CreateMarkDownCapabilities();
@@ -744,7 +744,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
 
-        var service = await GetHoverServiceAsync();
+        var service = GetHoverService();
         var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
         var clientCapabilities = CreateMarkDownCapabilities();
@@ -810,7 +810,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
             c => c.TryMapToGeneratedDocumentPosition(It.IsAny<IRazorGeneratedDocument>(), It.IsAny<int>(), out projectedPosition, out projectedIndex))
             .Returns(true);
 
-        var endpoint = await CreateEndpointAsync(languageServerFeatureOptions, documentMappingServiceMock.Object, clientConnectionMock.Object);
+        var endpoint = CreateEndpoint(languageServerFeatureOptions, documentMappingServiceMock.Object, clientConnectionMock.Object);
 
         var request = new TextDocumentPositionParams
         {
@@ -959,7 +959,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         var languageServer = new HoverLanguageServer(csharpServer, csharpDocumentUri, DisposalToken);
         var documentMappingService = new RazorDocumentMappingService(FilePathService, documentContextFactory, LoggerFactory);
 
-        var service = await GetHoverServiceAsync(documentMappingService);
+        var service = GetHoverService(documentMappingService);
 
         var endpoint = new HoverEndpoint(
             service,
@@ -1012,7 +1012,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         return documentContext;
     }
 
-    private async Task<HoverEndpoint> CreateEndpointAsync(
+    private HoverEndpoint CreateEndpoint(
         LanguageServerFeatureOptions languageServerFeatureOptions = null,
         IRazorDocumentMappingService documentMappingService = null,
         IClientConnection clientConnection = null)
@@ -1027,7 +1027,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
 
         clientConnection ??= Mock.Of<IClientConnection>(MockBehavior.Strict);
 
-        var service = await GetHoverServiceAsync();
+        var service = GetHoverService();
 
         var endpoint = new HoverEndpoint(
             service,
@@ -1039,10 +1039,9 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         return endpoint;
     }
 
-    private async Task<HoverService> GetHoverServiceAsync(IRazorDocumentMappingService mappingService = null)
+    private HoverService GetHoverService(IRazorDocumentMappingService mappingService = null)
     {
         var snapshotResolver = new TestSnapshotResolver();
-        await snapshotResolver.InitializeAsync(DisposalToken);
         var lspTagHelperTooltipFactory = new DefaultLSPTagHelperTooltipFactory(snapshotResolver);
         var vsLspTagHelperTooltipFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverServiceTest.cs
@@ -64,11 +64,12 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
-        var service = GetHoverTestAccessor();
+        var service = await GetHoverServiceAsync();
+        var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = await service.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreateMarkDownCapabilities(), CancellationToken.None);
+        var hover = await serviceAccessor.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreateMarkDownCapabilities(), DisposalToken);
 
         // Assert
         Assert.Contains("**Test1TagHelper**", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
@@ -93,11 +94,12 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
-        var service = GetHoverTestAccessor();
+        var service = await GetHoverServiceAsync();
+        var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = await service.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreateMarkDownCapabilities(), CancellationToken.None);
+        var hover = await serviceAccessor.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreateMarkDownCapabilities(), DisposalToken);
 
         // Assert
         Assert.Contains("**SomeChild**", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
@@ -122,11 +124,12 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPositionAndSpan(txt, out txt, out var cursorPosition, out var span);
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
-        var service = GetHoverTestAccessor();
+        var service = await GetHoverServiceAsync();
+        var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = await service.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreateMarkDownCapabilities(), CancellationToken.None);
+        var hover = await serviceAccessor.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreateMarkDownCapabilities(), DisposalToken);
 
         // Assert
         Assert.Contains("**Attribute**", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
@@ -145,11 +148,12 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
-        var service = GetHoverTestAccessor();
+        var service = await GetHoverServiceAsync();
+        var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = await service.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreateMarkDownCapabilities(), CancellationToken.None);
+        var hover = await serviceAccessor.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreateMarkDownCapabilities(), DisposalToken);
 
         // Assert
         Assert.Contains("**Test1TagHelper**", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
@@ -172,11 +176,12 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
-        var service = GetHoverTestAccessor();
+        var service = await GetHoverServiceAsync();
+        var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = await service.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreateMarkDownCapabilities(), CancellationToken.None);
+        var hover = await serviceAccessor.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreateMarkDownCapabilities(), DisposalToken);
 
         // Assert
         Assert.Contains("**BoolVal**", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
@@ -200,12 +205,13 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
-        var service = GetHoverTestAccessor();
+        var service = await GetHoverServiceAsync();
+        var serviceAccessor = service.GetTestAccessor();
         var edgeLocation = cursorPosition;
         var location = new SourceLocation(edgeLocation, 0, edgeLocation);
 
         // Act
-        var hover = await service.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreateMarkDownCapabilities(), CancellationToken.None);
+        var hover = await serviceAccessor.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreateMarkDownCapabilities(), DisposalToken);
 
         // Assert
         Assert.Contains("**BoolVal**", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
@@ -229,11 +235,12 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
-        var service = GetHoverTestAccessor();
+        var service = await GetHoverServiceAsync();
+        var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = await service.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreateMarkDownCapabilities(), CancellationToken.None);
+        var hover = await serviceAccessor.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreateMarkDownCapabilities(), DisposalToken);
 
         // Assert
         Assert.Null(hover);
@@ -250,11 +257,12 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
-        var service = GetHoverTestAccessor();
+        var service = await GetHoverServiceAsync();
+        var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = await service.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreateMarkDownCapabilities(), CancellationToken.None);
+        var hover = await serviceAccessor.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreateMarkDownCapabilities(), DisposalToken);
 
         // Assert
         Assert.Null(hover);
@@ -271,11 +279,12 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
-        var service = GetHoverTestAccessor();
+        var service = await GetHoverServiceAsync();
+        var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = await service.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreateMarkDownCapabilities(), CancellationToken.None);
+        var hover = await serviceAccessor.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreateMarkDownCapabilities(), DisposalToken);
 
         // Assert
         Assert.Null(hover);
@@ -292,11 +301,12 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
-        var service = GetHoverTestAccessor();
+        var service = await GetHoverServiceAsync();
+        var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = await service.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreateMarkDownCapabilities(), CancellationToken.None);
+        var hover = await serviceAccessor.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreateMarkDownCapabilities(), DisposalToken);
 
         // Assert
         Assert.Contains("**BoolVal**", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
@@ -324,11 +334,12 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
 
         var codeDocument = CreateCodeDocument(txt, "text.razor", DefaultTagHelpers);
-        var service = GetHoverTestAccessor();
+        var service = await GetHoverServiceAsync();
+        var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = await service.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreateMarkDownCapabilities(), CancellationToken.None);
+        var hover = await serviceAccessor.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreateMarkDownCapabilities(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -352,11 +363,12 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
-        var service = GetHoverTestAccessor();
+        var service = await GetHoverServiceAsync();
+        var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = await service.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreateMarkDownCapabilities(), CancellationToken.None);
+        var hover = await serviceAccessor.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreateMarkDownCapabilities(), DisposalToken);
 
         // Assert
         Assert.Contains("**Test1TagHelper**", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
@@ -379,11 +391,12 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
-        var service = GetHoverTestAccessor();
+        var service = await GetHoverServiceAsync();
+        var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = await service.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreateMarkDownCapabilities(), CancellationToken.None);
+        var hover = await serviceAccessor.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreateMarkDownCapabilities(), DisposalToken);
 
         // Assert
         Assert.Contains("**BoolVal**", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
@@ -407,11 +420,12 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false);
-        var service = GetHoverTestAccessor();
+        var service = await GetHoverServiceAsync();
+        var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = await service.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreateMarkDownCapabilities(), CancellationToken.None);
+        var hover = await serviceAccessor.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreateMarkDownCapabilities(), DisposalToken);
 
         // Assert
         Assert.Null(hover);
@@ -429,11 +443,12 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
 
-        var service = GetHoverTestAccessor();
+        var service = await GetHoverServiceAsync();
+        var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = await service.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreatePlainTextCapabilities(), CancellationToken.None);
+        var hover = await serviceAccessor.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreatePlainTextCapabilities(), DisposalToken);
 
         // Assert
         Assert.Contains("Test1TagHelper", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
@@ -458,11 +473,12 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
 
-        var service = GetHoverTestAccessor();
+        var service = await GetHoverServiceAsync();
+        var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = await service.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreatePlainTextCapabilities(), CancellationToken.None);
+        var hover = await serviceAccessor.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreatePlainTextCapabilities(), DisposalToken);
 
         // Assert
         Assert.Contains("Test1TagHelper", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
@@ -486,11 +502,12 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: true, DefaultTagHelpers);
 
-        var service = GetHoverTestAccessor();
+        var service = await GetHoverServiceAsync();
+        var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = await service.GetHoverInfoAsync("file.razor", codeDocument, location, CreatePlainTextCapabilities(), CancellationToken.None);
+        var hover = await serviceAccessor.GetHoverInfoAsync("file.razor", codeDocument, location, CreatePlainTextCapabilities(), DisposalToken);
 
         // Assert
         Assert.Contains("Text", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
@@ -516,11 +533,12 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: true, DefaultTagHelpers);
 
-        var service = GetHoverTestAccessor();
+        var service = await GetHoverServiceAsync();
+        var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = await service.GetHoverInfoAsync("file.razor", codeDocument, location, CreatePlainTextCapabilities(), CancellationToken.None);
+        var hover = await serviceAccessor.GetHoverInfoAsync("file.razor", codeDocument, location, CreatePlainTextCapabilities(), DisposalToken);
 
         // Assert
         Assert.Contains("Text", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
@@ -547,11 +565,12 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: true, DefaultTagHelpers);
 
-        var service = GetHoverTestAccessor();
+        var service = await GetHoverServiceAsync();
+        var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = await service.GetHoverInfoAsync("file.razor", codeDocument, location, CreatePlainTextCapabilities(), CancellationToken.None);
+        var hover = await serviceAccessor.GetHoverInfoAsync("file.razor", codeDocument, location, CreatePlainTextCapabilities(), DisposalToken);
 
         // Assert
         Assert.Null(hover);
@@ -573,11 +592,12 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: true, DefaultTagHelpers);
 
-        var service = GetHoverTestAccessor();
+        var service = await GetHoverServiceAsync();
+        var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = await service.GetHoverInfoAsync("file.razor", codeDocument, location, CreatePlainTextCapabilities(), CancellationToken.None);
+        var hover = await serviceAccessor.GetHoverInfoAsync("file.razor", codeDocument, location, CreatePlainTextCapabilities(), DisposalToken);
 
         // Assert
         Assert.Contains("Text", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
@@ -602,11 +622,12 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
 
-        var service = GetHoverTestAccessor();
+        var service = await GetHoverServiceAsync();
+        var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = await service.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreatePlainTextCapabilities(), CancellationToken.None);
+        var hover = await serviceAccessor.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreatePlainTextCapabilities(), DisposalToken);
 
         // Assert
         Assert.Contains("BoolVal", ((MarkupContent)hover.Contents).Value, StringComparison.Ordinal);
@@ -632,11 +653,12 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false);
 
-        var service = GetHoverTestAccessor();
+        var service = await GetHoverServiceAsync();
+        var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = await service.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreatePlainTextCapabilities(), CancellationToken.None);
+        var hover = await serviceAccessor.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreatePlainTextCapabilities(), DisposalToken);
 
         // Assert
         Assert.Null(hover);
@@ -654,11 +676,13 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false);
 
-        var service = GetHoverTestAccessor();
+        var service = await GetHoverServiceAsync();
+        var serviceAccessor = service.GetTestAccessor();
+
         var location = new SourceLocation(cursorPosition, -1, -1);
 
         // Act
-        var hover = await service.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreatePlainTextCapabilities(), CancellationToken.None);
+        var hover = await serviceAccessor.GetHoverInfoAsync("file.cshtml", codeDocument, location, CreatePlainTextCapabilities(), DisposalToken);
 
         // Assert
         Assert.Null(hover);
@@ -675,13 +699,14 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
-        var service = GetHoverTestAccessor();
+        var service = await GetHoverServiceAsync();
+        var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
         var clientCapabilities = CreateMarkDownCapabilities();
         clientCapabilities.SupportsVisualStudioExtensions = true;
 
         // Act
-        var vsHover = await service.GetHoverInfoAsync("file.cshtml", codeDocument, location, clientCapabilities, CancellationToken.None);
+        var vsHover = await serviceAccessor.GetHoverInfoAsync("file.cshtml", codeDocument, location, clientCapabilities, DisposalToken);
 
         // Assert
         Assert.False(vsHover.Contents.Value.TryGetFourth(out var _));
@@ -718,13 +743,15 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         TestFileMarkupParser.GetPosition(txt, out txt, out var cursorPosition);
 
         var codeDocument = CreateCodeDocument(txt, isRazorFile: false, DefaultTagHelpers);
-        var service = GetHoverTestAccessor();
+
+        var service = await GetHoverServiceAsync();
+        var serviceAccessor = service.GetTestAccessor();
         var location = new SourceLocation(cursorPosition, -1, -1);
         var clientCapabilities = CreateMarkDownCapabilities();
         clientCapabilities.SupportsVisualStudioExtensions = true;
 
         // Act
-        var vsHover = await service.GetHoverInfoAsync("file.cshtml", codeDocument, location, clientCapabilities, CancellationToken.None);
+        var vsHover = await serviceAccessor.GetHoverInfoAsync("file.cshtml", codeDocument, location, clientCapabilities, DisposalToken);
 
         // Assert
         Assert.False(vsHover.Contents.Value.TryGetFourth(out var _));
@@ -783,7 +810,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
             c => c.TryMapToGeneratedDocumentPosition(It.IsAny<IRazorGeneratedDocument>(), It.IsAny<int>(), out projectedPosition, out projectedIndex))
             .Returns(true);
 
-        var endpoint = CreateEndpoint(languageServerFeatureOptions, documentMappingServiceMock.Object, clientConnectionMock.Object);
+        var endpoint = await CreateEndpointAsync(languageServerFeatureOptions, documentMappingServiceMock.Object, clientConnectionMock.Object);
 
         var request = new TextDocumentPositionParams
         {
@@ -932,10 +959,10 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         var languageServer = new HoverLanguageServer(csharpServer, csharpDocumentUri, DisposalToken);
         var documentMappingService = new RazorDocumentMappingService(FilePathService, documentContextFactory, LoggerFactory);
 
-        var hoverService = GetHoverService(documentMappingService);
+        var service = await GetHoverServiceAsync(documentMappingService);
 
         var endpoint = new HoverEndpoint(
-            hoverService,
+            service,
             languageServerFeatureOptions,
             documentMappingService,
             languageServer,
@@ -985,12 +1012,11 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         return documentContext;
     }
 
-    private HoverEndpoint CreateEndpoint(
+    private async Task<HoverEndpoint> CreateEndpointAsync(
         LanguageServerFeatureOptions languageServerFeatureOptions = null,
         IRazorDocumentMappingService documentMappingService = null,
         IClientConnection clientConnection = null)
     {
-
         languageServerFeatureOptions ??= Mock.Of<LanguageServerFeatureOptions>(options => options.SupportsFileManipulation == true && options.SingleServerSupport == false, MockBehavior.Strict);
 
         var documentMappingServiceMock = new Mock<IRazorDocumentMappingService>(MockBehavior.Strict);
@@ -1001,8 +1027,10 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
 
         clientConnection ??= Mock.Of<IClientConnection>(MockBehavior.Strict);
 
+        var service = await GetHoverServiceAsync();
+
         var endpoint = new HoverEndpoint(
-            GetHoverService(),
+            service,
             languageServerFeatureOptions,
             documentMappingService,
             clientConnection,
@@ -1011,15 +1039,10 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         return endpoint;
     }
 
-    private HoverService.TestAccessor GetHoverTestAccessor()
-    {
-        var service = GetHoverService();
-        return service.GetTestAccessor();
-    }
-
-    private HoverService GetHoverService(IRazorDocumentMappingService mappingService = null)
+    private async Task<HoverService> GetHoverServiceAsync(IRazorDocumentMappingService mappingService = null)
     {
         var snapshotResolver = new TestSnapshotResolver();
+        await snapshotResolver.InitializeAsync(DisposalToken);
         var lspTagHelperTooltipFactory = new DefaultLSPTagHelperTooltipFactory(snapshotResolver);
         var vsLspTagHelperTooltipFactory = new DefaultVSLSPTagHelperTooltipFactory(snapshotResolver);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Implementation/ImplementationEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Implementation/ImplementationEndpointTest.cs
@@ -107,7 +107,7 @@ public class ImplementationEndpointTest(ITestOutputHelper testOutput) : SingleSe
             },
             Position = new Position(line, offset)
         };
-        var documentContext = await DocumentContextFactory.TryCreateForOpenDocumentAsync(request.TextDocument, DisposalToken);
+        var documentContext = DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument);
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Implementation/ImplementationEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Implementation/ImplementationEndpointTest.cs
@@ -107,7 +107,7 @@ public class ImplementationEndpointTest(ITestOutputHelper testOutput) : SingleSe
             },
             Position = new Position(line, offset)
         };
-        var documentContext = DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument);
+        Assert.True(DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument, out var documentContext));
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/InlayHints/InlayHintEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/InlayHints/InlayHintEndpointTest.cs
@@ -112,7 +112,7 @@ public class InlayHintEndpointTest(ITestOutputHelper testOutput) : SingleServerD
                 End = new(codeDocument.Source.Text.Lines.Count, 0)
             }
         };
-        var documentContext = await DocumentContextFactory.TryCreateForOpenDocumentAsync(request.TextDocument, DisposalToken);
+        var documentContext = DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument);
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/InlayHints/InlayHintEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/InlayHints/InlayHintEndpointTest.cs
@@ -112,7 +112,7 @@ public class InlayHintEndpointTest(ITestOutputHelper testOutput) : SingleServerD
                 End = new(codeDocument.Source.Text.Lines.Count, 0)
             }
         };
-        var documentContext = DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument);
+        Assert.True(DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument, out var documentContext));
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/MapCode/MapCodeTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/MapCode/MapCodeTest.cs
@@ -359,7 +359,7 @@ public class MapCodeTest(ITestOutputHelper testOutput) : LanguageServerTestBase(
             Mappings = mappings
         };
 
-        var documentContext = await documentContextFactory.TryCreateForOpenDocumentAsync(request.Mappings[0].TextDocument!, DisposalToken);
+        var documentContext = documentContextFactory.TryCreateForOpenDocument(request.Mappings[0].TextDocument!);
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/MapCode/MapCodeTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/MapCode/MapCodeTest.cs
@@ -359,7 +359,7 @@ public class MapCodeTest(ITestOutputHelper testOutput) : LanguageServerTestBase(
             Mappings = mappings
         };
 
-        var documentContext = documentContextFactory.TryCreateForOpenDocument(request.Mappings[0].TextDocument!);
+        Assert.True(documentContextFactory.TryCreateForOpenDocument(request.Mappings[0].TextDocument!, out var documentContext));
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectContexts/ProjectContextsEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectContexts/ProjectContextsEndpointTest.cs
@@ -39,7 +39,7 @@ public class ProjectContextsEndpointTest(ITestOutputHelper testOutput) : SingleS
             }
         };
 
-        var documentContext = await DocumentContextFactory.TryCreateForOpenDocumentAsync(request.TextDocument.Uri, DisposalToken);
+        var documentContext = DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument.Uri);
         var requestContext = CreateRazorRequestContext(documentContext);
 
         var results = await endpoint.HandleRequestAsync(request, requestContext, default);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectContexts/ProjectContextsEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectContexts/ProjectContextsEndpointTest.cs
@@ -39,7 +39,7 @@ public class ProjectContextsEndpointTest(ITestOutputHelper testOutput) : SingleS
             }
         };
 
-        var documentContext = DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument.Uri);
+        Assert.True(DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument.Uri, out var documentContext));
         var requestContext = CreateRazorRequestContext(documentContext);
 
         var results = await endpoint.HandleRequestAsync(request, requestContext, default);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorFileChangeDetectorManagerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorFileChangeDetectorManagerTest.cs
@@ -60,7 +60,7 @@ public class RazorFileChangeDetectorManagerTest(ITestOutputHelper testOutput) : 
         using (var detectorManager = new RazorFileChangeDetectorManager(workspaceDirectoryPathResolver, [detectorMock1.Object, detectorMock2.Object]))
         {
             // Act
-            await detectorManager.InitializedAsync(DisposalToken);
+            await detectorManager.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
         }
 
         // Assert
@@ -98,7 +98,7 @@ public class RazorFileChangeDetectorManagerTest(ITestOutputHelper testOutput) : 
         using var detectorManager = new RazorFileChangeDetectorManager(workspaceDirectoryPathResolver, [detectorMock.Object]);
 
         // Act
-        var initializeTask = detectorManager.InitializedAsync(DisposalToken);
+        var initializeTask = detectorManager.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
         detectorManager.Dispose();
 
         // Unblock the detector start

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorFileChangeDetectorManagerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorFileChangeDetectorManagerTest.cs
@@ -60,7 +60,7 @@ public class RazorFileChangeDetectorManagerTest(ITestOutputHelper testOutput) : 
         using (var detectorManager = new RazorFileChangeDetectorManager(workspaceDirectoryPathResolver, [detectorMock1.Object, detectorMock2.Object]))
         {
             // Act
-            await detectorManager.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+            await detectorManager.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
         }
 
         // Assert
@@ -98,7 +98,7 @@ public class RazorFileChangeDetectorManagerTest(ITestOutputHelper testOutput) : 
         using var detectorManager = new RazorFileChangeDetectorManager(workspaceDirectoryPathResolver, [detectorMock.Object]);
 
         // Act
-        var initializeTask = detectorManager.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        var initializeTask = detectorManager.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
         detectorManager.Dispose();
 
         // Unblock the detector start

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorFileChangeDetectorManagerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorFileChangeDetectorManagerTest.cs
@@ -60,7 +60,7 @@ public class RazorFileChangeDetectorManagerTest(ITestOutputHelper testOutput) : 
         using (var detectorManager = new RazorFileChangeDetectorManager(workspaceDirectoryPathResolver, [detectorMock1.Object, detectorMock2.Object]))
         {
             // Act
-            await detectorManager.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+            await detectorManager.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
         }
 
         // Assert
@@ -98,7 +98,7 @@ public class RazorFileChangeDetectorManagerTest(ITestOutputHelper testOutput) : 
         using var detectorManager = new RazorFileChangeDetectorManager(workspaceDirectoryPathResolver, [detectorMock.Object]);
 
         // Act
-        var initializeTask = detectorManager.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        var initializeTask = detectorManager.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
         detectorManager.Dispose();
 
         // Unblock the detector start

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
@@ -155,7 +155,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         var hostProject = new HostProject("C:/path/to/project.csproj", "C:/path/to/obj", RazorConfiguration.Default, "TestRootNamespace");
         var hostDocument = new HostDocument("C:/path/to/file.cshtml", "file.cshtml", FileKinds.Legacy);
 
-        var miscProject = await _snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
+        var miscProject = _snapshotResolver.GetMiscellaneousProject();
 
         await _projectManager.UpdateAsync(updater =>
         {
@@ -192,7 +192,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         var hostProject = new HostProject("C:/path/to/project.csproj", "C:/path/to/obj", RazorConfiguration.Default, "TestRootNamespace");
         var hostDocument = new HostDocument("C:/path/to/file.cshtml", "file.cshtml", FileKinds.Legacy);
 
-        var miscProject = await _snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
+        var miscProject = _snapshotResolver.GetMiscellaneousProject();
 
         var project = await _projectManager.UpdateAsync(updater =>
         {
@@ -230,10 +230,6 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         // Arrange
         var hostProject = new HostProject("path/to/project.csproj", "path/to/obj", RazorConfiguration.Default, "TestRootNamespace");
         var document = new HostDocument("path/to/file.cshtml", "file.cshtml", FileKinds.Legacy);
-
-        // Note: We acquire the miscellaneous project here to avoid a spurious 'ProjectAdded'
-        // notification when it would get created by UpdateProject(...) below.
-        _ = await _snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
 
         await _projectManager.UpdateAsync(updater =>
         {
@@ -505,7 +501,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         await _projectService.AddDocumentAsync(DocumentFilePath, DisposalToken);
         await _projectService.OpenDocumentAsync(DocumentFilePath, s_emptyText, version: 42, DisposalToken);
 
-        var miscProject = await _snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
+        var miscProject = _snapshotResolver.GetMiscellaneousProject();
 
         Assert.True(_projectManager.IsDocumentOpen(DocumentFilePath));
 
@@ -592,7 +588,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
 
         await _projectService.AddDocumentAsync(DocumentFilePath, DisposalToken);
 
-        var miscProject = await _snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
+        var miscProject = _snapshotResolver.GetMiscellaneousProject();
 
         Assert.False(_projectManager.IsDocumentOpen(DocumentFilePath));
 
@@ -643,7 +639,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
 
         await _projectService.AddDocumentAsync(DocumentFilePath, DisposalToken);
 
-        var miscProject = await _snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
+        var miscProject = _snapshotResolver.GetMiscellaneousProject();
 
         using var listener = _projectManager.ListenToNotifications();
 
@@ -686,7 +682,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         // Arrange
         const string DocumentFilePath = "document.cshtml";
 
-        var miscProject = await _snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
+        var miscProject = _snapshotResolver.GetMiscellaneousProject();
 
         using var listener = _projectManager.ListenToNotifications();
 
@@ -774,7 +770,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         await _projectService.OpenDocumentAsync(DocumentFilePath, s_emptyText, version: 42, DisposalToken);
 
         var ownerProject = _projectManager.GetLoadedProject(ownerProjectKey);
-        var miscProject = await _snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
+        var miscProject = _snapshotResolver.GetMiscellaneousProject();
 
         Assert.True(_projectManager.IsDocumentOpen(DocumentFilePath));
 
@@ -799,7 +795,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
 
         await _projectService.AddDocumentAsync(DocumentFilePath, DisposalToken);
 
-        var miscProject = await _snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
+        var miscProject = _snapshotResolver.GetMiscellaneousProject();
 
         Assert.False(_projectManager.IsDocumentOpen(DocumentFilePath));
 
@@ -842,7 +838,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         // Arrange
         const string DocumentFilePath = "document.cshtml";
 
-        var miscProject = await _snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
+        var miscProject = _snapshotResolver.GetMiscellaneousProject();
 
         Assert.False(_projectManager.IsDocumentOpen(DocumentFilePath));
 
@@ -929,7 +925,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         await _projectService.AddDocumentAsync(DocumentFilePath, DisposalToken);
         await _projectService.OpenDocumentAsync(DocumentFilePath, s_emptyText, version: 42, DisposalToken);
 
-        var miscProject = await _snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
+        var miscProject = _snapshotResolver.GetMiscellaneousProject();
 
         Assert.True(_projectManager.IsDocumentOpen(DocumentFilePath));
 
@@ -1042,7 +1038,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         const string DocumentFilePath1 = "C:/path/to/document1.cshtml";
         const string DocumentFilePath2 = "C:/path/to/document2.cshtml";
 
-        var miscProject = await _snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
+        var miscProject = _snapshotResolver.GetMiscellaneousProject();
 
         await _projectManager.UpdateAsync(updater =>
         {
@@ -1072,7 +1068,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         const string DocumentFilePath1 = "C:/path/to/document1.cshtml";
         const string DocumentFilePath2 = "C:/path/to/document2.cshtml";
 
-        var miscProject = await _snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
+        var miscProject = _snapshotResolver.GetMiscellaneousProject();
 
         await _projectManager.UpdateAsync(updater =>
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
@@ -41,7 +41,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
     {
         _projectManager = CreateProjectSnapshotManager();
         _snapshotResolver = new SnapshotResolver(_projectManager, LoggerFactory);
-        await _snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await _snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
         _documentVersionCache = new DocumentVersionCache(_projectManager);
 
         var remoteTextLoaderFactoryMock = new StrictMock<RemoteTextLoaderFactory>();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
@@ -41,7 +41,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
     {
         _projectManager = CreateProjectSnapshotManager();
         _snapshotResolver = new SnapshotResolver(_projectManager, LoggerFactory);
-        await _snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await _snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
         _documentVersionCache = new DocumentVersionCache(_projectManager);
 
         var remoteTextLoaderFactoryMock = new StrictMock<RemoteTextLoaderFactory>();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
@@ -24,20 +24,23 @@ using Xunit.Sdk;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
-public class RazorProjectServiceTest : LanguageServerTestBase
+public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageServerTestBase(testOutput)
 {
     private static readonly SourceText s_emptyText = SourceText.From("");
 
-    private readonly TestProjectSnapshotManager _projectManager;
-    private readonly SnapshotResolver _snapshotResolver;
-    private readonly DocumentVersionCache _documentVersionCache;
-    private readonly RazorProjectService _projectService;
+    // Each of these is initialized by InitializeAsync() below.
+#nullable disable
+    private TestProjectSnapshotManager _projectManager;
+    private SnapshotResolver _snapshotResolver;
+    private DocumentVersionCache _documentVersionCache;
+    private RazorProjectService _projectService;
+#nullable enable
 
-    public RazorProjectServiceTest(ITestOutputHelper testOutput)
-        : base(testOutput)
+    protected override async Task InitializeAsync()
     {
         _projectManager = CreateProjectSnapshotManager();
         _snapshotResolver = new SnapshotResolver(_projectManager, LoggerFactory);
+        await _snapshotResolver.InitializeAsync(DisposalToken);
         _documentVersionCache = new DocumentVersionCache(_projectManager);
 
         var remoteTextLoaderFactoryMock = new StrictMock<RemoteTextLoaderFactory>();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
@@ -17,6 +17,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CommonLanguageServerProtocol.Framework;
 using Moq;
 using Xunit;
 using Xunit.Abstractions;
@@ -40,7 +41,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
     {
         _projectManager = CreateProjectSnapshotManager();
         _snapshotResolver = new SnapshotResolver(_projectManager, LoggerFactory);
-        await _snapshotResolver.InitializeAsync(DisposalToken);
+        await _snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
         _documentVersionCache = new DocumentVersionCache(_projectManager);
 
         var remoteTextLoaderFactoryMock = new StrictMock<RemoteTextLoaderFactory>();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointDelegationTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointDelegationTest.cs
@@ -83,7 +83,7 @@ public class RenameEndpointDelegationTest(ITestOutputHelper testOutput) : Single
             Position = new Position(line, offset),
             NewName = newName
         };
-        var documentContext = await DocumentContextFactory.TryCreateForOpenDocumentAsync(request.TextDocument, DisposalToken);
+        var documentContext = DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument);
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointDelegationTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointDelegationTest.cs
@@ -83,7 +83,7 @@ public class RenameEndpointDelegationTest(ITestOutputHelper testOutput) : Single
             Position = new Position(line, offset),
             NewName = newName
         };
-        var documentContext = DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument);
+        Assert.True(DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument, out var documentContext));
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
@@ -613,7 +613,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
         var projectManager = CreateProjectSnapshotManager();
 
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         var documentVersionCache = new DocumentVersionCache(projectManager);
         var documentContextFactory = new DocumentContextFactory(projectManager, snapshotResolver, documentVersionCache, LoggerFactory);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
@@ -613,7 +613,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
         var projectManager = CreateProjectSnapshotManager();
 
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         var documentVersionCache = new DocumentVersionCache(projectManager);
         var documentContextFactory = new DocumentContextFactory(projectManager, snapshotResolver, documentVersionCache, LoggerFactory);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
@@ -612,8 +612,9 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
         var projectManager = CreateProjectSnapshotManager();
 
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        var documentVersionCache = new DocumentVersionCache(projectManager);
+        await snapshotResolver.InitializeAsync(DisposalToken);
 
+        var documentVersionCache = new DocumentVersionCache(projectManager);
         var documentContextFactory = new DocumentContextFactory(projectManager, snapshotResolver, documentVersionCache, LoggerFactory);
 
         var remoteTextLoaderFactoryMock = new StrictMock<RemoteTextLoaderFactory>();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
@@ -122,7 +122,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
             NewName = "Component5"
         };
 
-        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri);
+        Assert.True(documentContextFactory.TryCreateForOpenDocument(uri, out var documentContext));
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act
@@ -145,7 +145,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
             NewName = "Component5"
         };
 
-        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri);
+        Assert.True(documentContextFactory.TryCreateForOpenDocument(uri, out var documentContext));
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act
@@ -186,7 +186,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
             NewName = "Test2"
         };
 
-        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri);
+        Assert.True(documentContextFactory.TryCreateForOpenDocument(uri, out var documentContext));
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act
@@ -209,7 +209,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
             NewName = "Test2"
         };
 
-        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri);
+        Assert.True(documentContextFactory.TryCreateForOpenDocument(uri, out var documentContext));
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act
@@ -232,7 +232,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
             NewName = "Test2"
         };
 
-        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri);
+        Assert.True(documentContextFactory.TryCreateForOpenDocument(uri, out var documentContext));
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act
@@ -255,7 +255,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
             NewName = "Test2"
         };
 
-        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri);
+        Assert.True(documentContextFactory.TryCreateForOpenDocument(uri, out var documentContext));
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act
@@ -278,7 +278,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
             NewName = "Test2"
         };
 
-        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri);
+        Assert.True(documentContextFactory.TryCreateForOpenDocument(uri, out var documentContext));
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act
@@ -301,7 +301,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
             NewName = "Component5"
         };
 
-        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri);
+        Assert.True(documentContextFactory.TryCreateForOpenDocument(uri, out var documentContext));
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act
@@ -387,7 +387,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
             NewName = "Component5"
         };
 
-        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri);
+        Assert.True(documentContextFactory.TryCreateForOpenDocument(uri, out var documentContext));
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act
@@ -433,7 +433,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
             NewName = "Component5"
         };
 
-        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri);
+        Assert.True(documentContextFactory.TryCreateForOpenDocument(uri, out var documentContext));
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act
@@ -486,7 +486,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
             NewName = "TestComponent"
         };
 
-        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri);
+        Assert.True(documentContextFactory.TryCreateForOpenDocument(uri, out var documentContext));
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act
@@ -551,7 +551,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
             NewName = "Test2"
         };
 
-        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri);
+        Assert.True(documentContextFactory.TryCreateForOpenDocument(uri, out var documentContext));
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act
@@ -585,7 +585,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
             NewName = "Test2"
         };
 
-        var documentContext = documentContextFactory.TryCreateForOpenDocument(request.TextDocument.Uri);
+        Assert.True(documentContextFactory.TryCreateForOpenDocument(request.TextDocument.Uri, out var documentContext));
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
@@ -121,7 +121,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
             NewName = "Component5"
         };
 
-        var documentContext = await documentContextFactory.TryCreateForOpenDocumentAsync(uri, DisposalToken);
+        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri);
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act
@@ -144,7 +144,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
             NewName = "Component5"
         };
 
-        var documentContext = await documentContextFactory.TryCreateForOpenDocumentAsync(uri, DisposalToken);
+        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri);
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act
@@ -185,7 +185,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
             NewName = "Test2"
         };
 
-        var documentContext = await documentContextFactory.TryCreateForOpenDocumentAsync(uri, DisposalToken);
+        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri);
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act
@@ -208,7 +208,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
             NewName = "Test2"
         };
 
-        var documentContext = await documentContextFactory.TryCreateForOpenDocumentAsync(uri, DisposalToken);
+        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri);
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act
@@ -231,7 +231,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
             NewName = "Test2"
         };
 
-        var documentContext = await documentContextFactory.TryCreateForOpenDocumentAsync(uri, DisposalToken);
+        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri);
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act
@@ -254,7 +254,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
             NewName = "Test2"
         };
 
-        var documentContext = await documentContextFactory.TryCreateForOpenDocumentAsync(uri, DisposalToken);
+        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri);
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act
@@ -277,7 +277,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
             NewName = "Test2"
         };
 
-        var documentContext = await documentContextFactory.TryCreateForOpenDocumentAsync(uri, DisposalToken);
+        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri);
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act
@@ -300,7 +300,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
             NewName = "Component5"
         };
 
-        var documentContext = await documentContextFactory.TryCreateForOpenDocumentAsync(uri, DisposalToken);
+        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri);
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act
@@ -386,7 +386,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
             NewName = "Component5"
         };
 
-        var documentContext = await documentContextFactory.TryCreateForOpenDocumentAsync(uri, DisposalToken);
+        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri);
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act
@@ -432,7 +432,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
             NewName = "Component5"
         };
 
-        var documentContext = await documentContextFactory.TryCreateForOpenDocumentAsync(uri, DisposalToken);
+        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri);
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act
@@ -485,7 +485,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
             NewName = "TestComponent"
         };
 
-        var documentContext = await documentContextFactory.TryCreateForOpenDocumentAsync(uri, DisposalToken);
+        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri);
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act
@@ -550,7 +550,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
             NewName = "Test2"
         };
 
-        var documentContext = await documentContextFactory.TryCreateForOpenDocumentAsync(uri, DisposalToken);
+        var documentContext = documentContextFactory.TryCreateForOpenDocument(uri);
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act
@@ -584,7 +584,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
             NewName = "Test2"
         };
 
-        var documentContext = await documentContextFactory.TryCreateForOpenDocumentAsync(request.TextDocument.Uri, DisposalToken);
+        var documentContext = documentContextFactory.TryCreateForOpenDocument(request.TextDocument.Uri);
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
@@ -24,6 +24,7 @@ using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Moq;
 using Xunit;
@@ -612,7 +613,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
         var projectManager = CreateProjectSnapshotManager();
 
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         var documentVersionCache = new DocumentVersionCache(projectManager);
         var documentContextFactory = new DocumentContextFactory(projectManager, snapshotResolver, documentVersionCache, LoggerFactory);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokensTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokensTest.cs
@@ -1201,9 +1201,9 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
 
     private class TestDocumentContextFactory(VersionedDocumentContext? documentContext = null) : IDocumentContextFactory
     {
-        public Task<DocumentContext?> TryCreateAsync(Uri documentUri, VSProjectContext? projectContext, bool versioned, CancellationToken cancellationToken)
+        public DocumentContext? TryCreate(Uri documentUri, VSProjectContext? projectContext, bool versioned)
         {
-            return Task.FromResult<DocumentContext?>(documentContext);
+            return documentContext;
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokensTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokensTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -1201,9 +1202,14 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
 
     private class TestDocumentContextFactory(VersionedDocumentContext? documentContext = null) : IDocumentContextFactory
     {
-        public DocumentContext? TryCreate(Uri documentUri, VSProjectContext? projectContext, bool versioned)
+        public bool TryCreate(
+            Uri documentUri,
+            VSProjectContext? projectContext,
+            bool versioned,
+            [NotNullWhen(true)] out DocumentContext? context)
         {
-            return documentContext;
+            context = documentContext;
+            return context is not null;
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SignatureHelp/SignatureHelpEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SignatureHelp/SignatureHelpEndpointTest.cs
@@ -115,7 +115,7 @@ public class SignatureHelpEndpointTest(ITestOutputHelper testOutput) : SingleSer
             Context = signatureHelpContext
         };
 
-        var documentContext = await DocumentContextFactory.TryCreateForOpenDocumentAsync(request.TextDocument, DisposalToken);
+        var documentContext = DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument);
 
         var requestContext = CreateRazorRequestContext(documentContext);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SignatureHelp/SignatureHelpEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SignatureHelp/SignatureHelpEndpointTest.cs
@@ -115,7 +115,7 @@ public class SignatureHelpEndpointTest(ITestOutputHelper testOutput) : SingleSer
             Context = signatureHelpContext
         };
 
-        var documentContext = DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument);
+        Assert.True(DocumentContextFactory.TryCreateForOpenDocument(request.TextDocument, out var documentContext));
 
         var requestContext = CreateRazorRequestContext(documentContext);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SnapshotResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SnapshotResolverTest.cs
@@ -41,9 +41,9 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
         await snapshotResolver.InitializeAsync(DisposalToken);
 
-        await projectManager.UpdateAsync(async updater =>
+        await projectManager.UpdateAsync(updater =>
         {
-            var miscProject = await snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
+            var miscProject = snapshotResolver.GetMiscellaneousProject();
             var hostProject = new HostProject(miscProject.FilePath, miscProject.IntermediateOutputPath, FallbackRazorConfiguration.Latest, miscProject.RootNamespace);
             updater.DocumentAdded(
                 hostProject.Key,
@@ -100,8 +100,6 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
         await snapshotResolver.InitializeAsync(DisposalToken);
 
-        await snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
-
         // Act
         var projects = await snapshotResolver.TryResolveAllProjectsAsync(documentFilePath, DisposalToken);
 
@@ -121,7 +119,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var projects = await snapshotResolver.TryResolveAllProjectsAsync(documentFilePath, DisposalToken);
 
         // Assert
-        var miscFilesProject = await snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
+        var miscFilesProject = snapshotResolver.GetMiscellaneousProject();
         Assert.Single(projects, miscFilesProject);
     }
 
@@ -184,9 +182,9 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
         await snapshotResolver.InitializeAsync(DisposalToken);
 
-        var miscProject = await projectManager.UpdateAsync(async updater =>
+        var miscProject = await projectManager.UpdateAsync(updater =>
         {
-            var miscProject = (ProjectSnapshot)await snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
+            var miscProject = (ProjectSnapshot)snapshotResolver.GetMiscellaneousProject();
             updater.CreateAndAddDocument(miscProject, documentFilePath);
             updater.CreateAndAddProject("C:/path/to/project.csproj");
 
@@ -235,7 +233,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         await snapshotResolver.InitializeAsync(DisposalToken);
 
         // Act
-        var project = await snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
+        var project = snapshotResolver.GetMiscellaneousProject();
         var inManager = projectManager.GetLoadedProject(snapshotResolver.MiscellaneousHostProject.Key);
 
         // Assert
@@ -251,7 +249,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         await snapshotResolver.InitializeAsync(DisposalToken);
 
         // Act
-        var project = await snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
+        var project = snapshotResolver.GetMiscellaneousProject();
 
         // Assert
         Assert.Single(projectManager.GetProjects());
@@ -268,9 +266,9 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
 
         if (addToMiscellaneous)
         {
-            await projectManager.UpdateAsync(async updater =>
+            await projectManager.UpdateAsync(updater =>
             {
-                var miscProject = (ProjectSnapshot)await snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
+                var miscProject = (ProjectSnapshot)snapshotResolver.GetMiscellaneousProject();
                 updater.CreateAndAddDocument(miscProject, filePath);
             });
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SnapshotResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SnapshotResolverTest.cs
@@ -85,10 +85,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         // Act
-        var projects = snapshotResolver.TryResolveAllProjects(documentFilePath);
-
-        // Assert
-        Assert.Empty(projects);
+        Assert.False(snapshotResolver.TryResolveAllProjects(documentFilePath, out _));
     }
 
     [Fact]
@@ -101,10 +98,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         // Act
-        var projects = snapshotResolver.TryResolveAllProjects(documentFilePath);
-
-        // Assert
-        Assert.Empty(projects);
+        Assert.False(snapshotResolver.TryResolveAllProjects(documentFilePath, out _));
     }
 
     [Fact]
@@ -116,7 +110,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         // Act
-        var projects = snapshotResolver.TryResolveAllProjects(documentFilePath);
+        Assert.True(snapshotResolver.TryResolveAllProjects(documentFilePath, out var projects));
 
         // Assert
         var miscFilesProject = snapshotResolver.GetMiscellaneousProject();
@@ -138,10 +132,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         });
 
         // Act
-        var projects = snapshotResolver.TryResolveAllProjects(documentFilePath);
-
-        // Assert
-        Assert.Empty(projects);
+        Assert.False(snapshotResolver.TryResolveAllProjects(documentFilePath, out _));
     }
 
     [Fact]
@@ -164,7 +155,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         });
 
         // Act
-        var projects = snapshotResolver.TryResolveAllProjects(documentFilePath);
+        Assert.True(snapshotResolver.TryResolveAllProjects(documentFilePath, out var projects));
 
         // Assert
         var project = Assert.Single(projects);
@@ -192,7 +183,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         });
 
         // Act
-        var projects = snapshotResolver.TryResolveAllProjects(documentFilePath);
+        Assert.True(snapshotResolver.TryResolveAllProjects(documentFilePath, out var projects));
 
         // Assert
         var project = Assert.Single(projects);
@@ -217,7 +208,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         });
 
         // Act
-        var projects = snapshotResolver.TryResolveAllProjects(documentFilePath);
+        Assert.True(snapshotResolver.TryResolveAllProjects(documentFilePath, out var projects));
 
         // Assert
         var project = Assert.Single(projects);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SnapshotResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SnapshotResolverTest.cs
@@ -24,7 +24,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var snapshotResolver = await CreateSnapshotResolverAsync(normalizedFilePath);
 
         // Act
-        var document = await snapshotResolver.ResolveDocumentInAnyProjectAsync(documentFilePath, DisposalToken);
+        var document = snapshotResolver.ResolveDocumentInAnyProject(documentFilePath);
 
         // Assert
         Assert.NotNull(document);
@@ -52,7 +52,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         });
 
         // Act
-        var document = await snapshotResolver.ResolveDocumentInAnyProjectAsync(documentFilePath, DisposalToken);
+        var document = snapshotResolver.ResolveDocumentInAnyProject(documentFilePath);
 
         // Assert
         Assert.NotNull(document);
@@ -69,7 +69,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         await snapshotResolver.InitializeAsync(DisposalToken);
 
         // Act
-        var document = await snapshotResolver.ResolveDocumentInAnyProjectAsync(documentFilePath, DisposalToken);
+        var document = snapshotResolver.ResolveDocumentInAnyProject(documentFilePath);
 
         // Assert
         Assert.Null(document);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SnapshotResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SnapshotResolverTest.cs
@@ -40,7 +40,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var normalizedFilePath = "C:/path/to/document.cshtml";
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         await projectManager.UpdateAsync(updater =>
         {
@@ -66,7 +66,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var documentFilePath = @"C:\path\to\document.cshtml";
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         // Act
         Assert.False(snapshotResolver.TryResolveDocumentInAnyProject(documentFilePath, out var document));
@@ -82,7 +82,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var documentFilePath = "C:/path/to/document.cshtml";
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         // Act
         var projects = snapshotResolver.TryResolveAllProjects(documentFilePath);
@@ -98,7 +98,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var documentFilePath = "C:/path/to/document.cshtml";
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         // Act
         var projects = snapshotResolver.TryResolveAllProjects(documentFilePath);
@@ -113,7 +113,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         // Arrange
         var documentFilePath = Path.Combine(TempDirectory.Instance.DirectoryPath, "document.cshtml");
         var snapshotResolver = await CreateSnapshotResolverAsync(documentFilePath, addToMiscellaneous: true);
-        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         // Act
         var projects = snapshotResolver.TryResolveAllProjects(documentFilePath);
@@ -130,7 +130,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var documentFilePath = "C:/path/to/document.cshtml";
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         await projectManager.UpdateAsync(updater =>
         {
@@ -152,7 +152,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var projectManager = CreateProjectSnapshotManager();
 
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         var expectedProject = await projectManager.UpdateAsync(updater =>
         {
@@ -180,7 +180,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
 
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         var miscProject = await projectManager.UpdateAsync(updater =>
         {
@@ -206,7 +206,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var documentFilePath = "c:/path/to/document.cshtml";
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         var ownerProject = await projectManager.UpdateAsync(updater =>
         {
@@ -230,7 +230,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         // Arrange
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         // Act
         var project = snapshotResolver.GetMiscellaneousProject();
@@ -246,7 +246,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         // Arrange
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         // Act
         var project = snapshotResolver.GetMiscellaneousProject();
@@ -262,7 +262,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
 
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         if (addToMiscellaneous)
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SnapshotResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SnapshotResolverTest.cs
@@ -40,7 +40,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var normalizedFilePath = "C:/path/to/document.cshtml";
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         await projectManager.UpdateAsync(updater =>
         {
@@ -66,7 +66,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var documentFilePath = @"C:\path\to\document.cshtml";
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         // Act
         Assert.False(snapshotResolver.TryResolveDocumentInAnyProject(documentFilePath, out var document));
@@ -82,7 +82,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var documentFilePath = "C:/path/to/document.cshtml";
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         // Act
         Assert.False(snapshotResolver.TryResolveAllProjects(documentFilePath, out _));
@@ -95,7 +95,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var documentFilePath = "C:/path/to/document.cshtml";
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         // Act
         Assert.False(snapshotResolver.TryResolveAllProjects(documentFilePath, out _));
@@ -107,7 +107,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         // Arrange
         var documentFilePath = Path.Combine(TempDirectory.Instance.DirectoryPath, "document.cshtml");
         var snapshotResolver = await CreateSnapshotResolverAsync(documentFilePath, addToMiscellaneous: true);
-        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         // Act
         Assert.True(snapshotResolver.TryResolveAllProjects(documentFilePath, out var projects));
@@ -124,7 +124,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var documentFilePath = "C:/path/to/document.cshtml";
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         await projectManager.UpdateAsync(updater =>
         {
@@ -143,7 +143,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var projectManager = CreateProjectSnapshotManager();
 
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         var expectedProject = await projectManager.UpdateAsync(updater =>
         {
@@ -171,7 +171,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
 
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         var miscProject = await projectManager.UpdateAsync(updater =>
         {
@@ -197,7 +197,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var documentFilePath = "c:/path/to/document.cshtml";
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         var ownerProject = await projectManager.UpdateAsync(updater =>
         {
@@ -221,7 +221,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         // Arrange
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         // Act
         var project = snapshotResolver.GetMiscellaneousProject();
@@ -237,7 +237,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         // Arrange
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         // Act
         var project = snapshotResolver.GetMiscellaneousProject();
@@ -253,7 +253,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
 
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         if (addToMiscellaneous)
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SnapshotResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SnapshotResolverTest.cs
@@ -24,10 +24,9 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var snapshotResolver = await CreateSnapshotResolverAsync(normalizedFilePath);
 
         // Act
-        var document = snapshotResolver.ResolveDocumentInAnyProject(documentFilePath);
+        Assert.True(snapshotResolver.TryResolveDocumentInAnyProject(documentFilePath, out var document));
 
         // Assert
-        Assert.NotNull(document);
         Assert.Equal(normalizedFilePath, document.FilePath);
     }
 
@@ -52,10 +51,9 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         });
 
         // Act
-        var document = snapshotResolver.ResolveDocumentInAnyProject(documentFilePath);
+        Assert.True(snapshotResolver.TryResolveDocumentInAnyProject(documentFilePath, out var document));
 
         // Assert
-        Assert.NotNull(document);
         Assert.Equal(normalizedFilePath, document.FilePath);
     }
 
@@ -69,7 +67,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         await snapshotResolver.InitializeAsync(DisposalToken);
 
         // Act
-        var document = snapshotResolver.ResolveDocumentInAnyProject(documentFilePath);
+        Assert.False(snapshotResolver.TryResolveDocumentInAnyProject(documentFilePath, out var document));
 
         // Assert
         Assert.Null(document);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SnapshotResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SnapshotResolverTest.cs
@@ -39,6 +39,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var normalizedFilePath = "C:/path/to/document.cshtml";
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
+        await snapshotResolver.InitializeAsync(DisposalToken);
 
         await projectManager.UpdateAsync(async updater =>
         {
@@ -65,6 +66,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var documentFilePath = @"C:\path\to\document.cshtml";
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
+        await snapshotResolver.InitializeAsync(DisposalToken);
 
         // Act
         var document = await snapshotResolver.ResolveDocumentInAnyProjectAsync(documentFilePath, DisposalToken);
@@ -80,6 +82,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var documentFilePath = "C:/path/to/document.cshtml";
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
+        await snapshotResolver.InitializeAsync(DisposalToken);
 
         // Act
         var projects = await snapshotResolver.TryResolveAllProjectsAsync(documentFilePath, DisposalToken);
@@ -95,6 +98,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var documentFilePath = "C:/path/to/document.cshtml";
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
+        await snapshotResolver.InitializeAsync(DisposalToken);
 
         await snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
 
@@ -111,6 +115,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         // Arrange
         var documentFilePath = Path.Combine(TempDirectory.Instance.DirectoryPath, "document.cshtml");
         var snapshotResolver = await CreateSnapshotResolverAsync(documentFilePath, addToMiscellaneous: true);
+        await snapshotResolver.InitializeAsync(DisposalToken);
 
         // Act
         var projects = await snapshotResolver.TryResolveAllProjectsAsync(documentFilePath, DisposalToken);
@@ -127,6 +132,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var documentFilePath = "C:/path/to/document.cshtml";
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
+        await snapshotResolver.InitializeAsync(DisposalToken);
 
         await projectManager.UpdateAsync(updater =>
         {
@@ -147,6 +153,9 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var documentFilePath = "C:/path/to/document.cshtml";
         var projectManager = CreateProjectSnapshotManager();
 
+        var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
+        await snapshotResolver.InitializeAsync(DisposalToken);
+
         var expectedProject = await projectManager.UpdateAsync(updater =>
         {
             var expectedProject = updater.CreateAndAddProject("C:/path/to/project.csproj");
@@ -155,8 +164,6 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
 
             return expectedProject;
         });
-
-        var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
 
         // Act
         var projects = await snapshotResolver.TryResolveAllProjectsAsync(documentFilePath, DisposalToken);
@@ -175,6 +182,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
 
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
+        await snapshotResolver.InitializeAsync(DisposalToken);
 
         var miscProject = await projectManager.UpdateAsync(async updater =>
         {
@@ -200,6 +208,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var documentFilePath = "c:/path/to/document.cshtml";
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
+        await snapshotResolver.InitializeAsync(DisposalToken);
 
         var ownerProject = await projectManager.UpdateAsync(updater =>
         {
@@ -223,6 +232,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         // Arrange
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
+        await snapshotResolver.InitializeAsync(DisposalToken);
 
         // Act
         var project = await snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
@@ -238,6 +248,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         // Arrange
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
+        await snapshotResolver.InitializeAsync(DisposalToken);
 
         // Act
         var project = await snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
@@ -253,6 +264,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
 
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
+        await snapshotResolver.InitializeAsync(DisposalToken);
 
         if (addToMiscellaneous)
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SnapshotResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SnapshotResolverTest.cs
@@ -4,10 +4,12 @@
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
+using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.AspNetCore.Razor.Test.Common.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Utilities;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CommonLanguageServerProtocol.Framework;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -38,7 +40,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var normalizedFilePath = "C:/path/to/document.cshtml";
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         await projectManager.UpdateAsync(updater =>
         {
@@ -64,7 +66,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var documentFilePath = @"C:\path\to\document.cshtml";
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         // Act
         Assert.False(snapshotResolver.TryResolveDocumentInAnyProject(documentFilePath, out var document));
@@ -80,7 +82,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var documentFilePath = "C:/path/to/document.cshtml";
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         // Act
         var projects = snapshotResolver.TryResolveAllProjects(documentFilePath);
@@ -96,7 +98,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var documentFilePath = "C:/path/to/document.cshtml";
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         // Act
         var projects = snapshotResolver.TryResolveAllProjects(documentFilePath);
@@ -111,7 +113,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         // Arrange
         var documentFilePath = Path.Combine(TempDirectory.Instance.DirectoryPath, "document.cshtml");
         var snapshotResolver = await CreateSnapshotResolverAsync(documentFilePath, addToMiscellaneous: true);
-        await snapshotResolver.InitializeAsync(DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         // Act
         var projects = snapshotResolver.TryResolveAllProjects(documentFilePath);
@@ -128,7 +130,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var documentFilePath = "C:/path/to/document.cshtml";
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         await projectManager.UpdateAsync(updater =>
         {
@@ -150,7 +152,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var projectManager = CreateProjectSnapshotManager();
 
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         var expectedProject = await projectManager.UpdateAsync(updater =>
         {
@@ -178,7 +180,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
 
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         var miscProject = await projectManager.UpdateAsync(updater =>
         {
@@ -204,7 +206,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         var documentFilePath = "c:/path/to/document.cshtml";
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         var ownerProject = await projectManager.UpdateAsync(updater =>
         {
@@ -228,7 +230,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         // Arrange
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         // Act
         var project = snapshotResolver.GetMiscellaneousProject();
@@ -244,7 +246,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         // Arrange
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         // Act
         var project = snapshotResolver.GetMiscellaneousProject();
@@ -260,7 +262,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
 
         var projectManager = CreateProjectSnapshotManager();
         var snapshotResolver = new SnapshotResolver(projectManager, LoggerFactory);
-        await snapshotResolver.InitializeAsync(DisposalToken);
+        await snapshotResolver.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
 
         if (addToMiscellaneous)
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SnapshotResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SnapshotResolverTest.cs
@@ -85,7 +85,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         await snapshotResolver.InitializeAsync(DisposalToken);
 
         // Act
-        var projects = await snapshotResolver.TryResolveAllProjectsAsync(documentFilePath, DisposalToken);
+        var projects = snapshotResolver.TryResolveAllProjects(documentFilePath);
 
         // Assert
         Assert.Empty(projects);
@@ -101,7 +101,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         await snapshotResolver.InitializeAsync(DisposalToken);
 
         // Act
-        var projects = await snapshotResolver.TryResolveAllProjectsAsync(documentFilePath, DisposalToken);
+        var projects = snapshotResolver.TryResolveAllProjects(documentFilePath);
 
         // Assert
         Assert.Empty(projects);
@@ -116,7 +116,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         await snapshotResolver.InitializeAsync(DisposalToken);
 
         // Act
-        var projects = await snapshotResolver.TryResolveAllProjectsAsync(documentFilePath, DisposalToken);
+        var projects = snapshotResolver.TryResolveAllProjects(documentFilePath);
 
         // Assert
         var miscFilesProject = snapshotResolver.GetMiscellaneousProject();
@@ -138,7 +138,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         });
 
         // Act
-        var projects = await snapshotResolver.TryResolveAllProjectsAsync(documentFilePath, DisposalToken);
+        var projects = snapshotResolver.TryResolveAllProjects(documentFilePath);
 
         // Assert
         Assert.Empty(projects);
@@ -164,7 +164,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         });
 
         // Act
-        var projects = await snapshotResolver.TryResolveAllProjectsAsync(documentFilePath, DisposalToken);
+        var projects = snapshotResolver.TryResolveAllProjects(documentFilePath);
 
         // Assert
         var project = Assert.Single(projects);
@@ -192,7 +192,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         });
 
         // Act
-        var projects = await snapshotResolver.TryResolveAllProjectsAsync(documentFilePath, DisposalToken);
+        var projects = snapshotResolver.TryResolveAllProjects(documentFilePath);
 
         // Assert
         var project = Assert.Single(projects);
@@ -217,7 +217,7 @@ public class SnapshotResolverTest(ITestOutputHelper testOutput) : LanguageServer
         });
 
         // Act
-        var projects = await snapshotResolver.TryResolveAllProjectsAsync(documentFilePath, DisposalToken);
+        var projects = snapshotResolver.TryResolveAllProjects(documentFilePath);
 
         // Assert
         var project = Assert.Single(projects);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestSnapshotResolver.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestSnapshotResolver.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -27,9 +25,6 @@ internal class TestSnapshotResolver : ISnapshotResolver
         _filePath = filePath;
         _projects = [.. projects];
     }
-
-    public Task InitializeAsync(CancellationToken cancellationToken)
-        => Task.CompletedTask;
 
     public ImmutableArray<IProjectSnapshot> FindPotentialProjects(string documentFilePath)
         => documentFilePath == _filePath

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestSnapshotResolver.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestSnapshotResolver.cs
@@ -38,6 +38,6 @@ internal class TestSnapshotResolver : ISnapshotResolver
     public IProjectSnapshot GetMiscellaneousProject()
         => _miscProject;
 
-    public Task<IDocumentSnapshot?> ResolveDocumentInAnyProjectAsync(string documentFilePath, CancellationToken cancellationToken)
-        => Task.FromResult<IDocumentSnapshot?>(null);
+    public IDocumentSnapshot? ResolveDocumentInAnyProject(string documentFilePath)
+        => null;
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestSnapshotResolver.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestSnapshotResolver.cs
@@ -27,6 +27,9 @@ internal class TestSnapshotResolver : ISnapshotResolver
         _projects = [.. projects];
     }
 
+    public Task InitializeAsync(CancellationToken cancellationToken)
+        => Task.CompletedTask;
+
     public ImmutableArray<IProjectSnapshot> FindPotentialProjects(string documentFilePath)
         => documentFilePath == _filePath
             ? _projects

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestSnapshotResolver.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestSnapshotResolver.cs
@@ -35,8 +35,8 @@ internal class TestSnapshotResolver : ISnapshotResolver
             ? _projects
             : [];
 
-    public Task<IProjectSnapshot> GetMiscellaneousProjectAsync(CancellationToken cancellationToken)
-        => Task.FromResult(_miscProject);
+    public IProjectSnapshot GetMiscellaneousProject()
+        => _miscProject;
 
     public Task<IDocumentSnapshot?> ResolveDocumentInAnyProjectAsync(string documentFilePath, CancellationToken cancellationToken)
         => Task.FromResult<IDocumentSnapshot?>(null);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestSnapshotResolver.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestSnapshotResolver.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
@@ -38,6 +39,9 @@ internal class TestSnapshotResolver : ISnapshotResolver
     public IProjectSnapshot GetMiscellaneousProject()
         => _miscProject;
 
-    public IDocumentSnapshot? ResolveDocumentInAnyProject(string documentFilePath)
-        => null;
+    public bool TryResolveDocumentInAnyProject(string documentFilePath, [NotNullWhen(true)] out IDocumentSnapshot? document)
+    {
+        document = null;
+        return false;
+    }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/WrapWithTag/WrapWithTagEndpointTests.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/WrapWithTag/WrapWithTagEndpointTests.cs
@@ -270,7 +270,7 @@ public class WrapWithTagEndpointTest(ITestOutputHelper testOutput) : LanguageSer
 
         var uri = new Uri("file://path.razor");
         var factory = CreateDocumentContextFactory(uri, input);
-        var context = await factory.TryCreateAsync(uri, DisposalToken);
+        var context = factory.TryCreate(uri);
         Assert.NotNull(context);
         var inputSourceText = await context!.GetSourceTextAsync(DisposalToken);
 
@@ -320,7 +320,7 @@ public class WrapWithTagEndpointTest(ITestOutputHelper testOutput) : LanguageSer
 
         var uri = new Uri("file://path.razor");
         var factory = CreateDocumentContextFactory(uri, input);
-        var context = await factory.TryCreateAsync(uri, DisposalToken);
+        var context = factory.TryCreate(uri);
         Assert.NotNull(context);
         var inputSourceText = await context!.GetSourceTextAsync(DisposalToken);
 
@@ -371,7 +371,7 @@ public class WrapWithTagEndpointTest(ITestOutputHelper testOutput) : LanguageSer
 
         var uri = new Uri("file://path.razor");
         var factory = CreateDocumentContextFactory(uri, input);
-        var context = await factory.TryCreateAsync(uri, DisposalToken);
+        var context = factory.TryCreate(uri);
         Assert.NotNull(context);
         var inputSourceText = await context!.GetSourceTextAsync(DisposalToken);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/WrapWithTag/WrapWithTagEndpointTests.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/WrapWithTag/WrapWithTagEndpointTests.cs
@@ -270,8 +270,7 @@ public class WrapWithTagEndpointTest(ITestOutputHelper testOutput) : LanguageSer
 
         var uri = new Uri("file://path.razor");
         var factory = CreateDocumentContextFactory(uri, input);
-        var context = factory.TryCreate(uri);
-        Assert.NotNull(context);
+        Assert.True(factory.TryCreate(uri, out var context));
         var inputSourceText = await context!.GetSourceTextAsync(DisposalToken);
 
         var computedEdits = new TextEdit[]
@@ -320,8 +319,7 @@ public class WrapWithTagEndpointTest(ITestOutputHelper testOutput) : LanguageSer
 
         var uri = new Uri("file://path.razor");
         var factory = CreateDocumentContextFactory(uri, input);
-        var context = factory.TryCreate(uri);
-        Assert.NotNull(context);
+        Assert.True(factory.TryCreate(uri, out var context));
         var inputSourceText = await context!.GetSourceTextAsync(DisposalToken);
 
         var computedEdits = new TextEdit[]
@@ -371,8 +369,7 @@ public class WrapWithTagEndpointTest(ITestOutputHelper testOutput) : LanguageSer
 
         var uri = new Uri("file://path.razor");
         var factory = CreateDocumentContextFactory(uri, input);
-        var context = factory.TryCreate(uri);
-        Assert.NotNull(context);
+        Assert.True(factory.TryCreate(uri, out var context));
         var inputSourceText = await context!.GetSourceTextAsync(DisposalToken);
 
         var computedEdits = new TextEdit[]

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/TestDocumentContextFactory.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/TestDocumentContextFactory.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -27,23 +25,23 @@ internal class TestDocumentContextFactory : IDocumentContextFactory
         _version = version;
     }
 
-    public virtual Task<DocumentContext?> TryCreateAsync(Uri documentUri, VSProjectContext? projectContext, bool versioned, CancellationToken cancellationToken)
+    public virtual DocumentContext? TryCreate(Uri documentUri, VSProjectContext? projectContext, bool versioned)
     {
         if (FilePath is null || CodeDocument is null)
         {
-            return Task.FromResult<DocumentContext?>(null);
+            return null;
         }
 
         if (versioned)
         {
             if (_version is null)
             {
-                return Task.FromResult<DocumentContext?>(null);
+                return null;
             }
 
-            return Task.FromResult<DocumentContext?>(TestDocumentContext.From(FilePath, CodeDocument, _version.Value));
+            return TestDocumentContext.From(FilePath, CodeDocument, _version.Value);
         }
 
-        return Task.FromResult<DocumentContext?>(TestDocumentContext.From(FilePath, CodeDocument));
+        return TestDocumentContext.From(FilePath, CodeDocument);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/TestDocumentContextFactory.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/TestDocumentContextFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -25,23 +26,31 @@ internal class TestDocumentContextFactory : IDocumentContextFactory
         _version = version;
     }
 
-    public virtual DocumentContext? TryCreate(Uri documentUri, VSProjectContext? projectContext, bool versioned)
+    public virtual bool TryCreate(
+        Uri documentUri,
+        VSProjectContext? projectContext,
+        bool versioned,
+        [NotNullWhen(true)] out DocumentContext? context)
     {
         if (FilePath is null || CodeDocument is null)
         {
-            return null;
+            context = null;
+            return false;
         }
 
         if (versioned)
         {
             if (_version is null)
             {
-                return null;
+                context = null;
+                return false;
             }
 
-            return TestDocumentContext.From(FilePath, CodeDocument, _version.Value);
+            context = TestDocumentContext.From(FilePath, CodeDocument, _version.Value);
+            return true;
         }
 
-        return TestDocumentContext.From(FilePath, CodeDocument);
+        context = TestDocumentContext.From(FilePath, CodeDocument);
+        return true;
     }
 }


### PR DESCRIPTION
The work I did to make all of the public entry points on `RazorProjectService` async did so by breaking up the operations in multiple tasks. The operations themselves can't interleave because a semaphore gates just one operation at a time. However, the updates to the `ProjectSnapshotManager` made by each operation _can_ interleave with other updates to the `ProjectSnapshotManager`.

This change ensures that all of the `RazorProjectService` operations are atomic WRT to the `ProjectSnapshotManger` by running each operation within a call to `ProjectSnapshotManager.UpdateAsync(...)`. In addition, I've taken a suggestion from @ryzngard to change when the miscellaneous files project is added to the `ProjectSnapshotManager` in the language server. Before this change, the misc files project would be added by the first call to `ISnapshotResolver.GetMiscellaneousProjectAsync(...)`. Now, it's added during `SnapshotResolver` initialization. This allows `GetMiscellaneousProjectAsync(...)` to become a synchronous method, which has the positive effect allowing many of the downstream callers to be synchronous as well. Ultimately, this allows all of the `RazorProjectService` operations to be implemented synchronously, which helps ensure that they are actually atomic.