### PR TITLE
Don't try to find "potential" projects for newly created .razor files

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/IRazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/IRazorProjectService.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 
 internal interface IRazorProjectService
 {
-    Task AddDocumentAsync(string filePath, CancellationToken cancellationToken);
+    Task AddDocumentToMiscProjectAsync(string filePath, CancellationToken cancellationToken);
     Task OpenDocumentAsync(string filePath, SourceText sourceText, int version, CancellationToken cancellationToken);
     Task UpdateDocumentAsync(string filePath, SourceText sourceText, int version, CancellationToken cancellationToken);
     Task CloseDocumentAsync(string filePath, CancellationToken cancellationToken);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
@@ -50,7 +50,7 @@ internal class RazorProjectService(
         var textDocumentPath = FilePathNormalizer.Normalize(filePath);
 
         _logger.LogDebug($"Adding {filePath} to the miscellaneous files project, because we don't have project info (yet?)");
-        var miscFilesProject = await _snapshotResolver.GetMiscellaneousProjectAsync(cancellationToken).ConfigureAwait(false);
+        var miscFilesProject = _snapshotResolver.GetMiscellaneousProject();
 
         if (miscFilesProject.GetDocument(FilePathNormalizer.Normalize(textDocumentPath)) is not null)
         {
@@ -67,13 +67,13 @@ internal class RazorProjectService(
 
         _logger.LogInformation($"Adding document '{filePath}' to project '{miscFilesProject.Key}'.");
 
-        updater.DocumentAdded(projectSnapshot.Key, hostDocument, textLoader);
+        updater.DocumentAdded(miscFilesProject.Key, hostDocument, textLoader);
 
         // Adding a document to a project could also happen because a target was added to a project, or we're moving a document
         // from Misc Project to a real one, and means the newly added document could actually already be open.
         // If it is, we need to make sure we start generating it so we're ready to handle requests that could start coming in.
         if (_projectManager.IsDocumentOpen(textDocumentPath) &&
-            _projectManager.TryGetLoadedProject(projectSnapshot.Key, out var project) &&
+            _projectManager.TryGetLoadedProject(miscFilesProject.Key, out var project) &&
             project.GetDocument(textDocumentPath) is { } document)
         {
             document.GetGeneratedOutputAsync().Forget();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
@@ -46,14 +46,14 @@ internal class RazorProjectService(
         _gate.Dispose();
     }
 
-    public async Task AddDocumentAsync(string filePath, CancellationToken cancellationToken)
+    public async Task AddDocumentToMiscProjectAsync(string filePath, CancellationToken cancellationToken)
     {
         using var _ = await _gate.EnterAsync(cancellationToken).ConfigureAwait(false);
 
-        await AddDocumentNeedsLocksAsync(filePath, cancellationToken).ConfigureAwait(false);
+        await AddDocumentToMiscProjectNeedsLocksAsync(filePath, cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task AddDocumentNeedsLocksAsync(string filePath, CancellationToken cancellationToken)
+    private async Task AddDocumentToMiscProjectNeedsLocksAsync(string filePath, CancellationToken cancellationToken)
     {
         var textDocumentPath = FilePathNormalizer.Normalize(filePath);
 
@@ -122,7 +122,7 @@ internal class RazorProjectService(
         {
             // Document hasn't been added. This usually occurs when VSCode trumps all other initialization
             // processes and pre-initializes already open documents.
-            await AddDocumentNeedsLocksAsync(filePath, cancellationToken).ConfigureAwait(false);
+            await AddDocumentToMiscProjectNeedsLocksAsync(filePath, cancellationToken).ConfigureAwait(false);
         }
 
         await ActOnDocumentInMultipleProjectsAsync(

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
@@ -57,18 +57,9 @@ internal class RazorProjectService(
     {
         var textDocumentPath = FilePathNormalizer.Normalize(filePath);
 
-        var added = false;
-        foreach (var projectSnapshot in _snapshotResolver.FindPotentialProjects(textDocumentPath))
-        {
-            added = true;
-            await AddDocumentToProjectAsync(projectSnapshot, textDocumentPath, cancellationToken).ConfigureAwait(false);
-        }
-
-        if (!added)
-        {
-            var miscFilesProject = await _snapshotResolver.GetMiscellaneousProjectAsync(cancellationToken).ConfigureAwait(false);
-            await AddDocumentToProjectAsync(miscFilesProject, textDocumentPath, cancellationToken).ConfigureAwait(false);
-        }
+        _logger.LogDebug($"Adding {filePath} to the miscellaneous files project, because we don't have project info (yet?)");
+        var miscFilesProject = await _snapshotResolver.GetMiscellaneousProjectAsync(cancellationToken).ConfigureAwait(false);
+        await AddDocumentToProjectAsync(miscFilesProject, textDocumentPath, cancellationToken).ConfigureAwait(false);
 
         async Task AddDocumentToProjectAsync(IProjectSnapshot projectSnapshot, string textDocumentPath, CancellationToken cancellationToken)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
@@ -93,7 +93,8 @@ internal class RazorProjectService(
                 if (!_snapshotResolver.TryResolveDocumentInAnyProject(textDocumentPath, out var document))
                 {
                     // Document hasn't been added. This usually occurs when VSCode trumps all other initialization
-                    // processes and pre-initializes already open documents.
+                    // processes and pre-initializes already open documents. We add this to the misc project, and
+                    // if/when we get project info from the client, it will be migrated to a real project.
                     AddDocumentToMiscProjectCore(updater, filePath);
                 }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
@@ -67,16 +67,8 @@ internal class RazorProjectService(
             return;
         }
 
-        var targetFilePath = textDocumentPath;
-        var projectDirectory = FilePathNormalizer.GetNormalizedDirectoryName(miscFilesProject.FilePath);
-        if (targetFilePath.StartsWith(projectDirectory, FilePathComparison.Instance))
-        {
-            // Make relative
-            targetFilePath = textDocumentPath[projectDirectory.Length..];
-        }
-
         // Representing all of our host documents with a re-normalized target path to workaround GetRelatedDocument limitations.
-        var normalizedTargetFilePath = targetFilePath.Replace('/', '\\').TrimStart('\\');
+        var normalizedTargetFilePath = textDocumentPath.Replace('/', '\\').TrimStart('\\');
 
         var hostDocument = new HostDocument(textDocumentPath, normalizedTargetFilePath);
         var textLoader = _remoteTextLoaderFactory.Create(textDocumentPath);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileSynchronizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileSynchronizer.cs
@@ -17,6 +17,10 @@ internal class RazorFileSynchronizer(IRazorProjectService projectService) : IRaz
     public Task RazorFileChangedAsync(string filePath, RazorFileChangeKind kind, CancellationToken cancellationToken)
         => kind switch
         {
+            // We put the new file in the misc files project, so we don't confuse the client by sending updates for
+            // a razor file that we guess is going to be in a project, when the client might not have received that
+            // info yet. When the client does find out, it will tell us by updating the project info, and we'll
+            // migrate the file as necessary.
             RazorFileChangeKind.Added => _projectService.AddDocumentToMiscProjectAsync(filePath, cancellationToken),
             RazorFileChangeKind.Removed => _projectService.RemoveDocumentAsync(filePath, cancellationToken),
             _ => Task.CompletedTask

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileSynchronizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorFileSynchronizer.cs
@@ -17,7 +17,7 @@ internal class RazorFileSynchronizer(IRazorProjectService projectService) : IRaz
     public Task RazorFileChangedAsync(string filePath, RazorFileChangeKind kind, CancellationToken cancellationToken)
         => kind switch
         {
-            RazorFileChangeKind.Added => _projectService.AddDocumentAsync(filePath, cancellationToken),
+            RazorFileChangeKind.Added => _projectService.AddDocumentToMiscProjectAsync(filePath, cancellationToken),
             RazorFileChangeKind.Removed => _projectService.RemoveDocumentAsync(filePath, cancellationToken),
             _ => Task.CompletedTask
         };

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorComponentSearchEngineTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorComponentSearchEngineTest.cs
@@ -62,7 +62,7 @@ public class DefaultRazorComponentSearchEngineTest(ITestOutputHelper testOutput)
                 return textLoaderMock.Object;
             });
 
-        var projectService = new RazorProjectService(
+        var projectService = new TestRazorProjectService(
             remoteTextLoaderFactoryMock.Object,
             snapshotResolver,
             documentVersionCache,
@@ -77,10 +77,10 @@ public class DefaultRazorComponentSearchEngineTest(ITestOutputHelper testOutput)
             displayName: "",
             DisposalToken);
 
-        await projectService.AddDocumentToMiscProjectAsync(s_componentFilePath1, DisposalToken);
+        await projectService.AddDocumentToPotentialProjectsAsync(s_componentFilePath1, DisposalToken);
         await projectService.UpdateDocumentAsync(s_componentFilePath1, SourceText.From(""), version: 1, DisposalToken);
 
-        await projectService.AddDocumentToMiscProjectAsync(s_componentFilePath2, DisposalToken);
+        await projectService.AddDocumentToPotentialProjectsAsync(s_componentFilePath2, DisposalToken);
         await projectService.UpdateDocumentAsync(s_componentFilePath2, SourceText.From("@namespace Test"), version: 1, DisposalToken);
 
         await projectService.AddProjectAsync(
@@ -91,7 +91,7 @@ public class DefaultRazorComponentSearchEngineTest(ITestOutputHelper testOutput)
             displayName: "",
             DisposalToken);
 
-        await projectService.AddDocumentToMiscProjectAsync(s_componentFilePath3, DisposalToken);
+        await projectService.AddDocumentToPotentialProjectsAsync(s_componentFilePath3, DisposalToken);
         await projectService.UpdateDocumentAsync(s_componentFilePath3, SourceText.From(""), version: 1, DisposalToken);
     }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorComponentSearchEngineTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultRazorComponentSearchEngineTest.cs
@@ -77,10 +77,10 @@ public class DefaultRazorComponentSearchEngineTest(ITestOutputHelper testOutput)
             displayName: "",
             DisposalToken);
 
-        await projectService.AddDocumentAsync(s_componentFilePath1, DisposalToken);
+        await projectService.AddDocumentToMiscProjectAsync(s_componentFilePath1, DisposalToken);
         await projectService.UpdateDocumentAsync(s_componentFilePath1, SourceText.From(""), version: 1, DisposalToken);
 
-        await projectService.AddDocumentAsync(s_componentFilePath2, DisposalToken);
+        await projectService.AddDocumentToMiscProjectAsync(s_componentFilePath2, DisposalToken);
         await projectService.UpdateDocumentAsync(s_componentFilePath2, SourceText.From("@namespace Test"), version: 1, DisposalToken);
 
         await projectService.AddProjectAsync(
@@ -91,7 +91,7 @@ public class DefaultRazorComponentSearchEngineTest(ITestOutputHelper testOutput)
             displayName: "",
             DisposalToken);
 
-        await projectService.AddDocumentAsync(s_componentFilePath3, DisposalToken);
+        await projectService.AddDocumentToMiscProjectAsync(s_componentFilePath3, DisposalToken);
         await projectService.UpdateDocumentAsync(s_componentFilePath3, SourceText.From(""), version: 1, DisposalToken);
     }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorFileSynchronizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorFileSynchronizerTest.cs
@@ -22,7 +22,7 @@ public class RazorFileSynchronizerTest(ITestOutputHelper testOutput) : LanguageS
         var filePath = "/path/to/file.razor";
         var projectService = new StrictMock<IRazorProjectService>();
         projectService
-            .Setup(service => service.AddDocumentAsync(filePath, It.IsAny<CancellationToken>()))
+            .Setup(service => service.AddDocumentToMiscProjectAsync(filePath, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask)
             .Verifiable();
         var synchronizer = new RazorFileSynchronizer(projectService.Object);
@@ -41,7 +41,7 @@ public class RazorFileSynchronizerTest(ITestOutputHelper testOutput) : LanguageS
         var filePath = "/path/to/file.cshtml";
         var projectService = new StrictMock<IRazorProjectService>();
         projectService
-            .Setup(service => service.AddDocumentAsync(filePath, It.IsAny<CancellationToken>()))
+            .Setup(service => service.AddDocumentToMiscProjectAsync(filePath, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask)
             .Verifiable();
         var synchronizer = new RazorFileSynchronizer(projectService.Object);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
@@ -36,7 +36,9 @@ public class RazorProjectServiceTest : LanguageServerTestBase
     public RazorProjectServiceTest(ITestOutputHelper testOutput)
         : base(testOutput)
     {
-        _projectManager = CreateProjectSnapshotManager();
+        var optionsMonitor = TestRazorLSPOptionsMonitor.Create();
+        var projectEngineFactoryProvider = new LspProjectEngineFactoryProvider(optionsMonitor);
+        _projectManager = CreateProjectSnapshotManager(projectEngineFactoryProvider);
         _snapshotResolver = new SnapshotResolver(_projectManager, LoggerFactory);
         _documentVersionCache = new DocumentVersionCache(_projectManager);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
@@ -606,7 +606,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
     }
 
     [Fact]
-    public async Task OpenDocument_OpensAndAddsDocumentToOwnerProject()
+    public async Task OpenDocument_OpensAndAddsDocumentToMiscellaneousProject()
     {
         // Arrange
         const string ProjectFilePath = "C:/path/to/project.csproj";
@@ -617,7 +617,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
         var ownerProjectKey = await _projectService.AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
 
-        var ownerProject = _projectManager.GetLoadedProject(ownerProjectKey);
+        var miscProject = await _snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
 
         using var listener = _projectManager.ListenToNotifications();
 
@@ -626,8 +626,8 @@ public class RazorProjectServiceTest : LanguageServerTestBase
 
         // Assert
         listener.AssertNotifications(
-            x => x.DocumentAdded(DocumentFilePath, ownerProject.Key),
-            x => x.DocumentChanged(DocumentFilePath, ownerProject.Key));
+            x => x.DocumentAdded(DocumentFilePath, miscProject.Key),
+            x => x.DocumentChanged(DocumentFilePath, miscProject.Key));
 
         Assert.True(_projectManager.IsDocumentOpen(DocumentFilePath));
     }
@@ -678,7 +678,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
     }
 
     [Fact]
-    public async Task AddDocument_AddsDocumentToMiscellaneousProject()
+    public async Task AddDocumentToMiscProjectAsync_AddsDocumentToMiscellaneousProject()
     {
         // Arrange
         const string DocumentFilePath = "document.cshtml";
@@ -688,7 +688,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
         using var listener = _projectManager.ListenToNotifications();
 
         // Act
-        await _projectService.AddDocumentToPotentialProjectsAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
 
         // Assert
         listener.AssertNotifications(

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
@@ -439,7 +439,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
 
         var ownerProjectKey = await _projectService.AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
-        await _projectService.AddDocumentAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
         await _projectService.OpenDocumentAsync(DocumentFilePath, s_emptyText, version: 42, DisposalToken);
 
         var ownerProject = _projectManager.GetLoadedProject(ownerProjectKey);
@@ -472,7 +472,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
             ProjectFilePath, IntermediateOutputPath1, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
         var ownerProjectKey2 = await _projectService.AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath2, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
-        await _projectService.AddDocumentAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
         await _projectService.OpenDocumentAsync(DocumentFilePath, s_emptyText, version: 42, DisposalToken);
 
         var ownerProject1 = _projectManager.GetLoadedProject(ownerProjectKey1);
@@ -499,7 +499,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
         // Arrange
         const string DocumentFilePath = "document.cshtml";
 
-        await _projectService.AddDocumentAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
         await _projectService.OpenDocumentAsync(DocumentFilePath, s_emptyText, version: 42, DisposalToken);
 
         var miscProject = await _snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
@@ -529,7 +529,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
 
         var ownerProjectKey = await _projectService.AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
-        await _projectService.AddDocumentAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
 
         var ownerProject = _projectManager.GetLoadedProject(ownerProjectKey);
 
@@ -561,7 +561,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
             ProjectFilePath, IntermediateOutputPath1, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
         var ownerProjectKey2 = await _projectService.AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath2, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
-        await _projectService.AddDocumentAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
 
         var ownerProject1 = _projectManager.GetLoadedProject(ownerProjectKey1);
         var ownerProject2 = _projectManager.GetLoadedProject(ownerProjectKey2);
@@ -587,7 +587,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
         // Arrange
         const string DocumentFilePath = "document.cshtml";
 
-        await _projectService.AddDocumentAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
 
         var miscProject = await _snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
 
@@ -638,14 +638,14 @@ public class RazorProjectServiceTest : LanguageServerTestBase
         // Arrange
         const string DocumentFilePath = "document.cshtml";
 
-        await _projectService.AddDocumentAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
 
         var miscProject = await _snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
 
         using var listener = _projectManager.ListenToNotifications();
 
         // Act
-        await _projectService.AddDocumentAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
 
         // Assert
         listener.AssertNoNotifications();
@@ -668,7 +668,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
         using var listener = _projectManager.ListenToNotifications();
 
         // Act
-        await _projectService.AddDocumentAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
 
         // Assert
         listener.AssertNotifications(
@@ -688,7 +688,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
         using var listener = _projectManager.ListenToNotifications();
 
         // Act
-        await _projectService.AddDocumentAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
 
         // Assert
         listener.AssertNotifications(
@@ -708,7 +708,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
 
         var ownerProjectKey = await _projectService.AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
-        await _projectService.AddDocumentAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
 
         var ownerProject = _projectManager.GetLoadedProject(ownerProjectKey);
 
@@ -738,7 +738,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
             ProjectFilePath, IntermediateOutputPath1, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
         var ownerProjectKey2 = await _projectService.AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath2, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
-        await _projectService.AddDocumentAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
 
         var ownerProject1 = _projectManager.GetLoadedProject(ownerProjectKey1);
         var ownerProject2 = _projectManager.GetLoadedProject(ownerProjectKey2);
@@ -767,7 +767,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
 
         var ownerProjectKey = await _projectService.AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
-        await _projectService.AddDocumentAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
         await _projectService.OpenDocumentAsync(DocumentFilePath, s_emptyText, version: 42, DisposalToken);
 
         var ownerProject = _projectManager.GetLoadedProject(ownerProjectKey);
@@ -794,7 +794,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
         // Arrange
         const string DocumentFilePath = "document.cshtml";
 
-        await _projectService.AddDocumentAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
 
         var miscProject = await _snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
 
@@ -863,7 +863,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
 
         var ownerProjectKey = await _projectService.AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
-        await _projectService.AddDocumentAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
         await _projectService.OpenDocumentAsync(DocumentFilePath, s_emptyText, version: 42, DisposalToken);
 
         var ownerProject = _projectManager.GetLoadedProject(ownerProjectKey);
@@ -896,7 +896,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
             ProjectFilePath, IntermediateOutputPath1, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
         var ownerProjectKey2 = await _projectService.AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath2, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
-        await _projectService.AddDocumentAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
         await _projectService.OpenDocumentAsync(DocumentFilePath, s_emptyText, version: 42, DisposalToken);
 
         var ownerProject1 = _projectManager.GetLoadedProject(ownerProjectKey1);
@@ -923,7 +923,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
         // Arrange
         const string DocumentFilePath = "document.cshtml";
 
-        await _projectService.AddDocumentAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
         await _projectService.OpenDocumentAsync(DocumentFilePath, s_emptyText, version: 42, DisposalToken);
 
         var miscProject = await _snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
@@ -953,7 +953,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
 
         var ownerProjectKey = await _projectService.AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
-        await _projectService.AddDocumentAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
 
         var ownerProject = _projectManager.GetLoadedProject(ownerProjectKey);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
@@ -31,7 +31,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
     private readonly TestProjectSnapshotManager _projectManager;
     private readonly SnapshotResolver _snapshotResolver;
     private readonly DocumentVersionCache _documentVersionCache;
-    private readonly RazorProjectService _projectService;
+    private readonly TestRazorProjectService _projectService;
 
     public RazorProjectServiceTest(ITestOutputHelper testOutput)
         : base(testOutput)
@@ -45,7 +45,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
             .Setup(x => x.Create(It.IsAny<string>()))
             .Returns(CreateEmptyTextLoader());
 
-        _projectService = new RazorProjectService(
+        _projectService = new TestRazorProjectService(
             remoteTextLoaderFactoryMock.Object,
             _snapshotResolver,
             _documentVersionCache,
@@ -439,7 +439,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
 
         var ownerProjectKey = await _projectService.AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
-        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToPotentialProjectsAsync(DocumentFilePath, DisposalToken);
         await _projectService.OpenDocumentAsync(DocumentFilePath, s_emptyText, version: 42, DisposalToken);
 
         var ownerProject = _projectManager.GetLoadedProject(ownerProjectKey);
@@ -472,7 +472,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
             ProjectFilePath, IntermediateOutputPath1, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
         var ownerProjectKey2 = await _projectService.AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath2, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
-        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToPotentialProjectsAsync(DocumentFilePath, DisposalToken);
         await _projectService.OpenDocumentAsync(DocumentFilePath, s_emptyText, version: 42, DisposalToken);
 
         var ownerProject1 = _projectManager.GetLoadedProject(ownerProjectKey1);
@@ -499,7 +499,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
         // Arrange
         const string DocumentFilePath = "document.cshtml";
 
-        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToPotentialProjectsAsync(DocumentFilePath, DisposalToken);
         await _projectService.OpenDocumentAsync(DocumentFilePath, s_emptyText, version: 42, DisposalToken);
 
         var miscProject = await _snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
@@ -529,7 +529,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
 
         var ownerProjectKey = await _projectService.AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
-        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToPotentialProjectsAsync(DocumentFilePath, DisposalToken);
 
         var ownerProject = _projectManager.GetLoadedProject(ownerProjectKey);
 
@@ -561,7 +561,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
             ProjectFilePath, IntermediateOutputPath1, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
         var ownerProjectKey2 = await _projectService.AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath2, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
-        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToPotentialProjectsAsync(DocumentFilePath, DisposalToken);
 
         var ownerProject1 = _projectManager.GetLoadedProject(ownerProjectKey1);
         var ownerProject2 = _projectManager.GetLoadedProject(ownerProjectKey2);
@@ -638,14 +638,14 @@ public class RazorProjectServiceTest : LanguageServerTestBase
         // Arrange
         const string DocumentFilePath = "document.cshtml";
 
-        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToPotentialProjectsAsync(DocumentFilePath, DisposalToken);
 
         var miscProject = await _snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
 
         using var listener = _projectManager.ListenToNotifications();
 
         // Act
-        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToPotentialProjectsAsync(DocumentFilePath, DisposalToken);
 
         // Assert
         listener.AssertNoNotifications();
@@ -668,7 +668,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
         using var listener = _projectManager.ListenToNotifications();
 
         // Act
-        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToPotentialProjectsAsync(DocumentFilePath, DisposalToken);
 
         // Assert
         listener.AssertNotifications(
@@ -688,7 +688,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
         using var listener = _projectManager.ListenToNotifications();
 
         // Act
-        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToPotentialProjectsAsync(DocumentFilePath, DisposalToken);
 
         // Assert
         listener.AssertNotifications(
@@ -708,7 +708,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
 
         var ownerProjectKey = await _projectService.AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
-        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToPotentialProjectsAsync(DocumentFilePath, DisposalToken);
 
         var ownerProject = _projectManager.GetLoadedProject(ownerProjectKey);
 
@@ -738,7 +738,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
             ProjectFilePath, IntermediateOutputPath1, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
         var ownerProjectKey2 = await _projectService.AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath2, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
-        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToPotentialProjectsAsync(DocumentFilePath, DisposalToken);
 
         var ownerProject1 = _projectManager.GetLoadedProject(ownerProjectKey1);
         var ownerProject2 = _projectManager.GetLoadedProject(ownerProjectKey2);
@@ -767,7 +767,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
 
         var ownerProjectKey = await _projectService.AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
-        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToPotentialProjectsAsync(DocumentFilePath, DisposalToken);
         await _projectService.OpenDocumentAsync(DocumentFilePath, s_emptyText, version: 42, DisposalToken);
 
         var ownerProject = _projectManager.GetLoadedProject(ownerProjectKey);
@@ -863,7 +863,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
 
         var ownerProjectKey = await _projectService.AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
-        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToPotentialProjectsAsync(DocumentFilePath, DisposalToken);
         await _projectService.OpenDocumentAsync(DocumentFilePath, s_emptyText, version: 42, DisposalToken);
 
         var ownerProject = _projectManager.GetLoadedProject(ownerProjectKey);
@@ -896,7 +896,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
             ProjectFilePath, IntermediateOutputPath1, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
         var ownerProjectKey2 = await _projectService.AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath2, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
-        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToPotentialProjectsAsync(DocumentFilePath, DisposalToken);
         await _projectService.OpenDocumentAsync(DocumentFilePath, s_emptyText, version: 42, DisposalToken);
 
         var ownerProject1 = _projectManager.GetLoadedProject(ownerProjectKey1);
@@ -923,7 +923,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
         // Arrange
         const string DocumentFilePath = "document.cshtml";
 
-        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToPotentialProjectsAsync(DocumentFilePath, DisposalToken);
         await _projectService.OpenDocumentAsync(DocumentFilePath, s_emptyText, version: 42, DisposalToken);
 
         var miscProject = await _snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
@@ -953,7 +953,7 @@ public class RazorProjectServiceTest : LanguageServerTestBase
 
         var ownerProjectKey = await _projectService.AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
-        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
+        await _projectService.AddDocumentToPotentialProjectsAsync(DocumentFilePath, DisposalToken);
 
         var ownerProject = _projectManager.GetLoadedProject(ownerProjectKey);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
@@ -34,7 +34,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
     private TestProjectSnapshotManager _projectManager;
     private SnapshotResolver _snapshotResolver;
     private DocumentVersionCache _documentVersionCache;
-    private RazorProjectService _projectService;
+    private TestRazorProjectService _projectService;
 #nullable enable
 
     protected override async Task InitializeAsync()
@@ -202,7 +202,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
 
         await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
 
-        var miscProject = await _snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
+        var miscProject = _snapshotResolver.GetMiscellaneousProject();
 
         var project = _projectManager.GetLoadedProject(ownerProjectKey);
 
@@ -657,7 +657,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         var ownerProjectKey = await _projectService.AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
 
-        var miscProject = await _snapshotResolver.GetMiscellaneousProjectAsync(DisposalToken);
+        var miscProject = _snapshotResolver.GetMiscellaneousProject();
 
         using var listener = _projectManager.ListenToNotifications();
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
@@ -629,7 +629,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
                 return textLoaderMock.Object;
             });
 
-        var projectService = new RazorProjectService(
+        var projectService = new TestRazorProjectService(
             remoteTextLoaderFactoryMock.Object,
             snapshotResolver,
             documentVersionCache,
@@ -644,12 +644,12 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
             updater.ProjectWorkspaceStateChanged(projectKey1, ProjectWorkspaceState.Create(tagHelpers));
         });
 
-        await projectService.AddDocumentToMiscProjectAsync(s_componentFilePath1, DisposalToken);
-        await projectService.AddDocumentToMiscProjectAsync(s_componentFilePath2, DisposalToken);
-        await projectService.AddDocumentToMiscProjectAsync(s_directoryFilePath1, DisposalToken);
-        await projectService.AddDocumentToMiscProjectAsync(s_directoryFilePath2, DisposalToken);
-        await projectService.AddDocumentToMiscProjectAsync(s_componentFilePath1337, DisposalToken);
-        await projectService.AddDocumentToMiscProjectAsync(s_indexFilePath1, DisposalToken);
+        await projectService.AddDocumentToPotentialProjectsAsync(s_componentFilePath1, DisposalToken);
+        await projectService.AddDocumentToPotentialProjectsAsync(s_componentFilePath2, DisposalToken);
+        await projectService.AddDocumentToPotentialProjectsAsync(s_directoryFilePath1, DisposalToken);
+        await projectService.AddDocumentToPotentialProjectsAsync(s_directoryFilePath2, DisposalToken);
+        await projectService.AddDocumentToPotentialProjectsAsync(s_componentFilePath1337, DisposalToken);
+        await projectService.AddDocumentToPotentialProjectsAsync(s_indexFilePath1, DisposalToken);
 
         await projectService.UpdateDocumentAsync(s_componentFilePath1, SourceText.From(ComponentText1), version: 42, DisposalToken);
         await projectService.UpdateDocumentAsync(s_componentFilePath2, SourceText.From(ComponentText2), version: 42, DisposalToken);
@@ -666,9 +666,9 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
             updater.ProjectWorkspaceStateChanged(projectKey2, ProjectWorkspaceState.Create(tagHelpers));
         });
 
-        await projectService.AddDocumentToMiscProjectAsync(s_componentFilePath3, DisposalToken);
-        await projectService.AddDocumentToMiscProjectAsync(s_componentFilePath4, DisposalToken);
-        await projectService.AddDocumentToMiscProjectAsync(s_componentWithParamFilePath, DisposalToken);
+        await projectService.AddDocumentToPotentialProjectsAsync(s_componentFilePath3, DisposalToken);
+        await projectService.AddDocumentToPotentialProjectsAsync(s_componentFilePath4, DisposalToken);
+        await projectService.AddDocumentToPotentialProjectsAsync(s_componentWithParamFilePath, DisposalToken);
 
         await projectService.UpdateDocumentAsync(s_componentFilePath3, SourceText.From(ComponentText3), version: 42, DisposalToken);
         await projectService.UpdateDocumentAsync(s_componentFilePath4, SourceText.From(ComponentText4), version: 42, DisposalToken);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
@@ -644,12 +644,12 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
             updater.ProjectWorkspaceStateChanged(projectKey1, ProjectWorkspaceState.Create(tagHelpers));
         });
 
-        await projectService.AddDocumentAsync(s_componentFilePath1, DisposalToken);
-        await projectService.AddDocumentAsync(s_componentFilePath2, DisposalToken);
-        await projectService.AddDocumentAsync(s_directoryFilePath1, DisposalToken);
-        await projectService.AddDocumentAsync(s_directoryFilePath2, DisposalToken);
-        await projectService.AddDocumentAsync(s_componentFilePath1337, DisposalToken);
-        await projectService.AddDocumentAsync(s_indexFilePath1, DisposalToken);
+        await projectService.AddDocumentToMiscProjectAsync(s_componentFilePath1, DisposalToken);
+        await projectService.AddDocumentToMiscProjectAsync(s_componentFilePath2, DisposalToken);
+        await projectService.AddDocumentToMiscProjectAsync(s_directoryFilePath1, DisposalToken);
+        await projectService.AddDocumentToMiscProjectAsync(s_directoryFilePath2, DisposalToken);
+        await projectService.AddDocumentToMiscProjectAsync(s_componentFilePath1337, DisposalToken);
+        await projectService.AddDocumentToMiscProjectAsync(s_indexFilePath1, DisposalToken);
 
         await projectService.UpdateDocumentAsync(s_componentFilePath1, SourceText.From(ComponentText1), version: 42, DisposalToken);
         await projectService.UpdateDocumentAsync(s_componentFilePath2, SourceText.From(ComponentText2), version: 42, DisposalToken);
@@ -666,9 +666,9 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
             updater.ProjectWorkspaceStateChanged(projectKey2, ProjectWorkspaceState.Create(tagHelpers));
         });
 
-        await projectService.AddDocumentAsync(s_componentFilePath3, DisposalToken);
-        await projectService.AddDocumentAsync(s_componentFilePath4, DisposalToken);
-        await projectService.AddDocumentAsync(s_componentWithParamFilePath, DisposalToken);
+        await projectService.AddDocumentToMiscProjectAsync(s_componentFilePath3, DisposalToken);
+        await projectService.AddDocumentToMiscProjectAsync(s_componentFilePath4, DisposalToken);
+        await projectService.AddDocumentToMiscProjectAsync(s_componentWithParamFilePath, DisposalToken);
 
         await projectService.UpdateDocumentAsync(s_componentFilePath3, SourceText.From(ComponentText3), version: 42, DisposalToken);
         await projectService.UpdateDocumentAsync(s_componentFilePath4, SourceText.From(ComponentText4), version: 42, DisposalToken);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestRazorProjectService.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestRazorProjectService.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.Serialization;
+using Microsoft.AspNetCore.Razor.Utilities;
+using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.Logging;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
+
+internal class TestRazorProjectService(
+    RemoteTextLoaderFactory remoteTextLoaderFactory,
+    ISnapshotResolver snapshotResolver,
+    IDocumentVersionCache documentVersionCache,
+    IProjectSnapshotManager projectManager,
+    ILoggerFactory loggerFactory)
+    : RazorProjectService(remoteTextLoaderFactory, snapshotResolver, documentVersionCache, projectManager, loggerFactory)
+{
+    private readonly ISnapshotResolver _snapshotResolver = snapshotResolver;
+
+    public async Task AddDocumentToPotentialProjectsAsync(string textDocumentPath, CancellationToken cancellationToken)
+    {
+        foreach (var projectSnapshot in _snapshotResolver.FindPotentialProjects(textDocumentPath))
+        {
+            var normalizedProjectPath = FilePathNormalizer.NormalizeDirectory(projectSnapshot.FilePath);
+            var documents = ImmutableArray
+                .CreateRange(projectSnapshot.DocumentFilePaths)
+                .Add(textDocumentPath)
+                .Select(d => new DocumentSnapshotHandle(d, d, FileKinds.GetFileKindFromFilePath(d)))
+                .ToImmutableArray();
+
+            await this.UpdateProjectAsync(projectSnapshot.Key, projectSnapshot.Configuration, projectSnapshot.RootNamespace, projectSnapshot.DisplayName, projectSnapshot.ProjectWorkspaceState,
+                documents, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static string GetTargetPath(string documentFilePath, string normalizedProjectPath)
+    {
+        var targetFilePath = FilePathNormalizer.Normalize(documentFilePath);
+        if (targetFilePath.StartsWith(normalizedProjectPath, FilePathComparison.Instance))
+        {
+            // Make relative
+            targetFilePath = documentFilePath[normalizedProjectPath.Length..];
+        }
+
+        // Representing all of our host documents with a re-normalized target path to workaround GetRelatedDocument limitations.
+        var normalizedTargetFilePath = targetFilePath.Replace('/', '\\').TrimStart('\\');
+
+        return normalizedTargetFilePath;
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/9986

The issue at heart here is a race condition between our two project systems (one in the server, one in VS) and how they deal with/find new Razor files. What was happening was that the LSP server was discovering the newly named file, finding a project that it could fit in (based on path) and adding it to that project. It then starts generating C# code for that file, and sending it to VS. Meanwhile VS is discovering that same new file at its own pace, via CPS events etc., and adding the file to the project. VS then tells the LSP server about the new file, via project.razor.vs.bin, and all is right with the world. The problem comes when the LSP server sends generated C# to VS, before VS knows about the new file, but the server doesn't know that VS doesn't know. Once VS does know about the file, it receives an updated generated C# file at some point, which contains changes since the previous push, but to VS it's the first push.

I've long thought that the razor file watching has been unnecessary in the LSP server, as the client should be the source of truth for which files are in which projects. I'm not quite brave enough to remove it entirely though, so instead this change means newly created files are only added to the misc files project, and we never guess at which project(s) they should belong to. We wait for the client to tell us, and hence we avoid the race condition.