### PR TITLE
Lazily import ILoggerProviders

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
@@ -108,7 +108,7 @@ public class RazorLanguageServerBenchmarkBase : ProjectSnapshotManagerBenchmarkB
         }
     }
 
-    internal class NoopLoggerFactory() : AbstractLoggerFactory([new NoopLoggerProvider()]);
+    internal class NoopLoggerFactory() : AbstractLoggerFactory([new(() => new NoopLoggerProvider())]);
 
     internal class NoopLoggerProvider : ILoggerProvider
     {

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
@@ -19,7 +19,6 @@ using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Nerdbank.Streams;
 
 namespace Microsoft.AspNetCore.Razor.Microbenchmarks.LanguageServer;
@@ -108,7 +107,7 @@ public class RazorLanguageServerBenchmarkBase : ProjectSnapshotManagerBenchmarkB
         }
     }
 
-    internal class NoopLoggerFactory() : AbstractLoggerFactory([new(() => new NoopLoggerProvider())]);
+    internal class NoopLoggerFactory() : AbstractLoggerFactory([new NoopLoggerProvider()]);
 
     internal class NoopLoggerProvider : ILoggerProvider
     {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.LoggerFactoryWrapper.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.LoggerFactoryWrapper.cs
@@ -14,7 +14,7 @@ internal partial class RazorLanguageServer
     /// </summary>
     private sealed class LoggerFactoryWrapper(ILoggerFactory loggerFactory) : ILoggerFactory
     {
-        private ILoggerFactory _loggerFactory = loggerFactory;
+        private readonly ILoggerFactory _loggerFactory = loggerFactory;
 
         public void AddLoggerProvider(ILoggerProvider provider)
         {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Logging/AbstractLoggerFactory.AggregateLogger.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Logging/AbstractLoggerFactory.AggregateLogger.cs
@@ -19,9 +19,10 @@ internal abstract partial class AbstractLoggerFactory
         {
             // If the ILoggerProvider's metadata has a minimum log level, we can use that
             // rather than forcing the ILoggerProvider to be created.
-            if (_metadata.MinimumLogLevel is LogLevel minimumLogLevel)
+            if (_metadata.MinimumLogLevel is LogLevel minimumLogLevel &&
+                !logLevel.IsAtLeast(minimumLogLevel))
             {
-                return logLevel.IsAtLeast(minimumLogLevel);
+                return false;
             }
 
             return Instance.IsEnabled(logLevel);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Logging/LoggerProviderMetadata.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Logging/LoggerProviderMetadata.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.Razor.Logging;
+
+internal sealed class LoggerProviderMetadata
+{
+    public static LoggerProviderMetadata Empty { get; } = new();
+
+    public LogLevel? MinimumLogLevel { get; }
+
+    private LoggerProviderMetadata()
+    {
+    }
+
+    public LoggerProviderMetadata(IDictionary<string, object> data)
+        : this()
+    {
+        MinimumLogLevel = data.TryGetValue(nameof(MinimumLogLevel), out var minimumLogLevel)
+            ? (LogLevel?)minimumLogLevel
+            : null;
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Logging/RazorLogHubLogger.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Logging/RazorLogHubLogger.cs
@@ -9,16 +9,10 @@ using Microsoft.VisualStudio.Razor.Logging;
 
 namespace Microsoft.VisualStudio.Razor.LanguageClient.Logging;
 
-internal sealed class RazorLogHubLogger : ILogger
+internal sealed class RazorLogHubLogger(string categoryName, RazorLogHubTraceProvider traceProvider) : ILogger
 {
-    private string _categoryName;
-    private RazorLogHubTraceProvider _traceProvider;
-
-    public RazorLogHubLogger(string categoryName, RazorLogHubTraceProvider traceProvider)
-    {
-        _categoryName = categoryName;
-        _traceProvider = traceProvider;
-    }
+    private readonly string _categoryName = categoryName;
+    private readonly RazorLogHubTraceProvider _traceProvider = traceProvider;
 
     public bool IsEnabled(LogLevel logLevel)
     {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Logging/RazorLogHubLoggerProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Logging/RazorLogHubLoggerProvider.cs
@@ -7,16 +7,11 @@ using Microsoft.VisualStudio.Razor.Logging;
 
 namespace Microsoft.VisualStudio.Razor.LanguageClient.Logging;
 
-[Export(typeof(ILoggerProvider))]
-internal sealed class RazorLogHubLoggerProvider : ILoggerProvider
+[ExportLoggerProvider]
+[method: ImportingConstructor]
+internal sealed class RazorLogHubLoggerProvider(RazorLogHubTraceProvider traceProvider) : ILoggerProvider
 {
-    private readonly RazorLogHubTraceProvider _traceProvider;
-
-    [ImportingConstructor]
-    public RazorLogHubLoggerProvider(RazorLogHubTraceProvider traceProvider)
-    {
-        _traceProvider = traceProvider;
-    }
+    private readonly RazorLogHubTraceProvider _traceProvider = traceProvider;
 
     public ILogger CreateLogger(string categoryName)
     {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/ActivityLogLoggerProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/ActivityLogLoggerProvider.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Razor.Logging;
 /// <summary>
 /// An <see cref="ILoggerProvider"/> that logs any warnings or errors to the Visual Studio Activity Log.
 /// </summary>
-[Export(typeof(ILoggerProvider))]
+[ExportLoggerProvider(minimumLogLevel: LogLevel.Warning)]
 [method: ImportingConstructor]
 internal sealed partial class ActivityLogLoggerProvider(RazorActivityLog activityLog) : ILoggerProvider
 {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/ExportLoggerProviderAttribute.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/ExportLoggerProviderAttribute.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.Razor.Logging;
+
+namespace Microsoft.VisualStudio.Razor.Logging;
+
+[MetadataAttribute]
+[AttributeUsage(AttributeTargets.Class)]
+internal sealed class ExportLoggerProviderAttribute : ExportAttribute
+{
+    public LogLevel? MinimumLogLevel { get; }
+
+    public ExportLoggerProviderAttribute()
+        : base(typeof(ILoggerProvider))
+    {
+        MinimumLogLevel = null;
+    }
+
+    public ExportLoggerProviderAttribute(LogLevel minimumLogLevel)
+        : base(typeof(ILoggerProvider))
+    {
+        MinimumLogLevel = minimumLogLevel;
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/MemoryLoggerProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/MemoryLoggerProvider.cs
@@ -1,14 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Razor.Logging;
 
 namespace Microsoft.VisualStudio.Razor.Logging;
 
-[Export(typeof(ILoggerProvider))]
-[method: ImportingConstructor]
-internal partial class MemoryLoggerProvider() : ILoggerProvider
+[ExportLoggerProvider]
+internal partial class MemoryLoggerProvider : ILoggerProvider
 {
     // How many messages will the buffer contain
     private const int BufferSize = 5000;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/OutputWindowLoggerProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/OutputWindowLoggerProvider.cs
@@ -14,7 +14,7 @@ using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.Razor.Logging;
 
-[Export(typeof(ILoggerProvider))]
+[ExportLoggerProvider]
 [method: ImportingConstructor]
 internal class OutputWindowLoggerProvider(
     // Anything this class imports would have a circular dependency if they tried to log anything,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/VisualStudioLoggerFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/VisualStudioLoggerFactory.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.Razor.Logging;
 
 [Export(typeof(ILoggerFactory))]
 [method: ImportingConstructor]
-internal sealed class VisualStudioLoggerFactory([ImportMany] IEnumerable<Lazy<ILoggerProvider>> providers)
+internal sealed class VisualStudioLoggerFactory([ImportMany] IEnumerable<Lazy<ILoggerProvider, LoggerProviderMetadata>> providers)
     : AbstractLoggerFactory(providers.ToImmutableArray())
 {
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/VisualStudioLoggerFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/VisualStudioLoggerFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
@@ -10,7 +11,7 @@ namespace Microsoft.VisualStudio.Razor.Logging;
 
 [Export(typeof(ILoggerFactory))]
 [method: ImportingConstructor]
-internal sealed class VisualStudioLoggerFactory([ImportMany] IEnumerable<ILoggerProvider> providers)
+internal sealed class VisualStudioLoggerFactory([ImportMany] IEnumerable<Lazy<ILoggerProvider>> providers)
     : AbstractLoggerFactory(providers.ToImmutableArray())
 {
 }

--- a/src/Razor/src/rzls/LoggerFactory.cs
+++ b/src/Razor/src/rzls/LoggerFactory.cs
@@ -1,12 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Razor.Logging;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
-internal sealed class LoggerFactory(ImmutableArray<ILoggerProvider> providers)
+internal sealed class LoggerFactory(ImmutableArray<Lazy<ILoggerProvider>> providers)
     : AbstractLoggerFactory(providers)
 {
 }

--- a/src/Razor/src/rzls/LoggerFactory.cs
+++ b/src/Razor/src/rzls/LoggerFactory.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.Razor.Logging;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
-internal sealed class LoggerFactory(ImmutableArray<Lazy<ILoggerProvider>> providers)
+internal sealed class LoggerFactory(ImmutableArray<Lazy<ILoggerProvider, LoggerProviderMetadata>> providers)
     : AbstractLoggerFactory(providers)
 {
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Logging/TestOutputLoggerFactory.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Logging/TestOutputLoggerFactory.cs
@@ -7,6 +7,6 @@ using Xunit.Abstractions;
 namespace Microsoft.AspNetCore.Razor.Test.Common.Logging;
 
 internal sealed class TestOutputLoggerFactory(ITestOutputHelper output)
-    : AbstractLoggerFactory([new TestOutputLoggerProvider(output)])
+    : AbstractLoggerFactory([new(() => new TestOutputLoggerProvider(output))])
 {
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Logging/TestOutputLoggerFactory.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Logging/TestOutputLoggerFactory.cs
@@ -7,6 +7,6 @@ using Xunit.Abstractions;
 namespace Microsoft.AspNetCore.Razor.Test.Common.Logging;
 
 internal sealed class TestOutputLoggerFactory(ITestOutputHelper output)
-    : AbstractLoggerFactory([new(() => new TestOutputLoggerProvider(output))])
+    : AbstractLoggerFactory([new TestOutputLoggerProvider(output)])
 {
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/DictionaryExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/DictionaryExtensions.cs
@@ -76,21 +76,4 @@ internal static class DictionaryExtensions
             return value;
         }
     }
-
-    public static TValue GetValueOrDefault<TKey, TValue>(
-        this Dictionary<TKey, TValue> dictionary,
-        TKey key,
-        TValue defaultValue)
-        where TKey : notnull
-    {
-        if (dictionary.TryGetValue(key, out var existingValue))
-        {
-            return existingValue;
-        }
-        else
-        {
-            dictionary.Add(key, defaultValue);
-            return defaultValue;
-        }
-    }
 }


### PR DESCRIPTION
Fixes #10326

This change makes our `AbstractLoggerFactory` take a set of `Lazy<ILoggerProvider>` instances and only realize them the first time a message is logged.

🤔 _I wonder if it would be possible to change our `ILoggerProvider` instances to declare their minimum `LogLevel` via MEF and import that as metadata? That would allow us to avoid instantiating all the logger providers just to call `IsEnabled`._