### PR TITLE
Collapse Reset then Add to Update in project state synchronizer

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeEventArgs.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeEventArgs.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Serialization;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Utilities;
 using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
@@ -76,5 +77,11 @@ internal sealed class ProjectConfigurationFileChangeEventArgs(
         }
 
         return projectInfo is not null;
+    }
+
+    internal ProjectKey GetProjectKey()
+    {
+        var intermediateOutputPath = FilePathNormalizer.GetNormalizedDirectoryName(ConfigurationFilePath);
+        return ProjectKey.FromString(intermediateOutputPath);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.Comparer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.Comparer.cs
@@ -31,7 +31,7 @@ internal partial class ProjectConfigurationStateSynchronizer
             // are equal only if their identifying properties are equal. So, only
             // configuration file paths and project keys.
 
-            if (!FilePathComparer.Instance.Equals(x.ConfigurationFilePath, y.ConfigurationFilePath))
+            if (x.ProjectKey != y.ProjectKey)
             {
                 return false;
             }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.Work.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.Work.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer;
+
+internal partial class ProjectConfigurationStateSynchronizer
+{
+    private abstract class Work(ProjectKey projectKey)
+    {
+        public ProjectKey ProjectKey => projectKey;
+
+        public bool Skip { get; set; }
+    }
+
+    private sealed class AddProject(RazorProjectInfo projectInfo) : Work(ProjectKey.From(projectInfo))
+    {
+        public RazorProjectInfo ProjectInfo => projectInfo;
+
+        public void Deconstruct(out RazorProjectInfo projectInfo)
+        {
+            projectInfo = ProjectInfo;
+        }
+
+        public void Deconstruct(out ProjectKey projectKey, out RazorProjectInfo projectInfo)
+        {
+            projectKey = ProjectKey;
+            projectInfo = ProjectInfo;
+        }
+    }
+
+    private sealed class ResetProject(ProjectKey projectKey) : Work(projectKey)
+    {
+        public void Deconstruct(out ProjectKey projectKey)
+        {
+            projectKey = ProjectKey;
+        }
+    }
+
+    private sealed class UpdateProject(ProjectKey projectKey, RazorProjectInfo projectInfo) : Work(projectKey)
+    {
+        public RazorProjectInfo ProjectInfo => projectInfo;
+
+        public void Deconstruct(out ProjectKey projectKey, out RazorProjectInfo projectInfo)
+        {
+            projectKey = ProjectKey;
+            projectInfo = ProjectInfo;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectKey.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectKey.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Utilities;
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -18,6 +19,7 @@ internal readonly record struct ProjectKey
     // end up. All creation logic is here in one place to ensure this is consistent.
     public static ProjectKey From(HostProject hostProject) => new(hostProject.IntermediateOutputPath);
     public static ProjectKey From(IProjectSnapshot project) => new(project.IntermediateOutputPath);
+    public static ProjectKey From(RazorProjectInfo project) => new(FilePathNormalizer.GetNormalizedDirectoryName(project.SerializedFilePath));
     public static ProjectKey From(Project project)
     {
         var intermediateOutputPath = FilePathNormalizer.GetNormalizedDirectoryName(project.CompilationOutputInfo.AssemblyPath);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationStateSynchronizerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectConfigurationStateSynchronizerTest.cs
@@ -548,8 +548,278 @@ public class ProjectConfigurationStateSynchronizerTest(ITestOutputHelper testOut
         projectServiceMock.VerifyAll();
     }
 
+    [Fact]
+    public async Task ProjectConfigurationFileChanged_AddThenRemove_AddsAndRemoves()
+    {
+        // Arrange
+        var projectInfo = new RazorProjectInfo(
+            "/path/to/obj/project.razor.json",
+            "path/to/project.csproj",
+            RazorConfiguration.Default,
+            rootNamespace: "TestRootNamespace",
+            displayName: "project",
+            ProjectWorkspaceState.Create(LanguageVersion.CSharp5),
+            documents: []);
+        var intermediateOutputPath = FilePathNormalizer.GetNormalizedDirectoryName(projectInfo.SerializedFilePath);
+        var projectKey = TestProjectKey.Create(intermediateOutputPath);
+
+        var projectServiceMock = new StrictMock<IRazorProjectService>();
+        projectServiceMock
+           .Setup(p => p.AddProjectAsync(
+               projectInfo.FilePath,
+               intermediateOutputPath,
+               It.IsAny<RazorConfiguration>(),
+               projectInfo.RootNamespace,
+               projectInfo.DisplayName,
+               It.IsAny<CancellationToken>()))
+           .ReturnsAsync(projectKey);
+        projectServiceMock
+            .Setup(p => p.UpdateProjectAsync(
+                projectKey,
+                It.IsAny<RazorConfiguration>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<ProjectWorkspaceState>(),
+                It.IsAny<ImmutableArray<DocumentSnapshotHandle>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        using var synchronizer = GetSynchronizer(projectServiceMock.Object);
+        var synchronizerAccessor = synchronizer.GetTestAccessor();
+
+        var deserializer = CreateDeserializer(projectInfo);
+        var addedArgs = new ProjectConfigurationFileChangeEventArgs(projectInfo.SerializedFilePath, RazorFileChangeKind.Added, deserializer);
+        var removedArgs = new ProjectConfigurationFileChangeEventArgs(projectInfo.SerializedFilePath, RazorFileChangeKind.Removed, deserializer);
+
+        // Act
+        synchronizer.ProjectConfigurationFileChanged(addedArgs);
+        synchronizer.ProjectConfigurationFileChanged(removedArgs);
+
+        await synchronizerAccessor.WaitUntilCurrentBatchCompletesAsync();
+
+        // Assert
+        projectServiceMock.Verify(p => p.UpdateProjectAsync(
+            projectKey,
+            It.IsAny<RazorConfiguration>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<ProjectWorkspaceState>(),
+            It.IsAny<ImmutableArray<DocumentSnapshotHandle>>(),
+            It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+
+        projectServiceMock.VerifyAll();
+    }
+
+    [Fact]
+    public async Task ProjectConfigurationFileChanged_AddThenRemoveThenAdd_AddsAndUpdates()
+    {
+        // Arrange
+        var projectInfo = new RazorProjectInfo(
+            "/path/to/obj/project.razor.json",
+            "path/to/project.csproj",
+            RazorConfiguration.Default,
+            rootNamespace: "TestRootNamespace",
+            displayName: "project",
+            ProjectWorkspaceState.Create(LanguageVersion.CSharp5),
+            documents: []);
+        var intermediateOutputPath = FilePathNormalizer.GetNormalizedDirectoryName(projectInfo.SerializedFilePath);
+        var projectKey = TestProjectKey.Create(intermediateOutputPath);
+
+        var projectServiceMock = new StrictMock<IRazorProjectService>();
+        projectServiceMock
+           .Setup(p => p.AddProjectAsync(
+               projectInfo.FilePath,
+               intermediateOutputPath,
+               It.IsAny<RazorConfiguration>(),
+               projectInfo.RootNamespace,
+               projectInfo.DisplayName,
+               It.IsAny<CancellationToken>()))
+           .ReturnsAsync(projectKey);
+        projectServiceMock
+            .Setup(p => p.UpdateProjectAsync(
+                projectKey,
+                It.IsAny<RazorConfiguration>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<ProjectWorkspaceState>(),
+                It.IsAny<ImmutableArray<DocumentSnapshotHandle>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        using var synchronizer = GetSynchronizer(projectServiceMock.Object);
+        var synchronizerAccessor = synchronizer.GetTestAccessor();
+
+        var deserializer = CreateDeserializer(projectInfo);
+        var addedArgs = new ProjectConfigurationFileChangeEventArgs(projectInfo.SerializedFilePath, RazorFileChangeKind.Added, deserializer);
+        var removedArgs = new ProjectConfigurationFileChangeEventArgs(projectInfo.SerializedFilePath, RazorFileChangeKind.Removed, deserializer);
+
+        // Act
+        synchronizer.ProjectConfigurationFileChanged(addedArgs);
+        synchronizer.ProjectConfigurationFileChanged(removedArgs);
+        synchronizer.ProjectConfigurationFileChanged(addedArgs);
+
+        await synchronizerAccessor.WaitUntilCurrentBatchCompletesAsync();
+
+        // Assert
+        projectServiceMock.Verify(p => p.UpdateProjectAsync(
+            projectKey,
+            It.IsAny<RazorConfiguration>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<ProjectWorkspaceState>(),
+            It.IsAny<ImmutableArray<DocumentSnapshotHandle>>(),
+            It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+
+        projectServiceMock.VerifyAll();
+    }
+
+    [Fact]
+    public async Task ProjectConfigurationFileChanged_AddThenRemoveThenAddThenUpdate_AddsAndUpdates()
+    {
+        // Arrange
+        var projectInfo = new RazorProjectInfo(
+            "/path/to/obj/project.razor.json",
+            "path/to/project.csproj",
+            RazorConfiguration.Default,
+            rootNamespace: "TestRootNamespace",
+            displayName: "project",
+            ProjectWorkspaceState.Create(LanguageVersion.CSharp5),
+            documents: []);
+        var intermediateOutputPath = FilePathNormalizer.GetNormalizedDirectoryName(projectInfo.SerializedFilePath);
+        var projectKey = TestProjectKey.Create(intermediateOutputPath);
+
+        var projectServiceMock = new StrictMock<IRazorProjectService>();
+        projectServiceMock
+           .Setup(p => p.AddProjectAsync(
+               projectInfo.FilePath,
+               intermediateOutputPath,
+               It.IsAny<RazorConfiguration>(),
+               projectInfo.RootNamespace,
+               projectInfo.DisplayName,
+               It.IsAny<CancellationToken>()))
+           .ReturnsAsync(projectKey);
+        projectServiceMock
+            .Setup(p => p.UpdateProjectAsync(
+                projectKey,
+                It.IsAny<RazorConfiguration>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<ProjectWorkspaceState>(),
+                It.IsAny<ImmutableArray<DocumentSnapshotHandle>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        using var synchronizer = GetSynchronizer(projectServiceMock.Object);
+        var synchronizerAccessor = synchronizer.GetTestAccessor();
+
+        var deserializer = CreateDeserializer(projectInfo);
+        var addedArgs = new ProjectConfigurationFileChangeEventArgs(projectInfo.SerializedFilePath, RazorFileChangeKind.Added, deserializer);
+        var removedArgs = new ProjectConfigurationFileChangeEventArgs(projectInfo.SerializedFilePath, RazorFileChangeKind.Removed, deserializer);
+        var changedArgs = new ProjectConfigurationFileChangeEventArgs(projectInfo.SerializedFilePath, RazorFileChangeKind.Changed, deserializer);
+
+        // Act
+        synchronizer.ProjectConfigurationFileChanged(addedArgs);
+        synchronizer.ProjectConfigurationFileChanged(removedArgs);
+        synchronizer.ProjectConfigurationFileChanged(addedArgs);
+        synchronizer.ProjectConfigurationFileChanged(changedArgs);
+        synchronizer.ProjectConfigurationFileChanged(changedArgs);
+        synchronizer.ProjectConfigurationFileChanged(changedArgs);
+
+        await synchronizerAccessor.WaitUntilCurrentBatchCompletesAsync();
+
+        // Assert
+        // Update is only called twice because the Remove-then-Add is changed to an Update,
+        // then that Update is deduped with the one following
+        projectServiceMock.Verify(p => p.UpdateProjectAsync(
+            projectKey,
+            It.IsAny<RazorConfiguration>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<ProjectWorkspaceState>(),
+            It.IsAny<ImmutableArray<DocumentSnapshotHandle>>(),
+            It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+
+        projectServiceMock.VerifyAll();
+    }
+
+    [Fact]
+    public async Task ProjectConfigurationFileChanged_RemoveThenAddDifferentProjects_RemovesAndAdds()
+    {
+        // Arrange
+        var projectInfo1 = new RazorProjectInfo(
+            "/path/to/obj/project.razor.json",
+            "path/to/project.csproj",
+            RazorConfiguration.Default,
+            rootNamespace: "TestRootNamespace",
+            displayName: "project",
+            ProjectWorkspaceState.Create(LanguageVersion.CSharp5),
+            documents: []);
+        var intermediateOutputPath1 = FilePathNormalizer.GetNormalizedDirectoryName(projectInfo1.SerializedFilePath);
+        var projectKey1 = TestProjectKey.Create(intermediateOutputPath1);
+
+        var projectInfo2 = new RazorProjectInfo(
+           "/path/other/obj/project.razor.json",
+           "path/other/project.csproj",
+           RazorConfiguration.Default,
+           rootNamespace: "TestRootNamespace",
+           displayName: "project",
+           ProjectWorkspaceState.Create(LanguageVersion.CSharp5),
+           documents: []);
+        var intermediateOutputPath2 = FilePathNormalizer.GetNormalizedDirectoryName(projectInfo2.SerializedFilePath);
+        var projectKey2 = TestProjectKey.Create(intermediateOutputPath2);
+
+        var projectServiceMock = new StrictMock<IRazorProjectService>();
+        projectServiceMock
+            .Setup(p => p.UpdateProjectAsync(
+                projectKey1,
+                It.IsAny<RazorConfiguration>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<ProjectWorkspaceState>(),
+                It.IsAny<ImmutableArray<DocumentSnapshotHandle>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        projectServiceMock
+            .Setup(p => p.AddProjectAsync(
+                projectInfo2.FilePath,
+                intermediateOutputPath2,
+                It.IsAny<RazorConfiguration>(),
+                projectInfo2.RootNamespace,
+                projectInfo2.DisplayName,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(projectKey2);
+        projectServiceMock
+            .Setup(p => p.UpdateProjectAsync(
+                projectKey2,
+                It.IsAny<RazorConfiguration>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<ProjectWorkspaceState>(),
+                It.IsAny<ImmutableArray<DocumentSnapshotHandle>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        using var synchronizer = GetSynchronizer(projectServiceMock.Object);
+        var synchronizerAccessor = synchronizer.GetTestAccessor();
+
+        var removedArgs = new ProjectConfigurationFileChangeEventArgs(projectInfo1.SerializedFilePath, RazorFileChangeKind.Removed, CreateDeserializer(projectInfo1));
+        var addedArgs = new ProjectConfigurationFileChangeEventArgs(projectInfo2.SerializedFilePath, RazorFileChangeKind.Added, CreateDeserializer(projectInfo2));
+
+        // Act
+        synchronizer.ProjectConfigurationFileChanged(removedArgs);
+        synchronizer.ProjectConfigurationFileChanged(addedArgs);
+
+        await synchronizerAccessor.WaitUntilCurrentBatchCompletesAsync();
+
+        // Assert
+        projectServiceMock.VerifyAll();
+    }
+
     private TestProjectConfigurationStateSynchronizer GetSynchronizer(IRazorProjectService razorProjectService)
-        => new(razorProjectService, LoggerFactory, TestLanguageServerFeatureOptions.Instance, TimeSpan.FromMilliseconds(5));
+        => new(razorProjectService, LoggerFactory, TestLanguageServerFeatureOptions.Instance, TimeSpan.FromMilliseconds(50));
 
     private static IRazorProjectInfoDeserializer CreateDeserializer(RazorProjectInfo? projectInfo)
     {


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/10306
Alternative to https://github.com/dotnet/razor/pull/10308

This change keeps the AsyncBatchingWorkQueue in the project state synchronizer, but still collapses a Reset then Add to be an Update, so that we don't migrate every document onto the misc files project, and then back on to the real project, every time a new component is added.