### PR TITLE
YAPCSSF: Yet Another ProjectConfigurationStateSynchronizer fix

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.Comparer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.Comparer.cs
@@ -38,8 +38,6 @@ internal partial class ProjectConfigurationStateSynchronizer
 
             return (x, y) switch
             {
-                (AddProject, AddProject) => true,
-
                 (ResetProject { ProjectKey: var keyX },
                  ResetProject { ProjectKey: var keyY })
                     => keyX == keyY,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.Comparer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.Comparer.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
@@ -17,38 +18,13 @@ internal partial class ProjectConfigurationStateSynchronizer
         }
 
         public bool Equals(Work? x, Work? y)
-        {
-            if (x is null)
+            => (x, y) switch
             {
-                return y is null;
-            }
-            else if (y is null)
-            {
-                return x is null;
-            }
+                (Work(var keyX), Work(var keyY)) => keyX == keyY,
+                (null, null) => true,
 
-            // For purposes of removing duplicates from batches, two Work instances
-            // are equal only if their identifying properties are equal. So, only
-            // configuration file paths and project keys.
-
-            if (!FilePathComparer.Instance.Equals(x.ConfigurationFilePath, y.ConfigurationFilePath))
-            {
-                return false;
-            }
-
-            return (x, y) switch
-            {
-                (ResetProject { ProjectKey: var keyX },
-                 ResetProject { ProjectKey: var keyY })
-                    => keyX == keyY,
-
-                (UpdateProject { ProjectKey: var keyX },
-                 UpdateProject { ProjectKey: var keyY })
-                    => keyX == keyY,
-
-                _ => false,
+                _ => false
             };
-        }
 
         public int GetHashCode(Work obj)
             => obj.GetHashCode();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/MonitorProjectConfigurationFilePathEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/MonitorProjectConfigurationFilePathEndpoint.cs
@@ -180,7 +180,7 @@ internal class MonitorProjectConfigurationFilePathEndpoint : IRazorNotificationH
                 {
                     updater.ProjectRemoved(projectKey);
                 },
-                state: ProjectKey.FromString(projectKeyId),
+                state: ProjectKey.From(projectKeyId),
                 cancellationToken);
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/ProjectInfoEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/ProjectInfoEndpoint.cs
@@ -33,7 +33,7 @@ internal class ProjectInfoEndpoint : IRazorNotificationHandler<ProjectInfoParams
         var razorProjectInfo =
             RazorProjectInfoDeserializer.Instance.DeserializeFromString(request.ProjectInfo);
 
-        var projectKey = ProjectKey.FromString(request.ProjectKeyId);
+        var projectKey = ProjectKey.From(request.ProjectKeyId);
 
         return _projectConfigurationStateManager.ProjectInfoUpdatedAsync(projectKey, razorProjectInfo, cancellationToken);
     }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/VSProjectContextExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/VSProjectContextExtensions.cs
@@ -10,6 +10,6 @@ internal static class VSProjectContextExtensions
 {
     internal static ProjectKey ToProjectKey(this VSProjectContext projectContext)
     {
-        return ProjectKey.FromString(projectContext.Id);
+        return ProjectKey.From(projectContext.Id);
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectKey.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectKey.cs
@@ -24,7 +24,10 @@ internal readonly record struct ProjectKey
         return new(intermediateOutputPath);
     }
 
-    internal static ProjectKey FromString(string projectKeyId) => new(projectKeyId);
+    /// <summary>
+    /// Creates a <see cref="ProjectKey"/> from a <see cref="string"/> representing a project's intermediate output path.
+    /// </summary>
+    public static ProjectKey From(string id) => new(id);
 
     public string Id { get; }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_UpdateCSharpBuffer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_UpdateCSharpBuffer.cs
@@ -77,7 +77,7 @@ internal partial class RazorCustomMessageTarget
 
             foreach (var virtualDocument in virtualDocuments)
             {
-                if (virtualDocument.ProjectKey.Equals(ProjectKey.FromString(request.ProjectKeyId)))
+                if (virtualDocument.ProjectKey.Equals(ProjectKey.From(request.ProjectKeyId)))
                 {
                     _logger.LogDebug($"UpdateCSharpBuffer virtual doc for {request.HostDocumentVersion} of {virtualDocument.Uri}");
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
@@ -70,7 +70,7 @@ internal class DefaultWindowsRazorProjectHost : WindowsRazorProjectHostBase
                 await UpdateAsync(
                     updater =>
                     {
-                        var beforeProjectKey = ProjectKey.FromString(beforeIntermediateOutputPath);
+                        var beforeProjectKey = ProjectKey.From(beforeIntermediateOutputPath);
                         updater.ProjectRemoved(beforeProjectKey);
                     },
                     CancellationToken.None)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
@@ -120,7 +120,7 @@ internal class FallbackWindowsRazorProjectHost : WindowsRazorProjectHostBase
             await UpdateAsync(
                 updater =>
                 {
-                    var beforeProjectKey = ProjectKey.FromString(beforeIntermediateOutputPath);
+                    var beforeProjectKey = ProjectKey.From(beforeIntermediateOutputPath);
                     RemoveProject(updater, beforeProjectKey);
                 },
                 CancellationToken.None)


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/10306

This change takes a different approach than #10308 and #10330. The problem that all of these are trying to fix is to ensure that "add" or "change" events for configuration file for an unknown project result in a project add at the correct time. The timing details are in #10306.

The timing problem occurs because the project should be added before any other enqueued resets or updates run. However, recent changes to use an `AsyncBatchingWorkQueue` made all work happen in the same batch, including work to add missing projects. This change pulls project adds out of the work queue and just adds them immediately. This takes advantage of the fact that the `ProjectSnapshotManager` handles operations in a queue, so the project add will happen before any resets or updates. This is effectively how `ProjectConfigurationChangeSynchronizer` worked before, but this change keeps the batching work queue for project resets and updates.