### PR TITLE
YAPCSSF: Automatically add projects if they don't exist when updating

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeEventArgs.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationFileChangeEventArgs.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Serialization;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Utilities;
 using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
@@ -76,5 +77,11 @@ internal sealed class ProjectConfigurationFileChangeEventArgs(
         }
 
         return projectInfo is not null;
+    }
+
+    internal ProjectKey GetProjectKey()
+    {
+        var intermediateOutputPath = FilePathNormalizer.GetNormalizedDirectoryName(ConfigurationFilePath);
+        return ProjectKey.FromString(intermediateOutputPath);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.Comparer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.Comparer.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Razor;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
@@ -17,42 +18,15 @@ internal partial class ProjectConfigurationStateSynchronizer
         }
 
         public bool Equals(Work? x, Work? y)
-        {
-            if (x is null)
-            {
-                return y is null;
-            }
-            else if (y is null)
-            {
-                return x is null;
-            }
+             => (x, y) switch
+             {
+                 (Work(var keyX), Work(var keyY)) => keyX == keyY,
+                 (null, null) => true,
 
-            // For purposes of removing duplicates from batches, two Work instances
-            // are equal only if their identifying properties are equal. So, only
-            // configuration file paths and project keys.
-
-            if (!FilePathComparer.Instance.Equals(x.ConfigurationFilePath, y.ConfigurationFilePath))
-            {
-                return false;
-            }
-
-            return (x, y) switch
-            {
-                (AddProject, AddProject) => true,
-
-                (ResetProject { ProjectKey: var keyX },
-                 ResetProject { ProjectKey: var keyY })
-                    => keyX == keyY,
-
-                (UpdateProject { ProjectKey: var keyX },
-                 UpdateProject { ProjectKey: var keyY })
-                    => keyX == keyY,
-
-                _ => false,
-            };
-        }
+                 _ => false
+             };
 
         public int GetHashCode(Work obj)
-            => obj.GetHashCode();
+            => obj.ProjectKey.GetHashCode();
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectConfigurationStateSynchronizer.cs
@@ -4,29 +4,26 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.IO;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
+using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Utilities;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Utilities;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
-using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
 internal partial class ProjectConfigurationStateSynchronizer : IProjectConfigurationFileChangeListener, IDisposable
 {
-    private abstract record Work(string ConfigurationFilePath);
-    private sealed record AddProject(string ConfigurationFilePath, RazorProjectInfo ProjectInfo) : Work(ConfigurationFilePath);
-    private sealed record ResetProject(string ConfigurationFilePath, ProjectKey ProjectKey) : Work(ConfigurationFilePath);
-    private sealed record UpdateProject(string ConfigurationFilePath, ProjectKey ProjectKey, RazorProjectInfo ProjectInfo) : Work(ConfigurationFilePath);
+    private abstract record Work(ProjectKey ProjectKey);
+    private sealed record ResetProject(ProjectKey ProjectKey) : Work(ProjectKey);
+    private sealed record UpdateProject(ProjectKey ProjectKey, RazorProjectInfo ProjectInfo) : Work(ProjectKey);
 
     private static readonly TimeSpan s_delay = TimeSpan.FromMilliseconds(250);
 
@@ -37,8 +34,7 @@ internal partial class ProjectConfigurationStateSynchronizer : IProjectConfigura
     private readonly CancellationTokenSource _disposeTokenSource;
     private readonly AsyncBatchingWorkQueue<Work> _workQueue;
 
-    private ImmutableDictionary<string, ProjectKey> _filePathToProjectKeyMap =
-        ImmutableDictionary<string, ProjectKey>.Empty.WithComparers(keyComparer: FilePathComparer.Instance);
+    private readonly Dictionary<ProjectKey, ResetProject> _resetProjectMap = new();
 
     public ProjectConfigurationStateSynchronizer(
         IRazorProjectService projectService,
@@ -67,42 +63,24 @@ internal partial class ProjectConfigurationStateSynchronizer : IProjectConfigura
         _disposeTokenSource.Cancel();
         _disposeTokenSource.Dispose();
     }
+
     private async ValueTask ProcessBatchAsync(ImmutableArray<Work> items, CancellationToken token)
     {
         foreach (var item in items.GetMostRecentUniqueItems(Comparer.Instance))
         {
+            if (token.IsCancellationRequested)
+            {
+                return;
+            }
+
             var itemTask = item switch
             {
-                AddProject(var configurationFilePath, var projectInfo) => AddProjectAsync(configurationFilePath, projectInfo, token),
-                ResetProject(_, var projectKey) => ResetProjectAsync(projectKey, token),
-                UpdateProject(_, var projectKey, var projectInfo) => UpdateProjectAsync(projectKey, projectInfo, token),
+                ResetProject(var projectKey) => ResetProjectAsync(projectKey, token),
+                UpdateProject(var projectKey, var projectInfo) => UpdateProjectAsync(projectKey, projectInfo, token),
                 _ => Assumed.Unreachable<Task>()
             };
 
             await itemTask.ConfigureAwait(false);
-        }
-
-        async Task AddProjectAsync(string configurationFilePath, RazorProjectInfo projectInfo, CancellationToken token)
-        {
-            var projectFilePath = FilePathNormalizer.Normalize(projectInfo.FilePath);
-            var intermediateOutputPath = FilePathNormalizer.GetNormalizedDirectoryName(configurationFilePath);
-
-            var projectKey = await _projectService
-                .AddProjectAsync(
-                    projectFilePath,
-                    intermediateOutputPath,
-                    projectInfo.Configuration,
-                    projectInfo.RootNamespace,
-                    projectInfo.DisplayName,
-                    token)
-                .ConfigureAwait(false);
-
-            _logger.LogInformation($"Added {projectKey.Id}.");
-
-            ImmutableInterlocked.AddOrUpdate(ref _filePathToProjectKeyMap, configurationFilePath, projectKey, static (k, v) => v);
-            _logger.LogInformation($"Project configuration file added for project '{projectFilePath}': '{configurationFilePath}'");
-
-            await UpdateProjectAsync(projectKey, projectInfo, token).ConfigureAwait(false);
         }
 
         Task ResetProjectAsync(ProjectKey projectKey, CancellationToken token)
@@ -125,8 +103,9 @@ internal partial class ProjectConfigurationStateSynchronizer : IProjectConfigura
             _logger.LogInformation($"Updating {projectKey.Id}.");
 
             return _projectService
-                .UpdateProjectAsync(
+                .AddOrUpdateProjectAsync(
                     projectKey,
+                    projectInfo.FilePath,
                     projectInfo.Configuration,
                     projectInfo.RootNamespace,
                     projectInfo.DisplayName,
@@ -138,55 +117,25 @@ internal partial class ProjectConfigurationStateSynchronizer : IProjectConfigura
 
     public void ProjectConfigurationFileChanged(ProjectConfigurationFileChangeEventArgs args)
     {
-        var configurationFilePath = FilePathNormalizer.Normalize(args.ConfigurationFilePath);
-
         switch (args.Kind)
         {
             case RazorFileChangeKind.Changed:
                 {
                     if (args.TryDeserialize(_options, out var projectInfo))
                     {
-                        if (_filePathToProjectKeyMap.TryGetValue(configurationFilePath, out var projectKey))
-                        {
-                            _logger.LogInformation($"""
-                                Configuration file changed for project '{projectKey.Id}'.
-                                Configuration file path: '{configurationFilePath}'
-                                """);
+                        var projectKey = ProjectKey.From(projectInfo);
+                        _logger.LogInformation($"Configuration file changed for project '{projectKey.Id}'.");
 
-                            _workQueue.AddWork(new UpdateProject(configurationFilePath, projectKey, projectInfo));
-                        }
-                        else
-                        {
-                            _logger.LogWarning($"""
-                                Adding project for previously unseen configuration file.
-                                Configuration file path: '{configurationFilePath}'
-                                """);
-
-                            _workQueue.AddWork(new AddProject(configurationFilePath, projectInfo));
-                        }
+                        _workQueue.AddWork(new UpdateProject(projectKey, projectInfo));
                     }
                     else
                     {
-                        if (_filePathToProjectKeyMap.TryGetValue(configurationFilePath, out var projectKey))
-                        {
-                            _logger.LogWarning($"""
-                                Failed to deserialize after change to configuration file for project '{projectKey.Id}'.
-                                Configuration file path: '{configurationFilePath}'
-                                """);
+                        var projectKey = args.GetProjectKey();
+                        _logger.LogWarning($"Failed to deserialize after change to configuration file for project '{projectKey.Id}'.");
 
-                            // We found the last associated project file for the configuration file. Reset the project since we can't
-                            // accurately determine its configurations.
-
-                            _workQueue.AddWork(new ResetProject(configurationFilePath, projectKey));
-                        }
-                        else
-                        {
-                            // Could not resolve an associated project file.
-                            _logger.LogWarning($"""
-                                Failed to deserialize after change to previously unseen configuration file.
-                                Configuration file path: '{configurationFilePath}'
-                                """);
-                        }
+                        // We found the last associated project file for the configuration file. Reset the project since we can't
+                        // accurately determine its configurations.
+                        _workQueue.AddWork(new ResetProject(projectKey));
                     }
                 }
 
@@ -196,16 +145,17 @@ internal partial class ProjectConfigurationStateSynchronizer : IProjectConfigura
                 {
                     if (args.TryDeserialize(_options, out var projectInfo))
                     {
-                        _workQueue.AddWork(new AddProject(configurationFilePath, projectInfo));
+                        var projectKey = ProjectKey.From(projectInfo);
+                        _logger.LogInformation($"Configuration file added for project '{projectKey.Id}'.");
+
+                        // Update will add the project if it doesn't exist
+                        _workQueue.AddWork(new UpdateProject(projectKey, projectInfo));
                     }
                     else
                     {
                         // This is the first time we've seen this configuration file, but we can't deserialize it.
                         // The only thing we can really do is issue a warning.
-                        _logger.LogWarning($"""
-                            Failed to deserialize previously unseen configuration file.
-                            Configuration file path: '{configurationFilePath}'
-                            """);
+                        _logger.LogWarning($"Failed to deserialize previously unseen configuration file '{args.ConfigurationFilePath}'");
                     }
                 }
 
@@ -213,22 +163,10 @@ internal partial class ProjectConfigurationStateSynchronizer : IProjectConfigura
 
             case RazorFileChangeKind.Removed:
                 {
-                    if (ImmutableInterlocked.TryRemove(ref _filePathToProjectKeyMap, configurationFilePath, out var projectKey))
-                    {
-                        _logger.LogInformation($"""
-                            Configuration file removed for project '{projectKey}'.
-                            Configuration file path: '{configurationFilePath}'
-                            """);
+                    var projectKey = args.GetProjectKey();
+                    _logger.LogInformation($"Configuration file removed for project '{projectKey}'.");
 
-                        _workQueue.AddWork(new ResetProject(configurationFilePath, projectKey));
-                    }
-                    else
-                    {
-                        _logger.LogWarning($"""
-                            Failed to resolve associated project on configuration removed event.
-                            Configuration file path: '{configurationFilePath}'
-                            """);
-                    }
+                    _workQueue.AddWork(new ResetProject(projectKey));
                 }
 
                 break;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/IRazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/IRazorProjectService.cs
@@ -36,4 +36,14 @@ internal interface IRazorProjectService
         ProjectWorkspaceState projectWorkspaceState,
         ImmutableArray<DocumentSnapshotHandle> documents,
         CancellationToken cancellationToken);
+
+    Task AddOrUpdateProjectAsync(
+        ProjectKey projectKey,
+        string filePath,
+        RazorConfiguration? configuration,
+        string? rootNamespace,
+        string displayName,
+        ProjectWorkspaceState projectWorkspaceState,
+        ImmutableArray<DocumentSnapshotHandle> documents,
+        CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
@@ -228,22 +228,24 @@ internal class RazorProjectService(
         CancellationToken cancellationToken)
     {
         return _projectManager.UpdateAsync(
-            updater =>
-            {
-                var normalizedPath = FilePathNormalizer.Normalize(filePath);
-                var hostProject = new HostProject(
-                    normalizedPath, intermediateOutputPath, configuration ?? FallbackRazorConfiguration.Latest, rootNamespace, displayName);
-
-                // ProjectAdded will no-op if the project already exists
-                updater.ProjectAdded(hostProject);
-
-                _logger.LogInformation($"Added project '{filePath}' with key {hostProject.Key} to project system.");
-
-                TryMigrateMiscellaneousDocumentsToProject(updater);
-
-                return hostProject.Key;
-            },
+            updater => AddProjectCore(updater, filePath, intermediateOutputPath, configuration, rootNamespace, displayName),
             cancellationToken);
+    }
+
+    private ProjectKey AddProjectCore(ProjectSnapshotManager.Updater updater, string filePath, string intermediateOutputPath, RazorConfiguration? configuration, string? rootNamespace, string? displayName)
+    {
+        var normalizedPath = FilePathNormalizer.Normalize(filePath);
+        var hostProject = new HostProject(
+            normalizedPath, intermediateOutputPath, configuration ?? FallbackRazorConfiguration.Latest, rootNamespace, displayName);
+
+        // ProjectAdded will no-op if the project already exists
+        updater.ProjectAdded(hostProject);
+
+        _logger.LogInformation($"Added project '{filePath}' with key {hostProject.Key} to project system.");
+
+        TryMigrateMiscellaneousDocumentsToProject(updater);
+
+        return hostProject.Key;
     }
 
     public Task UpdateProjectAsync(
@@ -255,53 +257,92 @@ internal class RazorProjectService(
         ImmutableArray<DocumentSnapshotHandle> documents,
         CancellationToken cancellationToken)
     {
+        return AddOrUpdateProjectCoreAsync(projectKey, filePath: null, configuration, rootNamespace, displayName, projectWorkspaceState, documents, cancellationToken);
+    }
+
+    public Task AddOrUpdateProjectAsync(
+       ProjectKey projectKey,
+       string filePath,
+       RazorConfiguration? configuration,
+       string? rootNamespace,
+       string? displayName,
+       ProjectWorkspaceState projectWorkspaceState,
+       ImmutableArray<DocumentSnapshotHandle> documents,
+       CancellationToken cancellationToken)
+    {
+        return AddOrUpdateProjectCoreAsync(projectKey, filePath, configuration, rootNamespace, displayName, projectWorkspaceState, documents, cancellationToken);
+    }
+
+    private Task AddOrUpdateProjectCoreAsync(
+        ProjectKey projectKey,
+        string? filePath,
+        RazorConfiguration? configuration,
+        string? rootNamespace,
+        string? displayName,
+        ProjectWorkspaceState projectWorkspaceState,
+        ImmutableArray<DocumentSnapshotHandle> documents,
+        CancellationToken cancellationToken)
+    {
         return _projectManager.UpdateAsync(
-            updater =>
-            {
-                if (!_projectManager.TryGetLoadedProject(projectKey, out var project))
-                {
-                    // Never tracked the project to begin with, noop.
-                    _logger.LogInformation($"Failed to update untracked project '{projectKey}'.");
-                    return;
-                }
+                    updater =>
+                    {
+                        if (!_projectManager.TryGetLoadedProject(projectKey, out var project))
+                        {
+                            if (filePath is null)
+                            {
+                                // Never tracked the project to begin with, noop.
+                                _logger.LogInformation($"Failed to update untracked project '{projectKey}'.");
+                                return;
 
-                UpdateProjectDocuments(updater, documents, project.Key);
+                            }
 
-                if (!projectWorkspaceState.Equals(ProjectWorkspaceState.Default))
-                {
-                    _logger.LogInformation($"Updating project '{project.Key}' TagHelpers ({projectWorkspaceState.TagHelpers.Length}) and C# Language Version ({projectWorkspaceState.CSharpLanguageVersion}).");
-                }
+                            // If we've been given a project file path, then we have enough info to add the project ourselves, because we know
+                            // the intermediate output path from the id
+                            var intermediateOutputPath = projectKey.Id;
 
-                updater.ProjectWorkspaceStateChanged(project.Key, projectWorkspaceState);
+                            var newKey = AddProjectCore(updater, filePath, intermediateOutputPath, configuration, rootNamespace, displayName);
+                            Debug.Assert(newKey == projectKey);
 
-                var currentConfiguration = project.Configuration;
-                var currentRootNamespace = project.RootNamespace;
-                if (currentConfiguration.ConfigurationName == configuration?.ConfigurationName &&
-                    currentRootNamespace == rootNamespace)
-                {
-                    _logger.LogTrace($"Updating project '{project.Key}'. The project is already using configuration '{configuration.ConfigurationName}' and root namespace '{rootNamespace}'.");
-                    return;
-                }
+                            project = _projectManager.GetLoadedProject(projectKey);
+                        }
 
-                if (configuration is null)
-                {
-                    configuration = FallbackRazorConfiguration.Latest;
-                    _logger.LogInformation($"Updating project '{project.Key}' to use the latest configuration ('{configuration.ConfigurationName}')'.");
-                }
-                else if (currentConfiguration.ConfigurationName != configuration.ConfigurationName)
-                {
-                    _logger.LogInformation($"Updating project '{project.Key}' to Razor configuration '{configuration.ConfigurationName}' with language version '{configuration.LanguageVersion}'.");
-                }
+                        UpdateProjectDocuments(updater, documents, project.Key);
 
-                if (currentRootNamespace != rootNamespace)
-                {
-                    _logger.LogInformation($"Updating project '{project.Key}''s root namespace to '{rootNamespace}'.");
-                }
+                        if (!projectWorkspaceState.Equals(ProjectWorkspaceState.Default))
+                        {
+                            _logger.LogInformation($"Updating project '{project.Key}' TagHelpers ({projectWorkspaceState.TagHelpers.Length}) and C# Language Version ({projectWorkspaceState.CSharpLanguageVersion}).");
+                        }
 
-                var hostProject = new HostProject(project.FilePath, project.IntermediateOutputPath, configuration, rootNamespace, displayName);
-                updater.ProjectConfigurationChanged(hostProject);
-            },
-            cancellationToken);
+                        updater.ProjectWorkspaceStateChanged(project.Key, projectWorkspaceState);
+
+                        var currentConfiguration = project.Configuration;
+                        var currentRootNamespace = project.RootNamespace;
+                        if (currentConfiguration.ConfigurationName == configuration?.ConfigurationName &&
+                            currentRootNamespace == rootNamespace)
+                        {
+                            _logger.LogTrace($"Updating project '{project.Key}'. The project is already using configuration '{configuration.ConfigurationName}' and root namespace '{rootNamespace}'.");
+                            return;
+                        }
+
+                        if (configuration is null)
+                        {
+                            configuration = FallbackRazorConfiguration.Latest;
+                            _logger.LogInformation($"Updating project '{project.Key}' to use the latest configuration ('{configuration.ConfigurationName}')'.");
+                        }
+                        else if (currentConfiguration.ConfigurationName != configuration.ConfigurationName)
+                        {
+                            _logger.LogInformation($"Updating project '{project.Key}' to Razor configuration '{configuration.ConfigurationName}' with language version '{configuration.LanguageVersion}'.");
+                        }
+
+                        if (currentRootNamespace != rootNamespace)
+                        {
+                            _logger.LogInformation($"Updating project '{project.Key}''s root namespace to '{rootNamespace}'.");
+                        }
+
+                        var hostProject = new HostProject(project.FilePath, project.IntermediateOutputPath, configuration, rootNamespace, displayName);
+                        updater.ProjectConfigurationChanged(hostProject);
+                    },
+                    cancellationToken);
     }
 
     private void UpdateProjectDocuments(

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectKey.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectKey.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Utilities;
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -18,6 +19,7 @@ internal readonly record struct ProjectKey
     // end up. All creation logic is here in one place to ensure this is consistent.
     public static ProjectKey From(HostProject hostProject) => new(hostProject.IntermediateOutputPath);
     public static ProjectKey From(IProjectSnapshot project) => new(project.IntermediateOutputPath);
+    public static ProjectKey From(RazorProjectInfo project) => new(FilePathNormalizer.GetNormalizedDirectoryName(project.SerializedFilePath));
     public static ProjectKey From(Project project)
     {
         var intermediateOutputPath = FilePathNormalizer.GetNormalizedDirectoryName(project.CompilationOutputInfo.AssemblyPath);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/OpenDocumentGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/OpenDocumentGeneratorTest.cs
@@ -33,7 +33,7 @@ public class OpenDocumentGeneratorTest(ITestOutputHelper testOutput) : LanguageS
         // Arrange
         var projectManager = CreateProjectSnapshotManager();
         var listener = new TestDocumentProcessedListener();
-        using var generator = new TestOpenDocumentGenerator(projectManager, listener);
+        using var generator = CreateOpenDocumentGenerator(projectManager, listener);
 
         await projectManager.UpdateAsync(updater =>
         {
@@ -54,7 +54,7 @@ public class OpenDocumentGeneratorTest(ITestOutputHelper testOutput) : LanguageS
         // Arrange
         var projectManager = CreateProjectSnapshotManager();
         var listener = new TestDocumentProcessedListener();
-        using var generator = new TestOpenDocumentGenerator(projectManager, listener);
+        using var generator = CreateOpenDocumentGenerator(projectManager, listener);
 
         await projectManager.UpdateAsync(updater =>
         {
@@ -76,7 +76,7 @@ public class OpenDocumentGeneratorTest(ITestOutputHelper testOutput) : LanguageS
         // Arrange
         var projectManager = CreateProjectSnapshotManager();
         var listener = new TestDocumentProcessedListener();
-        using var generator = new TestOpenDocumentGenerator(projectManager, listener);
+        using var generator = CreateOpenDocumentGenerator(projectManager, listener);
 
         await projectManager.UpdateAsync(updater =>
         {
@@ -101,7 +101,7 @@ public class OpenDocumentGeneratorTest(ITestOutputHelper testOutput) : LanguageS
         // Arrange
         var projectManager = CreateProjectSnapshotManager();
         var listener = new TestDocumentProcessedListener();
-        using var generator = new TestOpenDocumentGenerator(projectManager, listener);
+        using var generator = CreateOpenDocumentGenerator(projectManager, listener);
 
         await projectManager.UpdateAsync(updater =>
         {
@@ -124,7 +124,7 @@ public class OpenDocumentGeneratorTest(ITestOutputHelper testOutput) : LanguageS
         // Arrange
         var projectManager = CreateProjectSnapshotManager();
         var listener = new TestDocumentProcessedListener();
-        using var generator = new TestOpenDocumentGenerator(projectManager, listener);
+        using var generator = CreateOpenDocumentGenerator(projectManager, listener);
 
         await projectManager.UpdateAsync(updater =>
         {
@@ -143,10 +143,12 @@ public class OpenDocumentGeneratorTest(ITestOutputHelper testOutput) : LanguageS
         Assert.Equal(document.FilePath, _documents[0].FilePath);
     }
 
-    private class TestOpenDocumentGenerator(
+    private OpenDocumentGenerator CreateOpenDocumentGenerator(
         IProjectSnapshotManager projectManager,
         params IDocumentProcessedListener[] listeners)
-        : OpenDocumentGenerator(listeners, projectManager, TestLanguageServerFeatureOptions.Instance);
+    {
+        return new OpenDocumentGenerator(listeners, projectManager, TestLanguageServerFeatureOptions.Instance, LoggerFactory);
+    }
 
     private class TestDocumentProcessedListener : IDocumentProcessedListener
     {


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/10306

This change takes a different approach than https://github.com/dotnet/razor/pull/10308 and https://github.com/dotnet/razor/pull/10330 and https://github.com/dotnet/razor/pull/10332 because life was meant to be interesting.

The original problem we were trying to solve is that when a Reset then Add came in, we would migrate all of the documents out of the project, then migrate them all back in again. The various solutions in the other PRs you can read about at your leisure, this one takes a rather simple approach:

1. Ignore everything but the most recent update for a specific project
2. If we need to update a project, but it doesn't exist, add it

In the long run we should remove `IRazorProjectService.AddProjectAsync` entirely, and rename `IRazorProjectService.UpdateProjectAsync` to `ResetProjectAsync`, but doing that now would just conflict with other open PRs.