### PR TITLE
UriPresentation to Cohost/OOP, Part 1

### DIFF
--- a/eng/targets/Services.props
+++ b/eng/targets/Services.props
@@ -19,5 +19,6 @@
     <ServiceHubService Include="Microsoft.VisualStudio.Razor.HtmlDocument" ClassName="Microsoft.CodeAnalysis.Remote.Razor.RemoteHtmlDocumentServiceFactory" />
     <ServiceHubService Include="Microsoft.VisualStudio.Razor.TagHelperProvider" ClassName="Microsoft.CodeAnalysis.Remote.Razor.RemoteTagHelperProviderServiceFactory"/>
     <ServiceHubService Include="Microsoft.VisualStudio.Razor.ClientInitialization" ClassName="Microsoft.CodeAnalysis.Remote.Razor.RemoteClientInitializationServiceFactory" />
+    <ServiceHubService Include="Microsoft.VisualStudio.Razor.UriPresentation" ClassName="Microsoft.CodeAnalysis.Remote.Razor.RemoteUriPresentationServiceFactory" />
   </ItemGroup>
 </Project>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
@@ -167,10 +167,13 @@ internal static class IServiceCollectionExtensions
         services.AddSingleton<HtmlCodeActionResolver, DefaultHtmlCodeActionResolver>();
     }
 
-    public static void AddTextDocumentServices(this IServiceCollection services)
+    public static void AddTextDocumentServices(this IServiceCollection services, LanguageServerFeatureOptions featureOptions)
     {
         services.AddHandlerWithCapabilities<TextDocumentTextPresentationEndpoint>();
-        services.AddHandlerWithCapabilities<TextDocumentUriPresentationEndpoint>();
+        if (!featureOptions.UseRazorCohostServer)
+        {
+            services.AddHandlerWithCapabilities<TextDocumentUriPresentationEndpoint>();
+        }
 
         services.AddHandlerWithCapabilities<DocumentSpellCheckEndpoint>();
         services.AddHandler<WorkspaceSpellCheckEndpoint>();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -123,7 +123,7 @@ internal partial class RazorLanguageServer : AbstractLanguageServer<RazorRequest
         services.AddCodeActionsServices();
         services.AddOptionsServices(_lspOptions);
         services.AddHoverServices();
-        services.AddTextDocumentServices();
+        services.AddTextDocumentServices(featureOptions);
 
         // Auto insert
         services.AddSingleton<IOnAutoInsertProvider, CloseTextTagOnAutoInsertProvider>();

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentPresentation/UriPresentationHelper.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentPresentation/UriPresentationHelper.cs
@@ -15,13 +15,13 @@ internal static class UriPresentationHelper
     {
         if (languageKind is not RazorLanguageKind.Html)
         {
-            // We don't do anything for HTML
+            // Component tags can only be inserted into Html contexts, so if this isn't Html there is nothing we can do.
             return null;
         }
 
         if (uris is null || uris.Length == 0)
         {
-            logger.LogInformation($"No URIs were included in the request?");
+            logger.LogDebug($"No URIs were included in the request?");
             return null;
         }
 
@@ -33,14 +33,14 @@ internal static class UriPresentationHelper
         // thinks they're just dragging the parent one, so we have to be a little bit clever with the filter here
         if (razorFileUri == null)
         {
-            logger.LogInformation($"No file in the drop was a razor file URI.");
+            logger.LogDebug($"No file in the drop was a razor file URI.");
             return null;
         }
 
         var fileName = Path.GetFileName(razorFileUri.GetAbsoluteOrUNCPath());
         if (uris.Any(uri => !Path.GetFileName(uri.GetAbsoluteOrUNCPath()).StartsWith(fileName, FilePathComparison.Instance)))
         {
-            logger.LogInformation($"One or more URIs were not a child file of the main .razor file.");
+            logger.LogDebug($"One or more URIs were not a child file of the main .razor file.");
             return null;
         }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentPresentation/UriPresentationHelper.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentPresentation/UriPresentationHelper.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis.Razor.Logging;
+using Microsoft.CodeAnalysis.Razor.Protocol;
+
+namespace Microsoft.CodeAnalysis.Razor.DocumentPresentation;
+
+internal static class UriPresentationHelper
+{
+    public static Uri? GetComponentFileNameFromUriPresentationRequest(RazorLanguageKind languageKind, Uri[]? uris, ILogger logger)
+    {
+        if (languageKind is not RazorLanguageKind.Html)
+        {
+            // We don't do anything for HTML
+            return null;
+        }
+
+        if (uris is null || uris.Length == 0)
+        {
+            logger.LogInformation($"No URIs were included in the request?");
+            return null;
+        }
+
+        var razorFileUri = uris.Where(
+            x => Path.GetFileName(x.GetAbsoluteOrUNCPath()).EndsWith(".razor", FilePathComparison.Instance)).FirstOrDefault();
+
+        // We only want to handle requests for a single .razor file, but when there are files nested under a .razor
+        // file (for example, Goo.razor.css, Goo.razor.cs etc.) then we'll get all of those files as well, when the user
+        // thinks they're just dragging the parent one, so we have to be a little bit clever with the filter here
+        if (razorFileUri == null)
+        {
+            logger.LogInformation($"No file in the drop was a razor file URI.");
+            return null;
+        }
+
+        var fileName = Path.GetFileName(razorFileUri.GetAbsoluteOrUNCPath());
+        if (uris.Any(uri => !Path.GetFileName(uri.GetAbsoluteOrUNCPath()).StartsWith(fileName, FilePathComparison.Instance)))
+        {
+            logger.LogInformation($"One or more URIs were not a child file of the main .razor file.");
+            return null;
+        }
+
+        return razorFileUri;
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/IRemoteUriPresentationService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/IRemoteUriPresentationService.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Razor.Remote;
+
+internal interface IRemoteUriPresentationService
+{
+    ValueTask<TextChange?> GetPresentationAsync(RazorPinnedSolutionInfoWrapper solutionInfo, DocumentId razorDocumentId, LinePositionSpan span, Uri[]? uris, CancellationToken cancellationToken);
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RazorServices.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RazorServices.cs
@@ -23,5 +23,6 @@ internal static class RazorServices
             (typeof(IRemoteClientInitializationService), null),
             (typeof(IRemoteSemanticTokensService), null),
             (typeof(IRemoteHtmlDocumentService), null),
+            (typeof(IRemoteUriPresentationService), null),
         ]);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SemanticTokens/RemoteSemanticTokensService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SemanticTokens/RemoteSemanticTokensService.cs
@@ -41,7 +41,6 @@ internal sealed class RemoteSemanticTokensService(
 
         var documentContext = Create(razorDocument);
 
-        // TODO: Telemetry?
         return await _razorSemanticTokensInfoService.GetSemanticTokensAsync(documentContext, span, colorBackground, correlationId, cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/UriPresentation/RemoteUriPresentationService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/UriPresentation/RemoteUriPresentationService.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Api;
+using Microsoft.CodeAnalysis.Razor.DocumentMapping;
+using Microsoft.CodeAnalysis.Razor.DocumentPresentation;
+using Microsoft.CodeAnalysis.Razor.Logging;
+using Microsoft.CodeAnalysis.Razor.Remote;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.ServiceHub.Framework;
+
+namespace Microsoft.CodeAnalysis.Remote.Razor;
+
+internal sealed class RemoteUriPresentationService(
+    IServiceBroker serviceBroker,
+    IRazorDocumentMappingService documentMappingService,
+    DocumentSnapshotFactory documentSnapshotFactory,
+    ILoggerFactory loggerFactory)
+    : RazorServiceBase(serviceBroker), IRemoteUriPresentationService
+{
+    private readonly IRazorDocumentMappingService _documentMappingService = documentMappingService;
+    private readonly DocumentSnapshotFactory _documentSnapshotFactory = documentSnapshotFactory;
+    private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<RemoteUriPresentationService>();
+
+    public ValueTask<TextChange?> GetPresentationAsync(RazorPinnedSolutionInfoWrapper solutionInfo, DocumentId razorDocumentId, LinePositionSpan span, Uri[]? uris, CancellationToken cancellationToken)
+    => RazorBrokeredServiceImplementation.RunServiceAsync(
+        solutionInfo,
+        ServiceBrokerClient,
+        solution => GetPresentationAsync(solution, razorDocumentId, span, uris, cancellationToken),
+        cancellationToken);
+
+    private async ValueTask<TextChange?> GetPresentationAsync(Solution solution, DocumentId razorDocumentId, LinePositionSpan span, Uri[]? uris, CancellationToken cancellationToken)
+    {
+        var razorDocument = solution.GetAdditionalDocument(razorDocumentId);
+        if (razorDocument is null)
+        {
+            return null;
+        }
+
+        var snapshot = _documentSnapshotFactory.GetOrCreate(razorDocument);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
+        var sourceText = await razorDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!sourceText.TryGetAbsoluteIndex(span.Start.Line, span.Start.Character, out var index))
+        {
+            return null;
+        }
+
+        var languageKind = _documentMappingService.GetLanguageKind(codeDocument, index, rightAssociative: true);
+
+        var razorFileUri = UriPresentationHelper.GetComponentFileNameFromUriPresentationRequest(languageKind, uris, _logger);
+        if (razorFileUri is null)
+        {
+            return null;
+        }
+
+        var ids = razorDocument.Project.Solution.GetDocumentIdsWithFilePath(GetDocumentFilePathFromUri(razorFileUri));
+        if (ids.Length == 0)
+        {
+            return null;
+        }
+
+        // We assume linked documents would produce the same component tag so just take the first
+        var otherDocument = razorDocument.Project.Solution.GetAdditionalDocument(ids.First());
+        if (otherDocument is null)
+        {
+            return null;
+        }
+
+        var otherSnapshot = _documentSnapshotFactory.GetOrCreate(otherDocument);
+        var descriptor = await otherSnapshot.TryGetTagHelperDescriptorAsync(cancellationToken).ConfigureAwait(false);
+
+        if (descriptor is null)
+        {
+            return null;
+        }
+
+        var tag = descriptor.TryGetComponentTag();
+        if (tag is null)
+        {
+            return null;
+        }
+
+        return new TextChange(span.ToTextSpan(sourceText), tag);
+    }
+
+    // TODO: Call the real Roslyn API once https://github.com/dotnet/roslyn/pull/73289 is merged
+    public static string GetDocumentFilePathFromUri(Uri uri)
+        => uri.IsFile ? uri.LocalPath : uri.AbsoluteUri;
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/UriPresentation/RemoteUriPresentationService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/UriPresentation/RemoteUriPresentationService.cs
@@ -68,7 +68,7 @@ internal sealed class RemoteUriPresentationService(
         }
 
         // We assume linked documents would produce the same component tag so just take the first
-        var otherDocument = razorDocument.Project.Solution.GetAdditionalDocument(ids.First());
+        var otherDocument = razorDocument.Project.Solution.GetAdditionalDocument(ids[0]);
         if (otherDocument is null)
         {
             return null;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/UriPresentation/RemoteUriPresentationService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/UriPresentation/RemoteUriPresentationService.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/UriPresentation/RemoteUriPresentationService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/UriPresentation/RemoteUriPresentationService.cs
@@ -29,11 +29,11 @@ internal sealed class RemoteUriPresentationService(
     private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<RemoteUriPresentationService>();
 
     public ValueTask<TextChange?> GetPresentationAsync(RazorPinnedSolutionInfoWrapper solutionInfo, DocumentId razorDocumentId, LinePositionSpan span, Uri[]? uris, CancellationToken cancellationToken)
-    => RazorBrokeredServiceImplementation.RunServiceAsync(
-        solutionInfo,
-        ServiceBrokerClient,
-        solution => GetPresentationAsync(solution, razorDocumentId, span, uris, cancellationToken),
-        cancellationToken);
+        => RazorBrokeredServiceImplementation.RunServiceAsync(
+            solutionInfo,
+            ServiceBrokerClient,
+            solution => GetPresentationAsync(solution, razorDocumentId, span, uris, cancellationToken),
+            cancellationToken);
 
     private async ValueTask<TextChange?> GetPresentationAsync(Solution solution, DocumentId razorDocumentId, LinePositionSpan span, Uri[]? uris, CancellationToken cancellationToken)
     {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/UriPresentation/RemoteUriPresentationServiceFactory.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/UriPresentation/RemoteUriPresentationServiceFactory.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Razor.DocumentMapping;
+using Microsoft.CodeAnalysis.Razor.Logging;
+using Microsoft.CodeAnalysis.Razor.Remote;
+using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.VisualStudio.Composition;
+
+namespace Microsoft.CodeAnalysis.Remote.Razor;
+
+internal sealed class RemoteUriPresentationServiceFactory : RazorServiceFactoryBase<IRemoteUriPresentationService>
+{
+    // WARNING: We must always have a parameterless constructor in order to be properly handled by ServiceHub.
+    public RemoteUriPresentationServiceFactory()
+        : base(RazorServices.Descriptors)
+    {
+    }
+
+    protected override IRemoteUriPresentationService CreateService(IServiceBroker serviceBroker, ExportProvider exportProvider)
+    {
+        var documentMappingService = exportProvider.GetExportedValue<IRazorDocumentMappingService>();
+        var documentSnapshotFactory = exportProvider.GetExportedValue<DocumentSnapshotFactory>();
+        var loggerFactory = exportProvider.GetExportedValue<ILoggerFactory>();
+        return new RemoteUriPresentationService(serviceBroker, documentMappingService, documentSnapshotFactory, loggerFactory);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostUriPresentationEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostUriPresentationEndpoint.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+using Microsoft.CodeAnalysis.Razor.Logging;
+using Microsoft.CodeAnalysis.Razor.Protocol.DocumentPresentation;
+using Microsoft.CodeAnalysis.Razor.Remote;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.Razor.LanguageClient.Extensions;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+
+#pragma warning disable RS0030 // Do not use banned APIs
+[Shared]
+[CohostEndpoint(VSInternalMethods.TextDocumentUriPresentationName)]
+[Export(typeof(IDynamicRegistrationProvider))]
+[ExportCohostStatelessLspService(typeof(CohostUriPresentationEndpoint))]
+[method: ImportingConstructor]
+#pragma warning restore RS0030 // Do not use banned APIs
+internal class CohostUriPresentationEndpoint(IRemoteClientProvider remoteClientProvider, ILoggerFactory loggerFactory)
+    : AbstractRazorCohostDocumentRequestHandler<UriPresentationParams, WorkspaceEdit?>, IDynamicRegistrationProvider
+{
+    private readonly IRemoteClientProvider _remoteClientProvider = remoteClientProvider;
+    private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<CohostUriPresentationEndpoint>();
+
+    protected override bool MutatesSolutionState => false;
+
+    protected override bool RequiresLSPSolution => true;
+
+    public Registration? GetRegistration(VSInternalClientCapabilities clientCapabilities, DocumentFilter[] filter, RazorCohostRequestContext requestContext)
+    {
+        if (clientCapabilities.SupportsVisualStudioExtensions)
+        {
+            return new Registration
+            {
+                Method = VSInternalMethods.TextDocumentUriPresentationName,
+                RegisterOptions = new TextDocumentRegistrationOptions()
+                {
+                    DocumentSelector = filter
+                }
+            };
+        }
+
+        return null;
+    }
+
+    protected override RazorTextDocumentIdentifier? GetRazorTextDocumentIdentifier(UriPresentationParams request)
+        => request.TextDocument.ToRazorTextDocumentIdentifier();
+
+    protected override async Task<WorkspaceEdit?> HandleRequestAsync(UriPresentationParams request, RazorCohostRequestContext context, CancellationToken cancellationToken)
+    {
+        var razorDocument = context.TextDocument.AssumeNotNull();
+
+        var remoteClient = await _remoteClientProvider.TryGetClientAsync(cancellationToken).ConfigureAwait(false);
+        if (remoteClient is null)
+        {
+            _logger.LogWarning($"Couldn't get remote client");
+            return null;
+        }
+
+        try
+        {
+            var data = await remoteClient.TryInvokeAsync<IRemoteUriPresentationService, TextChange?>(
+                razorDocument.Project.Solution,
+                (service, solutionInfo, cancellationToken) => service.GetPresentationAsync(solutionInfo, razorDocument.Id, request.Range.ToLinePositionSpan(), request.Uris, cancellationToken),
+                cancellationToken).ConfigureAwait(false);
+
+            if (data.Value is { } textChange)
+            {
+                var sourceText = await razorDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
+
+                return new WorkspaceEdit
+                {
+                    DocumentChanges = new TextDocumentEdit[]
+                    {
+                        new TextDocumentEdit
+                        {
+                            TextDocument = new()
+                            {
+                                Uri = request.TextDocument.Uri
+                            },
+                            Edits = [textChange.ToTextEdit(sourceText)]
+                        }
+                    }
+                };
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, $"Error calling remote");
+            return null;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Part of https://github.com/dotnet/razor/issues/9519

This enables the Uri Presentation endpoint in cohosting, which is used when draging and dropping a file only a Razor document, and handles placing a Razor component tag in the document. It's part 1 because part 2 involves calling out to Web Tools to allow the Html language server to do the same, but I haven't done that bit yet. No point reviewing it all in one huge lump though.

This is also a reasonable "bare minimum" changes necessary to create a new cohost endpoint and service.