### PR TITLE
Stop importing ILoggerFactory lazily

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Debugging/DefaultLSPBreakpointSpanProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Debugging/DefaultLSPBreakpointSpanProvider.cs
@@ -19,25 +19,15 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Debugging;
 internal class DefaultLSPBreakpointSpanProvider : LSPBreakpointSpanProvider
 {
     private readonly LSPRequestInvoker _requestInvoker;
-    private readonly Lazy<ILogger> _logger;
+    private readonly ILogger _logger;
 
     [ImportingConstructor]
     public DefaultLSPBreakpointSpanProvider(
         LSPRequestInvoker requestInvoker,
-        Lazy<ILoggerFactory> loggerFactory)
+        ILoggerFactory loggerFactory)
     {
-        if (requestInvoker is null)
-        {
-            throw new ArgumentNullException(nameof(requestInvoker));
-        }
-
-        if (loggerFactory is null)
-        {
-            throw new ArgumentNullException(nameof(loggerFactory));
-        }
-
         _requestInvoker = requestInvoker;
-        _logger = new Lazy<ILogger>(() => loggerFactory.Value.GetOrCreateLogger<DefaultLSPBreakpointSpanProvider>());
+        _logger = loggerFactory.GetOrCreateLogger<DefaultLSPBreakpointSpanProvider>();
     }
 
     public async override Task<Range?> GetBreakpointSpanAsync(LSPDocumentSnapshot documentSnapshot, Position position, CancellationToken cancellationToken)
@@ -69,7 +59,7 @@ internal class DefaultLSPBreakpointSpanProvider : LSPBreakpointSpanProvider
         var languageResponse = response?.Response;
         if (languageResponse is null)
         {
-            _logger.Value.LogInformation($"The breakpoint position could not be mapped to a valid range.");
+            _logger.LogInformation($"The breakpoint position could not be mapped to a valid range.");
             return null;
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Debugging/DefaultLSPProximityExpressionsProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Debugging/DefaultLSPProximityExpressionsProvider.cs
@@ -21,25 +21,15 @@ internal class DefaultLSPProximityExpressionsProvider : LSPProximityExpressionsP
 {
     private readonly LSPRequestInvoker _requestInvoker;
 
-    private readonly Lazy<ILogger> _logger;
+    private readonly ILogger _logger;
 
     [ImportingConstructor]
     public DefaultLSPProximityExpressionsProvider(
         LSPRequestInvoker requestInvoker,
-        Lazy<ILoggerFactory> loggerFactory)
+        ILoggerFactory loggerFactory)
     {
-        if (requestInvoker is null)
-        {
-            throw new ArgumentNullException(nameof(requestInvoker));
-        }
-
-        if (loggerFactory is null)
-        {
-            throw new ArgumentNullException(nameof(loggerFactory));
-        }
-
         _requestInvoker = requestInvoker;
-        _logger = new Lazy<ILogger>(() => loggerFactory.Value.GetOrCreateLogger<DefaultLSPProximityExpressionsProvider>());
+        _logger = loggerFactory.GetOrCreateLogger<DefaultLSPProximityExpressionsProvider>();
     }
 
     public async override Task<IReadOnlyList<string>?> GetProximityExpressionsAsync(LSPDocumentSnapshot documentSnapshot, Position position, CancellationToken cancellationToken)
@@ -71,7 +61,7 @@ internal class DefaultLSPProximityExpressionsProvider : LSPProximityExpressionsP
         var languageResponse = response?.Response;
         if (languageResponse is null)
         {
-            _logger.Value.LogInformation($"The proximity expressions could not be resolved.");
+            _logger.LogInformation($"The proximity expressions could not be resolved.");
             return null;
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/VSTelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/VSTelemetryReporter.cs
@@ -14,16 +14,16 @@ namespace Microsoft.VisualStudio.Razor.Telemetry;
 [Export(typeof(ITelemetryReporter))]
 internal class VSTelemetryReporter : TelemetryReporter
 {
-    private readonly Lazy<ILogger?> _logger;
+    private readonly ILogger _logger;
 
     [ImportingConstructor]
-    public VSTelemetryReporter(Lazy<ILoggerFactory> loggerFactory)
+    public VSTelemetryReporter(ILoggerFactory loggerFactory)
         // Get the DefaultSession for telemetry. This is set by VS with
         // TelemetryService.SetDefaultSession and provides the correct
         // appinsights keys etc
         : base(ImmutableArray.Create(TelemetryService.DefaultSession))
     {
-        _logger = new Lazy<ILogger?>(() => loggerFactory.Value.GetOrCreateLogger<VSTelemetryReporter>());
+        _logger = loggerFactory.GetOrCreateLogger<VSTelemetryReporter>();
     }
 
     protected override bool HandleException(Exception exception, string? message, params object?[] @params)
@@ -65,8 +65,8 @@ internal class VSTelemetryReporter : TelemetryReporter
     }
 
     protected override void LogTrace(string message)
-        => _logger.Value?.Log(LogLevel.Trace, message, exception: null);
+        => _logger.Log(LogLevel.Trace, message, exception: null);
 
     protected override void LogError(Exception exception, string message)
-        => _logger.Value?.Log(LogLevel.Error, message, exception);
+        => _logger.Log(LogLevel.Error, message, exception);
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Editor_NetFx/TestTelemetryReporter.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Editor_NetFx/TestTelemetryReporter.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.VisualStudio.Razor.Telemetry;
@@ -9,7 +8,7 @@ using Microsoft.VisualStudio.Telemetry;
 
 namespace Microsoft.VisualStudio.Editor.Razor.Test.Shared;
 
-internal class TestTelemetryReporter(ILoggerFactory loggerFactory) : VSTelemetryReporter(new Lazy<ILoggerFactory>(() => loggerFactory))
+internal class TestTelemetryReporter(ILoggerFactory loggerFactory) : VSTelemetryReporter(loggerFactory)
 {
     public List<TelemetryEvent> Events { get; } = [];
 


### PR DESCRIPTION
Awhile back, a few MEF components were changed to import ILoggerFactory lazily in order to avoid extra image loads for MS.Ext.Logging. However, that shouldn't be an issue anymore for two reasons:

1. We don't rely on that logging implementation anymore.
2. Our logging implementation is already lazy and does not force MEF components to be created until the first time a message is logged.
