### PR TITLE
Add warning wave support and warn for unnecessary `@` in component parameters

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentLoweringPass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentLoweringPass.cs
@@ -12,8 +12,15 @@ namespace Microsoft.AspNetCore.Razor.Language.Components;
 
 internal class ComponentLoweringPass : ComponentIntermediateNodePassBase, IRazorOptimizationPass
 {
+    private readonly int? _razorWarningLevel;
+
     // This pass runs earlier than our other passes that 'lower' specific kinds of attributes.
     public override int Order => 0;
+
+    public ComponentLoweringPass(RazorConfiguration configuration)
+    {
+        _razorWarningLevel = configuration.RazorWarningLevel;
+    }
 
     protected override void ExecuteCore(RazorCodeDocument codeDocument, DocumentIntermediateNode documentNode)
     {
@@ -137,7 +144,7 @@ internal class ComponentLoweringPass : ComponentIntermediateNodePassBase, IRazor
         }
     }
 
-    private static ComponentIntermediateNode RewriteAsComponent(TagHelperIntermediateNode node, TagHelperDescriptor tagHelper)
+    private ComponentIntermediateNode RewriteAsComponent(TagHelperIntermediateNode node, TagHelperDescriptor tagHelper)
     {
         var component = new ComponentIntermediateNode()
         {
@@ -214,8 +221,13 @@ internal class ComponentLoweringPass : ComponentIntermediateNodePassBase, IRazor
         }
     }
 
-    private static void WarnForUnnecessaryAt(ComponentIntermediateNode component)
+    private void WarnForUnnecessaryAt(ComponentIntermediateNode component)
     {
+        if (_razorWarningLevel is not >= 9)
+        {
+            return;
+        }
+
         foreach (var attribute in component.Attributes)
         {
             // IntParam="@x" has unnecessary `@`, can just use IntParam="x" -> warn

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentLoweringPass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentLoweringPass.cs
@@ -221,9 +221,11 @@ internal class ComponentLoweringPass : ComponentIntermediateNodePassBase, IRazor
             // IntParam="@x" has unnecessary `@`, can just use IntParam="x" -> warn
             // StrParam="@x" is different than StrParam="x" -> don't warn
             if (!attribute.BoundAttribute.IsStringProperty &&
+                attribute.Source is { } originalSource &&
                 attribute.Children is [CSharpExpressionIntermediateNode])
             {
-                attribute.Diagnostics.Add(RazorDiagnosticFactory.CreateComponentParameter_UnnecessaryAt(attribute.Source));
+                var source = originalSource.With(length: 1, endCharacterIndex: originalSource.CharacterIndex + 1);
+                attribute.Diagnostics.Add(RazorDiagnosticFactory.CreateComponentParameter_UnnecessaryAt(source));
             }
         }
     }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorConfiguration.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorConfiguration.cs
@@ -12,7 +12,8 @@ public sealed record class RazorConfiguration(
     string ConfigurationName,
     ImmutableArray<RazorExtension> Extensions,
     LanguageServerFlags? LanguageServerFlags = null,
-    bool UseConsolidatedMvcViews = false)
+    bool UseConsolidatedMvcViews = false,
+    int? RazorWarningLevel = null)
 {
     public static readonly RazorConfiguration Default = new(
         RazorLanguageVersion.Latest,
@@ -27,6 +28,7 @@ public sealed record class RazorConfiguration(
            ConfigurationName == other.ConfigurationName &&
            LanguageServerFlags == other.LanguageServerFlags &&
            UseConsolidatedMvcViews == other.UseConsolidatedMvcViews &&
+           RazorWarningLevel == other.RazorWarningLevel &&
            Extensions.SequenceEqual(other.Extensions);
 
     public override int GetHashCode()
@@ -37,6 +39,7 @@ public sealed record class RazorConfiguration(
         hash.Add(Extensions);
         hash.Add(UseConsolidatedMvcViews);
         hash.Add(LanguageServerFlags);
+        hash.Add(RazorWarningLevel);
         return hash;
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorDiagnosticFactory.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorDiagnosticFactory.cs
@@ -480,6 +480,14 @@ internal static class RazorDiagnosticFactory
     public static RazorDiagnostic CreateComponent_EditorRequiredParameterNotSpecified(SourceSpan? location, string tagName, string parameterName)
         => RazorDiagnostic.Create(Component_EditorRequiredParameterNotSpecified, location, tagName, parameterName);
 
+    internal static readonly RazorDiagnosticDescriptor ComponentParameter_UnnecessaryAt =
+        new($"{DiagnosticPrefix}2013",
+            Resources.ComponentParameter_UnnecessaryAt,
+            RazorDiagnosticSeverity.Warning);
+
+    public static RazorDiagnostic CreateComponentParameter_UnnecessaryAt(SourceSpan? location)
+        => RazorDiagnostic.Create(ComponentParameter_UnnecessaryAt, location);
+
     #endregion
 
     #region TagHelper Errors

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorProjectEngine.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorProjectEngine.cs
@@ -363,7 +363,7 @@ public class RazorProjectEngine
             NamespaceDirective.Register(builder);
             AttributeDirective.Register(builder);
 
-            AddComponentFeatures(builder, configuration.LanguageVersion);
+            AddComponentFeatures(builder, configuration);
         }
 
         configure?.Invoke(builder);
@@ -448,8 +448,10 @@ public class RazorProjectEngine
         });
     }
 
-    private static void AddComponentFeatures(RazorProjectEngineBuilder builder, RazorLanguageVersion razorLanguageVersion)
+    private static void AddComponentFeatures(RazorProjectEngineBuilder builder, RazorConfiguration configuration)
     {
+        RazorLanguageVersion razorLanguageVersion = configuration.LanguageVersion;
+
         // Project Engine Features
         builder.Features.Add(new ComponentImportProjectFeature());
 
@@ -486,7 +488,7 @@ public class RazorProjectEngine
 
         // Optimization
         builder.Features.Add(new ComponentComplexAttributeContentPass());
-        builder.Features.Add(new ComponentLoweringPass());
+        builder.Features.Add(new ComponentLoweringPass(configuration));
         builder.Features.Add(new ComponentEventHandlerLoweringPass());
         builder.Features.Add(new ComponentKeyLoweringPass());
         builder.Features.Add(new ComponentReferenceCaptureLoweringPass());

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Resources.resx
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Resources.resx
@@ -574,6 +574,9 @@
   <data name="Component_EditorRequiredParameterNotSpecified" xml:space="preserve">
     <value>Component '{0}' expects a value for the parameter '{1}', but a value may not have been provided.</value>
   </data>
+  <data name="ComponentParameter_UnnecessaryAt" xml:space="preserve">
+    <value>The '@' prefix is not necessary for component parameters whose type is not string.</value>
+  </data>
   <data name="An_item_with_the_same_key_has_already_been_added_Key_0" xml:space="preserve">
     <value>An item with the same key has already been added. Key: {0}</value>
   </data>

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/Diagnostics/DiagnosticIds.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/Diagnostics/DiagnosticIds.cs
@@ -6,6 +6,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
     internal static class DiagnosticIds
     {
         public const string InvalidRazorLangVersionRuleId = "RZ3600";
+        public const string InvalidRazorWarningLevelRuleId = "RZ3601";
         public const string ReComputingTagHelpersRuleId = "RSG001";
         public const string TargetPathNotProvidedRuleId = "RSG002";
         public const string GeneratedOutputFullPathNotProvidedRuleId = "RSG003";

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/Diagnostics/RazorDiagnostics.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/Diagnostics/RazorDiagnostics.cs
@@ -20,6 +20,14 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 
+        public static readonly DiagnosticDescriptor InvalidRazorWarningLevelDescriptor = new DiagnosticDescriptor(
+            DiagnosticIds.InvalidRazorWarningLevelRuleId,
+            new LocalizableResourceString(nameof(RazorSourceGeneratorResources.InvalidRazorWarningLevelTitle), RazorSourceGeneratorResources.ResourceManager, typeof(RazorSourceGeneratorResources)),
+            new LocalizableResourceString(nameof(RazorSourceGeneratorResources.InvalidRazorWarningLevelMessage), RazorSourceGeneratorResources.ResourceManager, typeof(RazorSourceGeneratorResources)),
+            "RazorSourceGenerator",
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+
         public static readonly DiagnosticDescriptor ReComputingTagHelpersDescriptor = new DiagnosticDescriptor(
             DiagnosticIds.ReComputingTagHelpersRuleId,
             new LocalizableResourceString(nameof(RazorSourceGeneratorResources.RecomputingTagHelpersTitle), RazorSourceGeneratorResources.ResourceManager, typeof(RazorSourceGeneratorResources)),

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/Diagnostics/RazorSourceGeneratorResources.resx
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/Diagnostics/RazorSourceGeneratorResources.resx
@@ -121,7 +121,13 @@
     <value>Invalid RazorLangVersion</value>
   </data>
   <data name="InvalidRazorLangMessage" xml:space="preserve">
-    <value>Invalid value '{0}'' for RazorLangVersion. Valid values include 'Latest' or a valid version in range 1.0 to 8.0.</value>
+    <value>Invalid value '{0}' for RazorLangVersion. Valid values include 'Latest' or a valid version in range 1.0 to 8.0.</value>
+  </data>
+	<data name="InvalidRazorWarningLevelTitle" xml:space="preserve">
+    <value>Invalid RazorWarningLevel</value>
+  </data>
+	<data name="InvalidRazorWarningLevelMessage" xml:space="preserve">
+    <value>Invalid value '{0}' for RazorWarningLevel. Must be empty or an integer.</value>
   </data>
   <data name="RecomputingTagHelpersTitle" xml:space="preserve">
     <value>Recomputing tag helpers</value>

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/IncrementalValueProviderExtensions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/IncrementalValueProviderExtensions.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.AspNetCore.Razor;
 using Microsoft.CodeAnalysis;
@@ -39,12 +40,12 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
             return source.Where((pair) => pair.Item1 != null).Select((pair, ct) => pair.Item1!);
         }
 
-        internal static IncrementalValueProvider<TSource> ReportDiagnostics<TSource>(this IncrementalValueProvider<(TSource?, Diagnostic?)> source, IncrementalGeneratorInitializationContext context)
+        internal static IncrementalValueProvider<TSource> ReportDiagnostics<TSource>(this IncrementalValueProvider<(TSource?, ImmutableArray<Diagnostic>)> source, IncrementalGeneratorInitializationContext context)
         {
             context.RegisterSourceOutput(source, (spc, source) =>
             {
-                var (_, diagnostic) = source;
-                if (diagnostic != null)
+                var (_, diagnostics) = source;
+                foreach (var diagnostic in diagnostics)
                 {
                     spc.ReportDiagnostic(diagnostic);
                 }

--- a/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGeneratorComponentTests.cs
+++ b/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGeneratorComponentTests.cs
@@ -309,7 +309,13 @@ public sealed class RazorSourceGeneratorComponentTests : RazorSourceGeneratorTes
         var result = RunGenerator(compilation!, ref driver, out compilation);
 
         // Assert
-        Assert.Empty(result.Diagnostics);
+        result.Diagnostics.VerifyRazor(project,
+            // Shared/Component1.razor(6,23): warning RZ2013: The '@' prefix is not necessary for component parameters whose type is not string.
+            // <Component2 IntParam="@(43)" StrParam="@hi" />
+            Diagnostic("RZ2013", "@(43)").WithLocation(6, 23),
+            // Shared/Component1.razor(7,23): warning RZ2013: The '@' prefix is not necessary for component parameters whose type is not string.
+            // <Component2 IntParam="@x" StrParam="@("lit")" />
+            Diagnostic("RZ2013", "@x").WithLocation(7, 23));
         Assert.Equal(3, result.GeneratedSources.Length);
         await VerifyRazorPageMatchesBaselineAsync(compilation, "Views_Home_Index");
     }

--- a/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGeneratorTests.cs
+++ b/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGeneratorTests.cs
@@ -3073,8 +3073,30 @@ namespace MyApp
             var result = RunGenerator(compilation!, ref driver);
 
             result.Diagnostics.Verify(
-                // error RZ3600: Invalid value '{0}'' for RazorLangVersion. Valid values include 'Latest' or a valid version in range 1.0 to 8.0.
+                // error RZ3600: Invalid value '{0}' for RazorLangVersion. Valid values include 'Latest' or a valid version in range 1.0 to 8.0.
                 Diagnostic("RZ3600").WithArguments(langVersion).WithLocation(1, 1));
+            Assert.Single(result.GeneratedSources);
+        }
+
+        [Theory, CombinatorialData]
+        public async Task RazorWarningLevel_Incorrect(
+            [CombinatorialValues("incorrect", "1.2", "0x1")] string warningLevel)
+        {
+            var project = CreateTestProject(new()
+            {
+                ["Pages/Index.razor"] = "<h1>Hello world</h1>",
+            });
+            var compilation = await project.GetCompilationAsync();
+            var driver = await GetDriverAsync(project, options =>
+            {
+                options.TestGlobalOptions["build_property.RazorWarningLevel"] = warningLevel;
+            });
+
+            var result = RunGenerator(compilation!, ref driver);
+
+            result.Diagnostics.Verify(
+                // error RZ3600: Invalid value '{0}' for RazorWarningLevel. Must be empty or an integer.
+                Diagnostic("RZ3601").WithArguments(warningLevel).WithLocation(1, 1));
             Assert.Single(result.GeneratedSources);
         }
 

--- a/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGeneratorTestsBase.cs
+++ b/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/RazorSourceGeneratorTestsBase.cs
@@ -545,4 +545,18 @@ internal static class Extensions
         Assert.Equal(payload1, e.Payload[0]);
         Assert.Equal(payload2, e.Payload[1]);
     }
+
+    public static void VerifyRazor(
+        this IEnumerable<Diagnostic> diagnostics,
+        Project project,
+        params DiagnosticDescription[] expected)
+    {
+        var mappedDiagnostics = diagnostics.PretendTheseAreCSharpDiagnostics(path =>
+        {
+            var document = project.AdditionalDocuments.Single(d => d.Name == path);
+            Assert.True(document.TryGetText(out var text));
+            return text;
+        });
+        mappedDiagnostics.Verify(expected);
+    }
 }

--- a/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/TestFiles/RazorSourceGeneratorComponentTests/ComponentParameter_UnnecessaryAt/Views_Home_Index.html
+++ b/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/TestFiles/RazorSourceGeneratorComponentTests/ComponentParameter_UnnecessaryAt/Views_Home_Index.html
@@ -1,0 +1,4 @@
+﻿I: 43, S: HI
+I: 44, S: STR
+I: 22, S: LIT
+I: 64, S: STRHEY

--- a/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/TestFiles/RazorSourceGeneratorComponentTests/ComponentParameter_UnnecessaryAt/Views_Home_Index.html
+++ b/src/Compiler/test/Microsoft.NET.Sdk.Razor.SourceGenerators.Tests/TestFiles/RazorSourceGeneratorComponentTests/ComponentParameter_UnnecessaryAt/Views_Home_Index.html
@@ -1,4 +1,5 @@
-﻿I: 43, S: HI
+I: 43, S: HI
 I: 44, S: STR
 I: 22, S: LIT
 I: 64, S: STRHEY
+I: 22, S: 

--- a/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/DiagnosticExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/DiagnosticExtensions.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis;
+
+public static class RazorDiagnosticExtensions
+{
+    /// <summary>
+    /// Provides better experience when verifying diagnostics in tests - includes squiggled text and code snippet.
+    /// </summary>
+    public static IEnumerable<Diagnostic> PretendTheseAreCSharpDiagnostics(
+        this IEnumerable<Diagnostic> diagnostics,
+        Func<string, SourceText> filePathToContent)
+    {
+        var texts = new Dictionary<string, SourceText>();
+        return diagnostics.Select(d =>
+        {
+            if (d.Location is { Kind: LocationKind.ExternalFile } originalLocation)
+            {
+                var mappedSpan = originalLocation.GetMappedLineSpan();
+                var path = mappedSpan.Path;
+                var text = texts.GetOrAdd(path, filePathToContent);
+                var syntaxTree = CSharpSyntaxTree.ParseText(text, path: path);
+                var span = text.Lines.GetTextSpan(mappedSpan.Span);
+                var location = Location.Create(syntaxTree, span);
+                return Diagnostic.Create(d.Descriptor, location);
+            }
+
+            return d;
+        });
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/dotnet/roslyn/issues/85498.
Related (internal): https://github.com/dotnet/Razor-Language-Design/discussions/5
Commit-by-commit review might be useful.

The warning waves feature needs an SDK counterpart change to fully work (prototype here: https://github.com/dotnet/sdk/pull/40720), but it shouldn't need any coordinated merging - without the SDK passing RazorWarningLevel through, the warnings simply stay disabled.