### PR TITLE
Support Linked Editing Ranges in Cohosting.

### DIFF
--- a/eng/targets/Services.props
+++ b/eng/targets/Services.props
@@ -15,6 +15,7 @@
     For example, if your service interface is IRemoteFrobulatorService, then the Include should be "Microsoft.VisualStudio.Razor.Frobulator".
   -->
   <ItemGroup>
+    <ServiceHubService Include="Microsoft.VisualStudio.Razor.LinkedEditingRange" ClassName="Microsoft.CodeAnalysis.Remote.Razor.RemoteLinkedEditingRangeServiceFactory" />
     <ServiceHubService Include="Microsoft.VisualStudio.Razor.SemanticTokens" ClassName="Microsoft.CodeAnalysis.Remote.Razor.RemoteSemanticTokensServiceFactory" />
     <ServiceHubService Include="Microsoft.VisualStudio.Razor.HtmlDocument" ClassName="Microsoft.CodeAnalysis.Remote.Razor.RemoteHtmlDocumentServiceFactory" />
     <ServiceHubService Include="Microsoft.VisualStudio.Razor.TagHelperProvider" ClassName="Microsoft.CodeAnalysis.Remote.Razor.RemoteTagHelperProviderServiceFactory"/>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeEndpoint.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
+using Microsoft.CodeAnalysis.Razor.LinkedEditingRange;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
@@ -18,12 +19,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.LinkedEditingRange;
 [RazorLanguageServerEndpoint(Methods.TextDocumentLinkedEditingRangeName)]
 internal class LinkedEditingRangeEndpoint : IRazorRequestHandler<LinkedEditingRangeParams, LinkedEditingRanges?>, ICapabilitiesProvider
 {
-    // The regex below excludes characters that can never be valid in a TagHelper name.
-    // This is loosely based off logic from the Razor compiler:
-    // https://github.com/dotnet/aspnetcore/blob/9da42b9fab4c61fe46627ac0c6877905ec845d5a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/HtmlTokenizer.cs
-    // Internal for testing only.
-    internal static readonly string WordPattern = @"!?[^ <>!\/\?\[\]=""\\@" + Environment.NewLine + "]+";
-
     private readonly ILogger _logger;
 
     public LinkedEditingRangeEndpoint(ILoggerFactory loggerFactory)
@@ -67,81 +62,19 @@ internal class LinkedEditingRangeEndpoint : IRazorRequestHandler<LinkedEditingRa
             return null;
         }
 
-        var syntaxTree = await documentContext.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-
-        var location = await GetSourceLocationAsync(request, documentContext, cancellationToken).ConfigureAwait(false);
-        if (location is not SourceLocation validLocation)
+        if (LinkedEditingRangeHelper.GetLinkedSpans(request.Position.ToLinePosition(), codeDocument, _logger) is { } linkedSpans && linkedSpans.Length == 2)
         {
-            return null;
-        }
-
-        // We only care if the user is within a TagHelper or HTML tag with a valid start and end tag.
-        if (TryGetNearestMarkupNameTokens(syntaxTree, validLocation, out var startTagNameToken, out var endTagNameToken) &&
-            (startTagNameToken.Span.Contains(validLocation.AbsoluteIndex) || endTagNameToken.Span.Contains(validLocation.AbsoluteIndex) ||
-            startTagNameToken.Span.End == validLocation.AbsoluteIndex || endTagNameToken.Span.End == validLocation.AbsoluteIndex))
-        {
-            var startSpan = startTagNameToken.GetLinePositionSpan(codeDocument.Source);
-            var endSpan = endTagNameToken.GetLinePositionSpan(codeDocument.Source);
-            var ranges = new Range[2] { startSpan.ToRange(), endSpan.ToRange() };
+            var ranges = new Range[2] { linkedSpans[0].ToRange(), linkedSpans[1].ToRange() };
 
             return new LinkedEditingRanges
             {
                 Ranges = ranges,
-                WordPattern = WordPattern
+                WordPattern = LinkedEditingRangeHelper.WordPattern
             };
         }
 
-        _logger.LogInformation($"LinkedEditingRange request was null at {location} for {request.TextDocument.Uri}");
+        _logger.LogInformation($"LinkedEditingRange request was null at line {request.Position.Line}, column {request.Position.Character} for {request.TextDocument.Uri}");
+
         return null;
-
-        async Task<SourceLocation?> GetSourceLocationAsync(
-            LinkedEditingRangeParams request,
-            DocumentContext documentContext,
-            CancellationToken cancellationToken)
-        {
-            var sourceText = await documentContext.GetSourceTextAsync(cancellationToken).ConfigureAwait(false);
-            if (request.Position.TryGetSourceLocation(sourceText, _logger, out var location))
-            {
-                return location;
-            }
-            else
-            {
-                return null;
-            }
-        }
-
-        static bool TryGetNearestMarkupNameTokens(
-            RazorSyntaxTree syntaxTree,
-            SourceLocation location,
-            [NotNullWhen(true)] out SyntaxToken? startTagNameToken,
-            [NotNullWhen(true)] out SyntaxToken? endTagNameToken)
-        {
-            var owner = syntaxTree.Root.FindInnermostNode(location.AbsoluteIndex);
-            var element = owner?.FirstAncestorOrSelf<MarkupSyntaxNode>(
-                a => a.Kind is SyntaxKind.MarkupTagHelperElement || a.Kind is SyntaxKind.MarkupElement);
-
-            if (element is null)
-            {
-                startTagNameToken = null;
-                endTagNameToken = null;
-                return false;
-            }
-
-            switch (element)
-            {
-                // Tag helper
-                case MarkupTagHelperElementSyntax markupTagHelperElement:
-                    startTagNameToken = markupTagHelperElement.StartTag?.Name;
-                    endTagNameToken = markupTagHelperElement.EndTag?.Name;
-                    return startTagNameToken is not null && endTagNameToken is not null;
-                // HTML
-                case MarkupElementSyntax markupElement:
-                    startTagNameToken = markupElement.StartTag?.Name;
-                    endTagNameToken = markupElement.EndTag?.Name;
-                    return startTagNameToken is not null && endTagNameToken is not null;
-                default:
-                    throw new InvalidOperationException("Element is expected to be a MarkupTagHelperElement or MarkupElement.");
-            }
-        }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -178,7 +178,10 @@ internal partial class RazorLanguageServer : AbstractLanguageServer<RazorRequest
 
             services.AddHandlerWithCapabilities<RenameEndpoint>();
             services.AddHandlerWithCapabilities<DefinitionEndpoint>();
-            services.AddHandlerWithCapabilities<LinkedEditingRangeEndpoint>();
+            if (!featureOptions.UseRazorCohostServer)
+            {
+                services.AddHandlerWithCapabilities<LinkedEditingRangeEndpoint>();
+            }
             services.AddHandler<WrapWithTagEndpoint>();
             services.AddHandler<RazorBreakpointSpanEndpoint>();
             services.AddHandler<RazorProximityExpressionsEndpoint>();

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LinkedEditingRange/LinkedEditingRangeHelper.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LinkedEditingRange/LinkedEditingRangeHelper.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.CodeAnalysis.Razor.Logging;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Microsoft.CodeAnalysis.Text;
+
+using RazorSyntaxToken = Microsoft.AspNetCore.Razor.Language.Syntax.SyntaxToken;
+
+namespace Microsoft.CodeAnalysis.Razor.LinkedEditingRange;
+
+internal static class LinkedEditingRangeHelper
+{
+    // The regex below excludes characters that can never be valid in a TagHelper name.
+    // This is loosely based off logic from the Razor compiler:
+    // https://github.com/dotnet/aspnetcore/blob/9da42b9fab4c61fe46627ac0c6877905ec845d5a/src/Razor/Microsoft.AspNetCore.Razor.Language/src/Legacy/HtmlTokenizer.cs
+    public static readonly string WordPattern = @"!?[^ <>!\/\?\[\]=""\\@" + Environment.NewLine + "]+";
+
+    public static LinePositionSpan[]? GetLinkedSpans(LinePosition linePosition, RazorCodeDocument codeDocument, ILogger logger)
+    {
+        if (GetSourceLocation(linePosition, codeDocument, logger) is not { } validLocation)
+        {
+            return null;
+        }
+
+        var syntaxTree = codeDocument.GetSyntaxTree();
+
+        // We only care if the user is within a TagHelper or HTML tag with a valid start and end tag.
+        if (TryGetNearestMarkupNameTokens(syntaxTree, validLocation, out var startTagNameToken, out var endTagNameToken) &&
+            (startTagNameToken.Span.Contains(validLocation.AbsoluteIndex) || endTagNameToken.Span.Contains(validLocation.AbsoluteIndex) ||
+            startTagNameToken.Span.End == validLocation.AbsoluteIndex || endTagNameToken.Span.End == validLocation.AbsoluteIndex))
+        {
+            var startSpan = startTagNameToken.GetLinePositionSpan(codeDocument.Source);
+            var endSpan = endTagNameToken.GetLinePositionSpan(codeDocument.Source);
+
+            return [startSpan, endSpan];
+        }
+
+        return null;
+    }
+
+    private static SourceLocation? GetSourceLocation(
+        LinePosition linePosition,
+        RazorCodeDocument codeDocument,
+        ILogger logger)
+    {
+        var sourceText = codeDocument.GetSourceText();
+
+        if (linePosition.ToPosition().TryGetSourceLocation(sourceText, logger, out var location))
+        {
+            return location;
+        }
+        else
+        {
+            return null;
+        }
+    }
+
+    private static bool TryGetNearestMarkupNameTokens(
+        RazorSyntaxTree syntaxTree,
+        SourceLocation location,
+        [NotNullWhen(true)] out RazorSyntaxToken? startTagNameToken,
+        [NotNullWhen(true)] out RazorSyntaxToken? endTagNameToken)
+    {
+        var owner = syntaxTree.Root.FindInnermostNode(location.AbsoluteIndex);
+        var element = owner?.FirstAncestorOrSelf<MarkupSyntaxNode>(
+            a => a.Kind is SyntaxKind.MarkupTagHelperElement || a.Kind is SyntaxKind.MarkupElement);
+
+        if (element is null)
+        {
+            startTagNameToken = null;
+            endTagNameToken = null;
+            return false;
+        }
+
+        switch (element)
+        {
+            // Tag helper
+            case MarkupTagHelperElementSyntax markupTagHelperElement:
+                startTagNameToken = markupTagHelperElement.StartTag?.Name;
+                endTagNameToken = markupTagHelperElement.EndTag?.Name;
+                return startTagNameToken is not null && endTagNameToken is not null;
+            // HTML
+            case MarkupElementSyntax markupElement:
+                startTagNameToken = markupElement.StartTag?.Name;
+                endTagNameToken = markupElement.EndTag?.Name;
+                return startTagNameToken is not null && endTagNameToken is not null;
+            default:
+                throw new InvalidOperationException("Element is expected to be a MarkupTagHelperElement or MarkupElement.");
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/IRemoteLinkedEditingRangeService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/IRemoteLinkedEditingRangeService.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Razor.Remote;
+
+interface IRemoteLinkedEditingRangeService
+{
+    ValueTask<LinePositionSpan[]?> GetRangesAsync(RazorPinnedSolutionInfoWrapper solutionInfo, DocumentId razorDocumentId, LinePosition linePosition, CancellationToken cancellationToken);
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RazorServices.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RazorServices.cs
@@ -19,6 +19,7 @@ internal static class RazorServices
         additionalResolvers: TopLevelResolvers.All,
         interfaces:
         [
+            (typeof(IRemoteLinkedEditingRangeService), null),
             (typeof(IRemoteTagHelperProviderService), null),
             (typeof(IRemoteClientInitializationService), null),
             (typeof(IRemoteSemanticTokensService), null),

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/LinkedEditingRange/RemoteLinkedEditingRangeService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/LinkedEditingRange/RemoteLinkedEditingRangeService.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Api;
+using Microsoft.CodeAnalysis.Razor.LinkedEditingRange;
+using Microsoft.CodeAnalysis.Razor.Logging;
+using Microsoft.CodeAnalysis.Razor.Remote;
+using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.ServiceHub.Framework;
+
+namespace Microsoft.CodeAnalysis.Remote.Razor;
+
+internal sealed class RemoteLinkedEditingRangeService(
+    IServiceBroker serviceBroker,
+    DocumentSnapshotFactory documentSnapshotFactory,
+    ILoggerFactory loggerFactory)
+    : RazorServiceBase(serviceBroker), IRemoteLinkedEditingRangeService
+{
+    private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<RemoteLinkedEditingRangeService>();
+    private readonly DocumentSnapshotFactory _documentSnapshotFactory = documentSnapshotFactory;
+
+    public ValueTask<LinePositionSpan[]?> GetRangesAsync(RazorPinnedSolutionInfoWrapper solutionInfo, DocumentId razorDocumentId, LinePosition linePosition, CancellationToken cancellationToken)
+        => RazorBrokeredServiceImplementation.RunServiceAsync(
+            solutionInfo,
+            ServiceBrokerClient,
+            solution => GetRangesAsync(solution, razorDocumentId, linePosition, cancellationToken),
+            cancellationToken);
+
+    public async ValueTask<LinePositionSpan[]?> GetRangesAsync(Solution solution, DocumentId razorDocumentId, LinePosition linePosition, CancellationToken cancellationToken)
+    {
+        var razorDocument = solution.GetAdditionalDocument(razorDocumentId);
+        if (razorDocument is null)
+        {
+            return null;
+        }
+
+        var snapshot = _documentSnapshotFactory.GetOrCreate(razorDocument);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
+
+        return LinkedEditingRangeHelper.GetLinkedSpans(linePosition, codeDocument, _logger);
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/LinkedEditingRange/RemoteLinkedEditingRangeServiceFactory.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/LinkedEditingRange/RemoteLinkedEditingRangeServiceFactory.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Razor.DocumentMapping;
+using Microsoft.CodeAnalysis.Razor.Logging;
+using Microsoft.CodeAnalysis.Razor.Remote;
+using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.VisualStudio.Composition;
+
+namespace Microsoft.CodeAnalysis.Remote.Razor;
+
+internal sealed class RemoteLinkedEditingRangeServiceFactory : RazorServiceFactoryBase<IRemoteLinkedEditingRangeService>
+{
+    // WARNING: We must always have a parameterless constructor in order to be properly handled by ServiceHub.
+    public RemoteLinkedEditingRangeServiceFactory()
+        : base(RazorServices.Descriptors)
+    {
+    }
+
+    protected override IRemoteLinkedEditingRangeService CreateService(IServiceBroker serviceBroker, ExportProvider exportProvider)
+    {
+        var documentMappingService = exportProvider.GetExportedValue<IRazorDocumentMappingService>();
+        var documentSnapshotFactory = exportProvider.GetExportedValue<DocumentSnapshotFactory>();
+        var loggerFactory = exportProvider.GetExportedValue<ILoggerFactory>();
+
+        return new RemoteLinkedEditingRangeService(serviceBroker, documentSnapshotFactory, loggerFactory);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostLinkedEditingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostLinkedEditingRangeEndpoint.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+using Microsoft.CodeAnalysis.Razor.LinkedEditingRange;
+using Microsoft.CodeAnalysis.Razor.Logging;
+using Microsoft.CodeAnalysis.Razor.Remote;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.Razor.LanguageClient.Extensions;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+
+#pragma warning disable RS0030 // Do not use banned APIs
+[Shared]
+[CohostEndpoint(Methods.TextDocumentLinkedEditingRangeName)]
+[Export(typeof(IDynamicRegistrationProvider))]
+[ExportCohostStatelessLspService(typeof(CohostLinkedEditingRangeEndpoint))]
+[method: ImportingConstructor]
+#pragma warning restore RS0030 // Do not use banned APIs
+internal class CohostLinkedEditingRangeEndpoint(IRemoteClientProvider remoteClientProvider, ILoggerFactory loggerFactory)
+    : AbstractRazorCohostDocumentRequestHandler<LinkedEditingRangeParams, LinkedEditingRanges?>, IDynamicRegistrationProvider
+{
+    private readonly IRemoteClientProvider _remoteClientProvider = remoteClientProvider;
+    private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<CohostLinkedEditingRangeEndpoint>();
+
+    protected override bool MutatesSolutionState => false;
+
+    // TODO: is this right?
+    protected override bool RequiresLSPSolution => true;
+
+    public Registration? GetRegistration(VSInternalClientCapabilities clientCapabilities, DocumentFilter[] filter, RazorCohostRequestContext requestContext)
+    {        
+        if (clientCapabilities.TextDocument?.LinkedEditingRange?.DynamicRegistration == true)
+        {
+            return new Registration
+            {
+                Method = Methods.TextDocumentLinkedEditingRangeName,
+                RegisterOptions = new LinkedEditingRangeRegistrationOptions()
+                {
+                    DocumentSelector = filter
+                }
+            };
+        }
+
+        return null;
+    }
+
+    protected override RazorTextDocumentIdentifier? GetRazorTextDocumentIdentifier(LinkedEditingRangeParams request)
+        => request.TextDocument.ToRazorTextDocumentIdentifier();
+
+    protected override async Task<LinkedEditingRanges?> HandleRequestAsync(LinkedEditingRangeParams request, RazorCohostRequestContext context, CancellationToken cancellationToken)
+    {
+        var razorDocument = context.TextDocument.AssumeNotNull();
+
+        var remoteClient = await _remoteClientProvider.TryGetClientAsync(cancellationToken).ConfigureAwait(false);
+        if (remoteClient is null)
+        {
+            _logger.LogWarning($"Couldn't get remote client");
+            return null;
+        }
+
+        try
+        {
+            var data = await remoteClient.TryInvokeAsync<IRemoteLinkedEditingRangeService, LinePositionSpan[]?>(
+                razorDocument.Project.Solution,
+                (service, solutionInfo, cancellationToken) => service.GetRangesAsync(solutionInfo, razorDocument.Id, request.Position.ToLinePosition(), cancellationToken),
+                cancellationToken).ConfigureAwait(false);
+
+            if (data.Value is { } linkedRanges && linkedRanges.Length == 2)
+            {
+                var ranges = new Range[2] { linkedRanges[0].ToRange(), linkedRanges[1].ToRange() };
+
+                return new LinkedEditingRanges
+                {
+                    Ranges = ranges,
+                    WordPattern = LinkedEditingRangeHelper.WordPattern
+                };
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, $"Error calling remote");
+            return null;
+        }
+
+        return null;
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/LinkedEditingRange/LinkedEditingRangeEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/LinkedEditingRange/LinkedEditingRangeEndpointTest.cs
@@ -7,6 +7,7 @@ using System;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Completion;
+using Microsoft.CodeAnalysis.Razor.LinkedEditingRange;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Xunit;
 using Xunit.Abstractions;
@@ -73,7 +74,7 @@ public class LinkedEditingRangeEndpointTest(ITestOutputHelper testOutput) : TagH
 
         // Assert
         Assert.Equal(expectedRanges, result.Ranges);
-        Assert.Equal(LinkedEditingRangeEndpoint.WordPattern, result.WordPattern);
+        Assert.Equal(LinkedEditingRangeHelper.WordPattern, result.WordPattern);
     }
 
     [Fact]
@@ -114,7 +115,7 @@ public class LinkedEditingRangeEndpointTest(ITestOutputHelper testOutput) : TagH
 
         // Assert
         Assert.Equal(expectedRanges, result.Ranges);
-        Assert.Equal(LinkedEditingRangeEndpoint.WordPattern, result.WordPattern);
+        Assert.Equal(LinkedEditingRangeHelper.WordPattern, result.WordPattern);
     }
 
     [Fact]
@@ -155,7 +156,7 @@ public class LinkedEditingRangeEndpointTest(ITestOutputHelper testOutput) : TagH
 
         // Assert
         Assert.Equal(expectedRanges, result.Ranges);
-        Assert.Equal(LinkedEditingRangeEndpoint.WordPattern, result.WordPattern);
+        Assert.Equal(LinkedEditingRangeHelper.WordPattern, result.WordPattern);
     }
 
     [Fact]
@@ -248,7 +249,7 @@ public class LinkedEditingRangeEndpointTest(ITestOutputHelper testOutput) : TagH
 
         // Assert
         Assert.Equal(expectedRanges, result.Ranges);
-        Assert.Equal(LinkedEditingRangeEndpoint.WordPattern, result.WordPattern);
+        Assert.Equal(LinkedEditingRangeHelper.WordPattern, result.WordPattern);
     }
 
     [Fact]
@@ -289,7 +290,7 @@ public class LinkedEditingRangeEndpointTest(ITestOutputHelper testOutput) : TagH
 
         // Assert
         Assert.Equal(expectedRanges, result.Ranges);
-        Assert.Equal(LinkedEditingRangeEndpoint.WordPattern, result.WordPattern);
+        Assert.Equal(LinkedEditingRangeHelper.WordPattern, result.WordPattern);
     }
 
     [Fact]
@@ -330,7 +331,7 @@ public class LinkedEditingRangeEndpointTest(ITestOutputHelper testOutput) : TagH
 
         // Assert
         Assert.Equal(expectedRanges, result.Ranges);
-        Assert.Equal(LinkedEditingRangeEndpoint.WordPattern, result.WordPattern);
+        Assert.Equal(LinkedEditingRangeHelper.WordPattern, result.WordPattern);
     }
 
     [Fact]
@@ -363,18 +364,18 @@ public class LinkedEditingRangeEndpointTest(ITestOutputHelper testOutput) : TagH
     public void VerifyWordPatternCorrect()
     {
         // Assert
-        Assert.True(Regex.Match("Test", LinkedEditingRangeEndpoint.WordPattern).Length == 4);
-        Assert.True(Regex.Match("!Test", LinkedEditingRangeEndpoint.WordPattern).Length == 5);
-        Assert.True(Regex.Match("!Test.Test2", LinkedEditingRangeEndpoint.WordPattern).Length == 11);
+        Assert.True(Regex.Match("Test", LinkedEditingRangeHelper.WordPattern).Length == 4);
+        Assert.True(Regex.Match("!Test", LinkedEditingRangeHelper.WordPattern).Length == 5);
+        Assert.True(Regex.Match("!Test.Test2", LinkedEditingRangeHelper.WordPattern).Length == 11);
 
-        Assert.True(Regex.Match("Te>st", LinkedEditingRangeEndpoint.WordPattern).Length != 5);
-        Assert.True(Regex.Match("Te/st", LinkedEditingRangeEndpoint.WordPattern).Length != 5);
-        Assert.True(Regex.Match("Te\\st", LinkedEditingRangeEndpoint.WordPattern).Length != 5);
-        Assert.True(Regex.Match("Te!st", LinkedEditingRangeEndpoint.WordPattern).Length != 5);
+        Assert.True(Regex.Match("Te>st", LinkedEditingRangeHelper.WordPattern).Length != 5);
+        Assert.True(Regex.Match("Te/st", LinkedEditingRangeHelper.WordPattern).Length != 5);
+        Assert.True(Regex.Match("Te\\st", LinkedEditingRangeHelper.WordPattern).Length != 5);
+        Assert.True(Regex.Match("Te!st", LinkedEditingRangeHelper.WordPattern).Length != 5);
         Assert.True(Regex.Match("""
             Te
             st
             """,
-            LinkedEditingRangeEndpoint.WordPattern).Length != 4 + Environment.NewLine.Length);
+            LinkedEditingRangeHelper.WordPattern).Length != 4 + Environment.NewLine.Length);
     }
 }


### PR DESCRIPTION
Factored out common code into a static helper and created the remote part of the code as well as cohosting endpoing.

﻿### Summary of the changes

- Factored out common code into LinkedEditingRangeHelper
- Created CohostLinkedEditingRangeEndpoint
- Created remote service and factory RemoteLinkedEditingRangeService and RemoteLinkedEditingRangeServiceFactory

Publishing as draft initially as I'd like to do a bit more cleanup (some code can be factored out in some remote services into an extra base class) and more testing, but it's mostly there. Also need to test cohosting scenario :) 