### PR TITLE
Reduce noise of ProjectWorkspaceStateGenerator.CancelUpdates logging

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectWorkspaceStateGenerator.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectWorkspaceStateGenerator.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.PooledObjects;
@@ -95,10 +96,15 @@ internal sealed partial class ProjectWorkspaceStateGenerator(
 
     public void CancelUpdates()
     {
-        _logger.LogTrace($"Cancelling all previously enqueued updates.");
-
         lock (_updates)
         {
+            if (_updates.Count == 0)
+            {
+                return;
+            }
+
+            _logger.LogTrace($"Cancelling all previously enqueued updates.");
+
             foreach (var (_, updateItem) in _updates)
             {
                 updateItem.CancelWorkAndCleanUp();


### PR DESCRIPTION
Noticed while looking through logs to diagnose an issue. It was hundreds if not thousands of events logged in quick succession that was noisy