### PR TITLE
Fix disco colors when modifying documents during project load

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
@@ -498,18 +498,27 @@ internal class RazorProjectService(
             }
 
             // Remove from miscellaneous project
-            var defaultMiscProject = miscellaneousProject;
-
-            updater.DocumentRemoved(defaultMiscProject.Key, documentSnapshot.State.HostDocument);
+            updater.DocumentRemoved(miscellaneousProject.Key, documentSnapshot.State.HostDocument);
 
             // Add to new project
 
             var textLoader = new DocumentSnapshotTextLoader(documentSnapshot);
-            var defaultProject = projectSnapshot;
-            var newHostDocument = new HostDocument(documentSnapshot.FilePath, documentSnapshot.TargetPath);
+
+            // If we're moving from the misc files project to a real project, then target path will be the full path to the file
+            // and the next update to the project will update it to be a relative path. To save a bunch of busy work if that is
+            // the only change necessary, we can proactively do that work here. This also means that when we later find out about
+            // this document the "real" way, it will be equal to the one we already know about, and we won't lose content
+            var projectDirectory = FilePathNormalizer.GetNormalizedDirectoryName(projectSnapshot.FilePath);
+            var newTargetPath = documentSnapshot.TargetPath;
+            if (FilePathNormalizer.Normalize(newTargetPath).StartsWith(projectDirectory))
+            {
+                newTargetPath = newTargetPath[projectDirectory.Length..];
+            }
+
+            var newHostDocument = new HostDocument(documentSnapshot.FilePath, newTargetPath, documentSnapshot.FileKind);
             _logger.LogInformation($"Migrating '{documentFilePath}' from the '{miscellaneousProject.Key}' project to '{projectSnapshot.Key}' project.");
 
-            updater.DocumentAdded(defaultProject.Key, newHostDocument, textLoader);
+            updater.DocumentAdded(projectSnapshot.Key, newHostDocument, textLoader);
         }
     }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
@@ -1157,8 +1157,6 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
                 new HostDocument(DocumentFilePath2, "C:/path/to/document2.cshtml"), CreateEmptyTextLoader());
         });
 
-        using var listener = _projectManager.ListenToNotifications();
-
         // Act
         var newProjectKey = await _projectService.AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, rootNamespace: null, displayName: null, DisposalToken);
@@ -1185,7 +1183,6 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
                 new HostDocument(DocumentFilePath1, "other/document1.cshtml"), CreateTextLoader(SourceText.From("Hello")));
         });
 
-        using var listener = _projectManager.ListenToNotifications();
         var projectKey = new ProjectKey(IntermediateOutputPath);
 
         var documentHandles = ImmutableArray.Create(new DocumentSnapshotHandle(DocumentFilePath1, "document1.cshtml", "mvc"));


### PR DESCRIPTION
Fixes an issue Andrew found in speedometer tests. When opening files and modifying them, before we migrate the document to the "real" project, things get out of sync.

Also matches some stacks on PRISM, but I think this bug was only introduced in the last two weeks, so I don't think its the only cause thats for sure.