### PR TITLE
Avoid image load due to co-hosting and CLaSP

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostUriPresentationEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostUriPresentationEndpoint.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
 using Microsoft.CodeAnalysis.Razor.Logging;
-using Microsoft.CodeAnalysis.Razor.Protocol.DocumentPresentation;
 using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Text;
@@ -25,7 +24,7 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 [method: ImportingConstructor]
 #pragma warning restore RS0030 // Do not use banned APIs
 internal class CohostUriPresentationEndpoint(IRemoteClientProvider remoteClientProvider, ILoggerFactory loggerFactory)
-    : AbstractRazorCohostDocumentRequestHandler<UriPresentationParams, WorkspaceEdit?>, IDynamicRegistrationProvider
+    : AbstractRazorCohostDocumentRequestHandler<VSInternalUriPresentationParams, WorkspaceEdit?>, IDynamicRegistrationProvider
 {
     private readonly IRemoteClientProvider _remoteClientProvider = remoteClientProvider;
     private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<CohostUriPresentationEndpoint>();
@@ -51,10 +50,10 @@ internal class CohostUriPresentationEndpoint(IRemoteClientProvider remoteClientP
         return null;
     }
 
-    protected override RazorTextDocumentIdentifier? GetRazorTextDocumentIdentifier(UriPresentationParams request)
+    protected override RazorTextDocumentIdentifier? GetRazorTextDocumentIdentifier(VSInternalUriPresentationParams request)
         => request.TextDocument.ToRazorTextDocumentIdentifier();
 
-    protected override async Task<WorkspaceEdit?> HandleRequestAsync(UriPresentationParams request, RazorCohostRequestContext context, CancellationToken cancellationToken)
+    protected override async Task<WorkspaceEdit?> HandleRequestAsync(VSInternalUriPresentationParams request, RazorCohostRequestContext context, CancellationToken cancellationToken)
     {
         var razorDocument = context.TextDocument.AssumeNotNull();
 


### PR DESCRIPTION
There's a long discussion about this, but it turns out that CLaSP relies on MEF metadata that exposes System.Types. This means that MEF must load assemblies in order to produce metadata. Recently, one of our co-hosting endpoints unintentionally pulled in Microsoft.CodeAnalysis.Razor.Workspaces by using a protocol type from MS.CA.Razor.Workspaces as generic type argument. Since, CLaSP loads the type, it had to additionally load MS.CA.Razor.Workspaces to satisfy the generic argument.

The fix is easy -- just don't use that protocol type. However, that's not sustainable and this change has started a conversation about potential re-architecture to CLaSP to avoid eagerly loading assemblies.
