### PR TITLE
Uri Presentation Part 2, aka Cohost Html on-demand generation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,7 @@
 /global.json                                   @dotnet/razor-tooling @dotnet/razor-compiler
 /azure-pipelines.yml                           @dotnet/razor-tooling @dotnet/razor-compiler
 /eng/                                          @dotnet/razor-tooling @dotnet/razor-compiler
+/eng/targets/Services.props                    @dotnet/razor-tooling
 /eng/common/                                   @dotnet/razor-tooling @dotnet/razor-compiler
 /eng/Versions.props                            @dotnet/razor-tooling @dotnet/razor-compiler
 /eng/Version.Details.xml                       @dotnet/razor-tooling @dotnet/razor-compiler

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -11,82 +11,82 @@
       <Sha>9c1cc994f8123ec2a923c5179c238c13da1b4ab7</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.11.0-2.24259.2">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.11.0-2.24260.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
+      <Sha>324e078a9b47b62cd6dec6c78c6308c4540aa1e5</Sha>
     </Dependency>
     <Dependency Name="Microsoft.CommonLanguageServerProtocol.Framework" Version="4.11.0-1.24214.4">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>84c5476ef3111c9abd78d43e65063280bb7202d9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.ExternalAccess.Razor" Version="4.11.0-2.24259.2">
+    <Dependency Name="Microsoft.CodeAnalysis.ExternalAccess.Razor" Version="4.11.0-2.24260.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
+      <Sha>324e078a9b47b62cd6dec6c78c6308c4540aa1e5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Common" Version="4.11.0-2.24259.2">
+    <Dependency Name="Microsoft.CodeAnalysis.Common" Version="4.11.0-2.24260.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
+      <Sha>324e078a9b47b62cd6dec6c78c6308c4540aa1e5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.11.0-2.24259.2">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.11.0-2.24260.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
+      <Sha>324e078a9b47b62cd6dec6c78c6308c4540aa1e5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.EditorFeatures" Version="4.11.0-2.24259.2">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.EditorFeatures" Version="4.11.0-2.24260.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
+      <Sha>324e078a9b47b62cd6dec6c78c6308c4540aa1e5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="4.11.0-2.24259.2">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="4.11.0-2.24260.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
+      <Sha>324e078a9b47b62cd6dec6c78c6308c4540aa1e5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0-2.24259.2">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0-2.24260.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
+      <Sha>324e078a9b47b62cd6dec6c78c6308c4540aa1e5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures" Version="4.11.0-2.24259.2">
+    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures" Version="4.11.0-2.24260.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
+      <Sha>324e078a9b47b62cd6dec6c78c6308c4540aa1e5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Common" Version="4.11.0-2.24259.2">
+    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Common" Version="4.11.0-2.24260.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
+      <Sha>324e078a9b47b62cd6dec6c78c6308c4540aa1e5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Text" Version="4.11.0-2.24259.2">
+    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Text" Version="4.11.0-2.24260.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
+      <Sha>324e078a9b47b62cd6dec6c78c6308c4540aa1e5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Wpf" Version="4.11.0-2.24259.2">
+    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Wpf" Version="4.11.0-2.24260.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
+      <Sha>324e078a9b47b62cd6dec6c78c6308c4540aa1e5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Remote.ServiceHub" Version="4.11.0-2.24259.2">
+    <Dependency Name="Microsoft.CodeAnalysis.Remote.ServiceHub" Version="4.11.0-2.24260.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
+      <Sha>324e078a9b47b62cd6dec6c78c6308c4540aa1e5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.11.0-2.24259.2">
+    <Dependency Name="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.11.0-2.24260.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
+      <Sha>324e078a9b47b62cd6dec6c78c6308c4540aa1e5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.11.0-2.24259.2">
+    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.11.0-2.24260.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
+      <Sha>324e078a9b47b62cd6dec6c78c6308c4540aa1e5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.11.0-2.24259.2">
+    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.11.0-2.24260.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
+      <Sha>324e078a9b47b62cd6dec6c78c6308c4540aa1e5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.VisualStudio.LanguageServices" Version="4.11.0-2.24259.2">
+    <Dependency Name="Microsoft.VisualStudio.LanguageServices" Version="4.11.0-2.24260.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
+      <Sha>324e078a9b47b62cd6dec6c78c6308c4540aa1e5</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Test.Utilities" Version="4.11.0-2.24259.2">
+    <Dependency Name="Microsoft.CodeAnalysis.Test.Utilities" Version="4.11.0-2.24260.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
+      <Sha>324e078a9b47b62cd6dec6c78c6308c4540aa1e5</Sha>
     </Dependency>
     <!-- Intermediate is necessary for source build. -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.roslyn" Version="4.11.0-2.24259.2">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.roslyn" Version="4.11.0-2.24260.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
+      <Sha>324e078a9b47b62cd6dec6c78c6308c4540aa1e5</Sha>
       <SourceBuild RepoName="roslyn" ManagedOnly="true" />
     </Dependency>
   </ProductDependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -11,82 +11,82 @@
       <Sha>9c1cc994f8123ec2a923c5179c238c13da1b4ab7</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.11.0-1.24214.4">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.11.0-2.24259.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>84c5476ef3111c9abd78d43e65063280bb7202d9</Sha>
+      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
     </Dependency>
     <Dependency Name="Microsoft.CommonLanguageServerProtocol.Framework" Version="4.11.0-1.24214.4">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>84c5476ef3111c9abd78d43e65063280bb7202d9</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.ExternalAccess.Razor" Version="4.11.0-1.24214.4">
+    <Dependency Name="Microsoft.CodeAnalysis.ExternalAccess.Razor" Version="4.11.0-2.24259.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>84c5476ef3111c9abd78d43e65063280bb7202d9</Sha>
+      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Common" Version="4.11.0-1.24214.4">
+    <Dependency Name="Microsoft.CodeAnalysis.Common" Version="4.11.0-2.24259.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>84c5476ef3111c9abd78d43e65063280bb7202d9</Sha>
+      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.11.0-1.24214.4">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.11.0-2.24259.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>84c5476ef3111c9abd78d43e65063280bb7202d9</Sha>
+      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.EditorFeatures" Version="4.11.0-1.24214.4">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.EditorFeatures" Version="4.11.0-2.24259.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>84c5476ef3111c9abd78d43e65063280bb7202d9</Sha>
+      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="4.11.0-1.24214.4">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="4.11.0-2.24259.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>84c5476ef3111c9abd78d43e65063280bb7202d9</Sha>
+      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0-1.24214.4">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0-2.24259.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>84c5476ef3111c9abd78d43e65063280bb7202d9</Sha>
+      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures" Version="4.11.0-1.24214.4">
+    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures" Version="4.11.0-2.24259.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>84c5476ef3111c9abd78d43e65063280bb7202d9</Sha>
+      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Common" Version="4.11.0-1.24214.4">
+    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Common" Version="4.11.0-2.24259.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>84c5476ef3111c9abd78d43e65063280bb7202d9</Sha>
+      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Text" Version="4.11.0-1.24214.4">
+    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Text" Version="4.11.0-2.24259.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>84c5476ef3111c9abd78d43e65063280bb7202d9</Sha>
+      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Wpf" Version="4.11.0-1.24214.4">
+    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Wpf" Version="4.11.0-2.24259.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>84c5476ef3111c9abd78d43e65063280bb7202d9</Sha>
+      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Remote.ServiceHub" Version="4.11.0-1.24214.4">
+    <Dependency Name="Microsoft.CodeAnalysis.Remote.ServiceHub" Version="4.11.0-2.24259.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>84c5476ef3111c9abd78d43e65063280bb7202d9</Sha>
+      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.11.0-1.24214.4">
+    <Dependency Name="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.11.0-2.24259.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>84c5476ef3111c9abd78d43e65063280bb7202d9</Sha>
+      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.11.0-1.24214.4">
+    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.11.0-2.24259.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>84c5476ef3111c9abd78d43e65063280bb7202d9</Sha>
+      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.11.0-1.24214.4">
+    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.11.0-2.24259.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>84c5476ef3111c9abd78d43e65063280bb7202d9</Sha>
+      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.VisualStudio.LanguageServices" Version="4.11.0-1.24214.4">
+    <Dependency Name="Microsoft.VisualStudio.LanguageServices" Version="4.11.0-2.24259.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>84c5476ef3111c9abd78d43e65063280bb7202d9</Sha>
+      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Test.Utilities" Version="4.11.0-1.24214.4">
+    <Dependency Name="Microsoft.CodeAnalysis.Test.Utilities" Version="4.11.0-2.24259.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>84c5476ef3111c9abd78d43e65063280bb7202d9</Sha>
+      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
     </Dependency>
     <!-- Intermediate is necessary for source build. -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.roslyn" Version="4.11.0-1.24214.4">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.roslyn" Version="4.11.0-2.24259.2">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>84c5476ef3111c9abd78d43e65063280bb7202d9</Sha>
+      <Sha>c23414e1365f21c6bd34ab5b007546066f25b5d4</Sha>
       <SourceBuild RepoName="roslyn" ManagedOnly="true" />
     </Dependency>
   </ProductDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -53,25 +53,25 @@
     <MicrosoftSourceBuildIntermediatearcadePackageVersion>8.0.0-beta.24204.3</MicrosoftSourceBuildIntermediatearcadePackageVersion>
     <MicrosoftDotNetXliffTasksPackageVersion>1.0.0-beta.23475.1</MicrosoftDotNetXliffTasksPackageVersion>
     <MicrosoftSourceBuildIntermediatexlifftasksPackageVersion>1.0.0-beta.23475.1</MicrosoftSourceBuildIntermediatexlifftasksPackageVersion>
-    <MicrosoftNetCompilersToolsetPackageVersion>4.11.0-1.24214.4</MicrosoftNetCompilersToolsetPackageVersion>
+    <MicrosoftNetCompilersToolsetPackageVersion>4.11.0-2.24259.2</MicrosoftNetCompilersToolsetPackageVersion>
     <MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>4.11.0-1.24214.4</MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>
-    <MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>4.11.0-1.24214.4</MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>
-    <MicrosoftCodeAnalysisCommonPackageVersion>4.11.0-1.24214.4</MicrosoftCodeAnalysisCommonPackageVersion>
-    <MicrosoftCodeAnalysisCSharpPackageVersion>4.11.0-1.24214.4</MicrosoftCodeAnalysisCSharpPackageVersion>
-    <MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion>4.11.0-1.24214.4</MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.11.0-1.24214.4</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>4.11.0-1.24214.4</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
-    <MicrosoftCodeAnalysisEditorFeaturesPackageVersion>4.11.0-1.24214.4</MicrosoftCodeAnalysisEditorFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisEditorFeaturesCommonPackageVersion>4.11.0-1.24214.4</MicrosoftCodeAnalysisEditorFeaturesCommonPackageVersion>
-    <MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>4.11.0-1.24214.4</MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>
-    <MicrosoftCodeAnalysisEditorFeaturesWpfPackageVersion>4.11.0-1.24214.4</MicrosoftCodeAnalysisEditorFeaturesWpfPackageVersion>
-    <MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>4.11.0-1.24214.4</MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>
-    <MicrosoftCodeAnalysisTestUtilitiesPackageVersion>4.11.0-1.24214.4</MicrosoftCodeAnalysisTestUtilitiesPackageVersion>
-    <MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>4.11.0-1.24214.4</MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>
-    <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>4.11.0-1.24214.4</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
-    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.11.0-1.24214.4</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
-    <MicrosoftSourceBuildIntermediateroslynPackageVersion>4.11.0-1.24214.4</MicrosoftSourceBuildIntermediateroslynPackageVersion>
-    <MicrosoftVisualStudioLanguageServicesPackageVersion>4.11.0-1.24214.4</MicrosoftVisualStudioLanguageServicesPackageVersion>
+    <MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>4.11.0-2.24259.2</MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>
+    <MicrosoftCodeAnalysisCommonPackageVersion>4.11.0-2.24259.2</MicrosoftCodeAnalysisCommonPackageVersion>
+    <MicrosoftCodeAnalysisCSharpPackageVersion>4.11.0-2.24259.2</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion>4.11.0-2.24259.2</MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.11.0-2.24259.2</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>4.11.0-2.24259.2</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisEditorFeaturesPackageVersion>4.11.0-2.24259.2</MicrosoftCodeAnalysisEditorFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisEditorFeaturesCommonPackageVersion>4.11.0-2.24259.2</MicrosoftCodeAnalysisEditorFeaturesCommonPackageVersion>
+    <MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>4.11.0-2.24259.2</MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>
+    <MicrosoftCodeAnalysisEditorFeaturesWpfPackageVersion>4.11.0-2.24259.2</MicrosoftCodeAnalysisEditorFeaturesWpfPackageVersion>
+    <MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>4.11.0-2.24259.2</MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>
+    <MicrosoftCodeAnalysisTestUtilitiesPackageVersion>4.11.0-2.24259.2</MicrosoftCodeAnalysisTestUtilitiesPackageVersion>
+    <MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>4.11.0-2.24259.2</MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>4.11.0-2.24259.2</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.11.0-2.24259.2</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
+    <MicrosoftSourceBuildIntermediateroslynPackageVersion>4.11.0-2.24259.2</MicrosoftSourceBuildIntermediateroslynPackageVersion>
+    <MicrosoftVisualStudioLanguageServicesPackageVersion>4.11.0-2.24259.2</MicrosoftVisualStudioLanguageServicesPackageVersion>
     <!--
       Exception - Microsoft.Extensions.ObjectPool and System.Collections.Immutable packages are not updated by automation,
       but are present in Version.Details.xml for source-build PVP flow. See the comment in Version.Details.xml for more information.

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -53,25 +53,25 @@
     <MicrosoftSourceBuildIntermediatearcadePackageVersion>8.0.0-beta.24204.3</MicrosoftSourceBuildIntermediatearcadePackageVersion>
     <MicrosoftDotNetXliffTasksPackageVersion>1.0.0-beta.23475.1</MicrosoftDotNetXliffTasksPackageVersion>
     <MicrosoftSourceBuildIntermediatexlifftasksPackageVersion>1.0.0-beta.23475.1</MicrosoftSourceBuildIntermediatexlifftasksPackageVersion>
-    <MicrosoftNetCompilersToolsetPackageVersion>4.11.0-2.24259.2</MicrosoftNetCompilersToolsetPackageVersion>
+    <MicrosoftNetCompilersToolsetPackageVersion>4.11.0-2.24260.2</MicrosoftNetCompilersToolsetPackageVersion>
     <MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>4.11.0-1.24214.4</MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>
-    <MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>4.11.0-2.24259.2</MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>
-    <MicrosoftCodeAnalysisCommonPackageVersion>4.11.0-2.24259.2</MicrosoftCodeAnalysisCommonPackageVersion>
-    <MicrosoftCodeAnalysisCSharpPackageVersion>4.11.0-2.24259.2</MicrosoftCodeAnalysisCSharpPackageVersion>
-    <MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion>4.11.0-2.24259.2</MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.11.0-2.24259.2</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>4.11.0-2.24259.2</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
-    <MicrosoftCodeAnalysisEditorFeaturesPackageVersion>4.11.0-2.24259.2</MicrosoftCodeAnalysisEditorFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisEditorFeaturesCommonPackageVersion>4.11.0-2.24259.2</MicrosoftCodeAnalysisEditorFeaturesCommonPackageVersion>
-    <MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>4.11.0-2.24259.2</MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>
-    <MicrosoftCodeAnalysisEditorFeaturesWpfPackageVersion>4.11.0-2.24259.2</MicrosoftCodeAnalysisEditorFeaturesWpfPackageVersion>
-    <MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>4.11.0-2.24259.2</MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>
-    <MicrosoftCodeAnalysisTestUtilitiesPackageVersion>4.11.0-2.24259.2</MicrosoftCodeAnalysisTestUtilitiesPackageVersion>
-    <MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>4.11.0-2.24259.2</MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>
-    <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>4.11.0-2.24259.2</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
-    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.11.0-2.24259.2</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
-    <MicrosoftSourceBuildIntermediateroslynPackageVersion>4.11.0-2.24259.2</MicrosoftSourceBuildIntermediateroslynPackageVersion>
-    <MicrosoftVisualStudioLanguageServicesPackageVersion>4.11.0-2.24259.2</MicrosoftVisualStudioLanguageServicesPackageVersion>
+    <MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>4.11.0-2.24260.2</MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>
+    <MicrosoftCodeAnalysisCommonPackageVersion>4.11.0-2.24260.2</MicrosoftCodeAnalysisCommonPackageVersion>
+    <MicrosoftCodeAnalysisCSharpPackageVersion>4.11.0-2.24260.2</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion>4.11.0-2.24260.2</MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.11.0-2.24260.2</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>4.11.0-2.24260.2</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisEditorFeaturesPackageVersion>4.11.0-2.24260.2</MicrosoftCodeAnalysisEditorFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisEditorFeaturesCommonPackageVersion>4.11.0-2.24260.2</MicrosoftCodeAnalysisEditorFeaturesCommonPackageVersion>
+    <MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>4.11.0-2.24260.2</MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>
+    <MicrosoftCodeAnalysisEditorFeaturesWpfPackageVersion>4.11.0-2.24260.2</MicrosoftCodeAnalysisEditorFeaturesWpfPackageVersion>
+    <MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>4.11.0-2.24260.2</MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>
+    <MicrosoftCodeAnalysisTestUtilitiesPackageVersion>4.11.0-2.24260.2</MicrosoftCodeAnalysisTestUtilitiesPackageVersion>
+    <MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>4.11.0-2.24260.2</MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>4.11.0-2.24260.2</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.11.0-2.24260.2</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
+    <MicrosoftSourceBuildIntermediateroslynPackageVersion>4.11.0-2.24260.2</MicrosoftSourceBuildIntermediateroslynPackageVersion>
+    <MicrosoftVisualStudioLanguageServicesPackageVersion>4.11.0-2.24260.2</MicrosoftVisualStudioLanguageServicesPackageVersion>
     <!--
       Exception - Microsoft.Extensions.ObjectPool and System.Collections.Immutable packages are not updated by automation,
       but are present in Version.Details.xml for source-build PVP flow. See the comment in Version.Details.xml for more information.

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentPresentation/TextDocumentUriPresentationEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentPresentation/TextDocumentUriPresentationEndpoint.cs
@@ -51,7 +51,13 @@ internal class TextDocumentUriPresentationEndpoint(
 
     protected override async Task<WorkspaceEdit?> TryGetRazorWorkspaceEditAsync(RazorLanguageKind languageKind, UriPresentationParams request, CancellationToken cancellationToken)
     {
-        var razorFileUri = UriPresentationHelper.GetComponentFileNameFromUriPresentationRequest(languageKind, request.Uris, Logger);
+        if (languageKind is not RazorLanguageKind.Html)
+        {
+            // Component tags can only be inserted into Html contexts, so if this isn't Html there is nothing we can do.
+            return null;
+        }
+
+        var razorFileUri = UriPresentationHelper.GetComponentFileNameFromUriPresentationRequest( request.Uris, Logger);
         if (razorFileUri == null)
         {
             return null;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentPresentation/TextDocumentUriPresentationEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentPresentation/TextDocumentUriPresentationEndpoint.cs
@@ -57,7 +57,7 @@ internal class TextDocumentUriPresentationEndpoint(
             return null;
         }
 
-        var razorFileUri = UriPresentationHelper.GetComponentFileNameFromUriPresentationRequest( request.Uris, Logger);
+        var razorFileUri = UriPresentationHelper.GetComponentFileNameFromUriPresentationRequest(request.Uris, Logger);
         if (razorFileUri == null)
         {
             return null;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentPresentation/UriPresentationHelper.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentPresentation/UriPresentationHelper.cs
@@ -5,20 +5,13 @@ using System;
 using System.IO;
 using System.Linq;
 using Microsoft.CodeAnalysis.Razor.Logging;
-using Microsoft.CodeAnalysis.Razor.Protocol;
 
 namespace Microsoft.CodeAnalysis.Razor.DocumentPresentation;
 
 internal static class UriPresentationHelper
 {
-    public static Uri? GetComponentFileNameFromUriPresentationRequest(RazorLanguageKind languageKind, Uri[]? uris, ILogger logger)
+    public static Uri? GetComponentFileNameFromUriPresentationRequest(Uri[]? uris, ILogger logger)
     {
-        if (languageKind is not RazorLanguageKind.Html)
-        {
-            // Component tags can only be inserted into Html contexts, so if this isn't Html there is nothing we can do.
-            return null;
-        }
-
         if (uris is null || uris.Length == 0)
         {
             logger.LogDebug($"No URIs were included in the request?");

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/HtmlDocuments/RemoteHtmlDocumentService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/HtmlDocuments/RemoteHtmlDocumentService.cs
@@ -19,10 +19,10 @@ internal sealed class RemoteHtmlDocumentService(
 {
     public ValueTask<string?> GetHtmlDocumentTextAsync(RazorPinnedSolutionInfoWrapper solutionInfo, DocumentId razorDocumentId, CancellationToken cancellationToken)
        => RazorBrokeredServiceImplementation.RunServiceAsync(
-            solutionInfo,
-            ServiceBrokerClient,
-            solution => GetHtmlDocumentTextAsync(solution, razorDocumentId, cancellationToken),
-            cancellationToken);
+           solutionInfo,
+           ServiceBrokerClient,
+           solution => GetHtmlDocumentTextAsync(solution, razorDocumentId, cancellationToken),
+           cancellationToken);
 
     private async ValueTask<string?> GetHtmlDocumentTextAsync(Solution solution, DocumentId razorDocumentId, CancellationToken _)
     {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/UriPresentation/RemoteUriPresentationService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/UriPresentation/RemoteUriPresentationService.cs
@@ -54,7 +54,16 @@ internal sealed class RemoteUriPresentationService(
 
         var languageKind = _documentMappingService.GetLanguageKind(codeDocument, index, rightAssociative: true);
 
-        var razorFileUri = UriPresentationHelper.GetComponentFileNameFromUriPresentationRequest(languageKind, uris, _logger);
+        if (languageKind is not RazorLanguageKind.Html)
+        {
+            // Roslyn doesn't currently support Uri presentation, and whilst it might seem counter intuitive,
+            // our support for Uri presentation is to insert a Html tag, so we only support Html
+
+            // If Roslyn add support in future then this is where it would go.
+            return null;
+        }
+
+        var razorFileUri = UriPresentationHelper.GetComponentFileNameFromUriPresentationRequest(uris, _logger);
         if (razorFileUri is null)
         {
             return null;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/UriPresentation/RemoteUriPresentationService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/UriPresentation/RemoteUriPresentationService.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.ExternalAccess.Razor.Api;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.DocumentPresentation;
 using Microsoft.CodeAnalysis.Razor.Logging;
+using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
@@ -69,7 +70,9 @@ internal sealed class RemoteUriPresentationService(
             return null;
         }
 
-        var ids = razorDocument.Project.Solution.GetDocumentIdsWithFilePath(GetDocumentFilePathFromUri(razorFileUri));
+        // Make sure we go through Roslyn to go from the Uri the client sent us, to one that it has a chance of finding in the solution
+        var uriToFind = RazorUri.GetDocumentFilePathFromUri(razorFileUri);
+        var ids = razorDocument.Project.Solution.GetDocumentIdsWithFilePath(uriToFind);
         if (ids.Length == 0)
         {
             return null;
@@ -98,8 +101,4 @@ internal sealed class RemoteUriPresentationService(
 
         return new TextChange(span.ToTextSpan(sourceText), tag);
     }
-
-    // TODO: Call the real Roslyn API once https://github.com/dotnet/roslyn/pull/73289 is merged
-    public static string GetDocumentFilePathFromUri(Uri uri)
-        => uri.IsFile ? uri.LocalPath : uri.AbsoluteUri;
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostUriPresentationEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostUriPresentationEndpoint.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Razor.LanguageClient.Extensions;
 
@@ -23,10 +24,18 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 [ExportCohostStatelessLspService(typeof(CohostUriPresentationEndpoint))]
 [method: ImportingConstructor]
 #pragma warning restore RS0030 // Do not use banned APIs
-internal class CohostUriPresentationEndpoint(IRemoteClientProvider remoteClientProvider, ILoggerFactory loggerFactory)
+internal class CohostUriPresentationEndpoint(
+    IRemoteClientProvider remoteClientProvider,
+    IHtmlDocumentSynchronizer htmlDocumentSynchronizer,
+    IFilePathService filePathService,
+    LSPRequestInvoker requestInvoker,
+    ILoggerFactory loggerFactory)
     : AbstractRazorCohostDocumentRequestHandler<VSInternalUriPresentationParams, WorkspaceEdit?>, IDynamicRegistrationProvider
 {
     private readonly IRemoteClientProvider _remoteClientProvider = remoteClientProvider;
+    private readonly IHtmlDocumentSynchronizer _htmlDocumentSynchronizer = htmlDocumentSynchronizer;
+    private readonly IFilePathService _filePathService = filePathService;
+    private readonly LSPRequestInvoker _requestInvoker = requestInvoker;
     private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<CohostUriPresentationEndpoint>();
 
     protected override bool MutatesSolutionState => false;
@@ -71,6 +80,7 @@ internal class CohostUriPresentationEndpoint(IRemoteClientProvider remoteClientP
                 (service, solutionInfo, cancellationToken) => service.GetPresentationAsync(solutionInfo, razorDocument.Id, request.Range.ToLinePositionSpan(), request.Uris, cancellationToken),
                 cancellationToken).ConfigureAwait(false);
 
+            // If we got a response back, then either Razor or C# wants to do something with this, so we're good to go
             if (data.Value is { } textChange)
             {
                 var sourceText = await razorDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
@@ -97,6 +107,50 @@ internal class CohostUriPresentationEndpoint(IRemoteClientProvider remoteClientP
             return null;
         }
 
-        return null;
+        // If we didn't get anything from Razor or Roslyn, lets ask Html what they want to do
+        var htmlDocument = await _htmlDocumentSynchronizer.TryGetSynchronizedHtmlDocumentAsync(razorDocument, cancellationToken).ConfigureAwait(false);
+        if (htmlDocument is null)
+        {
+            return null;
+        }
+
+        var presentationParams = new UriPresentationParams
+        {
+            Range = request.Range,
+            Uris = request.Uris,
+            TextDocument = new TextDocumentIdentifier { Uri = htmlDocument.Uri }
+        };
+
+        var result = await _requestInvoker.ReinvokeRequestOnServerAsync<UriPresentationParams, WorkspaceEdit?>(
+            htmlDocument.Buffer,
+            VSInternalMethods.TextDocumentUriPresentationName,
+            RazorLSPConstants.HtmlLanguageServerName,
+            presentationParams,
+            cancellationToken).ConfigureAwait(false);
+
+        // TODO: We _really_ should go back to OOP to remap the response to razor, but the fact is, Razor and Html are 1:1 mappings, so we're
+        //       just adjusting Uris, and we don't need OOP for that. If we ever do proper Html mapping then this will not be true.
+
+        if (result?.Response is not { } workspaceEdit)
+        {
+            return null;
+        }
+
+        if (!workspaceEdit.TryGetDocumentChanges(out var edits))
+        {
+            return null;
+        }
+
+        // TODO: We could have a helper service for this, because RazorDocumentMappingService used to do it, but we can't use that in devenv,
+        //       but if we move this all to OOP, per the above TODO, then that point is moot.
+        foreach (var edit in edits)
+        {
+            if (_filePathService.IsVirtualHtmlFile(edit.TextDocument.Uri))
+            {
+                edit.TextDocument = new OptionalVersionedTextDocumentIdentifier { Uri = _filePathService.GetRazorDocumentUri(edit.TextDocument.Uri) };
+            }
+        }
+
+        return workspaceEdit;
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostUriPresentationEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostUriPresentationEndpoint.cs
@@ -114,14 +114,14 @@ internal class CohostUriPresentationEndpoint(
             return null;
         }
 
-        var presentationParams = new UriPresentationParams
+        var presentationParams = new VSInternalUriPresentationParams
         {
             Range = request.Range,
             Uris = request.Uris,
             TextDocument = new TextDocumentIdentifier { Uri = htmlDocument.Uri }
         };
 
-        var result = await _requestInvoker.ReinvokeRequestOnServerAsync<UriPresentationParams, WorkspaceEdit?>(
+        var result = await _requestInvoker.ReinvokeRequestOnServerAsync<VSInternalUriPresentationParams, WorkspaceEdit?>(
             htmlDocument.Buffer,
             VSInternalMethods.TextDocumentUriPresentationName,
             RazorLSPConstants.HtmlLanguageServerName,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentPublisher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentPublisher.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.Razor.Logging;
+using Microsoft.CodeAnalysis.Razor.Remote;
+using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+
+[Export(typeof(IHtmlDocumentPublisher))]
+[method: ImportingConstructor]
+internal sealed class HtmlDocumentPublisher(
+    IRemoteClientProvider remoteClientProvider,
+    LSPDocumentManager documentManager,
+    JoinableTaskContext joinableTaskContext,
+    ILoggerFactory loggerFactory) : IHtmlDocumentPublisher
+{
+    private readonly IRemoteClientProvider _remoteClientProvider = remoteClientProvider;
+    private readonly JoinableTaskContext _joinableTaskContext = joinableTaskContext;
+    private readonly TrackingLSPDocumentManager _documentManager = documentManager as TrackingLSPDocumentManager ?? throw new InvalidOperationException("Expected TrackingLSPDocumentManager");
+    private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<HtmlDocumentPublisher>();
+
+    public async Task<string?> GetHtmlSourceFromOOPAsync(TextDocument document, CancellationToken cancellationToken)
+    {
+        var client = await _remoteClientProvider.TryGetClientAsync(cancellationToken).ConfigureAwait(false);
+        if (client is null)
+        {
+            _logger.LogError($"Couldn't get remote client for html document generation for {document.FilePath}. Html document contents will be stale");
+            return null;
+        }
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return null;
+        }
+
+        var htmlText = await client.TryInvokeAsync<IRemoteHtmlDocumentService, string?>(document.Project.Solution,
+            (service, solutionInfo, ct) => service.GetHtmlDocumentTextAsync(solutionInfo, document.Id, ct),
+            cancellationToken).ConfigureAwait(false);
+
+        return htmlText.Value;
+    }
+
+    public async Task PublishAsync(TextDocument document, string htmlText, CancellationToken cancellationToken)
+    {
+        // TODO: Eventually, for VS Code, the following piece of logic needs to make an LSP call rather than directly update the
+        // buffer, but the assembly this code currently lives in doesn't ship in VS Code, so we need to solve a few other things
+        // before we get there.
+
+        var uri = document.CreateUri();
+        if (!_documentManager.TryGetDocument(uri, out var documentSnapshot) ||
+            !documentSnapshot.TryGetVirtualDocument<HtmlVirtualDocumentSnapshot>(out var htmlDocument))
+        {
+            Debug.Fail("Got an LSP text document update before getting informed of the VS buffer. Create on demand?");
+            _logger.LogError($"Couldn't get Html text for {document.FilePath}. Html document contents will be stale");
+            return;
+        }
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+
+        _logger.LogDebug($"The html document for {document.FilePath} is {uri}");
+
+        await _joinableTaskContext.Factory.SwitchToMainThreadAsync(cancellationToken);
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+
+        VisualStudioTextChange[] changes = [new(0, htmlDocument.Snapshot.Length, htmlText)];
+        _documentManager.UpdateVirtualDocument<HtmlVirtualDocument>(uri, changes, documentSnapshot.Version, state: null);
+
+        _logger.LogDebug($"Finished Html document generation for {document.FilePath} (into {uri})");
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentResult.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentResult.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.VisualStudio.Text;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+
+internal record HtmlDocumentResult(Uri Uri, ITextBuffer Buffer);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentSynchronizer.RazorDocumentVersion.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentSynchronizer.RazorDocumentVersion.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+
+internal sealed partial class HtmlDocumentSynchronizer
+{
+    private readonly struct RazorDocumentVersion(int workspaceVersion, ChecksumWrapper checksum)
+    {
+        internal int WorkspaceVersion => workspaceVersion;
+        internal ChecksumWrapper Checksum => checksum;
+
+        public override string ToString()
+            => $"Checksum {checksum} from workspace version {workspaceVersion}";
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentSynchronizer.RazorDocumentVersion.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentSynchronizer.RazorDocumentVersion.cs
@@ -1,18 +1,30 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
+using System.Threading;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis;
 
 namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 
 internal sealed partial class HtmlDocumentSynchronizer
 {
-    private readonly struct RazorDocumentVersion(int workspaceVersion, ChecksumWrapper checksum)
+    internal readonly struct RazorDocumentVersion(int workspaceVersion, ChecksumWrapper checksum)
     {
         internal int WorkspaceVersion => workspaceVersion;
         internal ChecksumWrapper Checksum => checksum;
 
         public override string ToString()
             => $"Checksum {checksum} from workspace version {workspaceVersion}";
+
+        internal static async Task<RazorDocumentVersion> CreateAsync(TextDocument razorDocument, CancellationToken cancellationToken)
+        {
+            var workspaceVersion = razorDocument.Project.Solution.GetWorkspaceVersion();
+
+            var checksum = await razorDocument.GetChecksumAsync(cancellationToken).ConfigureAwait(false);
+
+            return new RazorDocumentVersion(workspaceVersion, checksum);
+        }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentSynchronizer.RazorDocumentVersion.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentSynchronizer.RazorDocumentVersion.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System.Threading.Tasks;
 using System.Threading;
-using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 
 namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentSynchronizer.SynchronizationRequest.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentSynchronizer.SynchronizationRequest.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+
+internal sealed partial class HtmlDocumentSynchronizer
+{
+    private class SynchronizationRequest(RazorDocumentVersion requestedVersion) : IDisposable
+    {
+        private readonly RazorDocumentVersion _requestedVersion = requestedVersion;
+        private readonly TaskCompletionSource<bool> _tcs = new();
+        private readonly CancellationTokenSource _cts = new(TimeSpan.FromMinutes(5));
+
+        public Task<bool> Task => _tcs.Task;
+
+        public RazorDocumentVersion RequestedVersion => _requestedVersion;
+
+        internal static SynchronizationRequest CreateAndStart(TextDocument document, RazorDocumentVersion requestedVersion, Func<TextDocument, CancellationToken, Task> syncFunction)
+        {
+            var request = new SynchronizationRequest(requestedVersion);
+            request.Start(document, syncFunction);
+            return request;
+        }
+
+        private void Start(TextDocument document, Func<TextDocument, CancellationToken, Task> syncFunction)
+        {
+            _cts.Token.Register(Dispose);
+            _ = syncFunction.Invoke(document, _cts.Token).ContinueWith((t, state) =>
+            {
+                var tcs = (TaskCompletionSource<bool>)state;
+                if (t.IsCanceled)
+                {
+                    tcs.SetResult(false);
+                }
+                else if (t.Exception is { } ex)
+                {
+                    tcs.SetException(ex);
+                }
+                else
+                {
+                    _cts.Dispose();
+                    tcs.SetResult(true);
+                }
+            }, _tcs, _cts.Token, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+        }
+
+        public void Dispose()
+        {
+            _cts.Cancel();
+            _cts.Dispose();
+            _tcs.SetResult(false);
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentSynchronizer.SynchronizationRequest.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentSynchronizer.SynchronizationRequest.cs
@@ -53,7 +53,7 @@ internal sealed partial class HtmlDocumentSynchronizer
         {
             _cts.Cancel();
             _cts.Dispose();
-            _tcs.SetResult(false);
+            _tcs.TrySetResult(false);
         }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentSynchronizer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentSynchronizer.cs
@@ -55,7 +55,7 @@ internal sealed partial class HtmlDocumentSynchronizer(
 
     public async Task<bool> TrySynchronizeAsync(TextDocument document, CancellationToken cancellationToken)
     {
-        var requestedVersion = await GetDocumentVersionAsync(document, cancellationToken).ConfigureAwait(false);
+        var requestedVersion = await RazorDocumentVersion.CreateAsync(document, cancellationToken).ConfigureAwait(false);
 
         _logger.LogDebug($"TrySynchronize for {document.FilePath} as at {requestedVersion}");
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentSynchronizer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentSynchronizer.cs
@@ -40,18 +40,20 @@ internal sealed partial class HtmlDocumentSynchronizer(
 
         if (!_documentManager.TryGetDocument(razorDocument.CreateUri(), out var snapshot))
         {
+            _logger.LogError($"Couldn't find document in LSPDocumentManager for {razorDocument.FilePath}");
             return null;
         }
 
         if (!snapshot.TryGetVirtualDocument<HtmlVirtualDocumentSnapshot>(out var document))
         {
+            _logger.LogError($"Couldn't find virtual document snapshot for {snapshot.Uri}");
             return null;
         }
 
         return new HtmlDocumentResult(document.Uri, document.Snapshot.TextBuffer);
     }
 
-    private async Task<bool> TrySynchronizeAsync(TextDocument document, CancellationToken cancellationToken)
+    public async Task<bool> TrySynchronizeAsync(TextDocument document, CancellationToken cancellationToken)
     {
         var requestedVersion = await GetDocumentVersionAsync(document, cancellationToken).ConfigureAwait(false);
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentSynchronizer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentSynchronizer.cs
@@ -114,14 +114,15 @@ internal sealed partial class HtmlDocumentSynchronizer(
     {
         var htmlText = await _htmlDocumentPublisher.GetHtmlSourceFromOOPAsync(document, cancellationToken).ConfigureAwait(false);
 
-        if (htmlText is null)
+        if (cancellationToken.IsCancellationRequested)
         {
-            _logger.LogError($"Couldn't get Html text for {document.FilePath}. Html document contents will be stale");
+            // Checking cancellation before logging, as a new request coming in doesn't count as "Couldn't get Html"
             return;
         }
 
-        if (cancellationToken.IsCancellationRequested)
+        if (htmlText is null)
         {
+            _logger.LogError($"Couldn't get Html text for {document.FilePath}. Html document contents will be stale");
             return;
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentSynchronizer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentSynchronizer.cs
@@ -129,12 +129,21 @@ internal sealed partial class HtmlDocumentSynchronizer(
         await _htmlDocumentPublisher.PublishAsync(document, htmlText, cancellationToken).ConfigureAwait(false);
     }
 
-    private static async Task<RazorDocumentVersion> GetDocumentVersionAsync(TextDocument razorDocument, CancellationToken cancellationToken)
+    internal TestAccessor GetTestAccessor()
     {
-        var workspaceVersion = razorDocument.Project.Solution.GetWorkspaceVersion();
+        return new TestAccessor(this);
+    }
 
-        var checksum = await razorDocument.GetChecksumAsync(cancellationToken).ConfigureAwait(false);
+    internal readonly struct TestAccessor
+    {
+        private readonly HtmlDocumentSynchronizer _instance;
 
-        return new RazorDocumentVersion(workspaceVersion, checksum);
+        internal TestAccessor(HtmlDocumentSynchronizer instance)
+        {
+            _instance = instance;
+        }
+
+        public Task<bool> GetSynchronizationRequestTaskAsync(TextDocument document, RazorDocumentVersion requestedVersion)
+            => _instance.GetSynchronizationRequestTaskAsync(document, requestedVersion);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentSynchronizer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentSynchronizer.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.Razor.Logging;
+using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+
+[Export(typeof(IHtmlDocumentSynchronizer))]
+[method: ImportingConstructor]
+internal sealed partial class HtmlDocumentSynchronizer(
+    LSPDocumentManager documentManager,
+    IHtmlDocumentPublisher htmlDocumentPublisher,
+    ILoggerFactory loggerFactory)
+    : IHtmlDocumentSynchronizer
+{
+    private static readonly Task<bool> s_falseTask = Task.FromResult(false);
+
+    private readonly IHtmlDocumentPublisher _htmlDocumentPublisher = htmlDocumentPublisher;
+    private readonly TrackingLSPDocumentManager _documentManager = documentManager as TrackingLSPDocumentManager ?? throw new InvalidOperationException("Expected TrackingLSPDocumentManager");
+    private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<HtmlDocumentSynchronizer>();
+
+    private readonly Dictionary<DocumentId, SynchronizationRequest> _synchronizationRequests = [];
+    private readonly object _gate = new();
+
+    public async Task<HtmlDocumentResult?> TryGetSynchronizedHtmlDocumentAsync(TextDocument razorDocument, CancellationToken cancellationToken)
+    {
+        var syncResult = await TrySynchronizeAsync(razorDocument, cancellationToken).ConfigureAwait(false);
+        if (!syncResult)
+        {
+            return null;
+        }
+
+        if (!_documentManager.TryGetDocument(razorDocument.CreateUri(), out var snapshot))
+        {
+            return null;
+        }
+
+        if (!snapshot.TryGetVirtualDocument<HtmlVirtualDocumentSnapshot>(out var document))
+        {
+            return null;
+        }
+
+        return new HtmlDocumentResult(document.Uri, document.Snapshot.TextBuffer);
+    }
+
+    private async Task<bool> TrySynchronizeAsync(TextDocument document, CancellationToken cancellationToken)
+    {
+        var requestedVersion = await GetDocumentVersionAsync(document, cancellationToken).ConfigureAwait(false);
+
+        _logger.LogDebug($"TrySynchronize for {document.FilePath} as at {requestedVersion}");
+
+        // We are not passing on the cancellation token through to the actual task that does the generation, because
+        // we do the actual work on whatever happens to be the first request that needs Html, without knowing how important
+        // that request is, nor why it might be cancelled. If that request is cancelled because of a document update,
+        // then the next request will cancel any work we start anyway, and if that request was cancelled for some other reason,
+        // then the next request probably wants the same version of the document, so we've got a head start.
+        return await GetSynchronizationRequestTaskAsync(document, requestedVersion).ConfigureAwait(false);
+    }
+
+    private Task<bool> GetSynchronizationRequestTaskAsync(TextDocument document, RazorDocumentVersion requestedVersion)
+    {
+        lock (_gate)
+        {
+            if (_synchronizationRequests.TryGetValue(document.Id, out var request))
+            {
+                if (requestedVersion.Checksum.Equals(request.RequestedVersion.Checksum))
+                {
+                    // Two documents are always equal if their checksums are equal, for the purposes of Html document generation, because
+                    // Html documents don't require semantic information. WorkspaceVersion changed too often to be used as a measure
+                    // of equality for this purpose.
+
+                    _logger.LogDebug($"Already {(request.Task.IsCompleted ? "finished" : "working on")} that version for {document.FilePath}");
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks
+                    return request.Task;
+#pragma warning restore VSTHRD003 // Avoid awaiting foreign Tasks
+                }
+                else if (requestedVersion.WorkspaceVersion < request.RequestedVersion.WorkspaceVersion)
+                {
+                    // We know the documents aren't the same, but checksums can't tell us which is newer, so we use WorkspaceVersion for that.
+                    // It is theoretically possible, however, that two different documents could have the same WorkspaceVersion, so we use the
+                    // fact that LSP change messages are strictly ordered, and only move the document forward, such that if we get a request
+                    // for a different checksum, but the same workspace version, we assume the new request is the newer document.
+
+                    _logger.LogDebug($"We've already seen {request.RequestedVersion} for {document.FilePath} so that's a no from me");
+                    return s_falseTask;
+                }
+                else if (!request.Task.IsCompleted)
+                {
+                    // We've had a previous request, but this is newer, and our previous work hasn't finished yet
+                    _logger.LogDebug($"We were working on {request.RequestedVersion} for {document.FilePath} but you're newer so we're giving up on that");
+                    request.Dispose();
+                }
+            }
+
+            _logger.LogDebug($"Going to start working on Html for {document.FilePath} as at {requestedVersion}");
+
+            var newRequest = SynchronizationRequest.CreateAndStart(document, requestedVersion, PublishHtmlDocumentAsync);
+            _synchronizationRequests[document.Id] = newRequest;
+            return newRequest.Task;
+        }
+    }
+
+    private async Task PublishHtmlDocumentAsync(TextDocument document, CancellationToken cancellationToken)
+    {
+        var htmlText = await _htmlDocumentPublisher.GetHtmlSourceFromOOPAsync(document, cancellationToken).ConfigureAwait(false);
+
+        if (htmlText is null)
+        {
+            _logger.LogError($"Couldn't get Html text for {document.FilePath}. Html document contents will be stale");
+            return;
+        }
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+
+        await _htmlDocumentPublisher.PublishAsync(document, htmlText, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<RazorDocumentVersion> GetDocumentVersionAsync(TextDocument razorDocument, CancellationToken cancellationToken)
+    {
+        var workspaceVersion = razorDocument.Project.Solution.GetWorkspaceVersion();
+
+        var checksum = await razorDocument.GetChecksumAsync(cancellationToken).ConfigureAwait(false);
+
+        return new RazorDocumentVersion(workspaceVersion, checksum);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/IHtmlDocumentPublisher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/IHtmlDocumentPublisher.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+
+internal interface IHtmlDocumentPublisher
+{
+    Task<string?> GetHtmlSourceFromOOPAsync(TextDocument document, CancellationToken cancellationToken);
+    Task PublishAsync(TextDocument document, string htmlText, CancellationToken cancellationToken);
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/IHtmlDocumentSynchronizer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/IHtmlDocumentSynchronizer.cs
@@ -10,4 +10,5 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 internal interface IHtmlDocumentSynchronizer
 {
     Task<HtmlDocumentResult?> TryGetSynchronizedHtmlDocumentAsync(TextDocument razorDocument, CancellationToken cancellationToken);
+    Task<bool> TrySynchronizeAsync(TextDocument document, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/IHtmlDocumentSynchronizer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/IHtmlDocumentSynchronizer.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+
+internal interface IHtmlDocumentSynchronizer
+{
+    Task<HtmlDocumentResult?> TryGetSynchronizedHtmlDocumentAsync(TextDocument razorDocument, CancellationToken cancellationToken);
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/HtmlDocumentSynchronizerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/HtmlDocumentSynchronizerTest.cs
@@ -1,0 +1,252 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.AspNetCore.Razor.Test.Common.VisualStudio;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
+using Xunit;
+using Xunit.Abstractions;
+using static Microsoft.VisualStudio.Razor.LanguageClient.Cohost.HtmlDocumentSynchronizer;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+
+public class HtmlDocumentSynchronizerTest(ITestOutputHelper testOutput) : VisualStudioWorkspaceTestBase(testOutput)
+{
+    private DocumentId? _documentId;
+
+    protected override void ConfigureWorkspace(AdhocWorkspace workspace)
+    {
+        var project = workspace.CurrentSolution.AddProject("Project", "Project.dll", LanguageNames.CSharp);
+        var document = project.AddAdditionalDocument("File.razor", SourceText.From("<div></div>"));
+        _documentId = document.Id;
+
+        Assert.True(workspace.TryApplyChanges(document.Project.Solution));
+    }
+
+    [Fact]
+    public async Task TrySynchronize_NewDocument_Generates()
+    {
+        var publisher = new TestHtmlDocumentPublisher();
+        var synchronizer = new HtmlDocumentSynchronizer(StrictMock.Of<TrackingLSPDocumentManager>(), publisher, LoggerFactory);
+
+        var document = Workspace.CurrentSolution.GetAdditionalDocument(_documentId).AssumeNotNull();
+
+        Assert.True(await synchronizer.TrySynchronizeAsync(document, DisposalToken));
+
+        var version = await RazorDocumentVersion.CreateAsync(document, DisposalToken);
+
+        Assert.Equal(1, version.WorkspaceVersion);
+
+        Assert.Collection(publisher.Publishes,
+            i =>
+            {
+                Assert.Equal(_documentId, i.Item1.Id);
+                Assert.Equal("<div></div>", i.Item2);
+            });
+    }
+
+    [Fact]
+    public async Task TrySynchronize_WorkspaceMovedForward_NoDocumentChanges_DoesntGenerate()
+    {
+        var publisher = new TestHtmlDocumentPublisher();
+        var synchronizer = new HtmlDocumentSynchronizer(StrictMock.Of<TrackingLSPDocumentManager>(), publisher, LoggerFactory);
+
+        var document = Workspace.CurrentSolution.GetAdditionalDocument(_documentId).AssumeNotNull();
+        var version1 = await RazorDocumentVersion.CreateAsync(document, DisposalToken);
+
+        Assert.True(await synchronizer.TrySynchronizeAsync(document, DisposalToken));
+
+        // Add a new document, moving the workspace forward but leaving our document unaffected
+        Assert.True(Workspace.TryApplyChanges(document.Project.AddAdditionalDocument("Foo2.razor", SourceText.From("")).Project.Solution));
+
+        document = Workspace.CurrentSolution.GetAdditionalDocument(_documentId).AssumeNotNull();
+        var version2 = await RazorDocumentVersion.CreateAsync(document, DisposalToken);
+
+        Assert.True(await synchronizer.TrySynchronizeAsync(document, DisposalToken));
+
+        // Validate that the workspace moved forward
+        Assert.NotEqual(version1.WorkspaceVersion, version2.WorkspaceVersion);
+
+        // Still only one publish
+        Assert.Collection(publisher.Publishes,
+            i =>
+            {
+                Assert.Equal(_documentId, i.Item1.Id);
+                Assert.Equal("<div></div>", i.Item2);
+            });
+    }
+
+    [Fact]
+    public async Task TrySynchronize_WorkspaceUnchanged_DocumentChanges_Generates()
+    {
+        var publisher = new TestHtmlDocumentPublisher();
+        var synchronizer = new HtmlDocumentSynchronizer(StrictMock.Of<TrackingLSPDocumentManager>(), publisher, LoggerFactory);
+
+        var document = Workspace.CurrentSolution.GetAdditionalDocument(_documentId).AssumeNotNull();
+        var version1 = await RazorDocumentVersion.CreateAsync(document, DisposalToken);
+
+        Assert.True(await synchronizer.TrySynchronizeAsync(document, DisposalToken));
+
+        // Change our document directly, but without applying changes (equivalent to LSP didChange)
+        var solution = Workspace.CurrentSolution.WithAdditionalDocumentText(_documentId.AssumeNotNull(), SourceText.From("<span></span>"));
+        document = solution.GetAdditionalDocument(_documentId).AssumeNotNull();
+        var version2 = await RazorDocumentVersion.CreateAsync(document, DisposalToken);
+
+        Assert.True(await synchronizer.TrySynchronizeAsync(document, DisposalToken));
+
+        // Validate that the workspace hasn't moved forward
+        Assert.Equal(version1.WorkspaceVersion, version2.WorkspaceVersion);
+
+        // We should have two publishes
+        Assert.Collection(publisher.Publishes,
+            i =>
+            {
+                Assert.Equal(_documentId, i.Item1.Id);
+                Assert.Equal("<div></div>", i.Item2);
+            },
+            i =>
+            {
+                Assert.Equal(_documentId, i.Item1.Id);
+                Assert.Equal("<span></span>", i.Item2);
+            });
+    }
+
+    [Fact]
+    public async Task TrySynchronize_RequestOldVersion_ImmediateFail()
+    {
+        var tcs = new TaskCompletionSource<bool>();
+        var publisher = new TestHtmlDocumentPublisher(() => tcs.Task);
+        var synchronizer = new HtmlDocumentSynchronizer(StrictMock.Of<TrackingLSPDocumentManager>(), publisher, LoggerFactory);
+
+        var document1 = Workspace.CurrentSolution.GetAdditionalDocument(_documentId).AssumeNotNull();
+        var version1 = await RazorDocumentVersion.CreateAsync(document1, DisposalToken);
+
+        Assert.True(Workspace.TryApplyChanges(Workspace.CurrentSolution.WithAdditionalDocumentText(_documentId.AssumeNotNull(), SourceText.From("<span></span>"))));
+        var document2 = Workspace.CurrentSolution.GetAdditionalDocument(_documentId).AssumeNotNull();
+
+        var task = synchronizer.TrySynchronizeAsync(document2, DisposalToken);
+
+        Assert.False(await synchronizer.TrySynchronizeAsync(document1, DisposalToken));
+
+        tcs.SetResult(true);
+
+        Assert.True(await task);
+
+        // We should have two publishes
+        Assert.Collection(publisher.Publishes,
+            i =>
+            {
+                Assert.Equal(_documentId, i.Item1.Id);
+                Assert.Equal("<span></span>", i.Item2);
+            });
+    }
+
+    [Fact]
+    public async Task TrySynchronize_RequestSameVersion_SingleGeneration()
+    {
+        var tcs = new TaskCompletionSource<bool>();
+        var publisher = new TestHtmlDocumentPublisher(() => tcs.Task);
+        var synchronizer = new HtmlDocumentSynchronizer(StrictMock.Of<TrackingLSPDocumentManager>(), publisher, LoggerFactory);
+
+        var document = Workspace.CurrentSolution.GetAdditionalDocument(_documentId).AssumeNotNull();
+
+        var task1 = synchronizer.TrySynchronizeAsync(document, DisposalToken);
+        var task2 = synchronizer.TrySynchronizeAsync(document, DisposalToken);
+
+        tcs.SetResult(true);
+
+        await Task.WhenAll(task1, task2);
+
+        Assert.Collection(publisher.Publishes,
+            i =>
+            {
+                Assert.Equal(_documentId, i.Item1.Id);
+                Assert.Equal("<div></div>", i.Item2);
+            });
+    }
+
+    [Fact]
+    public async Task TrySynchronize_RequestNewVersion_CancelOldTask()
+    {
+        var tcs = new TaskCompletionSource<bool>();
+        var publisher = new TestHtmlDocumentPublisher(() => tcs.Task);
+        var synchronizer = new HtmlDocumentSynchronizer(StrictMock.Of<TrackingLSPDocumentManager>(), publisher, LoggerFactory);
+
+        var document = Workspace.CurrentSolution.GetAdditionalDocument(_documentId).AssumeNotNull();
+
+        var task1 = synchronizer.TrySynchronizeAsync(document, DisposalToken);
+
+        // Change our document directly, but without applying changes (equivalent to LSP didChange)
+        var solution = Workspace.CurrentSolution.WithAdditionalDocumentText(_documentId.AssumeNotNull(), SourceText.From("<span></span>"));
+        document = solution.GetAdditionalDocument(_documentId).AssumeNotNull();
+
+        var task2 = synchronizer.TrySynchronizeAsync(document, DisposalToken);
+
+        tcs.SetResult(true);
+
+        await Task.WhenAll(task1, task2);
+#pragma warning disable xUnit1031 // Do not use blocking task operations in test method
+        Assert.False(task1.Result);
+#pragma warning restore xUnit1031 // Do not use blocking task operations in test method
+
+        Assert.Collection(publisher.Publishes,
+            i =>
+            {
+                Assert.Equal(_documentId, i.Item1.Id);
+                Assert.Equal("<span></span>", i.Item2);
+            });
+    }
+
+    [Fact]
+    public async Task GetSynchronizationRequestTask_RequestSameVersion_ReturnsSameTask()
+    {
+        var tcs = new TaskCompletionSource<bool>();
+        var publisher = new TestHtmlDocumentPublisher(() => tcs.Task);
+        var synchronizer = new HtmlDocumentSynchronizer(StrictMock.Of<TrackingLSPDocumentManager>(), publisher, LoggerFactory);
+
+        var document = Workspace.CurrentSolution.GetAdditionalDocument(_documentId).AssumeNotNull();
+        var version = await RazorDocumentVersion.CreateAsync(document, DisposalToken);
+
+        var accessor = synchronizer.GetTestAccessor();
+        var task1 = accessor.GetSynchronizationRequestTaskAsync(document, version);
+        var task2 = accessor.GetSynchronizationRequestTaskAsync(document, version);
+
+        Assert.Same(task1, task2);
+    }
+
+    private class TestHtmlDocumentPublisher(Func<Task>? generateTask = null) : IHtmlDocumentPublisher
+    {
+        private List<(TextDocument, string)> _publishes = [];
+
+        public List<(TextDocument, string)> Publishes => _publishes;
+
+        public async Task<string?> GetHtmlSourceFromOOPAsync(TextDocument document, CancellationToken cancellationToken)
+        {
+            if (generateTask is not null)
+            {
+                await generateTask();
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return null;
+            }
+
+            var source = await document.GetTextAsync();
+            return source.ToString();
+        }
+
+        public Task PublishAsync(TextDocument document, string htmlText, CancellationToken cancellationToken)
+        {
+            _publishes.Add((document, htmlText));
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/RazorCustomMessageTargetTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/RazorCustomMessageTargetTest.cs
@@ -15,10 +15,12 @@ using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Protocol.CodeActions;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Protocol.SemanticTokens;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 using Microsoft.VisualStudio.Razor.Settings;
 using Microsoft.VisualStudio.Razor.Snippets;
 using Microsoft.VisualStudio.Text;
@@ -65,6 +67,8 @@ public class RazorCustomMessageTargetTest : ToolingTestBase
             TestLanguageServerFeatureOptions.Instance,
             StrictMock.Of<IProjectSnapshotManager>(),
             new SnippetCache(),
+            StrictMock.Of<IWorkspaceProvider>(),
+            StrictMock.Of<IHtmlDocumentSynchronizer>(),
             LoggerFactory);
         var request = new UpdateBufferRequest()
         {
@@ -105,6 +109,8 @@ public class RazorCustomMessageTargetTest : ToolingTestBase
             TestLanguageServerFeatureOptions.Instance,
             StrictMock.Of<IProjectSnapshotManager>(),
             new SnippetCache(),
+            StrictMock.Of<IWorkspaceProvider>(),
+            StrictMock.Of<IHtmlDocumentSynchronizer>(),
             LoggerFactory);
         var request = new UpdateBufferRequest()
         {
@@ -156,6 +162,8 @@ public class RazorCustomMessageTargetTest : ToolingTestBase
             new TestLanguageServerFeatureOptions(includeProjectKeyInGeneratedFilePath: true),
             StrictMock.Of<IProjectSnapshotManager>(),
             new SnippetCache(),
+            StrictMock.Of<IWorkspaceProvider>(),
+            StrictMock.Of<IHtmlDocumentSynchronizer>(),
             LoggerFactory);
         var request = new UpdateBufferRequest()
         {
@@ -195,6 +203,8 @@ public class RazorCustomMessageTargetTest : ToolingTestBase
             TestLanguageServerFeatureOptions.Instance,
             StrictMock.Of<IProjectSnapshotManager>(),
             new SnippetCache(),
+            StrictMock.Of<IWorkspaceProvider>(),
+            StrictMock.Of<IHtmlDocumentSynchronizer>(),
             LoggerFactory);
         var request = new DelegatedCodeActionParams()
         {
@@ -274,6 +284,8 @@ public class RazorCustomMessageTargetTest : ToolingTestBase
             TestLanguageServerFeatureOptions.Instance,
             StrictMock.Of<IProjectSnapshotManager>(),
             new SnippetCache(),
+            StrictMock.Of<IWorkspaceProvider>(),
+            StrictMock.Of<IHtmlDocumentSynchronizer>(),
             LoggerFactory);
 
         var request = new DelegatedCodeActionParams()
@@ -360,6 +372,8 @@ public class RazorCustomMessageTargetTest : ToolingTestBase
             TestLanguageServerFeatureOptions.Instance,
             StrictMock.Of<IProjectSnapshotManager>(),
             new SnippetCache(),
+            StrictMock.Of<IWorkspaceProvider>(),
+            StrictMock.Of<IHtmlDocumentSynchronizer>(),
             LoggerFactory);
 
         var codeAction = new VSInternalCodeAction()
@@ -400,6 +414,8 @@ public class RazorCustomMessageTargetTest : ToolingTestBase
             TestLanguageServerFeatureOptions.Instance,
             StrictMock.Of<IProjectSnapshotManager>(),
             new SnippetCache(),
+            StrictMock.Of<IWorkspaceProvider>(),
+            StrictMock.Of<IHtmlDocumentSynchronizer>(),
             LoggerFactory);
 
         var request = new ProvideSemanticTokensRangesParams(
@@ -447,6 +463,8 @@ public class RazorCustomMessageTargetTest : ToolingTestBase
             TestLanguageServerFeatureOptions.Instance,
             StrictMock.Of<IProjectSnapshotManager>(),
             new SnippetCache(),
+            StrictMock.Of<IWorkspaceProvider>(),
+            StrictMock.Of<IHtmlDocumentSynchronizer>(),
             LoggerFactory);
 
         var request = new ProvideSemanticTokensRangesParams(
@@ -523,6 +541,8 @@ public class RazorCustomMessageTargetTest : ToolingTestBase
             TestLanguageServerFeatureOptions.Instance,
             StrictMock.Of<IProjectSnapshotManager>(),
             new SnippetCache(),
+            StrictMock.Of<IWorkspaceProvider>(),
+            StrictMock.Of<IHtmlDocumentSynchronizer>(),
             LoggerFactory);
 
         var request = new ProvideSemanticTokensRangesParams(
@@ -600,6 +620,8 @@ public class RazorCustomMessageTargetTest : ToolingTestBase
             TestLanguageServerFeatureOptions.Instance,
             StrictMock.Of<IProjectSnapshotManager>(),
             new SnippetCache(),
+            StrictMock.Of<IWorkspaceProvider>(),
+            StrictMock.Of<IHtmlDocumentSynchronizer>(),
             LoggerFactory);
 
         var request = new ProvideSemanticTokensRangesParams(


### PR DESCRIPTION
Part of https://github.com/dotnet/razor/issues/9519

Commit at a time might be easier. Not really sure.

This PR finished off Uri Presentation in cohosting, but more importantly it brings html document generation to cohosting. The generation is done completely on-demand as we get a request for a document, and in general is much simpler than the current system, because whilst we still need to push the document to a VS buffer, we don't have to wait for the document to be pushed to VS from the LSP server, and synchronize those two pushes. This isn't doing any buffer management specifically for cohosting yet, but all of that is still needed for C# anyway, at the moment.