### PR TITLE
using directive should be available in Razor components

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
@@ -26,8 +26,15 @@ internal class DirectiveCompletionItemProvider : IRazorCompletionItemProvider
         CSharpCodeParser.UsingDirectiveDescriptor
     };
 
+    private static readonly IEnumerable<DirectiveDescriptor> s_componentDefaultDirectives = new[]
+    {
+        CSharpCodeParser.UsingDirectiveDescriptor
+    };
+
+
     // Test accessor
     internal static IEnumerable<DirectiveDescriptor> DefaultDirectives => s_defaultDirectives;
+    internal static IEnumerable<DirectiveDescriptor> ComponentDefaultDirectives => s_componentDefaultDirectives;
 
     // internal for testing
     // Do not forget to update both insert and display text !important
@@ -133,7 +140,7 @@ internal class DirectiveCompletionItemProvider : IRazorCompletionItemProvider
     // Internal for testing
     internal static ImmutableArray<RazorCompletionItem> GetDirectiveCompletionItems(RazorSyntaxTree syntaxTree)
     {
-        var defaultDirectives = FileKinds.IsComponent(syntaxTree.Options.FileKind) ? Array.Empty<DirectiveDescriptor>() : s_defaultDirectives;
+        var defaultDirectives = FileKinds.IsComponent(syntaxTree.Options.FileKind) ? s_componentDefaultDirectives : s_defaultDirectives;
         var directives = syntaxTree.Options.Directives.Concat(defaultDirectives);
 
         using var completionItems = new PooledArrayBuilder<RazorCompletionItem>();

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
@@ -18,7 +18,7 @@ internal class DirectiveCompletionItemProvider : IRazorCompletionItemProvider
     internal static readonly ImmutableArray<RazorCommitCharacter> SingleLineDirectiveCommitCharacters = RazorCommitCharacter.CreateArray([" "]);
     internal static readonly ImmutableArray<RazorCommitCharacter> BlockDirectiveCommitCharacters = RazorCommitCharacter.CreateArray([" ", "{"]);
 
-    private static readonly IEnumerable<DirectiveDescriptor> s_MvcDefaultDirectives = new[]
+    private static readonly IEnumerable<DirectiveDescriptor> s_mvcDefaultDirectives = new[]
     {
         CSharpCodeParser.AddTagHelperDirectiveDescriptor,
         CSharpCodeParser.RemoveTagHelperDirectiveDescriptor,
@@ -33,7 +33,7 @@ internal class DirectiveCompletionItemProvider : IRazorCompletionItemProvider
 
 
     // Test accessor
-    internal static IEnumerable<DirectiveDescriptor> MvcDefaultDirectives => s_MvcDefaultDirectives;
+    internal static IEnumerable<DirectiveDescriptor> MvcDefaultDirectives => s_mvcDefaultDirectives;
     internal static IEnumerable<DirectiveDescriptor> ComponentDefaultDirectives => s_componentDefaultDirectives;
 
     // internal for testing
@@ -140,7 +140,7 @@ internal class DirectiveCompletionItemProvider : IRazorCompletionItemProvider
     // Internal for testing
     internal static ImmutableArray<RazorCompletionItem> GetDirectiveCompletionItems(RazorSyntaxTree syntaxTree)
     {
-        var defaultDirectives = FileKinds.IsComponent(syntaxTree.Options.FileKind) ? s_componentDefaultDirectives : s_MvcDefaultDirectives;
+        var defaultDirectives = FileKinds.IsComponent(syntaxTree.Options.FileKind) ? s_componentDefaultDirectives : s_mvcDefaultDirectives;
         var directives = syntaxTree.Options.Directives.Concat(defaultDirectives);
 
         using var completionItems = new PooledArrayBuilder<RazorCompletionItem>();

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveCompletionItemProvider.cs
@@ -18,7 +18,7 @@ internal class DirectiveCompletionItemProvider : IRazorCompletionItemProvider
     internal static readonly ImmutableArray<RazorCommitCharacter> SingleLineDirectiveCommitCharacters = RazorCommitCharacter.CreateArray([" "]);
     internal static readonly ImmutableArray<RazorCommitCharacter> BlockDirectiveCommitCharacters = RazorCommitCharacter.CreateArray([" ", "{"]);
 
-    private static readonly IEnumerable<DirectiveDescriptor> s_defaultDirectives = new[]
+    private static readonly IEnumerable<DirectiveDescriptor> s_MvcDefaultDirectives = new[]
     {
         CSharpCodeParser.AddTagHelperDirectiveDescriptor,
         CSharpCodeParser.RemoveTagHelperDirectiveDescriptor,
@@ -33,7 +33,7 @@ internal class DirectiveCompletionItemProvider : IRazorCompletionItemProvider
 
 
     // Test accessor
-    internal static IEnumerable<DirectiveDescriptor> DefaultDirectives => s_defaultDirectives;
+    internal static IEnumerable<DirectiveDescriptor> MvcDefaultDirectives => s_MvcDefaultDirectives;
     internal static IEnumerable<DirectiveDescriptor> ComponentDefaultDirectives => s_componentDefaultDirectives;
 
     // internal for testing
@@ -140,7 +140,7 @@ internal class DirectiveCompletionItemProvider : IRazorCompletionItemProvider
     // Internal for testing
     internal static ImmutableArray<RazorCompletionItem> GetDirectiveCompletionItems(RazorSyntaxTree syntaxTree)
     {
-        var defaultDirectives = FileKinds.IsComponent(syntaxTree.Options.FileKind) ? s_componentDefaultDirectives : s_defaultDirectives;
+        var defaultDirectives = FileKinds.IsComponent(syntaxTree.Options.FileKind) ? s_componentDefaultDirectives : s_MvcDefaultDirectives;
         var directives = syntaxTree.Options.Directives.Concat(defaultDirectives);
 
         using var completionItems = new PooledArrayBuilder<RazorCompletionItem>();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DirectiveVerifier.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/DirectiveVerifier.cs
@@ -18,9 +18,9 @@ internal static class DirectiveVerifier
 
     static DirectiveVerifier()
     {
-        var defaultDirectiveVerifierList = new List<Action<CompletionItem>>(DirectiveCompletionItemProvider.DefaultDirectives.Count() * 2);
+        var defaultDirectiveVerifierList = new List<Action<CompletionItem>>(DirectiveCompletionItemProvider.MvcDefaultDirectives.Count() * 2);
 
-        foreach (var directive in DirectiveCompletionItemProvider.DefaultDirectives)
+        foreach (var directive in DirectiveCompletionItemProvider.MvcDefaultDirectives)
         {
             defaultDirectiveVerifierList.Add(item => Assert.Equal(directive.Directive, item.InsertText));
             defaultDirectiveVerifierList.Add(item => AssertDirectiveSnippet(item, directive.Directive));

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
@@ -218,7 +218,7 @@ public class DirectiveCompletionItemProviderTest : ToolingTestBase
     }
 
     [Fact]
-    public void GetDirectiveCompletionItems_ComponentDocument_DoesNotReturnsDefaultDirectivesAsCompletionItems()
+    public void GetDirectiveCompletionItems_ComponentDocument_ReturnsDefaultComponentDirectivesAsCompletionItems()
     {
         // Arrange
         var syntaxTree = CreateSyntaxTree("@addTag", FileKinds.Component);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveCompletionItemProviderTest.cs
@@ -18,12 +18,12 @@ namespace Microsoft.CodeAnalysis.Razor.Completion;
 
 public class DirectiveCompletionItemProviderTest : ToolingTestBase
 {
-    private static readonly Action<RazorCompletionItem>[] s_defaultDirectiveCollectionVerifiers;
+    private static readonly Action<RazorCompletionItem>[] s_mvcDirectiveCollectionVerifiers;
     private static readonly Action<RazorCompletionItem>[] s_componentDirectiveCollectionVerifiers;
 
     static DirectiveCompletionItemProviderTest()
     {
-        s_defaultDirectiveCollectionVerifiers = GetDirectiveVerifies(DirectiveCompletionItemProvider.DefaultDirectives);
+        s_mvcDirectiveCollectionVerifiers = GetDirectiveVerifies(DirectiveCompletionItemProvider.MvcDefaultDirectives);
         s_componentDirectiveCollectionVerifiers = GetDirectiveVerifies(DirectiveCompletionItemProvider.ComponentDefaultDirectives);
     }
 
@@ -58,7 +58,7 @@ public class DirectiveCompletionItemProviderTest : ToolingTestBase
         // Assert
         Assert.Collection(
             completionItems,
-            s_defaultDirectiveCollectionVerifiers
+            s_mvcDirectiveCollectionVerifiers
         );
     }
 
@@ -78,7 +78,7 @@ public class DirectiveCompletionItemProviderTest : ToolingTestBase
             completionItems,
             [
                 item => AssertRazorCompletionItem(customDirective, item), ..
-                s_defaultDirectiveCollectionVerifiers
+                s_mvcDirectiveCollectionVerifiers
             ]
         );
     }
@@ -103,7 +103,7 @@ public class DirectiveCompletionItemProviderTest : ToolingTestBase
             completionItems,
             [
                 item => AssertRazorCompletionItem("different", customDirective, item), ..
-                s_defaultDirectiveCollectionVerifiers
+                s_mvcDirectiveCollectionVerifiers
             ]
         );
     }
@@ -128,7 +128,7 @@ public class DirectiveCompletionItemProviderTest : ToolingTestBase
             completionItems,
             [
                 item => AssertRazorCompletionItem("code", customDirective, item, DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters), ..
-                s_defaultDirectiveCollectionVerifiers
+                s_mvcDirectiveCollectionVerifiers
             ]
         );
     }
@@ -152,7 +152,7 @@ public class DirectiveCompletionItemProviderTest : ToolingTestBase
             completionItems,
             [
                 item => AssertRazorCompletionItem("section", customDirective, item, DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters), ..
-                s_defaultDirectiveCollectionVerifiers
+                s_mvcDirectiveCollectionVerifiers
             ]
         );
     }
@@ -212,7 +212,7 @@ public class DirectiveCompletionItemProviderTest : ToolingTestBase
             [
                 item => AssertRazorCompletionItem("model", customDirective, item, commitCharacters: DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters, isSnippet: false),
                 item => AssertRazorCompletionItem("model directive ...", customDirective, item, commitCharacters: DirectiveCompletionItemProvider.BlockDirectiveCommitCharacters, isSnippet: true), ..
-                s_defaultDirectiveCollectionVerifiers
+                s_mvcDirectiveCollectionVerifiers
             ]
         );
     }


### PR DESCRIPTION
﻿### Summary of the changes

- using directive was erroneously excluded from Razor components
- this PR makes it available

Fixes:
Internally filed https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1992434?src=WorkItemMention&src-action=artifact_link