### PR TITLE
Remove unnecessary dependencies from formatting

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPass.cs
@@ -17,23 +17,12 @@ using TextSpan = Microsoft.CodeAnalysis.Text.TextSpan;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 
-internal class CSharpFormattingPass : CSharpFormattingPassBase
+internal sealed class CSharpFormattingPass(
+    IRazorDocumentMappingService documentMappingService,
+    ILoggerFactory loggerFactory)
+    : CSharpFormattingPassBase(documentMappingService)
 {
-    private readonly ILogger _logger;
-
-    public CSharpFormattingPass(
-        IRazorDocumentMappingService documentMappingService,
-        IClientConnection clientConnection,
-        ILoggerFactory loggerFactory)
-        : base(documentMappingService, clientConnection)
-    {
-        if (loggerFactory is null)
-        {
-            throw new ArgumentNullException(nameof(loggerFactory));
-        }
-
-        _logger = loggerFactory.GetOrCreateLogger<CSharpFormattingPass>();
-    }
+    private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<CSharpFormattingPass>();
 
     // Run after the HTML and Razor formatter pass.
     public override int Order => DefaultOrder - 3;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPassBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/CSharpFormattingPassBase.cs
@@ -11,7 +11,6 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
-using Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Text;
@@ -21,10 +20,10 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 
 internal abstract class CSharpFormattingPassBase : FormattingPassBase
 {
-    protected CSharpFormattingPassBase(IRazorDocumentMappingService documentMappingService, IClientConnection clientConnection)
-        : base(documentMappingService, clientConnection)
+    protected CSharpFormattingPassBase(IRazorDocumentMappingService documentMappingService)
+        : base(documentMappingService)
     {
-        CSharpFormatter = new CSharpFormatter(documentMappingService, clientConnection);
+        CSharpFormatter = new CSharpFormatter(documentMappingService);
     }
 
     protected CSharpFormatter CSharpFormatter { get; }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContentValidationPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingContentValidationPass.cs
@@ -15,23 +15,12 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 
-internal class FormattingContentValidationPass : FormattingPassBase
+internal sealed class FormattingContentValidationPass(
+    IRazorDocumentMappingService documentMappingService,
+    ILoggerFactory loggerFactory)
+    : FormattingPassBase(documentMappingService)
 {
-    private readonly ILogger _logger;
-
-    public FormattingContentValidationPass(
-        IRazorDocumentMappingService documentMappingService,
-        IClientConnection clientConnection,
-        ILoggerFactory loggerFactory)
-        : base(documentMappingService, clientConnection)
-    {
-        if (loggerFactory is null)
-        {
-            throw new ArgumentNullException(nameof(loggerFactory));
-        }
-
-        _logger = loggerFactory.GetOrCreateLogger<FormattingContentValidationPass>();
-    }
+    private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<FormattingContentValidationPass>();
 
     // We want this to run at the very end.
     public override int Order => DefaultOrder + 1000;
@@ -79,7 +68,7 @@ internal class FormattingContentValidationPass : FormattingPassBase
                 Debug.Fail("A formatting result was rejected because it was going to change non-whitespace content in the document.");
             }
 
-            return Task.FromResult(new FormattingResult(Array.Empty<TextEdit>()));
+            return Task.FromResult(new FormattingResult([]));
         }
 
         return Task.FromResult(result);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingDiagnosticValidationPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingDiagnosticValidationPass.cs
@@ -17,23 +17,12 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 
-internal class FormattingDiagnosticValidationPass : FormattingPassBase
+internal sealed class FormattingDiagnosticValidationPass(
+    IRazorDocumentMappingService documentMappingService,
+    ILoggerFactory loggerFactory)
+    : FormattingPassBase(documentMappingService)
 {
-    private readonly ILogger _logger;
-
-    public FormattingDiagnosticValidationPass(
-        IRazorDocumentMappingService documentMappingService,
-        IClientConnection clientConnection,
-        ILoggerFactory loggerFactory)
-        : base(documentMappingService, clientConnection)
-    {
-        if (loggerFactory is null)
-        {
-            throw new ArgumentNullException(nameof(loggerFactory));
-        }
-
-        _logger = loggerFactory.GetOrCreateLogger<FormattingDiagnosticValidationPass>();
-    }
+    private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<FormattingDiagnosticValidationPass>();
 
     // We want this to run at the very end.
     public override int Order => DefaultOrder + 1000;
@@ -85,7 +74,7 @@ internal class FormattingDiagnosticValidationPass : FormattingPassBase
                 Debug.Fail("A formatting result was rejected because the formatted text produced different diagnostics compared to the original text.");
             }
 
-            return new FormattingResult(Array.Empty<TextEdit>());
+            return new FormattingResult([]);
         }
 
         return result;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingPassBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/FormattingPassBase.cs
@@ -12,32 +12,15 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 
-internal abstract class FormattingPassBase : IFormattingPass
+internal abstract class FormattingPassBase(IRazorDocumentMappingService documentMappingService) : IFormattingPass
 {
     protected static readonly int DefaultOrder = 1000;
-
-    public FormattingPassBase(
-        IRazorDocumentMappingService documentMappingService,
-        IClientConnection clientConnection)
-    {
-        if (documentMappingService is null)
-        {
-            throw new ArgumentNullException(nameof(documentMappingService));
-        }
-
-        if (clientConnection is null)
-        {
-            throw new ArgumentNullException(nameof(clientConnection));
-        }
-
-        DocumentMappingService = documentMappingService;
-    }
 
     public abstract bool IsValidationPass { get; }
 
     public virtual int Order => DefaultOrder;
 
-    protected IRazorDocumentMappingService DocumentMappingService { get; }
+    protected IRazorDocumentMappingService DocumentMappingService { get; } = documentMappingService;
 
     public abstract Task<FormattingResult> ExecuteAsync(FormattingContext context, FormattingResult result, CancellationToken cancellationToken);
 
@@ -61,7 +44,7 @@ internal abstract class FormattingPassBase : IFormattingPass
 
         if (codeDocument.IsUnsupported())
         {
-            return Array.Empty<TextEdit>();
+            return [];
         }
 
         var edits = DocumentMappingService.GetHostDocumentEdits(codeDocument.GetCSharpDocument(), projectedTextEdits);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormattingPass.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -15,40 +14,23 @@ using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
-using TextSpan = Microsoft.CodeAnalysis.Text.TextSpan;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 
-internal class HtmlFormattingPass : FormattingPassBase
+internal sealed class HtmlFormattingPass(
+    IRazorDocumentMappingService documentMappingService,
+    IClientConnection clientConnection,
+    IDocumentVersionCache documentVersionCache,
+    ILoggerFactory loggerFactory)
+    : FormattingPassBase(documentMappingService)
 {
-    private readonly ILogger _logger;
-    private readonly RazorLSPOptionsMonitor _optionsMonitor;
-
-    public HtmlFormattingPass(
-        IRazorDocumentMappingService documentMappingService,
-        IClientConnection clientConnection,
-        IDocumentVersionCache documentVersionCache,
-        RazorLSPOptionsMonitor optionsMonitor,
-        ILoggerFactory loggerFactory)
-        : base(documentMappingService, clientConnection)
-    {
-        if (loggerFactory is null)
-        {
-            throw new ArgumentNullException(nameof(loggerFactory));
-        }
-
-        _logger = loggerFactory.GetOrCreateLogger<HtmlFormattingPass>();
-
-        HtmlFormatter = new HtmlFormatter(clientConnection, documentVersionCache);
-        _optionsMonitor = optionsMonitor;
-    }
+    private readonly HtmlFormatter _htmlFormatter = new HtmlFormatter(clientConnection, documentVersionCache);
+    private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<HtmlFormattingPass>();
 
     // We want this to run first because it uses the client HTML formatter.
     public override int Order => DefaultOrder - 5;
 
     public override bool IsValidationPass => false;
-
-    protected HtmlFormatter HtmlFormatter { get; }
 
     public async override Task<FormattingResult> ExecuteAsync(FormattingContext context, FormattingResult result, CancellationToken cancellationToken)
     {
@@ -58,11 +40,11 @@ internal class HtmlFormattingPass : FormattingPassBase
 
         if (context.IsFormatOnType && result.Kind == RazorLanguageKind.Html)
         {
-            htmlEdits = await HtmlFormatter.FormatOnTypeAsync(context, cancellationToken).ConfigureAwait(false);
+            htmlEdits = await _htmlFormatter.FormatOnTypeAsync(context, cancellationToken).ConfigureAwait(false);
         }
         else if (!context.IsFormatOnType)
         {
-            htmlEdits = await HtmlFormatter.FormatAsync(context, cancellationToken).ConfigureAwait(false);
+            htmlEdits = await _htmlFormatter.FormatAsync(context, cancellationToken).ConfigureAwait(false);
         }
         else
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingPass.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/RazorFormattingPass.cs
@@ -18,14 +18,11 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 
-internal class RazorFormattingPass(
+internal sealed class RazorFormattingPass(
     IRazorDocumentMappingService documentMappingService,
-    IClientConnection clientConnection,
-    RazorLSPOptionsMonitor optionsMonitor,
-    ILoggerFactory loggerFactory)
-    : FormattingPassBase(documentMappingService, clientConnection)
+    RazorLSPOptionsMonitor optionsMonitor)
+    : FormattingPassBase(documentMappingService)
 {
-    private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<RazorFormattingPass>();
     private readonly RazorLSPOptionsMonitor _optionsMonitor = optionsMonitor;
 
     // Run after the C# formatter pass.
@@ -85,7 +82,7 @@ internal class RazorFormattingPass(
         return edits;
     }
 
-    private void TryFormatBlocks(FormattingContext context, List<TextEdit> edits, RazorSourceDocument source, SyntaxNode node)
+    private static void TryFormatBlocks(FormattingContext context, List<TextEdit> edits, RazorSourceDocument source, SyntaxNode node)
     {
         // We only want to run one of these
         _ = TryFormatFunctionsBlock(context, edits, source, node) ||

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingContentValidationPassTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingContentValidationPassTest.cs
@@ -6,7 +6,6 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
 using Microsoft.AspNetCore.Razor.LanguageServer.Test;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -31,7 +30,7 @@ public class FormattingContentValidationPassTest(ITestOutputHelper testOutput) :
 }
 ");
         using var context = CreateFormattingContext(source);
-        var input = new FormattingResult(Array.Empty<TextEdit>(), RazorLanguageKind.CSharp);
+        var input = new FormattingResult([], RazorLanguageKind.CSharp);
         var pass = GetPass();
 
         // Act
@@ -51,7 +50,7 @@ public class FormattingContentValidationPassTest(ITestOutputHelper testOutput) :
 }
 ");
         using var context = CreateFormattingContext(source);
-        var input = new FormattingResult(Array.Empty<TextEdit>(), RazorLanguageKind.Html);
+        var input = new FormattingResult([], RazorLanguageKind.Html);
         var pass = GetPass();
 
         // Act
@@ -121,8 +120,7 @@ public class Foo { }
     {
         var mappingService = new RazorDocumentMappingService(FilePathService, new TestDocumentContextFactory(), LoggerFactory);
 
-        var clientConnection = Mock.Of<IClientConnection>(MockBehavior.Strict);
-        var pass = new FormattingContentValidationPass(mappingService, clientConnection, LoggerFactory)
+        var pass = new FormattingContentValidationPass(mappingService, LoggerFactory)
         {
             DebugAssertsEnabled = false
         };

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingDiagnosticValidationPassTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingDiagnosticValidationPassTest.cs
@@ -5,14 +5,12 @@ using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
 using Microsoft.AspNetCore.Razor.LanguageServer.Test;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
-using Moq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -35,7 +33,7 @@ public class FormattingDiagnosticValidationPassTest(ITestOutputHelper testOutput
             NewText = "@ ",
             Range = new Range { Start = new Position(0, 0), End = new Position(0, 0) }
         };
-        var input = new FormattingResult(new[] { badEdit }, RazorLanguageKind.CSharp);
+        var input = new FormattingResult([badEdit], RazorLanguageKind.CSharp);
         var pass = GetPass();
 
         // Act
@@ -60,7 +58,7 @@ public class FormattingDiagnosticValidationPassTest(ITestOutputHelper testOutput
             NewText = "@ ",
             Range = new Range { Start = new Position(0, 0), End = new Position(0, 0) }
         };
-        var input = new FormattingResult(new[] { badEdit }, RazorLanguageKind.Html);
+        var input = new FormattingResult([badEdit], RazorLanguageKind.Html);
         var pass = GetPass();
 
         // Act
@@ -113,7 +111,7 @@ public class Foo { }
             NewText = "@ ", // Creates a diagnostic
             Range = new Range { Start = new Position(0, 0), End = new Position(0, 0) },
         };
-        var input = new FormattingResult(new[] { badEdit }, RazorLanguageKind.Razor);
+        var input = new FormattingResult([badEdit], RazorLanguageKind.Razor);
         var pass = GetPass();
 
         // Act
@@ -127,8 +125,7 @@ public class Foo { }
     {
         var mappingService = new RazorDocumentMappingService(FilePathService, new TestDocumentContextFactory(), LoggerFactory);
 
-        var clientConnection = Mock.Of<IClientConnection>(MockBehavior.Strict);
-        var pass = new FormattingDiagnosticValidationPass(mappingService, clientConnection, LoggerFactory)
+        var pass = new FormattingDiagnosticValidationPass(mappingService, LoggerFactory)
         {
             DebugAssertsEnabled = false
         };
@@ -159,7 +156,7 @@ public class Foo { }
         var projectEngine = RazorProjectEngine.Create(builder => builder.SetRootNamespace("Test"));
         var codeDocument = projectEngine.ProcessDesignTime(sourceDocument, fileKind, importSources: default, tagHelpers);
 
-        var documentSnapshot = FormattingTestBase.CreateDocumentSnapshot(path, tagHelpers, fileKind, ImmutableArray<RazorSourceDocument>.Empty, ImmutableArray<IDocumentSnapshot>.Empty, projectEngine, codeDocument);
+        var documentSnapshot = FormattingTestBase.CreateDocumentSnapshot(path, tagHelpers, fileKind, [], [], projectEngine, codeDocument);
 
         return (codeDocument, documentSnapshot);
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/TestRazorFormattingService.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/TestRazorFormattingService.cs
@@ -54,12 +54,12 @@ internal static class TestRazorFormattingService
 
         var passes = new List<IFormattingPass>()
         {
-            new HtmlFormattingPass(mappingService, client, versionCache, optionsMonitor, loggerFactory),
-            new CSharpFormattingPass(mappingService, client, loggerFactory),
-            new CSharpOnTypeFormattingPass(mappingService, client, optionsMonitor, loggerFactory),
-            new RazorFormattingPass(mappingService, client, optionsMonitor,  loggerFactory),
-            new FormattingDiagnosticValidationPass(mappingService, client, loggerFactory),
-            new FormattingContentValidationPass(mappingService, client, loggerFactory),
+            new HtmlFormattingPass(mappingService, client, versionCache, loggerFactory),
+            new CSharpFormattingPass(mappingService, loggerFactory),
+            new CSharpOnTypeFormattingPass(mappingService, loggerFactory),
+            new RazorFormattingPass(mappingService, optionsMonitor),
+            new FormattingDiagnosticValidationPass(mappingService, loggerFactory),
+            new FormattingContentValidationPass(mappingService, loggerFactory),
         };
 
         return new RazorFormattingService(passes, TestAdhocWorkspaceFactory.Instance);


### PR DESCRIPTION
All of our formatting passes took an `IClientConnection` but only Html actually uses it. Cleaning this up gives us a more accurate picture for cohosting.