### PR TITLE
Fix OOP service lifetimes

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Logging/RemoteLoggerFactory.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Logging/RemoteLoggerFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Composition;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.Razor.Logging;
@@ -13,14 +14,15 @@ internal partial class RemoteLoggerFactory() : ILoggerFactory
 {
     private static TraceSource? s_traceSource;
 
-    internal static void Initialize(TraceSource traceSource)
+    internal static TraceSource Initialize(IServiceProvider hostProvidedServices)
     {
-        s_traceSource ??= traceSource;
+        s_traceSource ??= (TraceSource)hostProvidedServices.GetService(typeof(TraceSource));
+        return s_traceSource;
     }
 
     public void AddLoggerProvider(ILoggerProvider provider)
     {
-        throw new System.NotImplementedException();
+        throw new NotImplementedException();
     }
 
     public ILogger GetOrCreateLogger(string categoryName)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/MEFComposition.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/MEFComposition.cs
@@ -9,16 +9,19 @@ using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor;
 
-internal abstract partial class RazorServiceFactoryBase<TService>
+internal static class MEFComposition
 {
-    internal static readonly ImmutableArray<Assembly> RemoteHostAssemblies = [typeof(RazorServiceFactoryBase<TService>).Assembly];
+    internal static readonly ImmutableArray<Assembly> RemoteHostAssemblies = [typeof(MEFComposition).Assembly];
 
 #pragma warning disable VSTHRD012 // Provide JoinableTaskFactory where allowed
-    private static readonly AsyncLazy<ExportProvider> s_exportProviderLazy = new(GetExportProviderAsync);
+    private static readonly AsyncLazy<ExportProvider> s_exportProviderLazy = new(CreateExportProviderAsync);
 #pragma warning restore VSTHRD012 // Provide JoinableTaskFactory where allowed
 
+    public static Task<ExportProvider> GetExportProviderAsync()
+        => s_exportProviderLazy.GetValueAsync();
+
     // Inspired by https://github.com/dotnet/roslyn/blob/25aa74d725e801b8232dbb3e5abcda0fa72da8c5/src/Workspaces/Remote/ServiceHub/Host/RemoteWorkspaceManager.cs#L77
-    private static async Task<ExportProvider> GetExportProviderAsync()
+    private static async Task<ExportProvider> CreateExportProviderAsync()
     {
         var resolver = Resolver.DefaultInstance;
         var discovery = new AttributedPartDiscovery(resolver, isNonPublicSupported: true); // MEFv2 only

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorServiceFactoryBase.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorServiceFactoryBase.cs
@@ -51,7 +51,7 @@ internal abstract class RazorServiceFactoryBase<TService> : IServiceHubServiceFa
         var descriptor = _razorServiceDescriptors.GetDescriptorForServiceFactory(typeof(TService));
         var serverConnection = descriptor.WithTraceSource(traceSource).ConstructRpcConnection(pipe);
 
-        var exportProvider = await MEFComposition.GetExportProviderAsync().ConfigureAwait(false);
+        var exportProvider = await RemoteMefComposition.GetExportProviderAsync().ConfigureAwait(false);
 
         var service = CreateService(serviceBroker, exportProvider);
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorServiceFactoryBase.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorServiceFactoryBase.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Remote.Razor;
 /// <remarks>
 /// Implementors of <see cref="IServiceHubServiceFactory" /> (and thus this class) MUST provide a parameterless constructor or ServiceHub will fail to construct them.
 /// </remarks>
-internal abstract partial class RazorServiceFactoryBase<TService> : IServiceHubServiceFactory where TService : class
+internal abstract class RazorServiceFactoryBase<TService> : IServiceHubServiceFactory where TService : class
 {
     private readonly RazorServiceDescriptorsWrapper _razorServiceDescriptors;
 
@@ -57,7 +57,7 @@ internal abstract partial class RazorServiceFactoryBase<TService> : IServiceHubS
         var descriptor = _razorServiceDescriptors.GetDescriptorForServiceFactory(typeof(TService));
         var serverConnection = descriptor.ConstructRpcConnection(pipe);
 
-        var exportProvider = await s_exportProviderLazy.GetValueAsync().ConfigureAwait(false);
+        var exportProvider = await MEFComposition.GetExportProviderAsync().ConfigureAwait(false);
 
         var service = CreateService(serviceBroker, exportProvider);
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RemoteMefComposition.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RemoteMefComposition.cs
@@ -9,9 +9,9 @@ using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor;
 
-internal static class MEFComposition
+internal static class RemoteMefComposition
 {
-    internal static readonly ImmutableArray<Assembly> RemoteHostAssemblies = [typeof(MEFComposition).Assembly];
+    internal static readonly ImmutableArray<Assembly> RemoteHostAssemblies = [typeof(RemoteMefComposition).Assembly];
 
 #pragma warning disable VSTHRD012 // Provide JoinableTaskFactory where allowed
     private static readonly AsyncLazy<ExportProvider> s_exportProviderLazy = new(CreateExportProviderAsync);


### PR DESCRIPTION
Remember when I said things like "ServiceHub and ALCs are weird!"? Well it turns out I just forgot how .NET worked for a minute, and accidentally created a static field in a generic type, which of course meant we were creating a MEF composition per service.

Hopefully my shame is punishment enough.

Also made everything log to the same trace source, like I originally intended, and did a minor bit of cleanup.