### PR TITLE
Simplify OOP service call API

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/IRemoteClientProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/IRemoteClientProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
@@ -9,5 +10,5 @@ namespace Microsoft.CodeAnalysis.Razor.Remote;
 
 internal interface IRemoteClientProvider
 {
-    Task<RazorRemoteHostClient?> TryGetClientAsync(CancellationToken cancellationToken);
+    ValueTask<TResult?> TryInvokeAsync<TService, TResult>(Solution solution, Func<TService, RazorPinnedSolutionInfoWrapper, CancellationToken, ValueTask<TResult>> invocation, CancellationToken cancellationToken) where TService : class;
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/IRemoteServiceProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/IRemoteServiceProvider.cs
@@ -16,5 +16,6 @@ internal interface IRemoteServiceProvider
         Func<TService, RazorPinnedSolutionInfoWrapper, CancellationToken, ValueTask<TResult>> invocation,
         CancellationToken cancellationToken,
         [CallerFilePath] string? callerFilePath = null,
-        [CallerMemberName] string? callerMemberName = null);
+        [CallerMemberName] string? callerMemberName = null)
+        where TService : class;
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/IRemoteServiceProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/IRemoteServiceProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
@@ -10,5 +11,10 @@ namespace Microsoft.CodeAnalysis.Razor.Remote;
 
 internal interface IRemoteServiceProvider
 {
-    ValueTask<TResult?> TryInvokeAsync<TService, TResult>(Solution solution, Func<TService, RazorPinnedSolutionInfoWrapper, CancellationToken, ValueTask<TResult>> invocation, CancellationToken cancellationToken) where TService : class;
+    ValueTask<TResult?> TryInvokeAsync<TService, TResult>(
+        Solution solution,
+        Func<TService, RazorPinnedSolutionInfoWrapper, CancellationToken, ValueTask<TResult>> invocation,
+        CancellationToken cancellationToken,
+        [CallerFilePath] string? callerFilePath = null,
+        [CallerMemberName] string? callerMemberName = null);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/IRemoteServiceProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/IRemoteServiceProvider.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 
 namespace Microsoft.CodeAnalysis.Razor.Remote;
 
-internal interface IRemoteClientProvider
+internal interface IRemoteServiceProvider
 {
     ValueTask<TResult?> TryInvokeAsync<TService, TResult>(Solution solution, Func<TService, RazorPinnedSolutionInfoWrapper, CancellationToken, ValueTask<TResult>> invocation, CancellationToken cancellationToken) where TService : class;
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostLinkedEditingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostLinkedEditingRangeEndpoint.cs
@@ -23,10 +23,10 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 [ExportCohostStatelessLspService(typeof(CohostLinkedEditingRangeEndpoint))]
 [method: ImportingConstructor]
 #pragma warning restore RS0030 // Do not use banned APIs
-internal class CohostLinkedEditingRangeEndpoint(IRemoteClientProvider remoteClientProvider, ILoggerFactory loggerFactory)
+internal class CohostLinkedEditingRangeEndpoint(IRemoteServiceProvider remoteServiceProvider, ILoggerFactory loggerFactory)
     : AbstractRazorCohostDocumentRequestHandler<LinkedEditingRangeParams, LinkedEditingRanges?>, IDynamicRegistrationProvider
 {
-    private readonly IRemoteClientProvider _remoteClientProvider = remoteClientProvider;
+    private readonly IRemoteServiceProvider _remoteServiceProvider = remoteServiceProvider;
     private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<CohostLinkedEditingRangeEndpoint>();
 
     protected override bool MutatesSolutionState => false;
@@ -57,7 +57,7 @@ internal class CohostLinkedEditingRangeEndpoint(IRemoteClientProvider remoteClie
     {
         var razorDocument = context.TextDocument.AssumeNotNull();
 
-        var linkedRanges = await _remoteClientProvider.TryInvokeAsync<IRemoteLinkedEditingRangeService, LinePositionSpan[]?>(
+        var linkedRanges = await _remoteServiceProvider.TryInvokeAsync<IRemoteLinkedEditingRangeService, LinePositionSpan[]?>(
             razorDocument.Project.Solution,
             (service, solutionInfo, cancellationToken) => service.GetRangesAsync(solutionInfo, razorDocument.Id, request.Position.ToLinePosition(), cancellationToken),
             cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostSemanticTokensRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostSemanticTokensRangeEndpoint.cs
@@ -28,14 +28,14 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 [method: ImportingConstructor]
 #pragma warning restore RS0030 // Do not use banned APIs
 internal sealed class CohostSemanticTokensRangeEndpoint(
-    IRemoteClientProvider remoteClientProvider,
+    IRemoteServiceProvider remoteServiceProvider,
     IClientSettingsManager clientSettingsManager,
     ISemanticTokensLegendService semanticTokensLegendService,
     ITelemetryReporter telemetryReporter,
     ILoggerFactory loggerFactory)
     : AbstractRazorCohostDocumentRequestHandler<SemanticTokensRangeParams, SemanticTokens?>, IDynamicRegistrationProvider
 {
-    private readonly IRemoteClientProvider _remoteClientProvider = remoteClientProvider;
+    private readonly IRemoteServiceProvider _remoteServiceProvider = remoteServiceProvider;
     private readonly IClientSettingsManager _clientSettingsManager = clientSettingsManager;
     private readonly ISemanticTokensLegendService _semanticTokensLegendService = semanticTokensLegendService;
     private readonly ITelemetryReporter _telemetryReporter = telemetryReporter;
@@ -78,7 +78,7 @@ internal sealed class CohostSemanticTokensRangeEndpoint(
         var correlationId = Guid.NewGuid();
         using var _ = _telemetryReporter.TrackLspRequest(Methods.TextDocumentSemanticTokensRangeName, RazorLSPConstants.CohostLanguageServerName, correlationId);
 
-        var tokens = await _remoteClientProvider.TryInvokeAsync<IRemoteSemanticTokensService, int[]?>(
+        var tokens = await _remoteServiceProvider.TryInvokeAsync<IRemoteSemanticTokensService, int[]?>(
             razorDocument.Project.Solution,
             (service, solutionInfo, cancellationToken) => service.GetSemanticTokensDataAsync(solutionInfo, razorDocument.Id, span, colorBackground, correlationId, cancellationToken),
             cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostUriPresentationEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostUriPresentationEndpoint.cs
@@ -1,13 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
 using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
-using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Text;
@@ -25,18 +23,16 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 [method: ImportingConstructor]
 #pragma warning restore RS0030 // Do not use banned APIs
 internal class CohostUriPresentationEndpoint(
-    IRemoteClientProvider remoteClientProvider,
+    IRemoteServiceProvider remoteServiceProvider,
     IHtmlDocumentSynchronizer htmlDocumentSynchronizer,
     IFilePathService filePathService,
-    LSPRequestInvoker requestInvoker,
-    ILoggerFactory loggerFactory)
+    LSPRequestInvoker requestInvoker)
     : AbstractRazorCohostDocumentRequestHandler<VSInternalUriPresentationParams, WorkspaceEdit?>, IDynamicRegistrationProvider
 {
-    private readonly IRemoteClientProvider _remoteClientProvider = remoteClientProvider;
+    private readonly IRemoteServiceProvider _remoteServiceProvider = remoteServiceProvider;
     private readonly IHtmlDocumentSynchronizer _htmlDocumentSynchronizer = htmlDocumentSynchronizer;
     private readonly IFilePathService _filePathService = filePathService;
     private readonly LSPRequestInvoker _requestInvoker = requestInvoker;
-    private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<CohostUriPresentationEndpoint>();
 
     protected override bool MutatesSolutionState => false;
 
@@ -66,7 +62,7 @@ internal class CohostUriPresentationEndpoint(
     {
         var razorDocument = context.TextDocument.AssumeNotNull();
 
-        var data = await _remoteClientProvider.TryInvokeAsync<IRemoteUriPresentationService, TextChange?>(
+        var data = await _remoteServiceProvider.TryInvokeAsync<IRemoteUriPresentationService, TextChange?>(
             razorDocument.Project.Solution,
             (service, solutionInfo, cancellationToken) => service.GetPresentationAsync(solutionInfo, razorDocument.Id, request.Range.ToLinePositionSpan(), request.Uris, cancellationToken),
             cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentPublisher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentPublisher.cs
@@ -28,25 +28,11 @@ internal sealed class HtmlDocumentPublisher(
     private readonly TrackingLSPDocumentManager _documentManager = documentManager as TrackingLSPDocumentManager ?? throw new InvalidOperationException("Expected TrackingLSPDocumentManager");
     private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<HtmlDocumentPublisher>();
 
-    public async Task<string?> GetHtmlSourceFromOOPAsync(TextDocument document, CancellationToken cancellationToken)
+    public Task<string?> GetHtmlSourceFromOOPAsync(TextDocument document, CancellationToken cancellationToken)
     {
-        var client = await _remoteClientProvider.TryGetClientAsync(cancellationToken).ConfigureAwait(false);
-        if (client is null)
-        {
-            _logger.LogError($"Couldn't get remote client for html document generation for {document.FilePath}. Html document contents will be stale");
-            return null;
-        }
-
-        if (cancellationToken.IsCancellationRequested)
-        {
-            return null;
-        }
-
-        var htmlText = await client.TryInvokeAsync<IRemoteHtmlDocumentService, string?>(document.Project.Solution,
+        return _remoteClientProvider.TryInvokeAsync<IRemoteHtmlDocumentService, string>(document.Project.Solution,
             (service, solutionInfo, ct) => service.GetHtmlDocumentTextAsync(solutionInfo, document.Id, ct),
-            cancellationToken).ConfigureAwait(false);
-
-        return htmlText.Value;
+            cancellationToken).AsTask();
     }
 
     public async Task PublishAsync(TextDocument document, string htmlText, CancellationToken cancellationToken)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentPublisher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentPublisher.cs
@@ -18,19 +18,19 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 [Export(typeof(IHtmlDocumentPublisher))]
 [method: ImportingConstructor]
 internal sealed class HtmlDocumentPublisher(
-    IRemoteClientProvider remoteClientProvider,
+    IRemoteServiceProvider remoteServiceProvider,
     LSPDocumentManager documentManager,
     JoinableTaskContext joinableTaskContext,
     ILoggerFactory loggerFactory) : IHtmlDocumentPublisher
 {
-    private readonly IRemoteClientProvider _remoteClientProvider = remoteClientProvider;
+    private readonly IRemoteServiceProvider _remoteServiceProvider = remoteServiceProvider;
     private readonly JoinableTaskContext _joinableTaskContext = joinableTaskContext;
     private readonly TrackingLSPDocumentManager _documentManager = documentManager as TrackingLSPDocumentManager ?? throw new InvalidOperationException("Expected TrackingLSPDocumentManager");
     private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<HtmlDocumentPublisher>();
 
     public Task<string?> GetHtmlSourceFromOOPAsync(TextDocument document, CancellationToken cancellationToken)
     {
-        return _remoteClientProvider.TryInvokeAsync<IRemoteHtmlDocumentService, string>(document.Project.Solution,
+        return _remoteServiceProvider.TryInvokeAsync<IRemoteHtmlDocumentService, string?>(document.Project.Solution,
             (service, solutionInfo, ct) => service.GetHtmlDocumentTextAsync(solutionInfo, document.Id, ct),
             cancellationToken).AsTask();
     }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/OutOfProcTagHelperResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/OutOfProcTagHelperResolver.cs
@@ -23,11 +23,11 @@ namespace Microsoft.VisualStudio.Razor.Remote;
 [Export(typeof(ITagHelperResolver))]
 [method: ImportingConstructor]
 internal class OutOfProcTagHelperResolver(
-    IRemoteClientProvider remoteClientProvider,
+    IRemoteServiceProvider remoteServiceProvider,
     ILoggerFactory loggerFactory,
     ITelemetryReporter telemetryReporter) : ITagHelperResolver
 {
-    private readonly IRemoteClientProvider _remoteClientProvider = remoteClientProvider;
+    private readonly IRemoteServiceProvider _remoteServiceProvider = remoteServiceProvider;
     private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<OutOfProcTagHelperResolver>();
     private readonly CompilationTagHelperResolver _innerResolver = new(telemetryReporter);
     private readonly TagHelperResultCache _resultCache = new();
@@ -75,7 +75,7 @@ internal class OutOfProcTagHelperResolver(
 
         var projectHandle = new ProjectSnapshotHandle(workspaceProject.Id, projectSnapshot.Configuration, projectSnapshot.RootNamespace);
 
-        var deltaResult = await _remoteClientProvider.TryInvokeAsync<IRemoteTagHelperProviderService, TagHelperDeltaResult>(
+        var deltaResult = await _remoteServiceProvider.TryInvokeAsync<IRemoteTagHelperProviderService, TagHelperDeltaResult>(
             workspaceProject.Solution,
             (service, solutionInfo, innerCancellationToken) =>
                 service.GetTagHelpersDeltaAsync(solutionInfo, projectHandle, lastResultId, innerCancellationToken),
@@ -110,7 +110,7 @@ internal class OutOfProcTagHelperResolver(
         if (checksumsToFetch.Count > 0)
         {
             // There are checksums that we don't have cached tag helpers for, so we need to fetch them from OOP.
-            var fetchResult = await _remoteClientProvider.TryInvokeAsync<IRemoteTagHelperProviderService, FetchTagHelpersResult>(
+            var fetchResult = await _remoteServiceProvider.TryInvokeAsync<IRemoteTagHelperProviderService, FetchTagHelpersResult>(
                 workspaceProject.Solution,
                 (service, solutionInfo, innerCancellationToken) =>
                     service.FetchTagHelpersAsync(solutionInfo, projectHandle, checksumsToFetch.DrainToImmutable(), innerCancellationToken),

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/RemoteServiceProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/RemoteServiceProvider.cs
@@ -4,7 +4,6 @@
 using System;
 using System.ComponentModel.Composition;
 using System.IO;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/RemoteServiceProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/RemoteServiceProvider.cs
@@ -59,7 +59,7 @@ internal sealed class RemoteServiceProvider(
 
             return result.Value;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogError(ex, $"Error calling remote method for {typeof(TService).Name} service, invocation: ${invocation.ToString()}");
             _telemetryReporter.ReportFault(ex, "Exception calling remote method for {service}", typeof(TService).FullName);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/RemoteServiceProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/RemoteServiceProvider.cs
@@ -16,23 +16,23 @@ using Microsoft.CodeAnalysis.Razor.Workspaces;
 
 namespace Microsoft.VisualStudio.Razor.Remote;
 
-[Export(typeof(IRemoteClientProvider))]
+[Export(typeof(IRemoteServiceProvider))]
 [method: ImportingConstructor]
-internal sealed class RemoteClientProvider(
+internal sealed class RemoteServiceProvider(
     IWorkspaceProvider workspaceProvider,
     LanguageServerFeatureOptions languageServerFeatureOptions,
     IClientCapabilitiesService clientCapabilitiesService,
     ISemanticTokensLegendService semanticTokensLegendService,
     ITelemetryReporter telemetryReporter,
     ILoggerFactory loggerFactory)
-    : IRemoteClientProvider
+    : IRemoteServiceProvider
 {
     private readonly IWorkspaceProvider _workspaceProvider = workspaceProvider;
     private readonly LanguageServerFeatureOptions _languageServerFeatureOptions = languageServerFeatureOptions;
     private readonly IClientCapabilitiesService _clientCapabilitiesService = clientCapabilitiesService;
     private readonly ISemanticTokensLegendService _semanticTokensLegendService = semanticTokensLegendService;
     private readonly ITelemetryReporter _telemetryReporter = telemetryReporter;
-    private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<RemoteClientProvider>();
+    private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<RemoteServiceProvider>();
 
     private bool _isInitialized;
     private bool _isLSPInitialized;

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Remote/OutOfProcTagHelperResolverTest.TestResolver.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Remote/OutOfProcTagHelperResolverTest.TestResolver.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.Razor.Remote;
 public partial class OutOfProcTagHelperResolverTest
 {
     private class TestResolver(
-        IRemoteClientProvider remoteClientProvider,
+        IRemoteServiceProvider remoteClientProvider,
         ILoggerFactory loggerFactory,
         ITelemetryReporter telemetryReporter)
         : OutOfProcTagHelperResolver(remoteClientProvider, loggerFactory, telemetryReporter)

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Remote/OutOfProcTagHelperResolverTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Remote/OutOfProcTagHelperResolverTest.cs
@@ -39,7 +39,7 @@ public partial class OutOfProcTagHelperResolverTest : VisualStudioTestBase
 
     private readonly Project _workspaceProject;
     private readonly TestProjectSnapshotManager _projectManager;
-    private readonly IRemoteClientProvider _remoteClientProvider;
+    private readonly IRemoteServiceProvider _remoteClientProvider;
 
     public OutOfProcTagHelperResolverTest(ITestOutputHelper testOutput)
         : base(testOutput)
@@ -47,7 +47,7 @@ public partial class OutOfProcTagHelperResolverTest : VisualStudioTestBase
         var workspace = new AdhocWorkspace();
         AddDisposable(workspace);
 
-        _remoteClientProvider = StrictMock.Of<IRemoteClientProvider>();
+        _remoteClientProvider = StrictMock.Of<IRemoteServiceProvider>();
 
         var info = ProjectInfo.Create(ProjectId.CreateNewId("Test"), VersionStamp.Default, "Test", "Test", LanguageNames.CSharp, filePath: "Test.csproj");
         _workspaceProject = workspace.CurrentSolution.AddProject(info).GetProject(info.Id).AssumeNotNull();


### PR DESCRIPTION
This makes our OOP services a bit easier to call, removes a bit of boiler plate, and fixes a bug where we could be overly chatty and send multiple initialization calls if a .razor document is restored from a previous VS session.