### PR TITLE
Add design time targets to the razor repo

### DIFF
--- a/src/Razor/src/rzls/Targets/Microsoft.NET.Sdk.Razor.DesignTime.targets
+++ b/src/Razor/src/rzls/Targets/Microsoft.NET.Sdk.Razor.DesignTime.targets
@@ -1,0 +1,131 @@
+<!--
+***********************************************************************************************
+Microsoft.NET.Sdk.Razor.DesignTime.targets
+
+WARNING:  DO NOT MODIFY this file unless you are knowledgeable about MSBuild and have
+          created a backup copy.  Incorrect changes to this file will make it
+          impossible to load or build your projects from the command-line or the IDE.
+
+Copyright (c) .NET Foundation. All rights reserved.
+***********************************************************************************************
+-->
+
+<Project ToolsVersion="14.0">
+
+  <PropertyGroup>
+    <!--
+      Defines the list of file extensions that VS will monitor to reload the application.
+      We'll only define these for C# projects targeting RazorLangVersion 3.0 or later, and let VS use defaults in other cases.
+    -->
+    <UpToDateReloadFileTypes Condition="'$(Language)'=='C#' AND '$(_Targeting30OrNewerRazorLangVersion)' == 'true' AND '$(RazorUpToDateReloadFileTypes)' != ''">$(UpToDateReloadFileTypes);$(RazorUpToDateReloadFileTypes)</UpToDateReloadFileTypes>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!--
+      Defines the generic .NET Core 'Razor' capability.
+
+      Note that we don't define any capabilities here that depend on the version of the runtime/toolset
+      in use by the project. Those capabilities are defined by the relevant runtime packages so that
+      we use the lack of the capability to detect downlevel scenarios.
+    -->
+    <ProjectCapability Include="DotNetCoreRazor"/>
+
+    <!--
+      Defines the ability to understand the configuration for the Razor language service provided by
+      the runtime/toolset packages. Introduced in 2.1
+    -->
+    <ProjectCapability Include="DotNetCoreRazorConfiguration" Condition="'$(_Targeting30OrNewerRazorLangVersion)' == 'true'"/>
+
+    <!--
+      Activates the set of nesting behaviors we want from solution explorer.
+    -->
+    <ProjectCapability Include="WebNestingDefaults" />
+
+    <!--
+      Tooling support for TypeScript files.
+    -->
+    <ProjectCapability Include="SupportsTypeScriptNuGet" />
+  </ItemGroup>
+
+  <!--
+    In order to properly support Blazor partial classes we need to ensure that older SDKs don't
+    add declaration files to the compile list. We do all the compilation work in-memory in latest
+    VS.
+  -->
+  <Target Name="_RemoveRazorDeclartionsFromCompile" AfterTargets="RazorGenerateComponentDeclaration">
+    <ItemGroup Condition="'$(DesignTimeBuild)'=='true'">
+      <Compile Remove="@(_RazorComponentDeclaration)" />
+    </ItemGroup>
+  </Target>
+
+  <!--
+    WebSdk imports these capabilities for nesting in DotNetCoreWeb projects.
+    Conditinally import these capabilities if the project isn't targeting the WebSdk.
+   -->
+  <ItemGroup Condition="'$(UsingMicrosoftNETSdkWeb)'==''">
+    <ProjectCapability Include="SupportHierarchyContextSvc" />
+    <ProjectCapability Include="DynamicDependentFile" />
+    <ProjectCapability Include="DynamicFileNesting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PropertyPageSchema Include="$(MSBuildThisFileDirectory)Rules\RazorConfiguration.xaml">
+      <Context>File</Context>
+    </PropertyPageSchema>
+    <PropertyPageSchema Include="$(MSBuildThisFileDirectory)Rules\RazorExtension.xaml">
+      <Context>File</Context>
+    </PropertyPageSchema>
+    <PropertyPageSchema Include="$(MSBuildThisFileDirectory)Rules\RazorGeneral.xaml">
+      <Context>Project</Context>
+    </PropertyPageSchema>
+    <PropertyPageSchema Include="$(MSBuildThisFileDirectory)Rules\RazorGenerateWithTargetPath.xaml">
+      <Context>Project</Context>
+    </PropertyPageSchema>
+    <PropertyPageSchema Include="$(MSBuildThisFileDirectory)Rules\RazorComponentWithTargetPath.xaml">
+      <Context>Project</Context>
+    </PropertyPageSchema>
+  </ItemGroup>
+
+  <Target
+    Name="RazorGenerateDesignTime"
+    DependsOnTargets="ResolveRazorGenerateInputs;AssignRazorGenerateTargetPaths"
+    Returns="@(RazorGenerateWithTargetPath)">
+  </Target>
+
+  <!--
+    Using DependsOnTargets here because real dependencies of this target aren't defined in
+    a downlevel (pre-3.0) SDK.
+  -->
+  <Target
+    Name="RazorGenerateComponentDesignTime"
+    DependsOnTargets="$(_RazorGenerateComponentDesignTimeDependsOn)"
+    Returns="@(RazorComponentWithTargetPath)">
+  </Target>
+
+
+  <!--
+    Using DependsOnTargets here because real dependencies of this target aren't defined in
+    a downlevel (pre-3.0) SDK.
+
+    Called by the project system to update generated declaration files
+  -->
+  <Target
+    Name="RazorGenerateComponentDeclarationDesignTime"
+    DependsOnTargets="$(_RazorGenerateComponentDeclarationDesignTimeDependsOn)">
+  </Target>
+
+  <!--
+    Backwards compatibility workaround for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1803616/.
+    Razor is dependent on RazorSourceGenerator.razorencconfig during design-time build in order to behave correctly.
+    The SDK conditionally includes this config file, however with the current global properties that are set,
+    the condition is not met and config file will not be included. This workaround ensures the config file is included during design-time build.
+    Tracking item to remove the workaround: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1806334.
+  -->
+  <Target Name="_FixRazorEditorConfigFiles" AfterTargets="_PrepareRazorSourceGenerators">
+    <ItemGroup>
+      <EditorConfigFiles Remove="$(RazorEncConfigFile)" Condition="'$(DesignTimeBuild)' == 'true'"/>
+      <EditorConfigFiles Include="$(RazorEncConfigFile)" Condition="'$(DesignTimeBuild)' == 'true'"/>
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Razor/src/rzls/Targets/Readme.md
+++ b/src/Razor/src/rzls/Targets/Readme.md
@@ -1,0 +1,3 @@
+### Note
+
+This (and code in Rules) was pulled from the [sdk](https://github.com/dotnet/sdk/blob/8f983a2c12162e49af7a7f2eb7744d220859f42b/src/RazorSdk/Targets/Microsoft.NET.Sdk.Razor.DesignTime.targets). These files are for tooling to define specific design time behavior and thus should be owned by tooling. As of writing these are only used in VS Code.

--- a/src/Razor/src/rzls/Targets/Rules/RazorComponentWithTargetPath.xaml
+++ b/src/Razor/src/rzls/Targets/Rules/RazorComponentWithTargetPath.xaml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Rule
+  Description="Razor Document Properties"
+  DisplayName="Razor Document Properties"
+  Name="RazorComponentWithTargetPath"
+  PageTemplate="generic"
+  xmlns="http://schemas.microsoft.com/build/2009/properties">
+  <Rule.DataSource>
+    <DataSource
+      Persistence="ProjectFile"
+      ItemType="RazorComponentWithTargetPath"
+      MSBuildTarget="RazorGenerateComponentDesignTime"
+      HasConfigurationCondition="False"
+      SourceOfDefaultValue="AfterContext"
+      SourceType="TargetResults" />
+  </Rule.DataSource>
+
+  <Rule.Categories>
+    <Category
+      Name="General"
+      DisplayName="General" />
+  </Rule.Categories>
+  
+  <StringProperty
+    Category="General"
+    Name="TargetPath"
+    ReadOnly="True"
+    Visible="False" />
+
+</Rule>

--- a/src/Razor/src/rzls/Targets/Rules/RazorConfiguration.xaml
+++ b/src/Razor/src/rzls/Targets/Rules/RazorConfiguration.xaml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Rule
+  Description="Configuration Properties"
+  DisplayName="Configuration Properties"
+  Name="RazorConfiguration"
+  PageTemplate="generic"
+  xmlns="http://schemas.microsoft.com/build/2009/properties">
+  <Rule.DataSource>
+    <DataSource
+      Persistence="ProjectFile"
+      HasConfigurationCondition="True" 
+      ItemType="RazorConfiguration" />
+  </Rule.DataSource>
+
+  <Rule.Categories>
+    <Category
+      Name="General"
+      DisplayName="General" />
+  </Rule.Categories>
+
+  <StringProperty
+    Category="General"
+    Description="Razor Extensions"
+    DisplayName="Razor Extensions"
+    Name="Extensions"
+    ReadOnly="True"
+    Visible="True" />
+
+</Rule>

--- a/src/Razor/src/rzls/Targets/Rules/RazorExtension.xaml
+++ b/src/Razor/src/rzls/Targets/Rules/RazorExtension.xaml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Rule
+  Description="Extension Properties"
+  DisplayName="Extension Properties"
+  Name="RazorExtension"
+  PageTemplate="generic"
+  xmlns="http://schemas.microsoft.com/build/2009/properties">
+  <Rule.DataSource>
+    <DataSource
+      Persistence="ProjectFile"
+      HasConfigurationCondition="True"
+      ItemType="RazorExtension" />
+  </Rule.DataSource>
+
+  <Rule.Categories>
+    <Category
+      Name="General"
+      DisplayName="General" />
+  </Rule.Categories>
+
+  <StringProperty
+    Category="General"
+    Description="Razor Extension Assembly Name"
+    DisplayName="Razor Extension Assembly Name"
+    Name="AssemblyName"
+    ReadOnly="True"
+    Visible="False" />
+
+  <StringProperty
+    Category="General"
+    Description="Razor Extension Assembly File Path"
+    DisplayName="Razor Extension Assembly File Path"
+    Name="AssemblyFilePath"
+    ReadOnly="True"
+    Visible="False" />
+
+</Rule>

--- a/src/Razor/src/rzls/Targets/Rules/RazorGeneral.xaml
+++ b/src/Razor/src/rzls/Targets/Rules/RazorGeneral.xaml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Rule
+  Description="Razor Properties"
+  DisplayName="Razor Properties"
+  Name="RazorGeneral"
+  PageTemplate="generic"
+  xmlns="http://schemas.microsoft.com/build/2009/properties">
+  <Rule.DataSource>
+    <DataSource
+      Persistence="ProjectFile"
+      HasConfigurationCondition="True" />
+  </Rule.DataSource>
+
+  <Rule.Categories>
+    <Category
+      Name="General"
+      DisplayName="General" />
+  </Rule.Categories>
+
+  <StringProperty
+    Category="General"
+    Description="Razor Language Version"
+    DisplayName="Razor Language Version"
+    Name="RazorLangVersion"
+    ReadOnly="True"
+    Visible="False" />
+
+  <StringProperty
+    Category="General"
+    Description="Razor Configuration Name"
+    DisplayName="Razor Configuration Name"
+    Name="RazorDefaultConfiguration"
+    ReadOnly="True"
+    Visible="False" />
+
+</Rule>

--- a/src/Razor/src/rzls/Targets/Rules/RazorGenerateWithTargetPath.xaml
+++ b/src/Razor/src/rzls/Targets/Rules/RazorGenerateWithTargetPath.xaml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Rule
+  Description="Razor Document Properties"
+  DisplayName="Razor Document Properties"
+  Name="RazorGenerateWithTargetPath"
+  PageTemplate="generic"
+  xmlns="http://schemas.microsoft.com/build/2009/properties">
+  <Rule.DataSource>
+    <DataSource
+      Persistence="ProjectFile"
+      ItemType="RazorGenerateWithTargetPath"
+      MSBuildTarget="RazorGenerateDesignTime"
+      HasConfigurationCondition="False"
+      SourceOfDefaultValue="AfterContext"
+      SourceType="TargetResults" />
+  </Rule.DataSource>
+
+  <Rule.Categories>
+    <Category
+      Name="General"
+      DisplayName="General" />
+  </Rule.Categories>
+  
+  <StringProperty
+    Category="General"
+    Name="TargetPath"
+    ReadOnly="True"
+    Visible="False" />
+
+</Rule>

--- a/src/Razor/src/rzls/rzls.csproj
+++ b/src/Razor/src/rzls/rzls.csproj
@@ -30,6 +30,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.AspNetCore.Razor.LanguageServer\Microsoft.AspNetCore.Razor.LanguageServer.csproj" />
+    <None Update=".\Targets\**\*.targets" CopyToOutputDirectory="PreserveNewest" />
+    <None Update=".\Targets\**\*.xaml" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/src/rzls/rzls.csproj
+++ b/src/Razor/src/rzls/rzls.csproj
@@ -30,12 +30,18 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.AspNetCore.Razor.LanguageServer\Microsoft.AspNetCore.Razor.LanguageServer.csproj" />
-    <None Update=".\Targets\**\*.targets" CopyToOutputDirectory="PreserveNewest" />
-    <None Update=".\Targets\**\*.xaml" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>
     <Content Include="$(RepositoryRoot)NOTICE.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+
+    <Content Include=".\Targets\**\*.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+
+    <Content Include=".\Targets\Rules\*.xaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>


### PR DESCRIPTION
Part of fixing https://github.com/dotnet/razor/issues/10351 

Copied build targets to the razor repo so they can be shipped by us and used in vs code