### PR TITLE
Suppress less

### DIFF
--- a/src/Razor/src/.editorconfig
+++ b/src/Razor/src/.editorconfig
@@ -2,6 +2,3 @@
 
 # Call ConfigureAwait
 dotnet_diagnostic.CA2007.severity = warning
-
-# Don't use SemaphoreSlim: See https://github.com/dotnet/razor/issues/10390
-dotnet_diagnostic.RS0030.severity = none

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LiveShare/Host/ProjectSnapshotManagerProxy.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LiveShare/Host/ProjectSnapshotManagerProxy.cs
@@ -15,6 +15,9 @@ namespace Microsoft.VisualStudio.Razor.LiveShare.Host;
 
 internal class ProjectSnapshotManagerProxy : IProjectSnapshotManagerProxy, ICollaborationService, IDisposable
 {
+    // AsyncSemaphore is banned. See https://github.com/dotnet/razor/issues/10390 for more info.
+#pragma warning disable RS0030 // Do not use banned APIs
+
     private readonly CollaborationSession _session;
     private readonly IProjectSnapshotManager _projectSnapshotManager;
     private readonly JoinableTaskFactory _jtf;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/VisualStudioWindowsLogHubTraceProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/VisualStudioWindowsLogHubTraceProvider.cs
@@ -14,6 +14,9 @@ namespace Microsoft.VisualStudio.Razor.Logging;
 [Export(typeof(RazorLogHubTraceProvider))]
 internal class VisualStudioWindowsLogHubTraceProvider : RazorLogHubTraceProvider
 {
+    // SemaphoreSlim is banned. See https://github.com/dotnet/razor/issues/10390 for more info.
+#pragma warning disable RS0030 // Do not use banned APIs
+
     private static readonly LoggerOptions s_logOptions = new(
         requestedLoggingLevel: new LoggingLevelSettings(SourceLevels.Information | SourceLevels.ActivityTracing),
         privacySetting: PrivacyFlags.MayContainPersonallyIdentifibleInformation | PrivacyFlags.MayContainPrivateInformation);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
@@ -21,6 +21,9 @@ namespace Microsoft.VisualStudio.Razor.ProjectSystem;
 
 internal abstract partial class WindowsRazorProjectHostBase : OnceInitializedOnceDisposedAsync, IProjectDynamicLoadComponent
 {
+    // AsyncSemaphore is banned. See https://github.com/dotnet/razor/issues/10390 for more info.
+#pragma warning disable RS0030 // Do not use banned APIs
+
     private static readonly DataflowLinkOptions s_dataflowLinkOptions = new DataflowLinkOptions() { PropagateCompletion = true };
 
     private readonly IServiceProvider _serviceProvider;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectWorkspaceStateGenerator.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectWorkspaceStateGenerator.cs
@@ -26,6 +26,9 @@ internal sealed partial class ProjectWorkspaceStateGenerator(
     ITelemetryReporter telemetryReporter)
     : IProjectWorkspaceStateGenerator, IDisposable
 {
+    // SemaphoreSlim is banned. See https://github.com/dotnet/razor/issues/10390 for more info.
+#pragma warning disable RS0030 // Do not use banned APIs
+
     private readonly IProjectSnapshotManager _projectManager = projectManager;
     private readonly ITagHelperResolver _tagHelperResolver = tagHelperResolver;
     private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<ProjectWorkspaceStateGenerator>();


### PR DESCRIPTION
Yesterday when I hit the `SemaphoreSlim` et al banning, I suppressed in an editorconfig file, without thinking too much. That was a mistake though, as it bans the entire BannedApiAnalyzer. This PR just suppresses the few spots we use SemaphoreSlim. Still not ideal to do it for the whole file, but I thought it was better than suppressing at every individual call site. If you disagree, let me know.

I did puth the suppression below the class definition at least, so our MEF related bannings still work.