### PR TITLE
Simplify OOP services

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Initialization/RemoteClientInitializationService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Initialization/RemoteClientInitializationService.cs
@@ -3,7 +3,6 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.ExternalAccess.Razor.Api;
 using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.CodeAnalysis.Remote.Razor.SemanticTokens;
 using Microsoft.ServiceHub.Framework;
@@ -15,7 +14,7 @@ internal sealed class RemoteClientInitializationService(
     : RazorServiceBase(serviceBroker), IRemoteClientInitializationService
 {
     public ValueTask InitializeAsync(RemoteClientInitializationOptions options, CancellationToken cancellationToken)
-        => RazorBrokeredServiceImplementation.RunServiceAsync(_ =>
+        => RunServiceAsync(ct =>
             {
                 RemoteLanguageServerFeatureOptions.SetOptions(options);
                 return default;
@@ -23,10 +22,10 @@ internal sealed class RemoteClientInitializationService(
             cancellationToken);
 
     public ValueTask InitializeLSPAsync(RemoteClientLSPInitializationOptions options, CancellationToken cancellationToken)
-        => RazorBrokeredServiceImplementation.RunServiceAsync(_ =>
-        {
-            RemoteSemanticTokensLegendService.SetLegend(options.TokenTypes, options.TokenModifiers);
-            return default;
-        },
+        => RunServiceAsync(ct =>
+            {
+                RemoteSemanticTokensLegendService.SetLegend(options.TokenTypes, options.TokenModifiers);
+                return default;
+            },
             cancellationToken);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/DocumentSnapshotFactory.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/DocumentSnapshotFactory.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Composition;
 using System.Runtime.CompilerServices;
-using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
 
@@ -12,11 +11,11 @@ namespace Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
 [method: ImportingConstructor]
 internal class DocumentSnapshotFactory(Lazy<ProjectSnapshotFactory> projectSnapshotFactory)
 {
-    private static readonly ConditionalWeakTable<TextDocument, IDocumentSnapshot> _documentSnapshots = new();
+    private static readonly ConditionalWeakTable<TextDocument, RemoteDocumentSnapshot> _documentSnapshots = new();
 
     private readonly Lazy<ProjectSnapshotFactory> _projectSnapshotFactory = projectSnapshotFactory;
 
-    public IDocumentSnapshot GetOrCreate(TextDocument textDocument)
+    public RemoteDocumentSnapshot GetOrCreate(TextDocument textDocument)
     {
         lock (_documentSnapshots)
         {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentContext.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentContext.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+namespace Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
+
+internal class RemoteDocumentContext : VersionedDocumentContext
+{
+    public TextDocument TextDocument => ((RemoteDocumentSnapshot)Snapshot).TextDocument;
+
+    public RemoteDocumentContext(Uri uri, RemoteDocumentSnapshot snapshot)
+        // HACK: Need to revisit version and projectContext here I guess
+        : base(uri, snapshot, projectContext: null, version: 1)
+    {
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorDocumentServiceBase.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorDocumentServiceBase.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
+using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
-using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
 using Microsoft.ServiceHub.Framework;
 
@@ -17,32 +17,33 @@ internal abstract class RazorDocumentServiceBase(
 {
     protected DocumentSnapshotFactory DocumentSnapshotFactory { get; } = documentSnapshotFactory;
 
-    protected async Task<(TextDocument?, RazorCodeDocument?)> GetRazorTextAndCodeDocumentsAsync(Solution solution, DocumentId razorDocumentId)
+    protected ValueTask<T> RunServiceAsync<T>(RazorPinnedSolutionInfoWrapper solutionInfo, DocumentId razorDocumentId, Func<RemoteDocumentContext, ValueTask<T>> implementation, CancellationToken cancellationToken)
+    {
+        return RunServiceAsync(
+            solutionInfo,
+            solution =>
+            {
+                var documentContext = CreateRazorDocumentContext(solution, razorDocumentId);
+                if (documentContext is null)
+                {
+                    return default;
+                }
+
+                return implementation(documentContext);
+            },
+            cancellationToken);
+    }
+
+    private RemoteDocumentContext? CreateRazorDocumentContext(Solution solution, DocumentId razorDocumentId)
     {
         var razorDocument = solution.GetAdditionalDocument(razorDocumentId);
         if (razorDocument is null)
         {
-            return (null, null);
+            return null;
         }
 
-        var snapshot = DocumentSnapshotFactory.GetOrCreate(razorDocument);
-        var codeDocument = await snapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
+        var documentSnapshot = DocumentSnapshotFactory.GetOrCreate(razorDocument);
 
-        return (razorDocument, codeDocument);
-    }
-
-    protected async Task<RazorCodeDocument?> GetRazorCodeDocumentAsync(Solution solution, DocumentId razorDocumentId)
-    {
-        var (_, codeDocument) = await GetRazorTextAndCodeDocumentsAsync(solution, razorDocumentId);
-
-        return codeDocument;
-    }
-
-    protected VersionedDocumentContext CreateRazorDocumentContext(TextDocument textDocument)
-    {
-        var documentSnapshot = DocumentSnapshotFactory.GetOrCreate(textDocument);
-
-        // HACK: Need to revisit version and projectContext here I guess
-        return new VersionedDocumentContext(textDocument.CreateUri(), documentSnapshot, projectContext: null, version: 1);
+        return new RemoteDocumentContext(razorDocument.CreateUri(), documentSnapshot);
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorServiceBase.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RazorServiceBase.cs
@@ -2,23 +2,31 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Api;
 using Microsoft.ServiceHub.Framework;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor;
 
 internal abstract class RazorServiceBase : IDisposable
 {
-    protected readonly ServiceBrokerClient ServiceBrokerClient;
+    private readonly ServiceBrokerClient _serviceBrokerClient;
 
     public RazorServiceBase(IServiceBroker serviceBroker)
     {
-#pragma warning disable VSTHRD012 // Provide JoinableTaskFactory where allowed
-        ServiceBrokerClient = new ServiceBrokerClient(serviceBroker);
-#pragma warning restore
+        _serviceBrokerClient = new ServiceBrokerClient(serviceBroker, joinableTaskFactory: null);
     }
+
+    protected ValueTask RunServiceAsync(Func<CancellationToken, ValueTask> implementation, CancellationToken cancellationToken)
+        => RazorBrokeredServiceImplementation.RunServiceAsync(implementation, cancellationToken);
+
+    protected ValueTask<T> RunServiceAsync<T>(RazorPinnedSolutionInfoWrapper solutionInfo, Func<Solution, ValueTask<T>> implementation, CancellationToken cancellationToken)
+        => RazorBrokeredServiceImplementation.RunServiceAsync(solutionInfo, _serviceBrokerClient, implementation, cancellationToken);
 
     public void Dispose()
     {
-        ServiceBrokerClient.Dispose();
+        _serviceBrokerClient.Dispose();
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/TagHelpers/RemoteTagHelperProviderService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/TagHelpers/RemoteTagHelperProviderService.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.AspNetCore.Razor.Serialization;
 using Microsoft.AspNetCore.Razor.Utilities;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
-using Microsoft.CodeAnalysis.ExternalAccess.Razor.Api;
 using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.ServiceHub.Framework;
 
@@ -29,9 +28,8 @@ internal sealed class RemoteTagHelperProviderService(
         ProjectSnapshotHandle projectHandle,
         ImmutableArray<Checksum> checksums,
         CancellationToken cancellationToken)
-        => RazorBrokeredServiceImplementation.RunServiceAsync(
+        => RunServiceAsync(
             solutionInfo,
-            ServiceBrokerClient,
             solution => FetchTagHelpersCoreAsync(solution, projectHandle, checksums, cancellationToken),
             cancellationToken);
 
@@ -102,9 +100,8 @@ internal sealed class RemoteTagHelperProviderService(
         ProjectSnapshotHandle projectHandle,
         int lastResultId,
         CancellationToken cancellationToken)
-        => RazorBrokeredServiceImplementation.RunServiceAsync(
+        => RunServiceAsync(
             solutionInfo,
-            ServiceBrokerClient,
             solution => GetTagHelpersDeltaCoreAsync(solution, projectHandle, lastResultId, cancellationToken),
             cancellationToken);
 


### PR DESCRIPTION
Previously @alexgav created some helper methods to get document info in OOP services, but it ended up being a little bit of an odd API to use if you needed to access multiple things. You'd either have to make multiple calls to get things, and end up looking up things in the solution multiple times etc., or have single methods that returned an arbitrary tuple of multiple things.

It occurred to me while doing the folding range work that `DocumentContext` was designed to hold all of these concepts together, so we could just use that, and use the single `CreateDocumentContext` method that Alex had already added. It then further occured to me that if we did that by wrapping `RazorBrokeredServiceImplementation.RunServiceAsync` then each service could just have a method that takes a document context, and that would be enough. So thats what this is.

It turns out I also hated the overloads of `RazorBrokeredServiceImplementation.RunServiceAsync` anyway, and found it very annoying to use, so I made all of that, and `ServiceBrokerClient`, an implementation detail of `RazorServiceBase` while I was here. Now there are just three overloads of `RunServiceAsync` and they each make sense: One that doesn't provide anything, one that provides a solution, and one that provides a document context.