### PR TITLE
Enable 1ES's SBOM generation

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -71,8 +71,6 @@ extends:
         name: NetCore1ESPool-Svc-Internal
         image: 1es-windows-2022
         os: windows
-      sbom:
-        enabled: false
     pool:
       name: NetCore1ESPool-Svc-Internal
       image: windows.vs2022preview.amd64


### PR DESCRIPTION
I've heard in https://github.com/dotnet/fsharp/issues/17265 that this will be required.
Official build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2466301&view=results