### PR TITLE
Allow delegated servers to use either System.Text.Json or Newtonsoft.Json

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/RazorVSInternalCodeAction.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Models/RazorVSInternalCodeAction.cs
@@ -1,11 +1,16 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
 
+[DataContract]
 internal class RazorVSInternalCodeAction : VSInternalCodeAction
 {
+    [JsonPropertyName("name")]
+    [DataMember(Name = "name")]
     public string? Name { get; set; }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/CodeActions/FormatNewFileParams.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/CodeActions/FormatNewFileParams.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.Razor.Protocol.CodeActions;
@@ -10,11 +11,14 @@ namespace Microsoft.CodeAnalysis.Razor.Protocol.CodeActions;
 internal record FormatNewFileParams
 {
     [DataMember(Name = "document")]
+    [JsonPropertyName("document")]
     public required TextDocumentIdentifier Document { get; set; }
 
     [DataMember(Name = "project")]
+    [JsonPropertyName("project")]
     public required TextDocumentIdentifier Project { get; set; }
 
     [DataMember(Name = "contents")]
+    [JsonPropertyName("contents")]
     public required string Contents { get; set; }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/CodeActions/SimplifyMethodParams.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/CodeActions/SimplifyMethodParams.cs
@@ -2,26 +2,19 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.Razor.Protocol.CodeActions;
 
-//
-// Summary:
-//     Class representing the parameters sent from the client to the server for the
-//     roslyn/simplifyMethod request.
 [DataContract]
 internal record SimplifyMethodParams : ITextDocumentParams
 {
-    //
-    // Summary:
-    //     Gets or sets the value which identifies the document in which the edit will be applied.
     [DataMember(Name = "textDocument")]
+    [JsonPropertyName("textDocument")]
     public required TextDocumentIdentifier TextDocument { get; set; }
 
-    //
-    // Summary:
-    //     Gets or sets the value which is the text edit to be simplified.
     [DataMember(Name = "textEdit")]
+    [JsonPropertyName("textEdit")]
     public required TextEdit TextEdit { get; set; }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/CodeActions/VSCodeActionParams.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/CodeActions/VSCodeActionParams.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.Razor.Protocol.CodeActions;
@@ -15,21 +16,15 @@ namespace Microsoft.CodeAnalysis.Razor.Protocol.CodeActions;
 [DataContract]
 internal class VSCodeActionParams
 {
-    //
-    // Summary:
-    //     Gets or sets the document identifier indicating where the command was invoked.
+    [JsonPropertyName("textDocument")]
     [DataMember(Name = "textDocument")]
     public required VSTextDocumentIdentifier TextDocument { get; set; }
 
-    //
-    // Summary:
-    //     Gets or sets the range in the document for which the command was invoked.
+    [JsonPropertyName("range")]
     [DataMember(Name = "range")]
     public required Range Range { get; set; }
 
-    //
-    // Summary:
-    //     Gets or sets the additional diagnostic information about the code action context.
+    [JsonPropertyName("context")]
     [DataMember(Name = "context")]
     public required VSInternalCodeActionContext Context { get; set; }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/JsonHelpers.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/JsonHelpers.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Text.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.CodeAnalysis.Razor.Protocol;
+
+internal static class JsonHelpers
+{
+    private const string s_convertedFlag = "__convertedFromJsonElement";
+
+    /// <summary>
+    /// Normalizes data from JsonElement to JObject as thats what we expect to process
+    /// </summary>
+    internal static object? TryConvertFromJsonElement(object? data)
+    {
+        if (data is JsonElement element)
+        {
+            var jObject = JObject.Parse(element.GetRawText());
+            jObject[s_convertedFlag] = true;
+            return jObject;
+        }
+
+        return data;
+    }
+
+    /// <summary>
+    /// Converts from JObject back to JsonElement, but only if the original conversion was done with <see cref="TryConvertFromJsonElement(object?)"/>
+    /// </summary>
+    internal static object? TryConvertBackToJsonElement(object? data)
+    {
+        if (data is JObject jObject &&
+           jObject.ContainsKey(s_convertedFlag))
+        {
+            return JsonDocument.Parse(jObject.ToString()).RootElement;
+        }
+
+        return data;
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_CodeActions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_CodeActions.cs
@@ -80,7 +80,11 @@ internal partial class RazorCustomMessageTarget
 
             if (response.Response != null)
             {
-                codeActions.AddRange(response.Response);
+                foreach (var codeAction in response.Response)
+                {
+                    codeAction.Data = JsonHelpers.TryConvertFromJsonElement(codeAction.Data);
+                    codeActions.Add(codeAction);
+                }
             }
         }
 
@@ -126,6 +130,8 @@ internal partial class RazorCustomMessageTarget
 
         var textBuffer = virtualDocumentSnapshot.Snapshot.TextBuffer;
         var codeAction = resolveCodeActionParams.CodeAction;
+        codeAction.Data = JsonHelpers.TryConvertBackToJsonElement(codeAction.Data);
+
         var requests = _requestInvoker.ReinvokeRequestOnMultipleServersAsync<CodeAction, VSInternalCodeAction?>(
             textBuffer,
             Methods.CodeActionResolveName,
@@ -138,7 +144,10 @@ internal partial class RazorCustomMessageTarget
             if (response.Response is not null)
             {
                 // Only take the first response from a resolution
-                return response.Response;
+                var resolved = response.Response;
+                resolved.Data = JsonHelpers.TryConvertFromJsonElement(resolved.Data);
+
+                return resolved;
             }
         }
 


### PR DESCRIPTION
Due to our custom message target stuff, which lives in the LSP client, there are a couple of places where we rely on knowing exactly what serializer our delegated servers (ie, Roslyn and Web Tools) are using in order to process their responses. This effectively blocks them from moving to System.Text.Json, as they'd break us. This PR is an attempt for us to be resilient to one of them moving to System.Text.Json, so that hopefully we can all do it without dual or triple insertions.

Testing is sadly manual (chicken and egg, Roslyn hasn't moved to STJ so can't test in CI, but Roslyn can't move until this is done) but basic functionality works, and code actions and completion are the only two things I can think of where we need to inspect json objects directly, so I'm hoping that anything else that is weird at least round-trips successfully.