### PR TITLE
Don't show misc files project in hover info

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/MiscFilesHostProject.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/MiscFilesHostProject.cs
@@ -17,6 +17,11 @@ internal sealed class MiscFilesHostProject : HostProject
 {
     public static MiscFilesHostProject Instance { get; } = Create();
 
+    public static bool IsMiscellaneousProject(IProjectSnapshot project)
+    {
+        return project.Key == Instance.Key;
+    }
+
     public string DirectoryPath { get; }
 
     private MiscFilesHostProject(

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
@@ -271,9 +271,9 @@ internal partial class RazorProjectService : IRazorProjectService, IRazorProject
                         if (_projectManager.IsDocumentOpen(textDocumentPath))
                         {
                             _logger.LogInformation($"Moving document '{textDocumentPath}' from project '{projectSnapshot.Key}' to misc files because it is open.");
-                            var miscellaneousProject = _projectManager.GetMiscellaneousProject();
-                            if (projectSnapshot != miscellaneousProject)
+                            if (!MiscFilesHostProject.IsMiscellaneousProject(projectSnapshot))
                             {
+                                var miscellaneousProject = _projectManager.GetMiscellaneousProject();
                                 MoveDocument(updater, textDocumentPath, fromProject: projectSnapshot, toProject: miscellaneousProject);
                             }
                         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/TagHelperTooltipFactoryBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Tooltip/TagHelperTooltipFactoryBase.cs
@@ -36,6 +36,11 @@ internal abstract class TagHelperTooltipFactoryBase(IProjectSnapshotManager proj
 
         foreach (var project in projectSnapshots)
         {
+            if (MiscFilesHostProject.IsMiscellaneousProject(project))
+            {
+                continue;
+            }
+
             var found = false;
             var tagHelpers = await project.GetTagHelpersAsync(cancellationToken).ConfigureAwait(false);
             foreach (var tagHelper in tagHelpers)


### PR DESCRIPTION
Fixes the integration tests. I guess this was always a bit broken, but we got lucky because misc files project wasn't added up front? But I would have thought we would have noticed earlier.... 🤷‍♂️