### PR TITLE
Preserve properties on the folding ranges we return

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Folding/FoldingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Folding/FoldingRangeEndpoint.cs
@@ -111,7 +111,12 @@ internal sealed class FoldingRangeEndpoint : IRazorRequestHandler<FoldingRangePa
                 range,
                 out var mappedRange))
             {
-                mappedRanges.Add(GetFoldingRange(mappedRange, foldingRange.CollapsedText));
+                foldingRange.StartLine = mappedRange.Start.Line;
+                foldingRange.StartCharacter = mappedRange.Start.Character;
+                foldingRange.EndLine = mappedRange.End.Line;
+                foldingRange.EndCharacter = mappedRange.End.Character;
+
+                mappedRanges.Add(foldingRange);
             }
         }
 
@@ -199,14 +204,4 @@ internal sealed class FoldingRangeEndpoint : IRazorRequestHandler<FoldingRangePa
                 Line = foldingRange.EndLine
             }
         };
-
-    private static FoldingRange GetFoldingRange(Range range, string? collapsedText)
-       => new()
-       {
-           StartLine = range.Start.Line,
-           StartCharacter = range.Start.Character,
-           EndCharacter = range.End.Character,
-           EndLine = range.End.Line,
-           CollapsedText = collapsedText
-       };
 }


### PR DESCRIPTION
Part of fixing https://github.com/dotnet/razor/issues/9492 along with https://github.com/dotnet/roslyn/pull/74069

The change here is to just change the properties we want to change, and let everything else flow through from Roslyn, rather than being so opinionated.