### PR TITLE
Remove support for internal runtime downloads

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -14,11 +14,6 @@ variables:
   value: 'All'
 - name: RunIntegrationTests
   value: false
-- group: DotNetBuilds storage account read tokens
-- name: _InternalRuntimeDownloadArgs
-  value: /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal
-          /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
-
 - group: DotNet-DevDiv-Insertion-Workflow-Variables
 - name: _DevDivDropAccessToken
   value: $(dn-bot-devdiv-drop-rw-code-rw)
@@ -109,15 +104,8 @@ extends:
                 inputs:
                   command: custom
                   arguments: 'locals all -clear'
-              - task: PowerShell@2
-                displayName: Setup Private Feeds Credentials
-                inputs:
-                  filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-                  arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-                env:
-                  Token: $(dn-bot-dnceng-artifact-feeds-rw)
               - task: NuGetAuthenticate@1
-              - powershell: ./restore.cmd -msbuildEngine dotnet -ci $(_InternalRuntimeDownloadArgs); ./eng/scripts/CodeCheck.ps1 -ci
+              - powershell: ./restore.cmd -msbuildEngine dotnet -ci; ./eng/scripts/CodeCheck.ps1 -ci
                 displayName: Run eng/scripts/CodeCheck.ps1
 
       # Windows based jobs. This needs to be separate from Unix based jobs because it generates
@@ -185,13 +173,6 @@ extends:
                 devenv, xunit.console, xunit.console.x86
               displayName: Start background dump collection
 
-            - task: PowerShell@2
-              displayName: Setup Private Feeds Credentials
-              inputs:
-                filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-                arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-              env:
-                Token: $(dn-bot-dnceng-artifact-feeds-rw)
             - task: NuGetAuthenticate@1
 
             # Don't create a binary log until we can customize the name
@@ -219,7 +200,6 @@ extends:
                 -sign
                 $(_BuildArgs)
                 $(_PublishArgs)
-                $(_InternalRuntimeDownloadArgs)
               name: Build
               displayName: Build and Deploy
               condition: succeeded()
@@ -336,7 +316,6 @@ extends:
                 --prepareMachine
                 --test
                 $(_BuildArgs)
-                $(_InternalRuntimeDownloadArgs)
               name: Build
               displayName: Restore, Build and Test
               condition: succeeded()
@@ -371,15 +350,7 @@ extends:
                   /p:OfficialBuildId=$(Build.BuildNumber)
 
             steps:
-            - task: Bash@3
-              displayName: Setup Private Feeds Credentials
-              inputs:
-                filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
-                arguments: $(Build.SourcesDirectory)/NuGet.config $Token
-              env:
-                Token: $(dn-bot-dnceng-artifact-feeds-rw)
             - task: NuGetAuthenticate@1
-
             - script: eng/cibuild.sh
                 --restore
                 --build
@@ -389,7 +360,6 @@ extends:
                 --prepareMachine
                 --test
                 $(_BuildArgs)
-                $(_InternalRuntimeDownloadArgs)
               name: Build
               displayName: Restore, Build and Test
               condition: succeeded()


### PR DESCRIPTION
There is no flow from runtime to this repo, and the SAS variables are going away.