### PR TITLE
[release/dev17.9] Remove support for internal runtime downloads

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -17,11 +17,6 @@ variables:
 - name: RunIntegrationTests
   value: false
 - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-  - group: DotNetBuilds storage account read tokens
-  - name: _InternalRuntimeDownloadArgs
-    value: /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal
-            /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
-
   - group: DotNet-DevDiv-Insertion-Workflow-Variables
   - name: _DevDivDropAccessToken
     value: $(dn-bot-devdiv-drop-rw-code-rw)
@@ -38,9 +33,6 @@ variables:
   - name: Insertion.TitlePrefix
     value: '[Auto Insertion]'
   - name: Insertion.TitleSuffix
-    value: ''
-- ${{ if eq(variables['System.TeamProject'], 'public') }}:
-  - name: _InternalRuntimeDownloadArgs
     value: ''
 
 trigger:
@@ -119,15 +111,8 @@ extends:
                 inputs:
                   command: custom
                   arguments: 'locals all -clear'
-              - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-                - task: PowerShell@2
-                  displayName: Setup Private Feeds Credentials
-                  inputs:
-                    filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-                    arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-                  env:
-                    Token: $(dn-bot-dnceng-artifact-feeds-rw)
-              - powershell: ./restore.cmd -msbuildEngine dotnet -ci $(_InternalRuntimeDownloadArgs); ./eng/scripts/CodeCheck.ps1 -ci
+
+              - powershell: ./restore.cmd -msbuildEngine dotnet -ci; ./eng/scripts/CodeCheck.ps1 -ci
                 displayName: Run eng/scripts/CodeCheck.ps1
 
       # Windows based jobs. This needs to be separate from Unix based jobs because it generates
@@ -208,14 +193,7 @@ extends:
                 devenv, xunit.console, xunit.console.x86
               displayName: Start background dump collection
 
-            - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-              - task: PowerShell@2
-                displayName: Setup Private Feeds Credentials
-                inputs:
-                  filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-                  arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-                env:
-                  Token: $(dn-bot-dnceng-artifact-feeds-rw)
+            - task: NuGetAuthenticate@1
 
             # Don't create a binary log until we can customize the name
             # https://github.com/dotnet/arcade/pull/12988
@@ -242,7 +220,6 @@ extends:
                 -sign
                 $(_BuildArgs)
                 $(_PublishArgs)
-                $(_InternalRuntimeDownloadArgs)
               name: Build
               displayName: Build and Deploy
               condition: succeeded()
@@ -362,7 +339,6 @@ extends:
                 --prepareMachine
                 --test
                 $(_BuildArgs)
-                $(_InternalRuntimeDownloadArgs)
               name: Build
               displayName: Restore, Build and Test
               condition: succeeded()
@@ -404,15 +380,7 @@ extends:
                   /p:OfficialBuildId=$(Build.BuildNumber)
 
             steps:
-            - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-              - task: Bash@3
-                displayName: Setup Private Feeds Credentials
-                inputs:
-                  filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
-                  arguments: $(Build.SourcesDirectory)/NuGet.config $Token
-                env:
-                  Token: $(dn-bot-dnceng-artifact-feeds-rw)
-
+            - task: NuGetAuthenticate@1
             - script: eng/cibuild.sh
                 --restore
                 --build
@@ -422,7 +390,6 @@ extends:
                 --prepareMachine
                 --test
                 $(_BuildArgs)
-                $(_InternalRuntimeDownloadArgs)
               name: Build
               displayName: Restore, Build and Test
               condition: succeeded()


### PR DESCRIPTION
There is no flow from runtime to this repo, and the SAS variables are going away.