### PR TITLE
[release/dev17.11] Remove support for internal runtime downloads

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -14,11 +14,6 @@ variables:
   value: 'All'
 - name: RunIntegrationTests
   value: false
-- group: DotNetBuilds storage account read tokens
-- name: _InternalRuntimeDownloadArgs
-  value: /p:DotNetRuntimeSourceFeed=https://dotnetbuilds.blob.core.windows.net/internal
-          /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
-
 - group: DotNet-DevDiv-Insertion-Workflow-Variables
 - name: _DevDivDropAccessToken
   value: $(dn-bot-devdiv-drop-rw-code-rw)
@@ -111,14 +106,7 @@ extends:
                 inputs:
                   command: custom
                   arguments: 'locals all -clear'
-              - task: PowerShell@2
-                displayName: Setup Private Feeds Credentials
-                inputs:
-                  filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-                  arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-                env:
-                  Token: $(dn-bot-dnceng-artifact-feeds-rw)
-              - powershell: ./restore.cmd -msbuildEngine dotnet -ci $(_InternalRuntimeDownloadArgs); ./eng/scripts/CodeCheck.ps1 -ci
+              - powershell: ./restore.cmd -msbuildEngine dotnet -ci; ./eng/scripts/CodeCheck.ps1 -ci
                 displayName: Run eng/scripts/CodeCheck.ps1
 
       # Windows based jobs. This needs to be separate from Unix based jobs because it generates
@@ -186,14 +174,6 @@ extends:
                 devenv, xunit.console, xunit.console.x86
               displayName: Start background dump collection
 
-            - task: PowerShell@2
-              displayName: Setup Private Feeds Credentials
-              inputs:
-                filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-                arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-              env:
-                Token: $(dn-bot-dnceng-artifact-feeds-rw)
-
             # Don't create a binary log until we can customize the name
             # https://github.com/dotnet/arcade/pull/12988
             - script: eng\cibuild.cmd
@@ -219,7 +199,6 @@ extends:
                 -sign
                 $(_BuildArgs)
                 $(_PublishArgs)
-                $(_InternalRuntimeDownloadArgs)
               name: Build
               displayName: Build and Deploy
               condition: succeeded()
@@ -335,7 +314,6 @@ extends:
                 --prepareMachine
                 --test
                 $(_BuildArgs)
-                $(_InternalRuntimeDownloadArgs)
               name: Build
               displayName: Restore, Build and Test
               condition: succeeded()
@@ -370,14 +348,6 @@ extends:
                   /p:OfficialBuildId=$(Build.BuildNumber)
 
             steps:
-            - task: Bash@3
-              displayName: Setup Private Feeds Credentials
-              inputs:
-                filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
-                arguments: $(Build.SourcesDirectory)/NuGet.config $Token
-              env:
-                Token: $(dn-bot-dnceng-artifact-feeds-rw)
-
             - script: eng/cibuild.sh
                 --restore
                 --build
@@ -387,7 +357,6 @@ extends:
                 --prepareMachine
                 --test
                 $(_BuildArgs)
-                $(_InternalRuntimeDownloadArgs)
               name: Build
               displayName: Restore, Build and Test
               condition: succeeded()


### PR DESCRIPTION
There is no flow from runtime to this repo, and the SAS variables are going away.