### PR TITLE
Don't use runtime identifiers in sourcebuild

### DIFF
--- a/src/Razor/src/rzls/rzls.csproj
+++ b/src/Razor/src/rzls/rzls.csproj
@@ -67,7 +67,7 @@
     TargetRid
          and other common properties, see
     https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/Unified-Build-Controls.md -->
-    <RuntimeIdentifiers Condition="'$(TargetRid)' != ''">$(TargetRid)</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="'$(TargetRid)' != '' and $(DotNetBuildSourceOnly)' != 'true'">$(TargetRid)</RuntimeIdentifiers>
     <RuntimeIdentifiers Condition="'$(TargetRid)' == ''">win-x64;win-arm64;linux-x64;linux-arm64;linux-musl-x64;linux-musl-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <!-- Publish ready to run executables when we're publishing platform specific executables. -->
     <PublishReadyToRun Condition="'$(RuntimeIdentifier)' != '' AND '$(Configuration)' == 'Release' ">true</PublishReadyToRun>

--- a/src/Razor/src/rzls/rzls.csproj
+++ b/src/Razor/src/rzls/rzls.csproj
@@ -67,7 +67,7 @@
     TargetRid
          and other common properties, see
     https://github.com/dotnet/arcade/blob/main/Documentation/UnifiedBuild/Unified-Build-Controls.md -->
-    <RuntimeIdentifiers Condition="'$(TargetRid)' != '' and $(DotNetBuildSourceOnly)' != 'true'">$(TargetRid)</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition="'$(TargetRid)' != '' and '$(DotNetBuildSourceOnly)' != 'true'">$(TargetRid)</RuntimeIdentifiers>
     <RuntimeIdentifiers Condition="'$(TargetRid)' == ''">win-x64;win-arm64;linux-x64;linux-arm64;linux-musl-x64;linux-musl-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
     <!-- Publish ready to run executables when we're publishing platform specific executables. -->
     <PublishReadyToRun Condition="'$(RuntimeIdentifier)' != '' AND '$(Configuration)' == 'Release' ">true</PublishReadyToRun>


### PR DESCRIPTION
Should fix sourcebuild for sdk insertion I think???