### PR TITLE
Fixing completion commit chars

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -38,7 +38,6 @@ internal class RazorCompletionEndpoint(
         {
             ResolveProvider = true,
             TriggerCharacters = _completionListProvider.AggregateTriggerCharacters.ToArray(),
-            AllCommitCharacters = new[] { ":", ">", " ", "=" },
         };
     }
 


### PR DESCRIPTION
﻿### Summary of the changes

We don't need to (and shouldn't) specify AllCommitCharacters in capabilities for our completion endpoint. Doing so causes them to always be added to all completion items.
-
Since we are using our completion endoint for VSCode now, it was causing undesirable behavior there. VSCode HTML doesn't use ">"  as the commit character, and having it specified in server capabilities was causing us to always use ":", ">", " ", and "=" as the commit characters for all items.

Fixes:

https://github.com/microsoft/vscode/issues/217772