### PR TITLE
Switch to regular pool in 17.10 branch

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -76,7 +76,7 @@ extends:
         enabled: false
     pool:
       name: NetCore1ESPool-Svc-Internal
-      image: windows.vs2022preview.amd64
+      image: windows.vs2022.amd64
       os: windows
     customBuildTags:
     - ES365AIMigrationTooling
@@ -105,10 +105,10 @@ extends:
               pool:
                 ${{ if eq(variables['System.TeamProject'], 'public') }}:
                   name: $(DncEngPublicBuildPool)
-                  demands: ImageOverride -equals windows.vs2022preview.amd64.open
+                  demands: ImageOverride -equals windows.vs2022.amd64.open
                 ${{ if ne(variables['System.TeamProject'], 'public') }}:
                   name: $(DncEngInternalBuildPool)
-                  demands: ImageOverride -equals windows.vs2022preview.amd64
+                  demands: ImageOverride -equals windows.vs2022.amd64
               steps:
               - task: NuGetCommand@2
                 displayName: 'Clear NuGet caches'
@@ -142,10 +142,10 @@ extends:
             pool:
               ${{ if eq(variables['System.TeamProject'], 'public') }}:
                 name: $(DncEngPublicBuildPool)
-                demands: ImageOverride -equals windows.vs2022preview.amd64.open
+                demands: ImageOverride -equals windows.vs2022.amd64.open
               ${{ if ne(variables['System.TeamProject'], 'public') }}:
                 name: $(DncEngInternalBuildPool)
-                demands: ImageOverride -equals windows.vs2022preview.amd64
+                demands: ImageOverride -equals windows.vs2022.amd64
             strategy:
               matrix:
                 ${{ if eq(variables['System.TeamProject'], 'public') }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,10 +87,10 @@ stages:
           pool:
             ${{ if eq(variables['System.TeamProject'], 'public') }}:
               name: $(DncEngPublicBuildPool)
-              demands: ImageOverride -equals windows.vs2022preview.amd64.open
+              demands: ImageOverride -equals windows.vs2022.amd64.open
             ${{ if ne(variables['System.TeamProject'], 'public') }}:
               name: $(DncEngInternalBuildPool)
-              demands: ImageOverride -equals windows.vs2022preview.amd64
+              demands: ImageOverride -equals windows.vs2022.amd64
           steps:
           - task: NuGetCommand@2
             displayName: 'Clear NuGet caches'
@@ -131,10 +131,10 @@ stages:
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
             name: $(DncEngPublicBuildPool)
-            demands: ImageOverride -equals windows.vs2022preview.amd64.open
+            demands: ImageOverride -equals windows.vs2022.amd64.open
           ${{ if ne(variables['System.TeamProject'], 'public') }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.vs2022preview.amd64
+            demands: ImageOverride -equals windows.vs2022.amd64
         strategy:
           matrix:
             ${{ if eq(variables['System.TeamProject'], 'public') }}:


### PR DESCRIPTION
Fixes broken official builds - the `vs2022preview` machines were updated to VS 17.11, so trying to deploy razor extension 17.10.* fails.

Official build of this PR: https://dev.azure.com/dnceng/internal/_build/results?buildId=2482027&view=results