### PR TITLE
Fixing regression in legacy Razor editor used in .Net Framework proje…

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/AggregateProjectCapabilityResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/AggregateProjectCapabilityResolver.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+
+namespace Microsoft.VisualStudio.Razor;
+
+[Export(typeof(IAggregateProjectCapabilityResolver))]
+internal sealed class AggregateProjectCapabilityResolver : IAggregateProjectCapabilityResolver
+{
+    private readonly IEnumerable<IProjectCapabilityResolver> _projectCapabilityResolvers;
+
+    [ImportingConstructor]
+    public AggregateProjectCapabilityResolver([ImportMany] IEnumerable<IProjectCapabilityResolver> projectCapabilityResolvers)
+    {
+        _projectCapabilityResolvers = projectCapabilityResolvers;
+    }
+
+    public bool HasCapability(string documentFilePath, object project, string capability)
+    {
+        foreach (var capabilityResolver in _projectCapabilityResolvers)
+        {
+            if (capabilityResolver.HasCapability(documentFilePath, project, capability))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/DynamicFiles/RazorDynamicFileInfoProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/DynamicFiles/RazorDynamicFileInfoProvider.cs
@@ -201,7 +201,7 @@ internal class RazorDynamicFileInfoProvider : IRazorDynamicFileInfoProviderInter
             throw new ArgumentNullException(nameof(documentFilePath));
         }
 
-        if (_lspEditorFeatureDetector.IsLspEditorEnabled())
+        if (_lspEditorFeatureDetector.IsLspEditorEnabledAndAvailable(documentFilePath))
         {
             return;
         }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/IAggregateProjectCapabilityResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/IAggregateProjectCapabilityResolver.cs
@@ -1,0 +1,7 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.Razor;
+
+// For MEF export and unit tests
+internal interface IAggregateProjectCapabilityResolver : IProjectCapabilityResolver { }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ILspEditorFeatureDetector.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ILspEditorFeatureDetector.cs
@@ -5,7 +5,7 @@ namespace Microsoft.VisualStudio.Razor;
 
 internal interface ILspEditorFeatureDetector
 {
-    bool IsLspEditorEnabled();
+    bool IsLspEditorEnabledAndAvailable(string documentMoniker);
 
     /// <summary>
     /// A remote client is a LiveShare guest or a Codespaces instance

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/IProjectCapabilityResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/IProjectCapabilityResolver.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.Razor;
+
+internal interface IProjectCapabilityResolver
+{
+    bool HasCapability(string documentFilePath, object project, string capability);
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/RazorFilePathToContentTypeProviderBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/RazorFilePathToContentTypeProviderBase.cs
@@ -32,7 +32,7 @@ internal abstract class RazorFilePathToContentTypeProviderBase : IFilePathToCont
 
     public bool TryGetContentTypeForFilePath(string filePath, [NotNullWhen(true)] out IContentType? contentType)
     {
-        if (_lspEditorFeatureDetector.IsLspEditorEnabled())
+        if (_lspEditorFeatureDetector.IsLspEditorEnabledAndAvailable(filePath))
         {
             contentType = _contentTypeRegistryService.GetContentType(RazorConstants.RazorLSPContentTypeName);
             return true;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LiveShare/LiveShareProjectCapabilityResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LiveShare/LiveShareProjectCapabilityResolver.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+using System.Threading;
+using Microsoft.VisualStudio.Razor.LiveShare.Guest;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.Razor.LiveShare;
+
+[Export(typeof(IProjectCapabilityResolver))]
+[method: ImportingConstructor]
+internal class LiveShareProjectCapabilityResolver(
+    ILiveShareSessionAccessor sessionAccessor,
+    JoinableTaskContext joinableTaskContext) : IProjectCapabilityResolver
+{
+    private readonly ILiveShareSessionAccessor _sessionAccessor = sessionAccessor;
+    private readonly JoinableTaskFactory _joinableTaskFactory = joinableTaskContext.Factory;
+
+    public bool HasCapability(string documentFilePath, object project, string capability)
+    {
+        if (!_sessionAccessor.IsGuestSessionActive)
+        {
+            // We don't provide capabilities for non-guest sessions.
+            return false;
+        }
+
+        var remoteHasCapability = RemoteHasCapability(documentFilePath, capability);
+        return remoteHasCapability;
+    }
+
+    private bool RemoteHasCapability(string documentMoniker, string capability)
+    {
+        // On a guest box. The project hierarchy is not fully populated. We need to ask the host machine
+        // questions on hierarchy capabilities.
+        return _joinableTaskFactory.Run(async () =>
+        {
+            var remoteHierarchyService = await _sessionAccessor.Session!.GetRemoteServiceAsync<IRemoteHierarchyService>(nameof(IRemoteHierarchyService), CancellationToken.None).ConfigureAwait(false);
+            var documentMonikerUri = _sessionAccessor.Session.ConvertLocalPathToSharedUri(documentMoniker);
+            var hasCapability = await remoteHierarchyService.HasCapabilityAsync(documentMonikerUri, capability, CancellationToken.None).ConfigureAwait(false);
+            return hasCapability;
+        });
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LspEditorFeatureDetector.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LspEditorFeatureDetector.cs
@@ -9,6 +9,8 @@ using Microsoft.Internal.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Razor.Extensions;
 using Microsoft.VisualStudio.Razor.Logging;
 using Microsoft.VisualStudio.Settings;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.VisualStudio.Razor;
@@ -16,26 +18,65 @@ namespace Microsoft.VisualStudio.Razor;
 [Export(typeof(ILspEditorFeatureDetector))]
 internal sealed class LspEditorFeatureDetector : ILspEditorFeatureDetector, IDisposable
 {
+    internal const string DotNetCoreCSharpCapability = "CSharp&CPS";
+    internal const string LegacyRazorEditorCapability = "LegacyRazorEditor";
+
     private readonly IUIContextService _uiContextService;
     private readonly JoinableTaskFactory _jtf;
     private readonly CancellationTokenSource _disposeTokenSource;
+    private readonly IAggregateProjectCapabilityResolver _projectCapabilityResolver;
+    private readonly Lazy<IVsUIShellOpenDocument> _vsUIShellOpenDocument;
     private readonly AsyncLazy<bool> _lazyUseLegacyEditorTask;
+    private readonly RazorActivityLog _activityLog;
 
     [ImportingConstructor]
     public LspEditorFeatureDetector(
+        IAggregateProjectCapabilityResolver projectCapabilityResolver,
         IVsService<SVsFeatureFlags, IVsFeatureFlags> vsFeatureFlagsService,
         IVsService<SVsSettingsPersistenceManager, ISettingsManager> vsSettingsManagerService,
         IUIContextService uiContextService,
         JoinableTaskContext joinableTaskContext,
         RazorActivityLog activityLog)
+        : this(
+              projectCapabilityResolver,
+              vsFeatureFlagsService,
+              vsSettingsManagerService,
+              uiContextService,
+              joinableTaskContext,
+              activityLog,
+              new Lazy<IVsUIShellOpenDocument>(() =>
+              {
+                // This method is first called by out IFilePathToContentTypeProvider.TryGetContentTypeForFilePath(...) implementations on UI thread.
+                ThreadHelper.ThrowIfNotOnUIThread();
+                var shellOpenDocument = (IVsUIShellOpenDocument)ServiceProvider.GlobalProvider.GetService(typeof(SVsUIShellOpenDocument));
+                Assumes.Present(shellOpenDocument);
+
+                return shellOpenDocument;
+              })
+        )
+    { }
+
+    // Primarily for unit tests
+    public LspEditorFeatureDetector(
+        IAggregateProjectCapabilityResolver projectCapabilityResolver,
+        IVsService<SVsFeatureFlags, IVsFeatureFlags> vsFeatureFlagsService,
+        IVsService<SVsSettingsPersistenceManager, ISettingsManager> vsSettingsManagerService,
+        IUIContextService uiContextService,
+        JoinableTaskContext joinableTaskContext,
+        RazorActivityLog activityLog,
+        Lazy<IVsUIShellOpenDocument> vsUIShellOpenDocument)
     {
         _uiContextService = uiContextService;
         _jtf = joinableTaskContext.Factory;
         _disposeTokenSource = new();
 
+        _projectCapabilityResolver = projectCapabilityResolver;
+        _vsUIShellOpenDocument = vsUIShellOpenDocument;
+
         _lazyUseLegacyEditorTask = new(() =>
              ComputeUseLegacyEditorAsync(vsFeatureFlagsService, vsSettingsManagerService, activityLog, _disposeTokenSource.Token),
              _jtf);
+        _activityLog = activityLog;
     }
 
     public void Dispose()
@@ -79,7 +120,12 @@ internal sealed class LspEditorFeatureDetector : ILspEditorFeatureDetector, IDis
         return false;
     }
 
-    public bool IsLspEditorEnabled()
+    /// <summary>
+    /// Checks that LSP editor is enabled via feature flag and tools/options setting, and available for document's project
+    /// </summary>
+    /// <param name="documentMoniker">Document to check for project compatibility with LSP</param>
+    /// <returns>true if LSP editor is enabled and available for document's project</returns>
+    public bool IsLspEditorEnabledAndAvailable(string documentMoniker)
     {
         // This method is first called by out IFilePathToContentTypeProvider.TryGetContentTypeForFilePath(...) implementations.
         // We call AsyncLazy<T>.GetValue() below to get the value. If the work hasn't yet completed, we guard against a hidden+
@@ -89,8 +135,64 @@ internal sealed class LspEditorFeatureDetector : ILspEditorFeatureDetector, IDis
         {
             _jtf.AssertUIThread();
         }
+        
+        var isLspEditorEnabled = !_lazyUseLegacyEditorTask.GetValue(_disposeTokenSource.Token);
 
-        return !_lazyUseLegacyEditorTask.GetValue(_disposeTokenSource.Token);
+        if (!isLspEditorEnabled)
+        {
+            _activityLog.LogInfo("Using Legacy editor because the option or feature flag was set to true");
+            return false;
+        }
+
+        // Even if LSP editor is enabled via feature flag and tools/options, document's project might not support
+        // LSP editor (e.g. .Net Framework projects don't support LSP Razor editor)
+        if (!ProjectSupportsLspEditor(documentMoniker))
+        {
+            // Current project hierarchy doesn't support the LSP Razor editor
+            _activityLog.LogInfo("Using Legacy editor because the current project does not support LSP Editor");
+            return false;
+        }
+
+        _activityLog.LogInfo("LSP Editor is enabled and available");
+        return true;
+    }
+
+    // NOTE: This code is needed for legacy Razor editor support in .Net Framework projects. Do not delete unless support for .Net Framework projects is discontinued.
+    private bool ProjectSupportsLspEditor(string documentMoniker)
+    {
+        var hr = _vsUIShellOpenDocument.Value.IsDocumentInAProject(documentMoniker, out var uiHierarchy, out _, out _, out _);
+        var hierarchy = uiHierarchy as IVsHierarchy;
+        if (!ErrorHandler.Succeeded(hr))
+        {
+            _activityLog.LogWarning($"Project does not support LSP Editor because {nameof(_vsUIShellOpenDocument.Value.IsDocumentInAProject)} failed with exit code {hr}");
+            return false;
+        }
+        
+        if (hierarchy is null)
+        {
+            _activityLog.LogWarning($"Project does not support LSP Editor because {nameof(hierarchy)} is null");
+            return false;
+        }
+
+        // We allow projects to specifically opt-out of the legacy Razor editor because there are legacy scenarios which would rely on behind-the-scenes
+        // opt-out mechanics to enable the .NET Core editor in non-.NET Core scenarios. Therefore, we need a similar mechanic to continue supporting
+        // those types of scenarios for the new .NET Core Razor editor.
+        if (_projectCapabilityResolver.HasCapability(documentMoniker, hierarchy, LegacyRazorEditorCapability))
+        {
+            _activityLog.LogInfo($"Project does not support LSP Editor because '{documentMoniker}' has Capability {LegacyRazorEditorCapability}");
+            // CPS project that requires the legacy editor
+            return false;
+        }
+
+        if (_projectCapabilityResolver.HasCapability(documentMoniker, hierarchy, DotNetCoreCSharpCapability))
+        {
+            // .NET Core project that supports C#
+            return true;
+        }
+
+        _activityLog.LogInfo($"Project {documentMoniker} does not support LSP Editor because it does not have the {DotNetCoreCSharpCapability} capability.");
+        // Not a C# .NET Core project. This typically happens for legacy Razor scenarios
+        return false;
     }
 
     public bool IsRemoteClient()

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioProjectCapabilityResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioProjectCapabilityResolver.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.Razor.Logging;
+using Microsoft.VisualStudio.Shell;
+using Microsoft.VisualStudio.Shell.Interop;
+
+namespace Microsoft.VisualStudio.Razor;
+
+[Export(typeof(IProjectCapabilityResolver))]
+[method: ImportingConstructor]
+internal sealed class VisualStudioProjectCapabilityResolver(ILoggerFactory loggerFactory) : IProjectCapabilityResolver
+{
+    private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<VisualStudioProjectCapabilityResolver>();
+
+    public bool HasCapability(string documentFilePath, object project, string capability)
+    {
+        if (project is not IVsHierarchy vsHierarchy)
+        {
+            return false;
+        }
+
+        var localHasCapability = LocalHasCapability(vsHierarchy, capability);
+        return localHasCapability;
+    }
+
+    private bool LocalHasCapability(IVsHierarchy hierarchy, string capability)
+    {
+        try
+        {
+            var hasCapability = hierarchy.IsCapabilityMatch(capability);
+            return hasCapability;
+        }
+        catch (NotSupportedException)
+        {
+            // IsCapabilityMatch throws a NotSupportedException if it can't create a
+            // BooleanSymbolExpressionEvaluator COM object
+            _logger.LogWarning($"Could not resolve project capability for hierarchy due to NotSupportedException.");
+            return false;
+        }
+        catch (ObjectDisposedException)
+        {
+            // IsCapabilityMatch throws an ObjectDisposedException if the underlying hierarchy has been disposed
+            _logger.LogWarning($"Could not resolve project capability for hierarchy due to hierarchy being disposed.");
+            return false;
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/RazorContentTypeChangeListenerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/RazorContentTypeChangeListenerTest.cs
@@ -215,7 +215,7 @@ public class RazorContentTypeChangeListenerTest : ToolingTestBase
         Mock.Get(textDocumentFactory).Setup(f => f.TryGetTextDocument(It.IsAny<ITextBuffer>(), out It.Ref<ITextDocument>.IsAny)).Returns(false);
 
         lspDocumentManager ??= Mock.Of<TrackingLSPDocumentManager>(MockBehavior.Strict);
-        lspEditorFeatureDetector ??= Mock.Of<ILspEditorFeatureDetector>(detector => detector.IsLspEditorEnabled() == true && detector.IsRemoteClient() == false, MockBehavior.Strict);
+        lspEditorFeatureDetector ??= Mock.Of<ILspEditorFeatureDetector>(detector => detector.IsLspEditorEnabledAndAvailable(It.IsAny<string>()) == true && detector.IsRemoteClient() == false, MockBehavior.Strict);
         fileToContentTypeService ??= Mock.Of<IFileToContentTypeService>(detector => detector.GetContentTypeForFilePath(It.IsAny<string>()) == _razorContentType, MockBehavior.Strict);
         var textManager = new Mock<IVsTextManager2>(MockBehavior.Strict);
         textManager.Setup(m => m.GetUserPreferences2(null, null, It.IsAny<LANGPREFERENCES2[]>(), null)).Returns(VSConstants.E_NOTIMPL);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LspEditorFeatureDetectorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LspEditorFeatureDetectorTest.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.VisualStudio;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.Internal.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.ProjectSystem.VS;
 using Microsoft.VisualStudio.Razor.Logging;
 using Microsoft.VisualStudio.Settings;
 using Microsoft.VisualStudio.Shell;
@@ -35,7 +37,36 @@ public class LspEditorFeatureDetectorTest(ITestOutputHelper testOutput) : Toolin
         var featureDetector = CreateLspEditorFeatureDetector(legacyEditorFeatureFlag, legacyEditorSetting);
 
         // Act
-        var result = featureDetector.IsLspEditorEnabled();
+        var result = featureDetector.IsLspEditorEnabledAndAvailable(@"c:\TestProject\TestFile.cshtml");
+
+        // Assert
+        Assert.Equal(expectedResult, result);
+    }
+
+    public static TheoryData<bool, bool, bool, bool, bool> IsLspEditorAvailableTestData { get; } = new()
+    {
+        // legacyEditorFeatureFlag, legacyEditorSetting, hasLegacyRazorEditorCapability, hasDotNetCoreCSharpCapability, expectedResult
+        { false, false, true, false, false }, // .Net Framework project - always non-LSP
+        { false, false, false, true, true },  // .Net Core project
+        { false, false, true, true, false },  // .Net Core project opts-in into legacy razor editor (exists in reality?)
+        { true, false, false, true, false },  // .Net Core project but legacy editor via feature flag
+        { false, true, false, true, false },  // .Net Core project but legacy editor via editor option
+    };
+
+    [UITheory]
+    [MemberData(nameof(IsLspEditorAvailableTestData))]
+    public void IsLspEditorAvailable(
+        bool legacyEditorFeatureFlag,
+        bool legacyEditorSetting,
+        bool hasLegacyRazorEditorCapability,
+        bool hasDotNetCoreCSharpCapability,
+        bool expectedResult)
+    {
+        // Arrange
+        var featureDetector = CreateLspEditorFeatureDetector(legacyEditorFeatureFlag, legacyEditorSetting, hasLegacyRazorEditorCapability, hasDotNetCoreCSharpCapability);
+
+        // Act
+        var result = featureDetector.IsLspEditorEnabledAndAvailable(@"c:\TestProject\TestFile.cshtml");
 
         // Assert
         Assert.Equal(expectedResult, result);
@@ -94,32 +125,62 @@ public class LspEditorFeatureDetectorTest(ITestOutputHelper testOutput) : Toolin
     }
 
     private ILspEditorFeatureDetector CreateLspEditorFeatureDetector(IUIContextService uiContextService)
-        => CreateLspEditorFeatureDetector(legacyEditorFeatureFlag: false, legacyEditorSetting: false, uiContextService);
+        => CreateLspEditorFeatureDetector(legacyEditorFeatureFlag: false, legacyEditorSetting: false, uiContextService, hasLegacyRazorEditorCapability: false, hasDotNetCoreCSharpCapability: true);
 
     private ILspEditorFeatureDetector CreateLspEditorFeatureDetector(
         bool legacyEditorFeatureFlag = false,
-        bool legacyEditorSetting = false)
+        bool legacyEditorSetting = false,
+        bool hasLegacyRazorEditorCapability = false,
+        bool hasDotNetCoreCSharpCapability = true)
     {
-        return CreateLspEditorFeatureDetector(legacyEditorFeatureFlag, legacyEditorSetting, CreateUIContextService());
+        return CreateLspEditorFeatureDetector(legacyEditorFeatureFlag, legacyEditorSetting, CreateUIContextService(), hasLegacyRazorEditorCapability, hasDotNetCoreCSharpCapability);
     }
 
     private ILspEditorFeatureDetector CreateLspEditorFeatureDetector(
         bool legacyEditorFeatureFlag,
         bool legacyEditorSetting,
-        IUIContextService uiContextService)
+        IUIContextService uiContextService,
+        bool hasLegacyRazorEditorCapability,
+        bool hasDotNetCoreCSharpCapability)
     {
         uiContextService ??= CreateUIContextService();
 
         var featureDetector = new LspEditorFeatureDetector(
+            CreateAggregateProjectCapabilityResolver(hasLegacyRazorEditorCapability, hasDotNetCoreCSharpCapability),
             CreateVsFeatureFlagsService(legacyEditorFeatureFlag),
             CreateVsSettingsManagerService(legacyEditorSetting),
             uiContextService,
             JoinableTaskContext,
-            CreateRazorActivityLog());
+            CreateRazorActivityLog(),
+            CreateVSUIShellOpenDocument());
 
         AddDisposable(featureDetector);
 
         return featureDetector;
+    }
+
+    private static IAggregateProjectCapabilityResolver CreateAggregateProjectCapabilityResolver(bool hasLegacyRazorEditorCapability, bool hasDotNetCoreCSharpCapability)
+    {
+        var aggregateProjectCapabilityResolverMock = new StrictMock<IAggregateProjectCapabilityResolver>();
+        aggregateProjectCapabilityResolverMock
+            .Setup(x => x.HasCapability(It.IsAny<string>(), It.IsAny<object>(), LspEditorFeatureDetector.LegacyRazorEditorCapability))
+            .Returns(hasLegacyRazorEditorCapability);
+        aggregateProjectCapabilityResolverMock
+            .Setup(x => x.HasCapability(It.IsAny<string>(), It.IsAny<object>(), LspEditorFeatureDetector.DotNetCoreCSharpCapability))
+            .Returns(hasDotNetCoreCSharpCapability);
+
+        return aggregateProjectCapabilityResolverMock.Object;
+    }
+
+    private static Lazy<IVsUIShellOpenDocument> CreateVSUIShellOpenDocument()
+    {
+        var vsUIShellOpenDocumentMock = new StrictMock<IVsUIShellOpenDocument>();
+        var hierarchy = new StrictMock<IVsUIHierarchy>().Object;
+        vsUIShellOpenDocumentMock
+            .Setup(x => x.IsDocumentInAProject(It.IsAny<string>(), out hierarchy, out It.Ref<uint>.IsAny, out It.Ref<OLE.Interop.IServiceProvider>.IsAny, out It.Ref<int>.IsAny))
+            .Returns(VSConstants.S_OK);
+
+        return new Lazy<IVsUIShellOpenDocument>(() => vsUIShellOpenDocumentMock.Object);
     }
 
     private static IVsService<SVsFeatureFlags, IVsFeatureFlags> CreateVsFeatureFlagsService(bool useLegacyEditor)
@@ -128,7 +189,6 @@ public class LspEditorFeatureDetectorTest(ITestOutputHelper testOutput) : Toolin
         vsFeatureFlagsMock
             .Setup(x => x.IsFeatureEnabled(WellKnownFeatureFlagNames.UseLegacyRazorEditor, It.IsAny<bool>()))
             .Returns(useLegacyEditor);
-
         return VsMocks.CreateVsService<SVsFeatureFlags, IVsFeatureFlags>(vsFeatureFlagsMock);
     }
 


### PR DESCRIPTION
* Fixing regression in legacy Razor editor used in .Net Framework projects

LspEditorFeatureDetector wasn't using project to detect whether LSP or Legacy editor needs to get used a result of !10490. This change restores usage of project capabilities to detect if project supports LSP editor, and fixes legacy editor usage in .Net Framework projects.