### PR TITLE
Support `DocumentSymbol` results from Roslyn

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentSymbols/DocumentSymbolEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentSymbols/DocumentSymbolEndpoint.cs
@@ -121,6 +121,13 @@ internal class DocumentSymbolEndpoint : IRazorRequestHandler<DocumentSymbolParam
 
                 mappedSymbols.Add(documentSymbol);
             }
+            else if (documentSymbol.Children is [_, ..] &&
+                RemapDocumentSymbols(csharpDocument, documentSymbol.Children) is [_, ..] mappedChildren)
+            {
+                // This range didn't map, but some/all of its children did, so we promote them to this level so we don't
+                // lose any information.
+                mappedSymbols.AddRange(mappedChildren);
+            }
         }
 
         return mappedSymbols.ToArray();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Debugging;
 using Microsoft.AspNetCore.Razor.LanguageServer.Definition;
 using Microsoft.AspNetCore.Razor.LanguageServer.DocumentColor;
 using Microsoft.AspNetCore.Razor.LanguageServer.DocumentHighlighting;
-using Microsoft.AspNetCore.Razor.LanguageServer.DocumentSymbol;
+using Microsoft.AspNetCore.Razor.LanguageServer.DocumentSymbols;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.FindAllReferences;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentSymbols/DocumentSymbolEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentSymbols/DocumentSymbolEndpointTest.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.LanguageServer.DocumentSymbol;
+using Microsoft.AspNetCore.Razor.LanguageServer.DocumentSymbols;
 using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
@@ -93,10 +93,11 @@ public class DocumentSymbolEndpointTest(ITestOutputHelper testOutput) : SingleSe
         var requestContext = CreateRazorRequestContext(documentContext);
 
         // Act
-        var symbolsInformations = await endpoint.HandleRequestAsync(request, requestContext, DisposalToken);
+        var result = await endpoint.HandleRequestAsync(request, requestContext, DisposalToken);
+        Assert.NotNull(result);
 
+        var symbolsInformations = result.Value.Second;
         // Assert
-        Assert.NotNull(symbolsInformations);
         Assert.Equal(spansDict.Values.Count(), symbolsInformations.Length);
 
         var sourceText = SourceText.From(input);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverServiceTest.cs
@@ -944,7 +944,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
         };
 
         await using var csharpServer = await CSharpTestLspServerHelpers.CreateCSharpLspServerAsync(
-            csharpSourceText, csharpDocumentUri, serverCapabilities, razorSpanMappingService: null, DisposalToken);
+            csharpSourceText, csharpDocumentUri, serverCapabilities, razorSpanMappingService: null, capabilitiesUpdater: null, DisposalToken);
         await csharpServer.OpenDocumentAsync(csharpDocumentUri, csharpSourceText.ToString());
 
         var razorFilePath = "C:/path/to/file.razor";

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokensTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokensTest.cs
@@ -50,7 +50,7 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
         }
     };
 
-    private static Regex s_matchNewLines = MyRegex();
+    private static readonly Regex s_matchNewLines = MyRegex();
 
 #if NET
     [GeneratedRegex("\r\n")]
@@ -1021,6 +1021,7 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             csharpDocumentUri,
             s_semanticTokensServerCapabilities,
             SpanMappingService,
+            capabilitiesUpdater: null,
             DisposalToken);
 
         var razorRange = GetSpan(documentText);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SingleServerDelegatingEndpointTestBase.TestLanguageServer.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SingleServerDelegatingEndpointTestBase.TestLanguageServer.cs
@@ -125,7 +125,7 @@ public abstract partial class SingleServerDelegatingEndpointTestBase
                 _cancellationToken);
         }
 
-        private Task<SymbolInformation[]> HandleDocumentSymbolAsync<TParams>(TParams @params)
+        private Task<SumType<DocumentSymbol[], SymbolInformation[]>?> HandleDocumentSymbolAsync<TParams>(TParams @params)
         {
             Assert.IsType<DelegatedDocumentSymbolParams>(@params);
 
@@ -137,7 +137,7 @@ public abstract partial class SingleServerDelegatingEndpointTestBase
                 },
             };
 
-            return _csharpServer.ExecuteRequestAsync<DocumentSymbolParams, SymbolInformation[]>(
+            return _csharpServer.ExecuteRequestAsync<DocumentSymbolParams, SumType<DocumentSymbol[], SymbolInformation[]>?>(
                 Methods.TextDocumentDocumentSymbolName,
                 delegatedRequest,
                 _cancellationToken);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SingleServerDelegatingEndpointTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SingleServerDelegatingEndpointTestBase.cs
@@ -20,23 +20,19 @@ using Xunit.Abstractions;
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
 [UseExportProvider]
-public abstract partial class SingleServerDelegatingEndpointTestBase : LanguageServerTestBase
+public abstract partial class SingleServerDelegatingEndpointTestBase(ITestOutputHelper testOutput) : LanguageServerTestBase(testOutput)
 {
     private protected IDocumentContextFactory? DocumentContextFactory { get; private set; }
     private protected LanguageServerFeatureOptions? LanguageServerFeatureOptions { get; private set; }
     private protected IRazorDocumentMappingService? DocumentMappingService { get; private set; }
-
-    protected SingleServerDelegatingEndpointTestBase(ITestOutputHelper testOutput)
-        : base(testOutput)
-    {
-    }
 
     [MemberNotNull(nameof(DocumentContextFactory), nameof(LanguageServerFeatureOptions), nameof(DocumentMappingService))]
     private protected async Task<TestLanguageServer> CreateLanguageServerAsync(
         RazorCodeDocument codeDocument,
         string razorFilePath,
         IEnumerable<(string, string)>? additionalRazorDocuments = null,
-        bool multiTargetProject = true)
+        bool multiTargetProject = true,
+        Action<VSInternalClientCapabilities>? capabilitiesUpdater = null)
     {
         var projectKey = TestProjectKey.Create("");
         var csharpSourceText = codeDocument.GetCSharpSourceText();
@@ -78,6 +74,7 @@ public abstract partial class SingleServerDelegatingEndpointTestBase : LanguageS
             },
             razorSpanMappingService: null,
             multiTargetProject,
+            capabilitiesUpdater,
             DisposalToken);
 
         AddDisposable(csharpServer);


### PR DESCRIPTION
Our custom message target currently returns `SumType<DocumentSymbol[], SymbolInformation[]>?` but our endpoint blindly assumes `SymbolInformation[]?` is the return type. This is a bad thing because Roslyn can return either type, based on a client capability, and even the spec notes:

> Servers should whenever possible return [DocumentSymbol](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#documentSymbol) since it is the richer data structure.

This PR adds support for `DocumentSymbol` to our langauge server, and tests that cover both possible result types.