### PR TITLE
Don't call C# for Uri or Text presentation

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentPresentation/AbstractTextDocumentPresentationEndpointBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentPresentation/AbstractTextDocumentPresentationEndpointBase.cs
@@ -85,7 +85,13 @@ internal abstract class AbstractTextDocumentPresentationEndpointBase<TParams> : 
             return result;
         }
 
-        if (languageKind is not (RazorLanguageKind.CSharp or RazorLanguageKind.Html))
+        if (languageKind is RazorLanguageKind.CSharp)
+        {
+            // Roslyn does not support Uri or Text presentation, so to prevent unnecessary LSP calls and misleading telemetry
+            // reports, we just return null here.
+            return null;
+        }
+        else if (languageKind is not RazorLanguageKind.Html)
         {
             _logger.LogInformation($"Unsupported language {languageKind}.");
             return null;
@@ -141,7 +147,7 @@ internal abstract class AbstractTextDocumentPresentationEndpointBase<TParams> : 
 
             if (documentEditList.Count > 0)
             {
-                documentChanges = documentEditList.ToArray();
+                documentChanges = [.. documentEditList];
                 return true;
             }
         }
@@ -213,7 +219,7 @@ internal abstract class AbstractTextDocumentPresentationEndpointBase<TParams> : 
             });
         }
 
-        return remappedDocumentEdits.ToArray();
+        return [.. remappedDocumentEdits];
     }
 
     private TextEdit[]? MapTextEdits(bool mapRanges, RazorCodeDocument codeDocument, IEnumerable<TextEdit> edits)
@@ -239,7 +245,7 @@ internal abstract class AbstractTextDocumentPresentationEndpointBase<TParams> : 
             mappedEdits.Add(newEdit);
         }
 
-        return mappedEdits.ToArray();
+        return [.. mappedEdits];
     }
 
     private WorkspaceEdit? MapWorkspaceEdit(WorkspaceEdit workspaceEdit, bool mapRanges, RazorCodeDocument codeDocument, int hostDocumentVersion)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentPresentation/TextDocumentTextPresentationEndpointTests.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentPresentation/TextDocumentTextPresentationEndpointTests.cs
@@ -36,7 +36,8 @@ public class TextDocumentTextPresentationEndpointTests(ITestOutputHelper testOut
         var clientConnection = new Mock<IClientConnection>(MockBehavior.Strict);
         clientConnection
             .Setup(l => l.SendRequestAsync<IRazorPresentationParams, WorkspaceEdit?>(CustomMessageNames.RazorTextPresentationEndpoint, It.IsAny<IRazorPresentationParams>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(response);
+            .ReturnsAsync(response)
+            .Verifiable();
 
         var endpoint = new TextDocumentTextPresentationEndpoint(
             documentMappingService,
@@ -67,7 +68,7 @@ public class TextDocumentTextPresentationEndpointTests(ITestOutputHelper testOut
     }
 
     [Fact]
-    public async Task Handle_CSharp_MakesRequest()
+    public async Task Handle_CSharp_DoesNotMakeRequest()
     {
         // Arrange
         var codeDocument = TestRazorCodeDocument.Create("@counter");
@@ -79,12 +80,7 @@ public class TextDocumentTextPresentationEndpointTests(ITestOutputHelper testOut
             s => s.GetLanguageKind(codeDocument, It.IsAny<int>(), It.IsAny<bool>()) == RazorLanguageKind.CSharp &&
             s.TryMapToGeneratedDocumentRange(csharpDocument, It.IsAny<LinePositionSpan>(), out projectedRange) == true, MockBehavior.Strict);
 
-        var response = (WorkspaceEdit?)null;
-
         var clientConnection = new Mock<IClientConnection>(MockBehavior.Strict);
-        clientConnection
-            .Setup(l => l.SendRequestAsync<IRazorPresentationParams, WorkspaceEdit?>(CustomMessageNames.RazorTextPresentationEndpoint, It.IsAny<IRazorPresentationParams>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(response);
 
         var endpoint = new TextDocumentTextPresentationEndpoint(
             documentMappingService,


### PR DESCRIPTION
As discussed offline, Roslyn doesn't support the Uri or Text presentation endpoints, and recent LSP client changes have caused erroneous failure telemetry to be logged as a result. This PR fixes that by just not calling Roslyn.