### PR TITLE
Pool CodeWriter ReadOnlyMemory<char> pages

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/CodeGeneration/CSharpCodeWriterTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/CodeGeneration/CSharpCodeWriterTest.cs
@@ -32,7 +32,7 @@ public class CSharpCodeWriterTest
     public void CSharpCodeWriter_TracksPosition_WithWrite()
     {
         // Arrange
-        var writer = new CodeWriter();
+        using var writer = new CodeWriter();
 
         // Act
         writer.Write("1234");
@@ -48,7 +48,7 @@ public class CSharpCodeWriterTest
     public void CSharpCodeWriter_TracksPosition_WithIndent()
     {
         // Arrange
-        var writer = new CodeWriter();
+        using var writer = new CodeWriter();
 
         // Act
         writer.WriteLine();
@@ -65,7 +65,7 @@ public class CSharpCodeWriterTest
     public void CSharpCodeWriter_TracksPosition_WithWriteLine()
     {
         // Arrange
-        var writer = new CodeWriter();
+        using var writer = new CodeWriter();
 
         // Act
         writer.WriteLine("1234");
@@ -83,7 +83,7 @@ public class CSharpCodeWriterTest
     public void CSharpCodeWriter_TracksPosition_WithWriteLine_WithNewLineInContent(string newLine)
     {
         // Arrange
-        var writer = new CodeWriter();
+        using var writer = new CodeWriter();
 
         // Act
         writer.WriteLine("1234" + newLine + "12");
@@ -104,7 +104,7 @@ public class CSharpCodeWriterTest
     public void CSharpCodeWriter_TracksPosition_WithWrite_WithNewlineInContent(string newLine)
     {
         // Arrange
-        var writer = new CodeWriter();
+        using var writer = new CodeWriter();
 
         // Act
         writer.Write("1234" + newLine + "123" + newLine + "12");
@@ -124,7 +124,7 @@ public class CSharpCodeWriterTest
     public void CSharpCodeWriter_TracksPosition_WithWrite_WithNewlineInContent_RepeatedN()
     {
         // Arrange
-        var writer = new CodeWriter();
+        using var writer = new CodeWriter();
 
         // Act
         writer.Write("1234\n\n123");
@@ -144,7 +144,7 @@ public class CSharpCodeWriterTest
     public void CSharpCodeWriter_TracksPosition_WithWrite_WithMixedNewlineInContent()
     {
         // Arrange
-        var writer = new CodeWriter();
+        using var writer = new CodeWriter();
 
         // Act
         writer.Write("1234\r123\r\n12\n1");
@@ -164,7 +164,7 @@ public class CSharpCodeWriterTest
     public void CSharpCodeWriter_TracksPosition_WithNewline_SplitAcrossWrites()
     {
         // Arrange
-        var writer = new CodeWriter();
+        using var writer = new CodeWriter();
 
         // Act
         writer.Write("1234\r");
@@ -185,7 +185,7 @@ public class CSharpCodeWriterTest
     public void CSharpCodeWriter_TracksPosition_WithTwoNewline_SplitAcrossWrites_R()
     {
         // Arrange
-        var writer = new CodeWriter();
+        using var writer = new CodeWriter();
 
         // Act
         writer.Write("1234\r");
@@ -206,7 +206,7 @@ public class CSharpCodeWriterTest
     public void CSharpCodeWriter_TracksPosition_WithTwoNewline_SplitAcrossWrites_N()
     {
         // Arrange
-        var writer = new CodeWriter();
+        using var writer = new CodeWriter();
 
         // Act
         writer.Write("1234\n");
@@ -227,7 +227,7 @@ public class CSharpCodeWriterTest
     public void CSharpCodeWriter_TracksPosition_WithTwoNewline_SplitAcrossWrites_Reversed()
     {
         // Arrange
-        var writer = new CodeWriter();
+        using var writer = new CodeWriter();
 
         // Act
         writer.Write("1234\n");
@@ -248,7 +248,7 @@ public class CSharpCodeWriterTest
     public void CSharpCodeWriter_TracksPosition_WithNewline_SplitAcrossWrites_AtBeginning()
     {
         // Arrange
-        var writer = new CodeWriter();
+        using var writer = new CodeWriter();
 
         // Act
         writer.Write("\r");
@@ -269,7 +269,7 @@ public class CSharpCodeWriterTest
     public void CSharpCodeWriter_LinesBreaksOutsideOfContentAreNotCounted()
     {
         // Arrange
-        var writer = new CodeWriter();
+        using var writer = new CodeWriter();
 
         // Act
         writer.Write("\r\nHello\r\nWorld\r\n", startIndex: 2, count: 12);
@@ -287,7 +287,7 @@ public class CSharpCodeWriterTest
         var filePath = "some-path";
         var mappingLocation = new SourceSpan(filePath, 10, 4, 3, 9);
 
-        var writer = new CodeWriter();
+        using var writer = new CodeWriter();
         var expected = $"#line 5 \"{filePath}\"" + writer.NewLine;
 
         // Act
@@ -302,7 +302,7 @@ public class CSharpCodeWriterTest
     public void WriteField_WritesFieldDeclaration()
     {
         // Arrange
-        var writer = new CodeWriter();
+        using var writer = new CodeWriter();
 
         // Act
         writer.WriteField(Array.Empty<string>(), new[] { "private" }, "global::System.String", "_myString");
@@ -319,7 +319,7 @@ public class CSharpCodeWriterTest
     public void WriteField_WithModifiers_WritesFieldDeclaration()
     {
         // Arrange
-        var writer = new CodeWriter();
+        using var writer = new CodeWriter();
 
         // Act
         writer.WriteField(Array.Empty<string>(), new[] { "private", "readonly", "static" }, "global::System.String", "_myString");
@@ -336,7 +336,7 @@ public class CSharpCodeWriterTest
     public void WriteField_WithModifiersAndSupressions_WritesFieldDeclaration()
     {
         // Arrange
-        var writer = new CodeWriter();
+        using var writer = new CodeWriter();
 
         // Act
         writer.WriteField(
@@ -362,7 +362,7 @@ public class CSharpCodeWriterTest
     public void WriteAutoPropertyDeclaration_WritesPropertyDeclaration()
     {
         // Arrange
-        var writer = new CodeWriter();
+        using var writer = new CodeWriter();
 
         // Act
         writer.WriteAutoPropertyDeclaration(new[] { "public" }, "global::System.String", "MyString");
@@ -379,7 +379,7 @@ public class CSharpCodeWriterTest
     public void WriteAutoPropertyDeclaration_WithModifiers_WritesPropertyDeclaration()
     {
         // Arrange
-        var writer = new CodeWriter();
+        using var writer = new CodeWriter();
 
         // Act
         writer.WriteAutoPropertyDeclaration(new[] { "public", "static" }, "global::System.String", "MyString");
@@ -402,7 +402,7 @@ public class CSharpCodeWriterTest
             o.IndentSize = 4;
         });
 
-        var writer = new CodeWriter(Environment.NewLine, options);
+        using var writer = new CodeWriter(Environment.NewLine, options);
 
         // Act
         writer.BuildClassDeclaration(Array.Empty<string>(), "C", "", Array.Empty<string>(), Array.Empty<TypeParameter>(), context: null);
@@ -428,7 +428,7 @@ public class CSharpCodeWriterTest
             o.IndentSize = 4;
         });
 
-        var writer = new CodeWriter(Environment.NewLine, options);
+        using var writer = new CodeWriter(Environment.NewLine, options);
 
         // Act
         writer.BuildClassDeclaration(Array.Empty<string>(), "C", "", Array.Empty<string>(), Array.Empty<TypeParameter>(), context: null);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/CodeGeneration/DesignTimeNodeWriterTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/CodeGeneration/DesignTimeNodeWriterTest.cs
@@ -506,7 +506,7 @@ Render Children
     public void LinePragma_Is_Adjusted_On_Windows(string fileName, string expectedFileName)
     {
         var writer = new DesignTimeNodeWriter();
-        var context = TestCodeRenderingContext.CreateDesignTime();
+        using var context = TestCodeRenderingContext.CreateDesignTime();
 
         Assert.True(context.Options.RemapLinePragmaPathsOnWindows);
 
@@ -553,7 +553,7 @@ Render Children
     public void LinePragma_Enhanced_Is_Adjusted_On_Windows(string fileName, string expectedFileName)
     {
         var writer = new RuntimeNodeWriter();
-        var context = TestCodeRenderingContext.CreateDesignTime(source: RazorSourceDocument.Create("", fileName));
+        using var context = TestCodeRenderingContext.CreateDesignTime(source: RazorSourceDocument.Create("", fileName));
 
         Assert.True(context.Options.RemapLinePragmaPathsOnWindows);
         Assert.True(context.Options.UseEnhancedLinePragma);

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriter.cs
@@ -384,7 +384,7 @@ public sealed partial class CodeWriter : IDisposable
     {
         foreach (var page in _pages)
         {
-            ArrayPool<ReadOnlyMemory<char>>.Shared.Return(page, clearArray: false);
+            ArrayPool<ReadOnlyMemory<char>>.Shared.Return(page, clearArray: true);
         }
 
         _pages.Clear();

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/DefaultCodeRenderingContext.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/DefaultCodeRenderingContext.cs
@@ -21,17 +21,11 @@ internal class DefaultCodeRenderingContext : CodeRenderingContext
     private readonly PooledObject<ImmutableArray<SourceMapping>.Builder> _sourceMappingsBuilder;
 
     public DefaultCodeRenderingContext(
-        CodeWriter codeWriter,
         IntermediateNodeWriter nodeWriter,
         RazorCodeDocument codeDocument,
         DocumentIntermediateNode documentNode,
         RazorCodeGenerationOptions options)
     {
-        if (codeWriter == null)
-        {
-            throw new ArgumentNullException(nameof(codeWriter));
-        }
-
         if (nodeWriter == null)
         {
             throw new ArgumentNullException(nameof(nodeWriter));
@@ -52,7 +46,7 @@ internal class DefaultCodeRenderingContext : CodeRenderingContext
             throw new ArgumentNullException(nameof(options));
         }
 
-        CodeWriter = codeWriter;
+        CodeWriter = new CodeWriter(Environment.NewLine, options);
         _codeDocument = codeDocument;
         _documentNode = documentNode;
         Options = options;
@@ -73,7 +67,7 @@ internal class DefaultCodeRenderingContext : CodeRenderingContext
         if (newLineString != null)
         {
             // Set new line character to a specific string regardless of platform, for testing purposes.
-            codeWriter.NewLine = (string)newLineString;
+            CodeWriter.NewLine = (string)newLineString;
         }
 
         Items[NewLineString] = codeDocument.Items[NewLineString];
@@ -220,6 +214,7 @@ internal class DefaultCodeRenderingContext : CodeRenderingContext
     public override void Dispose()
     {
         _sourceMappingsBuilder.Dispose();
+        CodeWriter.Dispose();
     }
 
     private struct ScopeInternal

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/DefaultCodeRenderingContext.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/DefaultCodeRenderingContext.cs
@@ -46,7 +46,6 @@ internal class DefaultCodeRenderingContext : CodeRenderingContext
             throw new ArgumentNullException(nameof(options));
         }
 
-        CodeWriter = new CodeWriter(Environment.NewLine, options);
         _codeDocument = codeDocument;
         _documentNode = documentNode;
         Options = options;
@@ -63,12 +62,9 @@ internal class DefaultCodeRenderingContext : CodeRenderingContext
             Diagnostics.Add(diagnostics[i]);
         }
 
-        var newLineString = codeDocument.Items[NewLineString];
-        if (newLineString != null)
-        {
-            // Set new line character to a specific string regardless of platform, for testing purposes.
-            CodeWriter.NewLine = (string)newLineString;
-        }
+        // Set new line character to a specific string regardless of platform, for testing purposes.
+        var newLineString = codeDocument.Items[NewLineString] as string ?? Environment.NewLine;
+        CodeWriter = new CodeWriter(newLineString, options);
 
         Items[NewLineString] = codeDocument.Items[NewLineString];
         Items[SuppressUniqueIds] = codeDocument.Items[SuppressUniqueIds] ?? options.SuppressUniqueIds;

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/DefaultDocumentWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/DefaultDocumentWriter.cs
@@ -34,7 +34,6 @@ internal class DefaultDocumentWriter : DocumentWriter
         }
 
         using var context = new DefaultCodeRenderingContext(
-            new CodeWriter(Environment.NewLine, _options),
             _codeTarget.CreateNodeWriter(),
             codeDocument,
             documentNode,

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorHtmlWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorHtmlWriter.cs
@@ -276,5 +276,6 @@ internal class RazorHtmlWriter : SyntaxWalker, IDisposable
     public void Dispose()
     {
         _sourceMappingsBuilder.Dispose();
+        Builder.Dispose();
     }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/Language/CodeGeneration/TestCodeRenderingContext.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/Language/CodeGeneration/TestCodeRenderingContext.cs
@@ -15,7 +15,6 @@ public static class TestCodeRenderingContext
         RazorSourceDocument source = null,
         IntermediateNodeWriter nodeWriter = null)
     {
-        var codeWriter = new CodeWriter();
         var documentNode = new DocumentIntermediateNode();
         var options = RazorCodeGenerationOptions.CreateDesignTimeDefault();
 
@@ -40,7 +39,7 @@ public static class TestCodeRenderingContext
             nodeWriter = new DesignTimeNodeWriter();
         }
 
-        var context = new DefaultCodeRenderingContext(codeWriter, nodeWriter, codeDocument, documentNode, options);
+        var context = new DefaultCodeRenderingContext(nodeWriter, codeDocument, documentNode, options);
         context.Visitor = new RenderChildrenVisitor(context);
 
         return context;
@@ -52,7 +51,6 @@ public static class TestCodeRenderingContext
         RazorSourceDocument source = null,
         IntermediateNodeWriter nodeWriter = null)
     {
-        var codeWriter = new CodeWriter();
         var documentNode = new DocumentIntermediateNode();
         var options = RazorCodeGenerationOptions.CreateDefault();
 
@@ -77,7 +75,7 @@ public static class TestCodeRenderingContext
             nodeWriter = new RuntimeNodeWriter();
         }
 
-        var context = new DefaultCodeRenderingContext(codeWriter, nodeWriter, codeDocument, documentNode, options);
+        var context = new DefaultCodeRenderingContext(nodeWriter, codeDocument, documentNode, options);
         context.Visitor = new RenderChildrenVisitor(context);
 
         return context;


### PR DESCRIPTION
These allocations are present in a customer trace I'm looking at, accounting for 1.4% of allocations in the VS process (around 100 MB).

The owner of the CodeWriter is already disposable, so making the CodeWriter disposable is trivial, and allows for all ReadOnlyMemory<char> pages added to _pages to be released back to a pool.

*** Customer trace ***
![image](https://github.com/dotnet/razor/assets/6785178/b6da10e2-7b83-43ec-89df-24a70bf99391)

*** local trace WITHOUT changes opening OrchardCore ***
![image](https://github.com/dotnet/razor/assets/6785178/32f5f814-b9a6-447d-abe3-88c87424c4fa)

*** local trace WITH changes opening OrchardCore ***
![image](https://github.com/dotnet/razor/assets/6785178/3e25c00e-1d5e-48b5-b5c5-245d6619a1d9)