### PR TITLE
fixed an error was causing the build to fail in linux using build.sh

### DIFF
--- a/eng/common/tools.sh
+++ b/eng/common/tools.sh
@@ -353,9 +353,9 @@ function InitializeBuildTool {
 function GetNuGetPackageCachePath {
   if [[ -z ${NUGET_PACKAGES:-} ]]; then
     if [[ "$use_global_nuget_cache" == true ]]; then
-      export NUGET_PACKAGES="$HOME/.nuget/packages"
+      export NUGET_PACKAGES="$HOME/.nuget/packages/"
     else
-      export NUGET_PACKAGES="$repo_root/.packages"
+      export NUGET_PACKAGES="$repo_root/.packages/"
       export RESTORENOCACHE=true
     fi
   fi


### PR DESCRIPTION
the error: "NUGET_PACKAGES should end with a slash or it will lead to editorconfig issues:"

added the needed trailing slash in eng/common/tools.sh that was causing the error when defining NUGET_PACKAGES variable


-