### PR TITLE
Removing unnecessary Razor Legacy Editor feature flag

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/WellKnownFeatureFlagNames.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/WellKnownFeatureFlagNames.cs
@@ -11,5 +11,4 @@ internal static class WellKnownFeatureFlagNames
     public const string UseRazorCohostServer = "Razor.LSP.UseRazorCohostServer";
     public const string DisableRazorLanguageServer = "Razor.LSP.DisableRazorLanguageServer";
     public const string ForceRuntimeCodeGeneration = "Razor.LSP.ForceRuntimeCodeGeneration";
-    public const string UseLegacyRazorEditor = "Razor.LSP.LegacyEditor";
 }

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
@@ -38,12 +38,6 @@
 "ShowBraceCompletion"=dword:00000001
 "ShowSmartIndent"=dword:00000001
 
-[$RootKey$\FeatureFlags\Razor\LSP\LegacyEditor]
-"Description"="Uses the legacy Razor editor when editing Razor (ASP.NET Core)."
-"Value"=dword:00000000
-"Title"="Use legacy Razor editor (requires restart)"
-"PreviewPaneChannels"="int.main"
-
 [$RootKey$\FeatureFlags\Razor\LSP\ShowAllCSharpCodeActions]
 "Description"="Show all C# code actions in Razor files. Note: This is experimental, some actions may not apply correctly, or at all!"
 "Value"=dword:00000000

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LspEditorFeatureDetectorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LspEditorFeatureDetectorTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.VisualStudio.Razor;
 
 public class LspEditorFeatureDetectorTest(ITestOutputHelper testOutput) : ToolingTestBase(testOutput)
 {
-    public static TheoryData< bool, bool> IsLspEditorEnabledTestData { get; } = new()
+    public static TheoryData<bool, bool> IsLspEditorEnabledTestData { get; } = new()
     {
         // legacyEditorSetting, expectedResult
         { false, true },

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LspEditorFeatureDetectorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LspEditorFeatureDetectorTest.cs
@@ -23,8 +23,6 @@ public class LspEditorFeatureDetectorTest(ITestOutputHelper testOutput) : Toolin
         // legacyEditorSetting, expectedResult
         { false, true },
         { true, false },
-        { false, false },
-        { true, false }
     };
 
     [UITheory]

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractRazorEditorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractRazorEditorTest.cs
@@ -144,9 +144,6 @@ public abstract class AbstractRazorEditorTest(ITestOutputHelper testOutputHelper
     {
         var settingsManager = (ISettingsManager)ServiceProvider.GlobalProvider.GetService(typeof(SVsSettingsPersistenceManager));
         Assumes.Present(settingsManager);
-        var featureFlags = (IVsFeatureFlags)AsyncPackage.GetGlobalService(typeof(SVsFeatureFlags));
-        var legacyEditorFeatureFlagEnabled = featureFlags.IsFeatureEnabled(WellKnownFeatureFlagNames.UseLegacyRazorEditor, defaultValue: false);
-        Assert.AreEqual(false, legacyEditorFeatureFlagEnabled, "Expected Legacy Editor Feature Flag to be disabled, but it was enabled");
 
         var useLegacyEditor = settingsManager.GetValueOrDefault<bool>(WellKnownSettingNames.UseLegacyASPNETCoreEditor);
         Assert.AreEqual(false, useLegacyEditor, "Expected the Legacy Razor Editor to be disabled, but it was enabled");


### PR DESCRIPTION
AFAIK it was introduced for new LSP editor rollout several years ago before we had Tools/Options/HTML Editor/Advanced/Use legacy Razor Editor option. Now that rollout is over, and there is a public non-preview mechanism for users to switch to the old editor if needed, the feature flag is no longer necessary and creates confusion (and extra code to test/maintain).

﻿### Summary of the changes

-Removing unnecessary Razor Legacy Editor feature flag

Fixes:
Removes redundant way to (internally only) enable legacy Razor editor 