### PR TITLE
Add tests for the cohost linked editing range endpoint

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/IBrokeredServiceInterceptor.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/IBrokeredServiceInterceptor.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Api;
+
+namespace Microsoft.CodeAnalysis.Remote.Razor;
+
+/// <summary>
+/// An abstraction to avoid calling the static <see cref="RazorBrokeredServiceImplementation"/> helper defined in Roslyn
+/// </summary>
+internal interface IBrokeredServiceInterceptor
+{
+    ValueTask RunServiceAsync(Func<CancellationToken, ValueTask> implementation, CancellationToken cancellationToken);
+
+    ValueTask<T> RunServiceAsync<T>(RazorPinnedSolutionInfoWrapper solutionInfo, Func<Solution, ValueTask<T>> implementation, CancellationToken cancellationToken);
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Microsoft.CodeAnalysis.Remote.Razor.csproj
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Microsoft.CodeAnalysis.Remote.Razor.csproj
@@ -54,6 +54,7 @@
     <InternalsVisibleTo Include="DynamicProxyGenAssembly2" Key="$(MoqPublicKey)" />
     <InternalsVisibleTo Include="Microsoft.AspNetCore.Razor.Microbenchmarks" Key="$(RazorKey)" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Remote.Razor.Test" Key="$(RazorKey)" />
+    <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.Razor.Test" />
   </ItemGroup>
 
 </Project>

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostLinkedEditingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostLinkedEditingRangeEndpoint.cs
@@ -5,6 +5,7 @@ using System.Composition;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
 using Microsoft.CodeAnalysis.Razor.LinkedEditingRange;
 using Microsoft.CodeAnalysis.Razor.Logging;
@@ -53,14 +54,15 @@ internal class CohostLinkedEditingRangeEndpoint(IRemoteServiceProvider remoteSer
     protected override RazorTextDocumentIdentifier? GetRazorTextDocumentIdentifier(LinkedEditingRangeParams request)
         => request.TextDocument.ToRazorTextDocumentIdentifier();
 
-    protected override async Task<LinkedEditingRanges?> HandleRequestAsync(LinkedEditingRangeParams request, RazorCohostRequestContext context, CancellationToken cancellationToken)
-    {
-        var razorDocument = context.TextDocument.AssumeNotNull();
+    protected override Task<LinkedEditingRanges?> HandleRequestAsync(LinkedEditingRangeParams request, RazorCohostRequestContext context, CancellationToken cancellationToken)
+        => HandleRequestAsync(request, context.TextDocument.AssumeNotNull(), cancellationToken);
 
+    private async Task<LinkedEditingRanges?> HandleRequestAsync(LinkedEditingRangeParams request, TextDocument razorDocument, CancellationToken cancellationToken)
+    {
         var linkedRanges = await _remoteServiceProvider.TryInvokeAsync<IRemoteLinkedEditingRangeService, LinePositionSpan[]?>(
-            razorDocument.Project.Solution,
-            (service, solutionInfo, cancellationToken) => service.GetRangesAsync(solutionInfo, razorDocument.Id, request.Position.ToLinePosition(), cancellationToken),
-            cancellationToken).ConfigureAwait(false);
+                    razorDocument.Project.Solution,
+                    (service, solutionInfo, cancellationToken) => service.GetRangesAsync(solutionInfo, razorDocument.Id, request.Position.ToLinePosition(), cancellationToken),
+                    cancellationToken).ConfigureAwait(false);
 
         if (linkedRanges is [{ } span1, { } span2])
         {
@@ -72,5 +74,13 @@ internal class CohostLinkedEditingRangeEndpoint(IRemoteServiceProvider remoteSer
         }
 
         return null;
+    }
+
+    internal TestAccessor GetTestAccessor() => new(this);
+
+    internal readonly struct TestAccessor(CohostLinkedEditingRangeEndpoint instance)
+    {
+        public Task<LinkedEditingRanges?> HandleRequestAsync(LinkedEditingRangeParams request, TextDocument razorDocument, CancellationToken cancellationToken)
+            => instance.HandleRequestAsync(request, razorDocument, cancellationToken);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostLinkedEditingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostLinkedEditingRangeEndpoint.cs
@@ -60,9 +60,9 @@ internal class CohostLinkedEditingRangeEndpoint(IRemoteServiceProvider remoteSer
     private async Task<LinkedEditingRanges?> HandleRequestAsync(LinkedEditingRangeParams request, TextDocument razorDocument, CancellationToken cancellationToken)
     {
         var linkedRanges = await _remoteServiceProvider.TryInvokeAsync<IRemoteLinkedEditingRangeService, LinePositionSpan[]?>(
-                    razorDocument.Project.Solution,
-                    (service, solutionInfo, cancellationToken) => service.GetRangesAsync(solutionInfo, razorDocument.Id, request.Position.ToLinePosition(), cancellationToken),
-                    cancellationToken).ConfigureAwait(false);
+            razorDocument.Project.Solution,
+            (service, solutionInfo, cancellationToken) => service.GetRangesAsync(solutionInfo, razorDocument.Id, request.Position.ToLinePosition(), cancellationToken),
+            cancellationToken).ConfigureAwait(false);
 
         if (linkedRanges is [{ } span1, { } span2])
         {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/RemoteServiceProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/RemoteServiceProvider.cs
@@ -71,7 +71,7 @@ internal sealed class RemoteServiceProvider(
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             var approximateCallingClassName = Path.GetFileNameWithoutExtension(callerFilePath);
-            _logger.LogError(ex, $"Error calling remote method for {typeof(TService).Name} service, invocation: ${approximateCallingClassName}.{callerMemberName}");
+            _logger.LogError(ex, $"Error calling remote method for {typeof(TService).Name} service, invocation: {approximateCallingClassName}.{callerMemberName}");
             _telemetryReporter.ReportFault(ex, "Exception calling remote method for {service}, invocation: {class}.{method}", typeof(TService).FullName, approximateCallingClassName, callerMemberName);
             return default;
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ToolingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ToolingTestBase.cs
@@ -70,6 +70,12 @@ public abstract partial class ToolingTestBase : IAsyncLifetime
     /// </summary>
     internal ILoggerFactory LoggerFactory { get; }
 
+    /// <summary>
+    /// An <see cref="ITestOutputHelper"/> that the currently running test can use to write
+    /// though using <see cref="LoggerFactory"/> is probably preferred.
+    /// </summary>
+    internal ITestOutputHelper TestOutputHelper { get; }
+
     private ILogger? _logger;
 
     /// <summary>
@@ -86,6 +92,7 @@ public abstract partial class ToolingTestBase : IAsyncLifetime
         _disposalTokenSource = new();
         DisposalToken = _disposalTokenSource.Token;
 
+        TestOutputHelper = testOutput;
         LoggerFactory = new TestOutputLoggerFactory(testOutput);
 
         // Give this thread a name, so it's easier to find in the VS Threads window.

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostLinkedEditingRangeTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostLinkedEditingRangeTest.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.Razor.LinkedEditingRange;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor.Test.Cohost;
+
+public class CohostLinkedEditingRangeTest(ITestOutputHelper testOutputHelper) : CohostTestBase(testOutputHelper)
+{
+    [Fact]
+    public async Task StartTag()
+    {
+        var input = """
+            This is a Razor document.
+
+            <[|$$div|]>
+                Here is some content.
+            </[|div|]>
+
+            The end.
+            """;
+
+        await VerifyLinkedEditingRangeAsync(input);
+    }
+
+    [Fact]
+    public async Task EndTag()
+    {
+        var input = """
+            This is a Razor document.
+
+            <[|div|]>
+                Here is some content.
+            </[|d$$iv|]>
+
+            The end.
+            """;
+
+        await VerifyLinkedEditingRangeAsync(input);
+    }
+
+    private async Task VerifyLinkedEditingRangeAsync(string input)
+    {
+        TestFileMarkupParser.GetPositionAndSpans(input, out input, out int cursorPosition, out ImmutableArray<TextSpan> spans);
+        var document = CreateRazorDocument(input);
+        var sourceText = await document.GetTextAsync(DisposalToken);
+        sourceText.GetLineAndOffset(cursorPosition, out var lineIndex, out var characterIndex);
+
+        var endpoint = new CohostLinkedEditingRangeEndpoint(RemoteServiceProvider, LoggerFactory);
+
+        var request = new LinkedEditingRangeParams()
+        {
+            TextDocument = new TextDocumentIdentifier()
+            {
+                Uri = document.CreateUri()
+            },
+            Position = new Position()
+            {
+                Line = lineIndex,
+                Character = characterIndex
+            }
+        };
+
+        var result = await endpoint.GetTestAccessor().HandleRequestAsync(request, document, DisposalToken);
+
+        Assert.NotNull(result);
+        Assert.Equal(LinkedEditingRangeHelper.WordPattern, result.WordPattern);
+        Assert.Equal(spans[0], result.Ranges[0].ToTextSpan(sourceText));
+        Assert.Equal(spans[1], result.Ranges[1].ToTextSpan(sourceText));
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostTestBase.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostTestBase.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Razor.Remote;
+using Microsoft.CodeAnalysis.Text;
+using Xunit.Abstractions;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor.Test.Cohost;
+
+public class CohostTestBase(ITestOutputHelper testOutputHelper) : WorkspaceTestBase(testOutputHelper)
+{
+    private readonly ITestOutputHelper _testOutputHelper = testOutputHelper;
+
+    private IRemoteServiceProvider? _remoteServiceProvider;
+
+    internal IRemoteServiceProvider RemoteServiceProvider => _remoteServiceProvider.AssumeNotNull();
+
+    protected override Task InitializeAsync()
+    {
+        _remoteServiceProvider = new ShortCircuitingRemoteServiceProvider(_testOutputHelper);
+
+        return base.InitializeAsync();
+    }
+
+    protected TextDocument CreateRazorDocument(string input)
+    {
+        var hostProject = TestProjectData.SomeProject;
+        var hostDocument = TestProjectData.SomeProjectComponentFile1;
+
+        var sourceText = SourceText.From(input);
+
+        var solution = Workspace.CurrentSolution.AddProject(ProjectInfo.Create(
+            ProjectId.CreateNewId(Path.GetFileNameWithoutExtension(hostProject.FilePath)),
+            VersionStamp.Create(),
+            Path.GetFileNameWithoutExtension(hostDocument.FilePath),
+            Path.GetFileNameWithoutExtension(hostDocument.FilePath),
+            LanguageNames.CSharp,
+            hostDocument.FilePath));
+
+        solution = solution.AddAdditionalDocument(
+            DocumentId.CreateNewId(solution.ProjectIds.Single(), hostDocument.FilePath),
+            hostDocument.FilePath,
+            sourceText,
+            filePath: hostDocument.FilePath);
+
+        var document = solution.Projects.Single().AdditionalDocuments.Single();
+
+        return document;
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostTestBase.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostTestBase.cs
@@ -26,29 +26,28 @@ public abstract class CohostTestBase(ITestOutputHelper testOutputHelper) : Works
         return base.InitializeAsync();
     }
 
-    protected TextDocument CreateRazorDocument(string input)
+    protected TextDocument CreateRazorDocument(string contents)
     {
-        var hostProject = TestProjectData.SomeProject;
-        var hostDocument = TestProjectData.SomeProjectComponentFile1;
-
-        var sourceText = SourceText.From(input);
+        var projectFilePath = TestProjectData.SomeProject.FilePath;
+        var documentFilePath = TestProjectData.SomeProjectComponentFile1.FilePath;
+        var projectName = Path.GetFileNameWithoutExtension(projectFilePath);
+        var projectId = ProjectId.CreateNewId(debugName: projectName);
+        var documentId = DocumentId.CreateNewId(projectId, debugName: documentFilePath);
 
         var solution = Workspace.CurrentSolution.AddProject(ProjectInfo.Create(
-            ProjectId.CreateNewId(Path.GetFileNameWithoutExtension(hostProject.FilePath)),
+            projectId,
             VersionStamp.Create(),
-            Path.GetFileNameWithoutExtension(hostDocument.FilePath),
-            Path.GetFileNameWithoutExtension(hostDocument.FilePath),
+            name: projectName,
+            assemblyName: projectName,
             LanguageNames.CSharp,
-            hostDocument.FilePath));
+            documentFilePath));
 
         solution = solution.AddAdditionalDocument(
-            DocumentId.CreateNewId(solution.ProjectIds.Single(), hostDocument.FilePath),
-            hostDocument.FilePath,
-            sourceText,
-            filePath: hostDocument.FilePath);
+            documentId,
+            documentFilePath,
+            SourceText.From(contents),
+            filePath: documentFilePath);
 
-        var document = solution.Projects.Single().AdditionalDocuments.Single();
-
-        return document;
+        return solution.GetAdditionalDocument(documentId).AssumeNotNull();
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostTestBase.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostTestBase.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Test.Common;
@@ -14,17 +13,15 @@ using Xunit.Abstractions;
 
 namespace Microsoft.VisualStudio.LanguageServices.Razor.Test.Cohost;
 
-public class CohostTestBase(ITestOutputHelper testOutputHelper) : WorkspaceTestBase(testOutputHelper)
+public abstract class CohostTestBase(ITestOutputHelper testOutputHelper) : WorkspaceTestBase(testOutputHelper)
 {
-    private readonly ITestOutputHelper _testOutputHelper = testOutputHelper;
-
     private IRemoteServiceProvider? _remoteServiceProvider;
 
-    internal IRemoteServiceProvider RemoteServiceProvider => _remoteServiceProvider.AssumeNotNull();
+    private protected IRemoteServiceProvider RemoteServiceProvider => _remoteServiceProvider.AssumeNotNull();
 
     protected override Task InitializeAsync()
     {
-        _remoteServiceProvider = new ShortCircuitingRemoteServiceProvider(_testOutputHelper);
+        _remoteServiceProvider = new ShortCircuitingRemoteServiceProvider(TestOutputHelper);
 
         return base.InitializeAsync();
     }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/InterceptingServiceBroker.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/InterceptingServiceBroker.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.IO.Pipelines;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.Remote.Razor;
+using Microsoft.ServiceHub.Framework;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor.Test.Cohost;
+
+internal class InterceptingServiceBroker(Solution solution) : IServiceBroker, IBrokeredServiceInterceptor
+{
+    public event EventHandler<BrokeredServicesChangedEventArgs>? AvailabilityChanged { add { } remove { } }
+
+    public ValueTask<IDuplexPipe?> GetPipeAsync(ServiceMoniker serviceMoniker, ServiceActivationOptions options = default, CancellationToken cancellationToken = default)
+    {
+        throw new NotImplementedException();
+    }
+
+    public ValueTask<T?> GetProxyAsync<T>(ServiceRpcDescriptor serviceDescriptor, ServiceActivationOptions options = default, CancellationToken cancellationToken = default) where T : class
+    {
+        throw new NotImplementedException();
+    }
+
+    public ValueTask RunServiceAsync(Func<CancellationToken, ValueTask> implementation, CancellationToken cancellationToken)
+    {
+        return implementation(cancellationToken);
+    }
+
+    public ValueTask<T> RunServiceAsync<T>(RazorPinnedSolutionInfoWrapper solutionInfo, Func<Solution, ValueTask<T>> implementation, CancellationToken cancellationToken)
+    {
+        return implementation(solution);
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/InterceptingServiceBroker.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/InterceptingServiceBroker.cs
@@ -21,7 +21,8 @@ internal class InterceptingServiceBroker(Solution solution) : IServiceBroker, IB
         throw new NotImplementedException();
     }
 
-    public ValueTask<T?> GetProxyAsync<T>(ServiceRpcDescriptor serviceDescriptor, ServiceActivationOptions options = default, CancellationToken cancellationToken = default) where T : class
+    public ValueTask<T?> GetProxyAsync<T>(ServiceRpcDescriptor serviceDescriptor, ServiceActivationOptions options = default, CancellationToken cancellationToken = default)
+        where T : class
     {
         throw new NotImplementedException();
     }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/ShortCircuitingRemoteServiceProvider.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/ShortCircuitingRemoteServiceProvider.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.Razor.Remote;
+using Microsoft.CodeAnalysis.Remote.Razor;
+using Microsoft.ServiceHub.Framework;
+using Nerdbank.Streams;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor.Test.Cohost;
+
+/// <summary>
+/// An implementation of IRemoteServiceProvider that doesn't actually do anything remote, but rather directly calls service methods
+/// </summary>
+internal class ShortCircuitingRemoteServiceProvider(ITestOutputHelper testOutputHelper) : IRemoteServiceProvider
+{
+    private static Dictionary<Type, IServiceHubServiceFactory> _factoryMap = BuildFactoryMap();
+
+    private readonly IServiceProvider _serviceProvider = new TestTraceSourceProvider(testOutputHelper);
+
+    private static Dictionary<Type, IServiceHubServiceFactory> BuildFactoryMap()
+    {
+        var result = new Dictionary<Type, IServiceHubServiceFactory>();
+
+        foreach (var type in typeof(RazorServiceFactoryBase<>).Assembly.GetTypes())
+        {
+            if (!type.IsAbstract &&
+                typeof(IServiceHubServiceFactory).IsAssignableFrom(type))
+            {
+                Debug.Assert(type.BaseType.GetGenericTypeDefinition() == typeof(RazorServiceFactoryBase<>));
+
+                var genericType = type.BaseType.GetGenericArguments().FirstOrDefault();
+                if (genericType != null)
+                {
+                    // ServiceHub requires a parameterless constructor, so we can safely rely on it existing too
+                    var factory = (IServiceHubServiceFactory)Activator.CreateInstance(type);
+                    result.Add(genericType, factory);
+                }
+            }
+        }
+
+        return result;
+    }
+
+    public async ValueTask<TResult?> TryInvokeAsync<TService, TResult>(Solution solution, Func<TService, RazorPinnedSolutionInfoWrapper, CancellationToken, ValueTask<TResult>> invocation, CancellationToken cancellationToken, [CallerFilePath] string? callerFilePath = null, [CallerMemberName] string? callerMemberName = null) where TService : class
+    {
+        Assert.True(_factoryMap.TryGetValue(typeof(TService), out var factory));
+
+        var testServiceBroker = new InterceptingServiceBroker(solution);
+
+        // We don't ever use this stream, because we never really use ServiceHub, but going through its factory method means the
+        // remote services under test are using their full MEF composition etc. so we get excellent coverage.
+        var (stream, _) = FullDuplexStream.CreatePair();
+        var service = (TService)await factory.CreateAsync(stream, _serviceProvider, serviceActivationOptions: default, testServiceBroker, authorizationServiceClient: default!);
+
+        // This is never used, we short-circuited things by passing the solution direct to the InterceptingServiceBroker
+        var solutionInfo = new RazorPinnedSolutionInfoWrapper();
+
+        testOutputHelper.WriteLine($"Pretend OOP call for {typeof(TService).Name}, invocation: {Path.GetFileNameWithoutExtension(callerFilePath)}.{callerMemberName}");
+        return await invocation(service, solutionInfo, cancellationToken);
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/TestTraceSourceProvider.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/TestTraceSourceProvider.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using Xunit.Abstractions;
+
+namespace Microsoft.VisualStudio.LanguageServices.Razor.Test.Cohost;
+
+/// <summary>
+/// An implementation of IServiceProvider that only provides a TraceSource, that writes to test output
+/// </summary>
+internal class TestTraceSourceProvider(ITestOutputHelper testOutputHelper) : IServiceProvider
+{
+    public object GetService(Type serviceType)
+    {
+        if (serviceType == typeof(TraceSource))
+        {
+            return new TestOutputTraceSource(testOutputHelper);
+        }
+
+        throw new NotImplementedException();
+    }
+
+    private class TestOutputTraceSource : TraceSource
+    {
+        public TestOutputTraceSource(ITestOutputHelper testOutputHelper)
+            : base("OOP", SourceLevels.All)
+        {
+            Listeners.Add(new TestOutputTraceListener(testOutputHelper));
+        }
+
+        private class TestOutputTraceListener(ITestOutputHelper testOutputHelper) : TraceListener
+        {
+            public override void Write(string message)
+            {
+                // ITestOutputHelper doesn't have a Write method, but all we lose is some extra ServiceHub details like log level
+            }
+
+            public override void WriteLine(string message)
+            {
+                // Ignore some specific ServiceHub noise, since we're not using ServiceHub anyway
+                if (message.StartsWith("Added local RPC method") || message == "Listening started.")
+                {
+                    return;
+                }
+
+                testOutputHelper.WriteLine(message);
+            }
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Microsoft.VisualStudio.LanguageServices.Razor.Test.csproj
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Microsoft.VisualStudio.LanguageServices.Razor.Test.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.CodeAnalysis.Remote.Razor\Microsoft.CodeAnalysis.Remote.Razor.csproj" />
     <ProjectReference Include="..\..\src\Microsoft.VisualStudio.LanguageServices.Razor\Microsoft.VisualStudio.LanguageServices.Razor.csproj" />
     <ProjectReference Include="..\..\..\Compiler\Microsoft.CodeAnalysis.Razor.Compiler\src\Microsoft.CodeAnalysis.Razor.Compiler.csproj" />
     <ProjectReference Include="..\Microsoft.AspNetCore.Razor.Test.Common.Tooling\Microsoft.AspNetCore.Razor.Test.Common.Tooling.csproj" />


### PR DESCRIPTION
Part of https://github.com/dotnet/razor/issues/9519

Finally some cohosting tests! Some people would say that I'm being lazy in adding tests for the simplest endpoint we have. Those people have a point.

The test infra here almost entirely avoids ServiceHub, and certainly avoids the Roslyn solution sync mechanism, but it _does_ use our real services and service factories, including the OOP services' separate MEF composition, so the services themselves are partying on a real Roslyn (test) solution and are using real implementations of all of their dependencies.

Things not covered by this test infra yet:
* OOP initialization
* Adding generated C# files to the Roslyn solution (IDynamicFile does this in real life)
* Dealing with Html documents in any way

Future PRs to add tests for more endpoints should add these as needed.