### PR TITLE
Fix unified settings

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
@@ -74,3 +74,10 @@
 "Value"=dword:00000000
 "Title"="Force use of runtime code generation for Razor (requires restart)"
 "PreviewPaneChannels"="IntPreview,int.main"
+
+// CacheTag value should be changed when registration file changes
+// See https://devdiv.visualstudio.com/DevDiv/_wiki/wikis/DevDiv.wiki/39345/Manifest-Build-Deployment-and-Setup-Authoring-In-Depth?anchor=example-pkgdef-key for more infomation
+[$RootKey$\SettingsManifests\{13b72f58-279e-49e0-a56d-296be02f0805}]
+@="Microsoft.VisualStudio.RazorExtension.RazorPackage"
+"ManifestPath"="$PackageFolder$\UnifiedSettings\razor.registration.json"
+"CacheTag"=qword:5DE8496A8900B809

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/RazorPackage.cs
@@ -34,6 +34,7 @@ namespace Microsoft.VisualStudio.RazorExtension;
 [ProvideMenuResource("SyntaxVisualizerMenu.ctmenu", 1)]
 [ProvideToolWindow(typeof(SyntaxVisualizerToolWindow))]
 [ProvideLanguageEditorOptionPage(typeof(AdvancedOptionPage), RazorConstants.RazorLSPContentTypeName, category: null, "Advanced", pageNameResourceId: "#1050", keywordListResourceId: 1060)]
+[ProvideSettingsManifest(PackageRelativeManifestFile = @"UnifiedSettings\razor.registration.json")]
 [Guid(PackageGuidString)]
 // We activate cohosting when the first Razor file is opened. This matches the previous behavior where the
 // LSP client MEF export had the Razor content type metadata.


### PR DESCRIPTION
While self-hosting I noticed unified settings were no longer available and were defaulting back to the classic experience. Looks like they updated how some of the registration works and added a fix for f5 debugging them. Worked locally on my machine but I will not claim any expertise here.