### PR TITLE
Add ImmutableArray extension methods for ordering

### DIFF
--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ImmutableArrayExtensionsTests.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ImmutableArrayExtensionsTests.cs
@@ -37,20 +37,23 @@ public class ImmutableArrayExtensionsTests
             s => Assert.Equal("WoRlD", s));
     }
 
-    public static TheoryData<ImmutableArray<int>, ImmutableArray<int>> OrderAsArrayData
-    {
-        get
+    private static Comparison<int> OddBeforeEven
+        => (x, y) => (x % 2 != 0, y % 2 != 0) switch
         {
-            return new()
-            {
-                { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
-                { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
-                { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
-                { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
-                { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
-            };
-        }
-    }
+            (true, false) => -1,
+            (false, true) => 1,
+            _ => x.CompareTo(y)
+        };
+
+    public static TheoryData<ImmutableArray<int>, ImmutableArray<int>> OrderAsArrayData
+        => new()
+        {
+            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+        };
 
     [Theory]
     [MemberData(nameof(OrderAsArrayData))]
@@ -60,26 +63,57 @@ public class ImmutableArrayExtensionsTests
         Assert.Equal<int>(expected, sorted);
     }
 
-    public static TheoryData<ImmutableArray<int>, ImmutableArray<int>> OrderDescendingAsArrayData
-    {
-        get
+    public static TheoryData<ImmutableArray<int>, ImmutableArray<int>> OrderAsArray_OddBeforeEvenData
+        => new()
         {
-            return new()
-            {
-                { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
-                { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
-                { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
-                { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
-                { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
-            };
-        }
+            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+        };
+
+    [Theory]
+    [MemberData(nameof(OrderAsArray_OddBeforeEvenData))]
+    public void OrderAsArray_OddBeforeEven(ImmutableArray<int> data, ImmutableArray<int> expected)
+    {
+        var sorted = data.OrderAsArray(OddBeforeEven);
+        Assert.Equal<int>(expected, sorted);
     }
+
+    public static TheoryData<ImmutableArray<int>, ImmutableArray<int>> OrderDescendingAsArrayData
+        => new()
+        {
+            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+        };
 
     [Theory]
     [MemberData(nameof(OrderAsArrayData))]
     public void OrderDescendingAsArray(ImmutableArray<int> data, ImmutableArray<int> expected)
     {
         var sorted = data.OrderAsArray();
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    public static TheoryData<ImmutableArray<int>, ImmutableArray<int>> OrderDescendingAsArray_OddBeforeEvenData
+        => new()
+        {
+            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+        };
+
+    [Theory]
+    [MemberData(nameof(OrderDescendingAsArray_OddBeforeEvenData))]
+    public void OrderDescendingAsArray_OddBeforeEven(ImmutableArray<int> data, ImmutableArray<int> expected)
+    {
+        var sorted = data.OrderDescendingAsArray(OddBeforeEven);
         Assert.Equal<int>(expected, sorted);
     }
 
@@ -90,19 +124,14 @@ public class ImmutableArrayExtensionsTests
     }
 
     public static TheoryData<ImmutableArray<ValueHolder>, ImmutableArray<ValueHolder>> OrderByAsArrayData
-    {
-        get
+        => new()
         {
-            return new()
-            {
-                { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
-                { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
-                { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
-                { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
-                { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
-            };
-        }
-    }
+            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+        };
 
     [Theory]
     [MemberData(nameof(OrderByAsArrayData))]
@@ -112,26 +141,57 @@ public class ImmutableArrayExtensionsTests
         Assert.Equal<ValueHolder>(expected, sorted);
     }
 
-    public static TheoryData<ImmutableArray<ValueHolder>, ImmutableArray<ValueHolder>> OrderByDescendingAsArrayData
-    {
-        get
+    public static TheoryData<ImmutableArray<ValueHolder>, ImmutableArray<ValueHolder>> OrderByAsArray_OddBeforeEvenData
+        => new()
         {
-            return new()
-            {
-                { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
-                { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
-                { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
-                { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
-                { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
-            };
-        }
+            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+        };
+
+    [Theory]
+    [MemberData(nameof(OrderByAsArray_OddBeforeEvenData))]
+    public void OrderByAsArray_OddBeforeEvent(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var sorted = data.OrderByAsArray(static x => x.Value, OddBeforeEven);
+        Assert.Equal<ValueHolder>(expected, sorted);
     }
+
+    public static TheoryData<ImmutableArray<ValueHolder>, ImmutableArray<ValueHolder>> OrderByDescendingAsArrayData
+        => new()
+        {
+            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+        };
 
     [Theory]
     [MemberData(nameof(OrderByDescendingAsArrayData))]
     public void OrderByDescendingAsArray(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
     {
         var sorted = data.OrderByDescendingAsArray(static x => x.Value);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
+
+    public static TheoryData<ImmutableArray<ValueHolder>, ImmutableArray<ValueHolder>> OrderByDescendingAsArray_OddBeforeEvenData
+        => new()
+        {
+            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+        };
+
+    [Theory]
+    [MemberData(nameof(OrderByDescendingAsArray_OddBeforeEvenData))]
+    public void OrderByDescendingAsArray_OddBeforeEven(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var sorted = data.OrderByDescendingAsArray(static x => x.Value, OddBeforeEven);
         Assert.Equal<ValueHolder>(expected, sorted);
     }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ImmutableArrayExtensionsTests.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ImmutableArrayExtensionsTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.Utilities.Shared.Test;
@@ -193,5 +194,125 @@ public class ImmutableArrayExtensionsTests
     {
         var sorted = data.OrderByDescendingAsArray(static x => x.Value, OddBeforeEven);
         Assert.Equal<ValueHolder>(expected, sorted);
+    }
+
+    [Fact]
+    public void OrderAsArray_EmptyArrayReturnsSameArray()
+    {
+        var array = ImmutableCollectionsMarshal.AsArray(ImmutableArray<int>.Empty);
+        var immutableArray = ImmutableArray<int>.Empty;
+
+        immutableArray = immutableArray.OrderAsArray();
+        Assert.Same(array, ImmutableCollectionsMarshal.AsArray(immutableArray));
+    }
+
+    [Fact]
+    public void OrderAsArray_SingleElementArrayReturnsSameArray()
+    {
+        var array = new int[] { 42 };
+        var immutableArray = ImmutableCollectionsMarshal.AsImmutableArray(array);
+
+        immutableArray = immutableArray.OrderAsArray();
+        Assert.Same(array, ImmutableCollectionsMarshal.AsArray(immutableArray));
+    }
+
+    [Fact]
+    public void OrderAsArray_SortedArrayReturnsSameArray()
+    {
+        var values = new int[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+        var immutableArray = ImmutableCollectionsMarshal.AsImmutableArray(values);
+
+        immutableArray = immutableArray.OrderAsArray();
+        Assert.Same(values, ImmutableCollectionsMarshal.AsArray(immutableArray));
+    }
+
+    [Fact]
+    public void OrderDescendingAsArray_EmptyArrayReturnsSameArray()
+    {
+        var array = ImmutableCollectionsMarshal.AsArray(ImmutableArray<int>.Empty);
+        var immutableArray = ImmutableArray<int>.Empty;
+
+        immutableArray = immutableArray.OrderDescendingAsArray();
+        Assert.Same(array, ImmutableCollectionsMarshal.AsArray(immutableArray));
+    }
+
+    [Fact]
+    public void OrderDescendingAsArray_SingleElementArrayReturnsSameArray()
+    {
+        var array = new int[] { 42 };
+        var immutableArray = ImmutableCollectionsMarshal.AsImmutableArray(array);
+
+        immutableArray = immutableArray.OrderDescendingAsArray();
+        Assert.Same(array, ImmutableCollectionsMarshal.AsArray(immutableArray));
+    }
+
+    [Fact]
+    public void OrderDescendingAsArray_SortedArrayReturnsSameArray()
+    {
+        var values = new int[] { 10, 9, 8, 7, 6, 5, 4, 3, 2, 1 };
+        var presortedArray = ImmutableCollectionsMarshal.AsImmutableArray(values);
+
+        presortedArray = presortedArray.OrderDescendingAsArray();
+        Assert.Same(values, ImmutableCollectionsMarshal.AsArray(presortedArray));
+    }
+
+    [Fact]
+    public void OrderByAsArray_EmptyArrayReturnsSameArray()
+    {
+        var array = ImmutableCollectionsMarshal.AsArray(ImmutableArray<ValueHolder>.Empty);
+        var immutableArray = ImmutableArray<ValueHolder>.Empty;
+
+        immutableArray = immutableArray.OrderByAsArray(static x => x.Value);
+        Assert.Same(array, ImmutableCollectionsMarshal.AsArray(immutableArray));
+    }
+
+    [Fact]
+    public void OrderByAsArray_SingleElementArrayReturnsSameArray()
+    {
+        var array = new ValueHolder[] { 42 };
+        var immutableArray = ImmutableCollectionsMarshal.AsImmutableArray(array);
+
+        immutableArray = immutableArray.OrderByAsArray(static x => x.Value);
+        Assert.Same(array, ImmutableCollectionsMarshal.AsArray(immutableArray));
+    }
+
+    [Fact]
+    public void OrderByAsArray_SortedArrayReturnsSameArray()
+    {
+        var values = new ValueHolder[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+        var presortedArray = ImmutableCollectionsMarshal.AsImmutableArray(values);
+
+        presortedArray = presortedArray.OrderByAsArray(static x => x.Value);
+        Assert.Same(values, ImmutableCollectionsMarshal.AsArray(presortedArray));
+    }
+
+    [Fact]
+    public void OrderByDescendingAsArray_EmptyArrayReturnsSameArray()
+    {
+        var array = ImmutableCollectionsMarshal.AsArray(ImmutableArray<ValueHolder>.Empty);
+        var immutableArray = ImmutableArray<ValueHolder>.Empty;
+
+        immutableArray = immutableArray.OrderByDescendingAsArray(static x => x.Value);
+        Assert.Same(array, ImmutableCollectionsMarshal.AsArray(immutableArray));
+    }
+
+    [Fact]
+    public void OrderByDescendingAsArray_SingleElementArrayReturnsSameArray()
+    {
+        var array = new ValueHolder[] { 42 };
+        var immutableArray = ImmutableCollectionsMarshal.AsImmutableArray(array);
+
+        immutableArray = immutableArray.OrderByDescendingAsArray(static x => x.Value);
+        Assert.Same(array, ImmutableCollectionsMarshal.AsArray(immutableArray));
+    }
+
+    [Fact]
+    public void OrderByDescendingAsArray_SortedArrayReturnsSameArray()
+    {
+        var values = new ValueHolder[] { 10, 9, 8, 7, 6, 5, 4, 3, 2, 1 };
+        var presortedArray = ImmutableCollectionsMarshal.AsImmutableArray(values);
+
+        presortedArray = presortedArray.OrderByDescendingAsArray(static x => x.Value);
+        Assert.Same(values, ImmutableCollectionsMarshal.AsArray(presortedArray));
     }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ImmutableArrayExtensionsTests.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ImmutableArrayExtensionsTests.cs
@@ -36,4 +36,102 @@ public class ImmutableArrayExtensionsTests
             },
             s => Assert.Equal("WoRlD", s));
     }
+
+    public static TheoryData<ImmutableArray<int>, ImmutableArray<int>> OrderAsArrayData
+    {
+        get
+        {
+            return new()
+            {
+                { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+                { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+                { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+                { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+                { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+            };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderAsArrayData))]
+    public void OrderAsArray(ImmutableArray<int> data, ImmutableArray<int> expected)
+    {
+        var sorted = data.OrderAsArray();
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    public static TheoryData<ImmutableArray<int>, ImmutableArray<int>> OrderDescendingAsArrayData
+    {
+        get
+        {
+            return new()
+            {
+                { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+                { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+                { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+                { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+                { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+            };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderAsArrayData))]
+    public void OrderDescendingAsArray(ImmutableArray<int> data, ImmutableArray<int> expected)
+    {
+        var sorted = data.OrderAsArray();
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    public readonly record struct ValueHolder(int Value)
+    {
+        public static implicit operator ValueHolder(int value)
+            => new(value);
+    }
+
+    public static TheoryData<ImmutableArray<ValueHolder>, ImmutableArray<ValueHolder>> OrderByAsArrayData
+    {
+        get
+        {
+            return new()
+            {
+                { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+                { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+                { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+                { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+                { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+            };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByAsArrayData))]
+    public void OrderByAsArray(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var sorted = data.OrderByAsArray(static x => x.Value);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
+
+    public static TheoryData<ImmutableArray<ValueHolder>, ImmutableArray<ValueHolder>> OrderByDescendingAsArrayData
+    {
+        get
+        {
+            return new()
+            {
+                { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+                { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+                { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+                { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+                { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+            };
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByDescendingAsArrayData))]
+    public void OrderByDescendingAsArray(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var sorted = data.OrderByDescendingAsArray(static x => x.Value);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
@@ -285,7 +285,7 @@ internal static class ImmutableArrayExtensions
 
     private static ImmutableArray<T> OrderAsArrayCore<T>(this ImmutableArray<T> array, IComparer<T> comparer)
     {
-        if (array.IsEmpty)
+        if (array.IsEmpty || array.Length == 1)
         {
             return array;
         }
@@ -304,7 +304,7 @@ internal static class ImmutableArrayExtensions
     private static ImmutableArray<TElement> OrderByAsArrayCore<TElement, TKey>(
         this ImmutableArray<TElement> array, Func<TElement, TKey> keySelector, IComparer<TKey> comparer)
     {
-        if (array.IsEmpty)
+        if (array.IsEmpty || array.Length == 1)
         {
             return array;
         }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
@@ -210,13 +210,8 @@ internal static class ImmutableArrayExtensions
 
     public static ImmutableArray<T> OrderAsArray<T>(this ImmutableArray<T> array)
     {
-        if (array.Length > 1)
-        {
-            var compareHelper = new CompareHelper<T>(comparer: null, descending: false);
-            return array.OrderAsArrayCore(in compareHelper);
-        }
-
-        return array;
+        var compareHelper = new CompareHelper<T>(comparer: null, descending: false);
+        return array.OrderAsArrayCore(in compareHelper);
     }
 
     public static ImmutableArray<T> OrderAsArray<T>(this ImmutableArray<T> array, IComparer<T> comparer)

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
@@ -66,11 +66,11 @@ internal static class ImmutableArrayExtensions
     {
         return source switch
         {
-            [] => [],
-            [var item] => [selector(item)],
-            [var item1, var item2] => [selector(item1), selector(item2)],
-            [var item1, var item2, var item3] => [selector(item1), selector(item2), selector(item3)],
-            [var item1, var item2, var item3, var item4] => [selector(item1), selector(item2), selector(item3), selector(item4)],
+        [] => [],
+        [var item] => [selector(item)],
+        [var item1, var item2] => [selector(item1), selector(item2)],
+        [var item1, var item2, var item3] => [selector(item1), selector(item2), selector(item3)],
+        [var item1, var item2, var item3, var item4] => [selector(item1), selector(item2), selector(item3), selector(item4)],
             var items => BuildResult(items, selector)
         };
 
@@ -209,121 +209,335 @@ internal static class ImmutableArrayExtensions
     }
 
     public static ImmutableArray<T> OrderAsArray<T>(this ImmutableArray<T> array)
-        => array.OrderAsArrayCore(GetComparer<T>(comparer: null, descending: false));
-
-    public static ImmutableArray<T> OrderAsArray<T>(this ImmutableArray<T> array, IComparer<T> comparer)
-        => array.OrderAsArrayCore(GetComparer(comparer, descending: false));
-
-    public static ImmutableArray<T> OrderAsArray<T>(this ImmutableArray<T> array, Comparison<T> comparison)
-        => array.OrderAsArrayCore(GetComparer(comparison, descending: false));
-
-    public static ImmutableArray<T> OrderDescendingAsArray<T>(this ImmutableArray<T> array)
-        => array.OrderAsArrayCore(GetComparer<T>(comparer: null, descending: true));
-
-    public static ImmutableArray<T> OrderDescendingAsArray<T>(this ImmutableArray<T> array, IComparer<T> comparer)
-        => array.OrderAsArrayCore(GetComparer(comparer, descending: true));
-
-    public static ImmutableArray<T> OrderDescendingAsArray<T>(this ImmutableArray<T> array, Comparison<T> comparison)
-        => array.OrderAsArrayCore(GetComparer(comparison, descending: true));
-
-    public static ImmutableArray<TElement> OrderByAsArray<TElement, TKey>(
-        this ImmutableArray<TElement> array, Func<TElement, TKey> keySelector)
-        => array.OrderByAsArrayCore(keySelector, GetComparer<TKey>(comparer: null, descending: false));
-
-    public static ImmutableArray<TElement> OrderByAsArray<TElement, TKey>(
-        this ImmutableArray<TElement> array, Func<TElement, TKey> keySelector, IComparer<TKey> comparer)
-        => array.OrderByAsArrayCore(keySelector, GetComparer(comparer, descending: false));
-
-    public static ImmutableArray<TElement> OrderByAsArray<TElement, TKey>(
-        this ImmutableArray<TElement> array, Func<TElement, TKey> keySelector, Comparison<TKey> comparison)
-        => array.OrderByAsArrayCore(keySelector, GetComparer(comparison, descending: false));
-
-    public static ImmutableArray<TElement> OrderByDescendingAsArray<TElement, TKey>(
-        this ImmutableArray<TElement> array, Func<TElement, TKey> keySelector)
-        => array.OrderByAsArrayCore(keySelector, GetComparer<TKey>(comparer: null, descending: true));
-
-    public static ImmutableArray<TElement> OrderByDescendingAsArray<TElement, TKey>(
-        this ImmutableArray<TElement> array, Func<TElement, TKey> keySelector, IComparer<TKey> comparer)
-        => array.OrderByAsArrayCore(keySelector, GetComparer(comparer, descending: true));
-
-    public static ImmutableArray<TElement> OrderByDescendingAsArray<TElement, TKey>(
-        this ImmutableArray<TElement> array, Func<TElement, TKey> keySelector, Comparison<TKey> comparison)
-        => array.OrderByAsArrayCore(keySelector, GetComparer(comparison, descending: true));
-
-    private static IComparer<T> GetComparer<T>(IComparer<T>? comparer, bool descending)
     {
-        if (comparer is null)
+        if (array.Length > 1)
         {
-            return descending
-                ? DescendingComparer<T>.Default
-                : Comparer<T>.Default;
+            var compareHelper = new CompareHelper<T>(comparer: null, descending: false);
+            return array.OrderAsArrayCore(in compareHelper);
         }
 
-        return descending
-            ? new DescendingComparer<T>(comparer)
-            : comparer;
+        return array;
     }
 
-    private static IComparer<T> GetComparer<T>(Comparison<T> comparison, bool descending)
+    public static ImmutableArray<T> OrderAsArray<T>(this ImmutableArray<T> array, IComparer<T> comparer)
     {
-        var comparer = Comparer<T>.Create(comparison);
-
-        return descending
-            ? new DescendingComparer<T>(comparer)
-            : comparer;
-    }
-
-    private sealed class DescendingComparer<T>(IComparer<T> comparer) : IComparer<T>
-    {
-        private static IComparer<T>? s_default;
-
-        public static IComparer<T> Default => s_default ??= new DescendingComparer<T>(Comparer<T>.Default);
-
-        public int Compare(T? x, T? y)
-            => comparer.Compare(y!, x!);
-    }
-
-    private static ImmutableArray<T> OrderAsArrayCore<T>(this ImmutableArray<T> array, IComparer<T> comparer)
-    {
-        if (array.IsEmpty || array.Length == 1)
+        if (array.Length > 1)
         {
+            var compareHelper = new CompareHelper<T>(comparer, descending: false);
+            return array.OrderAsArrayCore(in compareHelper);
+        }
+
+        return array;
+    }
+
+    public static ImmutableArray<T> OrderAsArray<T>(this ImmutableArray<T> array, Comparison<T> comparison)
+    {
+        if (array.Length > 1)
+        {
+            var compareHelper = new CompareHelper<T>(comparison, descending: false);
+            return array.OrderAsArrayCore(in compareHelper);
+        }
+
+        return array;
+    }
+
+    public static ImmutableArray<T> OrderDescendingAsArray<T>(this ImmutableArray<T> array)
+    {
+        if (array.Length > 1)
+        {
+            var compareHelper = new CompareHelper<T>(comparer: null, descending: true);
+            return array.OrderAsArrayCore(in compareHelper);
+        }
+
+        return array;
+    }
+
+    public static ImmutableArray<T> OrderDescendingAsArray<T>(this ImmutableArray<T> array, IComparer<T> comparer)
+    {
+        if (array.Length > 1)
+        {
+            var compareHelper = new CompareHelper<T>(comparer, descending: true);
+            return array.OrderAsArrayCore(in compareHelper);
+        }
+
+        return array;
+    }
+
+    public static ImmutableArray<T> OrderDescendingAsArray<T>(this ImmutableArray<T> array, Comparison<T> comparison)
+    {
+        if (array.Length > 1)
+        {
+            var compareHelper = new CompareHelper<T>(comparison, descending: true);
+            return array.OrderAsArrayCore(in compareHelper);
+        }
+
+        return array;
+    }
+
+    public static ImmutableArray<TElement> OrderByAsArray<TElement, TKey>(
+        this ImmutableArray<TElement> array, Func<TElement, TKey> keySelector)
+    {
+        if (array.Length > 1)
+        {
+            var compareHelper = new CompareHelper<TKey>(comparer: null, descending: false);
+            return array.OrderByAsArrayCore(keySelector, in compareHelper);
+        }
+
+        return array;
+    }
+
+    public static ImmutableArray<TElement> OrderByAsArray<TElement, TKey>(
+        this ImmutableArray<TElement> array, Func<TElement, TKey> keySelector, IComparer<TKey> comparer)
+    {
+        if (array.Length > 1)
+        {
+            var compareHelper = new CompareHelper<TKey>(comparer, descending: false);
+            return array.OrderByAsArrayCore(keySelector, in compareHelper);
+        }
+
+        return array;
+    }
+
+    public static ImmutableArray<TElement> OrderByAsArray<TElement, TKey>(
+        this ImmutableArray<TElement> array, Func<TElement, TKey> keySelector, Comparison<TKey> comparison)
+    {
+        if (array.Length > 1)
+        {
+            var compareHelper = new CompareHelper<TKey>(comparison, descending: false);
+            return array.OrderByAsArrayCore(keySelector, in compareHelper);
+        }
+
+        return array;
+    }
+
+    public static ImmutableArray<TElement> OrderByDescendingAsArray<TElement, TKey>(
+        this ImmutableArray<TElement> array, Func<TElement, TKey> keySelector)
+    {
+        if (array.Length > 1)
+        {
+            var compareHelper = new CompareHelper<TKey>(comparer: null, descending: true);
+            return array.OrderByAsArrayCore(keySelector, in compareHelper);
+        }
+
+        return array;
+    }
+
+    public static ImmutableArray<TElement> OrderByDescendingAsArray<TElement, TKey>(
+        this ImmutableArray<TElement> array, Func<TElement, TKey> keySelector, IComparer<TKey> comparer)
+    {
+        if (array.Length > 1)
+        {
+            var compareHelper = new CompareHelper<TKey>(comparer, descending: true);
+            return array.OrderByAsArrayCore(keySelector, in compareHelper);
+        }
+
+        return array;
+    }
+
+    public static ImmutableArray<TElement> OrderByDescendingAsArray<TElement, TKey>(
+        this ImmutableArray<TElement> array, Func<TElement, TKey> keySelector, Comparison<TKey> comparison)
+    {
+        if (array.Length > 1)
+        {
+            var compareHelper = new CompareHelper<TKey>(comparison, descending: true);
+            return array.OrderByAsArrayCore(keySelector, in compareHelper);
+        }
+
+        return array;
+    }
+
+    private static ImmutableArray<T> OrderAsArrayCore<T>(this ImmutableArray<T> array, ref readonly CompareHelper<T> compareHelper)
+    {
+        var items = array.AsSpan();
+
+        if (AreOrdered(items, in compareHelper))
+        {
+            // No need to sort - items are already ordered.
             return array;
         }
 
-        var span = array.AsSpan();
+        var length = items.Length;
+        var newArray = new T[length];
+        items.CopyTo(newArray);
 
-        var length = span.Length;
-        var items = new T[length];
-        span.CopyTo(items);
+        var comparer = compareHelper.GetOrCreateComparer();
 
-        Array.Sort(items, comparer);
+        Array.Sort(newArray, comparer);
 
-        return ImmutableCollectionsMarshal.AsImmutableArray(items);
+        return ImmutableCollectionsMarshal.AsImmutableArray(newArray);
     }
 
     private static ImmutableArray<TElement> OrderByAsArrayCore<TElement, TKey>(
-        this ImmutableArray<TElement> array, Func<TElement, TKey> keySelector, IComparer<TKey> comparer)
+        this ImmutableArray<TElement> array, Func<TElement, TKey> keySelector, ref readonly CompareHelper<TKey> compareHelper)
     {
-        if (array.IsEmpty || array.Length == 1)
-        {
-            return array;
-        }
-
-        var span = array.AsSpan();
-
-        var length = span.Length;
-        var items = new TElement[length];
-        span.CopyTo(items);
+        var items = array.AsSpan();
+        var length = items.Length;
 
         using var _ = ArrayPool<TKey>.Shared.GetPooledArray(minimumLength: length, out var keys);
 
-        for (var i = 0; i < length; i++)
+        if (SelectKeys(items, keySelector, compareHelper, keys.AsSpan(0, length)))
         {
-            keys[i] = keySelector(items[i]);
+            // No need to sort - keys are already ordered.
+            return array;
         }
 
-        Array.Sort(keys, items, 0, length, comparer);
+        var newArray = new TElement[length];
+        items.CopyTo(newArray);
 
-        return ImmutableCollectionsMarshal.AsImmutableArray(items);
+        var comparer = compareHelper.GetOrCreateComparer();
+
+        Array.Sort(keys, newArray, 0, length, comparer);
+
+        return ImmutableCollectionsMarshal.AsImmutableArray(newArray);
+    }
+
+    /// <summary>
+    ///  Walk through <paramref name="items"/> and determine whether they are already ordered using
+    ///  the provided <see cref="CompareHelper{T}"/>.
+    /// </summary>
+    /// <returns>
+    ///  <see langword="true"/> if the items are in order; otherwise <see langword="false"/>.
+    /// </returns>
+    /// <remarks>
+    ///  When the items are already ordered, there's no need to perform a sort.
+    /// </remarks>
+    private static bool AreOrdered<T>(ReadOnlySpan<T> items, ref readonly CompareHelper<T> compareHelper)
+    {
+        var isOutOfOrder = false;
+
+        for (var i = 1; i < items.Length; i++)
+        {
+            if (!compareHelper.InSortedOrder(items[i], items[i - 1]))
+            {
+                isOutOfOrder = true;
+                break;
+            }
+        }
+
+        return !isOutOfOrder;
+    }
+
+    /// <summary>
+    ///  Walk through <paramref name="items"/> and convert each element to a key using <paramref name="keySelector"/>.
+    ///  While walking, each computed key is compared with the previous one using the provided <see cref="CompareHelper{T}"/>
+    ///  to determine whether they are already ordered.
+    /// </summary>
+    /// <returns>
+    ///  <see langword="true"/> if the keys are in order; otherwise <see langword="false"/>.
+    /// </returns>
+    /// <remarks>
+    ///  When the keys are already ordered, there's no need to perform a sort.
+    /// </remarks>
+    private static bool SelectKeys<TElement, TKey>(
+        ReadOnlySpan<TElement> items, Func<TElement, TKey> keySelector, CompareHelper<TKey> compareHelper, Span<TKey> keys)
+    {
+        var isOutOfOrder = false;
+
+        keys[0] = keySelector(items[0]);
+
+        for (var i = 1; i < items.Length; i++)
+        {
+            keys[i] = keySelector(items[i]);
+
+            if (!isOutOfOrder && !compareHelper.InSortedOrder(keys[i], keys[i - 1]))
+            {
+                isOutOfOrder = true;
+
+                // Continue processing to finish converting elements to keys. However, we can stop comparing keys.
+            }
+        }
+
+        return !isOutOfOrder;
+    }
+
+    /// <summary>
+    ///  Helper that avoids creating an <see cref="IComparer{T}"/> until its needed.
+    /// </summary>
+    private readonly ref struct CompareHelper<T>
+    {
+        private readonly IComparer<T> _comparer;
+        private readonly Comparison<T> _comparison;
+        private readonly bool _comparerSpecified;
+        private readonly bool _useComparer;
+        private readonly bool _descending;
+
+        public CompareHelper(IComparer<T>? comparer, bool descending)
+        {
+            _comparerSpecified = comparer is not null;
+            _comparer = comparer ?? Comparer<T>.Default;
+            _useComparer = true;
+            _descending = descending;
+            _comparison = null!;
+        }
+
+        public CompareHelper(Comparison<T> comparison, bool descending)
+        {
+            _comparison = comparison;
+            _useComparer = false;
+            _descending = descending;
+            _comparer = null!;
+        }
+
+        public bool InSortedOrder(T? x, T? y)
+        {
+            // We assume that x and y are in sorted order if x is > y.
+            // We don't consider x == y to be sorted because the actual sor
+            // might not be stable, depending on T.
+
+            return _useComparer
+                ? !_descending ? _comparer.Compare(x!, y!) > 0 : _comparer.Compare(y!, x!) > 0
+                : !_descending ? _comparison(x!, y!) > 0 : _comparison(y!, x!) > 0;
+        }
+
+        public IComparer<T> GetOrCreateComparer()
+            // There are six cases to consider.
+            => (_useComparer, _comparerSpecified, _descending) switch
+            {
+                // Provided a comparer and the results are in ascending order.
+                (true, true, false) => _comparer,
+
+                // Provided a comparer and the results are in descending order.
+                (true, true, true) => DescendingComparer<T>.Create(_comparer),
+
+                // Not provided a comparer and the results are in ascending order.
+                // In this case, _comparer was already set to Comparer<T>.Default.
+                (true, false, false) => _comparer,
+
+                // Not provided a comparer and the results are in descending order.
+                (true, false, true) => DescendingComparer<T>.Default,
+
+                // Provided a comparison delegate and the results are in ascending order.
+                (false, _, false) => Comparer<T>.Create(_comparison),
+
+                // Provided a comparison delegate and the results are in descending order.
+                (false, _, true) => DescendingComparer<T>.Create(_comparison)
+            };
+    }
+
+    private abstract class DescendingComparer<T> : IComparer<T>
+    {
+        private static IComparer<T>? s_default;
+
+        public static IComparer<T> Default => s_default ??= new WrappedComparer(Comparer<T>.Default);
+
+        public static IComparer<T> Create(IComparer<T> comparer)
+            => new WrappedComparer(comparer);
+
+        public static IComparer<T> Create(Comparison<T> comparison)
+            => new WrappedComparison(comparison);
+
+        public abstract int Compare(T? x, T? y);
+
+        private sealed class WrappedComparer(IComparer<T> comparer) : DescendingComparer<T>
+        {
+            public override int Compare(T? x, T? y)
+                => comparer.Compare(y!, x!);
+        }
+
+        private sealed class WrappedComparison(Comparison<T> comparison) : DescendingComparer<T>
+        {
+            public override int Compare(T? x, T? y)
+                => comparison(y!, x!);
+        }
     }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
@@ -468,23 +468,23 @@ internal static class ImmutableArrayExtensions
     {
         private static IComparer<T>? s_default;
 
-        public static IComparer<T> Default => s_default ??= new WrappedComparer(Comparer<T>.Default);
+        public static IComparer<T> Default => s_default ??= new ReversedComparer(Comparer<T>.Default);
 
         public static IComparer<T> Create(IComparer<T> comparer)
-            => new WrappedComparer(comparer);
+            => new ReversedComparer(comparer);
 
         public static IComparer<T> Create(Comparison<T> comparison)
-            => new WrappedComparison(comparison);
+            => new ReversedComparison(comparison);
 
         public abstract int Compare(T? x, T? y);
 
-        private sealed class WrappedComparer(IComparer<T> comparer) : DescendingComparer<T>
+        private sealed class ReversedComparer(IComparer<T> comparer) : DescendingComparer<T>
         {
             public override int Compare(T? x, T? y)
                 => comparer.Compare(y!, x!);
         }
 
-        private sealed class WrappedComparison(Comparison<T> comparison) : DescendingComparer<T>
+        private sealed class ReversedComparison(Comparison<T> comparison) : DescendingComparer<T>
         {
             public override int Compare(T? x, T? y)
                 => comparison(y!, x!);

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
@@ -66,11 +66,11 @@ internal static class ImmutableArrayExtensions
     {
         return source switch
         {
-        [] => [],
-        [var item] => [selector(item)],
-        [var item1, var item2] => [selector(item1), selector(item2)],
-        [var item1, var item2, var item3] => [selector(item1), selector(item2), selector(item3)],
-        [var item1, var item2, var item3, var item4] => [selector(item1), selector(item2), selector(item3), selector(item4)],
+            [] => [],
+            [var item] => [selector(item)],
+            [var item1, var item2] => [selector(item1), selector(item2)],
+            [var item1, var item2, var item3] => [selector(item1), selector(item2), selector(item3)],
+            [var item1, var item2, var item3, var item4] => [selector(item1), selector(item2), selector(item3), selector(item4)],
             var items => BuildResult(items, selector)
         };
 

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
@@ -221,174 +221,129 @@ internal static class ImmutableArrayExtensions
 
     public static ImmutableArray<T> OrderAsArray<T>(this ImmutableArray<T> array, IComparer<T> comparer)
     {
-        if (array.Length > 1)
-        {
-            var compareHelper = new CompareHelper<T>(comparer, descending: false);
-            return array.OrderAsArrayCore(in compareHelper);
-        }
-
-        return array;
+        var compareHelper = new CompareHelper<T>(comparer, descending: false);
+        return array.OrderAsArrayCore(in compareHelper);
     }
 
     public static ImmutableArray<T> OrderAsArray<T>(this ImmutableArray<T> array, Comparison<T> comparison)
     {
-        if (array.Length > 1)
-        {
-            var compareHelper = new CompareHelper<T>(comparison, descending: false);
-            return array.OrderAsArrayCore(in compareHelper);
-        }
-
-        return array;
+        var compareHelper = new CompareHelper<T>(comparison, descending: false);
+        return array.OrderAsArrayCore(in compareHelper);
     }
 
     public static ImmutableArray<T> OrderDescendingAsArray<T>(this ImmutableArray<T> array)
     {
-        if (array.Length > 1)
-        {
-            var compareHelper = new CompareHelper<T>(comparer: null, descending: true);
-            return array.OrderAsArrayCore(in compareHelper);
-        }
-
-        return array;
+        var compareHelper = new CompareHelper<T>(comparer: null, descending: true);
+        return array.OrderAsArrayCore(in compareHelper);
     }
 
     public static ImmutableArray<T> OrderDescendingAsArray<T>(this ImmutableArray<T> array, IComparer<T> comparer)
     {
-        if (array.Length > 1)
-        {
-            var compareHelper = new CompareHelper<T>(comparer, descending: true);
-            return array.OrderAsArrayCore(in compareHelper);
-        }
-
-        return array;
+        var compareHelper = new CompareHelper<T>(comparer, descending: true);
+        return array.OrderAsArrayCore(in compareHelper);
     }
 
     public static ImmutableArray<T> OrderDescendingAsArray<T>(this ImmutableArray<T> array, Comparison<T> comparison)
     {
-        if (array.Length > 1)
-        {
-            var compareHelper = new CompareHelper<T>(comparison, descending: true);
-            return array.OrderAsArrayCore(in compareHelper);
-        }
-
-        return array;
+        var compareHelper = new CompareHelper<T>(comparison, descending: true);
+        return array.OrderAsArrayCore(in compareHelper);
     }
 
     public static ImmutableArray<TElement> OrderByAsArray<TElement, TKey>(
         this ImmutableArray<TElement> array, Func<TElement, TKey> keySelector)
     {
-        if (array.Length > 1)
-        {
-            var compareHelper = new CompareHelper<TKey>(comparer: null, descending: false);
-            return array.OrderByAsArrayCore(keySelector, in compareHelper);
-        }
-
-        return array;
+        var compareHelper = new CompareHelper<TKey>(comparer: null, descending: false);
+        return array.OrderByAsArrayCore(keySelector, in compareHelper);
     }
 
     public static ImmutableArray<TElement> OrderByAsArray<TElement, TKey>(
         this ImmutableArray<TElement> array, Func<TElement, TKey> keySelector, IComparer<TKey> comparer)
     {
-        if (array.Length > 1)
-        {
-            var compareHelper = new CompareHelper<TKey>(comparer, descending: false);
-            return array.OrderByAsArrayCore(keySelector, in compareHelper);
-        }
-
-        return array;
+        var compareHelper = new CompareHelper<TKey>(comparer, descending: false);
+        return array.OrderByAsArrayCore(keySelector, in compareHelper);
     }
 
     public static ImmutableArray<TElement> OrderByAsArray<TElement, TKey>(
         this ImmutableArray<TElement> array, Func<TElement, TKey> keySelector, Comparison<TKey> comparison)
     {
-        if (array.Length > 1)
-        {
-            var compareHelper = new CompareHelper<TKey>(comparison, descending: false);
-            return array.OrderByAsArrayCore(keySelector, in compareHelper);
-        }
-
-        return array;
+        var compareHelper = new CompareHelper<TKey>(comparison, descending: false);
+        return array.OrderByAsArrayCore(keySelector, in compareHelper);
     }
 
     public static ImmutableArray<TElement> OrderByDescendingAsArray<TElement, TKey>(
         this ImmutableArray<TElement> array, Func<TElement, TKey> keySelector)
     {
-        if (array.Length > 1)
-        {
-            var compareHelper = new CompareHelper<TKey>(comparer: null, descending: true);
-            return array.OrderByAsArrayCore(keySelector, in compareHelper);
-        }
-
-        return array;
+        var compareHelper = new CompareHelper<TKey>(comparer: null, descending: true);
+        return array.OrderByAsArrayCore(keySelector, in compareHelper);
     }
 
     public static ImmutableArray<TElement> OrderByDescendingAsArray<TElement, TKey>(
         this ImmutableArray<TElement> array, Func<TElement, TKey> keySelector, IComparer<TKey> comparer)
     {
-        if (array.Length > 1)
-        {
-            var compareHelper = new CompareHelper<TKey>(comparer, descending: true);
-            return array.OrderByAsArrayCore(keySelector, in compareHelper);
-        }
-
-        return array;
+        var compareHelper = new CompareHelper<TKey>(comparer, descending: true);
+        return array.OrderByAsArrayCore(keySelector, in compareHelper);
     }
 
     public static ImmutableArray<TElement> OrderByDescendingAsArray<TElement, TKey>(
         this ImmutableArray<TElement> array, Func<TElement, TKey> keySelector, Comparison<TKey> comparison)
     {
-        if (array.Length > 1)
-        {
-            var compareHelper = new CompareHelper<TKey>(comparison, descending: true);
-            return array.OrderByAsArrayCore(keySelector, in compareHelper);
-        }
-
-        return array;
+        var compareHelper = new CompareHelper<TKey>(comparison, descending: true);
+        return array.OrderByAsArrayCore(keySelector, in compareHelper);
     }
 
     private static ImmutableArray<T> OrderAsArrayCore<T>(this ImmutableArray<T> array, ref readonly CompareHelper<T> compareHelper)
     {
-        var items = array.AsSpan();
-
-        if (AreOrdered(items, in compareHelper))
+        if (array.Length > 1)
         {
-            // No need to sort - items are already ordered.
-            return array;
+            var items = array.AsSpan();
+
+            if (AreOrdered(items, in compareHelper))
+            {
+                // No need to sort - items are already ordered.
+                return array;
+            }
+
+            var length = items.Length;
+            var newArray = new T[length];
+            items.CopyTo(newArray);
+
+            var comparer = compareHelper.GetOrCreateComparer();
+
+            Array.Sort(newArray, comparer);
+
+            return ImmutableCollectionsMarshal.AsImmutableArray(newArray);
         }
 
-        var length = items.Length;
-        var newArray = new T[length];
-        items.CopyTo(newArray);
-
-        var comparer = compareHelper.GetOrCreateComparer();
-
-        Array.Sort(newArray, comparer);
-
-        return ImmutableCollectionsMarshal.AsImmutableArray(newArray);
+        return array;
     }
 
     private static ImmutableArray<TElement> OrderByAsArrayCore<TElement, TKey>(
         this ImmutableArray<TElement> array, Func<TElement, TKey> keySelector, ref readonly CompareHelper<TKey> compareHelper)
     {
-        var items = array.AsSpan();
-        var length = items.Length;
-
-        using var _ = ArrayPool<TKey>.Shared.GetPooledArray(minimumLength: length, out var keys);
-
-        if (SelectKeys(items, keySelector, compareHelper, keys.AsSpan(0, length)))
+        if (array.Length > 1)
         {
-            // No need to sort - keys are already ordered.
-            return array;
+            var items = array.AsSpan();
+            var length = items.Length;
+
+            using var _ = ArrayPool<TKey>.Shared.GetPooledArray(minimumLength: length, out var keys);
+
+            if (SelectKeys(items, keySelector, compareHelper, keys.AsSpan(0, length)))
+            {
+                // No need to sort - keys are already ordered.
+                return array;
+            }
+
+            var newArray = new TElement[length];
+            items.CopyTo(newArray);
+
+            var comparer = compareHelper.GetOrCreateComparer();
+
+            Array.Sort(keys, newArray, 0, length, comparer);
+
+            return ImmutableCollectionsMarshal.AsImmutableArray(newArray);
         }
 
-        var newArray = new TElement[length];
-        items.CopyTo(newArray);
-
-        var comparer = compareHelper.GetOrCreateComparer();
-
-        Array.Sort(keys, newArray, 0, length, comparer);
-
-        return ImmutableCollectionsMarshal.AsImmutableArray(newArray);
+        return array;
     }
 
     /// <summary>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
@@ -4,8 +4,6 @@
 using System.Buffers;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Threading;
-using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 
 namespace System.Collections.Immutable;


### PR DESCRIPTION
This change introduces four sets of extension methods with overloads:

- OrderAsArray(...)
- OrderDescendingAsArray(...)
- OrderByAsArray(...)
- OrderByDescendingAsArray(...)

Each of these operates on an `ImmutableArray<T>` and returns an `ImmutableArray<T>`.