### PR TITLE
Fix NRE when invoking completion in empty document

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
@@ -55,16 +55,12 @@ internal class TagHelperCompletionProvider : IRazorCompletionItemProvider
         {
             // This provider is trying to find the nearest Start or End tag. Most of the time, that's a level up, but if the index the user is typing at
             // is a token of a start or end tag directly, we already have the node we want.
-            MarkupStartTagSyntax or MarkupEndTagSyntax or MarkupTagHelperStartTagSyntax or MarkupTagHelperEndTagSyntax or MarkupTagHelperAttributeSyntax => owner,
+            MarkupStartTagSyntax or MarkupEndTagSyntax or MarkupTagHelperStartTagSyntax or MarkupTagHelperEndTagSyntax or MarkupTagHelperAttributeSyntax,
+            // Invoking completion in an empty file will give us RazorDocumentSyntax which always has null parent
+            RazorDocumentSyntax => owner,
             // Either the parent is a context we can handle, or it's not and we shouldn't show completions.
             _ => owner.Parent
         };
-
-        if (owner is null)
-        {
-            Debug.Assert(context.Owner is RazorDocumentSyntax, $"Expecting null parent only on {nameof(RazorDocumentSyntax)}");
-            return [];
-        }
 
         if (HtmlFacts.TryGetElementInfo(owner, out var containingTagNameToken, out var attributes, closingForwardSlashOrCloseAngleToken: out _) &&
             containingTagNameToken.Span.IntersectsWith(context.AbsoluteIndex))

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
@@ -48,7 +48,7 @@ internal class TagHelperCompletionProvider : IRazorCompletionItemProvider
         if (owner is null)
         {
             Debug.Fail("Owner should never be null.");
-            return ImmutableArray<RazorCompletionItem>.Empty;
+            return [];
         }
 
         owner = owner switch
@@ -59,6 +59,12 @@ internal class TagHelperCompletionProvider : IRazorCompletionItemProvider
             // Either the parent is a context we can handle, or it's not and we shouldn't show completions.
             _ => owner.Parent
         };
+
+        if (owner is null)
+        {
+            Debug.Assert(context.Owner is RazorDocumentSyntax, $"Expecting null parent only on {nameof(RazorDocumentSyntax)}");
+            return [];
+        }
 
         if (HtmlFacts.TryGetElementInfo(owner, out var containingTagNameToken, out var attributes, closingForwardSlashOrCloseAngleToken: out _) &&
             containingTagNameToken.Span.IntersectsWith(context.AbsoluteIndex))
@@ -118,7 +124,7 @@ internal class TagHelperCompletionProvider : IRazorCompletionItemProvider
         }
 
         // Invalid location for TagHelper completions.
-        return ImmutableArray<RazorCompletionItem>.Empty;
+        return [];
     }
 
     private ImmutableArray<RazorCompletionItem> GetAttributeCompletions(

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/TagHelperCompletionProvider.cs
@@ -55,7 +55,7 @@ internal class TagHelperCompletionProvider : IRazorCompletionItemProvider
         {
             // This provider is trying to find the nearest Start or End tag. Most of the time, that's a level up, but if the index the user is typing at
             // is a token of a start or end tag directly, we already have the node we want.
-            MarkupStartTagSyntax or MarkupEndTagSyntax or MarkupTagHelperStartTagSyntax or MarkupTagHelperEndTagSyntax or MarkupTagHelperAttributeSyntax,
+            MarkupStartTagSyntax or MarkupEndTagSyntax or MarkupTagHelperStartTagSyntax or MarkupTagHelperEndTagSyntax or MarkupTagHelperAttributeSyntax => owner,
             // Invoking completion in an empty file will give us RazorDocumentSyntax which always has null parent
             RazorDocumentSyntax => owner,
             // Either the parent is a context we can handle, or it's not and we shouldn't show completions.

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/TagHelperCompletionProviderTest.cs
@@ -90,6 +90,23 @@ public class TagHelperCompletionProviderTest(ITestOutputHelper testOutput) : Tag
     }
 
     [Fact]
+    public void GetCompletionAt_InEmptyDocument_ReturnsEmptyCompletionArray()
+    {
+        // Arrange
+        var service = new TagHelperCompletionProvider(RazorTagHelperCompletionService, TestRazorLSPOptionsMonitor.Create());
+        var context = CreateRazorCompletionContext(
+            "$$",
+            isRazorFile: true,
+            tagHelpers: DefaultTagHelpers);
+
+        // Act
+        var completions = service.GetCompletionItems(context);
+
+        // Assert
+        Assert.Empty(completions);
+    }
+
+    [Fact]
     public void GetCompletionAt_OutsideOfTagName_DoesNotReturnCompletions()
     {
         // Arrange


### PR DESCRIPTION
In empty document completion context will have RazorDocumentSyntax as Owner. RazorDoucmentSyntax has null as the parent, which makes sense. However compiler thinks we can't have a null here, while obviously we do.

I'm adding a null check and a test for this case. We would probably further discuss the implications here. I tried to track down how we get null in a non-nullable field, but it's a bit confusing since the class gets generated.

﻿### Summary of the changes

- Fix NRE thrown if completion is invoked in an empty razor document
