### PR TITLE
Fix project info reading

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace/RazorWorkspaceListenerBase.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace/RazorWorkspaceListenerBase.cs
@@ -286,6 +286,7 @@ public abstract class RazorWorkspaceListenerBase : IDisposable
             return;
         }
 
+        stream.WriteProjectInfoAction(ProjectInfoAction.Update);
         await stream.WriteProjectInfoAsync(projectInfo, cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/StreamExtensionTests.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/StreamExtensionTests.cs
@@ -38,7 +38,7 @@ public class StreamExtensionTests
 
     public static TheoryData<string, Encoding?> StringFunctionData = new TheoryData<string, Encoding?>
     {
-        {"", null },
+        { "", null },
         { "hello", null },
         { "", Encoding.UTF8 },
         { "hello", Encoding.UTF8 },

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/StreamExtensionTests.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/StreamExtensionTests.cs
@@ -1,0 +1,122 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.ProjectSystem;
+using Microsoft.AspNetCore.Razor.Serialization;
+using Microsoft.AspNetCore.Razor.Utilities;
+using Microsoft.CodeAnalysis;
+using Xunit;
+
+namespace Microsoft.AspNetCore.Razor.ProjectEngineHost.Test;
+
+public class StreamExtensionTests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(int.MaxValue)]
+    [InlineData(int.MinValue)]
+    [InlineData(-500)]
+    [InlineData(500)]
+    public void SizeFunctions(int size)
+    {
+        using var stream = new MemoryStream();
+
+        stream.WriteSize(size);
+        stream.Position = 0;
+
+        Assert.Equal(size, stream.ReadSize());
+    }
+
+    public static TheoryData<string, Encoding?> StringFunctionData = new TheoryData<string, Encoding?>
+    {
+        {"", null },
+        { "hello", null },
+        { "", Encoding.UTF8 },
+        { "hello", Encoding.UTF8 },
+        { "", Encoding.ASCII },
+        { "hello", Encoding.ASCII },
+        { "", Encoding.UTF32 },
+        { "hello", Encoding.UTF32 },
+        { "", Encoding.Unicode },
+        { "hello", Encoding.Unicode },
+        { "", Encoding.BigEndianUnicode },
+        { "hello", Encoding.BigEndianUnicode },
+    };
+
+    [Theory]
+    [MemberData(nameof(StringFunctionData))]
+    public async Task StringFunctions(string expected, Encoding? encoding)
+    {
+        using var stream = new MemoryStream();
+
+        await stream.WriteStringAsync(expected, encoding, default);
+        stream.Position = 0;
+
+        var actual = await stream.ReadStringAsync(encoding, default);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public async Task SerializeProjectInfo()
+    {
+        using var stream = new MemoryStream();
+
+        var configuration = new RazorConfiguration(
+            RazorLanguageVersion.Latest,
+            "TestConfiguration",
+            ImmutableArray<RazorExtension>.Empty);
+
+        var tagHelper = TagHelperDescriptorBuilder.Create("TypeName", "AssemblyName")
+            .TagMatchingRuleDescriptor(rule => rule.RequireTagName("tag-name"))
+            .Build();
+
+        var projectWorkspaceState = ProjectWorkspaceState.Create([tagHelper], CodeAnalysis.CSharp.LanguageVersion.Latest);
+
+        var projectInfo = new RazorProjectInfo(
+            new ProjectKey("TestProject"),
+            @"C:\test\test.csproj",
+            configuration,
+            "TestNamespace",
+            "Test",
+            projectWorkspaceState,
+            [new DocumentSnapshotHandle(@"C:\test\document.razor", @"document.razor", FileKinds.Component)]);
+
+        var bytesToSerialize = projectInfo.Serialize();
+
+        await stream.WriteProjectInfoAsync(projectInfo, default);
+
+        // WriteProjectInfoAsync prepends the size before writing which is 4 bytes long
+        Assert.Equal(bytesToSerialize.Length + 4, stream.Position);
+
+        var streamContents = stream.ToArray();
+        var expectedSize = BitConverter.GetBytes(bytesToSerialize.Length);
+        Assert.Equal(expectedSize, streamContents.Take(4).ToArray());
+
+        Assert.Equal(bytesToSerialize, streamContents.Skip(4).ToArray());
+
+        stream.Position = 0;
+        var deserialized = await stream.ReadProjectInfoAsync(default);
+
+        Assert.Equal(projectInfo, deserialized);
+    }
+
+    [Theory]
+    [CombinatorialData]
+    internal void ProjectInfoActionFunctions(ProjectInfoAction infoAction)
+    {
+        using var stream = new MemoryStream();
+        stream.WriteProjectInfoAction(infoAction);
+
+        stream.Position = 0;
+        Assert.Equal(infoAction, stream.ReadProjectInfoAction());
+    }
+}


### PR DESCRIPTION
When reading RazorProjectInfo from a stream the array being used was a pooled array. The code was not correctly trimming that array for the deserializer which meant that unknown bytes were being attempted to be read and were likely wrong. This fixes the code to make sure and trim before deserializing and adds tests. 

Fixes [AB#2137098](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2137098)
