### PR TITLE
Add GetPooledArraySpan(...) extension method

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/FilePathNormalizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/FilePathNormalizer.cs
@@ -28,16 +28,15 @@ internal static class FilePathNormalizer
         // Ensure that the array is at least 1 character larger, so that we can add
         // a trailing space after normalization if necessary.
         var arrayLength = directoryFilePathSpan.Length + 1;
-        using var _ = ArrayPool<char>.Shared.GetPooledArray(arrayLength, out var array);
-        var arraySpan = array.AsSpan(0, arrayLength);
-        var (start, length) = NormalizeCore(directoryFilePathSpan, arraySpan);
-        ReadOnlySpan<char> normalizedSpan = arraySpan.Slice(start, length);
+        using var _ = ArrayPool<char>.Shared.GetPooledArraySpan(arrayLength, out var destination);
+        var (start, length) = NormalizeCore(directoryFilePathSpan, destination);
+        ReadOnlySpan<char> normalizedSpan = destination.Slice(start, length);
 
         // Add a trailing slash if the normalized span doesn't end in one.
         if (normalizedSpan is not [.., '/'])
         {
-            arraySpan[start + length] = '/';
-            normalizedSpan = arraySpan.Slice(start, length + 1);
+            destination[start + length] = '/';
+            normalizedSpan = destination.Slice(start, length + 1);
         }
 
         if (directoryFilePathSpan.Equals(normalizedSpan, StringComparison.Ordinal))
@@ -58,8 +57,8 @@ internal static class FilePathNormalizer
         var filePathSpan = filePath.AsSpan();
 
         // Rent a buffer for Normalize to write to.
-        using var _ = ArrayPool<char>.Shared.GetPooledArray(filePathSpan.Length, out var array);
-        var normalizedSpan = NormalizeCoreAndGetSpan(filePathSpan, array);
+        using var _ = ArrayPool<char>.Shared.GetPooledArraySpan(filePathSpan.Length, out var destination);
+        var normalizedSpan = NormalizeCoreAndGetSpan(filePathSpan, destination);
 
         // If we didn't change anything, just return the original string.
         if (filePathSpan.Equals(normalizedSpan, StringComparison.Ordinal))
@@ -83,8 +82,8 @@ internal static class FilePathNormalizer
 
         var filePathSpan = filePath.AsSpan();
 
-        using var _1 = ArrayPool<char>.Shared.GetPooledArray(filePathSpan.Length, out var array);
-        var directoryNameSpan = NormalizeDirectoryNameCore(filePathSpan, array);
+        using var _1 = ArrayPool<char>.Shared.GetPooledArraySpan(filePathSpan.Length, out var destination);
+        var directoryNameSpan = NormalizeDirectoryNameCore(filePathSpan, destination);
 
         if (filePathSpan.Equals(directoryNameSpan, StringComparison.Ordinal))
         {
@@ -108,11 +107,11 @@ internal static class FilePathNormalizer
             return false;
         }
 
-        using var _1 = ArrayPool<char>.Shared.GetPooledArray(filePathSpan1.Length, out var array1);
-        var normalizedSpan1 = NormalizeDirectoryNameCore(filePathSpan1, array1);
+        using var _1 = ArrayPool<char>.Shared.GetPooledArraySpan(filePathSpan1.Length, out var destination1);
+        var normalizedSpan1 = NormalizeDirectoryNameCore(filePathSpan1, destination1);
 
-        using var _2 = ArrayPool<char>.Shared.GetPooledArray(filePathSpan2.Length, out var array2);
-        var normalizedSpan2 = NormalizeDirectoryNameCore(filePathSpan2, array2);
+        using var _2 = ArrayPool<char>.Shared.GetPooledArraySpan(filePathSpan2.Length, out var destination2);
+        var normalizedSpan2 = NormalizeDirectoryNameCore(filePathSpan2, destination2);
 
         return normalizedSpan1.Equals(normalizedSpan2, FilePathComparison.Instance);
     }
@@ -131,11 +130,11 @@ internal static class FilePathNormalizer
             return false;
         }
 
-        using var _1 = ArrayPool<char>.Shared.GetPooledArray(filePathSpan1.Length, out var array1);
-        var normalizedSpan1 = NormalizeCoreAndGetSpan(filePathSpan1, array1);
+        using var _1 = ArrayPool<char>.Shared.GetPooledArraySpan(filePathSpan1.Length, out var destination1);
+        var normalizedSpan1 = NormalizeCoreAndGetSpan(filePathSpan1, destination1);
 
-        using var _2 = ArrayPool<char>.Shared.GetPooledArray(filePathSpan2.Length, out var array2);
-        var normalizedSpan2 = NormalizeCoreAndGetSpan(filePathSpan2, array2);
+        using var _2 = ArrayPool<char>.Shared.GetPooledArraySpan(filePathSpan2.Length, out var destination2);
+        var normalizedSpan2 = NormalizeCoreAndGetSpan(filePathSpan2, destination2);
 
         return normalizedSpan1.Equals(normalizedSpan2, FilePathComparison.Instance);
     }
@@ -149,8 +148,8 @@ internal static class FilePathNormalizer
 
         var filePathSpan = filePath.AsSpanOrDefault();
 
-        using var _ = ArrayPool<char>.Shared.GetPooledArray(filePathSpan.Length, out var array1);
-        var normalizedSpan = NormalizeCoreAndGetSpan(filePathSpan, array1);
+        using var _ = ArrayPool<char>.Shared.GetPooledArraySpan(filePathSpan.Length, out var destination);
+        var normalizedSpan = NormalizeCoreAndGetSpan(filePathSpan, destination);
 
         var hashCombiner = HashCodeCombiner.Start();
 

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/BufferExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/BufferExtensions.cs
@@ -13,4 +13,11 @@ internal static class BufferExtensions
         array = result.Array;
         return result;
     }
+
+    public static PooledArray<T> GetPooledArraySpan<T>(this ArrayPool<T> pool, int minimumLength, out Span<T> span)
+    {
+        var result = new PooledArray<T>(pool, minimumLength);
+        span = result.Span;
+        return result;
+    }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/BufferExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/BufferExtensions.cs
@@ -10,13 +10,44 @@ internal static class BufferExtensions
     /// <summary>
     ///  Rents an array of the given minimum length from the specified <see cref="ArrayPool{T}"/>.
     /// </summary>
+    /// <param name="pool">
+    ///  The <see cref="ArrayPool{T}"/> to use.
+    /// </param>
+    /// <param name="minimumLength">
+    ///  The minimum length of the array.
+    /// </param>
+    /// <param name="array">
+    ///  The rented array.
+    /// </param>
     /// <remarks>
     ///  The array is guaranteed to be at least <paramref name="minimumLength"/> in length. However,
     ///  it will likely be larger.
     /// </remarks>
     public static PooledArray<T> GetPooledArray<T>(this ArrayPool<T> pool, int minimumLength, out T[] array)
+        => pool.GetPooledArray(minimumLength, clearOnReturn: false, out array);
+
+    /// <summary>
+    ///  Rents an array of the given minimum length from the specified <see cref="ArrayPool{T}"/>.
+    /// </summary>
+    /// <param name="pool">
+    ///  The <see cref="ArrayPool{T}"/> to use.
+    /// </param>
+    /// <param name="minimumLength">
+    ///  The minimum length of the array.
+    /// </param>
+    /// <param name="clearOnReturn">
+    ///  Indicates whether the contents of the array should be cleared before it is returned to the pool.
+    /// </param>
+    /// <param name="array">
+    ///  The rented array.
+    /// </param>
+    /// <remarks>
+    ///  The array is guaranteed to be at least <paramref name="minimumLength"/> in length. However,
+    ///  it will likely be larger.
+    /// </remarks>
+    public static PooledArray<T> GetPooledArray<T>(this ArrayPool<T> pool, int minimumLength, bool clearOnReturn, out T[] array)
     {
-        var result = new PooledArray<T>(pool, minimumLength);
+        var result = new PooledArray<T>(pool, minimumLength, clearOnReturn);
         array = result.Array;
         return result;
     }
@@ -26,9 +57,38 @@ internal static class BufferExtensions
     ///  The rented array is provided as a <see cref="Span{T}"/> representing a portion of the rented array
     ///  from its start to the minimum length.
     /// </summary>
+    /// <param name="pool">
+    ///  The <see cref="ArrayPool{T}"/> to use.
+    /// </param>
+    /// <param name="minimumLength">
+    ///  The minimum length of the array.
+    /// </param>
+    /// <param name="span">
+    ///  The <see cref="Span{T}"/> representing a portion of the rented array from its start to the minimum length.
+    /// </param>
     public static PooledArray<T> GetPooledArraySpan<T>(this ArrayPool<T> pool, int minimumLength, out Span<T> span)
+        => pool.GetPooledArraySpan(minimumLength, clearOnReturn: false, out span);
+
+    /// <summary>
+    ///  Rents an array of the given minimum length from the specified <see cref="ArrayPool{T}"/>.
+    ///  The rented array is provided as a <see cref="Span{T}"/> representing a portion of the rented array
+    ///  from its start to the minimum length.
+    /// </summary>
+    /// <param name="pool">
+    ///  The <see cref="ArrayPool{T}"/> to use.
+    /// </param>
+    /// <param name="minimumLength">
+    ///  The minimum length of the array.
+    /// </param>
+    /// <param name="clearOnReturn">
+    ///  Indicates whether the contents of the array should be cleared before it is returned to the pool.
+    /// </param>
+    /// <param name="span">
+    ///  The <see cref="Span{T}"/> representing a portion of the rented array from its start to the minimum length.
+    /// </param>
+    public static PooledArray<T> GetPooledArraySpan<T>(this ArrayPool<T> pool, int minimumLength, bool clearOnReturn, out Span<T> span)
     {
-        var result = new PooledArray<T>(pool, minimumLength);
+        var result = new PooledArray<T>(pool, minimumLength, clearOnReturn);
         span = result.Span;
         return result;
     }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/BufferExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/BufferExtensions.cs
@@ -7,6 +7,13 @@ namespace System.Buffers;
 
 internal static class BufferExtensions
 {
+    /// <summary>
+    ///  Rents an array of the given minimum length from the specified <see cref="ArrayPool{T}"/>.
+    /// </summary>
+    /// <remarks>
+    ///  The array is guaranteed to be at least <paramref name="minimumLength"/> in length. However,
+    ///  it will likely be larger.
+    /// </remarks>
     public static PooledArray<T> GetPooledArray<T>(this ArrayPool<T> pool, int minimumLength, out T[] array)
     {
         var result = new PooledArray<T>(pool, minimumLength);
@@ -14,6 +21,11 @@ internal static class BufferExtensions
         return result;
     }
 
+    /// <summary>
+    ///  Rents an array of the given minimum length from the specified <see cref="ArrayPool{T}"/>.
+    ///  The rented array is provided as a <see cref="Span{T}"/> representing a portion of the rented array
+    ///  from its start to the minimum length.
+    /// </summary>
     public static PooledArray<T> GetPooledArraySpan<T>(this ArrayPool<T> pool, int minimumLength, out Span<T> span)
     {
         var result = new PooledArray<T>(pool, minimumLength);

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledObjects/PooledArray`1.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledObjects/PooledArray`1.cs
@@ -9,6 +9,7 @@ namespace Microsoft.AspNetCore.Razor.PooledObjects;
 internal struct PooledArray<T> : IDisposable
 {
     private readonly ArrayPool<T> _pool;
+    private readonly int _minimumLength;
     private T[]? _array;
 
     // Because of how this API is intended to be used, we don't want the consumption code to have
@@ -16,10 +17,13 @@ internal struct PooledArray<T> : IDisposable
     // non-null until this is disposed.
     public readonly T[] Array => _array!;
 
+    public readonly Span<T> Span => _array!.AsSpan(0, _minimumLength);
+
     public PooledArray(ArrayPool<T> pool, int minimumLength)
         : this()
     {
         _pool = pool;
+        _minimumLength = minimumLength;
         _array = pool.Rent(minimumLength);
     }
 

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledObjects/PooledArray`1.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledObjects/PooledArray`1.cs
@@ -12,11 +12,21 @@ internal struct PooledArray<T> : IDisposable
     private readonly int _minimumLength;
     private T[]? _array;
 
-    // Because of how this API is intended to be used, we don't want the consumption code to have
-    // to deal with Array being a nullable reference type. Instead, the guarantee is that this is
-    // non-null until this is disposed.
+    /// <summary>
+    ///  Returns the array that was rented from <see cref="ArrayPool{T}.Shared"/>.
+    /// </summary>
+    /// <remarks>
+    ///  Returns a non-null array until <see cref="PooledArray{T}"/> is disposed.
+    /// </remarks>
     public readonly T[] Array => _array!;
 
+    /// <summary>
+    ///  Returns a <see cref="Span{T}"/> representing a portion of the rented array
+    ///  from its start to the minimum length.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///  The array has been returned to the pool.
+    /// </exception>
     public readonly Span<T> Span => _array!.AsSpan(0, _minimumLength);
 
     public PooledArray(ArrayPool<T> pool, int minimumLength)

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledObjects/PooledArray`1.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PooledObjects/PooledArray`1.cs
@@ -10,6 +10,7 @@ internal struct PooledArray<T> : IDisposable
 {
     private readonly ArrayPool<T> _pool;
     private readonly int _minimumLength;
+    private readonly bool _clearOnReturn;
     private T[]? _array;
 
     /// <summary>
@@ -29,11 +30,12 @@ internal struct PooledArray<T> : IDisposable
     /// </exception>
     public readonly Span<T> Span => _array!.AsSpan(0, _minimumLength);
 
-    public PooledArray(ArrayPool<T> pool, int minimumLength)
+    public PooledArray(ArrayPool<T> pool, int minimumLength, bool clearOnReturn)
         : this()
     {
         _pool = pool;
         _minimumLength = minimumLength;
+        _clearOnReturn = clearOnReturn;
         _array = pool.Rent(minimumLength);
     }
 
@@ -41,7 +43,7 @@ internal struct PooledArray<T> : IDisposable
     {
         if (_array is T[] array)
         {
-            _pool.Return(array);
+            _pool.Return(array, clearArray: _clearOnReturn);
             _array = null;
         }
     }


### PR DESCRIPTION
This change adds a new `GetPooledArraySpan(...)` extension method that returns a pooled array as a `Span<T>` with the expected length. This can help avoid bugs that can occur if a pooled array's `Length` is accidental used.
