### PR TITLE
Fix Visual Studio unit tests

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/AsyncBatchingWorkQueue`2.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/AsyncBatchingWorkQueue`2.cs
@@ -271,9 +271,8 @@ internal class AsyncBatchingWorkQueue<TItem, TResult>
         catch (OperationCanceledException)
         {
             // Silently continue to allow the next batch to be processed.
+            return default;
         }
-
-        return Assumed.Unreachable<TResult?>();
     }
 
     private (ImmutableArray<TItem> items, CancellationToken batchCancellationToken) GetNextBatchAndResetQueue()

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/RazorActivityLog.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/RazorActivityLog.cs
@@ -20,19 +20,15 @@ internal sealed class RazorActivityLog : IDisposable
     private enum EntryType { Error, Warning, Info }
 
     private readonly IAsyncServiceProvider _serviceProvider;
-    private readonly JoinableTaskFactory _jtf;
 
     private readonly CancellationTokenSource _disposeTokenSource;
     private readonly AsyncBatchingWorkQueue<(EntryType, string)> _loggingQueue;
     private IVsActivityLog? _vsActivityLog;
 
     [ImportingConstructor]
-    public RazorActivityLog(
-        [Import(typeof(SAsyncServiceProvider))] IAsyncServiceProvider serviceProvider,
-        JoinableTaskContext joinableTaskContext)
+    public RazorActivityLog([Import(typeof(SAsyncServiceProvider))] IAsyncServiceProvider serviceProvider)
     {
         _serviceProvider = serviceProvider;
-        _jtf = joinableTaskContext.Factory;
 
         _disposeTokenSource = new();
         _loggingQueue = new AsyncBatchingWorkQueue<(EntryType, string)>(TimeSpan.Zero, ProcessBatchAsync, _disposeTokenSource.Token);
@@ -51,9 +47,7 @@ internal sealed class RazorActivityLog : IDisposable
 
     private async ValueTask ProcessBatchAsync(ImmutableArray<(EntryType, string)> items, CancellationToken token)
     {
-        await _jtf.SwitchToMainThreadAsync(token);
-
-        _vsActivityLog ??= await _serviceProvider.GetServiceAsync<SVsActivityLog, IVsActivityLog>();
+        _vsActivityLog ??= await _serviceProvider.GetServiceAsync<SVsActivityLog, IVsActivityLog>(token).ConfigureAwait(false);
 
         foreach (var (entryType, message) in items)
         {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/RazorActivityLog.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/RazorActivityLog.cs
@@ -47,10 +47,20 @@ internal sealed class RazorActivityLog : IDisposable
 
     private async ValueTask ProcessBatchAsync(ImmutableArray<(EntryType, string)> items, CancellationToken token)
     {
+        if (token.IsCancellationRequested)
+        {
+            return;
+        }
+
         _vsActivityLog ??= await _serviceProvider.GetServiceAsync<SVsActivityLog, IVsActivityLog>(token).ConfigureAwait(false);
 
         foreach (var (entryType, message) in items)
         {
+            if (token.IsCancellationRequested)
+            {
+                return;
+            }
+
             var vsEntryType = entryType switch
             {
                 EntryType.Error => __ACTIVITYLOG_ENTRYTYPE.ALE_ERROR,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/VisualStudio_NetFx/VsMocks.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/VisualStudio_NetFx/VsMocks.cs
@@ -11,6 +11,7 @@ using Microsoft.VisualStudio;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.Razor;
 using Microsoft.VisualStudio.Razor.LanguageClient;
+using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Utilities;
 using Moq;
@@ -79,25 +80,6 @@ internal static class VsMocks
         return builder.Mock.Object;
     }
 
-    public static IVsService<TService, TInterface> CreateVsService<TService, TInterface>(Mock<TInterface> serviceMock)
-        where TService : class
-        where TInterface : class
-        => CreateVsService<TService, TInterface>(serviceMock.Object);
-
-    public static IVsService<TService, TInterface> CreateVsService<TService, TInterface>(TInterface service)
-        where TService : class
-        where TInterface : class
-    {
-        var mock = new StrictMock<IVsService<TService, TInterface>>();
-
-        mock.Setup(x => x.GetValueAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(service);
-        mock.Setup(x => x.GetValueOrNullAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(service);
-
-        return mock.Object;
-    }
-
     public interface IServiceProviderBuilder
     {
         void AddService<T>(T? serviceInstance)
@@ -160,6 +142,59 @@ internal static class VsMocks
         }
     }
 
+    public static IAsyncServiceProvider CreateAsyncServiceProvider(Action<IAsyncServiceProviderBuilder>? configure = null)
+    {
+        var builder = new AsyncServiceProviderBuilder();
+        configure?.Invoke(builder);
+        return builder.Mock.Object;
+    }
+
+    public interface IAsyncServiceProviderBuilder
+    {
+        void AddService<TService, TInterface>(TInterface service)
+            where TInterface : class;
+        void AddService<TService, TInterface>(Func<TInterface> service)
+            where TInterface : class;
+    }
+
+    private class AsyncServiceProviderBuilder : IAsyncServiceProviderBuilder
+    {
+        private readonly StrictMock<IAsyncServiceProvider> _mock1;
+        private readonly Mock<IAsyncServiceProvider2> _mock2;
+        private readonly Mock<IAsyncServiceProvider3> _mock3;
+
+        public StrictMock<IAsyncServiceProvider> Mock => _mock1;
+
+        public AsyncServiceProviderBuilder()
+        {
+            _mock1 = new();
+            _mock2 = Mock.As<IAsyncServiceProvider2>();
+            _mock3 = Mock.As<IAsyncServiceProvider3>();
+        }
+
+        public void AddService<TService, TInterface>(TInterface service)
+            where TInterface : class
+        {
+            _mock1.Setup(x => x.GetServiceAsync(typeof(TService)))
+                  .ReturnsAsync(service);
+            _mock2.Setup(x => x.GetServiceAsync(typeof(TService), /*swallowException*/ false))
+                  .ReturnsAsync(service);
+            _mock3.Setup(x => x.GetServiceAsync<TService, TInterface>(/*throwOnFailure*/ true, It.IsAny<CancellationToken>()))
+                  .ReturnsAsync(service);
+        }
+
+        public void AddService<TService, TInterface>(Func<TInterface> getServiceCallback)
+            where TInterface : class
+        {
+            _mock1.Setup(x => x.GetServiceAsync(typeof(TService)))
+                  .ReturnsAsync(() => getServiceCallback());
+            _mock2.Setup(x => x.GetServiceAsync(typeof(TService), /*swallowException*/ false))
+                  .ReturnsAsync(() => getServiceCallback());
+            _mock3.Setup(x => x.GetServiceAsync<TService, TInterface>(/*throwOnFailure*/ true, It.IsAny<CancellationToken>()))
+                  .ReturnsAsync(() => getServiceCallback());
+        }
+    }
+
     public static IComponentModel CreateComponentModel(Action<IComponentModelBuilder>? configure = null)
     {
         var builder = new ComponentModelBuilder();
@@ -218,5 +253,24 @@ internal static class VsMocks
                 yield return new Export(contractName, exportValueGetter);
             }
         }
+    }
+
+    public static IVsService<TService, TInterface> CreateVsService<TService, TInterface>(Mock<TInterface> serviceMock)
+        where TService : class
+        where TInterface : class
+        => CreateVsService<TService, TInterface>(serviceMock.Object);
+
+    public static IVsService<TService, TInterface> CreateVsService<TService, TInterface>(TInterface service)
+        where TService : class
+        where TInterface : class
+    {
+        var mock = new StrictMock<IVsService<TService, TInterface>>();
+
+        mock.Setup(x => x.GetValueAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(service);
+        mock.Setup(x => x.GetValueOrNullAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(service);
+
+        return mock.Object;
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LspEditorFeatureDetectorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LspEditorFeatureDetectorTest.cs
@@ -8,7 +8,6 @@ using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.Internal.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Razor.Logging;
 using Microsoft.VisualStudio.Settings;
-using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Moq;
 using Xunit;
@@ -221,12 +220,10 @@ public class LspEditorFeatureDetectorTest(ITestOutputHelper testOutput) : Toolin
             })
             .Returns(VSConstants.S_OK);
 
-        var serviceProviderMock = new StrictMock<IAsyncServiceProvider>();
-        serviceProviderMock
-            .Setup(x => x.GetServiceAsync(typeof(SVsActivityLog)))
-            .ReturnsAsync(vsActivityLogMock.Object);
+        var serviceProvider = VsMocks.CreateAsyncServiceProvider(b =>
+            b.AddService<SVsActivityLog, IVsActivityLog>(vsActivityLogMock.Object));
 
-        var activityLog = new RazorActivityLog(serviceProviderMock.Object, JoinableTaskContext);
+        var activityLog = new RazorActivityLog(serviceProvider);
 
         AddDisposable(activityLog);
 


### PR DESCRIPTION
It turns out that an old bug and some recent changes were causing `MS.VS.LanguageService.Razor.Test` unit tests to fail intermittently.

1. I made a mistake when porting `AsyncBatchingWorkQueue` from Roslyn that would cause an exception to be thrown if an `OperationCanceledException` was thrown during batch processing.
2. `RazorActivityLog` would switch to the main thread when processing a batch of messages. However, this is unnecessary, since `IVsActivityLog` is supposed to a be a thread-safe VS service.
3. `RazorActivityLog` didn't check its cancellation token while processing a batch of messages. This is problematic because it would continue logging messages after `RazorActivityLog` was disposed.
4. The `IAsyncServiceProvider` mock passed to `RazorActivityLog` didn't implement `IAsyncServiceProvider3`, which is super important. If that interface isn't implemented, Visual Studio's `GetServiceAsync<TService, TInterface>()` extension method will end up calling `ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync()`, which will fail in tests.

Together, these issues could cause the test process or AppDomain to crash when the `LspEditorFeatureDetectorTest` tests were run. Since these unit tests run in parallel, the end result would be strange exceptions in other tests due to the test environment being torn down.

FWIW, this doesn't completely fix the unit tests. There are still intermittent failures, but these are egregious bugs that need fixed.