### PR TITLE
Expand string and span extension methods

### DIFF
--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ArrayExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ArrayExtensions.cs
@@ -1,13 +1,188 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+
+#if !NET
+using ThrowHelper = Microsoft.AspNetCore.Razor.Utilities.ThrowHelper;
+#endif
 
 namespace Microsoft.AspNetCore.Razor;
 
 internal static class ArrayExtensions
 {
+    /// <summary>
+    ///  Creates a new span over the portion of the target array defined by an <see cref="Index"/> value.
+    /// </summary>
+    /// <param name="array">
+    ///  The array to convert.
+    /// </param>
+    /// <param name="startIndex">
+    ///  The starting index.
+    /// </param>
+    /// <remarks>
+    ///  This uses Razor's <see cref="Index"/> type, which is type-forwarded on .NET.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">
+    ///  <paramref name="array"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///  <paramref name="startIndex"/> is less than 0 or greater than <paramref name="array"/>.Length.
+    /// </exception>
+    /// <exception cref="ArrayTypeMismatchException">
+    ///  <paramref name="array"/> is covariant, and the array's type is not exactly <typeparamref name="T"/>[].
+    /// </exception>
+    public static ReadOnlySpan<T> AsSpan<T>(this T[]? array, Index startIndex)
+    {
+#if NET
+        return MemoryExtensions.AsSpan(array, startIndex);
+#else
+        if (array is null)
+        {
+            if (!startIndex.Equals(Index.Start))
+            {
+                ThrowHelper.ThrowArgumentOutOfRange(nameof(startIndex));
+            }
+
+            return default;
+        }
+
+        return MemoryExtensions.AsSpan(array, startIndex.GetOffset(array.Length));
+#endif
+    }
+
+    /// <summary>
+    ///  Creates a new span over the portion of the target array defined by a <see cref="Range"/> value.
+    /// </summary>
+    /// <param name="array">
+    ///  The array to convert.
+    /// </param>
+    /// <param name="range">
+    ///  The range of the array to convert.
+    /// </param>
+    /// <remarks>
+    ///  This uses Razor's <see cref="Range"/> type, which is type-forwarded on .NET.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">
+    ///  <paramref name="array"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///  <paramref name="range"/>'s start or end index is not within the bounds of the string.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///  <paramref name="range"/>'s start index is greater than its end index.
+    /// </exception>
+    /// <exception cref="ArrayTypeMismatchException">
+    ///  <paramref name="array"/> is covariant, and the array's type is not exactly <typeparamref name="T"/>[].
+    /// </exception>
+    public static ReadOnlySpan<T> AsSpan<T>(this T[]? array, Range range)
+    {
+#if NET
+        return MemoryExtensions.AsSpan(array, range);
+#else
+        if (array is null)
+        {
+            if (!range.Start.Equals(Index.Start) || !range.End.Equals(Index.Start))
+            {
+                ThrowHelper.ThrowArgumentNull(nameof(array));
+            }
+
+            return default;
+        }
+
+        var (start, length) = range.GetOffsetAndLength(array.Length);
+        return MemoryExtensions.AsSpan(array, start, length);
+#endif
+    }
+
+    /// <summary>
+    ///  Creates a new memory region over the portion of the target starting at the specified index
+    ///  to the end of the array.
+    /// </summary>
+    /// <param name="array">
+    ///  The array to convert.
+    /// </param>
+    /// <param name="startIndex">
+    ///  The first position of the array.
+    /// </param>
+    /// <remarks>
+    ///  This uses Razor's <see cref="Index"/> type, which is type-forwarded on .NET.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">
+    ///  <paramref name="array"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///  <paramref name="startIndex"/> is less than 0 or greater than <paramref name="array"/>.Length.
+    /// </exception>
+    /// <exception cref="ArrayTypeMismatchException">
+    ///  <paramref name="array"/> is covariant, and the array's type is not exactly <typeparamref name="T"/>[].
+    /// </exception>
+    public static ReadOnlyMemory<T> AsMemory<T>(this T[]? array, Index startIndex)
+    {
+#if NET
+        return MemoryExtensions.AsMemory(array, startIndex);
+#else
+        if (array is null)
+        {
+            if (!startIndex.Equals(Index.Start))
+            {
+                ThrowHelper.ThrowArgumentOutOfRange(nameof(startIndex));
+            }
+
+            return default;
+        }
+
+        return MemoryExtensions.AsMemory(array, startIndex.GetOffset(array.Length));
+#endif
+    }
+
+    /// <summary>
+    ///  Creates a new memory region over the portion of the target array beginning at
+    ///  inclusive start index of the range and ending at the exclusive end index of the range.
+    /// </summary>
+    /// <param name="array">
+    ///  The array to convert.
+    /// </param>
+    /// <param name="range">
+    ///  The range of the array to convert.
+    /// </param>
+    /// <remarks>
+    ///  This uses Razor's <see cref="Range"/> type, which is type-forwarded on .NET.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">
+    ///  <paramref name="array"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///  <paramref name="range"/>'s start or end index is not within the bounds of the string.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///  <paramref name="range"/>'s start index is greater than its end index.
+    /// </exception>
+    /// <exception cref="ArrayTypeMismatchException">
+    ///  <paramref name="array"/> is covariant, and the array's type is not exactly <typeparamref name="T"/>[].
+    /// </exception>
+    public static ReadOnlyMemory<T> AsMemory<T>(this T[]? array, Range range)
+    {
+#if NET
+        return MemoryExtensions.AsMemory(array, range);
+#else
+        if (array is null)
+        {
+            if (!range.Start.Equals(Index.Start) || !range.End.Equals(Index.Start))
+            {
+                ThrowHelper.ThrowArgumentNull(nameof(array));
+            }
+
+            return default;
+        }
+
+        var (start, length) = range.GetOffsetAndLength(array.Length);
+        return MemoryExtensions.AsMemory(array, start, length);
+#endif
+    }
+
     public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(
         this (TKey key, TValue value)[] array, IEqualityComparer<TKey> keyComparer)
         where TKey : notnull

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
@@ -29,39 +29,6 @@ internal static class ImmutableArrayExtensions
         }
     }
 
-    /// <summary>
-    ///  Returns the current contents as an <see cref="ImmutableArray{T}"/> and sets
-    ///  the collection to a zero length array.
-    /// </summary>
-    /// <remarks>
-    ///  If <see cref="ImmutableArray{T}.Builder.Capacity"/> equals
-    ///  <see cref="ImmutableArray{T}.Builder.Count"/>, the internal array will be extracted
-    ///  as an <see cref="ImmutableArray{T}"/> without copying the contents. Otherwise, the
-    ///  contents will be copied into a new array. The collection will then be set to a
-    ///  zero-length array.
-    /// </remarks>
-    /// <returns>An immutable array.</returns>
-    public static ImmutableArray<T> DrainToImmutable<T>(this ImmutableArray<T>.Builder builder)
-    {
-#if NET8_0_OR_GREATER
-        return builder.DrainToImmutable();
-#else
-        if (builder.Count == 0)
-        {
-            return [];
-        }
-
-        if (builder.Count == builder.Capacity)
-        {
-            return builder.MoveToImmutable();
-        }
-
-        var result = builder.ToImmutable();
-        builder.Clear();
-        return result;
-#endif
-    }
-
     public static ImmutableArray<TResult> SelectAsArray<T, TResult>(this ImmutableArray<T> source, Func<T, TResult> selector)
     {
         return source switch

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/StringExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/StringExtensions.cs
@@ -11,18 +11,64 @@ namespace System;
 
 internal static class StringExtensions
 {
-    public static bool IsNullOrEmpty([NotNullWhen(false)] this string? s)
-        => string.IsNullOrEmpty(s);
+    /// <summary>
+    ///  Indicates whether the specified string is <see langword="null"/> or an empty string ("").
+    /// </summary>
+    /// <param name="value">
+    ///  The string to test.
+    /// </param>
+    /// <returns>
+    ///  <see langword="true"/> if the <paramref name="value"/> parameter is <see langword="null"/>
+    ///  or an empty string (""); otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <remarks>
+    ///  This extension method is useful on .NET Framework and .NET Standard 2.0 where
+    ///  <see cref="string.IsNullOrEmpty(string?)"/> is not annotated for nullability.
+    /// </remarks>
+    public static bool IsNullOrEmpty([NotNullWhen(false)] this string? value)
+        => string.IsNullOrEmpty(value);
 
-    public static bool IsNullOrWhiteSpace([NotNullWhen(false)] this string? s)
-        => string.IsNullOrWhiteSpace(s);
+    /// <summary>
+    ///  Indicates whether a specified string is <see langword="null"/>, empty, or consists only
+    ///  of white-space characters.
+    /// </summary>
+    /// <param name="value">
+    ///  The string to test.
+    /// </param>
+    /// <returns>
+    ///  <see langword="true"/> if the <paramref name="value"/> parameter is <see langword="null"/>
+    ///  or <see cref="string.Empty"/>, or if <paramref name="value"/> consists exclusively of
+    ///  white-space characters.
+    /// </returns>
+    /// <remarks>
+    ///  This extension method is useful on .NET Framework and .NET Standard 2.0 where
+    ///  <see cref="string.IsNullOrWhiteSpace(string?)"/> is not annotated for nullability.
+    /// </remarks>
+    public static bool IsNullOrWhiteSpace([NotNullWhen(false)] this string? value)
+        => string.IsNullOrWhiteSpace(value);
 
-    public static ReadOnlySpan<char> AsSpan(this string? s, Index startIndex)
+    /// <summary>
+    ///  Creates a new <see cref="ReadOnlySpan{T}"/> over a portion of the target string from
+    ///  a specified position to the end of the string.
+    /// </summary>
+    /// <param name="text">
+    ///  The target string.
+    /// </param>
+    /// <param name="startIndex">
+    ///  The index at which to begin this slice.
+    /// </param>
+    /// <remarks>
+    ///  This uses Razor's <see cref="Index"/> type, which is type-forwarded on .NET.
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///  <paramref name="startIndex"/> is less than 0 or greater than <paramref name="text"/>.Length.
+    /// </exception>
+    public static ReadOnlySpan<char> AsSpan(this string? text, Index startIndex)
     {
 #if NET
-        return MemoryExtensions.AsSpan(s, startIndex);
+        return MemoryExtensions.AsSpan(text, startIndex);
 #else
-        if (s is null)
+        if (text is null)
         {
             if (!startIndex.Equals(Index.Start))
             {
@@ -32,74 +78,175 @@ internal static class StringExtensions
             return default;
         }
 
-        return s.AsSpan(startIndex.GetOffset(s.Length));
+        return text.AsSpan(startIndex.GetOffset(text.Length));
 #endif
     }
 
-    public static ReadOnlySpan<char> AsSpan(this string? s, Range range)
+    /// <summary>
+    ///  Creates a new <see cref="ReadOnlySpan{T}"/> over a portion of a target string using
+    ///  the range start and end indexes.
+    /// </summary>
+    /// <param name="text">
+    ///  The target string.
+    /// </param>
+    /// <param name="range">
+    ///  The range that has start and end indexes to use for slicing the string.
+    /// </param>
+    /// <remarks>
+    ///  This uses Razor's <see cref="Range"/> type, which is type-forwarded on .NET.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">
+    ///  <paramref name="range"/>'s start or end index is not within the bounds of the string.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///  <paramref name="range"/>'s start index is greater than its end index.
+    /// </exception>
+    public static ReadOnlySpan<char> AsSpan(this string? text, Range range)
     {
 #if NET
-        return MemoryExtensions.AsSpan(s, range);
+        return MemoryExtensions.AsSpan(text, range);
 #else
-        if (s is null)
+        if (text is null)
         {
             if (!range.Start.Equals(Index.Start) || !range.End.Equals(Index.Start))
             {
-                ThrowHelper.ThrowArgumentNull(nameof(s));
+                ThrowHelper.ThrowArgumentNull(nameof(text));
             }
 
             return default;
         }
 
-        var (start, length) = range.GetOffsetAndLength(s.Length);
-        return s.AsSpan(start, length);
+        var (start, length) = range.GetOffsetAndLength(text.Length);
+        return text.AsSpan(start, length);
 #endif
     }
 
-    public static ReadOnlySpan<char> AsSpanOrDefault(this string? s)
-        => s is not null ? s.AsSpan() : default;
+    /// <summary>
+    ///  Creates a new <see cref="ReadOnlySpan{T}"/> over a string. If the target string
+    ///  is <see langword="null"/> a <see langword="default"/>(<see cref="ReadOnlySpan{T}"/>) is returned.
+    /// </summary>
+    /// <param name="text">
+    ///  The target string.
+    /// </param>
+    public static ReadOnlySpan<char> AsSpanOrDefault(this string? text)
+        => text is not null ? text.AsSpan() : default;
 
-    public static ReadOnlySpan<char> AsSpanOrDefault(this string? s, int start)
-        => s is not null ? s.AsSpan(start) : default;
+    /// <summary>
+    ///  Creates a new <see cref="ReadOnlySpan{T}"/> over a portion of the target string from
+    ///  a specified position to the end of the string. If the target string is <see langword="null"/>
+    ///  a <see langword="default"/>(<see cref="ReadOnlySpan{T}"/>) is returned.
+    /// </summary>
+    /// <param name="text">
+    ///  The target string.
+    /// </param>
+    /// <param name="start">
+    ///  The index at which to begin this slice.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///  <paramref name="start"/> is less than 0 or greater than <paramref name="text"/>.Length.
+    /// </exception>
+    public static ReadOnlySpan<char> AsSpanOrDefault(this string? text, int start)
+        => text is not null ? text.AsSpan(start) : default;
 
-    public static ReadOnlySpan<char> AsSpanOrDefault(this string? s, int start, int length)
-        => s is not null ? s.AsSpan(start, length) : default;
+    /// <summary>
+    ///  Creates a new <see cref="ReadOnlySpan{T}"/> over a portion of the target string from
+    ///  a specified position for a specified number of characters. If the target string is
+    ///  <see langword="null"/> a <see langword="default"/>(<see cref="ReadOnlySpan{T}"/>) is returned.
+    /// </summary>
+    /// <param name="text">
+    ///  The target string.
+    /// </param>
+    /// <param name="start">
+    ///  The index at which to begin this slice.
+    /// </param>
+    /// <param name="length">
+    ///  The desired length for the slice.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///  <paramref name="start"/>, <paramref name="length"/>, or <paramref name="start"/> + <paramref name="length"/>
+    ///  is not in the range of <paramref name="text"/>.
+    /// </exception>
+    public static ReadOnlySpan<char> AsSpanOrDefault(this string? text, int start, int length)
+        => text is not null ? text.AsSpan(start, length) : default;
 
-    public static ReadOnlySpan<char> AsSpanOrDefault(this string? s, Index startIndex)
+    /// <summary>
+    ///  Creates a new <see cref="ReadOnlySpan{T}"/> over a portion of the target string from
+    ///  a specified position to the end of the string. If the target string is <see langword="null"/>
+    ///  a <see langword="default"/>(<see cref="ReadOnlySpan{T}"/>) is returned.
+    /// </summary>
+    /// <param name="text">
+    ///  The target string.
+    /// </param>
+    /// <param name="startIndex">
+    ///  The index at which to begin this slice.
+    /// </param>
+    public static ReadOnlySpan<char> AsSpanOrDefault(this string? text, Index startIndex)
     {
-        if (s is null)
+        if (text is null)
         {
             return default;
         }
 
 #if NET
-        return MemoryExtensions.AsSpan(s, startIndex);
+        return MemoryExtensions.AsSpan(text, startIndex);
 #else
-        return s.AsSpan(startIndex.GetOffset(s.Length));
+        return text.AsSpan(startIndex.GetOffset(text.Length));
 #endif
     }
 
-    public static ReadOnlySpan<char> AsSpanOrDefault(this string? s, Range range)
+    /// <summary>
+    ///  Creates a new <see cref="ReadOnlySpan{T}"/> over a portion of the target string using the range
+    ///  start and end indexes. If the target string is <see langword="null"/> a
+    ///  <see langword="default"/>(<see cref="ReadOnlySpan{T}"/>) is returned.
+    /// </summary>
+    /// <param name="text">
+    ///  The target string.
+    /// </param>
+    /// <param name="range">
+    ///  The range that has start and end indexes to use for slicing the string.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///  <paramref name="range"/>'s start or end index is not within the bounds of the string.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///  <paramref name="range"/>'s start index is greater than its end index.
+    /// </exception>
+    public static ReadOnlySpan<char> AsSpanOrDefault(this string? text, Range range)
     {
-        if (s is null)
+        if (text is null)
         {
             return default;
         }
 
 #if NET
-        return MemoryExtensions.AsSpan(s, range);
+        return MemoryExtensions.AsSpan(text, range);
 #else
-        var (start, length) = range.GetOffsetAndLength(s.Length);
-        return s.AsSpan(start, length);
+        var (start, length) = range.GetOffsetAndLength(text.Length);
+        return text.AsSpan(start, length);
 #endif
     }
 
-    public static ReadOnlyMemory<char> AsMemory(this string? s, Index startIndex)
+    /// <summary>
+    ///  Creates a new <see cref="ReadOnlyMemory{T}"/> over a portion of a target string starting at a specified index.
+    /// </summary>
+    /// <param name="text">
+    ///  The target string.
+    /// </param>
+    /// <param name="startIndex">
+    ///  The index at which to begin this slice.
+    /// </param>
+    /// <remarks>
+    ///  This uses Razor's <see cref="Index"/> type, which is type-forwarded on .NET.
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///  <paramref name="startIndex"/> is less than 0 or greater than <paramref name="text"/>.Length.
+    /// </exception>
+    public static ReadOnlyMemory<char> AsMemory(this string? text, Index startIndex)
     {
 #if NET
-        return MemoryExtensions.AsMemory(s, startIndex);
+        return MemoryExtensions.AsMemory(text, startIndex);
 #else
-        if (s is null)
+        if (text is null)
         {
             if (!startIndex.Equals(Index.Start))
             {
@@ -109,65 +256,151 @@ internal static class StringExtensions
             return default;
         }
 
-        return s.AsMemory(startIndex.GetOffset(s.Length));
+        return text.AsMemory(startIndex.GetOffset(text.Length));
 #endif
     }
 
-    public static ReadOnlyMemory<char> AsMemory(this string? s, Range range)
+    /// <summary>
+    ///  Creates a new <see cref="ReadOnlyMemory{T}"/> over a portion of a target string using
+    ///  the range start and end indexes.
+    /// </summary>
+    /// <param name="text">
+    ///  The target string.
+    /// </param>
+    /// <param name="range">
+    ///  The range that has start and end indexes to use for slicing the string.
+    /// </param>
+    /// <remarks>
+    ///  This uses Razor's <see cref="Range"/> type, which is type-forwarded on .NET.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">
+    ///  <paramref name="range"/>'s start or end index is not within the bounds of the string.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///  <paramref name="range"/>'s start index is greater than its end index.
+    /// </exception>
+    public static ReadOnlyMemory<char> AsMemory(this string? text, Range range)
     {
 #if NET
-        return MemoryExtensions.AsMemory(s, range);
+        return MemoryExtensions.AsMemory(text, range);
 #else
-        if (s is null)
+        if (text is null)
         {
             if (!range.Start.Equals(Index.Start) || !range.End.Equals(Index.Start))
             {
-                ThrowHelper.ThrowArgumentNull(nameof(s));
+                ThrowHelper.ThrowArgumentNull(nameof(text));
             }
 
             return default;
         }
 
-        var (start, length) = range.GetOffsetAndLength(s.Length);
-        return s.AsMemory(start, length);
+        var (start, length) = range.GetOffsetAndLength(text.Length);
+        return text.AsMemory(start, length);
 #endif
     }
 
-    public static ReadOnlyMemory<char> AsMemoryOrDefault(this string? s)
-        => s is not null ? s.AsMemory() : default;
+    /// <summary>
+    ///  Creates a new <see cref="ReadOnlyMemory{T}"/> over a string. If the target string
+    ///  is <see langword="null"/> a <see langword="default"/>(<see cref="ReadOnlyMemory{T}"/>) is returned.
+    /// </summary>
+    /// <param name="text">
+    ///  The target string.
+    /// </param>
+    public static ReadOnlyMemory<char> AsMemoryOrDefault(this string? text)
+        => text is not null ? text.AsMemory() : default;
 
-    public static ReadOnlyMemory<char> AsMemoryOrDefault(this string? s, int start)
-        => s is not null ? s.AsMemory(start) : default;
+    /// <summary>
+    ///  Creates a new <see cref="ReadOnlyMemory{T}"/> over a portion of the target string from
+    ///  a specified position to the end of the string. If the target string is <see langword="null"/>
+    ///  a <see langword="default"/>(<see cref="ReadOnlyMemory{T}"/>) is returned.
+    /// </summary>
+    /// <param name="text">
+    ///  The target string.
+    /// </param>
+    /// <param name="start">
+    ///  The index at which to begin this slice.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///  <paramref name="start"/> is less than 0 or greater than <paramref name="text"/>.Length.
+    /// </exception>
+    public static ReadOnlyMemory<char> AsMemoryOrDefault(this string? text, int start)
+        => text is not null ? text.AsMemory(start) : default;
 
-    public static ReadOnlyMemory<char> AsMemoryOrDefault(this string? s, int start, int length)
-        => s is not null ? s.AsMemory(start, length) : default;
+    /// <summary>
+    ///  Creates a new <see cref="ReadOnlyMemory{T}"/> over a portion of the target string from
+    ///  a specified position for a specified number of characters. If the target string is
+    ///  <see langword="null"/> a <see langword="default"/>(<see cref="ReadOnlyMemory{T}"/>) is returned.
+    /// </summary>
+    /// <param name="text">
+    ///  The target string.
+    /// </param>
+    /// <param name="start">
+    ///  The index at which to begin this slice.
+    /// </param>
+    /// <param name="length">
+    ///  The desired length for the slice.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///  <paramref name="start"/>, <paramref name="length"/>, or <paramref name="start"/> + <paramref name="length"/>
+    ///  is not in the range of <paramref name="text"/>.
+    /// </exception>
+    public static ReadOnlyMemory<char> AsMemoryOrDefault(this string? text, int start, int length)
+        => text is not null ? text.AsMemory(start, length) : default;
 
-    public static ReadOnlyMemory<char> AsMemoryOrDefault(this string? s, Index startIndex)
+    /// <summary>
+    ///  Creates a new <see cref="ReadOnlyMemory{T}"/> over a portion of the target string from
+    ///  a specified position to the end of the string. If the target string is <see langword="null"/>
+    ///  a <see langword="default"/>(<see cref="ReadOnlyMemory{T}"/>) is returned.
+    /// </summary>
+    /// <param name="text">
+    ///  The target string.
+    /// </param>
+    /// <param name="startIndex">
+    ///  The index at which to begin this slice.
+    /// </param>
+    public static ReadOnlyMemory<char> AsMemoryOrDefault(this string? text, Index startIndex)
     {
-        if (s is null)
+        if (text is null)
         {
             return default;
         }
 
 #if NET
-        return MemoryExtensions.AsMemory(s, startIndex);
+        return MemoryExtensions.AsMemory(text, startIndex);
 #else
-        return s.AsMemory(startIndex.GetOffset(s.Length));
+        return text.AsMemory(startIndex.GetOffset(text.Length));
 #endif
     }
 
-    public static ReadOnlyMemory<char> AsMemoryOrDefault(this string? s, Range range)
+    /// <summary>
+    ///  Creates a new <see cref="ReadOnlyMemory{T}"/> over a portion of the target string using the range
+    ///  start and end indexes. If the target string is <see langword="null"/> a
+    ///  <see langword="default"/>(<see cref="ReadOnlyMemory{T}"/>) is returned.
+    /// </summary>
+    /// <param name="text">
+    ///  The target string.
+    /// </param>
+    /// <param name="range">
+    ///  The range that has start and end indexes to use for slicing the string.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///  <paramref name="range"/>'s start or end index is not within the bounds of the string.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///  <paramref name="range"/>'s start index is greater than its end index.
+    /// </exception>
+    public static ReadOnlyMemory<char> AsMemoryOrDefault(this string? text, Range range)
     {
-        if (s is null)
+        if (text is null)
         {
             return default;
         }
 
 #if NET
-        return MemoryExtensions.AsMemory(s, range);
+        return MemoryExtensions.AsMemory(text, range);
 #else
-        var (start, length) = range.GetOffsetAndLength(s.Length);
-        return s.AsMemory(start, length);
+        var (start, length) = range.GetOffsetAndLength(text.Length);
+        return text.AsMemory(start, length);
 #endif
     }
 

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/StringExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/StringExtensions.cs
@@ -3,6 +3,10 @@
 
 using System.Diagnostics.CodeAnalysis;
 
+#if !NET
+using ThrowHelper = Microsoft.AspNetCore.Razor.Utilities.ThrowHelper;
+#endif
+
 namespace System;
 
 internal static class StringExtensions
@@ -13,11 +17,159 @@ internal static class StringExtensions
     public static bool IsNullOrWhiteSpace([NotNullWhen(false)] this string? s)
         => string.IsNullOrWhiteSpace(s);
 
+    public static ReadOnlySpan<char> AsSpan(this string? s, Index startIndex)
+    {
+#if NET
+        return MemoryExtensions.AsSpan(s, startIndex);
+#else
+        if (s is null)
+        {
+            if (!startIndex.Equals(Index.Start))
+            {
+                ThrowHelper.ThrowArgumentOutOfRange(nameof(startIndex));
+            }
+
+            return default;
+        }
+
+        return s.AsSpan(startIndex.GetOffset(s.Length));
+#endif
+    }
+
+    public static ReadOnlySpan<char> AsSpan(this string? s, Range range)
+    {
+#if NET
+        return MemoryExtensions.AsSpan(s, range);
+#else
+        if (s is null)
+        {
+            if (!range.Start.Equals(Index.Start) || !range.End.Equals(Index.Start))
+            {
+                ThrowHelper.ThrowArgumentNull(nameof(s));
+            }
+
+            return default;
+        }
+
+        var (start, length) = range.GetOffsetAndLength(s.Length);
+        return s.AsSpan(start, length);
+#endif
+    }
+
     public static ReadOnlySpan<char> AsSpanOrDefault(this string? s)
         => s is not null ? s.AsSpan() : default;
 
+    public static ReadOnlySpan<char> AsSpanOrDefault(this string? s, int start)
+        => s is not null ? s.AsSpan(start) : default;
+
+    public static ReadOnlySpan<char> AsSpanOrDefault(this string? s, int start, int length)
+        => s is not null ? s.AsSpan(start, length) : default;
+
+    public static ReadOnlySpan<char> AsSpanOrDefault(this string? s, Index startIndex)
+    {
+        if (s is null)
+        {
+            return default;
+        }
+
+#if NET
+        return MemoryExtensions.AsSpan(s, startIndex);
+#else
+        return s.AsSpan(startIndex.GetOffset(s.Length));
+#endif
+    }
+
+    public static ReadOnlySpan<char> AsSpanOrDefault(this string? s, Range range)
+    {
+        if (s is null)
+        {
+            return default;
+        }
+
+#if NET
+        return MemoryExtensions.AsSpan(s, range);
+#else
+        var (start, length) = range.GetOffsetAndLength(s.Length);
+        return s.AsSpan(start, length);
+#endif
+    }
+
+    public static ReadOnlyMemory<char> AsMemory(this string? s, Index startIndex)
+    {
+#if NET
+        return MemoryExtensions.AsMemory(s, startIndex);
+#else
+        if (s is null)
+        {
+            if (!startIndex.Equals(Index.Start))
+            {
+                ThrowHelper.ThrowArgumentOutOfRange(nameof(startIndex));
+            }
+
+            return default;
+        }
+
+        return s.AsMemory(startIndex.GetOffset(s.Length));
+#endif
+    }
+
+    public static ReadOnlyMemory<char> AsMemory(this string? s, Range range)
+    {
+#if NET
+        return MemoryExtensions.AsMemory(s, range);
+#else
+        if (s is null)
+        {
+            if (!range.Start.Equals(Index.Start) || !range.End.Equals(Index.Start))
+            {
+                ThrowHelper.ThrowArgumentNull(nameof(s));
+            }
+
+            return default;
+        }
+
+        var (start, length) = range.GetOffsetAndLength(s.Length);
+        return s.AsMemory(start, length);
+#endif
+    }
+
     public static ReadOnlyMemory<char> AsMemoryOrDefault(this string? s)
         => s is not null ? s.AsMemory() : default;
+
+    public static ReadOnlyMemory<char> AsMemoryOrDefault(this string? s, int start)
+        => s is not null ? s.AsMemory(start) : default;
+
+    public static ReadOnlyMemory<char> AsMemoryOrDefault(this string? s, int start, int length)
+        => s is not null ? s.AsMemory(start, length) : default;
+
+    public static ReadOnlyMemory<char> AsMemoryOrDefault(this string? s, Index startIndex)
+    {
+        if (s is null)
+        {
+            return default;
+        }
+
+#if NET
+        return MemoryExtensions.AsMemory(s, startIndex);
+#else
+        return s.AsMemory(startIndex.GetOffset(s.Length));
+#endif
+    }
+
+    public static ReadOnlyMemory<char> AsMemoryOrDefault(this string? s, Range range)
+    {
+        if (s is null)
+        {
+            return default;
+        }
+
+#if NET
+        return MemoryExtensions.AsMemory(s, range);
+#else
+        var (start, length) = range.GetOffsetAndLength(s.Length);
+        return s.AsMemory(start, length);
+#endif
+    }
 
     // This method doesn't exist on .NET Framework, but it does on .NET Core.
     public static bool Contains(this string s, char ch)

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/StringExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/StringExtensions.cs
@@ -171,11 +171,154 @@ internal static class StringExtensions
 #endif
     }
 
-    // This method doesn't exist on .NET Framework, but it does on .NET Core.
-    public static bool Contains(this string s, char ch)
-        => s.IndexOf(ch) >= 0;
+    /// <summary>
+    ///  Returns a value indicating whether a specified character occurs within a string instance.
+    /// </summary>
+    /// <param name="text">
+    ///  The string instance.
+    /// </param>
+    /// <param name="value">
+    ///  The character to seek.
+    /// </param>
+    /// <returns>
+    ///  <see langword="true"/> if the value parameter occurs within the string; otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <remarks>
+    ///  This method exists on .NET Core, but doesn't on .NET Framework or .NET Standard 2.0.
+    /// </remarks>
+    public static bool Contains(this string text, char value)
+    {
+#if NET
+        return text.Contains(value);
+#else
+        return text.IndexOf(value) >= 0;
+#endif
+    }
 
-    // This method doesn't exist on .NET Framework, but it does on .NET Core.
-    public static bool EndsWith(this string s, char ch)
-        => s.Length > 0 && s[^1] == ch;
+    /// <summary>
+    ///  Returns a value indicating whether a specified character occurs within a string instance,
+    ///  using the specified comparison rules.
+    /// </summary>
+    /// <param name="text">
+    ///  The string instance.
+    /// </param>
+    /// <param name="value">
+    ///  The character to seek.
+    /// </param>
+    /// <param name="comparisonType">
+    ///  One of the enumeration values that specifies the rules to use in the comparison.
+    /// </param>
+    /// <returns>
+    ///  <see langword="true"/> if the value parameter occurs within the string; otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <remarks>
+    ///  This method exists on .NET Core, but doesn't on .NET Framework or .NET Standard 2.0.
+    /// </remarks>
+    public static bool Contains(this string text, char value, StringComparison comparisonType)
+    {
+#if NET
+        return text.Contains(value, comparisonType);
+#else
+        return text.IndexOf(value, comparisonType) != 0;
+#endif
+    }
+
+    /// <summary>
+    ///  Reports the zero-based index of the first occurrence of the specified Unicode character in a string instance.
+    ///  A parameter specifies the type of search to use for the specified character.
+    /// </summary>
+    /// <param name="text">
+    ///  The string instance.
+    /// </param>
+    /// <param name="value">
+    ///  The character to compare to the character at the start of this string.
+    /// </param>
+    /// <param name="comparisonType">
+    ///  An enumeration value that specifies the rules for the search.
+    /// </param>
+    /// <returns>
+    ///  The zero-based index of <paramref name="value"/> if that character is found, or -1 if it is not.
+    /// </returns>
+    /// <remarks>
+    ///  <para>
+    ///   Index numbering starts from zero.
+    ///  </para>
+    ///  <para>
+    ///   The <paramref name="comparisonType"/> parameter is a <see cref="StringComparison"/> enumeration member
+    ///   that specifies whether the search for the <paramref name="value"/> argument uses the current or invariant culture,
+    ///   is case-sensitive or case-insensitive, or uses word or ordinal comparison rules.
+    ///  </para>
+    ///  <para>
+    ///   This method exists on .NET Core, but doesn't on .NET Framework or .NET Standard 2.0.
+    ///  </para>
+    /// </remarks>
+    public static int IndexOf(this string text, char value, StringComparison comparisonType)
+    {
+#if NET
+        return text.IndexOf(value, comparisonType);
+#else
+        // [ch] produces a ReadOnlySpan<char> using a ref to ch.
+        return text.AsSpan().IndexOf([value], comparisonType);
+#endif
+    }
+
+    /// <summary>
+    ///  Determines whether a string instance starts with the specified character.
+    /// </summary>
+    /// <param name="text">
+    ///  The string instance.
+    /// </param>
+    /// <param name="value">
+    ///  The character to compare to the character at the start of this string.
+    /// </param>
+    /// <returns>
+    ///  <see langword="true"/> if <paramref name="value"/> matches the start of the string;
+    ///  otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <remarks>
+    ///  <para>
+    ///   This method performs an ordinal (case-sensitive and culture-insensitive) comparison.
+    ///  </para>
+    ///  <para>
+    ///   This method exists on .NET Core, but doesn't on .NET Framework or .NET Standard 2.0.
+    ///  </para>
+    /// </remarks>
+    public static bool StartsWith(this string text, char value)
+    {
+#if NET
+        return text.StartsWith(value);
+#else
+        return text.Length > 0 && text[0] == value;
+#endif
+    }
+
+    /// <summary>
+    ///  Determines whether the end of a string instance matches the specified character.
+    /// </summary>
+    /// <param name="text">
+    ///  The string instance.
+    /// </param>
+    /// <param name="value">
+    ///  The character to compare to the character at the end of this string.
+    /// </param>
+    /// <returns>
+    ///  <see langword="true"/> if <paramref name="value"/> matches the end of this string;
+    ///  otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <remarks>
+    ///  <para>
+    ///   This method performs an ordinal (case-sensitive and culture-insensitive) comparison.
+    ///  </para>
+    ///  <para>
+    ///   This method exists on .NET Core, but doesn't on .NET Framework or .NET Standard 2.0.
+    ///  </para>
+    /// </remarks>
+    public static bool EndsWith(this string text, char value)
+    {
+#if NET
+        return text.EndsWith(value);
+#else
+        return text.Length > 0 && text[^1] == value;
+#endif
+    }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Utilities/ThrowHelper.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Utilities/ThrowHelper.cs
@@ -12,6 +12,34 @@ internal static class ThrowHelper
     ///  This is present to help the JIT inline methods that need to throw an <see cref="InvalidOperationException"/>.
     /// </summary>
     [DoesNotReturn]
+    public static void ThrowArgumentNull(string paramName)
+        => throw new ArgumentNullException(paramName);
+
+    /// <summary>
+    ///  This is present to help the JIT inline methods that need to throw an <see cref="InvalidOperationException"/>.
+    /// </summary>
+    [DoesNotReturn]
+    public static T ThrowArgumentNull<T>(string paramName)
+        => throw new ArgumentNullException(paramName);
+
+    /// <summary>
+    ///  This is present to help the JIT inline methods that need to throw an <see cref="InvalidOperationException"/>.
+    /// </summary>
+    [DoesNotReturn]
+    public static void ThrowArgumentOutOfRange(string paramName)
+        => throw new ArgumentOutOfRangeException(paramName);
+
+    /// <summary>
+    ///  This is present to help the JIT inline methods that need to throw an <see cref="InvalidOperationException"/>.
+    /// </summary>
+    [DoesNotReturn]
+    public static T ThrowArgumentOutOfRange<T>(string paramName)
+        => throw new ArgumentOutOfRangeException(paramName);
+
+    /// <summary>
+    ///  This is present to help the JIT inline methods that need to throw an <see cref="InvalidOperationException"/>.
+    /// </summary>
+    [DoesNotReturn]
     public static T ThrowInvalidOperation<T>(string message)
         => throw new InvalidOperationException(message);
 }


### PR DESCRIPTION
This change covers several pieces of work on shared extension methods:

1. Augment and document `AsSpan()`, `AsSpanOrDefault()`, `AsMemory()`, and `AsMemoryOrDefault()` extension methods targeting string.
2. Augment and document `Contains()`, `IndexOf()`, `StartsWith()`, and `EndsWith()` extension methods targeting string.
3. Add `AsSpan()` and `AsMemory()` extensions methods targeting array and Razor's polyfill `Index` and `Range` types.