### PR TITLE
Turn off trailing whitespace triming in strings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "files.trimTrailingWhitespace": true,
+  "files.trimTrailingWhitespaceInRegexAndStrings": false,
   "files.associations": {
     "*.*proj": "xml",
     "*.props": "xml",


### PR DESCRIPTION
We have tests with baselines that have trailing whitespaces. Our `trimTrailingWhitespace` setting means that those will get modified automatically, breaking those tests. To fix that, I implemented a vscode feature to avoid triming inside regex and strings, so let's use that.
