### PR TITLE
Move BuildAnalyzers.sln to eng

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -6,7 +6,7 @@
          that is treated as an analyzer, there can be file locking issues if Razor.Diagnostics.Analyzers isn't
          built before Razor.sln. Setting "BuildInParallel" to "false" ensures that this solution will be fully
          built first. -->
-    <ProjectToBuild Include="$(RepoRoot)BuildAnalyzers.sln" BuildInParallel="false" />
+    <ProjectToBuild Include="$(RepoRoot)\eng\BuildAnalyzers.sln" BuildInParallel="false" />
 
     <ProjectToBuild Condition="'$(OS)'=='WINDOWS_NT' and '$(SdkTaskProjects)'==''" Include="$(MSBuildThisFileDirectory)..\Razor.sln" />
 

--- a/eng/BuildAnalyzers.sln
+++ b/eng/BuildAnalyzers.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.8.34117.57
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Razor.Diagnostics.Analyzers", "src\Analyzers\Razor.Diagnostics.Analyzers\Razor.Diagnostics.Analyzers.csproj", "{42438A8F-6284-443A-A518-9AAD5371A403}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Razor.Diagnostics.Analyzers", "..\src\Analyzers\Razor.Diagnostics.Analyzers\Razor.Diagnostics.Analyzers.csproj", "{42438A8F-6284-443A-A518-9AAD5371A403}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
Having two sln files in the root directory means that `dotnet` CLI commands get confused about what sln to use and need to have it specified. To fix, we just move this solution file into eng, since it's only used for full builds anyways.
