### PR TITLE
Set RootNamespace for MS.VS.LanguageServices.Razor

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/ActivityLogLoggerProvider.Logger.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/ActivityLogLoggerProvider.Logger.cs
@@ -4,9 +4,8 @@
 using System;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.Razor.Logging;
-using Microsoft.VisualStudio.Razor.Logging;
 
-namespace Microsoft.VisualStudio.LanguageServices.Razor.Logging;
+namespace Microsoft.VisualStudio.Razor.Logging;
 
 internal sealed partial class ActivityLogLoggerProvider
 {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/ActivityLogLoggerProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Logging/ActivityLogLoggerProvider.cs
@@ -3,9 +3,8 @@
 
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Razor.Logging;
-using Microsoft.VisualStudio.Razor.Logging;
 
-namespace Microsoft.VisualStudio.LanguageServices.Razor.Logging;
+namespace Microsoft.VisualStudio.Razor.Logging;
 
 /// <summary>
 /// An <see cref="ILoggerProvider"/> that logs any warnings or errors to the Visual Studio Activity Log.

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Microsoft.VisualStudio.LanguageServices.Razor.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Microsoft.VisualStudio.LanguageServices.Razor.csproj
@@ -8,6 +8,7 @@
     <IsShippingPackage>false</IsShippingPackage>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
     <IsPackable Condition="'$(OS)' != 'Windows_NT'">false</IsPackable>
+    <RootNamespace>Microsoft.VisualStudio.Razor</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/JsonDataReader.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/JsonDataReader.cs
@@ -7,7 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.Extensions.ObjectPool;
 using Newtonsoft.Json;
-using SR = Microsoft.AspNetCore.Razor.Serialization.Json.Internal.SR;
+using SR = Microsoft.AspNetCore.Razor.Serialization.Json.Internal.Strings;
 
 namespace Microsoft.AspNetCore.Razor.Serialization.Json;
 

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/JsonReaderExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/JsonReaderExtensions.cs
@@ -5,7 +5,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using Newtonsoft.Json;
-using SR = Microsoft.AspNetCore.Razor.Serialization.Json.Internal.SR;
+using SR = Microsoft.AspNetCore.Razor.Serialization.Json.Internal.Strings;
 
 namespace Microsoft.AspNetCore.Razor.Serialization.Json;
 

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/Microsoft.AspNetCore.Razor.Serialization.Json.projitems
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/Microsoft.AspNetCore.Razor.Serialization.Json.projitems
@@ -24,7 +24,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Internal\Strings.resx">
       <GenerateSource>true</GenerateSource>
-      <ClassName>Microsoft.AspNetCore.Razor.Serialization.Json.Internal.SR</ClassName>
+      <Namespace>Microsoft.AspNetCore.Razor.Serialization.Json.Internal</Namespace>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectReaders.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectReaders.cs
@@ -10,7 +10,7 @@ using Microsoft.AspNetCore.Razor.Utilities;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using static Microsoft.AspNetCore.Razor.Language.RequiredAttributeDescriptor;
-using SR = Microsoft.AspNetCore.Razor.Serialization.Json.Internal.SR;
+using SR = Microsoft.AspNetCore.Razor.Serialization.Json.Internal.Strings;
 
 namespace Microsoft.AspNetCore.Razor.Serialization.Json;
 


### PR DESCRIPTION
All of the types MS.VS.LanguageServices.Razor elide "LanguageServices" from their namespaces. So, each type has `Microsoft.VisualStudio.Razor` its root namespace. These have been kept in sync by pure discipline until this change.

This change updates the `<RootNamespace>` for MS.VS.LanguageServices.Razor to not include "LanguageServices". That way, new files in this project will be created with a root namespace of `Microsoft.VisualStudio.Razor`. Normally, changing the `<RootNamespace>` should be a painless process. However, it was blocked due to issues caused by the MS.ANC.Razor.Serialization.Json shared project's embedded string resources. I've gone ahead and sorted that so that updating the `<RootNamespace>` is now possible.