### PR TITLE
Add latest .NET 8 runtime to global.json

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -141,14 +141,6 @@ stages:
           displayName: Build and Deploy
           condition: succeeded()
 
-        # Needed for Microsoft.AspNetCore.Razor.Microbenchmarks.Generator tests
-        - task: UseDotNet@2
-          displayName: 'Install .NET 8 runtime'
-          inputs:
-            packageType: runtime
-            version: 8.x
-            installationPath: '$(Build.SourcesDirectory)\.dotnet'
-
         - script: eng\CIBuild.cmd
             -configuration $(_BuildConfig)
             -prepareMachine

--- a/global.json
+++ b/global.json
@@ -5,7 +5,8 @@
       "dotnet": [
         "2.1.30",
         "$(MicrosoftNETCoreBrowserDebugHostTransportPackageVersion)",
-        "3.1.30"
+        "3.1.30",
+        "8.0.7"
       ]
     },
     "vs": {


### PR DESCRIPTION
Since we updated to a .NET 9 SDK, the
MS.ANC.Razor.Microbenchmarks.Generator unit tests have failed to run locally. This is because these test use Benchmark.NET, which performs a builder at runtime targeting .NET 8. This works fine in CI because it uses a .NET 8 SDK.

This change just adds the most recent .NET 8 runtime version to the list of runtimes in Razor's global.json. So, it'll get installed into the .dotnet folder and the Microbenchmarks.Generator will run and stop reporting a spurious error.
