### PR TITLE
Fix arcade property for Microsoft.VisualStudio.Razor.IntegrationTests.csproj

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractRazorEditorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractRazorEditorTest.cs
@@ -14,7 +14,7 @@ using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.Internal.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Settings;
 using Microsoft.VisualStudio.Shell;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.VisualStudio.Razor.IntegrationTests;
@@ -146,14 +146,14 @@ public abstract class AbstractRazorEditorTest(ITestOutputHelper testOutput) : Ab
         Assumes.Present(settingsManager);
 
         var useLegacyEditor = settingsManager.GetValueOrDefault<bool>(WellKnownSettingNames.UseLegacyASPNETCoreEditor);
-        Assert.AreEqual(false, useLegacyEditor, "Expected the Legacy Razor Editor to be disabled, but it was enabled");
+        Assert.False(useLegacyEditor, "Expected the Legacy Razor Editor to be disabled, but it was enabled");
     }
 
     private async Task EnsureTextViewRolesAsync(CancellationToken cancellationToken)
     {
         var textView = await TestServices.Editor.GetActiveTextViewAsync(cancellationToken);
         var contentType = textView.TextSnapshot.ContentType;
-        Assert.AreEqual("Razor", contentType.TypeName);
+        Assert.Equal("Razor", contentType.TypeName);
     }
 
     private async Task EnsureExtensionInstalledAsync(CancellationToken cancellationToken)

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Microsoft.VisualStudio.Razor.IntegrationTests.csproj
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Microsoft.VisualStudio.Razor.IntegrationTests.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Microsoft.VisualStudio.Razor.IntegrationTests</RootNamespace>
 
     <!-- Must use "dotnet test" to get blame-hang options -->
-    <TestRunnerName>MSTest</TestRunnerName>
+    <UseVSTestRunner>true</UseVSTestRunner>
     <TestRunnerAdditionalArguments>"--blame-hang-dump-type:full" "--blame-hang-timeout:20m"</TestRunnerAdditionalArguments>
   </PropertyGroup>
 

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Microsoft.VisualStudio.Razor.IntegrationTests.csproj
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/Microsoft.VisualStudio.Razor.IntegrationTests.csproj
@@ -39,19 +39,8 @@
     <PackageReference Include="Microsoft.VisualStudio.Language.Intellisense" />
     <PackageReference Include="NuGet.VisualStudio" />
     <PackageReference Include="Microsoft.Internal.VisualStudio.Shell.Framework" />
-    <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.utility" />
-
-    <!--
-      We need to reference XUnit, but Arcade won't import it because the test runner above is MSTest,
-      and we can't just reference the package we need because they are implicit references in Arcade
-      for other projects, and CPM doesn't play nicely with those. We could try to manually import
-      the Arcade XUnit.targets file, but finding that file is a pain, so instead we can just manually
-      import the package ourselves, but as an implicit definition to stop Nuget complaining.
-      TL;DR: MSBuild was designed to cause pain.
-    -->
     <PackageReference Include="xunit.runner.console" Version="$(XUnitRunnerConsoleVersion)" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="$(XUnitRunnerVisualStudioVersion)" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
﻿### Summary of the changes

Uses `UseVSTestRunner` instead of `TestRunneName`.

Fixes #10660
