### PR TITLE
Disable nullable warnings on .NET Standard and Framework

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -6,6 +6,21 @@
     <PackageVersion Condition=" '$(PackageVersion)' == '' ">$(Version)</PackageVersion>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!--
+      Disable nullable warnings when targeting anything other than our supported .NET core version(s).
+      This condition will be evaluated multiple times in multi-targeted projects hence need to be careful
+      to only set in the inner builds, not the outer build where only $(TargetFrameworks) is defined.
+      We still check $(TargetFrameworks) for empty though, because for single-targeted builds we want to
+      allow nullable warnings regardless of target framework.
+    -->
+    <DisableNullableWarnings Condition="'$(DisableNullableWarnings)' == '' AND  '$(TargetFrameworks)' != '' AND '$(TargetFramework)' != '' AND '$(TargetFrameworkIdentifier)' != '.NETCoreApp'">true</DisableNullableWarnings>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(DisableNullableWarnings)' == 'true'">
+    <NoWarn>$(NoWarn);Nullable</NoWarn>
+  </PropertyGroup>
+
   <Import Project="eng\targets\Packaging.targets" />
 
   <!-- Workaround https://github.com/dotnet/cli/issues/10528 -->


### PR DESCRIPTION
Those platforms do not have nullable-annotated BCLs, so things like `Debug.Assert` do not work as expected and cause spurious warnings. This is the same approach that Roslyn takes: https://github.com/dotnet/roslyn/blob/main/eng/targets/Imports.targets#L35-L42.
