### PR TITLE
Fix trailing comma in PublishData

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -105,6 +105,6 @@
       "vsMajorVersion": 17,
       "insertionCreateDraftPR": false,
       "insertionTitlePrefix": "[d17.12 P1]"
-    },
+    }
   }
 }


### PR DESCRIPTION
Official build containing this change: https://dev.azure.com/dnceng/internal/_build/results?buildId=2505642&view=results

Recent official builds are failing since snap: https://dev.azure.com/dnceng/internal/_build/results?buildId=2505159&view=logs&j=7ae71e7c-d4fe-51ea-64cd-240849b77ab1&t=4f9c0653-2f18-500e-227d-19e80298b3dc

```log
No PublishData found for branch 'main'. Using PublishData for branch 'main' with draft PR status.
The property 'insertionCreateDraftPR' cannot be found on this object. Verify that the property exists and can be set.
At D:\a\_work\_temp\548307e3-ff7c-45ff-9ccc-be3ab4e0bf53.ps1:12 char:3
+   $branchData.insertionCreateDraftPR = 'true'
```

The failure doesn't really make sense to me. Inspecting the diff from #10681, the most likely thing I can blame is the trailing comma is messing up parsing of the PublishData file.

Consider force merging for expediency @phil-allen-msft.