### PR TITLE
Remove 17.5 from servicing

### DIFF
--- a/eng/config/PublishData.json
+++ b/eng/config/PublishData.json
@@ -31,15 +31,6 @@
       "insertionCreateDraftPR": true,
       "insertionTitlePrefix": "[d17.12 P2]"
     },
-    "release/dev17.5": {
-      "nugetKind": [
-        "Shipping",
-        "NonShipping"
-      ],
-      "vsBranch": "rel/d17.5",
-      "vsMajorVersion": 17,
-      "insertionTitlePrefix": "[17.5]"
-    },
     "release/dev17.6": {
       "nugetKind": [
         "Shipping",


### PR DESCRIPTION
17.5 is not LTS so removing the PublishData entry for it. @phil-allen-msft 