### PR TITLE
Move down and interface-ize component search engine, and introduce IProjectCollectionResolver

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ComponentAccessibilityCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/ComponentAccessibilityCodeActionProvider.cs
@@ -16,6 +16,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Razor;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.AspNetCore.Razor.Utilities;
 using Microsoft.CodeAnalysis.Razor;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.Editor.Razor;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -157,7 +158,7 @@ internal sealed class ComponentAccessibilityCodeActionProvider : IRazorCodeActio
             {
                 // if fqn contains a generic typeparam, we should strip it out. Otherwise, replacing tag name will leave generic parameters in razor code, which are illegal
                 // e.g. <Component /> -> <Component<T> />
-                var fullyQualifiedName = DefaultRazorComponentSearchEngine.RemoveGenericContent(tagHelperPair.Short.Name.AsMemory()).ToString();
+                var fullyQualifiedName = RazorComponentSearchEngine.RemoveGenericContent(tagHelperPair.Short.Name.AsMemory()).ToString();
 
                 // If the match was case insensitive, then see if we can work out a new tag name to use as part of adding a using statement
                 TextDocumentEdit? additionalEdit = null;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/DefinitionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/DefinitionEndpoint.cs
@@ -29,14 +29,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition;
 
 [RazorLanguageServerEndpoint(Methods.TextDocumentDefinitionName)]
 internal sealed class DefinitionEndpoint(
-    RazorComponentSearchEngine componentSearchEngine,
+    IRazorComponentSearchEngine componentSearchEngine,
     IRazorDocumentMappingService documentMappingService,
     LanguageServerFeatureOptions languageServerFeatureOptions,
     IClientConnection clientConnection,
     ILoggerFactory loggerFactory)
     : AbstractRazorDelegatingEndpoint<TextDocumentPositionParams, DefinitionResult?>(languageServerFeatureOptions, documentMappingService, clientConnection, loggerFactory.GetOrCreateLogger<DefinitionEndpoint>()), ICapabilitiesProvider
 {
-    private readonly RazorComponentSearchEngine _componentSearchEngine = componentSearchEngine ?? throw new ArgumentNullException(nameof(componentSearchEngine));
+    private readonly IRazorComponentSearchEngine _componentSearchEngine = componentSearchEngine ?? throw new ArgumentNullException(nameof(componentSearchEngine));
     private readonly IRazorDocumentMappingService _documentMappingService = documentMappingService ?? throw new ArgumentNullException(nameof(documentMappingService));
 
     protected override bool PreferCSharpOverHtmlIfPossible => true;
@@ -73,7 +73,7 @@ internal sealed class DefinitionEndpoint(
             return default;
         }
 
-        var originComponentDocumentSnapshot = await _componentSearchEngine.TryLocateComponentAsync(originTagDescriptor).ConfigureAwait(false);
+        var originComponentDocumentSnapshot = await _componentSearchEngine.TryLocateComponentAsync(documentContext.Snapshot, originTagDescriptor).ConfigureAwait(false);
         if (originComponentDocumentSnapshot is null)
         {
             Logger.LogInformation($"Origin TagHelper document snapshot is null.");

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
@@ -226,6 +226,7 @@ internal static class IServiceCollectionExtensions
         // Add project snapshot manager
         services.AddSingleton<IProjectEngineFactoryProvider, LspProjectEngineFactoryProvider>();
         services.AddSingleton<IProjectSnapshotManager, LspProjectSnapshotManager>();
+        services.AddSingleton<IProjectCollectionResolver>(sp => (LspProjectSnapshotManager)sp.GetRequiredService<IProjectSnapshotManager>());
     }
 
     public static void AddHandlerWithCapabilities<T>(this IServiceCollection services)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/LspProjectSnapshotManager.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/LspProjectSnapshotManager.cs
@@ -9,16 +9,22 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.ProjectEngineHost;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 
 internal class LspProjectSnapshotManager(
     IProjectEngineFactoryProvider projectEngineFactoryProvider,
     ILoggerFactory loggerFactory)
-    : ProjectSnapshotManager(projectEngineFactoryProvider, loggerFactory, initializer: AddMiscFilesProject)
+    : ProjectSnapshotManager(projectEngineFactoryProvider, loggerFactory, initializer: AddMiscFilesProject), IProjectCollectionResolver
 {
     private static void AddMiscFilesProject(Updater updater)
     {
         updater.ProjectAdded(MiscFilesHostProject.Instance);
+    }
+
+    public IEnumerable<IProjectSnapshot> EnumerateProjects(IDocumentSnapshot snapshot)
+    {
+        return GetProjects();
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -20,15 +20,12 @@ using Microsoft.AspNetCore.Razor.LanguageServer.InlayHints;
 using Microsoft.AspNetCore.Razor.LanguageServer.LinkedEditingRange;
 using Microsoft.AspNetCore.Razor.LanguageServer.MapCode;
 using Microsoft.AspNetCore.Razor.LanguageServer.ProjectContexts;
-using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.AspNetCore.Razor.LanguageServer.Refactoring;
 using Microsoft.AspNetCore.Razor.LanguageServer.SignatureHelp;
 using Microsoft.AspNetCore.Razor.LanguageServer.WrapWithTag;
 using Microsoft.AspNetCore.Razor.Telemetry;
-using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.FoldingRanges;
 using Microsoft.CodeAnalysis.Razor.Logging;
-using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.Extensions.DependencyInjection;
@@ -153,7 +150,7 @@ internal partial class RazorLanguageServer : SystemTextJsonLanguageServer<RazorR
         }
 
         // Other
-        services.AddSingleton<RazorComponentSearchEngine, DefaultRazorComponentSearchEngine>();
+        services.AddSingleton<IRazorComponentSearchEngine, RazorComponentSearchEngine>();
 
         // Get the DefaultSession for telemetry. This is set by VS with
         // TelemetryService.SetDefaultSession and provides the correct

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/IProjectCollectionResolver.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/IProjectCollectionResolver.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+namespace Microsoft.CodeAnalysis.Razor.Workspaces;
+
+internal interface IProjectCollectionResolver
+{
+    IEnumerable<IProjectSnapshot> EnumerateProjects(IDocumentSnapshot snapshot);
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/IRazorComponentSearchEngine.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/IRazorComponentSearchEngine.cs
@@ -5,9 +5,9 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
-namespace Microsoft.AspNetCore.Razor.LanguageServer;
+namespace Microsoft.CodeAnalysis.Razor.Workspaces;
 
-internal abstract class RazorComponentSearchEngine
+internal interface IRazorComponentSearchEngine
 {
-    public abstract Task<IDocumentSnapshot?> TryLocateComponentAsync(TagHelperDescriptor tagHelper);
+    Task<IDocumentSnapshot?> TryLocateComponentAsync(IDocumentSnapshot contextSnapshot, TagHelperDescriptor tagHelper);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteProjectCollectionResolver.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteProjectCollectionResolver.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Composition;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
+
+namespace Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
+
+[Export(typeof(IProjectCollectionResolver)), Shared]
+[method: ImportingConstructor]
+internal class RemoteProjectCollectionResolver(ProjectSnapshotFactory projectSnapshotFactory) : IProjectCollectionResolver
+{
+    public IEnumerable<IProjectSnapshot> EnumerateProjects(IDocumentSnapshot snapshot)
+    {
+        Debug.Assert(snapshot is RemoteDocumentSnapshot);
+
+        var projects = ((RemoteDocumentSnapshot)snapshot).TextDocument.Project.Solution.Projects;
+
+        foreach (var project in projects)
+        {
+            yield return projectSnapshotFactory.GetOrCreate(project);
+        }
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/DefinitionEndpointDelegationTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/DefinitionEndpointDelegationTest.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -236,7 +237,7 @@ public class DefinitionEndpointDelegationTest(ITestOutputHelper testOutput) : Si
                 rootNamespace: "project"));
         });
 
-        var searchEngine = new DefaultRazorComponentSearchEngine(projectManager, LoggerFactory);
+        var searchEngine = new RazorComponentSearchEngine(projectManager, LoggerFactory);
 
         var razorUri = new Uri(razorFilePath);
         Assert.True(DocumentContextFactory.TryCreateForOpenDocument(razorUri, out var documentContext));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorComponentSearchEngineTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorComponentSearchEngineTest.cs
@@ -12,6 +12,8 @@ using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.AspNetCore.Razor.Test.Common.ProjectSystem;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Text;
 using Moq;
 using Xunit;
@@ -20,7 +22,7 @@ using static Microsoft.AspNetCore.Razor.Language.CommonMetadata;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Test;
 
-public class DefaultRazorComponentSearchEngineTest(ITestOutputHelper testOutput) : LanguageServerTestBase(testOutput)
+public class RazorComponentSearchEngineTest(ITestOutputHelper testOutput) : LanguageServerTestBase(testOutput)
 {
     private static readonly string s_project1BasePath = PathUtilities.CreateRootedPath("First");
     private static readonly string s_project2BasePath = PathUtilities.CreateRootedPath("Second");
@@ -99,11 +101,12 @@ public class DefaultRazorComponentSearchEngineTest(ITestOutputHelper testOutput)
         // Arrange
         var tagHelperDescriptor1 = CreateRazorComponentTagHelperDescriptor("First", RootNamespace1, "Component1", typeName: "Component1<TItem>");
         var tagHelperDescriptor2 = CreateRazorComponentTagHelperDescriptor("Second", RootNamespace2, "Component3", typeName: "Component3<TItem>");
-        var searchEngine = new DefaultRazorComponentSearchEngine(_projectManager, LoggerFactory);
+        var searchEngine = new RazorComponentSearchEngine(_projectManager, LoggerFactory);
+        var snapshot = StrictMock.Of<IDocumentSnapshot>();
 
         // Act
-        var documentSnapshot1 = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor1);
-        var documentSnapshot2 = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor2);
+        var documentSnapshot1 = await searchEngine.TryLocateComponentAsync(snapshot, tagHelperDescriptor1);
+        var documentSnapshot2 = await searchEngine.TryLocateComponentAsync(snapshot, tagHelperDescriptor2);
 
         // Assert
         Assert.NotNull(documentSnapshot1);
@@ -118,11 +121,12 @@ public class DefaultRazorComponentSearchEngineTest(ITestOutputHelper testOutput)
         // Arrange
         var tagHelperDescriptor1 = CreateRazorComponentTagHelperDescriptor("First", RootNamespace1, "Component1");
         var tagHelperDescriptor2 = CreateRazorComponentTagHelperDescriptor("Second", RootNamespace2, "Component3");
-        var searchEngine = new DefaultRazorComponentSearchEngine(_projectManager, LoggerFactory);
+        var searchEngine = new RazorComponentSearchEngine(_projectManager, LoggerFactory);
+        var snapshot = StrictMock.Of<IDocumentSnapshot>();
 
         // Act
-        var documentSnapshot1 = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor1);
-        var documentSnapshot2 = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor2);
+        var documentSnapshot1 = await searchEngine.TryLocateComponentAsync(snapshot, tagHelperDescriptor1);
+        var documentSnapshot2 = await searchEngine.TryLocateComponentAsync(snapshot, tagHelperDescriptor2);
 
         // Assert
         Assert.NotNull(documentSnapshot1);
@@ -136,10 +140,11 @@ public class DefaultRazorComponentSearchEngineTest(ITestOutputHelper testOutput)
     {
         // Arrange
         var tagHelperDescriptor = CreateRazorComponentTagHelperDescriptor("First", "Test", "Component2");
-        var searchEngine = new DefaultRazorComponentSearchEngine(_projectManager, LoggerFactory);
+        var searchEngine = new RazorComponentSearchEngine(_projectManager, LoggerFactory);
+        var snapshot = StrictMock.Of<IDocumentSnapshot>();
 
         // Act
-        var documentSnapshot = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor);
+        var documentSnapshot = await searchEngine.TryLocateComponentAsync(snapshot, tagHelperDescriptor);
 
         // Assert
         Assert.NotNull(documentSnapshot);
@@ -151,10 +156,11 @@ public class DefaultRazorComponentSearchEngineTest(ITestOutputHelper testOutput)
     {
         // Arrange
         var tagHelperDescriptor = CreateRazorComponentTagHelperDescriptor("Third", RootNamespace1, "Component3");
-        var searchEngine = new DefaultRazorComponentSearchEngine(_projectManager, LoggerFactory);
+        var searchEngine = new RazorComponentSearchEngine(_projectManager, LoggerFactory);
+        var snapshot = StrictMock.Of<IDocumentSnapshot>();
 
         // Act
-        var documentSnapshot = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor);
+        var documentSnapshot = await searchEngine.TryLocateComponentAsync(snapshot, tagHelperDescriptor);
 
         // Assert
         Assert.Null(documentSnapshot);
@@ -165,10 +171,11 @@ public class DefaultRazorComponentSearchEngineTest(ITestOutputHelper testOutput)
     {
         // Arrange
         var tagHelperDescriptor = CreateRazorComponentTagHelperDescriptor("First", RootNamespace1, "Component2");
-        var searchEngine = new DefaultRazorComponentSearchEngine(_projectManager, LoggerFactory);
+        var searchEngine = new RazorComponentSearchEngine(_projectManager, LoggerFactory);
+        var snapshot = StrictMock.Of<IDocumentSnapshot>();
 
         // Act
-        var documentSnapshot = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor);
+        var documentSnapshot = await searchEngine.TryLocateComponentAsync(snapshot, tagHelperDescriptor);
 
         // Assert
         Assert.Null(documentSnapshot);
@@ -179,10 +186,11 @@ public class DefaultRazorComponentSearchEngineTest(ITestOutputHelper testOutput)
     {
         // Arrange
         var tagHelperDescriptor = CreateRazorComponentTagHelperDescriptor("First", RootNamespace1, "Component3");
-        var searchEngine = new DefaultRazorComponentSearchEngine(_projectManager, LoggerFactory);
+        var searchEngine = new RazorComponentSearchEngine(_projectManager, LoggerFactory);
+        var snapshot = StrictMock.Of<IDocumentSnapshot>();
 
         // Act
-        var documentSnapshot = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor);
+        var documentSnapshot = await searchEngine.TryLocateComponentAsync(snapshot, tagHelperDescriptor);
 
         // Assert
         Assert.Null(documentSnapshot);
@@ -193,10 +201,11 @@ public class DefaultRazorComponentSearchEngineTest(ITestOutputHelper testOutput)
     {
         // Arrange
         var tagHelperDescriptor = CreateRazorComponentTagHelperDescriptor("AssemblyName", "Test", "Component2");
-        var searchEngine = new DefaultRazorComponentSearchEngine(_projectManager, LoggerFactory);
+        var searchEngine = new RazorComponentSearchEngine(_projectManager, LoggerFactory);
+        var snapshot = StrictMock.Of<IDocumentSnapshot>();
 
         // Act
-        var documentSnapshot = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor);
+        var documentSnapshot = await searchEngine.TryLocateComponentAsync(snapshot, tagHelperDescriptor);
 
         // Assert
         Assert.NotNull(documentSnapshot);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointDelegationTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointDelegationTest.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Test.Common.Mef;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -63,7 +64,7 @@ public class RenameEndpointDelegationTest(ITestOutputHelper testOutput) : Single
                 rootNamespace: "project"));
         });
 
-        var searchEngine = new DefaultRazorComponentSearchEngine(projectManager, LoggerFactory);
+        var searchEngine = new RazorComponentSearchEngine(projectManager, LoggerFactory);
 
         var endpoint = new RenameEndpoint(
             searchEngine,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
@@ -671,7 +671,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
         await projectService.UpdateDocumentAsync(s_componentFilePath4, SourceText.From(ComponentText4), version: 42, DisposalToken);
         await projectService.UpdateDocumentAsync(s_componentWithParamFilePath, SourceText.From(ComponentWithParamText), version: 42, DisposalToken);
 
-        var searchEngine = new DefaultRazorComponentSearchEngine(projectManager, LoggerFactory);
+        var searchEngine = new RazorComponentSearchEngine(projectManager, LoggerFactory);
         options ??= StrictMock.Of<LanguageServerFeatureOptions>(o =>
             o.SupportsFileManipulation == true &&
             o.SingleServerSupport == false &&

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ProjectSystem/TestProjectSnapshotManager.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ProjectSystem/TestProjectSnapshotManager.cs
@@ -2,12 +2,14 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer;
 using Microsoft.AspNetCore.Razor.ProjectEngineHost;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 
 namespace Microsoft.AspNetCore.Razor.Test.Common.ProjectSystem;
 
@@ -16,7 +18,7 @@ internal partial class TestProjectSnapshotManager(
     ILoggerFactory loggerFactory,
     CancellationToken disposalToken,
     Action<ProjectSnapshotManager.Updater>? initializer = null)
-    : ProjectSnapshotManager(projectEngineFactoryProvider, loggerFactory, initializer)
+    : ProjectSnapshotManager(projectEngineFactoryProvider, loggerFactory, initializer), IProjectCollectionResolver
 {
     private readonly CancellationToken _disposalToken = disposalToken;
 
@@ -31,6 +33,11 @@ internal partial class TestProjectSnapshotManager(
                 return documentSnapshot;
             },
             _disposalToken);
+    }
+
+    public IEnumerable<IProjectSnapshot> EnumerateProjects(IDocumentSnapshot snapshot)
+    {
+        return GetProjects();
     }
 
     public Listener ListenToNotifications() => new(this);


### PR DESCRIPTION
Started this for https://github.com/dotnet/razor/issues/10688 but saw that Go To Def used the same service, so figured @DustinCampbell would need to do the same thing, and thought it would be easier to put it up separately.

(Unless of course you've already done this, or similar, Dustin in which case I can just abandon this, nbd)