### PR TITLE
Add simple telemetry to initialize endpoint

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorInitializeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorInitializeEndpoint.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.Telemetry;
-using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -14,9 +13,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
 [RazorLanguageServerEndpoint(Methods.InitializeName)]
 internal class RazorInitializeEndpoint(
-        LanguageServerFeatureOptions languageServerFeatureOptions) : IRazorDocumentlessRequestHandler<InitializeParams, InitializeResult>
+    LanguageServerFeatureOptions options,
+    ITelemetryReporter telemetryReporter) : IRazorDocumentlessRequestHandler<InitializeParams, InitializeResult>
 {
-    private readonly LanguageServerFeatureOptions _languageServerFeatureOptions = languageServerFeatureOptions;
+    private static bool s_reportedFeatureFlagState = false;
+
+    private readonly LanguageServerFeatureOptions _options = options;
+    private readonly ITelemetryReporter _telemetryReporter = telemetryReporter;
 
     public bool MutatesSolutionState { get; } = true;
 
@@ -27,11 +30,15 @@ internal class RazorInitializeEndpoint(
         capabilitiesManager.SetInitializeParams(request);
         var serverCapabilities = capabilitiesManager.GetInitializeResult();
 
-        var telemetryReporter = requestContext.GetRequiredService<ITelemetryReporter>();
-
-        telemetryReporter.ReportEvent("initialize", Severity.Normal, new
-            Property(nameof(LanguageServerFeatureOptions.ForceRuntimeCodeGeneration), _languageServerFeatureOptions.ForceRuntimeCodeGeneration)
-            );
+        // Initialize can be called multiple times in a VS session, but the feature flag can't change in that time, so we only
+        // need to report once. In VS Code things could change between solution loads, but each solution load starts a new rzls
+        // process, so the static field gets reset anyway.
+        if (!s_reportedFeatureFlagState)
+        {
+            s_reportedFeatureFlagState = true;
+            _telemetryReporter.ReportEvent("initialize", Severity.Normal, new
+                Property(nameof(LanguageServerFeatureOptions.ForceRuntimeCodeGeneration), _options.ForceRuntimeCodeGeneration));
+        }
 
         return Task.FromResult(serverCapabilities);
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorInitializeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorInitializeEndpoint.cs
@@ -4,14 +4,20 @@
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
+using Microsoft.AspNetCore.Razor.Telemetry;
+using Microsoft.CodeAnalysis.Razor.Logging;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
 [RazorLanguageServerEndpoint(Methods.InitializeName)]
-internal class RazorInitializeEndpoint : IRazorDocumentlessRequestHandler<InitializeParams, InitializeResult>
+internal class RazorInitializeEndpoint(
+        LanguageServerFeatureOptions languageServerFeatureOptions) : IRazorDocumentlessRequestHandler<InitializeParams, InitializeResult>
 {
+    private readonly LanguageServerFeatureOptions _languageServerFeatureOptions = languageServerFeatureOptions;
+
     public bool MutatesSolutionState { get; } = true;
 
     public Task<InitializeResult> HandleRequestAsync(InitializeParams request, RazorRequestContext requestContext, CancellationToken cancellationToken)
@@ -20,6 +26,12 @@ internal class RazorInitializeEndpoint : IRazorDocumentlessRequestHandler<Initia
 
         capabilitiesManager.SetInitializeParams(request);
         var serverCapabilities = capabilitiesManager.GetInitializeResult();
+
+        var telemetryReporter = requestContext.GetRequiredService<ITelemetryReporter>();
+
+        telemetryReporter.ReportEvent("initialize", Severity.Normal, new
+            Property(nameof(LanguageServerFeatureOptions.ForceRuntimeCodeGeneration), _languageServerFeatureOptions.ForceRuntimeCodeGeneration)
+            );
 
         return Task.FromResult(serverCapabilities);
     }


### PR DESCRIPTION
Adds a single telemetry point so that we if we receive feedback that something unusual behavior occurs, we can determine if Fuse was engaged or not engaged.
