### PR TITLE
Introduce/expand several extension methods for ImmutableArray<T>, IReadOnlyList<T>, and IEnumerable<T>

### DIFF
--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/EnumerableExtensionsTests.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/EnumerableExtensionsTests.cs
@@ -1,0 +1,143 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+using Xunit;
+using SR = Microsoft.AspNetCore.Razor.Utilities.Shared.Resources.SR;
+
+namespace Microsoft.AspNetCore.Razor.Utilities.Shared.Test;
+
+public class EnumerableExtensionsTests
+{
+    [Fact]
+    public void CopyTo_ImmutableArray()
+    {
+        Span<int> source = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        var immutableArray = ImmutableArray.Create(source);
+
+        AssertCopyToCore(immutableArray, immutableArray.Length);
+    }
+
+    [Fact]
+    public void CopyTo_ImmutableArrayBuilder()
+    {
+        Span<int> source = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        var builder = ImmutableArray.CreateBuilder<int>();
+        builder.AddRange(source);
+
+        AssertCopyToCore(builder, builder.Count);
+    }
+
+    [Fact]
+    public void CopyTo_List()
+    {
+        IEnumerable<int> source = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        var list = new List<int>(source);
+
+        AssertCopyToCore(list, list.Count);
+    }
+
+    [Fact]
+    public void CopyTo_HashSet()
+    {
+        IEnumerable<int> source = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        var set = new HashSet<int>(source);
+
+        AssertCopyToCore(set, set.Count);
+    }
+
+    [Fact]
+    public void CopyTo_Array()
+    {
+        int[] array = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+        AssertCopyToCore(array, array.Length);
+    }
+
+    [Fact]
+    public void CopyTo_CustomEnumerable()
+    {
+        CustomEnumerable custom = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+        AssertCopyToCore(custom, 10);
+    }
+
+    [Fact]
+    public void CopyTo_CustomReadOnlyCollection()
+    {
+        CustomReadOnlyCollection custom = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+        AssertCopyToCore(custom, 10);
+    }
+
+    private static void AssertCopyToCore(IEnumerable<int> sequence, int count)
+    {
+        var destination1 = new int[count - 1];
+        var exception = Assert.Throws<ArgumentException>(() => sequence.CopyTo(destination1.AsSpan()));
+        Assert.StartsWith(SR.Destination_is_too_short, exception.Message);
+
+        Span<int> destination2 = stackalloc int[count];
+        sequence.CopyTo(destination2);
+        AssertElementsEqual(sequence, destination2);
+
+        Span<int> destination3 = stackalloc int[count + 1];
+        sequence.CopyTo(destination3);
+        AssertElementsEqual(sequence, destination3);
+
+        static void AssertElementsEqual<T>(IEnumerable<T> sequence, ReadOnlySpan<T> span)
+        {
+            var index = 0;
+
+            foreach (var item in sequence)
+            {
+                Assert.Equal(item, span[index++]);
+            }
+        }
+    }
+
+    [CollectionBuilder(typeof(CustomEnumerable), "Create")]
+    private sealed class CustomEnumerable(params ReadOnlySpan<int> values) : IEnumerable<int>
+    {
+        private readonly int[] _values = values.ToArray();
+
+        public IEnumerator<int> GetEnumerator()
+        {
+            foreach (var value in _values)
+            {
+                yield return value;
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+            => GetEnumerator();
+
+        public static CustomEnumerable Create(ReadOnlySpan<int> span)
+            => new(span);
+    }
+
+    [CollectionBuilder(typeof(CustomReadOnlyCollection), "Create")]
+    private sealed class CustomReadOnlyCollection(params ReadOnlySpan<int> values) : IReadOnlyCollection<int>
+    {
+        private readonly int[] _values = values.ToArray();
+
+        public int Count => _values.Length;
+
+        public IEnumerator<int> GetEnumerator()
+        {
+            foreach (var value in _values)
+            {
+                yield return value;
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+            => GetEnumerator();
+
+        public static CustomReadOnlyCollection Create(ReadOnlySpan<int> span)
+            => new(span);
+    }
+}

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/EnumerableExtensionsTests.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/EnumerableExtensionsTests.cs
@@ -140,4 +140,162 @@ public class EnumerableExtensionsTests
         public static CustomReadOnlyCollection Create(ReadOnlySpan<int> span)
             => new(span);
     }
+
+    private static Comparison<int> OddBeforeEven
+        => (x, y) => (x % 2 != 0, y % 2 != 0) switch
+        {
+            (true, false) => -1,
+            (false, true) => 1,
+            _ => x.CompareTo(y)
+        };
+
+    public readonly record struct ValueHolder(int Value)
+    {
+        public static implicit operator ValueHolder(int value)
+            => new(value);
+    }
+
+    public static TheoryData<IEnumerable<int>, ImmutableArray<int>> OrderTestData
+        => new()
+        {
+            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+        };
+
+    public static TheoryData<IEnumerable<int>, ImmutableArray<int>> OrderTestData_OddBeforeEven
+        => new()
+        {
+            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+        };
+
+    public static TheoryData<IEnumerable<int>, ImmutableArray<int>> OrderDescendingTestData
+        => new()
+        {
+            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+        };
+
+    public static TheoryData<IEnumerable<int>, ImmutableArray<int>> OrderDescendingTestData_OddBeforeEven
+        => new()
+        {
+            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+        };
+
+    public static TheoryData<IEnumerable<ValueHolder>, ImmutableArray<ValueHolder>> OrderByTestData
+        => new()
+        {
+            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+        };
+
+    public static TheoryData<IEnumerable<ValueHolder>, ImmutableArray<ValueHolder>> OrderByTestData_OddBeforeEven
+        => new()
+        {
+            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+        };
+
+    public static TheoryData<IEnumerable<ValueHolder>, ImmutableArray<ValueHolder>> OrderByDescendingTestData
+        => new()
+        {
+            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+        };
+
+    public static TheoryData<IEnumerable<ValueHolder>, ImmutableArray<ValueHolder>> OrderByDescendingTestData_OddBeforeEven
+        => new()
+        {
+            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+        };
+
+    [Theory]
+    [MemberData(nameof(OrderTestData))]
+    public void OrderAsArray(IEnumerable<int> data, ImmutableArray<int> expected)
+    {
+        var sorted = data.OrderAsArray();
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderTestData_OddBeforeEven))]
+    public void OrderAsArray_OddBeforeEven(IEnumerable<int> data, ImmutableArray<int> expected)
+    {
+        var sorted = data.OrderAsArray(OddBeforeEven);
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderDescendingTestData))]
+    public void OrderDescendingAsArray(IEnumerable<int> data, ImmutableArray<int> expected)
+    {
+        var sorted = data.OrderDescendingAsArray();
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderDescendingTestData_OddBeforeEven))]
+    public void OrderDescendingAsArray_OddBeforeEven(IEnumerable<int> data, ImmutableArray<int> expected)
+    {
+        var sorted = data.OrderDescendingAsArray(OddBeforeEven);
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByTestData))]
+    public void OrderByAsArray(IEnumerable<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var sorted = data.OrderByAsArray(static x => x.Value);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByTestData_OddBeforeEven))]
+    public void OrderByAsArray_OddBeforeEven(IEnumerable<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var sorted = data.OrderByAsArray(static x => x.Value, OddBeforeEven);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByDescendingTestData))]
+    public void OrderByDescendingAsArray(IEnumerable<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var sorted = data.OrderByDescendingAsArray(static x => x.Value);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByDescendingTestData_OddBeforeEven))]
+    public void OrderByDescendingAsArray_OddBeforeEven(IEnumerable<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var sorted = data.OrderByDescendingAsArray(static x => x.Value, OddBeforeEven);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/HashSetExtensionsTests.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/HashSetExtensionsTests.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System;
+using Xunit;
+using SR = Microsoft.AspNetCore.Razor.Utilities.Shared.Resources.SR;
+
+namespace Microsoft.AspNetCore.Razor.Utilities.Shared.Test;
+
+public class HashSetExtensionsTests
+{
+    [Fact]
+    public void CopyTo()
+    {
+        IEnumerable<int> source = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        var set = new HashSet<int>(source);
+
+        var destination1 = new int[set.Count - 1];
+        var exception = Assert.Throws<ArgumentException>(() => set.CopyTo(destination1.AsSpan()));
+        Assert.StartsWith(SR.Destination_is_too_short, exception.Message);
+
+        Span<int> destination2 = stackalloc int[set.Count];
+        set.CopyTo(destination2);
+        AssertElementsEqual(set, destination2);
+
+        Span<int> destination3 = stackalloc int[set.Count + 1];
+        set.CopyTo(destination3);
+        AssertElementsEqual(set, destination3);
+
+        static void AssertElementsEqual<T>(HashSet<T> set, ReadOnlySpan<T> span)
+        {
+            var index = 0;
+
+            foreach (var item in set)
+            {
+                Assert.Equal(item, span[index++]);
+            }
+        }
+    }
+}

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ImmutableArrayExtensionsTests.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ImmutableArrayExtensionsTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Runtime.InteropServices;
 using Xunit;
@@ -174,7 +175,7 @@ public class ImmutableArrayExtensionsTests
 
     [Theory]
     [MemberData(nameof(OrderByTestData_OddBeforeEven))]
-    public void OrderByAsArray_OddBeforeEvent(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    public void OrderByAsArray_OddBeforeEven(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
     {
         var sorted = data.OrderByAsArray(static x => x.Value, OddBeforeEven);
         Assert.Equal<ValueHolder>(expected, sorted);
@@ -193,6 +194,150 @@ public class ImmutableArrayExtensionsTests
     public void OrderByDescendingAsArray_OddBeforeEven(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
     {
         var sorted = data.OrderByDescendingAsArray(static x => x.Value, OddBeforeEven);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderTestData))]
+    public void OrderAsArray_ReadOnlyList(ImmutableArray<int> data, ImmutableArray<int> expected)
+    {
+        var readOnlyList = (IReadOnlyList<int>)data;
+        var sorted = readOnlyList.OrderAsArray();
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderTestData_OddBeforeEven))]
+    public void OrderAsArray_ReadOnlyList_OddBeforeEven(ImmutableArray<int> data, ImmutableArray<int> expected)
+    {
+        var readOnlyList = (IReadOnlyList<int>)data;
+        var sorted = readOnlyList.OrderAsArray(OddBeforeEven);
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderDescendingTestData))]
+    public void OrderDescendingAsArray_ReadOnlyList(ImmutableArray<int> data, ImmutableArray<int> expected)
+    {
+        var readOnlyList = (IReadOnlyList<int>)data;
+        var sorted = readOnlyList.OrderDescendingAsArray();
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderDescendingTestData_OddBeforeEven))]
+    public void OrderDescendingAsArray_ReadOnlyList_OddBeforeEven(ImmutableArray<int> data, ImmutableArray<int> expected)
+    {
+        var readOnlyList = (IReadOnlyList<int>)data;
+        var sorted = readOnlyList.OrderDescendingAsArray(OddBeforeEven);
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByTestData))]
+    public void OrderByAsArray_ReadOnlyList(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var readOnlyList = (IReadOnlyList<ValueHolder>)data;
+        var sorted = readOnlyList.OrderByAsArray(static x => x.Value);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByTestData_OddBeforeEven))]
+    public void OrderByAsArray_ReadOnlyList_OddBeforeEven(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var readOnlyList = (IReadOnlyList<ValueHolder>)data;
+        var sorted = readOnlyList.OrderByAsArray(static x => x.Value, OddBeforeEven);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByDescendingTestData))]
+    public void OrderByDescendingAsArray_ReadOnlyList(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var readOnlyList = (IReadOnlyList<ValueHolder>)data;
+        var sorted = readOnlyList.OrderByDescendingAsArray(static x => x.Value);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByDescendingTestData_OddBeforeEven))]
+    public void OrderByDescendingAsArray_ReadOnlyList_OddBeforeEven(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var readOnlyList = (IReadOnlyList<ValueHolder>)data;
+        var sorted = readOnlyList.OrderByDescendingAsArray(static x => x.Value, OddBeforeEven);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderTestData))]
+    public void OrderAsArray_Enumerable(ImmutableArray<int> data, ImmutableArray<int> expected)
+    {
+        var enumerable = (IEnumerable<int>)data;
+        var sorted = enumerable.OrderAsArray();
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderTestData_OddBeforeEven))]
+    public void OrderAsArray_Enumerable_OddBeforeEven(ImmutableArray<int> data, ImmutableArray<int> expected)
+    {
+        var enumerable = (IEnumerable<int>)data;
+        var sorted = enumerable.OrderAsArray(OddBeforeEven);
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderDescendingTestData))]
+    public void OrderDescendingAsArray_Enumerable(ImmutableArray<int> data, ImmutableArray<int> expected)
+    {
+        var enumerable = (IEnumerable<int>)data;
+        var sorted = enumerable.OrderDescendingAsArray();
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderDescendingTestData_OddBeforeEven))]
+    public void OrderDescendingAsArray_Enumerable_OddBeforeEven(ImmutableArray<int> data, ImmutableArray<int> expected)
+    {
+        var enumerable = (IEnumerable<int>)data;
+        var sorted = enumerable.OrderDescendingAsArray(OddBeforeEven);
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByTestData))]
+    public void OrderByAsArray_Enumerable(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var enumerable = (IEnumerable<ValueHolder>)data;
+        var sorted = enumerable.OrderByAsArray(static x => x.Value);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByTestData_OddBeforeEven))]
+    public void OrderByAsArray_Enumerable_OddBeforeEven(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var enumerable = (IEnumerable<ValueHolder>)data;
+        var sorted = enumerable.OrderByAsArray(static x => x.Value, OddBeforeEven);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByDescendingTestData))]
+    public void OrderByDescendingAsArray_Enumerable(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var enumerable = (IEnumerable<ValueHolder>)data;
+        var sorted = enumerable.OrderByDescendingAsArray(static x => x.Value);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByDescendingTestData_OddBeforeEven))]
+    public void OrderByDescendingAsArray_Enumerable_OddBeforeEven(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var enumerable = (IEnumerable<ValueHolder>)data;
+        var sorted = enumerable.OrderByDescendingAsArray(static x => x.Value, OddBeforeEven);
         Assert.Equal<ValueHolder>(expected, sorted);
     }
 

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ImmutableArrayExtensionsTests.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ImmutableArrayExtensionsTests.cs
@@ -341,6 +341,78 @@ public class ImmutableArrayExtensionsTests
         Assert.Equal<ValueHolder>(expected, sorted);
     }
 
+    [Theory]
+    [MemberData(nameof(OrderTestData))]
+    public void ToImmutableOrdered(ImmutableArray<int> data, ImmutableArray<int> expected)
+    {
+        var builder = data.ToBuilder();
+        var sorted = builder.ToImmutableOrdered();
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderTestData_OddBeforeEven))]
+    public void ToImmutableOrdered_OddBeforeEven(ImmutableArray<int> data, ImmutableArray<int> expected)
+    {
+        var builder = data.ToBuilder();
+        var sorted = builder.ToImmutableOrdered(OddBeforeEven);
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderDescendingTestData))]
+    public void ToImmutableOrderedDescending(ImmutableArray<int> data, ImmutableArray<int> expected)
+    {
+        var builder = data.ToBuilder();
+        var sorted = builder.ToImmutableOrderedDescending();
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderDescendingTestData_OddBeforeEven))]
+    public void ToImmutableOrderedDescending_OddBeforeEven(ImmutableArray<int> data, ImmutableArray<int> expected)
+    {
+        var builder = data.ToBuilder();
+        var sorted = builder.ToImmutableOrderedDescending(OddBeforeEven);
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByTestData))]
+    public void ToImmutableOrderedBy(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var builder = data.ToBuilder();
+        var sorted = builder.ToImmutableOrderedBy(static x => x.Value);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByTestData_OddBeforeEven))]
+    public void ToImmutableOrderedBy_OddBeforeEven(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var builder = data.ToBuilder();
+        var sorted = builder.ToImmutableOrderedBy(static x => x.Value, OddBeforeEven);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByDescendingTestData))]
+    public void ToImmutableOrderedByDescending(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var builder = data.ToBuilder();
+        var sorted = builder.ToImmutableOrderedByDescending(static x => x.Value);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByDescendingTestData_OddBeforeEven))]
+    public void ToImmutableOrderedByDescending_OddBeforeEven(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var builder = data.ToBuilder();
+        var sorted = builder.ToImmutableOrderedByDescending(static x => x.Value, OddBeforeEven);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
+
     [Fact]
     public void OrderAsArray_EmptyArrayReturnsSameArray()
     {

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ImmutableArrayExtensionsTests.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ImmutableArrayExtensionsTests.cs
@@ -46,85 +46,13 @@ public class ImmutableArrayExtensionsTests
             _ => x.CompareTo(y)
         };
 
-    public static TheoryData<ImmutableArray<int>, ImmutableArray<int>> OrderAsArrayData
-        => new()
-        {
-            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
-            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
-            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
-            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
-            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
-        };
-
-    [Theory]
-    [MemberData(nameof(OrderAsArrayData))]
-    public void OrderAsArray(ImmutableArray<int> data, ImmutableArray<int> expected)
-    {
-        var sorted = data.OrderAsArray();
-        Assert.Equal<int>(expected, sorted);
-    }
-
-    public static TheoryData<ImmutableArray<int>, ImmutableArray<int>> OrderAsArray_OddBeforeEvenData
-        => new()
-        {
-            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
-            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
-            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
-            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
-            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
-        };
-
-    [Theory]
-    [MemberData(nameof(OrderAsArray_OddBeforeEvenData))]
-    public void OrderAsArray_OddBeforeEven(ImmutableArray<int> data, ImmutableArray<int> expected)
-    {
-        var sorted = data.OrderAsArray(OddBeforeEven);
-        Assert.Equal<int>(expected, sorted);
-    }
-
-    public static TheoryData<ImmutableArray<int>, ImmutableArray<int>> OrderDescendingAsArrayData
-        => new()
-        {
-            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
-            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
-            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
-            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
-            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
-        };
-
-    [Theory]
-    [MemberData(nameof(OrderAsArrayData))]
-    public void OrderDescendingAsArray(ImmutableArray<int> data, ImmutableArray<int> expected)
-    {
-        var sorted = data.OrderAsArray();
-        Assert.Equal<int>(expected, sorted);
-    }
-
-    public static TheoryData<ImmutableArray<int>, ImmutableArray<int>> OrderDescendingAsArray_OddBeforeEvenData
-        => new()
-        {
-            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
-            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
-            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
-            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
-            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
-        };
-
-    [Theory]
-    [MemberData(nameof(OrderDescendingAsArray_OddBeforeEvenData))]
-    public void OrderDescendingAsArray_OddBeforeEven(ImmutableArray<int> data, ImmutableArray<int> expected)
-    {
-        var sorted = data.OrderDescendingAsArray(OddBeforeEven);
-        Assert.Equal<int>(expected, sorted);
-    }
-
     public readonly record struct ValueHolder(int Value)
     {
         public static implicit operator ValueHolder(int value)
             => new(value);
     }
 
-    public static TheoryData<ImmutableArray<ValueHolder>, ImmutableArray<ValueHolder>> OrderByAsArrayData
+    public static TheoryData<ImmutableArray<int>, ImmutableArray<int>> OrderTestData
         => new()
         {
             { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
@@ -134,15 +62,7 @@ public class ImmutableArrayExtensionsTests
             { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
         };
 
-    [Theory]
-    [MemberData(nameof(OrderByAsArrayData))]
-    public void OrderByAsArray(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
-    {
-        var sorted = data.OrderByAsArray(static x => x.Value);
-        Assert.Equal<ValueHolder>(expected, sorted);
-    }
-
-    public static TheoryData<ImmutableArray<ValueHolder>, ImmutableArray<ValueHolder>> OrderByAsArray_OddBeforeEvenData
+    public static TheoryData<ImmutableArray<int>, ImmutableArray<int>> OrderTestData_OddBeforeEven
         => new()
         {
             { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
@@ -152,15 +72,7 @@ public class ImmutableArrayExtensionsTests
             { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
         };
 
-    [Theory]
-    [MemberData(nameof(OrderByAsArray_OddBeforeEvenData))]
-    public void OrderByAsArray_OddBeforeEvent(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
-    {
-        var sorted = data.OrderByAsArray(static x => x.Value, OddBeforeEven);
-        Assert.Equal<ValueHolder>(expected, sorted);
-    }
-
-    public static TheoryData<ImmutableArray<ValueHolder>, ImmutableArray<ValueHolder>> OrderByDescendingAsArrayData
+    public static TheoryData<ImmutableArray<int>, ImmutableArray<int>> OrderDescendingTestData
         => new()
         {
             { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
@@ -170,15 +82,47 @@ public class ImmutableArrayExtensionsTests
             { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
         };
 
-    [Theory]
-    [MemberData(nameof(OrderByDescendingAsArrayData))]
-    public void OrderByDescendingAsArray(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
-    {
-        var sorted = data.OrderByDescendingAsArray(static x => x.Value);
-        Assert.Equal<ValueHolder>(expected, sorted);
-    }
+    public static TheoryData<ImmutableArray<int>, ImmutableArray<int>> OrderDescendingTestData_OddBeforeEven
+        => new()
+        {
+            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+        };
 
-    public static TheoryData<ImmutableArray<ValueHolder>, ImmutableArray<ValueHolder>> OrderByDescendingAsArray_OddBeforeEvenData
+    public static TheoryData<ImmutableArray<ValueHolder>, ImmutableArray<ValueHolder>> OrderByTestData
+        => new()
+        {
+            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+        };
+
+    public static TheoryData<ImmutableArray<ValueHolder>, ImmutableArray<ValueHolder>> OrderByTestData_OddBeforeEven
+        => new()
+        {
+            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+        };
+
+    public static TheoryData<ImmutableArray<ValueHolder>, ImmutableArray<ValueHolder>> OrderByDescendingTestData
+        => new()
+        {
+            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+        };
+
+    public static TheoryData<ImmutableArray<ValueHolder>, ImmutableArray<ValueHolder>> OrderByDescendingTestData_OddBeforeEven
         => new()
         {
             { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
@@ -189,7 +133,63 @@ public class ImmutableArrayExtensionsTests
         };
 
     [Theory]
-    [MemberData(nameof(OrderByDescendingAsArray_OddBeforeEvenData))]
+    [MemberData(nameof(OrderTestData))]
+    public void OrderAsArray(ImmutableArray<int> data, ImmutableArray<int> expected)
+    {
+        var sorted = data.OrderAsArray();
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderTestData_OddBeforeEven))]
+    public void OrderAsArray_OddBeforeEven(ImmutableArray<int> data, ImmutableArray<int> expected)
+    {
+        var sorted = data.OrderAsArray(OddBeforeEven);
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderDescendingTestData))]
+    public void OrderDescendingAsArray(ImmutableArray<int> data, ImmutableArray<int> expected)
+    {
+        var sorted = data.OrderDescendingAsArray();
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderDescendingTestData_OddBeforeEven))]
+    public void OrderDescendingAsArray_OddBeforeEven(ImmutableArray<int> data, ImmutableArray<int> expected)
+    {
+        var sorted = data.OrderDescendingAsArray(OddBeforeEven);
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByTestData))]
+    public void OrderByAsArray(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var sorted = data.OrderByAsArray(static x => x.Value);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByTestData_OddBeforeEven))]
+    public void OrderByAsArray_OddBeforeEvent(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var sorted = data.OrderByAsArray(static x => x.Value, OddBeforeEven);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByDescendingTestData))]
+    public void OrderByDescendingAsArray(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var sorted = data.OrderByDescendingAsArray(static x => x.Value);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByDescendingTestData_OddBeforeEven))]
     public void OrderByDescendingAsArray_OddBeforeEven(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
     {
         var sorted = data.OrderByDescendingAsArray(static x => x.Value, OddBeforeEven);
@@ -314,5 +314,85 @@ public class ImmutableArrayExtensionsTests
 
         presortedArray = presortedArray.OrderByDescendingAsArray(static x => x.Value);
         Assert.Same(values, ImmutableCollectionsMarshal.AsArray(presortedArray));
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderTestData))]
+    public void UnsafeOrder(ImmutableArray<int> data, ImmutableArray<int> expected)
+    {
+        // Clone array, since we're modifying it in-place.
+        var sorted = ImmutableArray.Create(data.AsSpan());
+        sorted.Unsafe().Order();
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderTestData_OddBeforeEven))]
+    public void UnsafeOrder_OddBeforeEven(ImmutableArray<int> data, ImmutableArray<int> expected)
+    {
+        // Clone array, since we're modifying it in-place.
+        var sorted = ImmutableArray.Create(data.AsSpan());
+        sorted.Unsafe().Order(OddBeforeEven);
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderDescendingTestData))]
+    public void UnsafeOrderDescending(ImmutableArray<int> data, ImmutableArray<int> expected)
+    {
+        // Clone array, since we're modifying it in-place.
+        var sorted = ImmutableArray.Create(data.AsSpan());
+        sorted.Unsafe().OrderDescending();
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderDescendingTestData_OddBeforeEven))]
+    public void UnsafeOrderDescending_OddBeforeEven(ImmutableArray<int> data, ImmutableArray<int> expected)
+    {
+        // Clone array, since we're modifying it in-place.
+        var sorted = ImmutableArray.Create(data.AsSpan());
+        sorted.Unsafe().OrderDescending(OddBeforeEven);
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByTestData))]
+    public void UnsafeOrderBy(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        // Clone array, since we're modifying it in-place.
+        var sorted = ImmutableArray.Create(data.AsSpan());
+        sorted.Unsafe().OrderBy(static x => x.Value);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByTestData_OddBeforeEven))]
+    public void UnsafeOrderBy_OddBeforeEven(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        // Clone array, since we're modifying it in-place.
+        var sorted = ImmutableArray.Create(data.AsSpan());
+        sorted.Unsafe().OrderBy(static x => x.Value, OddBeforeEven);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByDescendingTestData))]
+    public void UnsafeOrderByDescending(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        // Clone array, since we're modifying it in-place.
+        var sorted = ImmutableArray.Create(data.AsSpan());
+        sorted.Unsafe().OrderByDescending(static x => x.Value);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByDescendingTestData_OddBeforeEven))]
+    public void UnsafeOrderByDescending_OddBeforeEven(ImmutableArray<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        // Clone array, since we're modifying it in-place.
+        var sorted = ImmutableArray.Create(data.AsSpan());
+        sorted.Unsafe().OrderByDescending(static x => x.Value, OddBeforeEven);
+        Assert.Equal<ValueHolder>(expected, sorted);
     }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ListExtensionsTests.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ListExtensionsTests.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+using SR = Microsoft.AspNetCore.Razor.Utilities.Shared.Resources.SR;
+
+namespace Microsoft.AspNetCore.Razor.Utilities.Shared.Test;
+
+public class ListExtensionsTests
+{
+    [Fact]
+    public void CopyTo()
+    {
+        IEnumerable<int> source = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        var list = new List<int>(source);
+
+        var destination1 = new int[list.Count - 1];
+        var exception = Assert.Throws<ArgumentException>(() => list.CopyTo(destination1.AsSpan()));
+        Assert.StartsWith(SR.Destination_is_too_short, exception.Message);
+
+        Span<int> destination2 = stackalloc int[list.Count];
+        list.CopyTo(destination2);
+        AssertElementsEqual(list, destination2);
+
+        Span<int> destination3 = stackalloc int[list.Count + 1];
+        list.CopyTo(destination3);
+        AssertElementsEqual(list, destination3);
+
+        static void AssertElementsEqual<T>(List<T> list, ReadOnlySpan<T> span)
+        {
+            var count = list.Count;
+            for (var i = 0; i < count; i++)
+            {
+                Assert.Equal(list[i], span[i]);
+            }
+        }
+    }
+}

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ReadOnlyListExtensionsTests.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ReadOnlyListExtensionsTests.cs
@@ -435,4 +435,76 @@ public class ReadOnlyListExtensionsTest
         var sorted = data.OrderByDescendingAsArray(static x => x.Value, OddBeforeEven);
         Assert.Equal<ValueHolder>(expected, sorted);
     }
+
+    [Theory]
+    [MemberData(nameof(OrderTestData))]
+    public void OrderAsArray_Enumerable(IReadOnlyList<int> data, ImmutableArray<int> expected)
+    {
+        var enumerable = (IEnumerable<int>)data;
+        var sorted = enumerable.OrderAsArray();
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderTestData_OddBeforeEven))]
+    public void OrderAsArray_Enumerable_OddBeforeEven(IReadOnlyList<int> data, ImmutableArray<int> expected)
+    {
+        var enumerable = (IEnumerable<int>)data;
+        var sorted = enumerable.OrderAsArray(OddBeforeEven);
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderDescendingTestData))]
+    public void OrderDescendingAsArray_Enumerable(IReadOnlyList<int> data, ImmutableArray<int> expected)
+    {
+        var enumerable = (IEnumerable<int>)data;
+        var sorted = enumerable.OrderDescendingAsArray();
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderDescendingTestData_OddBeforeEven))]
+    public void OrderDescendingAsArray_Enumerable_OddBeforeEven(IReadOnlyList<int> data, ImmutableArray<int> expected)
+    {
+        var enumerable = (IEnumerable<int>)data;
+        var sorted = enumerable.OrderDescendingAsArray(OddBeforeEven);
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByTestData))]
+    public void OrderByAsArray_Enumerable(IReadOnlyList<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var enumerable = (IEnumerable<ValueHolder>)data;
+        var sorted = enumerable.OrderByAsArray(static x => x.Value);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByTestData_OddBeforeEven))]
+    public void OrderByAsArray_Enumerable_OddBeforeEven(IReadOnlyList<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var enumerable = (IEnumerable<ValueHolder>)data;
+        var sorted = enumerable.OrderByAsArray(static x => x.Value, OddBeforeEven);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByDescendingTestData))]
+    public void OrderByDescendingAsArray_Enumerable(IReadOnlyList<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var enumerable = (IEnumerable<ValueHolder>)data;
+        var sorted = enumerable.OrderByDescendingAsArray(static x => x.Value);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByDescendingTestData_OddBeforeEven))]
+    public void OrderByDescendingAsArray_Enumerable_OddBeforeEven(IReadOnlyList<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var enumerable = (IEnumerable<ValueHolder>)data;
+        var sorted = enumerable.OrderByDescendingAsArray(static x => x.Value, OddBeforeEven);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ReadOnlyListExtensionsTests.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ReadOnlyListExtensionsTests.cs
@@ -277,4 +277,162 @@ public class ReadOnlyListExtensionsTest
         public static CustomReadOnlyList Create(ReadOnlySpan<int> span)
             => new(span);
     }
+
+    private static Comparison<int> OddBeforeEven
+        => (x, y) => (x % 2 != 0, y % 2 != 0) switch
+        {
+            (true, false) => -1,
+            (false, true) => 1,
+            _ => x.CompareTo(y)
+        };
+
+    public readonly record struct ValueHolder(int Value)
+    {
+        public static implicit operator ValueHolder(int value)
+            => new(value);
+    }
+
+    public static TheoryData<IReadOnlyList<int>, ImmutableArray<int>> OrderTestData
+        => new()
+        {
+            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+        };
+
+    public static TheoryData<IReadOnlyList<int>, ImmutableArray<int>> OrderTestData_OddBeforeEven
+        => new()
+        {
+            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+        };
+
+    public static TheoryData<IReadOnlyList<int>, ImmutableArray<int>> OrderDescendingTestData
+        => new()
+        {
+            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+        };
+
+    public static TheoryData<IReadOnlyList<int>, ImmutableArray<int>> OrderDescendingTestData_OddBeforeEven
+        => new()
+        {
+            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+        };
+
+    public static TheoryData<IReadOnlyList<ValueHolder>, ImmutableArray<ValueHolder>> OrderByTestData
+        => new()
+        {
+            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] },
+        };
+
+    public static TheoryData<IReadOnlyList<ValueHolder>, ImmutableArray<ValueHolder>> OrderByTestData_OddBeforeEven
+        => new()
+        {
+            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [1, 3, 5, 7, 9, 2, 4, 6, 8, 10] },
+        };
+
+    public static TheoryData<IReadOnlyList<ValueHolder>, ImmutableArray<ValueHolder>> OrderByDescendingTestData
+        => new()
+        {
+            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [10, 9, 8, 7, 6, 5, 4, 3, 2, 1] },
+        };
+
+    public static TheoryData<IReadOnlyList<ValueHolder>, ImmutableArray<ValueHolder>> OrderByDescendingTestData_OddBeforeEven
+        => new()
+        {
+            { [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+            { [10, 9, 8, 7, 6, 5, 4, 3, 2, 1], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+            { [1, 3, 5, 7, 9, 2, 4, 6, 8, 10], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+            { [2, 5, 8, 1, 3, 9, 7, 4, 10, 6], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+            { [6, 10, 4, 7, 9, 3, 1, 8, 5, 2], [10, 8, 6, 4, 2, 9, 7, 5, 3, 1] },
+        };
+
+    [Theory]
+    [MemberData(nameof(OrderTestData))]
+    public void OrderAsArray(IReadOnlyList<int> data, ImmutableArray<int> expected)
+    {
+        var sorted = data.OrderAsArray();
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderTestData_OddBeforeEven))]
+    public void OrderAsArray_OddBeforeEven(IReadOnlyList<int> data, ImmutableArray<int> expected)
+    {
+        var sorted = data.OrderAsArray(OddBeforeEven);
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderDescendingTestData))]
+    public void OrderDescendingAsArray(IReadOnlyList<int> data, ImmutableArray<int> expected)
+    {
+        var sorted = data.OrderDescendingAsArray();
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderDescendingTestData_OddBeforeEven))]
+    public void OrderDescendingAsArray_OddBeforeEven(IReadOnlyList<int> data, ImmutableArray<int> expected)
+    {
+        var sorted = data.OrderDescendingAsArray(OddBeforeEven);
+        Assert.Equal<int>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByTestData))]
+    public void OrderByAsArray(IReadOnlyList<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var sorted = data.OrderByAsArray(static x => x.Value);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByTestData_OddBeforeEven))]
+    public void OrderByAsArray_OddBeforeEven(IReadOnlyList<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var sorted = data.OrderByAsArray(static x => x.Value, OddBeforeEven);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByDescendingTestData))]
+    public void OrderByDescendingAsArray(IReadOnlyList<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var sorted = data.OrderByDescendingAsArray(static x => x.Value);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(OrderByDescendingTestData_OddBeforeEven))]
+    public void OrderByDescendingAsArray_OddBeforeEven(IReadOnlyList<ValueHolder> data, ImmutableArray<ValueHolder> expected)
+    {
+        var sorted = data.OrderByDescendingAsArray(static x => x.Value, OddBeforeEven);
+        Assert.Equal<ValueHolder>(expected, sorted);
+    }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ArgHelper.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ArgHelper.cs
@@ -176,4 +176,13 @@ internal static class ArgHelper
         }
 #endif
     }
+
+    public static void ThrowIfDestinationTooShort<T>(
+        Span<T> destination, int expectedLength, [CallerArgumentExpression(nameof(destination))] string? paramName = null)
+    {
+        if (destination.Length < expectedLength)
+        {
+            ThrowHelper.ThrowArgumentException(paramName, SR.Destination_is_too_short);
+        }
+    }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/BufferExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/BufferExtensions.cs
@@ -16,6 +16,41 @@ internal static class BufferExtensions
     /// <param name="minimumLength">
     ///  The minimum length of the array.
     /// </param>
+    /// <remarks>
+    ///  The array is guaranteed to be at least <paramref name="minimumLength"/> in length. However,
+    ///  it will likely be larger.
+    /// </remarks>
+    public static PooledArray<T> GetPooledArray<T>(this ArrayPool<T> pool, int minimumLength)
+        => pool.GetPooledArray(minimumLength, clearOnReturn: false);
+
+    /// <summary>
+    ///  Rents an array of the given minimum length from the specified <see cref="ArrayPool{T}"/>.
+    /// </summary>
+    /// <param name="pool">
+    ///  The <see cref="ArrayPool{T}"/> to use.
+    /// </param>
+    /// <param name="minimumLength">
+    ///  The minimum length of the array.
+    /// </param>
+    /// <param name="clearOnReturn">
+    ///  Indicates whether the contents of the array should be cleared before it is returned to the pool.
+    /// </param>
+    /// <remarks>
+    ///  The array is guaranteed to be at least <paramref name="minimumLength"/> in length. However,
+    ///  it will likely be larger.
+    /// </remarks>
+    public static PooledArray<T> GetPooledArray<T>(this ArrayPool<T> pool, int minimumLength, bool clearOnReturn)
+        => new(pool, minimumLength, clearOnReturn);
+
+    /// <summary>
+    ///  Rents an array of the given minimum length from the specified <see cref="ArrayPool{T}"/>.
+    /// </summary>
+    /// <param name="pool">
+    ///  The <see cref="ArrayPool{T}"/> to use.
+    /// </param>
+    /// <param name="minimumLength">
+    ///  The minimum length of the array.
+    /// </param>
     /// <param name="array">
     ///  The rented array.
     /// </param>
@@ -47,7 +82,7 @@ internal static class BufferExtensions
     /// </remarks>
     public static PooledArray<T> GetPooledArray<T>(this ArrayPool<T> pool, int minimumLength, bool clearOnReturn, out T[] array)
     {
-        var result = new PooledArray<T>(pool, minimumLength, clearOnReturn);
+        var result = pool.GetPooledArray(minimumLength, clearOnReturn);
         array = result.Array;
         return result;
     }
@@ -88,7 +123,7 @@ internal static class BufferExtensions
     /// </param>
     public static PooledArray<T> GetPooledArraySpan<T>(this ArrayPool<T> pool, int minimumLength, bool clearOnReturn, out Span<T> span)
     {
-        var result = new PooledArray<T>(pool, minimumLength, clearOnReturn);
+        var result = pool.GetPooledArray(minimumLength, clearOnReturn);
         span = result.Span;
         return result;
     }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/HashSetExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/HashSetExtensions.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using Microsoft.AspNetCore.Razor;
 
 namespace System.Collections.Generic;
 
@@ -21,6 +22,31 @@ internal static class HashSetExtensions
         foreach (var item in array)
         {
             set.Add(item);
+        }
+    }
+
+    /// <summary>
+    ///  Copies the contents of the set to a destination <see cref="Span{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of elements in the set.</typeparam>
+    /// <param name="set">The set to copy items from.</param>
+    /// <param name="destination">The span to copy items into.</param>
+    /// <exception cref="ArgumentNullException">
+    ///  The <paramref name="set"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    ///  The destination span is shorter than the source set.
+    /// </exception>
+    public static void CopyTo<T>(this HashSet<T> set, Span<T> destination)
+    {
+        ArgHelper.ThrowIfNull(set);
+        ArgHelper.ThrowIfDestinationTooShort(destination, set.Count);
+
+        var index = 0;
+
+        foreach (var item in set)
+        {
+            destination[index++] = item;
         }
     }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
@@ -11,7 +11,7 @@ namespace System.Collections.Immutable;
 /// <summary>
 /// <see cref="ImmutableArray{T}"/> extension methods
 /// </summary>
-internal static class ImmutableArrayExtensions
+internal static partial class ImmutableArrayExtensions
 {
     /// <summary>
     /// Returns an empty array if the input array is null (default)
@@ -403,9 +403,9 @@ internal static class ImmutableArrayExtensions
             var items = array.AsSpan();
             var length = items.Length;
 
-            using var _ = ArrayPool<TKey>.Shared.GetPooledArray(minimumLength: length, out var keys);
+            using var keys = ArrayPool<TKey>.Shared.GetPooledArray(minimumLength: length);
 
-            if (SelectKeys(items, keySelector, compareHelper, keys.AsSpan(0, length)))
+            if (SelectKeys(items, keySelector, compareHelper, keys.Span))
             {
                 // No need to sort - keys are already ordered.
                 return array;
@@ -416,7 +416,7 @@ internal static class ImmutableArrayExtensions
 
             var comparer = compareHelper.GetOrCreateComparer();
 
-            Array.Sort(keys, newArray, 0, length, comparer);
+            Array.Sort(keys.Array, newArray, 0, length, comparer);
 
             return ImmutableCollectionsMarshal.AsImmutableArray(newArray);
         }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
@@ -376,7 +376,7 @@ internal static partial class ImmutableArrayExtensions
         {
             var items = array.AsSpan();
 
-            if (AreOrdered(items, in compareHelper))
+            if (SortHelper.AreOrdered(items, in compareHelper))
             {
                 // No need to sort - items are already ordered.
                 return array;
@@ -406,7 +406,7 @@ internal static partial class ImmutableArrayExtensions
 
             using var keys = ArrayPool<TKey>.Shared.GetPooledArray(minimumLength: length);
 
-            if (SelectKeys(items, keySelector, in compareHelper, keys.Span))
+            if (SortHelper.SelectKeys(items, keySelector, in compareHelper, keys.Span))
             {
                 // No need to sort - keys are already ordered.
                 return array;
@@ -423,64 +423,5 @@ internal static partial class ImmutableArrayExtensions
         }
 
         return array;
-    }
-
-    /// <summary>
-    ///  Walk through <paramref name="items"/> and determine whether they are already ordered using
-    ///  the provided <see cref="CompareHelper{T}"/>.
-    /// </summary>
-    /// <returns>
-    ///  <see langword="true"/> if the items are in order; otherwise <see langword="false"/>.
-    /// </returns>
-    /// <remarks>
-    ///  When the items are already ordered, there's no need to perform a sort.
-    /// </remarks>
-    private static bool AreOrdered<T>(ReadOnlySpan<T> items, ref readonly CompareHelper<T> compareHelper)
-    {
-        var isOutOfOrder = false;
-
-        for (var i = 1; i < items.Length; i++)
-        {
-            if (!compareHelper.InSortedOrder(items[i], items[i - 1]))
-            {
-                isOutOfOrder = true;
-                break;
-            }
-        }
-
-        return !isOutOfOrder;
-    }
-
-    /// <summary>
-    ///  Walk through <paramref name="items"/> and convert each element to a key using <paramref name="keySelector"/>.
-    ///  While walking, each computed key is compared with the previous one using the provided <see cref="CompareHelper{T}"/>
-    ///  to determine whether they are already ordered.
-    /// </summary>
-    /// <returns>
-    ///  <see langword="true"/> if the keys are in order; otherwise <see langword="false"/>.
-    /// </returns>
-    /// <remarks>
-    ///  When the keys are already ordered, there's no need to perform a sort.
-    /// </remarks>
-    private static bool SelectKeys<TElement, TKey>(
-        ReadOnlySpan<TElement> items, Func<TElement, TKey> keySelector, ref readonly CompareHelper<TKey> compareHelper, Span<TKey> keys)
-    {
-        var isOutOfOrder = false;
-
-        keys[0] = keySelector(items[0]);
-
-        for (var i = 1; i < items.Length; i++)
-        {
-            keys[i] = keySelector(items[i]);
-
-            if (!isOutOfOrder && !compareHelper.InSortedOrder(keys[i], keys[i - 1]))
-            {
-                isOutOfOrder = true;
-
-                // Continue processing to finish converting elements to keys. However, we can stop comparing keys.
-            }
-        }
-
-        return !isOutOfOrder;
     }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
@@ -175,42 +175,104 @@ internal static class ImmutableArrayExtensions
         return ~min;
     }
 
+    /// <summary>
+    ///  Sorts the elements of an <see cref="ImmutableArray{T}"/> in ascending order.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <param name="array">An array to ordered.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in ascending order.
+    /// </returns>
     public static ImmutableArray<T> OrderAsArray<T>(this ImmutableArray<T> array)
     {
         var compareHelper = new CompareHelper<T>(comparer: null, descending: false);
         return array.OrderAsArrayCore(in compareHelper);
     }
 
+    /// <summary>
+    ///  Sorts the elements of an <see cref="ImmutableArray{T}"/> in ascending order.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <param name="array">An array to ordered.</param>
+    /// <param name="comparer">An <see cref="IComparer{T}"/> to compare elements.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in ascending order.
+    /// </returns>
     public static ImmutableArray<T> OrderAsArray<T>(this ImmutableArray<T> array, IComparer<T> comparer)
     {
         var compareHelper = new CompareHelper<T>(comparer, descending: false);
         return array.OrderAsArrayCore(in compareHelper);
     }
 
+    /// <summary>
+    ///  Sorts the elements of an <see cref="ImmutableArray{T}"/> in ascending order.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <param name="array">An array to ordered.</param>
+    /// <param name="comparison">A <see cref="Comparison{T}"/> to compare elements.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in ascending order.
+    /// </returns>
     public static ImmutableArray<T> OrderAsArray<T>(this ImmutableArray<T> array, Comparison<T> comparison)
     {
         var compareHelper = new CompareHelper<T>(comparison, descending: false);
         return array.OrderAsArrayCore(in compareHelper);
     }
 
+    /// <summary>
+    ///  Sorts the elements of an <see cref="ImmutableArray{T}"/> in descending order.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <param name="array">An array to ordered.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in descending order.
+    /// </returns>
     public static ImmutableArray<T> OrderDescendingAsArray<T>(this ImmutableArray<T> array)
     {
         var compareHelper = new CompareHelper<T>(comparer: null, descending: true);
         return array.OrderAsArrayCore(in compareHelper);
     }
 
+    /// <summary>
+    ///  Sorts the elements of an <see cref="ImmutableArray{T}"/> in descending order.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <param name="array">An array to ordered.</param>
+    /// <param name="comparer">An <see cref="IComparer{T}"/> to compare elements.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in descending order.
+    /// </returns>
     public static ImmutableArray<T> OrderDescendingAsArray<T>(this ImmutableArray<T> array, IComparer<T> comparer)
     {
         var compareHelper = new CompareHelper<T>(comparer, descending: true);
         return array.OrderAsArrayCore(in compareHelper);
     }
 
+    /// <summary>
+    ///  Sorts the elements of an <see cref="ImmutableArray{T}"/> in descending order.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <param name="array">An array to ordered.</param>
+    /// <param name="comparison">A <see cref="Comparison{T}"/> to compare elements.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in descending order.
+    /// </returns>
     public static ImmutableArray<T> OrderDescendingAsArray<T>(this ImmutableArray<T> array, Comparison<T> comparison)
     {
         var compareHelper = new CompareHelper<T>(comparison, descending: true);
         return array.OrderAsArrayCore(in compareHelper);
     }
 
+    /// <summary>
+    ///  Sorts the elements of an <see cref="ImmutableArray{T}"/> in ascending order according to a key.
+    /// </summary>
+    /// <typeparam name="TElement">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
+    /// <param name="array">An array to ordered.</param>
+    /// <param name="keySelector">A function to extract a key from an element.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in ascending order according to a key.
+    /// </returns>
     public static ImmutableArray<TElement> OrderByAsArray<TElement, TKey>(
         this ImmutableArray<TElement> array, Func<TElement, TKey> keySelector)
     {
@@ -218,6 +280,17 @@ internal static class ImmutableArrayExtensions
         return array.OrderByAsArrayCore(keySelector, in compareHelper);
     }
 
+    /// <summary>
+    ///  Sorts the elements of an <see cref="ImmutableArray{T}"/> in ascending order according to a key.
+    /// </summary>
+    /// <typeparam name="TElement">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
+    /// <param name="array">An array to ordered.</param>
+    /// <param name="keySelector">A function to extract a key from an element.</param>
+    /// <param name="comparer">An <see cref="IComparer{T}"/> to compare keys.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in ascending order according to a key.
+    /// </returns>
     public static ImmutableArray<TElement> OrderByAsArray<TElement, TKey>(
         this ImmutableArray<TElement> array, Func<TElement, TKey> keySelector, IComparer<TKey> comparer)
     {
@@ -225,6 +298,17 @@ internal static class ImmutableArrayExtensions
         return array.OrderByAsArrayCore(keySelector, in compareHelper);
     }
 
+    /// <summary>
+    ///  Sorts the elements of an <see cref="ImmutableArray{T}"/> in ascending order according to a key.
+    /// </summary>
+    /// <typeparam name="TElement">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
+    /// <param name="array">An array to ordered.</param>
+    /// <param name="keySelector">A function to extract a key from an element.</param>
+    /// <param name="comparison">A <see cref="Comparison{T}"/> to compare keys.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in ascending order according to a key.
+    /// </returns>
     public static ImmutableArray<TElement> OrderByAsArray<TElement, TKey>(
         this ImmutableArray<TElement> array, Func<TElement, TKey> keySelector, Comparison<TKey> comparison)
     {
@@ -232,6 +316,16 @@ internal static class ImmutableArrayExtensions
         return array.OrderByAsArrayCore(keySelector, in compareHelper);
     }
 
+    /// <summary>
+    ///  Sorts the elements of an <see cref="ImmutableArray{T}"/> in descending order according to a key.
+    /// </summary>
+    /// <typeparam name="TElement">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
+    /// <param name="array">An array to ordered.</param>
+    /// <param name="keySelector">A function to extract a key from an element.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in descending order according to a key.
+    /// </returns>
     public static ImmutableArray<TElement> OrderByDescendingAsArray<TElement, TKey>(
         this ImmutableArray<TElement> array, Func<TElement, TKey> keySelector)
     {
@@ -239,6 +333,17 @@ internal static class ImmutableArrayExtensions
         return array.OrderByAsArrayCore(keySelector, in compareHelper);
     }
 
+    /// <summary>
+    ///  Sorts the elements of an <see cref="ImmutableArray{T}"/> in descending order according to a key.
+    /// </summary>
+    /// <typeparam name="TElement">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
+    /// <param name="array">An array to ordered.</param>
+    /// <param name="keySelector">A function to extract a key from an element.</param>
+    /// <param name="comparer">An <see cref="IComparer{T}"/> to compare keys.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in descending order according to a key.
+    /// </returns>
     public static ImmutableArray<TElement> OrderByDescendingAsArray<TElement, TKey>(
         this ImmutableArray<TElement> array, Func<TElement, TKey> keySelector, IComparer<TKey> comparer)
     {
@@ -246,6 +351,17 @@ internal static class ImmutableArrayExtensions
         return array.OrderByAsArrayCore(keySelector, in compareHelper);
     }
 
+    /// <summary>
+    ///  Sorts the elements of an <see cref="ImmutableArray{T}"/> in descending order according to a key.
+    /// </summary>
+    /// <typeparam name="TElement">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
+    /// <param name="array">An array to ordered.</param>
+    /// <param name="keySelector">A function to extract a key from an element.</param>
+    /// <param name="comparison">A <see cref="Comparison{T}"/> to compare keys.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in descending order according to a key.
+    /// </returns>
     public static ImmutableArray<TElement> OrderByDescendingAsArray<TElement, TKey>(
         this ImmutableArray<TElement> array, Func<TElement, TKey> keySelector, Comparison<TKey> comparison)
     {

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions_Unsafe.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions_Unsafe.cs
@@ -1,0 +1,210 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Buffers;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace System.Collections.Immutable;
+
+internal static partial class ImmutableArrayExtensions
+{
+    /// <summary>
+    ///  Provides a set of unsafe operations that can be performed on an <see cref="ImmutableArray{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <param name="array">The array that unsafe operations will target.</param>
+    /// <returns>
+    ///  Returns a struct that provides access to unsafe operations to perform on the
+    ///  <see cref="ImmutableArray{T}"/>. These operations mutate the internal array
+    ///  of the <see cref="ImmutableArray{T}"/> and should be only be used in
+    ///  performance-critical code.
+    /// </returns>
+    public static UnsafeOperations<T> Unsafe<T>(this ImmutableArray<T> array)
+        => new(array);
+
+    public readonly ref struct UnsafeOperations<T>(ImmutableArray<T> array)
+    {
+        /// <summary>
+        ///  Sorts the elements of this <see cref="ImmutableArray{T}"/> in ascending order.
+        /// </summary>
+        public void Order()
+        {
+            var compareHelper = new CompareHelper<T>(comparer: null, descending: false);
+            array.UnsafeOrderCore(in compareHelper);
+        }
+
+        /// <summary>
+        ///  Sorts the elements of this <see cref="ImmutableArray{T}"/> in ascending order.
+        /// </summary>
+        /// <param name="comparer">An <see cref="IComparer{T}"/> to compare elements.</param>
+        public void Order(IComparer<T> comparer)
+        {
+            var compareHelper = new CompareHelper<T>(comparer, descending: false);
+            array.UnsafeOrderCore(in compareHelper);
+        }
+
+        /// <summary>
+        ///  Sorts the elements of this <see cref="ImmutableArray{T}"/> in ascending order.
+        /// </summary>
+        /// <param name="comparison">A <see cref="Comparison{T}"/> to compare elements.</param>
+        public void Order(Comparison<T> comparison)
+        {
+            var compareHelper = new CompareHelper<T>(comparison, descending: false);
+            array.UnsafeOrderCore(in compareHelper);
+        }
+
+        /// <summary>
+        ///  Sorts the elements of this <see cref="ImmutableArray{T}"/> in descending order.
+        /// </summary>
+        public void OrderDescending()
+        {
+            var compareHelper = new CompareHelper<T>(comparer: null, descending: true);
+            array.UnsafeOrderCore(in compareHelper);
+        }
+
+        /// <summary>
+        ///  Sorts the elements of this <see cref="ImmutableArray{T}"/> in descending order.
+        /// </summary>
+        /// <param name="comparer">An <see cref="IComparer{T}"/> to compare elements.</param>
+        public void OrderDescending(IComparer<T> comparer)
+        {
+            var compareHelper = new CompareHelper<T>(comparer, descending: true);
+            array.UnsafeOrderCore(in compareHelper);
+        }
+
+        /// <summary>
+        ///  Sorts the elements of this <see cref="ImmutableArray{T}"/> in descending order.
+        /// </summary>
+        /// <param name="comparison">A <see cref="Comparison{T}"/> to compare elements.</param>
+        public void OrderDescending(Comparison<T> comparison)
+        {
+            var compareHelper = new CompareHelper<T>(comparison, descending: true);
+            array.UnsafeOrderCore(in compareHelper);
+        }
+
+        /// <summary>
+        ///  Sorts the elements of this <see cref="ImmutableArray{T}"/> in ascending order according to a key.
+        /// </summary>
+        /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
+        /// <param name="keySelector">A function to extract a key from an element.</param>
+        public void OrderBy<TKey>(Func<T, TKey> keySelector)
+        {
+            var compareHelper = new CompareHelper<TKey>(comparer: null, descending: false);
+            array.UnsafeOrderByCore(keySelector, in compareHelper);
+        }
+
+        /// <summary>
+        ///  Sorts the elements of this <see cref="ImmutableArray{T}"/> in ascending order according to a key.
+        /// </summary>
+        /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
+        /// <param name="keySelector">A function to extract a key from an element.</param>
+        /// <param name="comparer">An <see cref="IComparer{T}"/> to compare elements.</param>
+        public void OrderBy<TKey>(Func<T, TKey> keySelector, IComparer<TKey> comparer)
+        {
+            var compareHelper = new CompareHelper<TKey>(comparer, descending: false);
+            array.UnsafeOrderByCore(keySelector, in compareHelper);
+        }
+
+        /// <summary>
+        ///  Sorts the elements of this <see cref="ImmutableArray{T}"/> in ascending order according to a key.
+        /// </summary>
+        /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
+        /// <param name="keySelector">A function to extract a key from an element.</param>
+        /// <param name="comparison">An <see cref="Comparison{T}"/> to compare elements.</param>
+        public void OrderBy<TKey>(Func<T, TKey> keySelector, Comparison<TKey> comparison)
+        {
+            var compareHelper = new CompareHelper<TKey>(comparison, descending: false);
+            array.UnsafeOrderByCore(keySelector, in compareHelper);
+        }
+
+        /// <summary>
+        ///  Sorts the elements of this <see cref="ImmutableArray{T}"/> in descending order according to a key.
+        /// </summary>
+        /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
+        /// <param name="keySelector">A function to extract a key from an element.</param>
+        public void OrderByDescending<TKey>(Func<T, TKey> keySelector)
+        {
+            var compareHelper = new CompareHelper<TKey>(comparer: null, descending: true);
+            array.UnsafeOrderByCore(keySelector, in compareHelper);
+        }
+
+        /// <summary>
+        ///  Sorts the elements of this <see cref="ImmutableArray{T}"/> in descending order according to a key.
+        /// </summary>
+        /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
+        /// <param name="keySelector">A function to extract a key from an element.</param>
+        /// <param name="comparer">An <see cref="IComparer{T}"/> to compare elements.</param>
+        public void OrderByDescending<TKey>(Func<T, TKey> keySelector, IComparer<TKey> comparer)
+        {
+            var compareHelper = new CompareHelper<TKey>(comparer, descending: true);
+            array.UnsafeOrderByCore(keySelector, in compareHelper);
+        }
+
+        /// <summary>
+        ///  Sorts the elements of this <see cref="ImmutableArray{T}"/> in descending order according to a key.
+        /// </summary>
+        /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
+        /// <param name="keySelector">A function to extract a key from an element.</param>
+        /// <param name="comparison">An <see cref="Comparison{T}"/> to compare elements.</param>
+        public void OrderByDescending<TKey>(Func<T, TKey> keySelector, Comparison<TKey> comparison)
+        {
+            var compareHelper = new CompareHelper<TKey>(comparison, descending: true);
+            array.UnsafeOrderByCore(keySelector, in compareHelper);
+        }
+    }
+
+    private static ImmutableArray<T> UnsafeOrderCore<T>(this ImmutableArray<T> array, ref readonly CompareHelper<T> compareHelper)
+    {
+        // Note: Checking the length will throw if array.IsDefault returns true.
+        // So, we can assume that the inner array below is non-null.
+        if (array.Length <= 1)
+        {
+            return array;
+        }
+
+        var innerArray = ImmutableCollectionsMarshal.AsArray(array)!;
+        var items = innerArray.AsSpan();
+
+        if (AreOrdered(items, in compareHelper))
+        {
+            // No need to sort - items are already ordered.
+            return array;
+        }
+
+        var comparer = compareHelper.GetOrCreateComparer();
+
+        Array.Sort(innerArray, comparer);
+
+        return array;
+    }
+
+    private static ImmutableArray<TElement> UnsafeOrderByCore<TElement, TKey>(
+        this ImmutableArray<TElement> array, Func<TElement, TKey> keySelector, ref readonly CompareHelper<TKey> compareHelper)
+    {
+        // Note: Checking the length will throw if array.IsDefault returns true.
+        // So, we can assume that the inner array below is non-null.
+        if (array.Length <= 1)
+        {
+            return array;
+        }
+
+        var innerArray = ImmutableCollectionsMarshal.AsArray(array)!;
+        var items = innerArray.AsSpan();
+        var length = items.Length;
+
+        using var keys = ArrayPool<TKey>.Shared.GetPooledArray(minimumLength: length);
+
+        if (SelectKeys(items, keySelector, compareHelper, keys.Span))
+        {
+            // No need to sort - keys are already ordered.
+            return array;
+        }
+
+        var comparer = compareHelper.GetOrCreateComparer();
+
+        Array.Sort(keys.Array, innerArray, 0, length, comparer);
+
+        return array;
+    }
+}

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions_Unsafe.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions_Unsafe.cs
@@ -167,7 +167,7 @@ internal static partial class ImmutableArrayExtensions
         var innerArray = ImmutableCollectionsMarshal.AsArray(array)!;
         var items = innerArray.AsSpan();
 
-        if (AreOrdered(items, in compareHelper))
+        if (SortHelper.AreOrdered(items, in compareHelper))
         {
             // No need to sort - items are already ordered.
             return array;
@@ -196,7 +196,7 @@ internal static partial class ImmutableArrayExtensions
 
         using var keys = ArrayPool<TKey>.Shared.GetPooledArray(minimumLength: length);
 
-        if (SelectKeys(items, keySelector, in compareHelper, keys.Span))
+        if (SortHelper.SelectKeys(items, keySelector, in compareHelper, keys.Span))
         {
             // No need to sort - keys are already ordered.
             return array;

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions_Unsafe.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions_Unsafe.cs
@@ -4,6 +4,7 @@
 using System.Buffers;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using Microsoft.AspNetCore.Razor.Utilities;
 
 namespace System.Collections.Immutable;
 
@@ -195,7 +196,7 @@ internal static partial class ImmutableArrayExtensions
 
         using var keys = ArrayPool<TKey>.Shared.GetPooledArray(minimumLength: length);
 
-        if (SelectKeys(items, keySelector, compareHelper, keys.Span))
+        if (SelectKeys(items, keySelector, in compareHelper, keys.Span))
         {
             // No need to sort - keys are already ordered.
             return array;

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ListExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ListExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.AspNetCore.Razor;
@@ -33,4 +34,33 @@ internal static class ListExtensions
 
     public static bool Any<T>(this List<T> list)
         => list.Count > 0;
+
+    /// <summary>
+    ///  Copies the contents of the list to a destination <see cref="Span{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of elements in the list.</typeparam>
+    /// <param name="list">The list to copy items from.</param>
+    /// <param name="destination">The span to copy items into.</param>
+    /// <exception cref="ArgumentNullException">
+    ///  The <paramref name="list"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    ///  The destination span is shorter than the source list.
+    /// </exception>
+    public static void CopyTo<T>(this List<T> list, Span<T> destination)
+    {
+#if NET8_0_OR_GREATER
+        CollectionExtensions.CopyTo(list, destination);
+#else
+        ArgHelper.ThrowIfNull(list);
+        ArgHelper.ThrowIfDestinationTooShort(destination, list.Count);
+
+        var index = 0;
+
+        foreach (var item in list)
+        {
+            destination[index++] = item;
+        }
+#endif
+    }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ReadOnlyListExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ReadOnlyListExtensions.cs
@@ -952,4 +952,47 @@ internal static class ReadOnlyListExtensions
             _current = default!;
         }
     }
+
+    /// <summary>
+    ///  Copies the contents of the list to a destination <see cref="Span{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of elements in the list.</typeparam>
+    /// <param name="list">The list to copy items from.</param>
+    /// <param name="destination">The span to copy items into.</param>
+    /// <exception cref="ArgumentException">
+    ///  The destination span is shorter than the source list.
+    /// </exception>
+    public static void CopyTo<T>(this IReadOnlyList<T> list, Span<T> destination)
+    {
+        ArgHelper.ThrowIfDestinationTooShort(destination, list.Count);
+
+        switch (list)
+        {
+            case ImmutableArray<T> array:
+                array.CopyTo(destination);
+                break;
+
+            case ImmutableArray<T>.Builder builder:
+                builder.CopyTo(destination);
+                break;
+
+            case List<T> listOfT:
+                ListExtensions.CopyTo(listOfT, destination);
+                break;
+
+            case T[] array:
+                MemoryExtensions.CopyTo(array, destination);
+                break;
+
+            default:
+                var count = list.Count;
+
+                for (var i = 0; i < count; i++)
+                {
+                    destination[i] = list[i];
+                }
+
+                break;
+        }
+    }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Utilities/CompareHelper`1.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Utilities/CompareHelper`1.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.Utilities;
+
+/// <summary>
+///  Helper that avoids creating an <see cref="IComparer{T}"/> until its needed.
+/// </summary>
+internal readonly ref struct CompareHelper<T>
+{
+    private readonly IComparer<T> _comparer;
+    private readonly Comparison<T> _comparison;
+    private readonly bool _comparerSpecified;
+    private readonly bool _useComparer;
+    private readonly bool _descending;
+
+    public CompareHelper(IComparer<T>? comparer, bool descending)
+    {
+        _comparerSpecified = comparer is not null;
+        _comparer = comparer ?? Comparer<T>.Default;
+        _useComparer = true;
+        _descending = descending;
+        _comparison = null!;
+    }
+
+    public CompareHelper(Comparison<T> comparison, bool descending)
+    {
+        _comparison = comparison;
+        _useComparer = false;
+        _descending = descending;
+        _comparer = null!;
+    }
+
+    public bool InSortedOrder(T? x, T? y)
+    {
+        // We assume that x and y are in sorted order if x is > y.
+        // We don't consider x == y to be sorted because the actual sor
+        // might not be stable, depending on T.
+
+        return _useComparer
+            ? !_descending ? _comparer.Compare(x!, y!) > 0 : _comparer.Compare(y!, x!) > 0
+            : !_descending ? _comparison(x!, y!) > 0 : _comparison(y!, x!) > 0;
+    }
+
+    public IComparer<T> GetOrCreateComparer()
+        // There are six cases to consider.
+        => (_useComparer, _comparerSpecified, _descending) switch
+        {
+            // Provided a comparer and the results are in ascending order.
+            (true, true, false) => _comparer,
+
+            // Provided a comparer and the results are in descending order.
+            (true, true, true) => DescendingComparer<T>.Create(_comparer),
+
+            // Not provided a comparer and the results are in ascending order.
+            // In this case, _comparer was already set to Comparer<T>.Default.
+            (true, false, false) => _comparer,
+
+            // Not provided a comparer and the results are in descending order.
+            (true, false, true) => DescendingComparer<T>.Default,
+
+            // Provided a comparison delegate and the results are in ascending order.
+            (false, _, false) => Comparer<T>.Create(_comparison),
+
+            // Provided a comparison delegate and the results are in descending order.
+            (false, _, true) => DescendingComparer<T>.Create(_comparison)
+        };
+}

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Utilities/DescendingComparer`1.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Utilities/DescendingComparer`1.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.Utilities;
+
+internal abstract class DescendingComparer<T> : IComparer<T>
+{
+    private static IComparer<T>? s_default;
+
+    public static IComparer<T> Default => s_default ??= new ReversedComparer(Comparer<T>.Default);
+
+    public static IComparer<T> Create(IComparer<T> comparer)
+        => new ReversedComparer(comparer);
+
+    public static IComparer<T> Create(Comparison<T> comparison)
+        => new ReversedComparison(comparison);
+
+    public abstract int Compare(T? x, T? y);
+
+    private sealed class ReversedComparer(IComparer<T> comparer) : DescendingComparer<T>
+    {
+        public override int Compare(T? x, T? y)
+            => comparer.Compare(y!, x!);
+    }
+
+    private sealed class ReversedComparison(Comparison<T> comparison) : DescendingComparer<T>
+    {
+        public override int Compare(T? x, T? y)
+            => comparison(y!, x!);
+    }
+}

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Utilities/SortHelper.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Utilities/SortHelper.cs
@@ -1,0 +1,130 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.AspNetCore.Razor.Utilities;
+
+internal static class SortHelper
+{
+    /// <summary>
+    ///  Walk through <paramref name="items"/> and determine whether they are already ordered using
+    ///  the provided <see cref="CompareHelper{T}"/>.
+    /// </summary>
+    /// <returns>
+    ///  <see langword="true"/> if the items are in order; otherwise <see langword="false"/>.
+    /// </returns>
+    /// <remarks>
+    ///  When the items are already ordered, there's no need to perform a sort.
+    /// </remarks>
+    public static bool AreOrdered<T>(ReadOnlySpan<T> items, ref readonly CompareHelper<T> compareHelper)
+    {
+        var isOutOfOrder = false;
+
+        for (var i = 1; i < items.Length; i++)
+        {
+            if (!compareHelper.InSortedOrder(items[i], items[i - 1]))
+            {
+                isOutOfOrder = true;
+                break;
+            }
+        }
+
+        return !isOutOfOrder;
+    }
+
+    /// <summary>
+    ///  Walk through <paramref name="list"/> and determine whether they are already ordered using
+    ///  the provided <see cref="CompareHelper{T}"/>.
+    /// </summary>
+    /// <returns>
+    ///  <see langword="true"/> if the items are in order; otherwise <see langword="false"/>.
+    /// </returns>
+    /// <remarks>
+    ///  When the items are already ordered, there's no need to perform a sort.
+    /// </remarks>
+    public static bool AreOrdered<T>(IReadOnlyList<T> list, ref readonly CompareHelper<T> compareHelper)
+    {
+        var isOutOfOrder = false;
+        var count = list.Count;
+
+        for (var i = 1; i < count; i++)
+        {
+            if (!compareHelper.InSortedOrder(list[i], list[i - 1]))
+            {
+                isOutOfOrder = true;
+                break;
+            }
+        }
+
+        return !isOutOfOrder;
+    }
+
+    /// <summary>
+    ///  Walk through <paramref name="items"/> and convert each element to a key using <paramref name="keySelector"/>.
+    ///  While walking, each computed key is compared with the previous one using the provided <see cref="CompareHelper{T}"/>
+    ///  to determine whether they are already ordered.
+    /// </summary>
+    /// <returns>
+    ///  <see langword="true"/> if the keys are in order; otherwise <see langword="false"/>.
+    /// </returns>
+    /// <remarks>
+    ///  When the keys are already ordered, there's no need to perform a sort.
+    /// </remarks>
+    public static bool SelectKeys<TElement, TKey>(
+        ReadOnlySpan<TElement> items, Func<TElement, TKey> keySelector, ref readonly CompareHelper<TKey> compareHelper, Span<TKey> keys)
+    {
+        var isOutOfOrder = false;
+
+        keys[0] = keySelector(items[0]);
+
+        for (var i = 1; i < items.Length; i++)
+        {
+            keys[i] = keySelector(items[i]);
+
+            if (!isOutOfOrder && !compareHelper.InSortedOrder(keys[i], keys[i - 1]))
+            {
+                isOutOfOrder = true;
+
+                // Continue processing to finish converting elements to keys. However, we can stop comparing keys.
+            }
+        }
+
+        return !isOutOfOrder;
+    }
+
+    /// <summary>
+    ///  Walk through <paramref name="list"/> and convert each element to a key using <paramref name="keySelector"/>.
+    ///  While walking, each computed key is compared with the previous one using the provided <see cref="CompareHelper{T}"/>
+    ///  to determine whether they are already ordered.
+    /// </summary>
+    /// <returns>
+    ///  <see langword="true"/> if the keys are in order; otherwise <see langword="false"/>.
+    /// </returns>
+    /// <remarks>
+    ///  When the keys are already ordered, there's no need to perform a sort.
+    /// </remarks>
+    public static bool SelectKeys<TElement, TKey>(
+        IReadOnlyList<TElement> list, Func<TElement, TKey> keySelector, ref readonly CompareHelper<TKey> compareHelper, Span<TKey> keys)
+    {
+        var isOutOfOrder = false;
+        var count = list.Count;
+
+        keys[0] = keySelector(list[0]);
+
+        for (var i = 1; i < count; i++)
+        {
+            keys[i] = keySelector(list[i]);
+
+            if (!isOutOfOrder && !compareHelper.InSortedOrder(keys[i], keys[i - 1]))
+            {
+                isOutOfOrder = true;
+
+                // Continue processing to finish converting elements to keys. However, we can stop comparing keys.
+            }
+        }
+
+        return !isOutOfOrder;
+    }
+}


### PR DESCRIPTION
This pull request is completely within shared code, but none of it is exercised by anything but tests. I've extracted them from another branch containing a much larger compiler change to avoid muddying that change.