### PR TITLE
Don't add already known documents to the misc files project

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
@@ -734,6 +734,29 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
     }
 
     [Fact]
+    public async Task AddDocumentToMiscProjectAsync_IgnoresKnownDocument()
+    {
+        // Arrange
+        const string ProjectFilePath = "C:/path/to/project.csproj";
+        const string IntermediateOutputPath = "C:/path/to/obj";
+        const string RootNamespace = "TestRootNamespace";
+        const string DocumentFilePath = "C:/path/to/document.cshtml";
+
+        await _projectService.AddProjectAsync(
+            ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
+        await _projectService.AddDocumentToPotentialProjectsAsync(DocumentFilePath, DisposalToken);
+
+        // Act
+        using var listener = _projectManager.ListenToNotifications();
+
+        // Act
+        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
+
+        // Assert
+        listener.AssertNoNotifications();
+    }
+
+    [Fact]
     public async Task RemoveDocument_RemovesDocumentFromOwnerProject()
     {
         // Arrange

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
@@ -757,6 +757,24 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
     }
 
     [Fact]
+    public async Task AddDocumentToMiscProjectAsync_IgnoresKnownDocument_InMiscFiles()
+    {
+        // Arrange
+        const string DocumentFilePath = "C:/path/to/document.cshtml";
+
+        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
+
+        // Act
+        using var listener = _projectManager.ListenToNotifications();
+
+        // Act
+        await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
+
+        // Assert
+        listener.AssertNoNotifications();
+    }
+
+    [Fact]
     public async Task RemoveDocument_RemovesDocumentFromOwnerProject()
     {
         // Arrange


### PR DESCRIPTION
Noticed in the logs that we were double-compiling files, and it was causing issues in my "self versioned documents" branch. Separated out of that to make it easier to review.

RCA is because we now share a project manager across VS and LSP server, so we get real project information much sooner than before, which beats file watchers etc.