### PR TITLE
Fix Formatting and On Enter integration tests

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractRazorEditorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/AbstractRazorEditorTest.cs
@@ -44,6 +44,9 @@ public abstract class AbstractRazorEditorTest(ITestOutputHelper testOutput) : Ab
 
         VisualStudioLogging.AddCustomLoggers();
 
+        // Our expected test results have spaces not tabs
+        await TestServices.Shell.SetInsertSpacesAsync(ControlledHangMitigatingCancellationToken);
+
         _projectFilePath = await CreateAndOpenBlazorProjectAsync(ControlledHangMitigatingCancellationToken);
 
         await TestServices.SolutionExplorer.RestoreNuGetPackagesAsync(ControlledHangMitigatingCancellationToken);

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/ShellInProcess.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/ShellInProcess.cs
@@ -4,7 +4,10 @@
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.VisualStudio.Razor;
 using Microsoft.VisualStudio.Shell.Interop;
+using Microsoft.VisualStudio.TextManager.Interop;
+using Xunit;
 
 namespace Microsoft.VisualStudio.Extensibility.Testing;
 
@@ -21,5 +24,17 @@ internal partial class ShellInProcess
         ErrorHandler.ThrowOnFailure(windowFrame.GetProperty((int)__VSFPROPID.VSFPROPID_pszMkDocument, out var documentPathObj));
         var documentPath = (string)documentPathObj;
         return Path.GetFileName(documentPath);
+    }
+
+    public async Task SetInsertSpacesAsync(CancellationToken cancellationToken)
+    {
+        var textManager = await GetRequiredGlobalServiceAsync<SVsTextManager, IVsTextManager4>(cancellationToken);
+
+        var langPrefs3 = new LANGPREFERENCES3[] { new LANGPREFERENCES3() { guidLang = RazorConstants.RazorLanguageServiceGuid } };
+        Assert.Equal(VSConstants.S_OK, textManager.GetUserPreferences4(null, langPrefs3, null));
+
+        langPrefs3[0].fInsertTabs = 0;
+
+        Assert.Equal(VSConstants.S_OK, textManager.SetUserPreferences4(null, langPrefs3, null));
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/VisualStudioLogging.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/VisualStudioLogging.cs
@@ -89,7 +89,14 @@ internal static class VisualStudioLogging
         var files = new List<string>();
         foreach (var feedbackFileProvider in feedbackFileProviders)
         {
-            files.AddRange(feedbackFileProvider.GetFiles());
+            try
+            {
+                files.AddRange(feedbackFileProvider.GetFiles());
+            }
+            catch
+            {
+                // If one of the providers has issues, we don't want it causing us to not be able to report our stuff properly
+            }
         }
 
         _ = CollectFeedbackItemsAsync(files, filePath, expectedFileParts);


### PR DESCRIPTION
Since the end of last week, these tests have been failing. Seems like something changed on the platform side, perhaps a default value of a setting. Have started a thread with the editor team to see if we need to do more.