### PR TITLE
Fix provisional completion corrupting generated C# documents

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_Completion.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_Completion.cs
@@ -189,7 +189,7 @@ internal partial class RazorCustomMessageTarget
             revertedProvisionalTextEdit = VsLspFactory.CreateTextEdit(
                 range: VsLspFactory.CreateSingleLineRange(
                     range.Start,
-                    length: range.End.Character + provisionalTextEdit.NewText.Length),
+                    length: provisionalTextEdit.NewText.Length),
                 newText: string.Empty);
         }
         else


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/10759

Initially when investigating this I was digging into buffer versions and race conditions, but now that the editor fix is in, and we are self versioned, the bug stood out much more obviously: A character offset was being passed in to a parameter that expected a length 🤦‍♂️

Sadly none of the `RazorCustomMessageTarget` code is testable. Cohosting will make this trivial though, as we would simply create a new `Document` with the provisional change, and drop it on the floor when we're finished.