### PR TITLE
Fix find all references calls to Roslyn

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_FindAllReferences.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_FindAllReferences.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Razor.Protocol;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using StreamJsonRpc;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Endpoints;
+
+internal partial class RazorCustomMessageTarget
+{
+    [JsonRpcMethod(CustomMessageNames.RazorReferencesEndpointName, UseSingleObjectParameterDeserialization = true)]
+    public async Task<VSInternalReferenceItem[]?> ReferencesAsync(DelegatedPositionParams request, CancellationToken cancellationToken)
+    {
+        var delegationDetails = await GetProjectedRequestDetailsAsync(request, cancellationToken).ConfigureAwait(false);
+        if (delegationDetails is null)
+        {
+            return default;
+        }
+
+        var referenceParams = new ReferenceParams()
+        {
+            TextDocument = new VSTextDocumentIdentifier()
+            {
+                Uri = delegationDetails.Value.ProjectedUri,
+                ProjectContext = null,
+            },
+            Position = request.ProjectedPosition,
+            Context = new ReferenceContext(),
+        };
+
+        var response = await _requestInvoker.ReinvokeRequestOnServerAsync<ReferenceParams, VSInternalReferenceItem[]?>(
+            delegationDetails.Value.TextBuffer,
+            Methods.TextDocumentReferencesName,
+            delegationDetails.Value.LanguageServerName,
+            referenceParams,
+            cancellationToken).ConfigureAwait(false);
+
+        if (response is null)
+        {
+            return default;
+        }
+
+        return response.Response;
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_TextDocumentPosition.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_TextDocumentPosition.cs
@@ -29,10 +29,6 @@ internal partial class RazorCustomMessageTarget
     public Task<SumType<Location[], VSInternalReferenceItem[]>> ImplementationAsync(DelegatedPositionParams request, CancellationToken cancellationToken)
         => DelegateTextDocumentPositionAndProjectContextAsync<SumType<Location[], VSInternalReferenceItem[]>>(request, Methods.TextDocumentImplementationName, cancellationToken);
 
-    [JsonRpcMethod(CustomMessageNames.RazorReferencesEndpointName, UseSingleObjectParameterDeserialization = true)]
-    public Task<VSInternalReferenceItem[]?> ReferencesAsync(DelegatedPositionParams request, CancellationToken cancellationToken)
-        => DelegateTextDocumentPositionAndProjectContextAsync<VSInternalReferenceItem[]>(request, Methods.TextDocumentReferencesName, cancellationToken);
-
     [JsonRpcMethod(CustomMessageNames.RazorSignatureHelpEndpointName, UseSingleObjectParameterDeserialization = true)]
     public Task<SignatureHelp?> SignatureHelpAsync(DelegatedPositionParams request, CancellationToken cancellationToken)
         => DelegateTextDocumentPositionAndProjectContextAsync<SignatureHelp>(request, Methods.TextDocumentSignatureHelpName, cancellationToken);


### PR DESCRIPTION
Fixes integration test failures in Find All References.

Roslyns LSP types got much more spec compliant in https://github.com/dotnet/roslyn/pull/73911 and we were never sending the `Context` property in our request, so deserialization failed on their end.