### PR TITLE
Clarify [EventHandler] tag helper discovery logic and avoid exception

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/test/EventHandlerTagHelperDescriptorProviderTest.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/test/EventHandlerTagHelperDescriptorProviderTest.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#nullable disable
-
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
@@ -14,22 +12,22 @@ namespace Microsoft.CodeAnalysis.Razor;
 public class EventHandlerTagHelperDescriptorProviderTest : TagHelperDescriptorProviderTestBase
 {
     [Fact]
-    public void Execute_EventHandler_CreatesDescriptor()
+    public void Execute_EventHandler_TwoArgumentsCreatesDescriptor()
     {
         // Arrange
-        var compilation = BaseCompilation.AddSyntaxTrees(Parse(@"
-using System;
-using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
+        var compilation = BaseCompilation.AddSyntaxTrees(Parse("""
+            using System;
+            using Microsoft.AspNetCore.Components;
+            using Microsoft.AspNetCore.Components.Web;
 
-namespace Test
-{
-    [EventHandler(""onclick"", typeof(Action<MouseEventArgs>))]
-    public class EventHandlers
-    {
-    }
-}
-"));
+            namespace Test
+            {
+                [EventHandler("onclick", typeof(Action<MouseEventArgs>))]
+                public class EventHandlers
+                {
+                }
+            }
+            """));
 
         Assert.Empty(compilation.GetDiagnostics());
 
@@ -102,9 +100,9 @@ namespace Test
 
         Assert.Collection(
             attribute.Metadata.OrderBy(kvp => kvp.Key),
-            kvp => Assert.Equal(kvp, new KeyValuePair<string, string>(ComponentMetadata.Common.DirectiveAttribute, bool.TrueString)),
-            kvp => Assert.Equal(kvp, new KeyValuePair<string, string>("Common.PropertyName", "onclick")),
-            kvp => Assert.Equal(kvp, new KeyValuePair<string, string>(ComponentMetadata.Component.WeaklyTypedKey, bool.TrueString)));
+            kvp => Assert.Equal(kvp, new KeyValuePair<string, string?>(ComponentMetadata.Common.DirectiveAttribute, bool.TrueString)),
+            kvp => Assert.Equal(kvp, new KeyValuePair<string, string?>("Common.PropertyName", "onclick")),
+            kvp => Assert.Equal(kvp, new KeyValuePair<string, string?>(ComponentMetadata.Component.WeaklyTypedKey, bool.TrueString)));
 
         Assert.Equal(
             "Sets the '@onclick' attribute to the provided string or delegate value. " +
@@ -120,6 +118,239 @@ namespace Test
         Assert.False(attribute.IsStringProperty);
         Assert.False(attribute.IsBooleanProperty);
         Assert.False(attribute.IsEnum);
+    }
+
+    [Fact]
+    public void Execute_EventHandler_FourArgumentsCreatesDescriptorWithDiagnostic()
+    {
+        // Arrange
+        var compilation = BaseCompilation.AddSyntaxTrees(Parse("""
+            using System;
+            using Microsoft.AspNetCore.Components;
+            using Microsoft.AspNetCore.Components.Web;
+
+            namespace Test
+            {
+                [EventHandler("onclick", typeof(Action<MouseEventArgs>), true, true)]
+                public class EventHandlers
+                {
+                }
+            }
+            """));
+
+        Assert.Empty(compilation.GetDiagnostics());
+
+        var context = new TagHelperDescriptorProviderContext(compilation);
+        var provider = new EventHandlerTagHelperDescriptorProvider();
+
+        // Act
+        provider.Execute(context);
+
+        // Assert
+        var matches = GetEventHandlerTagHelpers(context);
+        var item = Assert.Single(matches);
+
+        // These are features Event Handler Tag Helpers don't use. Verifying them once here and
+        // then ignoring them.
+        Assert.Empty(item.AllowedChildTags);
+        Assert.Null(item.TagOutputHint);
+
+        // These are features that are invariants of all Event Handler Helpers. Verifying them once
+        // here and then ignoring them.
+        Assert.Empty(item.Diagnostics);
+        Assert.False(item.HasErrors);
+        Assert.Equal(ComponentMetadata.EventHandler.TagHelperKind, item.Kind);
+        Assert.Equal(bool.TrueString, item.Metadata[TagHelperMetadata.Common.ClassifyAttributesOnly]);
+        Assert.Equal(ComponentMetadata.EventHandler.RuntimeName, item.Metadata[TagHelperMetadata.Runtime.Name]);
+        Assert.False(item.IsDefaultKind());
+        Assert.False(item.KindUsesDefaultTagHelperRuntime());
+        Assert.False(item.IsComponentOrChildContentTagHelper);
+        Assert.True(item.CaseSensitive);
+
+        Assert.Equal(
+            "Sets the '@onclick' attribute to the provided string or delegate value. " +
+            "A delegate value should be of type 'System.Action<Microsoft.AspNetCore.Components.Web.MouseEventArgs>'.",
+            item.Documentation);
+
+        // These are all trivially derived from the assembly/namespace/type name
+        Assert.Equal("Microsoft.AspNetCore.Components", item.AssemblyName);
+        Assert.Equal("onclick", item.Name);
+        Assert.Equal("Test.EventHandlers", item.DisplayName);
+        Assert.Equal("Test.EventHandlers", item.GetTypeName());
+
+        Assert.Equal(3, item.TagMatchingRules.Length);
+
+        var catchAllRule = item.TagMatchingRules[0];
+        Assert.Empty(catchAllRule.Diagnostics);
+        Assert.False(catchAllRule.HasErrors);
+        Assert.Null(catchAllRule.ParentTag);
+        Assert.Equal("*", catchAllRule.TagName);
+        Assert.Equal(TagStructure.Unspecified, catchAllRule.TagStructure);
+
+        var catchAllRequiredAttribute = Assert.Single(catchAllRule.Attributes);
+        Assert.Empty(catchAllRequiredAttribute.Diagnostics);
+        Assert.Equal("@onclick", catchAllRequiredAttribute.DisplayName);
+        Assert.Equal("@onclick", catchAllRequiredAttribute.Name);
+        Assert.Equal(RequiredAttributeDescriptor.NameComparisonMode.FullMatch, catchAllRequiredAttribute.NameComparison);
+        Assert.Null(catchAllRequiredAttribute.Value);
+        Assert.Equal(RequiredAttributeDescriptor.ValueComparisonMode.None, catchAllRequiredAttribute.ValueComparison);
+
+        var preventDefaultRule = item.TagMatchingRules[1];
+        Assert.Empty(preventDefaultRule.Diagnostics);
+        Assert.False(preventDefaultRule.HasErrors);
+        Assert.Null(preventDefaultRule.ParentTag);
+        Assert.Equal("*", preventDefaultRule.TagName);
+        Assert.Equal(TagStructure.Unspecified, preventDefaultRule.TagStructure);
+
+        var preventDefaultRequiredAttribute = Assert.Single(preventDefaultRule.Attributes);
+        Assert.Empty(preventDefaultRequiredAttribute.Diagnostics);
+        Assert.Equal("@onclick:preventDefault", preventDefaultRequiredAttribute.DisplayName);
+        Assert.Equal("@onclick:preventDefault", preventDefaultRequiredAttribute.Name);
+        Assert.Equal(RequiredAttributeDescriptor.NameComparisonMode.FullMatch, preventDefaultRequiredAttribute.NameComparison);
+        Assert.Null(preventDefaultRequiredAttribute.Value);
+        Assert.Equal(RequiredAttributeDescriptor.ValueComparisonMode.None, preventDefaultRequiredAttribute.ValueComparison);
+
+        var stopPropagationRule = item.TagMatchingRules[2];
+        Assert.Empty(stopPropagationRule.Diagnostics);
+        Assert.False(stopPropagationRule.HasErrors);
+        Assert.Null(stopPropagationRule.ParentTag);
+        Assert.Equal("*", stopPropagationRule.TagName);
+        Assert.Equal(TagStructure.Unspecified, stopPropagationRule.TagStructure);
+
+        var stopPropagationRequiredAttribute = Assert.Single(stopPropagationRule.Attributes);
+        Assert.Empty(stopPropagationRequiredAttribute.Diagnostics);
+        Assert.Equal("@onclick:stopPropagation", stopPropagationRequiredAttribute.DisplayName);
+        Assert.Equal("@onclick:stopPropagation", stopPropagationRequiredAttribute.Name);
+        Assert.Equal(RequiredAttributeDescriptor.NameComparisonMode.FullMatch, stopPropagationRequiredAttribute.NameComparison);
+        Assert.Null(stopPropagationRequiredAttribute.Value);
+        Assert.Equal(RequiredAttributeDescriptor.ValueComparisonMode.None, stopPropagationRequiredAttribute.ValueComparison);
+
+        var attribute = Assert.Single(item.BoundAttributes);
+
+        // Invariants
+        Assert.Empty(attribute.Diagnostics);
+        Assert.False(attribute.HasErrors);
+        Assert.Equal(ComponentMetadata.EventHandler.TagHelperKind, attribute.Kind);
+        Assert.False(attribute.IsDefaultKind());
+        Assert.False(attribute.HasIndexer);
+        Assert.Null(attribute.IndexerNamePrefix);
+        Assert.Null(attribute.IndexerTypeName);
+        Assert.False(attribute.IsIndexerBooleanProperty);
+        Assert.False(attribute.IsIndexerStringProperty);
+
+        Assert.Collection(
+            attribute.Metadata.OrderBy(kvp => kvp.Key),
+            kvp => Assert.Equal(kvp, new KeyValuePair<string, string?>(ComponentMetadata.Common.DirectiveAttribute, bool.TrueString)),
+            kvp => Assert.Equal(kvp, new KeyValuePair<string, string?>("Common.PropertyName", "onclick")),
+            kvp => Assert.Equal(kvp, new KeyValuePair<string, string?>(ComponentMetadata.Component.WeaklyTypedKey, bool.TrueString)));
+
+        Assert.Equal(
+            "Sets the '@onclick' attribute to the provided string or delegate value. " +
+            "A delegate value should be of type 'System.Action<Microsoft.AspNetCore.Components.Web.MouseEventArgs>'.",
+            attribute.Documentation);
+
+        Assert.Equal("@onclick", attribute.Name);
+        Assert.Equal("onclick", attribute.GetPropertyName());
+        Assert.Equal("Microsoft.AspNetCore.Components.EventCallback<System.Action<Microsoft.AspNetCore.Components.Web.MouseEventArgs>> Test.EventHandlers.onclick", attribute.DisplayName);
+
+        // Defined from the property type
+        Assert.Equal("Microsoft.AspNetCore.Components.EventCallback<System.Action<Microsoft.AspNetCore.Components.Web.MouseEventArgs>>", attribute.TypeName);
+        Assert.False(attribute.IsStringProperty);
+        Assert.False(attribute.IsBooleanProperty);
+        Assert.False(attribute.IsEnum);
+    }
+
+    [Fact]
+    public void Execute_EventHandler_NoArgumentsDoesNotCreateDescriptor()
+    {
+        // Arrange
+        var compilation = BaseCompilation.AddSyntaxTrees(Parse("""
+            using System;
+            using Microsoft.AspNetCore.Components;
+            using Microsoft.AspNetCore.Components.Web;
+
+            namespace Test
+            {
+                [EventHandler]
+                public class EventHandlers
+                {
+                }
+            }
+            """));
+
+        Assert.NotEmpty(compilation.GetDiagnostics());
+
+        var context = new TagHelperDescriptorProviderContext(compilation);
+        var provider = new EventHandlerTagHelperDescriptorProvider();
+
+        // Act
+        provider.Execute(context);
+
+        // Assert
+        var matches = GetEventHandlerTagHelpers(context);
+        Assert.Empty(matches);
+    }
+
+    [Fact]
+    public void Execute_EventHandler_OneArgumentDoesNotCreateDescriptor()
+    {
+        // Arrange
+        var compilation = BaseCompilation.AddSyntaxTrees(Parse("""
+            using System;
+            using Microsoft.AspNetCore.Components;
+            using Microsoft.AspNetCore.Components.Web;
+
+            namespace Test
+            {
+                [EventHandler("onclick")]
+                public class EventHandlers
+                {
+                }
+            }
+            """));
+
+        Assert.NotEmpty(compilation.GetDiagnostics());
+
+        var context = new TagHelperDescriptorProviderContext(compilation);
+        var provider = new EventHandlerTagHelperDescriptorProvider();
+
+        // Act
+        provider.Execute(context);
+
+        // Assert
+        var matches = GetEventHandlerTagHelpers(context);
+        Assert.Empty(matches);
+    }
+
+    [Fact]
+    public void Execute_EventHandler_ThreeArgumentsDoesNotCreateDiagnostic()
+    {
+        // Arrange
+        var compilation = BaseCompilation.AddSyntaxTrees(Parse("""
+            using System;
+            using Microsoft.AspNetCore.Components;
+            using Microsoft.AspNetCore.Components.Web;
+
+            namespace Test
+            {
+                [EventHandler("onclick", typeof(Action<MouseEventArgs>), true)]
+                public class EventHandlers
+                {
+                }
+            }
+            """));
+
+        Assert.NotEmpty(compilation.GetDiagnostics());
+
+        var context = new TagHelperDescriptorProviderContext(compilation);
+        var provider = new EventHandlerTagHelperDescriptorProvider();
+
+        // Act
+        provider.Execute(context);
+
+        // Assert
+        var matches = GetEventHandlerTagHelpers(context);
+        Assert.Empty(matches);
     }
 
     private static TagHelperDescriptor[] GetEventHandlerTagHelpers(TagHelperDescriptorProviderContext context)


### PR DESCRIPTION
This fixes an issue that @tmat pointed out to me over email. In a recent change (#10720), I added a call to `Assumed.Unreachable()` when `[EventHandler]` tag helper discovery encounters an attribute with invalid constructor attributes. However, throwing an exception during tag helper discovery is usually the wrong approach. Normally, if Roslyn symbols aren't in the proper shape during tag helper discovery, Razor will simply not produce a tag helper. (We _do_ support diagnostics for tag helpers, but those are usually reserved for warnings and errors that are related to a tag helper's data that would make it unusable, such as a name containing whitespace.)

It turns out that the "unreachable" condition wasn't actually all that unreachable and @tmat was hitting it while working on hot reload tests. So, I've changed the code to make the success conditions clearer, i.e., the attribute data must match one of the two constructor calls. And, I changed the logic to simply skip `[EventHandler]` attributes that don't meet the success conditions.