### PR TITLE
Cleanup default RemoteAutoInsertOptions

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RemoteAutoInsertOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RemoteAutoInsertOptions.cs
@@ -1,7 +1,6 @@
 ﻿using System.Runtime.Serialization;
 using Microsoft.CodeAnalysis.Razor.Formatting;
 using Microsoft.CodeAnalysis.Razor.Settings;
-using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.Razor.Remote;
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RemoteAutoInsertOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RemoteAutoInsertOptions.cs
@@ -21,11 +21,11 @@ internal readonly record struct RemoteAutoInsertOptions
     {
     }
 
-    public static RemoteAutoInsertOptions From(ClientSettings clientSettings, FormattingOptions formattingOptions)
+    public static RemoteAutoInsertOptions From(ClientSettings clientSettings, RazorFormattingOptions formattingOptions)
         => new()
         {
             EnableAutoClosingTags = clientSettings.AdvancedSettings.AutoClosingTags,
             FormatOnType = clientSettings.AdvancedSettings.FormatOnType,
-            FormattingOptions = RazorFormattingOptions.From(formattingOptions, codeBlockBraceOnNextLine: false)
+            FormattingOptions = formattingOptions
         };
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RemoteAutoInsertOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RemoteAutoInsertOptions.cs
@@ -15,11 +15,7 @@ internal readonly record struct RemoteAutoInsertOptions
     public bool FormatOnType { get; init; } = true;
 
     [DataMember(Order = 2)]
-    public RazorFormattingOptions FormattingOptions { get; init; } = new RazorFormattingOptions()
-    {
-        InsertSpaces = true,
-        TabSize = 4
-    };
+    public RazorFormattingOptions FormattingOptions { get; init; } = new ();
 
     public RemoteAutoInsertOptions()
     {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RemoteAutoInsertOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RemoteAutoInsertOptions.cs
@@ -15,7 +15,7 @@ internal readonly record struct RemoteAutoInsertOptions
     public bool FormatOnType { get; init; } = true;
 
     [DataMember(Order = 2)]
-    public RazorFormattingOptions FormattingOptions { get; init; } = new ();
+    public RazorFormattingOptions FormattingOptions { get; init; } = new();
 
     public RemoteAutoInsertOptions()
     {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostOnAutoInsertEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostOnAutoInsertEndpoint.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
 using Microsoft.CodeAnalysis.Razor.AutoInsert;
+using Microsoft.CodeAnalysis.Razor.Formatting;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.Protocol.AutoInsert;
 using Microsoft.CodeAnalysis.Razor.Remote;
@@ -93,7 +94,8 @@ internal class CohostOnAutoInsertEndpoint(
         _logger.LogDebug($"Resolving auto-insertion for {razorDocument.FilePath}");
 
         var clientSettings = _clientSettingsManager.GetClientSettings();
-        var autoInsertOptions = RemoteAutoInsertOptions.From(clientSettings, request.Options);
+        var razorFormattingOptions = RazorFormattingOptions.From(request.Options, codeBlockBraceOnNextLine: false);
+        var autoInsertOptions = RemoteAutoInsertOptions.From(clientSettings, razorFormattingOptions);
 
         _logger.LogDebug($"Calling OOP to resolve insertion at {request.Position} invoked by typing '{request.Character}'");
         var data = await _remoteServiceInvoker.TryInvokeAsync<IRemoteAutoInsertService, Response>(


### PR DESCRIPTION
Use default RazorFormattingOptions constructor in init of RemoteAutoInsertOptions to avoid having potentially two sets of defaults.
