### PR TITLE
Remove toolset compiler workaround

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,12 +43,6 @@
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
 
     <DefaultNetFxTargetFramework>net472</DefaultNetFxTargetFramework>
-
-    <!--
-      Needed to avoid error NU1010: The PackageReference items Microsoft.Net.Compilers.Toolset.Framework do not have corresponding PackageVersion.
-      Related to https://github.com/dotnet/sdk/issues/41791.
-    -->
-    <BuildWithNetFrameworkHostedCompiler>false</BuildWithNetFrameworkHostedCompiler>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
It should not be needed with .NET SDK 9 preview 7.