### PR TITLE
Switch to new VMR control schema.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,7 +24,7 @@
     <GenerateResxSourceEmitFormatMethods>true</GenerateResxSourceEmitFormatMethods>
     <ExcludeFromSourceBuild Condition="'$(IsUnitTestProject)' == 'true'">true</ExcludeFromSourceBuild>
     <RepositoryRoot>$(MSBuildThisFileDirectory)</RepositoryRoot>
-    <EnableWindowsTargeting Condition="'$(DotNetBuildFromSource)' != 'true'">true</EnableWindowsTargeting>
+    <EnableWindowsTargeting Condition="'$(DotNetBuildSourceOnly)' != 'true'">true</EnableWindowsTargeting>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
 
@@ -61,7 +61,7 @@
         necessary as the output of this leg is used in other CI source build legs. Those could be
         targeting NetCurrent or NetPrevious hence we must produce both.
     -->
-    <When Condition="'$(DotNetBuildFromSource)' == 'true' AND '$(DotNetBuildFromSourceFlavor)' != 'Product'">
+    <When Condition="'$(DotNetBuildSourceOnly)' == 'true' AND '$(DotNetBuildOrchestrator)' != 'true'">
       <PropertyGroup>
         <DefaultNetCoreTargetFramework>$(NetCurrent)</DefaultNetCoreTargetFramework>
         <DefaultNetCoreTargetFrameworks>$(DefaultNetCoreTargetFramework);$(NetPrevious)</DefaultNetCoreTargetFrameworks>
@@ -71,7 +71,7 @@
     <!--
       2. Source build the product: this is the all up build of the product which needs only NetCurrent
     -->
-    <When Condition="'$(DotNetBuildFromSource)' == 'true' AND '$(DotNetBuildFromSourceFlavor)' == 'Product'">
+    <When Condition="'$(DotNetBuildSourceOnly)' == 'true' AND '$(DotNetBuildOrchestrator)' == 'true'">
       <PropertyGroup>
         <DefaultNetCoreTargetFramework>$(NetCurrent)</DefaultNetCoreTargetFramework>
         <DefaultNetCoreTargetFrameworks>$(DefaultNetCoreTargetFramework)</DefaultNetCoreTargetFrameworks>

--- a/eng/AfterSigning.targets
+++ b/eng/AfterSigning.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
 
-  <Target Name="_EnsureVSIXWasGenerated" AfterTargets="GenerateVisualStudioInsertionManifests" Condition="'$(OS)'=='WINDOWS_NT' AND '$(ArcadeBuildFromSource)' != 'true'">
+  <Target Name="_EnsureVSIXWasGenerated" AfterTargets="GenerateVisualStudioInsertionManifests" Condition="'$(OS)'=='WINDOWS_NT' AND '$(DotNetBuildSourceOnly)' != 'true'">
     <PropertyGroup>
       <VSSetupDir>$(ArtifactsDir)VSSetup\</VSSetupDir>
       <RazorExtensionVSIXName>Microsoft.VisualStudio.RazorExtension.vsix</RazorExtensionVSIXName>
@@ -27,7 +27,7 @@
           AfterTargets="GenerateVisualStudioInsertionManifests"
           Inputs="$(_RazorAssemblyVersion)"
           Outputs="$(_DependentAssemblyVersionsFile)"
-          Condition="'$(OS)'=='WINDOWS_NT' AND '$(ArcadeBuildFromSource)' != 'true'">
+          Condition="'$(OS)'=='WINDOWS_NT' AND '$(DotNetBuildSourceOnly)' != 'true'">
     <ItemGroup>
       <_AssemblyVersionEntry Include="RazorRuntimeAssembly" />
       <_AssemblyVersionEntry Include="RazorToolingAssembly" />

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -27,7 +27,7 @@
     <ItemGroup>
       <!-- Packages can be built on all platforms, but are only published on Windows to avoid collisions from the other
            platforms. This does not affect the SB intermediate package. -->
-      <ItemsToPushToBlobFeed Remove="$(ArtifactsDir)**\*.nupkg" Condition="'$(OS)' != 'Windows_NT' and '$(ArcadeBuildFromSource)' != 'true'" />
+      <ItemsToPushToBlobFeed Remove="$(ArtifactsDir)**\*.nupkg" Condition="'$(OS)' != 'Windows_NT' and '$(DotNetBuild)' != 'true'" />
 
       <ItemsToPushToBlobFeed Include="@(_ItemsToPublish)">
         <IsShipping>false</IsShipping>

--- a/eng/configure-toolset.sh
+++ b/eng/configure-toolset.sh
@@ -2,6 +2,6 @@
 # We could potentially try to find an existing installation that has all the required runtimes,
 # but it's unlikely one will be available.
 
-if [ "${DotNetBuildFromSource:-false}" = false ]; then
+if [ "${DotNetBuildSourceOnly:-false}" = false ]; then
     use_installed_dotnet_cli="false"
 fi

--- a/eng/scripts/ci-source-build.sh
+++ b/eng/scripts/ci-source-build.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 scriptroot="$( cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 reporoot="$(dirname "$(dirname "$scriptroot")")"
 
-export DotNetBuildFromSource='true'
+export DotNetBuildSourceOnly='true'
 
  # Build repo tasks
 "$reporoot/eng/common/build.sh" --restore --build --ci --configuration Release /p:ProjectToBuild=$reporoot/eng/tools/RepoTasks/RepoTasks.csproj "$@"

--- a/src/Compiler/Directory.Build.props
+++ b/src/Compiler/Directory.Build.props
@@ -37,7 +37,7 @@
     <WarningsNotAsErrors>$(WarningsNotAsErrors);xUnit1004</WarningsNotAsErrors>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" NoWarn="NU1608" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" PrivateAssets="All" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" PrivateAssets="All" />

--- a/src/Compiler/Directory.Packages.props
+++ b/src/Compiler/Directory.Packages.props
@@ -1,7 +1,7 @@
 ﻿<Project>
   <PropertyGroup>
     <_RoslynPackageVersion>4.9.2</_RoslynPackageVersion>
-    <_RoslynPackageVersion Condition="'$(DotNetBuildFromSource)' == 'true'">$(MicrosoftCodeAnalysisCommonPackageVersion)</_RoslynPackageVersion>
+    <_RoslynPackageVersion Condition="'$(DotNetBuildSourceOnly)' == 'true'">$(MicrosoftCodeAnalysisCommonPackageVersion)</_RoslynPackageVersion>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Packages.props, $(MSBuildThisFileDirectory)..))" />

--- a/src/Shared/Directory.Build.props
+++ b/src/Shared/Directory.Build.props
@@ -14,7 +14,7 @@
     <RollForward Condition="'$(IsTestProject)' == 'true'">LatestMajor</RollForward>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(DotNetBuildFromSource)' != 'true'">
+  <ItemGroup Condition="'$(DotNetBuildSourceOnly)' != 'true'">
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" NoWarn="NU1608" />
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" />
     <PackageReference Include="Roslyn.Diagnostics.Analyzers" />


### PR DESCRIPTION
Now that razor is on .NET 9 arcade, it can switch over to the new control schema. For this repo, this is roughly:
- DotNetBuildFromSource -> DotNetBuildSourceOnly - Building a source-only build.
- DotnetBuildFromSourceFlavor == Product -> DotNetBuildOrchestrator == true - Building in the VMR, could be source-only or MS's build.
- ArcadeBuildFromSource -> DotNetBuildRepo == true -> Indicates an outer repo build.
