### PR TITLE
Disable test parallelisation in language services

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Microsoft.VisualStudio.LanguageServices.Razor.Test.csproj
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Microsoft.VisualStudio.LanguageServices.Razor.Test.csproj
@@ -30,4 +30,8 @@
     <EmbeddedResource Include="TestFiles\**\*" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\Microsoft.AspNetCore.Razor.LanguageServer.Test\XunitAssemblyInfo.cs" Link="XunitAssemblyInfo.cs" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/10874

This project uses the `ExportProviderFactory` which has static state, and running tests in parallel is therefore racey. https://github.com/dotnet/razor/pull/10882 is removing that system, but that has to wait for a Roslyn insertion etc. so this is a short term workaround