### PR TITLE
Fix #10891 - Formatting does not respect indentation within Razor comment blocks

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/HtmlFormattingPassBase.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/HtmlFormattingPassBase.cs
@@ -30,7 +30,9 @@ internal abstract class HtmlFormattingPassBase(ILogger logger) : IFormattingPass
 
         if (changes.Length > 0)
         {
-            changedText = originalText.WithChanges(changes);
+            var filteredChanges = FilterIncomingChanges(changedContext, changes);
+
+            changedText = originalText.WithChanges(filteredChanges);
             // Create a new formatting context for the changed razor document.
             changedContext = await context.WithTextAsync(changedText).ConfigureAwait(false);
 
@@ -46,6 +48,27 @@ internal abstract class HtmlFormattingPassBase(ILogger logger) : IFormattingPass
         }
 
         return changedText.GetTextChangesArray(originalText);
+    }
+
+    private static ImmutableArray<TextChange> FilterIncomingChanges(FormattingContext context, ImmutableArray<TextChange> changes)
+    {
+        var syntaxTree = context.CodeDocument.GetSyntaxTree();
+
+        using var changesToKeep = new PooledArrayBuilder<TextChange>(capacity: changes.Length);
+
+        for (var i = 0; i < changes.Length; i++)
+        {
+            // Don't keep changes that start inside of a razor comment block.
+            var comment = syntaxTree.Root.FindInnermostNode(changes[i].Span.Start)?.FirstAncestorOrSelf<RazorCommentBlockSyntax>();
+            if (comment is not null)
+            {
+                continue;
+            }
+
+            changesToKeep.Add(changes[i]);
+        }
+
+        return changesToKeep.DrainToImmutable();
     }
 
     private static ImmutableArray<TextChange> AdjustRazorIndentation(FormattingContext context)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/HtmlFormattingPassBase.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/HtmlFormattingPassBase.cs
@@ -56,16 +56,16 @@ internal abstract class HtmlFormattingPassBase(ILogger logger) : IFormattingPass
 
         using var changesToKeep = new PooledArrayBuilder<TextChange>(capacity: changes.Length);
 
-        for (var i = 0; i < changes.Length; i++)
+        foreach (var change in changes)
         {
             // Don't keep changes that start inside of a razor comment block.
-            var comment = syntaxTree.Root.FindInnermostNode(changes[i].Span.Start)?.FirstAncestorOrSelf<RazorCommentBlockSyntax>();
+            var comment = syntaxTree.Root.FindInnermostNode(change.Span.Start)?.FirstAncestorOrSelf<RazorCommentBlockSyntax>();
             if (comment is not null)
             {
                 continue;
             }
 
-            changesToKeep.Add(changes[i]);
+            changesToKeep.Add(change);
         }
 
         return changesToKeep.DrainToImmutable();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/RazorFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/RazorFormattingTest.cs
@@ -711,18 +711,18 @@ public class RazorFormattingTest(ITestOutputHelper testOutput) : FormattingTestB
         await RunFormattingTestAsync(
             input: """
                     <div>
-                        @*
-                            <div>
-                                This comment's indentation will be preserved
+                    @* <div>
+                    This comment's opening at-star will be aligned, and the
+                    indentation of the rest of its lines will be preserved.
                             </div>
                         *@
                     </div>
                     """,
             expected: """
                     <div>
-                        @*
-                            <div>
-                                This comment's indentation will be preserved
+                        @* <div>
+                    This comment's opening at-star will be aligned, and the
+                    indentation of the rest of its lines will be preserved.
                             </div>
                         *@
                     </div>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/RazorFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/RazorFormattingTest.cs
@@ -705,6 +705,31 @@ public class RazorFormattingTest(ITestOutputHelper testOutput) : FormattingTestB
             fileKind: FileKinds.Legacy);
     }
 
+    [Fact]
+    public async Task MultiLineComment_WithinHtml ()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                    <div>
+                        @*
+                            <div>
+                                This comment's indentation will be preserved
+                            </div>
+                        *@
+                    </div>
+                    """,
+            expected: """
+                    <div>
+                        @*
+                            <div>
+                                This comment's indentation will be preserved
+                            </div>
+                        *@
+                    </div>
+                    """,
+            fileKind: FileKinds.Legacy);
+    }
+
     // Regression prevention tests:
     [Fact]
     public async Task Using()


### PR DESCRIPTION
Altered `HtmlFormattingPassBase` to discard any `TextChange`s that start within a `RazorCommentBlockSyntax` and added a test to catch any regressions in the future.

Fixes https://github.com/dotnet/razor/issues/10891
