### PR TITLE
Fixing HTML attribute commit

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -37,8 +37,9 @@ internal class RazorCompletionEndpoint(
             ResolveProvider = true,
             TriggerCharacters = _completionListProvider.AggregateTriggerCharacters.ToArray(),
             // This is the intersection of C# and HTML commit characters.
-            // We need to specify it so that platform can correctly calculate ApplicableToSpan
-            // See https://github.com/dotnet/razor/issues/10787
+            // We need to specify it so that platform can correctly calculate ApplicableToSpan in
+            // https://devdiv.visualstudio.com/DevDiv/_git/VSLanguageServerClient?path=/src/product/RemoteLanguage/Impl/Features/Completion/AsyncCompletionSource.cs&version=GBdevelop&line=855&lineEnd=855&lineStartColumn=9&lineEndColumn=49&lineStyle=plain&_a=contents
+            // This is needed to fix https://github.com/dotnet/razor/issues/10787 in particular
             AllCommitCharacters = [" ", ">", ";", "="]
         };
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -36,6 +36,10 @@ internal class RazorCompletionEndpoint(
         {
             ResolveProvider = true,
             TriggerCharacters = _completionListProvider.AggregateTriggerCharacters.ToArray(),
+            // This is the intersection of C# and HTML commit characters.
+            // We need to specify it so that platform can correctly calculate ApplicableToSpan
+            // See https://github.com/dotnet/razor/issues/10787
+            AllCommitCharacters = [" ", ">", ";", "="]
         };
     }
 

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/CompletionIntegrationTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/CompletionIntegrationTests.cs
@@ -17,55 +17,221 @@ public class CompletionIntegrationTests(ITestOutputHelper testOutputHelper) : Ab
     [IdeFact]
     public async Task SnippetCompletion_Html()
     {
+        await VerifyTypeAndCommitCompletionAsync(
+            input: """
+                @page "Test"
+
+                <PageTitle>Test</PageTitle>
+
+                <h1>Test</h1>
+
+                @code {
+                    private int currentCount = 0;
+
+                    private void IncrementCount()
+                    {
+                        currentCount++;
+                    }
+                }
+                """,
+            output: """
+                @page "Test"
+
+                <PageTitle>Test</PageTitle>
+
+                <h1>Test</h1>
+                <dl>
+                    <dt></dt>
+                    <dd></dd>
+                </dl>
+
+                @code {
+                    private int currentCount = 0;
+
+                    private void IncrementCount()
+                    {
+                        currentCount++;
+                    }
+                }
+                """,
+            search: "<h1>Test</h1>",
+            stringsToType: ["{ENTER}", "d", "d"]);
+    }
+
+    [IdeFact, WorkItem("https://github.com/dotnet/razor/issues/10787")]
+    public async Task CompletionCommit_HtmlAttributeWithoutValue()
+    {
+        await VerifyTypeAndCommitCompletionAsync(
+            input: """
+                @page "Test"
+
+                <PageTitle>Test</PageTitle>
+
+                <button></button>
+
+                @code {
+                    private int currentCount = 0;
+
+                    private void IncrementCount()
+                    {
+                        currentCount++;
+                    }
+                }
+                """,
+            output: """
+                @page "Test"
+
+                <PageTitle>Test</PageTitle>
+
+                <button disabled></button>
+
+                @code {
+                    private int currentCount = 0;
+
+                    private void IncrementCount()
+                    {
+                        currentCount++;
+                    }
+                }
+                """,
+            search: "<button",
+            stringsToType: [" ", "d", "i", "s"]);
+    }
+
+    [IdeFact]
+    public async Task CompletionCommit_HtmlAttributeWithValue()
+    {
+        await VerifyTypeAndCommitCompletionAsync(
+            input: """
+                @page "Test"
+
+                <PageTitle>Test</PageTitle>
+
+                <button></button>
+
+                @code {
+                    private int currentCount = 0;
+
+                    private void IncrementCount()
+                    {
+                        currentCount++;
+                    }
+                }
+                """,
+            output: """
+                @page "Test"
+
+                <PageTitle>Test</PageTitle>
+
+                <button style=""></button>
+
+                @code {
+                    private int currentCount = 0;
+
+                    private void IncrementCount()
+                    {
+                        currentCount++;
+                    }
+                }
+                """,
+            search: "<button",
+            stringsToType: [" ", "s", "t", "y"]);
+    }
+
+    [IdeFact]
+    public async Task CompletionCommit_HtmlTag()
+    {
+        await VerifyTypeAndCommitCompletionAsync(
+            input: """
+                @page "Test"
+
+                <PageTitle>Test</PageTitle>
+
+                @code {
+                    private int currentCount = 0;
+
+                    private void IncrementCount()
+                    {
+                        currentCount++;
+                    }
+                }
+                """,
+            output: """
+                @page "Test"
+
+                <PageTitle>Test</PageTitle>
+
+                <span
+
+                @code {
+                    private int currentCount = 0;
+
+                    private void IncrementCount()
+                    {
+                        currentCount++;
+                    }
+                }
+                """,
+            search: "</PageTitle>",
+            stringsToType: ["{ENTER}", "{ENTER}", "<", "s", "p", "a"]);
+    }
+
+    [IdeFact]
+    public async Task CompletionCommit_CSharp()
+    {
+        await VerifyTypeAndCommitCompletionAsync(
+            input: """
+                @page "Test"
+
+                <PageTitle>Test</PageTitle>
+
+                @code {
+                    private int myCurrentCount = 0;
+
+                    private void IncrementCount()
+                    {
+                        myCurrentCount++;
+                    }
+                }
+                """,
+            output: """
+                @page "Test"
+
+                <PageTitle>Test</PageTitle>
+
+                @code {
+                    private int myCurrentCount = 0;
+
+                    private void IncrementCount()
+                    {
+                        myCurrentCount++;
+
+                        myCurrentCount
+                    }
+                }
+                """,
+            search: "myCurrentCount++;",
+            stringsToType: ["{ENTER}", "{ENTER}", "m", "y", "C", "u", "r"]);
+    }
+
+    private async Task VerifyTypeAndCommitCompletionAsync(string input, string output, string search, string[] stringsToType)
+    {
         await TestServices.SolutionExplorer.AddFileAsync(
             RazorProjectConstants.BlazorProjectName,
             "Test.razor",
-            """
-@page "Test"
-
-<PageTitle>Test</PageTitle>
-
-<h1>Test</h1>
-
-@code {
-    private int currentCount = 0;
-
-    private void IncrementCount()
-    {
-        currentCount++;
-    }
-}
-""",
+            input,
             open: true,
             ControlledHangMitigatingCancellationToken);
 
         await TestServices.Editor.WaitForComponentClassificationAsync(ControlledHangMitigatingCancellationToken);
 
-        await TestServices.Editor.PlaceCaretAsync("<h1>Test</h1>", charsOffset: 1, ControlledHangMitigatingCancellationToken);
-        TestServices.Input.Send("{ENTER}");
-        TestServices.Input.Send("d");
-        TestServices.Input.Send("d");
+        await TestServices.Editor.PlaceCaretAsync(search, charsOffset: 1, ControlledHangMitigatingCancellationToken);
+        foreach (var stringToType in stringsToType)
+        {
+            TestServices.Input.Send(stringToType);
+        }
 
-        await CommitCompletionAndVerifyAsync("""
-@page "Test"
-
-<PageTitle>Test</PageTitle>
-
-<h1>Test</h1>
-<dl>
-    <dt></dt>
-    <dd></dd>
-</dl>
-
-@code {
-    private int currentCount = 0;
-
-    private void IncrementCount()
-    {
-        currentCount++;
-    }
-}
-""");
+        await CommitCompletionAndVerifyAsync(output);
     }
 
     [IdeFact]


### PR DESCRIPTION
﻿### Summary of the changes

-VS Platform (languageserver.client code) uses various characters specified by completion capabilities, including commit characters, to figure out which text span a completion item should replace when committed. It's known as "applicable-to" span. If we don't specify commit characters HTML uses in Razor commit character set in our completion endpoint capabilities, we end up eating some of those characters if they happen to be in the document text following (or preceding) item being commited.

Fixes: https://github.com/dotnet/razor/issues/10787
