### PR TITLE
Harden completion test

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/CompletionIntegrationTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/CompletionIntegrationTests.cs
@@ -437,6 +437,12 @@ public class CompletionIntegrationTests(ITestOutputHelper testOutputHelper) : Ab
         Assert.NotNull(session);
         if (commitChar.HasValue)
         {
+            // Commit using the specified commit character
+            session.Commit(commitChar.Value, HangMitigatingCancellationToken);
+
+            // session.Commit call above commits as if the commit character was typed,
+            // but doesn't actually insert the character into the buffer.
+            // So we still need to insert the character into the buffer ourselves.
             TestServices.Input.Send(commitChar.Value.ToString());
         }
         else

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/CompletionIntegrationTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/CompletionIntegrationTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Roslyn.Test.Utilities;
@@ -212,7 +213,8 @@ public class CompletionIntegrationTests(ITestOutputHelper testOutputHelper) : Ab
                 """,
             search: "</PageTitle>",
             stringsToType: ["{ENTER}", "{ENTER}", "<", "s", "p", "a"],
-            commitChar: '>');
+            commitChar: '>',
+            "span");
     }
 
     [IdeFact]
@@ -253,7 +255,7 @@ public class CompletionIntegrationTests(ITestOutputHelper testOutputHelper) : Ab
             stringsToType: ["{ENTER}", "{ENTER}", "m", "y", "C", "u", "r"]);
     }
 
-    private async Task VerifyTypeAndCommitCompletionAsync(string input, string output, string search, string[] stringsToType, char? commitChar = null)
+    private async Task VerifyTypeAndCommitCompletionAsync(string input, string output, string search, string[] stringsToType, char? commitChar = null, string? expectedSelectedItemLabel = null)
     {
         await TestServices.SolutionExplorer.AddFileAsync(
             RazorProjectConstants.BlazorProjectName,
@@ -270,7 +272,14 @@ public class CompletionIntegrationTests(ITestOutputHelper testOutputHelper) : Ab
             TestServices.Input.Send(stringToType);
         }
 
-        await CommitCompletionAndVerifyAsync(output, commitChar);
+        if (expectedSelectedItemLabel is not null)
+        {
+            await CommitCompletionAndVerifyAsync(output, expectedSelectedItemLabel, commitChar);
+        }
+        else
+        {
+            await CommitCompletionAndVerifyAsync(output, commitChar);
+        }
     }
 
     [IdeFact]
@@ -457,4 +466,41 @@ public class CompletionIntegrationTests(ITestOutputHelper testOutputHelper) : Ab
         // tests allow for it as long as the content is correct
         AssertEx.AssertEqualToleratingWhitespaceDifferences(expected, text);
     }
+
+    private async Task CommitCompletionAndVerifyAsync(string expected, string expectedSelectedItemLabel, char? commitChar = null)
+    {
+        // Actually open completion UI and wait for it have selected item we are interested in
+        var session = await TestServices.Editor.OpenCompletionSessionAndWaitForItemAsync(TimeSpan.FromSeconds(10), expectedSelectedItemLabel, HangMitigatingCancellationToken);
+
+        Assert.NotNull(session);
+        if (commitChar.HasValue)
+        {
+            // Commit using the specified commit character
+            session.Commit(commitChar.Value, HangMitigatingCancellationToken);
+
+            // session.Commit call above commits as if the commit character was typed,
+            // but doesn't actually insert the character into the buffer.
+            // So we still need to insert the character into the buffer ourselves.
+            TestServices.Input.Send(commitChar.Value.ToString());
+        }
+        else
+        {
+            Assert.True(session.CommitIfUnique(HangMitigatingCancellationToken));
+        }
+
+        var textView = await TestServices.Editor.GetActiveTextViewAsync(HangMitigatingCancellationToken);
+
+        var stopwatch = new Stopwatch();
+        string text;
+        while ((text = textView.TextBuffer.CurrentSnapshot.GetText()) != expected && stopwatch.ElapsedMilliseconds < 10000)
+        {
+            // Text might get updated *after* completion by something like auto-insert, so wait for the desired text
+            await Task.Delay(100);
+        }
+
+        // Snippets may have slight whitespace differences due to line endings. These
+        // tests allow for it as long as the content is correct
+        Assert.Equal(expected, text);
+    }
+
 }


### PR DESCRIPTION
Another attempt to harden completion integration test. There are three changes here:

1. We now actually open completion UI. Previously we may or may not have had the UI open, because IAsyncCompletionBroker.TriggerCompletion doesn't actually cause completion pop-up window UI to show (at least per doc comments). IAsyncCompletionSession.OpenOrUpdate actually shows completion window UI.
2. We now wait for a specified item to be present and selected prior to trying to commit. We will re-update (re-calculate) completion items while waiting.
3. We now wait for the correct text to be in the editor. After completion commit, there may be another action, such as OnAutoInsert that may modify the text further. We specify the final expected state of the text, so we should wait for it to be fully updated.