### PR TITLE
More hardening of the completion test

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/CompletionIntegrationTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/CompletionIntegrationTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Roslyn.Test.Utilities;
@@ -17,55 +18,268 @@ public class CompletionIntegrationTests(ITestOutputHelper testOutputHelper) : Ab
     [IdeFact]
     public async Task SnippetCompletion_Html()
     {
+        await VerifyTypeAndCommitCompletionAsync(
+            input: """
+                @page "Test"
+
+                <PageTitle>Test</PageTitle>
+
+                <h1>Test</h1>
+
+                @code {
+                    private int currentCount = 0;
+
+                    private void IncrementCount()
+                    {
+                        currentCount++;
+                    }
+                }
+                """,
+            output: """
+                @page "Test"
+
+                <PageTitle>Test</PageTitle>
+
+                <h1>Test</h1>
+                <dl>
+                    <dt></dt>
+                    <dd></dd>
+                </dl>
+
+                @code {
+                    private int currentCount = 0;
+
+                    private void IncrementCount()
+                    {
+                        currentCount++;
+                    }
+                }
+                """,
+            search: "<h1>Test</h1>",
+            stringsToType: ["{ENTER}", "d", "d"]);
+    }
+
+    [IdeFact, WorkItem("https://github.com/dotnet/razor/issues/10787")]
+    public async Task CompletionCommit_HtmlAttributeWithoutValue()
+    {
+        await VerifyTypeAndCommitCompletionAsync(
+            input: """
+                @page "Test"
+
+                <PageTitle>Test</PageTitle>
+
+                <button></button>
+
+                @code {
+                    private int currentCount = 0;
+
+                    private void IncrementCount()
+                    {
+                        currentCount++;
+                    }
+                }
+                """,
+            output: """
+                @page "Test"
+
+                <PageTitle>Test</PageTitle>
+
+                <button disabled></button>
+
+                @code {
+                    private int currentCount = 0;
+
+                    private void IncrementCount()
+                    {
+                        currentCount++;
+                    }
+                }
+                """,
+            search: "<button",
+            stringsToType: [" ", "d", "i", "s"]);
+    }
+
+    [IdeFact]
+    public async Task CompletionCommit_HtmlAttributeWithValue()
+    {
+        await VerifyTypeAndCommitCompletionAsync(
+            input: """
+                @page "Test"
+
+                <PageTitle>Test</PageTitle>
+
+                <button></button>
+
+                @code {
+                    private int currentCount = 0;
+
+                    private void IncrementCount()
+                    {
+                        currentCount++;
+                    }
+                }
+                """,
+            output: """
+                @page "Test"
+
+                <PageTitle>Test</PageTitle>
+
+                <button style=""></button>
+
+                @code {
+                    private int currentCount = 0;
+
+                    private void IncrementCount()
+                    {
+                        currentCount++;
+                    }
+                }
+                """,
+            search: "<button",
+            stringsToType: [" ", "s", "t", "y"]);
+    }
+
+    [IdeFact]
+    public async Task CompletionCommit_HtmlTag()
+    {
+        await VerifyTypeAndCommitCompletionAsync(
+            input: """
+                @page "Test"
+
+                <PageTitle>Test</PageTitle>
+
+                @code {
+                    private int currentCount = 0;
+
+                    private void IncrementCount()
+                    {
+                        currentCount++;
+                    }
+                }
+                """,
+            output: """
+                @page "Test"
+
+                <PageTitle>Test</PageTitle>
+
+                <span
+
+                @code {
+                    private int currentCount = 0;
+
+                    private void IncrementCount()
+                    {
+                        currentCount++;
+                    }
+                }
+                """,
+            search: "</PageTitle>",
+            stringsToType: ["{ENTER}", "{ENTER}", "<", "s", "p", "a"]);
+    }
+
+    [IdeFact]
+    public async Task CompletionCommit_WithAngleBracket_HtmlTag()
+    {
+        await VerifyTypeAndCommitCompletionAsync(
+            input: """
+                @page "Test"
+
+                <PageTitle>Test</PageTitle>
+
+                @code {
+                    private int currentCount = 0;
+
+                    private void IncrementCount()
+                    {
+                        currentCount++;
+                    }
+                }
+                """,
+            output: """
+                @page "Test"
+
+                <PageTitle>Test</PageTitle>
+
+                <span></span>
+
+                @code {
+                    private int currentCount = 0;
+
+                    private void IncrementCount()
+                    {
+                        currentCount++;
+                    }
+                }
+                """,
+            search: "</PageTitle>",
+            stringsToType: ["{ENTER}", "{ENTER}", "<", "s", "p", "a"],
+            commitChar: '>',
+            "span");
+    }
+
+    [IdeFact]
+    public async Task CompletionCommit_CSharp()
+    {
+        await VerifyTypeAndCommitCompletionAsync(
+            input: """
+                @page "Test"
+
+                <PageTitle>Test</PageTitle>
+
+                @code {
+                    private int myCurrentCount = 0;
+
+                    private void IncrementCount()
+                    {
+                        myCurrentCount++;
+                    }
+                }
+                """,
+            output: """
+                @page "Test"
+
+                <PageTitle>Test</PageTitle>
+
+                @code {
+                    private int myCurrentCount = 0;
+
+                    private void IncrementCount()
+                    {
+                        myCurrentCount++;
+
+                        myCurrentCount
+                    }
+                }
+                """,
+            search: "myCurrentCount++;",
+            stringsToType: ["{ENTER}", "{ENTER}", "m", "y", "C", "u", "r"]);
+    }
+
+    private async Task VerifyTypeAndCommitCompletionAsync(string input, string output, string search, string[] stringsToType, char? commitChar = null, string? expectedSelectedItemLabel = null)
+    {
         await TestServices.SolutionExplorer.AddFileAsync(
             RazorProjectConstants.BlazorProjectName,
             "Test.razor",
-            """
-@page "Test"
-
-<PageTitle>Test</PageTitle>
-
-<h1>Test</h1>
-
-@code {
-    private int currentCount = 0;
-
-    private void IncrementCount()
-    {
-        currentCount++;
-    }
-}
-""",
+            input,
             open: true,
             ControlledHangMitigatingCancellationToken);
 
         await TestServices.Editor.WaitForComponentClassificationAsync(ControlledHangMitigatingCancellationToken);
 
-        await TestServices.Editor.PlaceCaretAsync("<h1>Test</h1>", charsOffset: 1, ControlledHangMitigatingCancellationToken);
-        TestServices.Input.Send("{ENTER}");
-        TestServices.Input.Send("d");
-        TestServices.Input.Send("d");
+        await TestServices.Editor.PlaceCaretAsync(search, charsOffset: 1, ControlledHangMitigatingCancellationToken);
+        foreach (var stringToType in stringsToType)
+        {
+            TestServices.Input.Send(stringToType);
+        }
 
-        await CommitCompletionAndVerifyAsync("""
-@page "Test"
-
-<PageTitle>Test</PageTitle>
-
-<h1>Test</h1>
-<dl>
-    <dt></dt>
-    <dd></dd>
-</dl>
-
-@code {
-    private int currentCount = 0;
-
-    private void IncrementCount()
-    {
-        currentCount++;
-    }
-}
-""");
+        if (expectedSelectedItemLabel is not null)
+        {
+            await CommitCompletionAndVerifyAsync(output, expectedSelectedItemLabel, commitChar);
+        }
+        else
+        {
+            await CommitCompletionAndVerifyAsync(output, commitChar);
+        }
     }
 
     [IdeFact]
@@ -225,12 +439,25 @@ public class CompletionIntegrationTests(ITestOutputHelper testOutputHelper) : Ab
             """);
     }
 
-    private async Task CommitCompletionAndVerifyAsync(string expected)
+    private async Task CommitCompletionAndVerifyAsync(string expected, char? commitChar = null)
     {
         var session = await TestServices.Editor.WaitForCompletionSessionAsync(HangMitigatingCancellationToken);
 
         Assert.NotNull(session);
-        Assert.True(session.CommitIfUnique(HangMitigatingCancellationToken));
+        if (commitChar.HasValue)
+        {
+            // Commit using the specified commit character
+            session.Commit(commitChar.Value, HangMitigatingCancellationToken);
+
+            // session.Commit call above commits as if the commit character was typed,
+            // but doesn't actually insert the character into the buffer.
+            // So we still need to insert the character into the buffer ourselves.
+            TestServices.Input.Send(commitChar.Value.ToString());
+        }
+        else
+        {
+            Assert.True(session.CommitIfUnique(HangMitigatingCancellationToken));
+        }
 
         var textView = await TestServices.Editor.GetActiveTextViewAsync(HangMitigatingCancellationToken);
         var text = textView.TextBuffer.CurrentSnapshot.GetText();
@@ -239,4 +466,41 @@ public class CompletionIntegrationTests(ITestOutputHelper testOutputHelper) : Ab
         // tests allow for it as long as the content is correct
         AssertEx.AssertEqualToleratingWhitespaceDifferences(expected, text);
     }
+
+    private async Task CommitCompletionAndVerifyAsync(string expected, string expectedSelectedItemLabel, char? commitChar = null)
+    {
+        // Actually open completion UI and wait for it have selected item we are interested in
+        var session = await TestServices.Editor.OpenCompletionSessionAndWaitForItemAsync(TimeSpan.FromSeconds(10), expectedSelectedItemLabel, HangMitigatingCancellationToken);
+
+        Assert.NotNull(session);
+        if (commitChar.HasValue)
+        {
+            // Commit using the specified commit character
+            session.Commit(commitChar.Value, HangMitigatingCancellationToken);
+
+            // session.Commit call above commits as if the commit character was typed,
+            // but doesn't actually insert the character into the buffer.
+            // So we still need to insert the character into the buffer ourselves.
+            TestServices.Input.Send(commitChar.Value.ToString());
+        }
+        else
+        {
+            Assert.True(session.CommitIfUnique(HangMitigatingCancellationToken));
+        }
+
+        var textView = await TestServices.Editor.GetActiveTextViewAsync(HangMitigatingCancellationToken);
+
+        var stopwatch = new Stopwatch();
+        string text;
+        while ((text = textView.TextBuffer.CurrentSnapshot.GetText()) != expected && stopwatch.ElapsedMilliseconds < 10000)
+        {
+            // Text might get updated *after* completion by something like auto-insert, so wait for the desired text
+            await Task.Delay(100);
+        }
+
+        // Snippets may have slight whitespace differences due to line endings. These
+        // tests allow for it as long as the content is correct
+        Assert.Equal(expected, text);
+    }
+
 }

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/CompletionIntegrationTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/CompletionIntegrationTests.cs
@@ -174,7 +174,9 @@ public class CompletionIntegrationTests(ITestOutputHelper testOutputHelper) : Ab
                 }
                 """,
             search: "</PageTitle>",
-            stringsToType: ["{ENTER}", "{ENTER}", "<", "s", "p", "a"]);
+            stringsToType: ["{ENTER}", "{ENTER}", "<", "s", "p", "a"],
+            commitChar: null,
+            expectedSelectedItemLabel: "span");
     }
 
     [IdeFact]

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/EditorInProcess_Completion.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/EditorInProcess_Completion.cs
@@ -12,6 +12,8 @@ namespace Microsoft.VisualStudio.Extensibility.Testing;
 
 internal partial class EditorInProcess
 {
+    public const int DefaultCompletionWaitTimeMilliseconds = 10000;
+
     public async Task DismissCompletionSessionsAsync(CancellationToken cancellationToken)
     {
         await JoinableTaskFactory.SwitchToMainThreadAsync(cancellationToken);
@@ -87,7 +89,7 @@ internal partial class EditorInProcess
                 return null;
             }
 
-            await Task.Delay(TimeSpan.FromMilliseconds(100), cancellationToken);
+            await Task.Delay(100, cancellationToken);
 
             session.OpenOrUpdate(new CompletionTrigger(CompletionTriggerReason.Insertion, textView.TextSnapshot), textView.Caret.Position.BufferPosition, cancellationToken);
         }


### PR DESCRIPTION
We now wait for a specific item in the actual shown completion UI, and also wait for the correct text in the editor post-commit to account for actions such as OnAutoInsert

1. We now actually open completion UI. Previously we may or may not have had the UI open, because IAsyncCompletionBroker.TriggerCompletion doesn't actually cause completion pop-up window UI to show (at least per doc comments). IAsyncCompletionSession.OpenOrUpdate actually shows completion window UI.
2. We now wait for a specified item to be present and selected prior to trying to commit. We will re-update (re-calculate) completion items while waiting.
3. We now wait for the correct text to be in the editor. After completion commit, there may be another action, such as OnAutoInsert that may modify the text further. We specify the final expected state of the text, so we should wait for it to be fully updated.