### PR TITLE
Add a filter for faults to avoid bucketing

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
@@ -9,7 +9,7 @@ using Microsoft.VisualStudio.Telemetry;
 using Microsoft.AspNetCore.Razor.Telemetry;
 using System.Collections.Frozen;
 
-#if !DEBUG
+#if DEBUG
 using System.Linq;
 #endif
 
@@ -302,7 +302,7 @@ internal abstract class TelemetryReporter : ITelemetryReporter
     {
         try
         {
-#if DEBUG
+#if !DEBUG
             foreach (var session in TelemetrySessions)
             {
                 session.PostEvent(telemetryEvent);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
@@ -5,9 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Collections.Frozen;
 using Microsoft.VisualStudio.Telemetry;
 using Microsoft.AspNetCore.Razor.Telemetry;
-using System.Collections.Frozen;
 
 #if DEBUG
 using System.Linq;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
@@ -7,8 +7,9 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.VisualStudio.Telemetry;
 using Microsoft.AspNetCore.Razor.Telemetry;
+using System.Collections.Frozen;
 
-#if DEBUG
+#if !DEBUG
 using System.Linq;
 #endif
 
@@ -16,6 +17,15 @@ namespace Microsoft.VisualStudio.Razor.Telemetry;
 
 internal abstract class TelemetryReporter : ITelemetryReporter
 {
+    private const string CodeAnalysisNamespace = nameof(Microsoft) + "." + nameof(CodeAnalysis);
+    private const string AspNetCoreNamespace = nameof(Microsoft) + "." + nameof(AspNetCore);
+
+    // Types that will not contribute to fault bucketing. Fully qualified name is
+    // required in order to match correctly.
+    private static readonly FrozenSet<string> s_faultIgnoredTypeNames = new string[] {
+        "Microsoft.AspNetCore.Razor.NullableExtensions"
+    }.ToFrozenSet();
+
     protected ImmutableArray<TelemetrySession> TelemetrySessions { get; set; }
 
     protected TelemetryReporter(ImmutableArray<TelemetrySession> telemetrySessions = default)
@@ -163,6 +173,11 @@ internal abstract class TelemetryReporter : ITelemetryReporter
                     return 0;
                 });
 
+            var (moduleName, methodName) = GetModifiedMethodNameFaultNames(exception);
+            faultEvent.SetFailureParameters(
+                failureParameter1: moduleName,
+                failureParameter2: methodName);
+
             Report(faultEvent);
         }
         catch (Exception)
@@ -170,11 +185,87 @@ internal abstract class TelemetryReporter : ITelemetryReporter
         }
     }
 
+    private static (string?, string?) GetModifiedMethodNameFaultNames(Exception exception)
+    {
+        var frame = WalkStack(exception, frame =>
+        {
+            var method = frame?.GetMethod();
+            var methodName = method?.Name;
+            if (methodName is null)
+            {
+                return false;
+            }
+
+            var declaringTypeName = method?.DeclaringType?.FullName;
+            if (declaringTypeName == null)
+            {
+                return false;
+            }
+
+            if (!declaringTypeName.StartsWith(CodeAnalysisNamespace) &&
+                !declaringTypeName.StartsWith(AspNetCoreNamespace))
+            {
+                return false;
+            }
+
+            if (s_faultIgnoredTypeNames.Contains(declaringTypeName))
+            {
+                return false;
+            }
+
+            return true;
+        });
+
+        var method = frame?.GetMethod();
+        if (method is null)
+        {
+            return (null, null);
+        }
+
+        return (method.Module.Name, method.Name);
+    }
+
     private static string GetExceptionDetails(Exception exception)
     {
-        const string CodeAnalysisNamespace = nameof(Microsoft) + "." + nameof(CodeAnalysis);
-        const string AspNetCoreNamespace = nameof(Microsoft) + "." + nameof(AspNetCore);
+        var frame = WalkStack(exception, frame =>
+        {
+            var method = frame?.GetMethod();
+            var methodName = method?.Name;
+            if (methodName is null)
+            {
+                return false;
+            }
 
+            var declaringTypeName = method?.DeclaringType?.FullName;
+            if (declaringTypeName == null)
+            {
+                return false;
+            }
+
+            if (!declaringTypeName.StartsWith(CodeAnalysisNamespace) &&
+                !declaringTypeName.StartsWith(AspNetCoreNamespace))
+            {
+                return false;
+            }
+
+            return true;
+        });
+
+        var method = frame?.GetMethod();
+
+        var declaringTypeName = method?.DeclaringType?.FullName;
+        var methodName = method?.Name;
+
+        if (declaringTypeName is null || methodName is null)
+        {
+            return exception.Message;
+        }
+
+        return declaringTypeName + "." + methodName;
+    }
+
+    private static StackFrame? WalkStack(Exception exception, Func<StackFrame, bool> predicate)
+    {
         // Be resilient to failing here.  If we can't get a suitable name, just fall back to the standard name we
         // used to report.
         try
@@ -188,42 +279,26 @@ internal abstract class TelemetryReporter : ITelemetryReporter
             {
                 foreach (var frame in frames)
                 {
-                    var method = frame?.GetMethod();
-                    var methodName = method?.Name;
-                    if (methodName is null)
+                    if (predicate(frame))
                     {
-                        continue;
+                        return frame;
                     }
-
-                    var declaringTypeName = method?.DeclaringType?.FullName;
-                    if (declaringTypeName == null)
-                    {
-                        continue;
-                    }
-
-                    if (!declaringTypeName.StartsWith(CodeAnalysisNamespace) &&
-                        !declaringTypeName.StartsWith(AspNetCoreNamespace))
-                    {
-                        continue;
-                    }
-
-                    return declaringTypeName + "." + methodName;
                 }
             }
+
+            return null;
         }
         catch
         {
+            return null;
         }
-
-        // If we couldn't get a stack, do this
-        return exception.Message;
     }
 
     protected virtual void Report(TelemetryEvent telemetryEvent)
     {
         try
         {
-#if !DEBUG
+#if DEBUG
             foreach (var session in TelemetrySessions)
             {
                 session.PostEvent(telemetryEvent);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
@@ -2,10 +2,10 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Collections.Frozen;
 using Microsoft.VisualStudio.Telemetry;
 using Microsoft.AspNetCore.Razor.Telemetry;
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
@@ -8,6 +8,8 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.VisualStudio.Telemetry;
 using Microsoft.AspNetCore.Razor.Telemetry;
+using Microsoft.AspNetCore.Razor;
+
 
 #if DEBUG
 using System.Linq;
@@ -19,6 +21,7 @@ internal abstract class TelemetryReporter : ITelemetryReporter
 {
     private const string CodeAnalysisNamespace = nameof(Microsoft) + "." + nameof(CodeAnalysis);
     private const string AspNetCoreNamespace = nameof(Microsoft) + "." + nameof(AspNetCore);
+    private const string MicrosoftVSRazorNamespace = $"{nameof(Microsoft)}.{nameof(VisualStudio)}.{nameof(Razor)}";
 
     // Types that will not contribute to fault bucketing. Fully qualified name is
     // required in order to match correctly.
@@ -185,119 +188,6 @@ internal abstract class TelemetryReporter : ITelemetryReporter
         }
     }
 
-    /// <summary>
-    /// Returns values that should be set to (failureParameter1, failureParameter2) when reporting a fault.
-    /// Those values represent the blamed stackframe module and method name.
-    /// </summary>
-    private static (string?, string?) GetModifiedFaultParameters(Exception exception)
-    {
-        var frame = WalkStack(exception, frame =>
-        {
-            var method = frame?.GetMethod();
-            var methodName = method?.Name;
-            if (methodName is null)
-            {
-                return false;
-            }
-
-            var declaringTypeName = method?.DeclaringType?.FullName;
-            if (declaringTypeName == null)
-            {
-                return false;
-            }
-
-            if (!declaringTypeName.StartsWith(CodeAnalysisNamespace) &&
-                !declaringTypeName.StartsWith(AspNetCoreNamespace))
-            {
-                return false;
-            }
-
-            if (s_faultIgnoredTypeNames.Contains(declaringTypeName))
-            {
-                return false;
-            }
-
-            return true;
-        });
-
-        var method = frame?.GetMethod();
-        if (method is null)
-        {
-            return (null, null);
-        }
-
-        return (method.Module.Name, method.Name);
-    }
-
-    private static string GetExceptionDetails(Exception exception)
-    {
-        var frame = WalkStack(exception, frame =>
-        {
-            var method = frame?.GetMethod();
-            var methodName = method?.Name;
-            if (methodName is null)
-            {
-                return false;
-            }
-
-            var declaringTypeName = method?.DeclaringType?.FullName;
-            if (declaringTypeName == null)
-            {
-                return false;
-            }
-
-            if (!declaringTypeName.StartsWith(CodeAnalysisNamespace) &&
-                !declaringTypeName.StartsWith(AspNetCoreNamespace))
-            {
-                return false;
-            }
-
-            return true;
-        });
-
-        var method = frame?.GetMethod();
-
-        var declaringTypeName = method?.DeclaringType?.FullName;
-        var methodName = method?.Name;
-
-        if (declaringTypeName is null || methodName is null)
-        {
-            return exception.Message;
-        }
-
-        return declaringTypeName + "." + methodName;
-    }
-
-    private static StackFrame? WalkStack(Exception exception, Func<StackFrame, bool> predicate)
-    {
-        // Be resilient to failing here.  If we can't get a suitable name, just fall back to the standard name we
-        // used to report.
-        try
-        {
-            // walk up the stack looking for the first call from a type that isn't in the ErrorReporting namespace.
-            var frames = new StackTrace(exception).GetFrames();
-
-            // On the .NET Framework, GetFrames() can return null even though it's not documented as such.
-            // At least one case here is if the exception's stack trace itself is null.
-            if (frames != null)
-            {
-                foreach (var frame in frames)
-                {
-                    if (predicate(frame))
-                    {
-                        return frame;
-                    }
-                }
-            }
-
-            return null;
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
     protected virtual void Report(TelemetryEvent telemetryEvent)
     {
         try
@@ -376,4 +266,122 @@ internal abstract class TelemetryReporter : ITelemetryReporter
             new("eventscope.languageservername", languageServerName),
             new("eventscope.correlationid", correlationId));
     }
+
+
+    /// <summary>
+    /// Returns values that should be set to (failureParameter1, failureParameter2) when reporting a fault.
+    /// Those values represent the blamed stackframe module and method name.
+    /// </summary>
+    internal static (string?, string?) GetModifiedFaultParameters(Exception exception)
+    {
+        var frame = FindFirstRazorStackFrame(exception, static (declaringTypeName, _) =>
+        {
+            if (s_faultIgnoredTypeNames.Contains(declaringTypeName))
+            {
+                return false;
+            }
+
+            return true;
+        });
+
+        var method = frame?.GetMethod();
+        if (method is null)
+        {
+            return (null, null);
+        }
+
+        return (method.Module.Name, method.Name);
+    }
+
+    private static string GetExceptionDetails(Exception exception)
+    {
+        var frame = FindFirstRazorStackFrame(exception);
+
+        if (frame is null)
+        {
+            return exception.Message;
+        }
+
+        var method = frame.GetMethod();
+
+        // These are checked in FindFirstRazorStackFrame
+        method.AssumeNotNull();
+        method.DeclaringType.AssumeNotNull();
+
+        var declaringTypeName = method.DeclaringType.FullName;
+        var methodName = method.Name;
+
+        return declaringTypeName + "." + methodName;
+    }
+
+    /// <summary>
+    /// Finds the first stack frame in exception stack that originates from razor code based on namespace
+    /// </summary>
+    /// <param name="exception">The exception to get the stack from</param>
+    /// <param name="predicate">Optional predicate to filter by declaringTypeName and methodName</param>
+    /// <returns></returns>
+    private static StackFrame? FindFirstRazorStackFrame(
+        Exception exception,
+        Func<string, string, bool>? predicate = null)
+    {
+        // Be resilient to failing here.  If we can't get a suitable name, just fall back to the standard name we
+        // used to report.
+        try
+        {
+            // walk up the stack looking for the first call from a type that isn't in the ErrorReporting namespace.
+            var frames = new StackTrace(exception).GetFrames();
+
+            // On the .NET Framework, GetFrames() can return null even though it's not documented as such.
+            // At least one case here is if the exception's stack trace itself is null.
+            if (frames != null)
+            {
+                foreach (var frame in frames)
+                {
+                    if (frame is null)
+                    {
+                        continue;
+                    }
+
+                    var method = frame.GetMethod();
+                    var methodName = method?.Name;
+                    if (methodName is null)
+                    {
+                        continue;
+                    }
+
+                    var declaringTypeName = method?.DeclaringType?.FullName;
+                    if (declaringTypeName == null)
+                    {
+                        continue;
+                    }
+
+                    if (!IsInOwnedNamespace(declaringTypeName))
+                    {
+                        continue;
+                    }
+
+                    if (predicate is null)
+                    {
+                        return frame;
+                    }
+
+                    if (predicate(declaringTypeName, methodName))
+                    {
+                        return frame;
+                    }
+                }
+            }
+
+            return null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static bool IsInOwnedNamespace(string declaringTypeName)
+        => declaringTypeName.StartsWith(CodeAnalysisNamespace) ||
+            declaringTypeName.StartsWith(AspNetCoreNamespace) ||
+            declaringTypeName.StartsWith(MicrosoftVSRazorNamespace);
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
@@ -9,6 +9,8 @@ using System.Diagnostics;
 using Microsoft.VisualStudio.Telemetry;
 using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.AspNetCore.Razor;
+using System.IO;
+
 
 
 #if DEBUG
@@ -290,7 +292,8 @@ internal abstract class TelemetryReporter : ITelemetryReporter
             return (null, null);
         }
 
-        return (method.Module.Name, method.Name);
+        var moduleName = Path.GetFileNameWithoutExtension(method.Module.Name);
+        return (moduleName, method.Name);
     }
 
     private static string GetExceptionDetails(Exception exception)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
@@ -12,7 +12,6 @@ using Microsoft.AspNetCore.Razor;
 using System.IO;
 
 
-
 #if DEBUG
 using System.Linq;
 #endif

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
@@ -173,7 +173,7 @@ internal abstract class TelemetryReporter : ITelemetryReporter
                     return 0;
                 });
 
-            var (moduleName, methodName) = GetModifiedMethodNameFaultNames(exception);
+            var (moduleName, methodName) = GetModifiedFaultParameters(exception);
             faultEvent.SetFailureParameters(
                 failureParameter1: moduleName,
                 failureParameter2: methodName);
@@ -185,7 +185,11 @@ internal abstract class TelemetryReporter : ITelemetryReporter
         }
     }
 
-    private static (string?, string?) GetModifiedMethodNameFaultNames(Exception exception)
+    /// <summary>
+    /// Returns values that should be set to (failureParameter1, failureParameter2) when reporting a fault.
+    /// Those values represent the blamed stackframe module and method name.
+    /// </summary>
+    private static (string?, string?) GetModifiedFaultParameters(Exception exception)
     {
         var frame = WalkStack(exception, frame =>
         {

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Telemetry/TelemetryReporterTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Telemetry/TelemetryReporterTests.cs
@@ -406,20 +406,17 @@ public class TelemetryReporterTests(ITestOutputHelper testOutput) : ToolingTestB
         {
             var (param1, param2) = TestTelemetryReporter.GetModifiedFaultParameters(ex);
 
-            Assert.Equal("Microsoft.VisualStudio.LanguageServices.Razor.Test.dll", param1);
+            Assert.Equal("Microsoft.VisualStudio.LanguageServices.Razor.Test", param1);
             Assert.NotNull(param2);
 
-            // Depending on compilation the stack can contain a constructor or
+            // Depending on debug/release the stack can contain a constructor or
             // a call to this method. We expect one or the other and both
             // are valid
-            if (param2.StartsWith("GetModifiedFaultParameters"))
-            {
-                Assert.Equal("GetModifiedFaultParameters_FiltersCorrect", param2);
-            }
-            else
-            {
-                Assert.StartsWith("<.cctor>", param2);
-            }
+#if DEBUG
+            Assert.StartsWith("<.cctor>", param2);
+#else 
+            Assert.Equal("GetModifiedFaultParameters_FiltersCorrectly", param2);
+#endif
         }
     }
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Telemetry/TelemetryReporterTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Telemetry/TelemetryReporterTests.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.VisualStudio.Editor.Razor.Test.Shared;
@@ -392,4 +394,23 @@ public class TelemetryReporterTests(ITestOutputHelper testOutput) : ToolingTestB
         // Assert
         Assert.Empty(reporter.Events);
     }
+
+    [Theory, MemberData(nameof(s_throwFunctions))]
+    public void GetModifiedFaultParameters_FiltersCorrectly(Func<object> throwAction)
+    {
+        try
+        {
+            throwAction();
+        }
+        catch (Exception ex)
+        {
+            var (param1, param2) = TestTelemetryReporter.GetModifiedFaultParameters(ex);
+            Assert.Equal("Microsoft.VisualStudio.LanguageServices.Razor.Test.dll", param1);
+            Assert.Equal("<.cctor>b__20_0", param2);
+        }
+    }
+
+    public static readonly IEnumerable<object[]> s_throwFunctions = [
+        [() => ((object?)null).AssumeNotNull()]
+    ];
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Telemetry/TelemetryReporterTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Telemetry/TelemetryReporterTests.cs
@@ -405,8 +405,21 @@ public class TelemetryReporterTests(ITestOutputHelper testOutput) : ToolingTestB
         catch (Exception ex)
         {
             var (param1, param2) = TestTelemetryReporter.GetModifiedFaultParameters(ex);
+
             Assert.Equal("Microsoft.VisualStudio.LanguageServices.Razor.Test.dll", param1);
-            Assert.Equal("<.cctor>b__20_0", param2);
+            Assert.NotNull(param2);
+
+            // Depending on compilation the stack can contain a constructor or
+            // a call to this method. We expect one or the other and both
+            // are valid
+            if (param2.StartsWith("GetModifiedFaultParameters"))
+            {
+                Assert.Equal("GetModifiedFaultParameters_FiltersCorrect", param2);
+            }
+            else
+            {
+                Assert.StartsWith("<.cctor>", param2);
+            }
         }
     }
 


### PR DESCRIPTION
Helps remove `AssumeNotNull` from the fault parameters and blame something in our code stack instead