### PR TITLE
Fix on type formatting

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DocumentOnTypeFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DocumentOnTypeFormattingEndpoint.cs
@@ -89,7 +89,8 @@ internal class DocumentOnTypeFormattingEndpoint(
             return null;
         }
 
-        if (!_razorFormattingService.TryGetOnTypeFormattingTriggerKind(codeDocument, hostDocumentIndex, request.Character, out var triggerCharacterKind))
+        if (!_razorFormattingService.TryGetOnTypeFormattingTriggerKind(codeDocument, hostDocumentIndex, request.Character, out var triggerCharacterKind) ||
+            triggerCharacterKind == RazorLanguageKind.Razor)
         {
             return null;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DocumentOnTypeFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DocumentOnTypeFormattingEndpoint.cs
@@ -89,7 +89,7 @@ internal class DocumentOnTypeFormattingEndpoint(
             return null;
         }
 
-        if (_razorFormattingService.TryGetOnTypeFormattingTriggerKind(codeDocument, hostDocumentIndex, request.Character, out var triggerCharacterKind))
+        if (!_razorFormattingService.TryGetOnTypeFormattingTriggerKind(codeDocument, hostDocumentIndex, request.Character, out var triggerCharacterKind))
         {
             return null;
         }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Formatting/RemoteFormattingService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Formatting/RemoteFormattingService.cs
@@ -97,10 +97,10 @@ internal sealed class RemoteFormattingService(in ServiceArgs args) : RazorDocume
         => RunServiceAsync(
             solutionInfo,
             documentId,
-            context => IsValidOnTypeFormattingTriggerAsync(context, linePosition, triggerCharacter, cancellationToken),
+            context => GetOnTypeFormattingTriggerKindAsync(context, linePosition, triggerCharacter, cancellationToken),
             cancellationToken);
 
-    private async ValueTask<Response> IsValidOnTypeFormattingTriggerAsync(RemoteDocumentContext context, LinePosition linePosition, string triggerCharacter, CancellationToken cancellationToken)
+    private async ValueTask<Response> GetOnTypeFormattingTriggerKindAsync(RemoteDocumentContext context, LinePosition linePosition, string triggerCharacter, CancellationToken cancellationToken)
     {
         var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
         var sourceText = codeDocument.Source.Text;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/CSharpStatementBlockOnTypeFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/CSharpStatementBlockOnTypeFormattingTest.cs
@@ -124,6 +124,23 @@ public class CSharpStatementBlockOnTypeFormattingTest(HtmlFormattingFixture fixt
     }
 
     [Fact]
+    public async Task Semicolon_PropertyGet()
+    {
+        await RunOnTypeFormattingTestAsync(
+            input: """
+                    @code {
+                     private string Name {get;$$}
+                    }
+                    """,
+            expected: """
+                    @code {
+                        private string Name { get; }
+                    }
+                    """,
+            triggerCharacter: ';');
+    }
+
+    [Fact]
     public async Task Semicolon_AddsLineAtEndOfDocument()
     {
         await RunOnTypeFormattingTestAsync(

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingLanguageServerTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingLanguageServerTestBase.cs
@@ -48,7 +48,8 @@ public abstract class FormattingLanguageServerTestBase(ITestOutputHelper testOut
 
         public Task<ImmutableArray<TextChange>> GetCSharpOnTypeFormattingChangesAsync(DocumentContext documentContext, RazorFormattingOptions options, int hostDocumentIndex, char triggerCharacter, CancellationToken cancellationToken)
         {
-            throw new NotImplementedException();
+            Called = true;
+            return SpecializedTasks.EmptyImmutableArray<TextChange>();
         }
 
         public Task<TextChange?> TryGetCSharpSnippetFormattingEditAsync(DocumentContext documentContext, ImmutableArray<TextChange> edits, RazorFormattingOptions options, CancellationToken cancellationToken)


### PR DESCRIPTION
Oops! I broke on type formatting, by missing a `!`, in https://github.com/dotnet/razor/pull/10822

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2264292

FYI @phil-allen-msft as I'm targetting 17.12 P3 with the fix.