### PR TITLE
Fixing auto-insert inside of a C# statement.

### DIFF
--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/AutoClosingTagOnAutoInsertProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/AutoInsert/AutoClosingTagOnAutoInsertProviderTest.cs
@@ -169,7 +169,7 @@ public class AutoClosingTagOnAutoInsertProviderTest(ITestOutputHelper testOutput
 
     [Fact]
     [WorkItem("https://github.com/dotnet/aspnetcore/issues/36125")]
-    public void OnTypeCloseAngle_TagDoesNotAutoCloseOutOfScope()
+    public void OnTypeCloseAngle_TagDoesAutoCloseOutOfScope()
     {
         RunAutoInsertTest(
             input: """
@@ -183,8 +183,58 @@ public class AutoClosingTagOnAutoInsertProviderTest(ITestOutputHelper testOutput
                 <div>
                     @if (true)
                     {
-                        <div></div>
+                        <div>$0</div></div>
                     }
+                """);
+    }
+
+    [Fact]
+    [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2251322")]
+    public void OnTypeCloseAngle_TagDoesAutoCloseInsideCSharpStatement()
+    {
+        RunAutoInsertTest(
+            input: """
+                <div>
+                    @if (true)
+                    {
+                        <div>$$
+                    }
+                </div>
+                """,
+            expected: """
+                <div>
+                    @if (true)
+                    {
+                        <div>$0</div>
+                    }
+                </div>
+                """);
+    }
+
+    [Fact]
+    [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2251322")]
+    public void OnTypeCloseAngle_TagDoesAutoCloseInsideDifferentTag()
+    {
+        RunAutoInsertTest(
+            input: """
+                <div>
+                    <blockquote>
+                        @if (true)
+                        {
+                            <div>$$
+                        }
+                    </blockquote>
+                </div>
+                """,
+            expected: """
+                <div>
+                    <blockquote>
+                        @if (true)
+                        {
+                            <div>$0</div>
+                        }
+                    </blockquote>
+                </div>
                 """);
     }
 


### PR DESCRIPTION
Current code was defining allowed auto-insert scenario too narrowly, with the main issue being that at the moment of the auto-insert the end tag for the newly typed tag is missing and if there is an enclosing/parent tag with the same name, the inner tag ends up "stealing" the end tag from that. We need to walk up the tree looking for the unclosed parent tag with the same name.

﻿### Summary of the changes

- If our current tag (the one where we just completed the start tag by typing ```>```) appears to contain end tag, it might be stealing end tag from the enclosing tag with the same name, e.g.
```
<div>
    <div>|
</div>
```
we currently handle that case, but not completely. 
- Now we walk up the tree, and we don't stop if current tag is inside of something other than a tag, because when a tag is wrapped into a C# statement, inner html tag will have MarkupBlock as its parent rather than another tag. E.g. in this case
```
<div>
    @if(true)
    {
        <div>|
    }
</div>
```
we previously would've stopped going up the tree looking for an unclosed <div>. After this fix we will go until we hit the tree root.
- If our tag is inside of another tag with a different name, we previously would've stopped. However, when we have an unclosed tag, the entire tree is _strange_ and we should not stop in such cases. E.g. this now works as well
```
<div>
    <blockquote>
        @if(true)
        {
            <div>|
        }
    </blockquote>
</div>
```
- Unfortunately, the unlikely scenario that we were trying to keep working properly now doesn't work quite as well. That unlikely (IMHO) opinion scenario is 
```
<div>
    @if(true)
    {
        <div>|</div>
    }
```
I say it's unlikely since it would happen only if the outer/parent tag was unclosed, the inner tag (at the caret position) was already closed, and we either deleted and re-typed ```>```, or typed another opening tag there. Previously nothing would've happened. Now you will get
```
<div>
    @if(true)
    {
        <div>|</div></div>
    }
```
which is not ideal, but we can't really understand exactly where to terminate the outer tag. Again, this scenario seems fairly unlikely to me. I would think that the tag at the current position will be unterminated most of the time when auto-inset occurs while outer tag will be terminated. We can monitor user feedback and adjust behavior if needed.

Fixes: https://developercommunity.visualstudio.com/t/Razor-Development:-HTML-Tag-Does-Not-Aut/10745294
