### PR TITLE
Refresh diagnostics on project changes

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
@@ -105,6 +105,7 @@ internal static class IServiceCollectionExtensions
         services.AddHandlerWithCapabilities<DocumentPullDiagnosticsEndpoint>();
         services.AddSingleton<RazorTranslateDiagnosticsService>();
         services.AddSingleton(sp => new Lazy<RazorTranslateDiagnosticsService>(sp.GetRequiredService<RazorTranslateDiagnosticsService>));
+        services.AddSingleton<IRazorStartupService, WorkspaceDiagnosticsRefresh>();
     }
 
     public static void AddHoverServices(this IServiceCollection services)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
@@ -105,7 +105,7 @@ internal static class IServiceCollectionExtensions
         services.AddHandlerWithCapabilities<DocumentPullDiagnosticsEndpoint>();
         services.AddSingleton<RazorTranslateDiagnosticsService>();
         services.AddSingleton(sp => new Lazy<RazorTranslateDiagnosticsService>(sp.GetRequiredService<RazorTranslateDiagnosticsService>));
-        services.AddSingleton<IRazorStartupService, WorkspaceDiagnosticsRefresh>();
+        services.AddSingleton<IRazorStartupService, WorkspaceDiagnosticsRefresher>();
     }
 
     public static void AddHoverServices(this IServiceCollection services)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/WorkspaceDiagnosticsRefresh.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/WorkspaceDiagnosticsRefresh.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Protocol;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer;
+
+internal class WorkspaceDiagnosticsRefresh : IRazorStartupService
+{
+    private readonly object _gate = new();
+    private readonly IClientCapabilitiesService _clientCapabilitiesService;
+    private readonly IClientConnection _clientConnection;
+    private bool _refreshQueued;
+    private Task? _refreshTask;
+
+    private static readonly TimeSpan s_delay = TimeSpan.FromMilliseconds(200);
+
+    public WorkspaceDiagnosticsRefresh(
+        IProjectSnapshotManager projectSnapshotManager,
+        IClientCapabilitiesService clientCapabilitiesService,
+        IClientConnection clientConnection)
+    {
+        projectSnapshotManager.Changed += ProjectSnapshotManager_Changed;
+        _clientCapabilitiesService = clientCapabilitiesService;
+        _clientConnection = clientConnection;
+    }
+
+    private void ProjectSnapshotManager_Changed(object? sender, ProjectChangeEventArgs e)
+    {
+        if (e.SolutionIsClosing)
+        {
+            return;
+        }
+
+        if (e.Kind is not ProjectChangeKind.DocumentChanged)
+        {
+            QueueRefresh();
+        }
+    }
+
+    private void QueueRefresh()
+    {
+        lock(_gate)
+        {
+            if (_refreshQueued)
+            {
+                return;
+            }
+
+            if (!_clientCapabilitiesService.CanGetClientCapabilities)
+            {
+                return;
+            }
+
+            var supported = _clientCapabilitiesService.ClientCapabilities.Workspace?.Diagnostics?.RefreshSupport;
+            if (supported != true)
+            {
+                return;
+            }
+
+            _refreshQueued = true;
+            _refreshTask = RefreshAfterDelayAsync();
+        }
+    }
+
+    private async Task RefreshAfterDelayAsync()
+    {
+        await Task.Delay(s_delay).ConfigureAwait(false);
+
+        _clientConnection
+            .SendNotificationAsync(Methods.WorkspaceDiagnosticRefreshName, default)
+            .Forget();
+
+        _refreshQueued = false;
+    }
+
+    public TestAccessor GetTestAccessor()
+        => new(this);
+
+    public class TestAccessor
+    {
+        private readonly WorkspaceDiagnosticsRefresh _instance;
+
+        public TestAccessor(WorkspaceDiagnosticsRefresh instance)
+        {
+            _instance = instance;
+        }
+
+        public Task WaitForRefreshAsync()
+        {
+            return _instance._refreshTask ?? Task.CompletedTask;
+        }
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/WorkspaceDiagnosticsRefresher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/WorkspaceDiagnosticsRefresher.cs
@@ -44,10 +44,10 @@ internal sealed class WorkspaceDiagnosticsRefresher : IRazorStartupService, IDis
     private ValueTask ProcessBatchAsync(CancellationToken token)
     {
         _clientConnection
-            .SendNotificationAsync(Methods.WorkspaceDiagnosticRefreshName, _disposeTokenSource.Token)
+            .SendNotificationAsync(Methods.WorkspaceDiagnosticRefreshName, token)
             .Forget();
 
-        return new ValueTask(Task.CompletedTask);
+        return default;
     }
 
     private void ProjectSnapshotManager_Changed(object? sender, ProjectChangeEventArgs e)
@@ -97,6 +97,7 @@ internal sealed class WorkspaceDiagnosticsRefresher : IRazorStartupService, IDis
         }
 
         _disposeTokenSource.Cancel();
+        _disposeTokenSource.Dispose();
         _projectSnapshotManager.Changed -= ProjectSnapshotManager_Changed;
     }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/WorkspaceDiagnosticsRefresher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/WorkspaceDiagnosticsRefresher.cs
@@ -17,7 +17,7 @@ using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
-internal class WorkspaceDiagnosticsRefresher : IRazorStartupService
+internal sealed class WorkspaceDiagnosticsRefresher : IRazorStartupService
 {
     private readonly AsyncBatchingWorkQueue _queue;
     private readonly IClientCapabilitiesService _clientCapabilitiesService;
@@ -89,10 +89,10 @@ internal class WorkspaceDiagnosticsRefresher : IRazorStartupService
         return _clientCapabilitiesService.ClientCapabilities.Workspace?.Diagnostics?.RefreshSupport;
     }
 
-    public TestAccessor GetTestAccessor()
+    internal TestAccessor GetTestAccessor()
         => new(this);
 
-    public class TestAccessor
+    internal sealed class TestAccessor
     {
         private readonly WorkspaceDiagnosticsRefresher _instance;
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/WorkspaceDiagnosticsRefresher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/WorkspaceDiagnosticsRefresher.cs
@@ -15,7 +15,7 @@ using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
-internal class WorkspaceDiagnosticsRefresh : IRazorStartupService
+internal class WorkspaceDiagnosticsRefresher : IRazorStartupService
 {
     private readonly object _gate = new();
     private readonly IClientCapabilitiesService _clientCapabilitiesService;
@@ -25,7 +25,7 @@ internal class WorkspaceDiagnosticsRefresh : IRazorStartupService
 
     private static readonly TimeSpan s_delay = TimeSpan.FromMilliseconds(200);
 
-    public WorkspaceDiagnosticsRefresh(
+    public WorkspaceDiagnosticsRefresher(
         IProjectSnapshotManager projectSnapshotManager,
         IClientCapabilitiesService clientCapabilitiesService,
         IClientConnection clientConnection)
@@ -89,9 +89,9 @@ internal class WorkspaceDiagnosticsRefresh : IRazorStartupService
 
     public class TestAccessor
     {
-        private readonly WorkspaceDiagnosticsRefresh _instance;
+        private readonly WorkspaceDiagnosticsRefresher _instance;
 
-        public TestAccessor(WorkspaceDiagnosticsRefresh instance)
+        public TestAccessor(WorkspaceDiagnosticsRefresher instance)
         {
             _instance = instance;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/WorkspaceDiagnosticsRefresher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/WorkspaceDiagnosticsRefresher.cs
@@ -41,6 +41,18 @@ internal sealed class WorkspaceDiagnosticsRefresher : IRazorStartupService, IDis
         _projectSnapshotManager.Changed += ProjectSnapshotManager_Changed;
     }
 
+    public void Dispose()
+    {
+        if (_disposeTokenSource.IsCancellationRequested)
+        {
+            return;
+        }
+
+        _disposeTokenSource.Cancel();
+        _disposeTokenSource.Dispose();
+        _projectSnapshotManager.Changed -= ProjectSnapshotManager_Changed;
+    }
+
     private ValueTask ProcessBatchAsync(CancellationToken token)
     {
         _clientConnection
@@ -68,7 +80,6 @@ internal sealed class WorkspaceDiagnosticsRefresher : IRazorStartupService, IDis
         {
             return;
         }
-        
 
         if (e.Kind is not ProjectChangeKind.DocumentChanged)
         {
@@ -88,18 +99,6 @@ internal sealed class WorkspaceDiagnosticsRefresher : IRazorStartupService, IDis
 
     internal TestAccessor GetTestAccessor()
         => new(this);
-
-    public void Dispose()
-    {
-        if (_disposeTokenSource.IsCancellationRequested)
-        {
-            return;
-        }
-
-        _disposeTokenSource.Cancel();
-        _disposeTokenSource.Dispose();
-        _projectSnapshotManager.Changed -= ProjectSnapshotManager_Changed;
-    }
 
     internal sealed class TestAccessor
     {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/WorkspaceDiagnosticsRefresher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/WorkspaceDiagnosticsRefresher.cs
@@ -29,13 +29,14 @@ internal sealed class WorkspaceDiagnosticsRefresher : IRazorStartupService, IDis
     public WorkspaceDiagnosticsRefresher(
         IProjectSnapshotManager projectSnapshotManager,
         IClientCapabilitiesService clientCapabilitiesService,
-        IClientConnection clientConnection)
+        IClientConnection clientConnection,
+        TimeSpan? delay = null)
     {
         _clientConnection = clientConnection;
         _projectSnapshotManager = projectSnapshotManager;
         _clientCapabilitiesService = clientCapabilitiesService;
         _queue = new(
-            TimeSpan.FromMilliseconds(200),
+            delay ?? TimeSpan.FromMilliseconds(200),
             ProcessBatchAsync,
             _disposeTokenSource.Token);
         _projectSnapshotManager.Changed += ProjectSnapshotManager_Changed;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/WorkspaceSemanticTokensRefreshNotifier.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/WorkspaceSemanticTokensRefreshNotifier.cs
@@ -14,8 +14,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
 internal sealed class WorkspaceSemanticTokensRefreshNotifier : IWorkspaceSemanticTokensRefreshNotifier, IDisposable
 {
-    private static readonly TimeSpan s_delay = TimeSpan.FromMilliseconds(250);
-
     private readonly IClientCapabilitiesService _clientCapabilitiesService;
     private readonly IClientConnection _clientConnection;
     private readonly CancellationTokenSource _disposeTokenSource;
@@ -106,6 +104,11 @@ internal sealed class WorkspaceSemanticTokensRefreshNotifier : IWorkspaceSemanti
     {
         public Task WaitForNotificationAsync()
         {
+            if (instance._disposeTokenSource.IsCancellationRequested)
+            {
+                return Task.CompletedTask;
+            }
+
             return instance._queue.WaitUntilCurrentBatchCompletesAsync();
         }
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/WorkspaceSemanticTokensRefreshNotifier.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/WorkspaceSemanticTokensRefreshNotifier.cs
@@ -12,7 +12,7 @@ using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
-internal class WorkspaceSemanticTokensRefreshNotifier : IWorkspaceSemanticTokensRefreshNotifier, IDisposable
+internal sealed class WorkspaceSemanticTokensRefreshNotifier : IWorkspaceSemanticTokensRefreshNotifier, IDisposable
 {
     private static readonly TimeSpan s_delay = TimeSpan.FromMilliseconds(250);
 
@@ -22,7 +22,6 @@ internal class WorkspaceSemanticTokensRefreshNotifier : IWorkspaceSemanticTokens
     private readonly IDisposable _optionsChangeListener;
 
     private readonly AsyncBatchingWorkQueue _queue;
-    private Task _refreshTask = Task.CompletedTask;
 
     private bool _isColoringBackground;
     private bool? _supportsRefresh;
@@ -103,7 +102,7 @@ internal class WorkspaceSemanticTokensRefreshNotifier : IWorkspaceSemanticTokens
     internal TestAccessor GetTestAccessor()
         => new(this);
 
-    internal class TestAccessor(WorkspaceSemanticTokensRefreshNotifier instance)
+    internal sealed class TestAccessor(WorkspaceSemanticTokensRefreshNotifier instance)
     {
         public Task WaitForNotificationAsync()
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/WorkspaceSemanticTokensRefreshNotifier.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/WorkspaceSemanticTokensRefreshNotifier.cs
@@ -48,10 +48,10 @@ internal sealed class WorkspaceSemanticTokensRefreshNotifier : IWorkspaceSemanti
     private ValueTask ProcessBatchAsync(CancellationToken token)
     {
         _clientConnection
-            .SendNotificationAsync(Methods.WorkspaceSemanticTokensRefreshName, _disposeTokenSource.Token)
+            .SendNotificationAsync(Methods.WorkspaceSemanticTokensRefreshName, token)
             .Forget();
 
-        return new(Task.CompletedTask);
+        return default;
     }
 
     public void Dispose()

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/WorkspaceDiagnosticRefreshTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/WorkspaceDiagnosticRefreshTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading;
@@ -19,6 +20,8 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Test;
 
 public class WorkspaceDiagnosticRefreshTest(ITestOutputHelper testOutputHelper) : LanguageServerTestBase(testOutputHelper)
 {
+    private static readonly TimeSpan s_delay = TimeSpan.FromMilliseconds(10);
+
     [Fact]
     public async Task WorkspaceRefreshSent()
     {
@@ -41,7 +44,8 @@ public class WorkspaceDiagnosticRefreshTest(ITestOutputHelper testOutputHelper) 
                     }
                 }
             }),
-            clientConnection.Object);
+            clientConnection.Object,
+            s_delay);
 
         var testAccessor = publisher.GetTestAccessor();
 
@@ -77,7 +81,8 @@ public class WorkspaceDiagnosticRefreshTest(ITestOutputHelper testOutputHelper) 
                     }
                 }
             }),
-            clientConnection.Object);
+            clientConnection.Object,
+            s_delay);
 
         var testAccessor = publisher.GetTestAccessor();
 
@@ -125,7 +130,8 @@ public class WorkspaceDiagnosticRefreshTest(ITestOutputHelper testOutputHelper) 
                     }
                 }
             }),
-            clientConnection.Object);
+            clientConnection.Object,
+            s_delay);
 
         var testAccessor = publisher.GetTestAccessor();
 
@@ -160,7 +166,8 @@ public class WorkspaceDiagnosticRefreshTest(ITestOutputHelper testOutputHelper) 
                     }
                 }
             }),
-            clientConnection.Object);
+            clientConnection.Object,
+            s_delay);
 
         var testAccessor = publisher.GetTestAccessor();
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/WorkspaceDiagnosticRefreshTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/WorkspaceDiagnosticRefreshTest.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
+using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
+using Microsoft.AspNetCore.Razor.Test.Common.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Moq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Test;
+
+public class WorkspaceDiagnosticRefreshTest(ITestOutputHelper testOutputHelper) : LanguageServerTestBase(testOutputHelper)
+{
+    [Fact]
+    public async Task WorkspaceRefreshSent()
+    {
+        var projectSnapshotManager = CreateProjectSnapshotManager();
+        var clientConnection = new Mock<IClientConnection>(MockBehavior.Strict);
+        clientConnection
+            .Setup(c => c.SendNotificationAsync(Methods.WorkspaceDiagnosticRefreshName, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask)
+            .Verifiable();
+
+        var publisher = new WorkspaceDiagnosticsRefresher(
+            projectSnapshotManager,
+            new TestClientCapabilitiesService(new()
+            {
+                Workspace = new()
+                {
+                    Diagnostics = new()
+                    {
+                        RefreshSupport = true
+                    }
+                }
+            }),
+            clientConnection.Object);
+
+        var testAccessor = publisher.GetTestAccessor();
+
+        await projectSnapshotManager.UpdateAsync(
+            static updater =>
+            {
+                updater.CreateAndAddProject("C:/path/to/project.csproj");
+            });
+
+        await testAccessor.WaitForRefreshAsync();
+
+        clientConnection.Verify();
+    }
+
+    [Fact]
+    public async Task WorkspaceRefreshSent_MultipleTimes()
+    {
+        var projectSnapshotManager = CreateProjectSnapshotManager();
+        var clientConnection = new Mock<IClientConnection>(MockBehavior.Strict);
+        clientConnection
+            .Verify(c => c.SendNotificationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                    Times.Exactly(2));
+
+        var publisher = new WorkspaceDiagnosticsRefresher(
+            projectSnapshotManager,
+            new TestClientCapabilitiesService(new()
+            {
+                Workspace = new()
+                {
+                    Diagnostics = new()
+                    {
+                        RefreshSupport = true
+                    }
+                }
+            }),
+            clientConnection.Object);
+
+        var testAccessor = publisher.GetTestAccessor();
+
+        await projectSnapshotManager.UpdateAsync(
+            static updater =>
+            {
+                updater.CreateAndAddProject("C:/path/to/project.csproj");
+            });
+
+        await testAccessor.WaitForRefreshAsync();
+
+        await projectSnapshotManager.UpdateAsync(
+            static updater =>
+            {
+                var project = (ProjectSnapshot)updater.GetProjects().Single();
+                updater.CreateAndAddDocument(project, "C:/path/to/document.razor");
+            });
+
+        await testAccessor.WaitForRefreshAsync();
+
+        clientConnection.Verify();
+    }
+
+    [Fact]
+    public async Task WorkspaceRefreshNotSent_ClientDoesNotSupport()
+    {
+        var projectSnapshotManager = CreateProjectSnapshotManager();
+        var clientConnection = new Mock<IClientConnection>(MockBehavior.Strict);
+        clientConnection
+            .Verify(c => c.SendNotificationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+                    Times.Never);
+
+        var publisher = new WorkspaceDiagnosticsRefresher(
+            projectSnapshotManager,
+            new TestClientCapabilitiesService(new()
+            {
+                Workspace = new()
+                {
+                    Diagnostics = new()
+                    {
+                        RefreshSupport = false
+                    }
+                }
+            }),
+            clientConnection.Object);
+
+        var testAccessor = publisher.GetTestAccessor();
+
+        await projectSnapshotManager.UpdateAsync(
+            static updater =>
+            {
+                updater.CreateAndAddProject("C:/path/to/project.csproj");
+            });
+
+        await testAccessor.WaitForRefreshAsync();
+
+        clientConnection.Verify();
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/WorkspaceDiagnosticRefreshTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/WorkspaceDiagnosticRefreshTest.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
+using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.AspNetCore.Razor.Test.Common.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -22,7 +23,7 @@ public class WorkspaceDiagnosticRefreshTest(ITestOutputHelper testOutputHelper) 
     public async Task WorkspaceRefreshSent()
     {
         var projectSnapshotManager = CreateProjectSnapshotManager();
-        var clientConnection = new Mock<IClientConnection>(MockBehavior.Strict);
+        var clientConnection = new StrictMock<IClientConnection>();
         clientConnection
             .Setup(c => c.SendNotificationAsync(Methods.WorkspaceDiagnosticRefreshName, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask)
@@ -59,7 +60,7 @@ public class WorkspaceDiagnosticRefreshTest(ITestOutputHelper testOutputHelper) 
     public async Task WorkspaceRefreshSent_MultipleTimes()
     {
         var projectSnapshotManager = CreateProjectSnapshotManager();
-        var clientConnection = new Mock<IClientConnection>(MockBehavior.Strict);
+        var clientConnection = new StrictMock<IClientConnection>();
         clientConnection
             .Setup(c => c.SendNotificationAsync(Methods.WorkspaceDiagnosticRefreshName, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
@@ -110,7 +111,7 @@ public class WorkspaceDiagnosticRefreshTest(ITestOutputHelper testOutputHelper) 
     public async Task WorkspaceRefreshNotSent_ClientDoesNotSupport()
     {
         var projectSnapshotManager = CreateProjectSnapshotManager();
-        var clientConnection = new Mock<IClientConnection>(MockBehavior.Strict);
+        var clientConnection = new StrictMock<IClientConnection>();
 
         using var publisher = new WorkspaceDiagnosticsRefresher(
             projectSnapshotManager,
@@ -145,7 +146,7 @@ public class WorkspaceDiagnosticRefreshTest(ITestOutputHelper testOutputHelper) 
     public async Task WorkspaceRefreshNotSent_RefresherDisposed()
     {
         var projectSnapshotManager = CreateProjectSnapshotManager();
-        var clientConnection = new Mock<IClientConnection>(MockBehavior.Strict);
+        var clientConnection = new StrictMock<IClientConnection>();
 
         var publisher = new WorkspaceDiagnosticsRefresher(
             projectSnapshotManager,


### PR DESCRIPTION
This notifies a client to refresh diagnostics when we experience project snapshot changes (except for document changed). This should help for cases where the project engine is updating but doesn't have all taghelper information yet. 