### PR TITLE
Fix Generate Event Handler code action

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/GenerateMethodCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/GenerateMethodCodeActionResolver.cs
@@ -215,7 +215,7 @@ internal sealed class GenerateMethodCodeActionResolver(
 
                 var formattedChange = await _razorFormattingService.TryGetCSharpCodeActionEditAsync(
                     documentContext,
-                    result.SelectAsArray(code.Source.Text.GetTextChange),
+                    result.SelectAsArray(code.GetCSharpSourceText().GetTextChange),
                     formattingOptions,
                     cancellationToken).ConfigureAwait(false);
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
@@ -10,8 +10,6 @@ using Microsoft.VisualStudio.Telemetry;
 using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.AspNetCore.Razor;
 using System.IO;
-
-
 #if DEBUG
 using System.Linq;
 #endif
@@ -267,7 +265,6 @@ internal abstract class TelemetryReporter : ITelemetryReporter
             new("eventscope.languageservername", languageServerName),
             new("eventscope.correlationid", correlationId));
     }
-
 
     /// <summary>
     /// Returns values that should be set to (failureParameter1, failureParameter2) when reporting a fault.


### PR DESCRIPTION
Cherry pick of the commit from https://github.com/dotnet/razor/pull/10959 that fixes code actions in FUSE, **and fixing the generate event handler code action which is unrelated to FUSE**, in case we decide we want to take it for 17.12 P3

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2268945