### PR TITLE
Add IProjectSnapshot.ContainsDocument to test document paths cheaply

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/IProjectSnapshotManagerExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/IProjectSnapshotManagerExtensions.cs
@@ -57,7 +57,7 @@ internal static partial class IProjectSnapshotManagerExtensions
 
         foreach (var project in potentialProjects)
         {
-            if (project.GetDocument(documentFilePath) is not null)
+            if (project.ContainsDocument(documentFilePath))
             {
                 builder.Add(project);
             }
@@ -65,7 +65,7 @@ internal static partial class IProjectSnapshotManagerExtensions
 
         var normalizedDocumentPath = FilePathNormalizer.Normalize(documentFilePath);
         var miscProject = projectManager.GetMiscellaneousProject();
-        if (miscProject.GetDocument(normalizedDocumentPath) is not null)
+        if (miscProject.ContainsDocument(normalizedDocumentPath))
         {
             builder.Add(miscProject);
         }
@@ -87,10 +87,9 @@ internal static partial class IProjectSnapshotManagerExtensions
 
         foreach (var project in potentialProjects)
         {
-            if (project.GetDocument(normalizedDocumentPath) is { } projectDocument)
+            if (project.TryGetDocument(normalizedDocumentPath, out document))
             {
                 logger.LogTrace($"Found {documentFilePath} in {project.FilePath}");
-                document = projectDocument;
                 return true;
             }
         }
@@ -98,10 +97,9 @@ internal static partial class IProjectSnapshotManagerExtensions
         logger.LogTrace($"Looking for {documentFilePath} in miscellaneous project.");
         var miscellaneousProject = projectManager.GetMiscellaneousProject();
 
-        if (miscellaneousProject.GetDocument(normalizedDocumentPath) is { } miscDocument)
+        if (miscellaneousProject.TryGetDocument(normalizedDocumentPath, out document))
         {
             logger.LogTrace($"Found {documentFilePath} in miscellaneous project.");
-            document = miscDocument;
             return true;
         }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshot.cs
@@ -37,6 +37,8 @@ internal interface IProjectSnapshot
     ProjectWorkspaceState ProjectWorkspaceState { get; }
 
     RazorProjectEngine GetProjectEngine();
+
+    bool ContainsDocument(string filePath);
     IDocumentSnapshot? GetDocument(string filePath);
     bool TryGetDocument(string filePath, [NotNullWhen(true)] out IDocumentSnapshot? document);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshotExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshotExtensions.cs
@@ -20,7 +20,7 @@ internal static class IProjectSnapshotExtensions
 
         foreach (var documentFilePath in project.DocumentFilePaths)
         {
-            if (project.GetDocument(documentFilePath) is { } document)
+            if (project.TryGetDocument(documentFilePath, out var document))
             {
                 var documentHandle = document.ToHandle();
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshot.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
@@ -16,23 +15,14 @@ using Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
-internal class ProjectSnapshot : IProjectSnapshot
+internal class ProjectSnapshot(ProjectState state) : IProjectSnapshot
 {
-    private readonly object _lock;
-
-    private readonly Dictionary<string, DocumentSnapshot> _documents;
-
-    public ProjectSnapshot(ProjectState state)
-    {
-        State = state ?? throw new ArgumentNullException(nameof(state));
-
-        _lock = new object();
-        _documents = new Dictionary<string, DocumentSnapshot>(FilePathNormalizingComparer.Instance);
-    }
+    private readonly object _gate = new();
+    private readonly Dictionary<string, DocumentSnapshot> _filePathToDocumentMap = new(FilePathNormalizingComparer.Instance);
 
     public ProjectKey Key => State.HostProject.Key;
 
-    public ProjectState State { get; }
+    public ProjectState State { get; } = state;
 
     public RazorConfiguration Configuration => HostProject.Configuration;
 
@@ -58,25 +48,36 @@ internal class ProjectSnapshot : IProjectSnapshot
 
     public ProjectWorkspaceState ProjectWorkspaceState => State.ProjectWorkspaceState;
 
-    public virtual IDocumentSnapshot? GetDocument(string filePath)
+    public bool ContainsDocument(string filePath)
     {
-        lock (_lock)
+        lock (_gate)
         {
-            if (!_documents.TryGetValue(filePath, out var result) &&
-                State.Documents.TryGetValue(filePath, out var state))
-            {
-                result = new DocumentSnapshot(this, state);
-                _documents.Add(filePath, result);
-            }
-
-            return result;
+            return _filePathToDocumentMap.ContainsKey(filePath) ||
+                   State.Documents.ContainsKey(filePath);
         }
     }
 
+    public IDocumentSnapshot? GetDocument(string filePath)
+        => TryGetDocument(filePath, out var document)
+            ? document
+            : null;
+
     public bool TryGetDocument(string filePath, [NotNullWhen(true)] out IDocumentSnapshot? document)
     {
-        document = GetDocument(filePath);
-        return document is not null;
+        lock (_gate)
+        {
+            // We only create a new DocumentSnapshot if we haven't created one yet
+            // but have DocumentState for it.
+            if (!_filePathToDocumentMap.TryGetValue(filePath, out var snapshot) &&
+                State.Documents.TryGetValue(filePath, out var state))
+            {
+                snapshot = new DocumentSnapshot(this, state);
+                _filePathToDocumentMap.Add(filePath, snapshot);
+            }
+
+            document = snapshot;
+            return document is not null;
+        }
     }
 
     /// <summary>
@@ -86,31 +87,26 @@ internal class ProjectSnapshot : IProjectSnapshot
     /// </summary>
     public ImmutableArray<IDocumentSnapshot> GetRelatedDocuments(IDocumentSnapshot document)
     {
-        if (document is null)
-        {
-            throw new ArgumentNullException(nameof(document));
-        }
-
         var targetPath = document.TargetPath.AssumeNotNull();
 
         if (!State.ImportsToRelatedDocuments.TryGetValue(targetPath, out var relatedDocuments))
         {
-            return ImmutableArray<IDocumentSnapshot>.Empty;
+            return [];
         }
 
-        lock (_lock)
+        lock (_gate)
         {
-            using var _ = ArrayBuilderPool<IDocumentSnapshot>.GetPooledObject(out var builder);
+            using var builder = new PooledArrayBuilder<IDocumentSnapshot>(capacity: relatedDocuments.Length);
 
             foreach (var relatedDocumentFilePath in relatedDocuments)
             {
-                if (GetDocument(relatedDocumentFilePath) is { } relatedDocument)
+                if (TryGetDocument(relatedDocumentFilePath, out var relatedDocument))
                 {
                     builder.Add(relatedDocument);
                 }
             }
 
-            return builder.ToImmutableArray();
+            return builder.DrainToImmutable();
         }
     }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/RazorComponentSearchEngine.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/RazorComponentSearchEngine.cs
@@ -41,18 +41,18 @@ internal class RazorComponentSearchEngine(ILoggerFactory loggerFactory) : IRazor
             foreach (var path in project.DocumentFilePaths)
             {
                 // Get document and code document
-                if (project.GetDocument(path) is not { } documentSnapshot)
+                if (!project.TryGetDocument(path, out var document))
                 {
                     continue;
                 }
 
                 // Rule out if not Razor component with correct name
-                if (!documentSnapshot.IsPathCandidateForComponent(lookupSymbolName))
+                if (!document.IsPathCandidateForComponent(lookupSymbolName))
                 {
                     continue;
                 }
 
-                var razorCodeDocument = await documentSnapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
+                var razorCodeDocument = await document.GetGeneratedOutputAsync().ConfigureAwait(false);
                 if (razorCodeDocument is null)
                 {
                     continue;
@@ -64,7 +64,7 @@ internal class RazorComponentSearchEngine(ILoggerFactory loggerFactory) : IRazor
                     continue;
                 }
 
-                return documentSnapshot;
+                return document;
             }
         }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Rename/RenameService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Rename/RenameService.cs
@@ -120,7 +120,7 @@ internal class RenameService(
                 }
 
                 // Add to the list and add the path to the set
-                if (project.GetDocument(documentPath) is not { } snapshot)
+                if (!project.TryGetDocument(documentPath, out var snapshot))
                 {
                     throw new InvalidOperationException($"{documentPath} in project {project.FilePath} but not retrievable");
                 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteProjectSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteProjectSnapshot.cs
@@ -133,18 +133,53 @@ internal sealed class RemoteProjectSnapshot : IProjectSnapshot
         }
     }
 
-    public IDocumentSnapshot? GetDocument(string filePath)
+    public bool ContainsDocument(string filePath)
     {
-        var document = _project.AdditionalDocuments.FirstOrDefault(d => d.FilePath == filePath);
-        return document is not null
-            ? GetDocument(document)
-            : null;
+        if (!filePath.IsRazorFilePath())
+        {
+            throw new ArgumentException(SR.Format0_is_not_a_Razor_file_path(filePath), nameof(filePath));
+        }
+
+        var documentIds = _project.Solution.GetDocumentIdsWithFilePath(filePath);
+
+        foreach (var documentId in documentIds)
+        {
+            if (_project.Id == documentId.ProjectId &&
+                _project.ContainsAdditionalDocument(documentId))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
+
+    public IDocumentSnapshot? GetDocument(string filePath)
+        => TryGetDocument(filePath, out var document)
+            ? document
+            : null;
 
     public bool TryGetDocument(string filePath, [NotNullWhen(true)] out IDocumentSnapshot? document)
     {
-        document = GetDocument(filePath);
-        return document is not null;
+        if (!filePath.IsRazorFilePath())
+        {
+            throw new ArgumentException(SR.Format0_is_not_a_Razor_file_path(filePath), nameof(filePath));
+        }
+
+        var documentIds = _project.Solution.GetDocumentIdsWithFilePath(filePath);
+
+        foreach (var documentId in documentIds)
+        {
+            if (_project.Id == documentId.ProjectId &&
+                _project.GetAdditionalDocument(documentId) is { } doc)
+            {
+                document = GetDocumentCore(doc);
+                return true;
+            }
+        }
+
+        document = null;
+        return false;
     }
 
     public RazorProjectEngine GetProjectEngine() => throw new InvalidOperationException("Should not be called for cohosted projects.");

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Documents/RazorCodeDocumentProvidingSnapshotChangeTrigger.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Documents/RazorCodeDocumentProvidingSnapshotChangeTrigger.cs
@@ -74,8 +74,7 @@ internal class RazorCodeDocumentProvidingSnapshotChangeTrigger : IRazorStartupSe
             return null;
         }
 
-        var document = project.GetDocument(filePath);
-        if (document is null)
+        if (!project.TryGetDocument(filePath, out var document))
         {
             return null;
         }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/DynamicFiles/RazorDocumentExcerptService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/DynamicFiles/RazorDocumentExcerptService.cs
@@ -41,8 +41,7 @@ internal class RazorDocumentExcerptService(
         }
 
         var project = _document.Project;
-        var razorDocument = project.GetDocument(mappedSpans[0].FilePath);
-        if (razorDocument is null)
+        if (!project.TryGetDocument(mappedSpans[0].FilePath, out var razorDocument))
         {
             return null;
         }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/CSharpVirtualDocumentFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/CSharpVirtualDocumentFactory.cs
@@ -199,7 +199,7 @@ internal class CSharpVirtualDocumentFactory : VirtualDocumentFactoryBase
         var normalizedDocumentPath = RazorDynamicFileInfoProvider.GetProjectSystemFilePath(hostDocumentUri);
         foreach (var projectSnapshot in projects)
         {
-            if (projectSnapshot.GetDocument(normalizedDocumentPath) is not null)
+            if (projectSnapshot.ContainsDocument(normalizedDocumentPath))
             {
                 inAny = true;
                 yield return projectSnapshot.Key;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_ProjectContexts.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_ProjectContexts.cs
@@ -32,7 +32,7 @@ internal partial class RazorCustomMessageTarget
         foreach (var project in projects)
         {
             if (project is ProjectSnapshot snapshot &&
-                project.GetDocument(documentFilePath) is not null)
+                project.ContainsDocument(documentFilePath))
             {
                 projectContexts.Add(new VSProjectContext
                 {

--- a/src/Razor/src/Microsoft.VisualStudio.LegacyEditor.Razor/EphemeralProjectSnapshot.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LegacyEditor.Razor/EphemeralProjectSnapshot.cs
@@ -56,6 +56,9 @@ internal class EphemeralProjectSnapshot : IProjectSnapshot
 
     public ProjectWorkspaceState ProjectWorkspaceState => ProjectWorkspaceState.Default;
 
+    public bool ContainsDocument(string filePath)
+        => false;
+
     public IDocumentSnapshot? GetDocument(string filePath)
     {
         if (filePath is null)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ProjectSystem/TestProjectSnapshot.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ProjectSystem/TestProjectSnapshot.cs
@@ -50,11 +50,6 @@ internal class TestProjectSnapshot : ProjectSnapshot
 
     public override VersionStamp Version => throw new NotImplementedException();
 
-    public override IDocumentSnapshot? GetDocument(string filePath)
-    {
-        return base.GetDocument(filePath);
-    }
-
     public override RazorProjectEngine GetProjectEngine()
     {
         return RazorProjectEngine.Create(RazorConfiguration.Default, RazorProjectFileSystem.Create("C:/"));


### PR DESCRIPTION
There's a fair amount of code in Razor that uses `IProjectSnapshot.GetDocument(...)` to test for the presence of a document with a given file path in a project. However, `GetDocument` has the side effect of creating a document snapshot which ultimately may be thrown away.

This change adds an `IProjectSnapshot.ContainsDocument(...)` method that tests for the presence of a document by file path and returns true or false without creating a new document snapshot. In addition, I've cleaned up the `IProjectSnapshot` implementations a bit.