### PR TITLE
Enable TSA reporting

### DIFF
--- a/eng/TSAConfig.gdntsa
+++ b/eng/TSAConfig.gdntsa
@@ -11,8 +11,5 @@
     "projectName": "DevDiv",
     "areaPath": "DevDiv\\NET Developer Experience\\Razor Tooling",
     "iterationPath": "DevDiv",
-    "tools": [
-        "APIScan",
-        "BinSkim"
-    ]
+    "allTools": true
 }


### PR DESCRIPTION
Move to reporting TSA data for all the tools. The previous configuration was causing us to miss Polichcek, PSScriptAnalyzer, CredScan, etc ...
