### PR TITLE
RazorProjectService cleanup

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/IRazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/IRazorProjectService.cs
@@ -18,31 +18,4 @@ internal interface IRazorProjectService
     Task UpdateDocumentAsync(string filePath, SourceText sourceText, CancellationToken cancellationToken);
     Task CloseDocumentAsync(string filePath, CancellationToken cancellationToken);
     Task RemoveDocumentAsync(string filePath, CancellationToken cancellationToken);
-
-    Task<ProjectKey> AddProjectAsync(
-        string filePath,
-        string intermediateOutputPath,
-        RazorConfiguration? configuration,
-        string? rootNamespace,
-        string? displayName,
-        CancellationToken cancellationToken);
-
-    Task UpdateProjectAsync(
-        ProjectKey projectKey,
-        RazorConfiguration? configuration,
-        string? rootNamespace,
-        string displayName,
-        ProjectWorkspaceState projectWorkspaceState,
-        ImmutableArray<DocumentSnapshotHandle> documents,
-        CancellationToken cancellationToken);
-
-    Task AddOrUpdateProjectAsync(
-        ProjectKey projectKey,
-        string filePath,
-        RazorConfiguration? configuration,
-        string? rootNamespace,
-        string displayName,
-        ProjectWorkspaceState projectWorkspaceState,
-        ImmutableArray<DocumentSnapshotHandle> documents,
-        CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.TestAccessor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.TestAccessor.cs
@@ -1,7 +1,12 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Collections.Immutable;
+using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.ProjectSystem;
+using Microsoft.AspNetCore.Razor.Serialization;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 
@@ -13,5 +18,47 @@ internal partial class RazorProjectService
     {
         public ValueTask WaitForInitializationAsync()
             => instance.WaitForInitializationAsync();
+
+        public async Task UpdateProjectAsync(
+           ProjectKey projectKey,
+           RazorConfiguration? configuration,
+           string? rootNamespace,
+           string? displayName,
+           ProjectWorkspaceState projectWorkspaceState,
+           ImmutableArray<DocumentSnapshotHandle> documents,
+           CancellationToken cancellationToken)
+        {
+            await instance.WaitForInitializationAsync().ConfigureAwait(false);
+
+            await instance.AddOrUpdateProjectCoreAsync(
+                projectKey,
+                filePath: null,
+                configuration,
+                rootNamespace,
+                displayName,
+                projectWorkspaceState,
+                documents,
+                cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        public async Task<ProjectKey> AddProjectAsync(
+            string filePath,
+            string intermediateOutputPath,
+            RazorConfiguration? configuration,
+            string? rootNamespace,
+            string? displayName,
+            CancellationToken cancellationToken)
+        {
+            var service = instance;
+
+            await service.WaitForInitializationAsync().ConfigureAwait(false);
+
+            return await instance._projectManager
+                .UpdateAsync(
+                    updater => service.AddProjectCore(updater, filePath, intermediateOutputPath, configuration, rootNamespace, displayName),
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.TestAccessor.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.TestAccessor.cs
@@ -19,29 +19,6 @@ internal partial class RazorProjectService
         public ValueTask WaitForInitializationAsync()
             => instance.WaitForInitializationAsync();
 
-        public async Task UpdateProjectAsync(
-           ProjectKey projectKey,
-           RazorConfiguration? configuration,
-           string? rootNamespace,
-           string? displayName,
-           ProjectWorkspaceState projectWorkspaceState,
-           ImmutableArray<DocumentSnapshotHandle> documents,
-           CancellationToken cancellationToken)
-        {
-            await instance.WaitForInitializationAsync().ConfigureAwait(false);
-
-            await instance.AddOrUpdateProjectCoreAsync(
-                projectKey,
-                filePath: null,
-                configuration,
-                rootNamespace,
-                displayName,
-                projectWorkspaceState,
-                documents,
-                cancellationToken)
-                .ConfigureAwait(false);
-        }
-
         public async Task<ProjectKey> AddProjectAsync(
             string filePath,
             string intermediateOutputPath,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
@@ -313,23 +313,6 @@ internal partial class RazorProjectService : IRazorProjectService, IRazorProject
         }
     }
 
-    public async Task<ProjectKey> AddProjectAsync(
-        string filePath,
-        string intermediateOutputPath,
-        RazorConfiguration? configuration,
-        string? rootNamespace,
-        string? displayName,
-        CancellationToken cancellationToken)
-    {
-        await WaitForInitializationAsync().ConfigureAwait(false);
-
-        return await _projectManager
-            .UpdateAsync(
-                updater => AddProjectCore(updater, filePath, intermediateOutputPath, configuration, rootNamespace, displayName),
-                cancellationToken)
-            .ConfigureAwait(false);
-    }
-
     private ProjectKey AddProjectCore(ProjectSnapshotManager.Updater updater, string filePath, string intermediateOutputPath, RazorConfiguration? configuration, string? rootNamespace, string? displayName)
     {
         var normalizedPath = FilePathNormalizer.Normalize(filePath);
@@ -344,53 +327,6 @@ internal partial class RazorProjectService : IRazorProjectService, IRazorProject
         TryMigrateMiscellaneousDocumentsToProject(updater);
 
         return hostProject.Key;
-    }
-
-    public async Task UpdateProjectAsync(
-        ProjectKey projectKey,
-        RazorConfiguration? configuration,
-        string? rootNamespace,
-        string? displayName,
-        ProjectWorkspaceState projectWorkspaceState,
-        ImmutableArray<DocumentSnapshotHandle> documents,
-        CancellationToken cancellationToken)
-    {
-        await WaitForInitializationAsync().ConfigureAwait(false);
-
-        await AddOrUpdateProjectCoreAsync(
-            projectKey,
-            filePath: null,
-            configuration,
-            rootNamespace,
-            displayName,
-            projectWorkspaceState,
-            documents,
-            cancellationToken)
-            .ConfigureAwait(false);
-    }
-
-    public async Task AddOrUpdateProjectAsync(
-       ProjectKey projectKey,
-       string filePath,
-       RazorConfiguration? configuration,
-       string? rootNamespace,
-       string? displayName,
-       ProjectWorkspaceState projectWorkspaceState,
-       ImmutableArray<DocumentSnapshotHandle> documents,
-       CancellationToken cancellationToken)
-    {
-        await WaitForInitializationAsync().ConfigureAwait(false);
-
-        await AddOrUpdateProjectCoreAsync(
-            projectKey,
-            filePath,
-            configuration,
-            rootNamespace,
-            displayName,
-            projectWorkspaceState,
-            documents,
-            cancellationToken)
-            .ConfigureAwait(false);
     }
 
     private Task AddOrUpdateProjectCoreAsync(

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorComponentSearchEngineTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorComponentSearchEngineTest.cs
@@ -66,7 +66,7 @@ public class RazorComponentSearchEngineTest(ITestOutputHelper testOutput) : Lang
             LoggerFactory);
         AddDisposable(projectService);
 
-        await projectService.AddProjectAsync(
+        await projectService.GetTestAccessor().AddProjectAsync(
             s_projectFilePath1,
             s_intermediateOutputPath1,
             RazorConfiguration.Default,
@@ -80,7 +80,7 @@ public class RazorComponentSearchEngineTest(ITestOutputHelper testOutput) : Lang
         await projectService.AddDocumentToPotentialProjectsAsync(s_componentFilePath2, DisposalToken);
         await projectService.UpdateDocumentAsync(s_componentFilePath2, SourceText.From("@namespace Test"), DisposalToken);
 
-        await projectService.AddProjectAsync(
+        await projectService.GetTestAccessor().AddProjectAsync(
             s_projectFilePath2,
             s_intermediateOutputPath2,
             RazorConfiguration.Default,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
@@ -56,7 +56,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
     }
 
     [Fact]
-    public async Task UpdateProject_UpdatesProjectWorkspaceState()
+    public async Task IProjectInfoListener_UpdatedAsync_UpdatesProjectWorkspaceState()
     {
         // Arrange
         var hostProject = new HostProject("C:/path/to/project.csproj", "C:/path/to/obj", RazorConfiguration.Default, "TestRootNamespace");
@@ -85,7 +85,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
     }
 
     [Fact]
-    public async Task UpdateProject_UpdatingDocument_MapsRelativeFilePathToActualDocument()
+    public async Task IProjectInfoListener_UpdatedAsync_UpdatingDocument_MapsRelativeFilePathToActualDocument()
     {
         // Arrange
         var hostProject = new HostProject("C:/path/to/project.csproj", "C:/path/to/obj", RazorConfiguration.Default, "TestRootNamespace");
@@ -118,7 +118,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
     }
 
     [Fact]
-    public async Task UpdateProject_AddsNewDocuments()
+    public async Task IProjectInfoListener_UpdatedAsync_AddsNewDocuments()
     {
         // Arrange
         var hostProject = new HostProject("C:/path/to/project.csproj", "C:/path/to/obj", RazorConfiguration.Default, "TestRootNamespace");
@@ -151,7 +151,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
     }
 
     [Fact]
-    public async Task UpdateProject_MovesDocumentsFromMisc()
+    public async Task IProjectInfoListener_UpdatedAsync_MovesDocumentsFromMisc()
     {
         // Arrange
         var hostProject = new HostProject("C:/path/to/project.csproj", "C:/path/to/obj", RazorConfiguration.Default, "TestRootNamespace");
@@ -189,7 +189,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
     }
 
     [Fact]
-    public async Task UpdateProject_MovesDocumentsFromMisc_ViaService()
+    public async Task IProjectInfoListener_UpdatedAsync_MovesDocumentsFromMisc_ViaService()
     {
         // Arrange
         const string DocumentFilePath = "C:/path/to/file.cshtml";
@@ -228,7 +228,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
     }
 
     [Fact]
-    public async Task UpdateProject_MovesExistingDocumentToMisc()
+    public async Task IProjectInfoListener_UpdatedAsync_MovesExistingDocumentToMisc()
     {
         // Arrange
         var hostProject = new HostProject("C:/path/to/project.csproj", "C:/path/to/obj", RazorConfiguration.Default, "TestRootNamespace");
@@ -268,7 +268,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
     }
 
     [Fact]
-    public async Task UpdateProject_KnownDocuments()
+    public async Task IProjectInfoListener_UpdatedAsync_KnownDocuments()
     {
         // Arrange
         var hostProject = new HostProject("path/to/project.csproj", "path/to/obj", RazorConfiguration.Default, "TestRootNamespace");
@@ -299,7 +299,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
     }
 
     [Fact]
-    public async Task UpdateProject_UpdatesLegacyDocumentsAsComponents()
+    public async Task IProjectInfoListener_UpdatedAsync_UpdatesLegacyDocumentsAsComponents()
     {
         // Arrange
         var hostProject = new HostProject("C:/path/to/project.csproj", "C:/path/to/obj", RazorConfiguration.Default, "TestRootNamespace");
@@ -332,7 +332,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
     }
 
     [Fact]
-    public async Task UpdateProject_SameConfigurationDifferentRootNamespace_UpdatesRootNamespace()
+    public async Task IProjectInfoListener_UpdatedAsync_SameConfigurationDifferentRootNamespace_UpdatesRootNamespace()
     {
         // Arrange
         const string ProjectFilePath = "C:/path/to/project.csproj";
@@ -365,7 +365,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
     }
 
     [Fact]
-    public async Task UpdateProject_SameConfigurationAndRootNamespaceNoops()
+    public async Task IProjectInfoListener_UpdatedAsync_SameConfigurationAndRootNamespaceNoops()
     {
         // Arrange
         const string ProjectFilePath = "C:/path/to/project.csproj";
@@ -394,7 +394,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
     }
 
     [Fact]
-    public async Task UpdateProject_ChangesProjectToUseProvidedConfiguration()
+    public async Task IProjectInfoListener_UpdatedAsync_ChangesProjectToUseProvidedConfiguration()
     {
         // Arrange
         const string ProjectFilePath = "C:/path/to/project.csproj";

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -68,7 +66,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         var projectWorkspaceState = ProjectWorkspaceState.Create(LanguageVersion.LatestMajor);
 
         // Act
-        await _projectService.UpdateProjectAsync(
+        await _projectService.GetTestAccessor().UpdateProjectAsync(
             hostProject.Key,
             hostProject.Configuration,
             hostProject.RootNamespace,
@@ -98,7 +96,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         var newDocument = new DocumentSnapshotHandle("file.cshtml", "file.cshtml", FileKinds.Component);
 
         // Act
-        await _projectService.UpdateProjectAsync(
+        await _projectService.GetTestAccessor().UpdateProjectAsync(
             hostProject.Key,
             hostProject.Configuration,
             hostProject.RootNamespace,
@@ -131,7 +129,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         var newDocument = new DocumentSnapshotHandle("C:/path/to/file2.cshtml", "file2.cshtml", FileKinds.Legacy);
 
         // Act
-        await _projectService.UpdateProjectAsync(
+        await _projectService.GetTestAccessor().UpdateProjectAsync(
             hostProject.Key,
             hostProject.Configuration,
             hostProject.RootNamespace,
@@ -166,7 +164,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         var addedDocument = new DocumentSnapshotHandle(hostDocument.FilePath, hostDocument.TargetPath, hostDocument.FileKind);
 
         // Act
-        await _projectService.UpdateProjectAsync(
+        await _projectService.GetTestAccessor().UpdateProjectAsync(
             hostProject.Key,
             hostProject.Configuration,
             hostProject.RootNamespace,
@@ -192,7 +190,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         const string IntermediateOutputPath = "C:/path/to/obj";
         const string RootNamespace = "TestRootNamespace";
 
-        var ownerProjectKey = await _projectService.AddProjectAsync(
+        var ownerProjectKey = await _projectService.GetTestAccessor().AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
 
         await _projectService.AddDocumentToMiscProjectAsync(DocumentFilePath, DisposalToken);
@@ -204,7 +202,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         var addedDocument = new DocumentSnapshotHandle(DocumentFilePath, DocumentFilePath, FileKinds.Legacy);
 
         // Act
-        await _projectService.UpdateProjectAsync(
+        await _projectService.GetTestAccessor().UpdateProjectAsync(
             project.Key,
             project.Configuration,
             project.RootNamespace,
@@ -243,7 +241,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         var newDocument = new DocumentSnapshotHandle("C:/path/to/file2.cshtml", "file2.cshtml", FileKinds.Legacy);
 
         // Act
-        await _projectService.UpdateProjectAsync(
+        await _projectService.GetTestAccessor().UpdateProjectAsync(
             hostProject.Key,
             hostProject.Configuration,
             hostProject.RootNamespace,
@@ -278,7 +276,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         using var listener = _projectManager.ListenToNotifications();
 
         // Act & Assert
-        await _projectService.UpdateProjectAsync(
+        await _projectService.GetTestAccessor().UpdateProjectAsync(
             hostProject.Key,
             hostProject.Configuration,
             hostProject.RootNamespace,
@@ -306,7 +304,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         var newDocument = new DocumentSnapshotHandle(legacyDocument.FilePath, legacyDocument.TargetPath, FileKinds.Component);
 
         // Act
-        await _projectService.UpdateProjectAsync(
+        await _projectService.GetTestAccessor().UpdateProjectAsync(
             hostProject.Key,
             hostProject.Configuration,
             hostProject.RootNamespace,
@@ -330,7 +328,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         const string IntermediateOutputPath = "C:/path/to/obj";
         const string NewRootNamespace = "NewRootNamespace";
 
-        var ownerProjectKey = await _projectService.AddProjectAsync(
+        var ownerProjectKey = await _projectService.GetTestAccessor().AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, rootNamespace: null, displayName: null, DisposalToken);
 
         var ownerProject = _projectManager.GetLoadedProject(ownerProjectKey);
@@ -338,7 +336,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         using var listener = _projectManager.ListenToNotifications();
 
         // Act
-        await _projectService.UpdateProjectAsync(
+        await _projectService.GetTestAccessor().UpdateProjectAsync(
             ownerProject.Key,
             ownerProject.Configuration,
             NewRootNamespace,
@@ -362,7 +360,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         const string IntermediateOutputPath = "C:/path/to/obj";
         const string RootNamespace = "TestRootNamespace";
 
-        var ownerProjectKey = await _projectService.AddProjectAsync(
+        var ownerProjectKey = await _projectService.GetTestAccessor().AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
 
         var ownerProject = _projectManager.GetLoadedProject(ownerProjectKey);
@@ -370,7 +368,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         using var listener = _projectManager.ListenToNotifications();
 
         // Act & Assert
-        await _projectService.UpdateProjectAsync(
+        await _projectService.GetTestAccessor().UpdateProjectAsync(
             ownerProject.Key,
             ownerProject.Configuration,
             ownerProject.RootNamespace,
@@ -390,7 +388,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         const string IntermediateOutputPath = "C:/path/to/obj";
         const string RootNamespace = "TestRootNamespace";
 
-        var ownerProjectKey = await _projectService.AddProjectAsync(
+        var ownerProjectKey = await _projectService.GetTestAccessor().AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
 
         var ownerProject = _projectManager.GetLoadedProject(ownerProjectKey);
@@ -398,7 +396,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         using var listener = _projectManager.ListenToNotifications();
 
         // Act
-        await _projectService.UpdateProjectAsync(
+        await _projectService.GetTestAccessor().UpdateProjectAsync(
             ownerProject.Key,
             configuration: null,
             "TestRootNamespace",
@@ -421,7 +419,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         const string IntermediateOutputPath = "C:/path/to/obj";
         const string RootNamespace = "TestRootNamespace";
 
-        var ownerProjectKey = await _projectService.AddProjectAsync(
+        var ownerProjectKey = await _projectService.GetTestAccessor().AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
 
         var ownerProject = _projectManager.GetLoadedProject(ownerProjectKey);
@@ -429,7 +427,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         using var listener = _projectManager.ListenToNotifications();
 
         // Act
-        await _projectService.UpdateProjectAsync(
+        await _projectService.GetTestAccessor().UpdateProjectAsync(
             ownerProject.Key,
             FallbackRazorConfiguration.MVC_1_1,
             "TestRootNamespace",
@@ -451,7 +449,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         using var listener = _projectManager.ListenToNotifications();
 
         // Act & Assert
-        await _projectService.UpdateProjectAsync(
+        await _projectService.GetTestAccessor().UpdateProjectAsync(
             TestProjectKey.Create("C:/path/to/obj"),
             FallbackRazorConfiguration.MVC_1_1,
             "TestRootNamespace",
@@ -472,7 +470,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         const string RootNamespace = "TestRootNamespace";
         const string DocumentFilePath = "C:/path/to/document.cshtml";
 
-        var ownerProjectKey = await _projectService.AddProjectAsync(
+        var ownerProjectKey = await _projectService.GetTestAccessor().AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
         await _projectService.AddDocumentToPotentialProjectsAsync(DocumentFilePath, DisposalToken);
         await _projectService.OpenDocumentAsync(DocumentFilePath, s_emptyText, DisposalToken);
@@ -503,9 +501,9 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         const string RootNamespace = "TestRootNamespace";
         const string DocumentFilePath = "C:/path/to/document.cshtml";
 
-        var ownerProjectKey1 = await _projectService.AddProjectAsync(
+        var ownerProjectKey1 = await _projectService.GetTestAccessor().AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath1, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
-        var ownerProjectKey2 = await _projectService.AddProjectAsync(
+        var ownerProjectKey2 = await _projectService.GetTestAccessor().AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath2, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
         await _projectService.AddDocumentToPotentialProjectsAsync(DocumentFilePath, DisposalToken);
         await _projectService.OpenDocumentAsync(DocumentFilePath, s_emptyText, DisposalToken);
@@ -562,7 +560,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         const string RootNamespace = "TestRootNamespace";
         const string DocumentFilePath = "C:/path/to/document.cshtml";
 
-        var ownerProjectKey = await _projectService.AddProjectAsync(
+        var ownerProjectKey = await _projectService.GetTestAccessor().AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
         await _projectService.AddDocumentToPotentialProjectsAsync(DocumentFilePath, DisposalToken);
 
@@ -592,9 +590,9 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         const string RootNamespace = "TestRootNamespace";
         const string DocumentFilePath = "C:/path/to/document.cshtml";
 
-        var ownerProjectKey1 = await _projectService.AddProjectAsync(
+        var ownerProjectKey1 = await _projectService.GetTestAccessor().AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath1, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
-        var ownerProjectKey2 = await _projectService.AddProjectAsync(
+        var ownerProjectKey2 = await _projectService.GetTestAccessor().AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath2, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
         await _projectService.AddDocumentToPotentialProjectsAsync(DocumentFilePath, DisposalToken);
 
@@ -649,7 +647,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         const string RootNamespace = "TestRootNamespace";
         const string DocumentFilePath = "C:/path/to/document.cshtml";
 
-        var ownerProjectKey = await _projectService.AddProjectAsync(
+        var ownerProjectKey = await _projectService.GetTestAccessor().AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
 
         var miscProject = _projectManager.GetMiscellaneousProject();
@@ -693,7 +691,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         const string RootNamespace = "TestRootNamespace";
         const string DocumentFilePath = "C:/path/to/document.cshtml";
 
-        var ownerProjectKey = await _projectService.AddProjectAsync(
+        var ownerProjectKey = await _projectService.GetTestAccessor().AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
 
         var ownerProject = _projectManager.GetLoadedProject(ownerProjectKey);
@@ -739,7 +737,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         const string RootNamespace = "TestRootNamespace";
         const string DocumentFilePath = "C:/path/to/document.cshtml";
 
-        await _projectService.AddProjectAsync(
+        await _projectService.GetTestAccessor().AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
         await _projectService.AddDocumentToPotentialProjectsAsync(DocumentFilePath, DisposalToken);
 
@@ -780,7 +778,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         const string RootNamespace = "TestRootNamespace";
         const string DocumentFilePath = "C:/path/to/document.cshtml";
 
-        var ownerProjectKey = await _projectService.AddProjectAsync(
+        var ownerProjectKey = await _projectService.GetTestAccessor().AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
         await _projectService.AddDocumentToPotentialProjectsAsync(DocumentFilePath, DisposalToken);
 
@@ -808,9 +806,9 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         const string RootNamespace = "TestRootNamespace";
         const string DocumentFilePath = "C:/path/to/document.cshtml";
 
-        var ownerProjectKey1 = await _projectService.AddProjectAsync(
+        var ownerProjectKey1 = await _projectService.GetTestAccessor().AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath1, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
-        var ownerProjectKey2 = await _projectService.AddProjectAsync(
+        var ownerProjectKey2 = await _projectService.GetTestAccessor().AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath2, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
         await _projectService.AddDocumentToPotentialProjectsAsync(DocumentFilePath, DisposalToken);
 
@@ -839,7 +837,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         const string RootNamespace = "TestRootNamespace";
         const string DocumentFilePath = "C:/path/to/document.cshtml";
 
-        var ownerProjectKey = await _projectService.AddProjectAsync(
+        var ownerProjectKey = await _projectService.GetTestAccessor().AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
         await _projectService.AddDocumentToPotentialProjectsAsync(DocumentFilePath, DisposalToken);
         await _projectService.OpenDocumentAsync(DocumentFilePath, s_emptyText, DisposalToken);
@@ -925,7 +923,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         const string RootNamespace = "TestRootNamespace";
         const string DocumentFilePath = "C:/path/to/document.cshtml";
 
-        var ownerProjectKey = await _projectService.AddProjectAsync(
+        var ownerProjectKey = await _projectService.GetTestAccessor().AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
         await _projectService.AddDocumentToPotentialProjectsAsync(DocumentFilePath, DisposalToken);
         await _projectService.OpenDocumentAsync(DocumentFilePath, s_emptyText, DisposalToken);
@@ -956,9 +954,9 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         const string RootNamespace = "TestRootNamespace";
         const string DocumentFilePath = "C:/path/to/document.cshtml";
 
-        var ownerProjectKey1 = await _projectService.AddProjectAsync(
+        var ownerProjectKey1 = await _projectService.GetTestAccessor().AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath1, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
-        var ownerProjectKey2 = await _projectService.AddProjectAsync(
+        var ownerProjectKey2 = await _projectService.GetTestAccessor().AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath2, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
         await _projectService.AddDocumentToPotentialProjectsAsync(DocumentFilePath, DisposalToken);
         await _projectService.OpenDocumentAsync(DocumentFilePath, s_emptyText, DisposalToken);
@@ -1015,7 +1013,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         const string RootNamespace = "TestRootNamespace";
         const string DocumentFilePath = "C:/path/to/document.cshtml";
 
-        var ownerProjectKey = await _projectService.AddProjectAsync(
+        var ownerProjectKey = await _projectService.GetTestAccessor().AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
         await _projectService.AddDocumentToPotentialProjectsAsync(DocumentFilePath, DisposalToken);
 
@@ -1042,7 +1040,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         const string IntermediateOutputPath = "C:/path/to/obj";
 
         // Act
-        var projectKey = await _projectService.AddProjectAsync(
+        var projectKey = await _projectService.GetTestAccessor().AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, configuration: null, rootNamespace: null, displayName: null, DisposalToken);
 
         var project = _projectManager.GetLoadedProject(projectKey);
@@ -1064,7 +1062,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         var configuration = new RazorConfiguration(RazorLanguageVersion.Version_1_0, "TestName", Extensions: []);
 
         // Act
-        var projectKey = await _projectService.AddProjectAsync(
+        var projectKey = await _projectService.GetTestAccessor().AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, configuration, RootNamespace, displayName: null, DisposalToken);
 
         var project = _projectManager.GetLoadedProject(projectKey);
@@ -1097,7 +1095,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         using var listener = _projectManager.ListenToNotifications();
 
         // Act
-        var newProjectKey = await _projectService.AddProjectAsync(
+        var newProjectKey = await _projectService.GetTestAccessor().AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, rootNamespace: null, displayName: null, DisposalToken);
 
         // Assert
@@ -1127,7 +1125,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         using var listener = _projectManager.ListenToNotifications();
 
         // Act
-        var newProjectKey = await _projectService.AddProjectAsync(
+        var newProjectKey = await _projectService.GetTestAccessor().AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, rootNamespace: null, displayName: null, DisposalToken);
 
         // Assert
@@ -1162,43 +1160,13 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         });
 
         // Act
-        var newProjectKey = await _projectService.AddProjectAsync(
+        var newProjectKey = await _projectService.GetTestAccessor().AddProjectAsync(
             ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, rootNamespace: null, displayName: null, DisposalToken);
 
         // Assert
         var newProject = _projectManager.GetLoadedProject(newProjectKey);
         Assert.Equal("document1.cshtml", newProject.GetDocument(DocumentFilePath1)!.TargetPath);
         Assert.Equal("document2.cshtml", newProject.GetDocument(DocumentFilePath2)!.TargetPath);
-    }
-
-    [Fact]
-    public async Task AddOrUpdateProjectAsync_MigratesMiscellaneousDocumentsToNewOwnerProject_MaintainsTextState()
-    {
-        // Arrange
-        const string ProjectFilePath = "C:/path/to/project.csproj";
-        const string IntermediateOutputPath = "C:/path/to/obj";
-        const string DocumentFilePath1 = "C:/path/to/document1.cshtml";
-
-        var miscProject = _projectManager.GetMiscellaneousProject();
-
-        await _projectManager.UpdateAsync(updater =>
-        {
-            updater.DocumentAdded(miscProject.Key,
-                new HostDocument(DocumentFilePath1, "other/document1.cshtml"), CreateTextLoader(SourceText.From("Hello")));
-        });
-
-        var projectKey = new ProjectKey(IntermediateOutputPath);
-
-        var documentHandles = ImmutableArray.Create(new DocumentSnapshotHandle(DocumentFilePath1, "document1.cshtml", "mvc"));
-
-        // Act
-        await _projectService.AddOrUpdateProjectAsync(
-            projectKey, ProjectFilePath, RazorConfiguration.Default, rootNamespace: null, displayName: null, ProjectWorkspaceState.Default, documentHandles, DisposalToken);
-
-        // Assert
-        var newProject = _projectManager.GetLoadedProject(projectKey);
-        var documentText = await newProject.GetDocument(DocumentFilePath1)!.GetTextAsync();
-        Assert.Equal("Hello", documentText.ToString());
     }
 
     private static TextLoader CreateTextLoader(SourceText text)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
@@ -31,6 +31,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
 #nullable disable
     private TestProjectSnapshotManager _projectManager;
     private TestRazorProjectService _projectService;
+    private IRazorProjectInfoListener _projectInfoListener;
 #nullable enable
 
     protected override Task InitializeAsync()
@@ -49,6 +50,8 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
             _projectManager,
             LoggerFactory);
 
+        _projectInfoListener = _projectService;
+
         return Task.CompletedTask;
     }
 
@@ -66,13 +69,14 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         var projectWorkspaceState = ProjectWorkspaceState.Create(LanguageVersion.LatestMajor);
 
         // Act
-        await _projectService.GetTestAccessor().UpdateProjectAsync(
+        await _projectInfoListener.UpdatedAsync(new RazorProjectInfo(
             hostProject.Key,
+            hostProject.FilePath,
             hostProject.Configuration,
             hostProject.RootNamespace,
             hostProject.DisplayName,
             projectWorkspaceState,
-            documents: [],
+            documents: []),
             DisposalToken);
 
         // Assert
@@ -96,13 +100,14 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         var newDocument = new DocumentSnapshotHandle("file.cshtml", "file.cshtml", FileKinds.Component);
 
         // Act
-        await _projectService.GetTestAccessor().UpdateProjectAsync(
+        await _projectInfoListener.UpdatedAsync(new RazorProjectInfo(
             hostProject.Key,
+            hostProject.FilePath,
             hostProject.Configuration,
             hostProject.RootNamespace,
             hostProject.DisplayName,
             ProjectWorkspaceState.Default,
-            [newDocument],
+            [newDocument]),
             DisposalToken);
 
         // Assert
@@ -129,13 +134,14 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         var newDocument = new DocumentSnapshotHandle("C:/path/to/file2.cshtml", "file2.cshtml", FileKinds.Legacy);
 
         // Act
-        await _projectService.GetTestAccessor().UpdateProjectAsync(
+        await _projectInfoListener.UpdatedAsync(new RazorProjectInfo(
             hostProject.Key,
+            hostProject.FilePath,
             hostProject.Configuration,
             hostProject.RootNamespace,
             hostProject.DisplayName,
             ProjectWorkspaceState.Default,
-            [oldDocument, newDocument],
+            [oldDocument, newDocument]),
             DisposalToken);
 
         // Assert
@@ -164,13 +170,14 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         var addedDocument = new DocumentSnapshotHandle(hostDocument.FilePath, hostDocument.TargetPath, hostDocument.FileKind);
 
         // Act
-        await _projectService.GetTestAccessor().UpdateProjectAsync(
+        await _projectInfoListener.UpdatedAsync(new RazorProjectInfo(
             hostProject.Key,
+            hostProject.FilePath,
             hostProject.Configuration,
             hostProject.RootNamespace,
             hostProject.DisplayName,
             ProjectWorkspaceState.Default,
-            [addedDocument],
+            [addedDocument]),
             DisposalToken);
 
         // Assert
@@ -202,13 +209,14 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         var addedDocument = new DocumentSnapshotHandle(DocumentFilePath, DocumentFilePath, FileKinds.Legacy);
 
         // Act
-        await _projectService.GetTestAccessor().UpdateProjectAsync(
+        await _projectInfoListener.UpdatedAsync(new RazorProjectInfo(
             project.Key,
+            project.FilePath,
             project.Configuration,
             project.RootNamespace,
             project.DisplayName,
             ProjectWorkspaceState.Default,
-            [addedDocument],
+            [addedDocument]),
             DisposalToken);
 
         // Assert
@@ -241,13 +249,14 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         var newDocument = new DocumentSnapshotHandle("C:/path/to/file2.cshtml", "file2.cshtml", FileKinds.Legacy);
 
         // Act
-        await _projectService.GetTestAccessor().UpdateProjectAsync(
+        await _projectInfoListener.UpdatedAsync(new RazorProjectInfo(
             hostProject.Key,
+            hostProject.FilePath,
             hostProject.Configuration,
             hostProject.RootNamespace,
             hostProject.DisplayName,
             ProjectWorkspaceState.Default,
-            [newDocument],
+            [newDocument]),
             DisposalToken);
 
         // Assert
@@ -276,13 +285,14 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         using var listener = _projectManager.ListenToNotifications();
 
         // Act & Assert
-        await _projectService.GetTestAccessor().UpdateProjectAsync(
+        await _projectInfoListener.UpdatedAsync(new RazorProjectInfo(
             hostProject.Key,
+            hostProject.FilePath,
             hostProject.Configuration,
             hostProject.RootNamespace,
             hostProject.DisplayName,
             ProjectWorkspaceState.Default,
-            [newDocument],
+            [newDocument]),
             DisposalToken);
 
         listener.AssertNoNotifications();
@@ -304,13 +314,14 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         var newDocument = new DocumentSnapshotHandle(legacyDocument.FilePath, legacyDocument.TargetPath, FileKinds.Component);
 
         // Act
-        await _projectService.GetTestAccessor().UpdateProjectAsync(
+        await _projectInfoListener.UpdatedAsync(new RazorProjectInfo(
             hostProject.Key,
+            hostProject.FilePath,
             hostProject.Configuration,
             hostProject.RootNamespace,
             hostProject.DisplayName,
             ProjectWorkspaceState.Default,
-            [newDocument],
+            [newDocument]),
             DisposalToken);
 
         // Assert
@@ -336,13 +347,14 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         using var listener = _projectManager.ListenToNotifications();
 
         // Act
-        await _projectService.GetTestAccessor().UpdateProjectAsync(
+        await _projectInfoListener.UpdatedAsync(new RazorProjectInfo(
             ownerProject.Key,
+            ownerProject.FilePath,
             ownerProject.Configuration,
             NewRootNamespace,
             ownerProject.DisplayName,
             ProjectWorkspaceState.Default,
-            documents: [],
+            documents: []),
             DisposalToken);
 
         var notification = Assert.Single(listener);
@@ -368,13 +380,14 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         using var listener = _projectManager.ListenToNotifications();
 
         // Act & Assert
-        await _projectService.GetTestAccessor().UpdateProjectAsync(
+        await _projectInfoListener.UpdatedAsync(new RazorProjectInfo(
             ownerProject.Key,
+            ownerProject.FilePath,
             ownerProject.Configuration,
             ownerProject.RootNamespace,
             displayName: "",
             ProjectWorkspaceState.Default,
-            documents: [],
+            documents: []),
             DisposalToken);
 
         listener.AssertNoNotifications();
@@ -396,13 +409,14 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         using var listener = _projectManager.ListenToNotifications();
 
         // Act
-        await _projectService.GetTestAccessor().UpdateProjectAsync(
+        await _projectInfoListener.UpdatedAsync(new RazorProjectInfo(
             ownerProject.Key,
+            ownerProject.FilePath,
             configuration: null,
             "TestRootNamespace",
             displayName: "",
             ProjectWorkspaceState.Default,
-            documents: [],
+            documents: []),
             DisposalToken);
 
         // Assert
@@ -427,13 +441,14 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         using var listener = _projectManager.ListenToNotifications();
 
         // Act
-        await _projectService.GetTestAccessor().UpdateProjectAsync(
+        await _projectInfoListener.UpdatedAsync(new RazorProjectInfo(
             ownerProject.Key,
+            ownerProject.FilePath,
             FallbackRazorConfiguration.MVC_1_1,
             "TestRootNamespace",
             displayName: "",
             ProjectWorkspaceState.Default,
-            documents: [],
+            documents: []),
             DisposalToken);
 
         // Assert
@@ -449,13 +464,14 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         using var listener = _projectManager.ListenToNotifications();
 
         // Act & Assert
-        await _projectService.GetTestAccessor().UpdateProjectAsync(
+        await _projectInfoListener.UpdatedAsync(new RazorProjectInfo(
             TestProjectKey.Create("C:/path/to/obj"),
+            "C:/path/to/project.csproj",
             FallbackRazorConfiguration.MVC_1_1,
             "TestRootNamespace",
             displayName: "",
             ProjectWorkspaceState.Default,
-            documents: [],
+            documents: []),
             DisposalToken);
 
         listener.AssertNoNotifications();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
@@ -394,38 +394,6 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
     }
 
     [Fact]
-    public async Task UpdateProject_NullConfigurationUsesDefault()
-    {
-        // Arrange
-        const string ProjectFilePath = "C:/path/to/project.csproj";
-        const string IntermediateOutputPath = "C:/path/to/obj";
-        const string RootNamespace = "TestRootNamespace";
-
-        var ownerProjectKey = await _projectService.GetTestAccessor().AddProjectAsync(
-            ProjectFilePath, IntermediateOutputPath, RazorConfiguration.Default, RootNamespace, displayName: null, DisposalToken);
-
-        var ownerProject = _projectManager.GetLoadedProject(ownerProjectKey);
-
-        using var listener = _projectManager.ListenToNotifications();
-
-        // Act
-        await _projectInfoListener.UpdatedAsync(new RazorProjectInfo(
-            ownerProject.Key,
-            ownerProject.FilePath,
-            configuration: null,
-            "TestRootNamespace",
-            displayName: "",
-            ProjectWorkspaceState.Default,
-            documents: []),
-            DisposalToken);
-
-        // Assert
-        var notification = Assert.Single(listener);
-        Assert.NotNull(notification.Newer);
-        Assert.Same(FallbackRazorConfiguration.Latest, notification.Newer.Configuration);
-    }
-
-    [Fact]
     public async Task UpdateProject_ChangesProjectToUseProvidedConfiguration()
     {
         // Arrange
@@ -455,26 +423,6 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         var notification = Assert.Single(listener);
         Assert.NotNull(notification.Newer);
         Assert.Same(FallbackRazorConfiguration.MVC_1_1, notification.Newer.Configuration);
-    }
-
-    [Fact]
-    public async Task UpdateProject_UntrackedProjectNoops()
-    {
-        // Arrange
-        using var listener = _projectManager.ListenToNotifications();
-
-        // Act & Assert
-        await _projectInfoListener.UpdatedAsync(new RazorProjectInfo(
-            TestProjectKey.Create("C:/path/to/obj"),
-            "C:/path/to/project.csproj",
-            FallbackRazorConfiguration.MVC_1_1,
-            "TestRootNamespace",
-            displayName: "",
-            ProjectWorkspaceState.Default,
-            documents: []),
-            DisposalToken);
-
-        listener.AssertNoNotifications();
     }
 
     [Fact]

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Refactoring/RenameEndpointTest.cs
@@ -654,7 +654,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
                 projectManager,
                 LoggerFactory));
 
-        var projectKey1 = await projectService.AddProjectAsync(
+        var projectKey1 = await projectService.GetTestAccessor().AddProjectAsync(
             s_projectFilePath1, s_intermediateOutputPath1, RazorConfiguration.Default, RootNamespace1, displayName: null, DisposalToken);
 
         await projectManager.UpdateAsync(updater =>
@@ -676,7 +676,7 @@ public class RenameEndpointTest(ITestOutputHelper testOutput) : LanguageServerTe
         await projectService.UpdateDocumentAsync(s_componentFilePath1337, SourceText.From(ComponentText1337), DisposalToken);
         await projectService.UpdateDocumentAsync(s_indexFilePath1, SourceText.From(IndexText1), DisposalToken);
 
-        var projectKey2 = await projectService.AddProjectAsync(
+        var projectKey2 = await projectService.GetTestAccessor().AddProjectAsync(
             s_projectFilePath2, s_intermediateOutputPath2, RazorConfiguration.Default, RootNamespace2, displayName: null, DisposalToken);
 
         await projectManager.UpdateAsync(updater =>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestRazorProjectService.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestRazorProjectService.cs
@@ -52,7 +52,7 @@ internal class TestRazorProjectService(
                 .Select(d => new DocumentSnapshotHandle(d, d, FileKinds.GetFileKindFromFilePath(d)))
                 .ToImmutableArray();
 
-            await this.UpdateProjectAsync(projectSnapshot.Key, projectSnapshot.Configuration, projectSnapshot.RootNamespace, projectSnapshot.DisplayName, projectSnapshot.ProjectWorkspaceState,
+            await this.GetTestAccessor().UpdateProjectAsync(projectSnapshot.Key, projectSnapshot.Configuration, projectSnapshot.RootNamespace, projectSnapshot.DisplayName, projectSnapshot.ProjectWorkspaceState,
                 documents, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestRazorProjectService.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestRazorProjectService.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
+using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Serialization;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Utilities;
@@ -52,8 +53,8 @@ internal class TestRazorProjectService(
                 .Select(d => new DocumentSnapshotHandle(d, d, FileKinds.GetFileKindFromFilePath(d)))
                 .ToImmutableArray();
 
-            await this.GetTestAccessor().UpdateProjectAsync(projectSnapshot.Key, projectSnapshot.Configuration, projectSnapshot.RootNamespace, projectSnapshot.DisplayName, projectSnapshot.ProjectWorkspaceState,
-                documents, cancellationToken).ConfigureAwait(false);
+            await ((IRazorProjectInfoListener)this).UpdatedAsync(new RazorProjectInfo(projectSnapshot.Key, projectSnapshot.FilePath, projectSnapshot.Configuration, projectSnapshot.RootNamespace, projectSnapshot.DisplayName, projectSnapshot.ProjectWorkspaceState,
+                documents), cancellationToken).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
Noticed while working on my previous PR. There were a few methods in RazorProjectService that were only used by tests, and also resulted in some tests validating things that could never happen in the product (like passing `null` for a project file path in an update). This PR removes one unused method, moves one to a test accessor where it rightly should be, and updates the tests that were calling `UpdateProjectAsync` to instead call through `IRazorProjectServiceListener.UpdatedAsync`.

I don't love that these tests have to call through that interface, but I didn't change the method to be implicitly implemented because I don't think the name makes sense when written that way.

There are, or at least should be, no functionality changes in this PR.