### PR TITLE
IDocumentSnapshot finally gets ValueTasks and CancellationTokens

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCSharpFormattingBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCSharpFormattingBenchmark.cs
@@ -58,7 +58,7 @@ public class RazorCSharpFormattingBenchmark : RazorLanguageServerBenchmarkBase
 
         DocumentUri = new Uri(_filePath);
         DocumentSnapshot = await GetDocumentSnapshotAsync(projectFilePath, _filePath, targetPath);
-        DocumentText = await DocumentSnapshot.GetTextAsync();
+        DocumentText = await DocumentSnapshot.GetTextAsync(CancellationToken.None);
     }
 
     private static void WriteSampleFormattingFile(string filePath, bool preformatted, int blocks)

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCodeActionsBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCodeActionsBenchmark.cs
@@ -77,7 +77,7 @@ public class RazorCodeActionsBenchmark : RazorLanguageServerBenchmarkBase
 
         DocumentUri = new Uri(_filePath);
         DocumentSnapshot = await GetDocumentSnapshotAsync(projectFilePath, _filePath, targetPath);
-        DocumentText = await DocumentSnapshot.GetTextAsync();
+        DocumentText = await DocumentSnapshot.GetTextAsync(CancellationToken.None);
 
         RazorCodeActionRange = DocumentText.GetZeroWidthRange(razorCodeActionIndex);
         CSharpCodeActionRange = DocumentText.GetZeroWidthRange(csharpCodeActionIndex);

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCompletionBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCompletionBenchmark.cs
@@ -75,7 +75,7 @@ public class RazorCompletionBenchmark : RazorLanguageServerBenchmarkBase
 
         DocumentUri = new Uri(_filePath);
         DocumentSnapshot = await GetDocumentSnapshotAsync(projectFilePath, _filePath, targetPath);
-        DocumentText = await DocumentSnapshot.GetTextAsync();
+        DocumentText = await DocumentSnapshot.GetTextAsync(CancellationToken.None);
 
         RazorPosition = DocumentText.GetPosition(razorCodeActionIndex);
 

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorDocumentMappingBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorDocumentMappingBenchmark.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Razor.Language;
@@ -50,7 +51,7 @@ public class RazorDocumentMappingBenchmark : RazorLanguageServerBenchmarkBase
 
         DocumentSnapshot = await GetDocumentSnapshotAsync(projectFilePath, _filePath, targetPath);
 
-        var codeDocument = await DocumentSnapshot.GetGeneratedOutputAsync();
+        var codeDocument = await DocumentSnapshot.GetGeneratedOutputAsync(CancellationToken.None);
         CSharpDocument = codeDocument.GetCSharpDocument();
     }
 

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensScrollingBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensScrollingBenchmark.cs
@@ -51,7 +51,7 @@ public class RazorSemanticTokensScrollingBenchmark : RazorLanguageServerBenchmar
         var documentSnapshot = await GetDocumentSnapshotAsync(ProjectFilePath, filePath, TargetPath);
         DocumentContext = new DocumentContext(documentUri, documentSnapshot, projectContext: null);
 
-        var text = await DocumentSnapshot.GetTextAsync().ConfigureAwait(false);
+        var text = await DocumentSnapshot.GetTextAsync(CancellationToken.None).ConfigureAwait(false);
         Range = VsLspFactory.CreateRange(
             start: (0, 0),
             end: (text.Lines.Count - 1, 0));

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/ProjectSystem/BackgroundCodeGenerationBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/ProjectSystem/BackgroundCodeGenerationBenchmark.cs
@@ -59,6 +59,6 @@ public class BackgroundCodeGenerationBenchmark : ProjectSnapshotManagerBenchmark
         var project = ProjectManager.GetLoadedProject(e.ProjectKey);
         var document = project.GetDocument(e.DocumentFilePath);
 
-        Tasks.Add(document.GetGeneratedOutputAsync());
+        Tasks.Add(document.GetGeneratedOutputAsync().AsTask());
     }
 }

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/ProjectSystem/BackgroundCodeGenerationBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/ProjectSystem/BackgroundCodeGenerationBenchmark.cs
@@ -59,6 +59,6 @@ public class BackgroundCodeGenerationBenchmark : ProjectSnapshotManagerBenchmark
         var project = ProjectManager.GetLoadedProject(e.ProjectKey);
         var document = project.GetDocument(e.DocumentFilePath);
 
-        Tasks.Add(document.GetGeneratedOutputAsync().AsTask());
+        Tasks.Add(document.GetGeneratedOutputAsync(CancellationToken.None).AsTask());
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/UnformattedRemappingCSharpCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CSharp/UnformattedRemappingCSharpCodeActionResolver.cs
@@ -70,7 +70,7 @@ internal sealed class UnformattedRemappingCSharpCodeActionResolver(
             return codeAction;
         }
 
-        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
+        var codeDocument = await documentContext.Snapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         if (codeDocument.IsUnsupported())
         {
             return codeAction;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
@@ -139,13 +139,13 @@ internal sealed class CodeActionEndpoint(
         IDocumentSnapshot documentSnapshot,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         if (codeDocument.IsUnsupported())
         {
             return null;
         }
 
-        var sourceText = await documentSnapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
+        var sourceText = codeDocument.Source.Text;
 
         // VS Provides `CodeActionParams.Context.SelectionRange` in addition to
         // `CodeActionParams.Range`. The `SelectionRange` is relative to where the

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
@@ -65,7 +65,7 @@ internal sealed class CodeActionEndpoint(
             return null;
         }
 
-        var razorCodeActionContext = await GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot).ConfigureAwait(false);
+        var razorCodeActionContext = await GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot, cancellationToken).ConfigureAwait(false);
         if (razorCodeActionContext is null)
         {
             return null;
@@ -134,7 +134,10 @@ internal sealed class CodeActionEndpoint(
     }
 
     // internal for testing
-    internal async Task<RazorCodeActionContext?> GenerateRazorCodeActionContextAsync(VSCodeActionParams request, IDocumentSnapshot documentSnapshot)
+    internal async Task<RazorCodeActionContext?> GenerateRazorCodeActionContextAsync(
+        VSCodeActionParams request,
+        IDocumentSnapshot documentSnapshot,
+        CancellationToken cancellationToken)
     {
         var codeDocument = await documentSnapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
         if (codeDocument.IsUnsupported())
@@ -142,7 +145,7 @@ internal sealed class CodeActionEndpoint(
             return null;
         }
 
-        var sourceText = await documentSnapshot.GetTextAsync().ConfigureAwait(false);
+        var sourceText = await documentSnapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
         // VS Provides `CodeActionParams.Context.SelectionRange` in addition to
         // `CodeActionParams.Range`. The `SelectionRange` is relative to where the

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Html/DefaultHtmlCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Html/DefaultHtmlCodeActionProvider.cs
@@ -49,7 +49,7 @@ internal sealed class DefaultHtmlCodeActionProvider(IEditMappingService editMapp
 
         if (codeAction.Edit.TryGetTextDocumentEdits(out var documentEdits))
         {
-            var codeDocument = await documentSnapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
+            var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
             var htmlSourceText = codeDocument.GetHtmlSourceText();
 
             foreach (var edit in documentEdits)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/AddUsingsCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/Razor/AddUsingsCodeActionResolver.cs
@@ -45,7 +45,7 @@ internal sealed class AddUsingsCodeActionResolver(IDocumentContextFactory docume
 
         var documentSnapshot = documentContext.Snapshot;
 
-        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         if (codeDocument.IsUnsupported())
         {
             return null;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/DocumentPullDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/DocumentPullDiagnosticsEndpoint.cs
@@ -80,7 +80,7 @@ internal class DocumentPullDiagnosticsEndpoint : IRazorRequestHandler<VSInternal
 
         var documentSnapshot = documentContext.Snapshot;
 
-        var razorDiagnostics = await GetRazorDiagnosticsAsync(documentSnapshot).ConfigureAwait(false);
+        var razorDiagnostics = await GetRazorDiagnosticsAsync(documentSnapshot, cancellationToken).ConfigureAwait(false);
 
         await ReportRZ10012TelemetryAsync(documentContext, razorDiagnostics, cancellationToken).ConfigureAwait(false);
 
@@ -106,7 +106,9 @@ internal class DocumentPullDiagnosticsEndpoint : IRazorRequestHandler<VSInternal
             {
                 if (report.Diagnostics is not null)
                 {
-                    var mappedDiagnostics = await _translateDiagnosticsService.TranslateAsync(RazorLanguageKind.CSharp, report.Diagnostics, documentSnapshot).ConfigureAwait(false);
+                    var mappedDiagnostics = await _translateDiagnosticsService
+                        .TranslateAsync(RazorLanguageKind.CSharp, report.Diagnostics, documentSnapshot, cancellationToken)
+                        .ConfigureAwait(false);
                     report.Diagnostics = mappedDiagnostics;
                 }
 
@@ -120,7 +122,9 @@ internal class DocumentPullDiagnosticsEndpoint : IRazorRequestHandler<VSInternal
             {
                 if (report.Diagnostics is not null)
                 {
-                    var mappedDiagnostics = await _translateDiagnosticsService.TranslateAsync(RazorLanguageKind.Html, report.Diagnostics, documentSnapshot).ConfigureAwait(false);
+                    var mappedDiagnostics = await _translateDiagnosticsService
+                        .TranslateAsync(RazorLanguageKind.Html, report.Diagnostics, documentSnapshot, cancellationToken)
+                        .ConfigureAwait(false);
                     report.Diagnostics = mappedDiagnostics;
                 }
 
@@ -131,9 +135,9 @@ internal class DocumentPullDiagnosticsEndpoint : IRazorRequestHandler<VSInternal
         return allDiagnostics.ToArray();
     }
 
-    private static async Task<VSInternalDiagnosticReport[]?> GetRazorDiagnosticsAsync(IDocumentSnapshot documentSnapshot)
+    private static async Task<VSInternalDiagnosticReport[]?> GetRazorDiagnosticsAsync(IDocumentSnapshot documentSnapshot, CancellationToken cancellationToken)
     {
-        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var sourceText = codeDocument.Source.Text;
         var csharpDocument = codeDocument.GetCSharpDocument();
         var diagnostics = csharpDocument.Diagnostics;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/RazorDiagnosticsPublisher.cs
@@ -113,10 +113,10 @@ internal partial class RazorDiagnosticsPublisher : IDocumentProcessedListener, I
         }
     }
 
-    private async Task PublishDiagnosticsAsync(IDocumentSnapshot document, CancellationToken token)
+    private async Task PublishDiagnosticsAsync(IDocumentSnapshot document, CancellationToken cancellationToken)
     {
-        var result = await document.GetGeneratedOutputAsync().ConfigureAwait(false);
-        var csharpDiagnostics = await GetCSharpDiagnosticsAsync(document, token).ConfigureAwait(false);
+        var result = await document.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var csharpDiagnostics = await GetCSharpDiagnosticsAsync(document, cancellationToken).ConfigureAwait(false);
         var razorDiagnostics = result.GetCSharpDocument().Diagnostics;
 
         lock (_publishedDiagnostics)
@@ -188,7 +188,7 @@ internal partial class RazorDiagnosticsPublisher : IDocumentProcessedListener, I
                     if (_documentContextFactory.Value.TryCreate(delegatedParams.TextDocument.Uri, projectContext: null, out var documentContext))
                     {
                         return await _translateDiagnosticsService.Value
-                            .TranslateAsync(RazorLanguageKind.CSharp, fullDiagnostics.Items, documentContext.Snapshot)
+                            .TranslateAsync(RazorLanguageKind.CSharp, fullDiagnostics.Items, documentContext.Snapshot, cancellationToken)
                             .ConfigureAwait(false);
                     }
                 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentSnapshotTextLoader.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentSnapshotTextLoader.cs
@@ -9,23 +9,13 @@ using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
-internal class DocumentSnapshotTextLoader : TextLoader
+internal class DocumentSnapshotTextLoader(IDocumentSnapshot documentSnapshot) : TextLoader
 {
-    private readonly IDocumentSnapshot _documentSnapshot;
-
-    public DocumentSnapshotTextLoader(IDocumentSnapshot documentSnapshot)
-    {
-        if (documentSnapshot is null)
-        {
-            throw new ArgumentNullException(nameof(documentSnapshot));
-        }
-
-        _documentSnapshot = documentSnapshot;
-    }
+    private readonly IDocumentSnapshot _documentSnapshot = documentSnapshot;
 
     public override async Task<TextAndVersion> LoadTextAndVersionAsync(LoadTextOptions options, CancellationToken cancellationToken)
     {
-        var sourceText = await _documentSnapshot.GetTextAsync().ConfigureAwait(false);
+        var sourceText = await _documentSnapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
         var textAndVersion = TextAndVersion.Create(sourceText, VersionStamp.Default);
 
         return textAndVersion;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormatter.cs
@@ -47,7 +47,7 @@ internal sealed class HtmlFormatter(
             return [];
         }
 
-        var sourceText = await documentSnapshot.GetTextAsync().ConfigureAwait(false);
+        var sourceText = await documentSnapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
         return result.Edits.SelectAsArray(sourceText.GetTextChange);
     }
 
@@ -78,7 +78,7 @@ internal sealed class HtmlFormatter(
             return [];
         }
 
-        var sourceText = await documentSnapshot.GetTextAsync().ConfigureAwait(false);
+        var sourceText = await documentSnapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
         return result.Edits.SelectAsArray(sourceText.GetTextChange);
     }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/LspFormattingCodeDocumentProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/LspFormattingCodeDocumentProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Razor.Formatting;
@@ -10,9 +11,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 
 internal sealed class LspFormattingCodeDocumentProvider : IFormattingCodeDocumentProvider
 {
-    public ValueTask<RazorCodeDocument> GetCodeDocumentAsync(IDocumentSnapshot snapshot)
+    public ValueTask<RazorCodeDocument> GetCodeDocumentAsync(IDocumentSnapshot snapshot, CancellationToken cancellationToken)
     {
         // Formatting always uses design time
-        return snapshot.GetGeneratedOutputAsync(forceDesignTimeGeneratedOutput: true);
+        return snapshot.GetGeneratedOutputAsync(forceDesignTimeGeneratedOutput: true, cancellationToken);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/LspFormattingCodeDocumentProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/LspFormattingCodeDocumentProvider.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 
 internal sealed class LspFormattingCodeDocumentProvider : IFormattingCodeDocumentProvider
 {
-    public Task<RazorCodeDocument> GetCodeDocumentAsync(IDocumentSnapshot snapshot)
+    public ValueTask<RazorCodeDocument> GetCodeDocumentAsync(IDocumentSnapshot snapshot)
     {
         // Formatting always uses design time
         return snapshot.GetGeneratedOutputAsync(forceDesignTimeGeneratedOutput: true);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MapCode/MapCodeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MapCode/MapCodeEndpoint.cs
@@ -228,7 +228,7 @@ internal sealed class MapCodeEndpoint(
                     razorNodesToMap.Add(nodeToMap);
                 }
 
-                var sourceText = await documentContext.Snapshot.GetTextAsync().ConfigureAwait(false);
+                var sourceText = await documentContext.Snapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
                 foreach (var nodeToMap in razorNodesToMap)
                 {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MapCode/MapCodeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MapCode/MapCodeEndpoint.cs
@@ -105,7 +105,7 @@ internal sealed class MapCodeEndpoint(
 
                 // We create a new Razor file based on each content in each mapping order to get the syntax tree that we'll later use to map.
                 var newSnapshot = snapshot.WithText(SourceText.From(content));
-                var codeToMap = await newSnapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
+                var codeToMap = await newSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
                 var mappingSuccess = await TryMapCodeAsync(
                     codeToMap, mapping.FocusLocations, changes, mapCodeCorrelationId, documentContext, cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Mapping/RazorLanguageQueryEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Mapping/RazorLanguageQueryEndpoint.cs
@@ -42,7 +42,7 @@ internal sealed class RazorLanguageQueryEndpoint(IDocumentMappingService documen
         var documentSnapshot = documentContext.Snapshot;
         var documentVersion = documentContext.Snapshot.Version;
 
-        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var sourceText = codeDocument.Source.Text;
         var hostDocumentIndex = sourceText.GetPosition(request.Position);
         var responsePosition = request.Position;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Mapping/RazorLanguageQueryEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Mapping/RazorLanguageQueryEndpoint.cs
@@ -43,7 +43,7 @@ internal sealed class RazorLanguageQueryEndpoint(IDocumentMappingService documen
         var documentVersion = documentContext.Snapshot.Version;
 
         var codeDocument = await documentSnapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
-        var sourceText = await documentSnapshot.GetTextAsync().ConfigureAwait(false);
+        var sourceText = codeDocument.Source.Text;
         var hostDocumentIndex = sourceText.GetPosition(request.Position);
         var responsePosition = request.Position;
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/OpenDocumentGenerator.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/OpenDocumentGenerator.cs
@@ -75,7 +75,7 @@ internal partial class OpenDocumentGenerator : IRazorStartupService, IDisposable
                 return;
             }
 
-            var codeDocument = await document.GetGeneratedOutputAsync().ConfigureAwait(false);
+            var codeDocument = await document.GetGeneratedOutputAsync(token).ConfigureAwait(false);
 
             foreach (var listener in _listeners)
             {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Diagnostics/RazorTranslateDiagnosticsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Diagnostics/RazorTranslateDiagnosticsService.cs
@@ -6,6 +6,7 @@ using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
@@ -45,18 +46,27 @@ internal class RazorTranslateDiagnosticsService(IDocumentMappingService document
     ]).ToFrozenSet();
 
     /// <summary>
-    /// Translates code diagnostics from one representation into another.
+    ///  Translates code diagnostics from one representation into another.
     /// </summary>
-    /// <param name="diagnosticKind">The `RazorLanguageKind` of the `Diagnostic` objects included in `diagnostics`.</param>
-    /// <param name="diagnostics">An array of `Diagnostic` objects to translate.</param>
-    /// <param name="documentSnapshot">The `DocumentContext` for the code document associated with the diagnostics.</param>
+    /// <param name="diagnosticKind">
+    ///  The <see cref="RazorLanguageKind"/> of the <see cref="Diagnostic"/> objects
+    ///  included in <paramref name="diagnostics"/>.
+    /// </param>
+    /// <param name="diagnostics">
+    ///  An array of <see cref="Diagnostic"/> objects to translate.
+    /// </param>
+    /// <param name="documentSnapshot">
+    ///  The <see cref="IDocumentSnapshot"/> for the code document associated with the diagnostics.
+    /// </param>
+    /// <param name="cancellationToken">A token that can be checked to cancel work.</param>
     /// <returns>An array of translated diagnostics</returns>
     internal async Task<LspDiagnostic[]> TranslateAsync(
         RazorLanguageKind diagnosticKind,
         LspDiagnostic[] diagnostics,
-        IDocumentSnapshot documentSnapshot)
+        IDocumentSnapshot documentSnapshot,
+        CancellationToken cancellationToken)
     {
-        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         if (codeDocument.IsUnsupported() != false)
         {
             _logger.LogInformation($"Unsupported code document.");

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/RazorCodeDocumentExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/RazorCodeDocumentExtensions.cs
@@ -6,11 +6,8 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Threading;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
@@ -21,7 +18,6 @@ namespace Microsoft.AspNetCore.Razor.Language;
 internal static class RazorCodeDocumentExtensions
 {
     private static readonly object s_csharpSourceTextKey = new();
-    private static readonly object s_csharpSyntaxTreeKey = new();
     private static readonly object s_htmlSourceTextKey = new();
 
     public static SourceText GetCSharpSourceText(this RazorCodeDocument document)
@@ -36,20 +32,6 @@ internal static class RazorCodeDocumentExtensions
         }
 
         return sourceText.AssumeNotNull();
-    }
-
-    public static SyntaxTree GetCSharpSyntaxTree(this RazorCodeDocument document, CancellationToken cancellationToken = default)
-    {
-        if (!document.Items.TryGetValue(s_csharpSyntaxTreeKey, out SyntaxTree? syntaxTree))
-        {
-            var csharpText = document.GetCSharpSourceText();
-            syntaxTree = CSharpSyntaxTree.ParseText(csharpText, cancellationToken: cancellationToken);
-            document.Items[s_csharpSyntaxTreeKey] = syntaxTree;
-
-            return syntaxTree;
-        }
-
-        return syntaxTree.AssumeNotNull();
     }
 
     public static SourceText GetHtmlSourceText(this RazorCodeDocument document)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/FormattingContext.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/FormattingContext.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
@@ -224,11 +225,13 @@ internal sealed class FormattingContext
         return false;
     }
 
-    public async Task<FormattingContext> WithTextAsync(SourceText changedText)
+    public async Task<FormattingContext> WithTextAsync(SourceText changedText, CancellationToken cancellationToken)
     {
         var changedSnapshot = OriginalSnapshot.WithText(changedText);
 
-        var codeDocument = await _codeDocumentProvider.GetCodeDocumentAsync(changedSnapshot).ConfigureAwait(false);
+        var codeDocument = await _codeDocumentProvider
+            .GetCodeDocumentAsync(changedSnapshot, cancellationToken)
+            .ConfigureAwait(false);
 
         DEBUG_ValidateComponents(CodeDocument, codeDocument);
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/IFormattingCodeDocumentProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/IFormattingCodeDocumentProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -9,5 +10,5 @@ namespace Microsoft.CodeAnalysis.Razor.Formatting;
 
 internal interface IFormattingCodeDocumentProvider
 {
-    ValueTask<RazorCodeDocument> GetCodeDocumentAsync(IDocumentSnapshot snapshot);
+    ValueTask<RazorCodeDocument> GetCodeDocumentAsync(IDocumentSnapshot snapshot, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/IFormattingCodeDocumentProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/IFormattingCodeDocumentProvider.cs
@@ -9,5 +9,5 @@ namespace Microsoft.CodeAnalysis.Razor.Formatting;
 
 internal interface IFormattingCodeDocumentProvider
 {
-    Task<RazorCodeDocument> GetCodeDocumentAsync(IDocumentSnapshot snapshot);
+    ValueTask<RazorCodeDocument> GetCodeDocumentAsync(IDocumentSnapshot snapshot);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpFormattingPass.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpFormattingPass.cs
@@ -37,7 +37,7 @@ internal sealed class CSharpFormattingPass(
         if (changes.Length > 0)
         {
             changedText = changedText.WithChanges(changes);
-            changedContext = await context.WithTextAsync(changedText).ConfigureAwait(false);
+            changedContext = await context.WithTextAsync(changedText, cancellationToken).ConfigureAwait(false);
         }
 
         cancellationToken.ThrowIfCancellationRequested();
@@ -48,7 +48,7 @@ internal sealed class CSharpFormattingPass(
         if (csharpChanges.Length > 0)
         {
             changedText = changedText.WithChanges(csharpChanges);
-            changedContext = await changedContext.WithTextAsync(changedText).ConfigureAwait(false);
+            changedContext = await changedContext.WithTextAsync(changedText, cancellationToken).ConfigureAwait(false);
 
             _logger.LogTestOnly($"After FormatCSharpAsync:\r\n{changedText}");
         }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpOnTypeFormattingPass.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpOnTypeFormattingPass.cs
@@ -121,8 +121,6 @@ internal sealed class CSharpOnTypeFormattingPass(
 
         changedContext = await changedContext.WithTextAsync(cleanedText, cancellationToken).ConfigureAwait(false);
 
-        cancellationToken.ThrowIfCancellationRequested();
-
         // At this point we should have applied all edits that adds/removes newlines.
         // Let's now ensure the indentation of each of those lines is correct.
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpOnTypeFormattingPass.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpOnTypeFormattingPass.cs
@@ -109,7 +109,7 @@ internal sealed class CSharpOnTypeFormattingPass(
         var formattedText = ApplyChangesAndTrackChange(originalText, filteredChanges, out _, out var spanAfterFormatting);
         _logger.LogTestOnly($"After C# changes:\r\n{formattedText}");
 
-        var changedContext = await context.WithTextAsync(formattedText).ConfigureAwait(false);
+        var changedContext = await context.WithTextAsync(formattedText, cancellationToken).ConfigureAwait(false);
         var linePositionSpanAfterFormatting = formattedText.GetLinePositionSpan(spanAfterFormatting);
 
         cancellationToken.ThrowIfCancellationRequested();
@@ -119,7 +119,7 @@ internal sealed class CSharpOnTypeFormattingPass(
         var cleanedText = formattedText.WithChanges(cleanupChanges);
         _logger.LogTestOnly($"After CleanupDocument:\r\n{cleanedText}");
 
-        changedContext = await changedContext.WithTextAsync(cleanedText).ConfigureAwait(false);
+        changedContext = await changedContext.WithTextAsync(cleanedText, cancellationToken).ConfigureAwait(false);
 
         cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/FormattingDiagnosticValidationPass.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/FormattingDiagnosticValidationPass.cs
@@ -27,7 +27,7 @@ internal sealed class FormattingDiagnosticValidationPass(ILoggerFactory loggerFa
 
         var text = context.SourceText;
         var changedText = text.WithChanges(changes);
-        var changedContext = await context.WithTextAsync(changedText).ConfigureAwait(false);
+        var changedContext = await context.WithTextAsync(changedText, cancellationToken).ConfigureAwait(false);
         var changedDiagnostics = changedContext.CodeDocument.GetSyntaxTree().Diagnostics;
 
         // We want to ensure diagnostics didn't change, but since we're formatting things, its expected

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/HtmlFormattingPassBase.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/HtmlFormattingPassBase.cs
@@ -34,7 +34,7 @@ internal abstract class HtmlFormattingPassBase(ILogger logger) : IFormattingPass
 
             changedText = originalText.WithChanges(filteredChanges);
             // Create a new formatting context for the changed razor document.
-            changedContext = await context.WithTextAsync(changedText).ConfigureAwait(false);
+            changedContext = await context.WithTextAsync(changedText, cancellationToken).ConfigureAwait(false);
 
             _logger.LogTestOnly($"After normalizedEdits:\r\n{changedText}");
         }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/RazorFormattingPass.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/RazorFormattingPass.cs
@@ -30,7 +30,7 @@ internal sealed class RazorFormattingPass : IFormattingPass
         if (changes.Length > 0)
         {
             changedText = changedText.WithChanges(changes);
-            changedContext = await context.WithTextAsync(changedText).ConfigureAwait(false);
+            changedContext = await context.WithTextAsync(changedText, cancellationToken).ConfigureAwait(false);
 
             cancellationToken.ThrowIfCancellationRequested();
         }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/RazorFormattingService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/RazorFormattingService.cs
@@ -67,7 +67,9 @@ internal class RazorFormattingService : IRazorFormattingService
         RazorFormattingOptions options,
         CancellationToken cancellationToken)
     {
-        var codeDocument = await _codeDocumentProvider.GetCodeDocumentAsync(documentContext.Snapshot).ConfigureAwait(false);
+        var codeDocument = await _codeDocumentProvider
+            .GetCodeDocumentAsync(documentContext.Snapshot, cancellationToken)
+            .ConfigureAwait(false);
 
         // Range formatting happens on every paste, and if there are Razor diagnostics in the file
         // that can make some very bad results. eg, given:
@@ -223,8 +225,8 @@ internal class RazorFormattingService : IRazorFormattingService
         // Code actions were computed on the regular document, which with FUSE could be a runtime document. We have to make
         // sure for code actions specifically we are formatting that same document, or TextChange spans may not line up
         var codeDocument = isCodeActionFormattingRequest
-            ? await documentSnapshot.GetGeneratedOutputAsync(forceDesignTimeGeneratedOutput: false).ConfigureAwait(false)
-            : await _codeDocumentProvider.GetCodeDocumentAsync(documentSnapshot).ConfigureAwait(false);
+            ? await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false)
+            : await _codeDocumentProvider.GetCodeDocumentAsync(documentSnapshot, cancellationToken).ConfigureAwait(false);
 
         var context = FormattingContext.CreateForOnTypeFormatting(
             documentSnapshot,

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/GoToDefinition/AbstractRazorComponentDefinitionService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/GoToDefinition/AbstractRazorComponentDefinitionService.cs
@@ -44,7 +44,7 @@ internal abstract class AbstractRazorComponentDefinitionService(
             return null;
         }
 
-        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         if (!RazorComponentDefinitionHelpers.TryGetBoundTagHelpers(codeDocument, positionInfo.HostDocumentIndex, ignoreAttributes, _logger, out var boundTagHelper, out var boundAttribute))
         {
@@ -52,7 +52,10 @@ internal abstract class AbstractRazorComponentDefinitionService(
             return null;
         }
 
-        var componentDocument = await _componentSearchEngine.TryLocateComponentAsync(boundTagHelper, solutionQueryOperations).ConfigureAwait(false);
+        var componentDocument = await _componentSearchEngine
+            .TryLocateComponentAsync(boundTagHelper, solutionQueryOperations, cancellationToken)
+            .ConfigureAwait(false);
+
         if (componentDocument is null)
         {
             _logger.LogInformation($"Could not locate component document.");

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/GoToDefinition/RazorComponentDefinitionHelpers.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/GoToDefinition/RazorComponentDefinitionHelpers.cs
@@ -150,7 +150,7 @@ internal static class RazorComponentDefinitionHelpers
 
         var csharpSyntaxTree = await documentSnapshot.GetCSharpSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
         var root = await csharpSyntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
-        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         // Since we know how the compiler generates the C# source we can be a little specific here, and avoid
         // long tree walks. If the compiler ever changes how they generate their code, the tests for this will break

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/IRazorComponentSearchEngine.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/IRazorComponentSearchEngine.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -9,5 +10,8 @@ namespace Microsoft.CodeAnalysis.Razor.Workspaces;
 
 internal interface IRazorComponentSearchEngine
 {
-    Task<IDocumentSnapshot?> TryLocateComponentAsync(TagHelperDescriptor tagHelper, ISolutionQueryOperations solutionQueryOperations);
+    Task<IDocumentSnapshot?> TryLocateComponentAsync(
+        TagHelperDescriptor tagHelper,
+        ISolutionQueryOperations solutionQueryOperations,
+        CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentContext.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentContext.cs
@@ -70,9 +70,7 @@ internal class DocumentContext(Uri uri, IDocumentSnapshot snapshot, VSProjectCon
 
         async ValueTask<SourceText> GetSourceTextCoreAsync(CancellationToken cancellationToken)
         {
-            var sourceText = await Snapshot.GetTextAsync().ConfigureAwait(false);
-
-            cancellationToken.ThrowIfCancellationRequested();
+            var sourceText = await Snapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
             // Interlock to ensure that we only ever return one instance of RazorCodeDocument.
             // In race scenarios, when more than one RazorCodeDocument is produced, we want to

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentContext.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentContext.cs
@@ -51,9 +51,9 @@ internal class DocumentContext(Uri uri, IDocumentSnapshot snapshot, VSProjectCon
 
         async ValueTask<RazorCodeDocument> GetCodeDocumentCoreAsync(CancellationToken cancellationToken)
         {
-            var codeDocument = await Snapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
-
-            cancellationToken.ThrowIfCancellationRequested();
+            var codeDocument = await Snapshot
+                .GetGeneratedOutputAsync(cancellationToken)
+                .ConfigureAwait(false);
 
             // Interlock to ensure that we only ever return one instance of RazorCodeDocument.
             // In race scenarios, when more than one RazorCodeDocument is produced, we want to

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentSnapshot.cs
@@ -26,7 +26,7 @@ internal sealed class DocumentSnapshot(ProjectSnapshot project, DocumentState st
     public Task<SourceText> GetTextAsync()
         => _state.GetTextAsync();
 
-    public Task<VersionStamp> GetTextVersionAsync()
+    public ValueTask<VersionStamp> GetTextVersionAsync()
         => _state.GetTextVersionAsync();
 
     public bool TryGetText([NotNullWhen(true)] out SourceText? result)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentSnapshot.cs
@@ -5,7 +5,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -67,7 +66,7 @@ internal sealed class DocumentSnapshot(ProjectSnapshot project, DocumentState st
         }
     }
 
-    public async Task<RazorCodeDocument> GetGeneratedOutputAsync(bool forceDesignTimeGeneratedOutput)
+    public async ValueTask<RazorCodeDocument> GetGeneratedOutputAsync(bool forceDesignTimeGeneratedOutput)
     {
         if (forceDesignTimeGeneratedOutput)
         {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentSnapshot.cs
@@ -23,11 +23,11 @@ internal sealed class DocumentSnapshot(ProjectSnapshot project, DocumentState st
     public IProjectSnapshot Project => _project;
     public int Version => _state.Version;
 
-    public ValueTask<SourceText> GetTextAsync()
-        => _state.GetTextAsync();
+    public ValueTask<SourceText> GetTextAsync(CancellationToken cancellationToken)
+        => _state.GetTextAsync(cancellationToken);
 
-    public ValueTask<VersionStamp> GetTextVersionAsync()
-        => _state.GetTextVersionAsync();
+    public ValueTask<VersionStamp> GetTextVersionAsync(CancellationToken cancellationToken)
+        => _state.GetTextVersionAsync(cancellationToken);
 
     public bool TryGetText([NotNullWhen(true)] out SourceText? result)
         => _state.TryGetText(out result);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentSnapshot.cs
@@ -23,7 +23,7 @@ internal sealed class DocumentSnapshot(ProjectSnapshot project, DocumentState st
     public IProjectSnapshot Project => _project;
     public int Version => _state.Version;
 
-    public Task<SourceText> GetTextAsync()
+    public ValueTask<SourceText> GetTextAsync()
         => _state.GetTextAsync();
 
     public ValueTask<VersionStamp> GetTextVersionAsync()

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.ComputedStateTracker.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.ComputedStateTracker.cs
@@ -46,20 +46,39 @@ internal partial class DocumentState
             }
         }
 
-        public async Task<(RazorCodeDocument, VersionStamp)> GetGeneratedOutputAndVersionAsync(ProjectSnapshot project, IDocumentSnapshot document)
+        public bool TryGetGeneratedOutputAndVersion(out (RazorCodeDocument Output, VersionStamp InputVersion) result)
+        {
+            if (_computedOutput?.TryGetCachedOutput(out var output, out var version) == true)
+            {
+                result = (output, version);
+                return true;
+            }
+
+            result = default;
+            return false;
+        }
+
+        public async Task<(RazorCodeDocument, VersionStamp)> GetGeneratedOutputAndVersionAsync(
+            ProjectSnapshot project,
+            IDocumentSnapshot document,
+            CancellationToken cancellationToken)
         {
             if (_computedOutput?.TryGetCachedOutput(out var cachedCodeDocument, out var cachedInputVersion) == true)
             {
                 return (cachedCodeDocument, cachedInputVersion);
             }
 
-            var (codeDocument, inputVersion) = await GetMemoizedGeneratedOutputAndVersionAsync(project, document).ConfigureAwait(false);
+            var (codeDocument, inputVersion) = await GetMemoizedGeneratedOutputAndVersionAsync(project, document, cancellationToken)
+                .ConfigureAwait(false);
 
             _computedOutput = new ComputedOutput(codeDocument, inputVersion);
             return (codeDocument, inputVersion);
         }
 
-        private Task<(RazorCodeDocument, VersionStamp)> GetMemoizedGeneratedOutputAndVersionAsync(ProjectSnapshot project, IDocumentSnapshot document)
+        private Task<(RazorCodeDocument, VersionStamp)> GetMemoizedGeneratedOutputAndVersionAsync(
+            ProjectSnapshot project,
+            IDocumentSnapshot document,
+            CancellationToken cancellationToken)
         {
             if (project is null)
             {
@@ -99,7 +118,7 @@ internal partial class DocumentState
                 }
 
                 // Typically in VS scenarios this will run synchronously because all resources are readily available.
-                var outputTask = ComputeGeneratedOutputAndVersionAsync(project, document);
+                var outputTask = ComputeGeneratedOutputAndVersionAsync(project, document, cancellationToken);
                 if (outputTask.IsCompleted)
                 {
                     // Compiling ran synchronously, lets just immediately propagate to the TCS
@@ -150,7 +169,10 @@ internal partial class DocumentState
             }
         }
 
-        private async Task<(RazorCodeDocument, VersionStamp)> ComputeGeneratedOutputAndVersionAsync(ProjectSnapshot project, IDocumentSnapshot document)
+        private async Task<(RazorCodeDocument, VersionStamp)> ComputeGeneratedOutputAndVersionAsync(
+            ProjectSnapshot project,
+            IDocumentSnapshot document,
+            CancellationToken cancellationToken)
         {
             // We only need to produce the generated code if any of our inputs is newer than the
             // previously cached output.
@@ -164,8 +186,8 @@ internal partial class DocumentState
             var configurationVersion = project.ConfigurationVersion;
             var projectWorkspaceStateVersion = project.ProjectWorkspaceStateVersion;
             var documentCollectionVersion = project.DocumentCollectionVersion;
-            var imports = await GetImportsAsync(document, project.GetProjectEngine()).ConfigureAwait(false);
-            var documentVersion = await document.GetTextVersionAsync(CancellationToken.None).ConfigureAwait(false);
+            var imports = await GetImportsAsync(document, project.GetProjectEngine(), cancellationToken).ConfigureAwait(false);
+            var documentVersion = await document.GetTextVersionAsync(cancellationToken).ConfigureAwait(false);
 
             // OK now that have the previous output and all of the versions, we can see if anything
             // has changed that would require regenerating the code.
@@ -210,9 +232,9 @@ internal partial class DocumentState
                 }
             }
 
-            var tagHelpers = await project.GetTagHelpersAsync(CancellationToken.None).ConfigureAwait(false);
+            var tagHelpers = await project.GetTagHelpersAsync(cancellationToken).ConfigureAwait(false);
             var forceRuntimeCodeGeneration = project.Configuration.LanguageServerFlags?.ForceRuntimeCodeGeneration ?? false;
-            var codeDocument = await GenerateCodeDocumentAsync(document, project.GetProjectEngine(), imports, tagHelpers, forceRuntimeCodeGeneration).ConfigureAwait(false);
+            var codeDocument = await GenerateCodeDocumentAsync(document, project.GetProjectEngine(), imports, tagHelpers, forceRuntimeCodeGeneration, cancellationToken).ConfigureAwait(false);
             return (codeDocument, inputVersion);
         }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.ComputedStateTracker.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.ComputedStateTracker.cs
@@ -11,23 +11,17 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 internal partial class DocumentState
 {
-    private class ComputedStateTracker
+    private class ComputedStateTracker(ComputedStateTracker? older = null)
     {
-        private readonly object _lock;
+        private readonly object _lock = new();
 
-        private ComputedStateTracker? _older;
+        private ComputedStateTracker? _older = older;
 
         // We utilize a WeakReference here to avoid bloating committed memory. If pieces request document output inbetween GC collections
         // then we will provide the weak referenced task; otherwise we require any state requests to be re-computed.
         private WeakReference<Task<(RazorCodeDocument, VersionStamp)>>? _taskUnsafeReference;
 
         private ComputedOutput? _computedOutput;
-
-        public ComputedStateTracker(DocumentState state, ComputedStateTracker? older = null)
-        {
-            _lock = state._lock;
-            _older = older;
-        }
 
         public bool IsResultAvailable
         {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.ComputedStateTracker.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.ComputedStateTracker.cs
@@ -165,7 +165,7 @@ internal partial class DocumentState
             var projectWorkspaceStateVersion = project.ProjectWorkspaceStateVersion;
             var documentCollectionVersion = project.DocumentCollectionVersion;
             var imports = await GetImportsAsync(document, project.GetProjectEngine()).ConfigureAwait(false);
-            var documentVersion = await document.GetTextVersionAsync().ConfigureAwait(false);
+            var documentVersion = await document.GetTextVersionAsync(CancellationToken.None).ConfigureAwait(false);
 
             // OK now that have the previous output and all of the versions, we can see if anything
             // has changed that would require regenerating the code.

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.cs
@@ -102,16 +102,18 @@ internal partial class DocumentState
         return textAsVersion.Text;
     }
 
-    public async Task<VersionStamp> GetTextVersionAsync()
+    public ValueTask<VersionStamp> GetTextVersionAsync()
     {
-        if (TryGetTextVersion(out var version))
+        return TryGetTextVersion(out var version)
+            ? new(version)
+            : GetTextVersionCoreAsync(CancellationToken.None);
+
+        async ValueTask<VersionStamp> GetTextVersionCoreAsync(CancellationToken cancellationToken)
         {
-            return version;
+            var textAsVersion = await GetTextAndVersionAsync(cancellationToken).ConfigureAwait(false);
+
+            return textAsVersion.Version;
         }
-
-        var textAsVersion = await GetTextAndVersionAsync(CancellationToken.None).ConfigureAwait(false);
-
-        return textAsVersion.Version;
     }
 
     public bool TryGetText([NotNullWhen(true)] out SourceText? result)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.cs
@@ -90,11 +90,11 @@ internal partial class DocumentState
         }
     }
 
-    public ValueTask<SourceText> GetTextAsync()
+    public ValueTask<SourceText> GetTextAsync(CancellationToken cancellationToken)
     {
         return TryGetText(out var text)
             ? new(text)
-            : GetTextCoreAsync(CancellationToken.None);
+            : GetTextCoreAsync(cancellationToken);
 
         async ValueTask<SourceText> GetTextCoreAsync(CancellationToken cancellationToken)
         {
@@ -104,11 +104,11 @@ internal partial class DocumentState
         }
     }
 
-    public ValueTask<VersionStamp> GetTextVersionAsync()
+    public ValueTask<VersionStamp> GetTextVersionAsync(CancellationToken cancellationToken)
     {
         return TryGetTextVersion(out var version)
             ? new(version)
-            : GetTextVersionCoreAsync(CancellationToken.None);
+            : GetTextVersionCoreAsync(cancellationToken);
 
         async ValueTask<VersionStamp> GetTextVersionCoreAsync(CancellationToken cancellationToken)
         {
@@ -258,7 +258,7 @@ internal partial class DocumentState
 
         foreach (var snapshot in imports)
         {
-            var versionStamp = await snapshot.GetTextVersionAsync().ConfigureAwait(false);
+            var versionStamp = await snapshot.GetTextVersionAsync(CancellationToken.None).ConfigureAwait(false);
             result.Add(new ImportItem(snapshot.FilePath, versionStamp, snapshot));
         }
 
@@ -267,7 +267,7 @@ internal partial class DocumentState
 
     private static async Task<RazorSourceDocument> GetRazorSourceDocumentAsync(IDocumentSnapshot document, RazorProjectItem? projectItem)
     {
-        var sourceText = await document.GetTextAsync().ConfigureAwait(false);
+        var sourceText = await document.GetTextAsync(CancellationToken.None).ConfigureAwait(false);
         return RazorSourceDocument.Create(sourceText, RazorSourceDocumentProperties.Create(document.FilePath, projectItem?.RelativePhysicalPath));
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.cs
@@ -90,16 +90,18 @@ internal partial class DocumentState
         }
     }
 
-    public async Task<SourceText> GetTextAsync()
+    public ValueTask<SourceText> GetTextAsync()
     {
-        if (TryGetText(out var text))
+        return TryGetText(out var text)
+            ? new(text)
+            : GetTextCoreAsync(CancellationToken.None);
+
+        async ValueTask<SourceText> GetTextCoreAsync(CancellationToken cancellationToken)
         {
-            return text;
+            var textAsVersion = await GetTextAndVersionAsync(cancellationToken).ConfigureAwait(false);
+
+            return textAsVersion.Text;
         }
-
-        var textAsVersion = await GetTextAndVersionAsync(CancellationToken.None).ConfigureAwait(false);
-
-        return textAsVersion.Text;
     }
 
     public ValueTask<VersionStamp> GetTextVersionAsync()

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshot.cs
@@ -18,7 +18,7 @@ internal interface IDocumentSnapshot
 
     int Version { get; }
 
-    Task<SourceText> GetTextAsync();
+    ValueTask<SourceText> GetTextAsync();
     ValueTask<VersionStamp> GetTextVersionAsync();
     Task<RazorCodeDocument> GetGeneratedOutputAsync(bool forceDesignTimeGeneratedOutput);
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshot.cs
@@ -18,8 +18,8 @@ internal interface IDocumentSnapshot
 
     int Version { get; }
 
-    ValueTask<SourceText> GetTextAsync();
-    ValueTask<VersionStamp> GetTextVersionAsync();
+    ValueTask<SourceText> GetTextAsync(CancellationToken cancellationToken);
+    ValueTask<VersionStamp> GetTextVersionAsync(CancellationToken cancellationToken);
     Task<RazorCodeDocument> GetGeneratedOutputAsync(bool forceDesignTimeGeneratedOutput);
 
     /// <summary>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshot.cs
@@ -26,7 +26,7 @@ internal interface IDocumentSnapshot
     /// Gets the Roslyn syntax tree for the generated C# for this Razor document
     /// </summary>
     /// <remarks>Using this from the LSP server side of things is not ideal. Use sparingly :)</remarks>
-    Task<SyntaxTree> GetCSharpSyntaxTreeAsync(CancellationToken cancellationToken);
+    ValueTask<SyntaxTree> GetCSharpSyntaxTreeAsync(CancellationToken cancellationToken);
 
     bool TryGetText([NotNullWhen(true)] out SourceText? result);
     bool TryGetTextVersion(out VersionStamp result);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshot.cs
@@ -25,9 +25,11 @@ internal interface IDocumentSnapshot
         CancellationToken cancellationToken);
 
     /// <summary>
-    /// Gets the Roslyn syntax tree for the generated C# for this Razor document
+    ///  Gets the Roslyn syntax tree for the generated C# for this Razor document
     /// </summary>
-    /// <remarks>Using this from the LSP server side of things is not ideal. Use sparingly :)</remarks>
+    /// <remarks>
+    ///  ⚠️ Should be used sparingly in language server scenarios.
+    /// </remarks>
     ValueTask<SyntaxTree> GetCSharpSyntaxTreeAsync(CancellationToken cancellationToken);
 
     bool TryGetText([NotNullWhen(true)] out SourceText? result);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshot.cs
@@ -19,7 +19,7 @@ internal interface IDocumentSnapshot
     int Version { get; }
 
     Task<SourceText> GetTextAsync();
-    Task<VersionStamp> GetTextVersionAsync();
+    ValueTask<VersionStamp> GetTextVersionAsync();
     Task<RazorCodeDocument> GetGeneratedOutputAsync(bool forceDesignTimeGeneratedOutput);
 
     /// <summary>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshot.cs
@@ -20,7 +20,9 @@ internal interface IDocumentSnapshot
 
     ValueTask<SourceText> GetTextAsync(CancellationToken cancellationToken);
     ValueTask<VersionStamp> GetTextVersionAsync(CancellationToken cancellationToken);
-    ValueTask<RazorCodeDocument> GetGeneratedOutputAsync(bool forceDesignTimeGeneratedOutput);
+    ValueTask<RazorCodeDocument> GetGeneratedOutputAsync(
+        bool forceDesignTimeGeneratedOutput,
+        CancellationToken cancellationToken);
 
     /// <summary>
     /// Gets the Roslyn syntax tree for the generated C# for this Razor document

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshot.cs
@@ -20,7 +20,7 @@ internal interface IDocumentSnapshot
 
     ValueTask<SourceText> GetTextAsync(CancellationToken cancellationToken);
     ValueTask<VersionStamp> GetTextVersionAsync(CancellationToken cancellationToken);
-    Task<RazorCodeDocument> GetGeneratedOutputAsync(bool forceDesignTimeGeneratedOutput);
+    ValueTask<RazorCodeDocument> GetGeneratedOutputAsync(bool forceDesignTimeGeneratedOutput);
 
     /// <summary>
     /// Gets the Roslyn syntax tree for the generated C# for this Razor document

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshotExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshotExtensions.cs
@@ -53,9 +53,8 @@ internal static class IDocumentSnapshotExtensions
         return fileName.AsSpan().Equals(path.Span, FilePathComparison.Instance);
     }
 
-    public static Task<RazorCodeDocument> GetGeneratedOutputAsync(this IDocumentSnapshot documentSnapshot)
+    public static ValueTask<RazorCodeDocument> GetGeneratedOutputAsync(this IDocumentSnapshot documentSnapshot)
     {
         return documentSnapshot.GetGeneratedOutputAsync(forceDesignTimeGeneratedOutput: false);
     }
-
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshotExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshotExtensions.cs
@@ -11,7 +11,9 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 internal static class IDocumentSnapshotExtensions
 {
-    public static async Task<TagHelperDescriptor?> TryGetTagHelperDescriptorAsync(this IDocumentSnapshot documentSnapshot, CancellationToken cancellationToken)
+    public static async Task<TagHelperDescriptor?> TryGetTagHelperDescriptorAsync(
+        this IDocumentSnapshot documentSnapshot,
+        CancellationToken cancellationToken)
     {
         // No point doing anything if its not a component
         if (documentSnapshot.FileKind != FileKinds.Component)
@@ -19,7 +21,7 @@ internal static class IDocumentSnapshotExtensions
             return null;
         }
 
-        var razorCodeDocument = await documentSnapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
+        var razorCodeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         if (razorCodeDocument is null)
         {
             return null;
@@ -53,8 +55,10 @@ internal static class IDocumentSnapshotExtensions
         return fileName.AsSpan().Equals(path.Span, FilePathComparison.Instance);
     }
 
-    public static ValueTask<RazorCodeDocument> GetGeneratedOutputAsync(this IDocumentSnapshot documentSnapshot)
+    public static ValueTask<RazorCodeDocument> GetGeneratedOutputAsync(
+        this IDocumentSnapshot documentSnapshot,
+        CancellationToken cancellationToken)
     {
-        return documentSnapshot.GetGeneratedOutputAsync(forceDesignTimeGeneratedOutput: false);
+        return documentSnapshot.GetGeneratedOutputAsync(forceDesignTimeGeneratedOutput: false, cancellationToken);
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ImportDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ImportDocumentSnapshot.cs
@@ -13,8 +13,6 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 internal sealed class ImportDocumentSnapshot(IProjectSnapshot project, RazorProjectItem item) : IDocumentSnapshot
 {
-    private static readonly Task<VersionStamp> s_versionTask = Task.FromResult(VersionStamp.Default);
-
     public IProjectSnapshot Project { get; } = project;
 
     private readonly RazorProjectItem _importItem = item;
@@ -46,8 +44,8 @@ internal sealed class ImportDocumentSnapshot(IProjectSnapshot project, RazorProj
     public Task<RazorCodeDocument> GetGeneratedOutputAsync(bool forceDesignTimeGeneratedOutput)
         => throw new NotSupportedException();
 
-    public Task<VersionStamp> GetTextVersionAsync()
-        => s_versionTask;
+    public ValueTask<VersionStamp> GetTextVersionAsync()
+        => new(VersionStamp.Default);
 
     public bool TryGetText([NotNullWhen(true)] out SourceText? result)
     {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ImportDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ImportDocumentSnapshot.cs
@@ -41,7 +41,9 @@ internal sealed class ImportDocumentSnapshot(IProjectSnapshot project, RazorProj
         }
     }
 
-    public ValueTask<RazorCodeDocument> GetGeneratedOutputAsync(bool forceDesignTimeGeneratedOutput)
+    public ValueTask<RazorCodeDocument> GetGeneratedOutputAsync(
+        bool forceDesignTimeGeneratedOutput,
+        CancellationToken cancellationToken)
         => throw new NotSupportedException();
 
     public ValueTask<VersionStamp> GetTextVersionAsync(CancellationToken cancellationToken)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ImportDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ImportDocumentSnapshot.cs
@@ -41,7 +41,7 @@ internal sealed class ImportDocumentSnapshot(IProjectSnapshot project, RazorProj
         }
     }
 
-    public Task<RazorCodeDocument> GetGeneratedOutputAsync(bool forceDesignTimeGeneratedOutput)
+    public ValueTask<RazorCodeDocument> GetGeneratedOutputAsync(bool forceDesignTimeGeneratedOutput)
         => throw new NotSupportedException();
 
     public ValueTask<VersionStamp> GetTextVersionAsync(CancellationToken cancellationToken)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ImportDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ImportDocumentSnapshot.cs
@@ -25,7 +25,7 @@ internal sealed class ImportDocumentSnapshot(IProjectSnapshot project, RazorProj
 
     public int Version => 1;
 
-    public ValueTask<SourceText> GetTextAsync()
+    public ValueTask<SourceText> GetTextAsync(CancellationToken cancellationToken)
     {
         return TryGetText(out var text)
             ? new(text)
@@ -44,7 +44,7 @@ internal sealed class ImportDocumentSnapshot(IProjectSnapshot project, RazorProj
     public Task<RazorCodeDocument> GetGeneratedOutputAsync(bool forceDesignTimeGeneratedOutput)
         => throw new NotSupportedException();
 
-    public ValueTask<VersionStamp> GetTextVersionAsync()
+    public ValueTask<VersionStamp> GetTextVersionAsync(CancellationToken cancellationToken)
         => new(VersionStamp.Default);
 
     public bool TryGetText([NotNullWhen(true)] out SourceText? result)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ImportDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ImportDocumentSnapshot.cs
@@ -65,6 +65,6 @@ internal sealed class ImportDocumentSnapshot(IProjectSnapshot project, RazorProj
     public IDocumentSnapshot WithText(SourceText text)
         => throw new NotSupportedException();
 
-    public Task<SyntaxTree> GetCSharpSyntaxTreeAsync(CancellationToken cancellationToken)
+    public ValueTask<SyntaxTree> GetCSharpSyntaxTreeAsync(CancellationToken cancellationToken)
         => throw new NotSupportedException();
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.ProjectEngineHost;
@@ -224,7 +223,7 @@ internal class ProjectState
 
     public VersionStamp ConfigurationVersion { get; }
 
-    public ProjectState WithAddedHostDocument(HostDocument hostDocument, Func<Task<TextAndVersion>> loader)
+    public ProjectState WithAddedHostDocument(HostDocument hostDocument, TextLoader loader)
     {
         if (hostDocument is null)
         {
@@ -321,7 +320,7 @@ internal class ProjectState
         return state;
     }
 
-    public ProjectState WithChangedHostDocument(HostDocument hostDocument, Func<Task<TextAndVersion>> loader)
+    public ProjectState WithChangedHostDocument(HostDocument hostDocument, TextLoader loader)
     {
         if (hostDocument is null)
         {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/RazorComponentSearchEngine.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/RazorComponentSearchEngine.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Razor.Logging;
@@ -13,18 +14,35 @@ internal class RazorComponentSearchEngine(ILoggerFactory loggerFactory) : IRazor
 {
     private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<RazorComponentSearchEngine>();
 
-    /// <summary>Search for a component in a project based on its tag name and fully qualified name.</summary>
+    /// <summary>
+    ///  Search for a component in a project based on its tag name and fully qualified name.
+    /// </summary>
+    /// <param name="tagHelper">
+    ///  A <see cref="TagHelperDescriptor"/> to find the corresponding Razor component for.
+    /// </param>
+    /// <param name="solutionQueryOperations">
+    ///  An <see cref="ISolutionQueryOperations"/> to enumerate project snapshots.
+    /// </param>
+    /// <param name="cancellationToken">
+    ///  A token that is checked to cancel work.
+    /// </param>
+    /// <returns>
+    ///  The corresponding <see cref="IDocumentSnapshot"/> if found, <see langword="null"/> otherwise.
+    /// </returns>
     /// <remarks>
-    /// This method makes several assumptions about the nature of components. First, it assumes that a component
-    /// a given name "Name" will be located in a file "Name.razor". Second, it assumes that the namespace the
-    /// component is present in has the same name as the assembly its corresponding tag helper is loaded from.
-    /// Implicitly, this method inherits any assumptions made by TrySplitNamespaceAndType.
+    ///  This method makes several assumptions about the nature of components. First,
+    ///  it assumes that a component a given name "Name" will be located in a file
+    ///  "Name.razor". Second, it assumes that the namespace the component is present in
+    ///  has the same name as the assembly its corresponding tag helper is loaded from.
+    ///  Implicitly, this method inherits any assumptions made by TrySplitNamespaceAndType.
     /// </remarks>
-    /// <param name="tagHelper">A TagHelperDescriptor to find the corresponding Razor component for.</param>
-    /// <param name="solutionQueryOperations">An <see cref="ISolutionQueryOperations"/> to enumerate project snapshots.</param>
-    /// <returns>The corresponding DocumentSnapshot if found, null otherwise.</returns>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="tagHelper"/> is null.</exception>
-    public async Task<IDocumentSnapshot?> TryLocateComponentAsync(TagHelperDescriptor tagHelper, ISolutionQueryOperations solutionQueryOperations)
+    /// <exception cref="ArgumentNullException">
+    ///  Thrown if <paramref name="tagHelper"/> is <see langword="null"/>.
+    /// </exception>
+    public async Task<IDocumentSnapshot?> TryLocateComponentAsync(
+        TagHelperDescriptor tagHelper,
+        ISolutionQueryOperations solutionQueryOperations,
+        CancellationToken cancellationToken)
     {
         var typeName = tagHelper.GetTypeNameIdentifier();
         var namespaceName = tagHelper.GetTypeNamespace();
@@ -52,7 +70,7 @@ internal class RazorComponentSearchEngine(ILoggerFactory loggerFactory) : IRazor
                     continue;
                 }
 
-                var razorCodeDocument = await document.GetGeneratedOutputAsync().ConfigureAwait(false);
+                var razorCodeDocument = await document.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
                 if (razorCodeDocument is null)
                 {
                     continue;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Rename/RenameService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Rename/RenameService.cs
@@ -58,7 +58,9 @@ internal class RenameService(
             return null;
         }
 
-        var originComponentDocumentSnapshot = await _componentSearchEngine.TryLocateComponentAsync(originTagHelpers.First(), solutionQueryOperations).ConfigureAwait(false);
+        var originComponentDocumentSnapshot = await _componentSearchEngine
+            .TryLocateComponentAsync(originTagHelpers.First(), solutionQueryOperations, cancellationToken)
+            .ConfigureAwait(false);
         if (originComponentDocumentSnapshot is null)
         {
             return null;
@@ -80,7 +82,7 @@ internal class RenameService(
 
         foreach (var documentSnapshot in documentSnapshots)
         {
-            await AddEditsForCodeDocumentAsync(documentChanges, originTagHelpers, newName, documentSnapshot).ConfigureAwait(false);
+            await AddEditsForCodeDocumentAsync(documentChanges, originTagHelpers, newName, documentSnapshot, cancellationToken).ConfigureAwait(false);
         }
 
         foreach (var documentChange in documentChanges)
@@ -165,14 +167,15 @@ internal class RenameService(
         List<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>> documentChanges,
         ImmutableArray<TagHelperDescriptor> originTagHelpers,
         string newName,
-        IDocumentSnapshot documentSnapshot)
+        IDocumentSnapshot documentSnapshot,
+        CancellationToken cancellationToken)
     {
         if (!FileKinds.IsComponent(documentSnapshot.FileKind))
         {
             return;
         }
 
-        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         if (codeDocument.IsUnsupported())
         {
             return;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/AutoInsert/RemoteAutoInsertService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/AutoInsert/RemoteAutoInsertService.cs
@@ -137,7 +137,9 @@ internal sealed class RemoteAutoInsertService(in ServiceArgs args)
             return Response.NoFurtherHandling;
         }
 
-        var generatedDocument = await remoteDocumentContext.Snapshot.GetGeneratedDocumentAsync().ConfigureAwait(false);
+        var generatedDocument = await remoteDocumentContext.Snapshot
+            .GetGeneratedDocumentAsync(cancellationToken)
+            .ConfigureAwait(false);
 
         var autoInsertResponseItem = await OnAutoInsert.GetOnAutoInsertResponseAsync(
             generatedDocument,

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Diagnostics/RemoteDiagnosticsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Diagnostics/RemoteDiagnosticsService.cs
@@ -49,8 +49,8 @@ internal sealed class RemoteDiagnosticsService(in ServiceArgs args) : RazorDocum
 
         return [
             .. RazorDiagnosticConverter.Convert(razorDiagnostics, codeDocument.Source.Text, context.Snapshot),
-            .. await _translateDiagnosticsService.TranslateAsync(RazorLanguageKind.CSharp, csharpDiagnostics, context.Snapshot),
-            .. await _translateDiagnosticsService.TranslateAsync(RazorLanguageKind.Html, htmlDiagnostics, context.Snapshot)
+            .. await _translateDiagnosticsService.TranslateAsync(RazorLanguageKind.CSharp, csharpDiagnostics, context.Snapshot, cancellationToken),
+            .. await _translateDiagnosticsService.TranslateAsync(RazorLanguageKind.Html, htmlDiagnostics, context.Snapshot, cancellationToken)
         ];
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentHighlight/RemoteDocumentHighlightService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentHighlight/RemoteDocumentHighlightService.cs
@@ -64,7 +64,9 @@ internal sealed partial class RemoteDocumentHighlightService(in ServiceArgs args
         var csharpDocument = codeDocument.GetCSharpDocument();
         if (DocumentMappingService.TryMapToGeneratedDocumentPosition(csharpDocument, index, out var mappedPosition, out _))
         {
-            var generatedDocument = await context.Snapshot.GetGeneratedDocumentAsync().ConfigureAwait(false);
+            var generatedDocument = await context.Snapshot
+                .GetGeneratedDocumentAsync(cancellationToken)
+                .ConfigureAwait(false);
 
             var highlights = await DocumentHighlights.GetHighlightsAsync(generatedDocument, mappedPosition, cancellationToken).ConfigureAwait(false);
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentMapping/RemoteDocumentMappingService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentMapping/RemoteDocumentMappingService.cs
@@ -54,8 +54,9 @@ internal sealed class RemoteDocumentMappingService(
 
         var razorDocumentSnapshot = _snapshotManager.GetSnapshot(razorDocument);
 
-        var razorCodeDocument = await razorDocumentSnapshot.GetGeneratedOutputAsync().ConfigureAwait(false);
-        cancellationToken.ThrowIfCancellationRequested();
+        var razorCodeDocument = await razorDocumentSnapshot
+            .GetGeneratedOutputAsync(cancellationToken)
+            .ConfigureAwait(false);
 
         if (razorCodeDocument is null)
         {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentSymbols/RemoteDocumentSymbolService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentSymbols/RemoteDocumentSymbolService.cs
@@ -33,7 +33,10 @@ internal sealed partial class RemoteDocumentSymbolService(in ServiceArgs args) :
 
     private async ValueTask<SumType<DocumentSymbol[], SymbolInformation[]>?> GetDocumentSymbolsAsync(RemoteDocumentContext context, bool useHierarchicalSymbols, CancellationToken cancellationToken)
     {
-        var generatedDocument = await context.Snapshot.GetGeneratedDocumentAsync().ConfigureAwait(false);
+        var generatedDocument = await context.Snapshot
+            .GetGeneratedDocumentAsync(cancellationToken)
+            .ConfigureAwait(false);
+
         var csharpSymbols = await ExternalHandlers.DocumentSymbols.GetDocumentSymbolsAsync(generatedDocument, useHierarchicalSymbols, cancellationToken).ConfigureAwait(false);
 
         var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/FoldingRanges/RemoteFoldingRangeService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/FoldingRanges/RemoteFoldingRangeService.cs
@@ -41,7 +41,9 @@ internal sealed class RemoteFoldingRangeService(in ServiceArgs args) : RazorDocu
         ImmutableArray<RemoteFoldingRange> htmlRanges,
         CancellationToken cancellationToken)
     {
-        var generatedDocument = await context.Snapshot.GetGeneratedDocumentAsync().ConfigureAwait(false);
+        var generatedDocument = await context.Snapshot
+            .GetGeneratedDocumentAsync(cancellationToken)
+            .ConfigureAwait(false);
 
         var csharpRanges = await ExternalHandlers.FoldingRanges.GetFoldingRangesAsync(generatedDocument, cancellationToken).ConfigureAwait(false);
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Formatting/RemoteFormattingCodeDocumentProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Formatting/RemoteFormattingCodeDocumentProvider.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Remote.Razor.Formatting;
 [Export(typeof(IFormattingCodeDocumentProvider)), Shared]
 internal sealed class RemoteFormattingCodeDocumentProvider : IFormattingCodeDocumentProvider
 {
-    public Task<RazorCodeDocument> GetCodeDocumentAsync(IDocumentSnapshot snapshot)
+    public ValueTask<RazorCodeDocument> GetCodeDocumentAsync(IDocumentSnapshot snapshot)
     {
         // Formatting always uses design time
         return snapshot.GetGeneratedOutputAsync(forceDesignTimeGeneratedOutput: true);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Formatting/RemoteFormattingCodeDocumentProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Formatting/RemoteFormattingCodeDocumentProvider.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Composition;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Razor.Formatting;
@@ -12,9 +13,9 @@ namespace Microsoft.CodeAnalysis.Remote.Razor.Formatting;
 [Export(typeof(IFormattingCodeDocumentProvider)), Shared]
 internal sealed class RemoteFormattingCodeDocumentProvider : IFormattingCodeDocumentProvider
 {
-    public ValueTask<RazorCodeDocument> GetCodeDocumentAsync(IDocumentSnapshot snapshot)
+    public ValueTask<RazorCodeDocument> GetCodeDocumentAsync(IDocumentSnapshot snapshot, CancellationToken cancellationToken)
     {
         // Formatting always uses design time
-        return snapshot.GetGeneratedOutputAsync(forceDesignTimeGeneratedOutput: true);
+        return snapshot.GetGeneratedOutputAsync(forceDesignTimeGeneratedOutput: true, cancellationToken);
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/GoToDefinition/RemoteGoToDefinitionService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/GoToDefinition/RemoteGoToDefinitionService.cs
@@ -83,7 +83,9 @@ internal sealed class RemoteGoToDefinitionService(in ServiceArgs args) : RazorDo
         }
 
         // Finally, call into C#.
-        var generatedDocument = await context.Snapshot.GetGeneratedDocumentAsync().ConfigureAwait(false);
+        var generatedDocument = await context.Snapshot
+            .GetGeneratedDocumentAsync(cancellationToken)
+            .ConfigureAwait(false);
 
         var locations = await ExternalHandlers.GoToDefinition
             .GetDefinitionsAsync(

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/GoToImplementation/RemoteGoToImplementationService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/GoToImplementation/RemoteGoToImplementationService.cs
@@ -73,7 +73,9 @@ internal sealed class RemoteGoToImplementationService(in ServiceArgs args) : Raz
         }
 
         // Finally, call into C#.
-        var generatedDocument = await context.Snapshot.GetGeneratedDocumentAsync().ConfigureAwait(false);
+        var generatedDocument = await context.Snapshot
+            .GetGeneratedDocumentAsync(cancellationToken)
+            .ConfigureAwait(false);
 
         var locations = await ExternalHandlers.GoToImplementation
             .FindImplementationsAsync(

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/InlayHints/RemoteInlayHintService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/InlayHints/RemoteInlayHintService.cs
@@ -61,7 +61,9 @@ internal sealed partial class RemoteInlayHintService(in ServiceArgs args) : Razo
             return null;
         }
 
-        var generatedDocument = await context.Snapshot.GetGeneratedDocumentAsync().ConfigureAwait(false);
+        var generatedDocument = await context.Snapshot
+            .GetGeneratedDocumentAsync(cancellationToken)
+            .ConfigureAwait(false);
 
         var textDocument = inlayHintParams.TextDocument.WithUri(generatedDocument.CreateUri());
         var range = projectedLinePositionSpan.ToRange();
@@ -115,7 +117,9 @@ internal sealed partial class RemoteInlayHintService(in ServiceArgs args) : Razo
 
     private async ValueTask<InlayHint> ResolveInlayHintAsync(RemoteDocumentContext context, InlayHint inlayHint, CancellationToken cancellationToken)
     {
-        var generatedDocument = await context.Snapshot.GetGeneratedDocumentAsync().ConfigureAwait(false);
+        var generatedDocument = await context.Snapshot
+            .GetGeneratedDocumentAsync(cancellationToken)
+            .ConfigureAwait(false);
 
         return await InlayHints.ResolveInlayHintAsync(generatedDocument, inlayHint, cancellationToken).ConfigureAwait(false);
     }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentSnapshot.cs
@@ -42,18 +42,18 @@ internal sealed class RemoteDocumentSnapshot : IDocumentSnapshot
 
     public int Version => -999; // We don't expect to use this in cohosting, but plenty of existing code logs it's value
 
-    public ValueTask<SourceText> GetTextAsync()
+    public ValueTask<SourceText> GetTextAsync(CancellationToken cancellationToken)
     {
         return TryGetText(out var result)
             ? new(result)
-            : new(TextDocument.GetTextAsync());
+            : new(TextDocument.GetTextAsync(cancellationToken));
     }
 
-    public ValueTask<VersionStamp> GetTextVersionAsync()
+    public ValueTask<VersionStamp> GetTextVersionAsync(CancellationToken cancellationToken)
     {
         return TryGetTextVersion(out var result)
             ? new(result)
-            : new(TextDocument.GetTextVersionAsync());
+            : new(TextDocument.GetTextVersionAsync(cancellationToken));
     }
 
     public bool TryGetText([NotNullWhen(true)] out SourceText? result)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentSnapshot.cs
@@ -42,8 +42,12 @@ internal sealed class RemoteDocumentSnapshot : IDocumentSnapshot
 
     public int Version => -999; // We don't expect to use this in cohosting, but plenty of existing code logs it's value
 
-    public Task<SourceText> GetTextAsync()
-        => TextDocument.GetTextAsync();
+    public ValueTask<SourceText> GetTextAsync()
+    {
+        return TryGetText(out var result)
+            ? new(result)
+            : new(TextDocument.GetTextAsync());
+    }
 
     public ValueTask<VersionStamp> GetTextVersionAsync()
     {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentSnapshot.cs
@@ -45,8 +45,12 @@ internal sealed class RemoteDocumentSnapshot : IDocumentSnapshot
     public Task<SourceText> GetTextAsync()
         => TextDocument.GetTextAsync();
 
-    public Task<VersionStamp> GetTextVersionAsync()
-        => TextDocument.GetTextVersionAsync();
+    public ValueTask<VersionStamp> GetTextVersionAsync()
+    {
+        return TryGetTextVersion(out var result)
+            ? new(result)
+            : new(TextDocument.GetTextVersionAsync());
+    }
 
     public bool TryGetText([NotNullWhen(true)] out SourceText? result)
         => TextDocument.TryGetText(out result);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Rename/RemoteRenameService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Rename/RemoteRenameService.cs
@@ -52,7 +52,9 @@ internal sealed class RemoteRenameService(in ServiceArgs args) : RazorDocumentSe
             return NoFurtherHandling;
         }
 
-        var generatedDocument = await context.Snapshot.GetGeneratedDocumentAsync().ConfigureAwait(false);
+        var generatedDocument = await context.Snapshot
+            .GetGeneratedDocumentAsync(cancellationToken)
+            .ConfigureAwait(false);
 
         var razorEdit = await _renameService
             .TryGetRazorRenameEditsAsync(context, positionInfo, newName, context.GetSolutionQueryOperations(), cancellationToken)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SemanticTokens/RemoteCSharpSemanticTokensProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SemanticTokens/RemoteCSharpSemanticTokensProvider.cs
@@ -31,13 +31,17 @@ internal class RemoteCSharpSemanticTokensProvider(IFilePathService filePathServi
         // We have a razor document, lets find the generated C# document
         Debug.Assert(documentContext is RemoteDocumentContext, "This method only works on document snapshots created in the OOP process");
         var snapshot = (RemoteDocumentSnapshot)documentContext.Snapshot;
-        var generatedDocument = await snapshot.GetGeneratedDocumentAsync().ConfigureAwait(false);
+        var generatedDocument = await snapshot
+            .GetGeneratedDocumentAsync(cancellationToken)
+            .ConfigureAwait(false);
 
-        var data = await SemanticTokensRange.GetSemanticTokensAsync(
-            generatedDocument,
-            csharpRanges,
-            supportsVisualStudioExtensions: true,
-            cancellationToken).ConfigureAwait(false);
+        var data = await SemanticTokensRange
+            .GetSemanticTokensAsync(
+                generatedDocument,
+                csharpRanges,
+                supportsVisualStudioExtensions: true,
+                cancellationToken)
+            .ConfigureAwait(false);
 
         return data;
     }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SignatureHelp/RemoteSignatureHelpService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SignatureHelp/RemoteSignatureHelpService.cs
@@ -35,7 +35,9 @@ internal sealed class RemoteSignatureHelpService(in ServiceArgs args) : RazorDoc
         var linePosition = new LinePosition(position.Line, position.Character);
         var absoluteIndex = codeDocument.Source.Text.GetRequiredAbsoluteIndex(linePosition);
 
-        var generatedDocument = await context.Snapshot.GetGeneratedDocumentAsync().ConfigureAwait(false);
+        var generatedDocument = await context.Snapshot
+            .GetGeneratedDocumentAsync(cancellationToken)
+            .ConfigureAwait(false);
 
         if (DocumentMappingService.TryMapToGeneratedDocumentPosition(codeDocument.GetCSharpDocument(), absoluteIndex, out var mappedPosition, out _))
         {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SpellCheck/RemoteCSharpSpellCheckRangeProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SpellCheck/RemoteCSharpSpellCheckRangeProvider.cs
@@ -21,7 +21,7 @@ internal sealed class RemoteCSharpSpellCheckRangeProvider() : ICSharpSpellCheckR
         // We have a razor document, lets find the generated C# document
         Debug.Assert(documentContext is RemoteDocumentContext, "This method only works on document snapshots created in the OOP process");
         var snapshot = (RemoteDocumentSnapshot)documentContext.Snapshot;
-        var generatedDocument = await snapshot.GetGeneratedDocumentAsync().ConfigureAwait(false);
+        var generatedDocument = await snapshot.GetGeneratedDocumentAsync(cancellationToken).ConfigureAwait(false);
 
         var csharpRanges = await ExternalAccess.Razor.Cohost.Handlers.SpellCheck.GetSpellCheckSpansAsync(generatedDocument, cancellationToken).ConfigureAwait(false);
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Documents/RazorCodeDocumentProvidingSnapshotChangeTrigger.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Documents/RazorCodeDocumentProvidingSnapshotChangeTrigger.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
@@ -61,7 +62,7 @@ internal class RazorCodeDocumentProvidingSnapshotChangeTrigger : IRazorStartupSe
         }
     }
 
-    public async Task<RazorCodeDocument?> GetRazorCodeDocumentAsync(string filePath)
+    public async Task<RazorCodeDocument?> GetRazorCodeDocumentAsync(string filePath, CancellationToken cancellationToken)
     {
         if (!_documentProjectMap.TryGetValue(filePath, out var projectKey))
         {
@@ -79,8 +80,6 @@ internal class RazorCodeDocumentProvidingSnapshotChangeTrigger : IRazorStartupSe
             return null;
         }
 
-        var razorDocument = await document.GetGeneratedOutputAsync().ConfigureAwait(false);
-
-        return razorDocument;
+        return await document.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/DynamicFiles/BackgroundDocumentGenerator.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/DynamicFiles/BackgroundDocumentGenerator.cs
@@ -71,9 +71,9 @@ internal partial class BackgroundDocumentGenerator : IRazorStartupService, IDisp
     protected Task WaitUntilCurrentBatchCompletesAsync()
         => _workQueue.WaitUntilCurrentBatchCompletesAsync();
 
-    protected virtual async Task ProcessDocumentAsync(IProjectSnapshot project, IDocumentSnapshot document)
+    protected virtual async Task ProcessDocumentAsync(IProjectSnapshot project, IDocumentSnapshot document, CancellationToken cancellationToken)
     {
-        await document.GetGeneratedOutputAsync().ConfigureAwait(false);
+        await document.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
 
         UpdateFileInfo(project, document);
     }
@@ -116,7 +116,7 @@ internal partial class BackgroundDocumentGenerator : IRazorStartupService, IDisp
 
             try
             {
-                await ProcessDocumentAsync(project, document).ConfigureAwait(false);
+                await ProcessDocumentAsync(project, document, token).ConfigureAwait(false);
             }
             catch (UnauthorizedAccessException)
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/DynamicFiles/RazorDocumentExcerptService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/DynamicFiles/RazorDocumentExcerptService.cs
@@ -46,7 +46,7 @@ internal class RazorDocumentExcerptService(
             return null;
         }
 
-        var razorDocumentText = await razorDocument.GetTextAsync().ConfigureAwait(false);
+        var razorDocumentText = await razorDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
         var razorDocumentSpan = razorDocumentText.Lines.GetTextSpan(mappedSpans[0].LinePositionSpan);
 
         var generatedDocument = document;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/DynamicFiles/RazorDocumentExcerptService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/DynamicFiles/RazorDocumentExcerptService.cs
@@ -56,7 +56,7 @@ internal class RazorDocumentExcerptService(
 
         // Then we'll classify the spans based on the primary document, since that's the coordinate
         // space that our output mappings use.
-        var output = await _document.GetGeneratedOutputAsync().ConfigureAwait(false);
+        var output = await _document.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         var mappings = output.GetCSharpDocument().SourceMappings;
         var classifiedSpans = await ClassifyPreviewAsync(
             excerptSpan,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/DynamicFiles/RazorSpanMappingService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/DynamicFiles/RazorSpanMappingService.cs
@@ -42,8 +42,8 @@ internal class RazorSpanMappingService(IDocumentSnapshot document) : IRazorSpanM
             return ImmutableArray<RazorMappedSpanResult>.Empty;
         }
 
-        var source = await _document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-        var output = await _document.GetGeneratedOutputAsync().ConfigureAwait(false);
+        var output = await _document.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+        var source = output.Source.Text;
 
         var csharpDocument = output.GetCSharpDocument();
         var filePath = output.Source.FilePath.AssumeNotNull();

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/DynamicFiles/RazorSpanMappingService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/DynamicFiles/RazorSpanMappingService.cs
@@ -42,7 +42,7 @@ internal class RazorSpanMappingService(IDocumentSnapshot document) : IRazorSpanM
             return ImmutableArray<RazorMappedSpanResult>.Empty;
         }
 
-        var source = await _document.GetTextAsync().ConfigureAwait(false);
+        var source = await _document.GetTextAsync(cancellationToken).ConfigureAwait(false);
         var output = await _document.GetGeneratedOutputAsync().ConfigureAwait(false);
 
         var csharpDocument = output.GetCSharpDocument();

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/SyntaxVisualizer/SyntaxVisualizerControl.xaml.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/SyntaxVisualizer/SyntaxVisualizerControl.xaml.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Threading;
 using System.Windows;
 using System.Windows.Controls;
 using Microsoft.AspNetCore.Razor.Language;
@@ -539,7 +540,8 @@ internal partial class SyntaxVisualizerControl : UserControl, IVsRunningDocTable
 
         var filePath = hostDocumentUri.GetAbsoluteOrUNCPath().Replace('/', '\\');
 
-        var codeDocument = _joinableTaskFactory.Run(() => _codeDocumentProvider.GetRazorCodeDocumentAsync(filePath));
+        var codeDocument = _joinableTaskFactory.Run(
+            () => _codeDocumentProvider.GetRazorCodeDocumentAsync(filePath, CancellationToken.None));
         if (codeDocument is null)
         {
             return null;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/DefaultCSharpCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/DefaultCSharpCodeActionProviderTest.cs
@@ -337,7 +337,7 @@ $$Path;
             .Setup(x => x.GetGeneratedOutputAsync(It.IsAny<bool>()))
             .ReturnsAsync(codeDocument);
         documentSnapshotMock
-            .Setup(x => x.GetTextAsync())
+            .Setup(x => x.GetTextAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(codeDocument.Source.Text);
         documentSnapshotMock
             .Setup(x => x.Project.GetTagHelpersAsync(It.IsAny<CancellationToken>()))

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/DefaultCSharpCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/DefaultCSharpCodeActionProviderTest.cs
@@ -334,7 +334,7 @@ $$Path;
 
         var documentSnapshotMock = new StrictMock<IDocumentSnapshot>();
         documentSnapshotMock
-            .Setup(x => x.GetGeneratedOutputAsync(It.IsAny<bool>()))
+            .Setup(x => x.GetGeneratedOutputAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(codeDocument);
         documentSnapshotMock
             .Setup(x => x.GetTextAsync(It.IsAny<CancellationToken>()))

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/DefaultCSharpCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/DefaultCSharpCodeActionProviderTest.cs
@@ -9,12 +9,12 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
 using Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
+using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol.CodeActions;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Moq;
 using Xunit;
@@ -332,15 +332,24 @@ $$Path;
         var csharpDocumentWithDiagnostic = new RazorCSharpDocument(codeDocument, csharpDocument.GeneratedCode, csharpDocument.Options, [diagnostic]);
         codeDocument.SetCSharpDocument(csharpDocumentWithDiagnostic);
 
-        var documentSnapshot = Mock.Of<IDocumentSnapshot>(document =>
-            document.GetGeneratedOutputAsync(It.IsAny<bool>()) == Task.FromResult(codeDocument) &&
-            document.GetTextAsync() == Task.FromResult(codeDocument.Source.Text) &&
-            document.Project.GetTagHelpersAsync(It.IsAny<CancellationToken>()) == new ValueTask<ImmutableArray<TagHelperDescriptor>>(tagHelpers), MockBehavior.Strict);
+        var documentSnapshotMock = new StrictMock<IDocumentSnapshot>();
+        documentSnapshotMock
+            .Setup(x => x.GetGeneratedOutputAsync(It.IsAny<bool>()))
+            .ReturnsAsync(codeDocument);
+        documentSnapshotMock
+            .Setup(x => x.GetTextAsync())
+            .ReturnsAsync(codeDocument.Source.Text);
+        documentSnapshotMock
+            .Setup(x => x.Project.GetTagHelpersAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tagHelpers);
 
-        var sourceText = SourceText.From(text);
-
-        var context = new RazorCodeActionContext(request, documentSnapshot, codeDocument, location, sourceText, supportsFileCreation, supportsCodeActionResolve);
-
-        return context;
+        return new RazorCodeActionContext(
+            request,
+            documentSnapshotMock.Object,
+            codeDocument,
+            location,
+            codeDocument.Source.Text,
+            supportsFileCreation,
+            supportsCodeActionResolve);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/TypeAccessibilityCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/TypeAccessibilityCodeActionProviderTest.cs
@@ -467,7 +467,7 @@ public class TypeAccessibilityCodeActionProviderTest(ITestOutputHelper testOutpu
             .Setup(x => x.GetGeneratedOutputAsync(It.IsAny<bool>()))
             .ReturnsAsync(codeDocument);
         documentSnapshotMock
-            .Setup(x => x.GetTextAsync())
+            .Setup(x => x.GetTextAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(codeDocument.Source.Text);
         documentSnapshotMock
             .Setup(x => x.Project.GetTagHelpersAsync(It.IsAny<CancellationToken>()))

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/TypeAccessibilityCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/TypeAccessibilityCodeActionProviderTest.cs
@@ -15,7 +15,6 @@ using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Protocol.CodeActions;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Moq;
 using Xunit;
@@ -463,15 +462,24 @@ public class TypeAccessibilityCodeActionProviderTest(ITestOutputHelper testOutpu
         var csharpDocumentWithDiagnostic = new RazorCSharpDocument(codeDocument, csharpDocument.GeneratedCode, csharpDocument.Options, [diagnostic]);
         codeDocument.SetCSharpDocument(csharpDocumentWithDiagnostic);
 
-        var documentSnapshot = Mock.Of<IDocumentSnapshot>(document =>
-            document.GetGeneratedOutputAsync(It.IsAny<bool>()) == Task.FromResult(codeDocument) &&
-            document.GetTextAsync() == Task.FromResult(codeDocument.Source.Text) &&
-            document.Project.GetTagHelpersAsync(It.IsAny<CancellationToken>()) == new ValueTask<ImmutableArray<TagHelperDescriptor>>(tagHelpers), MockBehavior.Strict);
+        var documentSnapshotMock = new StrictMock<IDocumentSnapshot>();
+        documentSnapshotMock
+            .Setup(x => x.GetGeneratedOutputAsync(It.IsAny<bool>()))
+            .ReturnsAsync(codeDocument);
+        documentSnapshotMock
+            .Setup(x => x.GetTextAsync())
+            .ReturnsAsync(codeDocument.Source.Text);
+        documentSnapshotMock
+            .Setup(x => x.Project.GetTagHelpersAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tagHelpers);
 
-        var sourceText = SourceText.From(text);
-
-        var context = new RazorCodeActionContext(request, documentSnapshot, codeDocument, location, sourceText, supportsFileCreation, supportsCodeActionResolve);
-
-        return context;
+        return new RazorCodeActionContext(
+            request,
+            documentSnapshotMock.Object,
+            codeDocument,
+            location,
+            codeDocument.Source.Text,
+            supportsFileCreation,
+            supportsCodeActionResolve);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/TypeAccessibilityCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/TypeAccessibilityCodeActionProviderTest.cs
@@ -464,7 +464,7 @@ public class TypeAccessibilityCodeActionProviderTest(ITestOutputHelper testOutpu
 
         var documentSnapshotMock = new StrictMock<IDocumentSnapshot>();
         documentSnapshotMock
-            .Setup(x => x.GetGeneratedOutputAsync(It.IsAny<bool>()))
+            .Setup(x => x.GetGeneratedOutputAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(codeDocument);
         documentSnapshotMock
             .Setup(x => x.GetTextAsync(It.IsAny<CancellationToken>()))

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
@@ -471,7 +471,7 @@ public class CodeActionEndpointTest(ITestOutputHelper testOutput) : LanguageServ
         };
 
         // Act
-        var razorCodeActionContext = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot);
+        var razorCodeActionContext = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot, DisposalToken);
 
         // Assert
         Assert.NotNull(razorCodeActionContext);
@@ -499,7 +499,7 @@ public class CodeActionEndpointTest(ITestOutputHelper testOutput) : LanguageServ
         };
 
         // Act
-        var razorCodeActionContext = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot);
+        var razorCodeActionContext = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot, DisposalToken);
 
         // Assert
         Assert.NotNull(razorCodeActionContext);
@@ -524,7 +524,7 @@ public class CodeActionEndpointTest(ITestOutputHelper testOutput) : LanguageServ
             Context = new VSInternalCodeActionContext()
         };
 
-        var context = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot);
+        var context = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot, DisposalToken);
         Assert.NotNull(context);
 
         // Act
@@ -560,7 +560,7 @@ public class CodeActionEndpointTest(ITestOutputHelper testOutput) : LanguageServ
             }
         };
 
-        var context = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot);
+        var context = await codeActionEndpoint.GenerateRazorCodeActionContextAsync(request, documentContext.Snapshot, DisposalToken);
         Assert.NotNull(context);
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Html/DefaultHtmlCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Html/DefaultHtmlCodeActionProviderTest.cs
@@ -152,7 +152,7 @@ public class DefaultHtmlCodeActionProviderTest(ITestOutputHelper testOutput) : L
 
         var documentSnapshotMock = new StrictMock<IDocumentSnapshot>();
         documentSnapshotMock
-            .Setup(x => x.GetGeneratedOutputAsync(It.IsAny<bool>()))
+            .Setup(x => x.GetGeneratedOutputAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(codeDocument);
         documentSnapshotMock
             .Setup(x => x.GetTextAsync(It.IsAny<CancellationToken>()))

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Html/DefaultHtmlCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Html/DefaultHtmlCodeActionProviderTest.cs
@@ -14,7 +14,6 @@ using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol.CodeActions;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Moq;
 using Xunit;
@@ -151,15 +150,25 @@ public class DefaultHtmlCodeActionProviderTest(ITestOutputHelper testOutput) : L
         var projectEngine = RazorProjectEngine.Create(builder => builder.AddTagHelpers(tagHelpers));
         var codeDocument = projectEngine.ProcessDesignTime(sourceDocument, FileKinds.Component, importSources: default, tagHelpers);
 
-        var documentSnapshot = Mock.Of<IDocumentSnapshot>(document =>
-            document.GetGeneratedOutputAsync(It.IsAny<bool>()) == Task.FromResult(codeDocument) &&
-            document.GetTextAsync() == Task.FromResult(codeDocument.Source.Text) &&
-            document.Project.GetTagHelpersAsync(It.IsAny<CancellationToken>()) == new ValueTask<ImmutableArray<TagHelperDescriptor>>(tagHelpers), MockBehavior.Strict);
+        var documentSnapshotMock = new StrictMock<IDocumentSnapshot>();
+        documentSnapshotMock
+            .Setup(x => x.GetGeneratedOutputAsync(It.IsAny<bool>()))
+            .ReturnsAsync(codeDocument);
+        documentSnapshotMock
+            .Setup(x => x.GetTextAsync())
+            .ReturnsAsync(codeDocument.Source.Text);
+        documentSnapshotMock
+            .Setup(x => x.Project.GetTagHelpersAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tagHelpers);
 
-        var sourceText = SourceText.From(text);
+        return new RazorCodeActionContext(
+            request,
+            documentSnapshotMock.Object,
+            codeDocument,
+            location,
+            codeDocument.Source.Text,
+            supportsFileCreation,
+            supportsCodeActionResolve);
 
-        var context = new RazorCodeActionContext(request, documentSnapshot, codeDocument, location, sourceText, supportsFileCreation, supportsCodeActionResolve);
-
-        return context;
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Html/DefaultHtmlCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Html/DefaultHtmlCodeActionProviderTest.cs
@@ -155,7 +155,7 @@ public class DefaultHtmlCodeActionProviderTest(ITestOutputHelper testOutput) : L
             .Setup(x => x.GetGeneratedOutputAsync(It.IsAny<bool>()))
             .ReturnsAsync(codeDocument);
         documentSnapshotMock
-            .Setup(x => x.GetTextAsync())
+            .Setup(x => x.GetTextAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(codeDocument.Source.Text);
         documentSnapshotMock
             .Setup(x => x.Project.GetTagHelpersAsync(It.IsAny<CancellationToken>()))

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ComponentAccessibilityCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ComponentAccessibilityCodeActionProviderTest.cs
@@ -468,7 +468,7 @@ public class ComponentAccessibilityCodeActionProviderTest(ITestOutputHelper test
             .Setup(x => x.GetGeneratedOutputAsync(It.IsAny<bool>()))
             .ReturnsAsync(codeDocument);
         documentSnapshotMock
-            .Setup(x => x.GetTextAsync())
+            .Setup(x => x.GetTextAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(codeDocument.Source.Text);
         documentSnapshotMock
             .Setup(x => x.Project.GetTagHelpersAsync(It.IsAny<CancellationToken>()))

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ComponentAccessibilityCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ComponentAccessibilityCodeActionProviderTest.cs
@@ -465,7 +465,7 @@ public class ComponentAccessibilityCodeActionProviderTest(ITestOutputHelper test
 
         var documentSnapshotMock = new StrictMock<IDocumentSnapshot>();
         documentSnapshotMock
-            .Setup(x => x.GetGeneratedOutputAsync(It.IsAny<bool>()))
+            .Setup(x => x.GetGeneratedOutputAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(codeDocument);
         documentSnapshotMock
             .Setup(x => x.GetTextAsync(It.IsAny<CancellationToken>()))

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ComponentAccessibilityCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ComponentAccessibilityCodeActionProviderTest.cs
@@ -7,11 +7,11 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Components;
+using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol.CodeActions;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Moq;
 using Xunit;
@@ -463,15 +463,24 @@ public class ComponentAccessibilityCodeActionProviderTest(ITestOutputHelper test
         var csharpDocumentWithDiagnostic = new RazorCSharpDocument(codeDocument, csharpDocument.GeneratedCode, csharpDocument.Options, [diagnostic]);
         codeDocument.SetCSharpDocument(csharpDocumentWithDiagnostic);
 
-        var documentSnapshot = Mock.Of<IDocumentSnapshot>(document =>
-            document.GetGeneratedOutputAsync(It.IsAny<bool>()) == Task.FromResult(codeDocument) &&
-            document.GetTextAsync() == Task.FromResult(codeDocument.Source.Text) &&
-            document.Project.GetTagHelpersAsync(It.IsAny<CancellationToken>()) == new ValueTask<ImmutableArray<TagHelperDescriptor>>(tagHelpers), MockBehavior.Strict);
+        var documentSnapshotMock = new StrictMock<IDocumentSnapshot>();
+        documentSnapshotMock
+            .Setup(x => x.GetGeneratedOutputAsync(It.IsAny<bool>()))
+            .ReturnsAsync(codeDocument);
+        documentSnapshotMock
+            .Setup(x => x.GetTextAsync())
+            .ReturnsAsync(codeDocument.Source.Text);
+        documentSnapshotMock
+            .Setup(x => x.Project.GetTagHelpersAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(tagHelpers);
 
-        var sourceText = SourceText.From(text);
-
-        var context = new RazorCodeActionContext(request, documentSnapshot, codeDocument, location, sourceText, supportsFileCreation, SupportsCodeActionResolve: true);
-
-        return context;
+        return new RazorCodeActionContext(
+            request,
+            documentSnapshotMock.Object,
+            codeDocument,
+            location,
+            codeDocument.Source.Text,
+            supportsFileCreation,
+            SupportsCodeActionResolve: true);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionProviderTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Components;
@@ -401,7 +402,7 @@ public class ExtractToCodeBehindCodeActionProviderTest(ITestOutputHelper testOut
             .Setup(x => x.GetGeneratedOutputAsync(It.IsAny<bool>()))
             .ReturnsAsync(codeDocument);
         documentSnapshotMock
-            .Setup(x => x.GetTextAsync())
+            .Setup(x => x.GetTextAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(codeDocument.Source.Text);
 
         return new RazorCodeActionContext(

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionProviderTest.cs
@@ -399,7 +399,7 @@ public class ExtractToCodeBehindCodeActionProviderTest(ITestOutputHelper testOut
 
         var documentSnapshotMock = new StrictMock<IDocumentSnapshot>();
         documentSnapshotMock
-            .Setup(x => x.GetGeneratedOutputAsync(It.IsAny<bool>()))
+            .Setup(x => x.GetGeneratedOutputAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(codeDocument);
         documentSnapshotMock
             .Setup(x => x.GetTextAsync(It.IsAny<CancellationToken>()))

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionProviderTest.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions.Models;
+using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol.CodeActions;
@@ -395,14 +396,21 @@ public class ExtractToCodeBehindCodeActionProviderTest(ITestOutputHelper testOut
         }));
         codeDocument.SetSyntaxTree(syntaxTree);
 
-        var documentSnapshot = Mock.Of<IDocumentSnapshot>(document =>
-            document.GetGeneratedOutputAsync(It.IsAny<bool>()) == Task.FromResult(codeDocument) &&
-            document.GetTextAsync() == Task.FromResult(codeDocument.Source.Text), MockBehavior.Strict);
+        var documentSnapshotMock = new StrictMock<IDocumentSnapshot>();
+        documentSnapshotMock
+            .Setup(x => x.GetGeneratedOutputAsync(It.IsAny<bool>()))
+            .ReturnsAsync(codeDocument);
+        documentSnapshotMock
+            .Setup(x => x.GetTextAsync())
+            .ReturnsAsync(codeDocument.Source.Text);
 
-        var sourceText = SourceText.From(text);
-
-        var context = new RazorCodeActionContext(request, documentSnapshot, codeDocument, location, sourceText, supportsFileCreation, SupportsCodeActionResolve: true);
-
-        return context;
+        return new RazorCodeActionContext(
+            request,
+            documentSnapshotMock.Object,
+            codeDocument,
+            location,
+            codeDocument.Source.Text,
+            supportsFileCreation,
+            SupportsCodeActionResolve: true);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeDocumentReferenceHolderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeDocumentReferenceHolderTest.cs
@@ -44,7 +44,7 @@ public class CodeDocumentReferenceHolderTest(ITestOutputHelper testOutput) : Lan
     {
         // Arrange
         var documentSnapshot = await CreateDocumentSnapshotAsync();
-        var codeDocumentReference = await ProcessDocumentAndRetrieveOutputAsync(documentSnapshot);
+        var codeDocumentReference = await ProcessDocumentAndRetrieveOutputAsync(documentSnapshot, DisposalToken);
 
         // Act
         PerformFullGC();
@@ -70,8 +70,8 @@ public class CodeDocumentReferenceHolderTest(ITestOutputHelper testOutput) : Lan
 
         Assert.NotNull(unrelatedDocumentSnapshot);
 
-        var mainCodeDocumentReference = await ProcessDocumentAndRetrieveOutputAsync(documentSnapshot);
-        var unrelatedCodeDocumentReference = await ProcessDocumentAndRetrieveOutputAsync(unrelatedDocumentSnapshot);
+        var mainCodeDocumentReference = await ProcessDocumentAndRetrieveOutputAsync(documentSnapshot, DisposalToken);
+        var unrelatedCodeDocumentReference = await ProcessDocumentAndRetrieveOutputAsync(unrelatedDocumentSnapshot, DisposalToken);
 
         // Act
         await _projectManager.UpdateAsync(updater =>
@@ -91,7 +91,7 @@ public class CodeDocumentReferenceHolderTest(ITestOutputHelper testOutput) : Lan
     {
         // Arrange
         var documentSnapshot = await CreateDocumentSnapshotAsync();
-        var codeDocumentReference = await ProcessDocumentAndRetrieveOutputAsync(documentSnapshot);
+        var codeDocumentReference = await ProcessDocumentAndRetrieveOutputAsync(documentSnapshot, DisposalToken);
 
         // Act
 
@@ -111,7 +111,7 @@ public class CodeDocumentReferenceHolderTest(ITestOutputHelper testOutput) : Lan
     {
         // Arrange
         var documentSnapshot = await CreateDocumentSnapshotAsync();
-        var codeDocumentReference = await ProcessDocumentAndRetrieveOutputAsync(documentSnapshot);
+        var codeDocumentReference = await ProcessDocumentAndRetrieveOutputAsync(documentSnapshot, DisposalToken);
 
         // Act
         await _projectManager.UpdateAsync(updater =>
@@ -130,7 +130,7 @@ public class CodeDocumentReferenceHolderTest(ITestOutputHelper testOutput) : Lan
     {
         // Arrange
         var documentSnapshot = await CreateDocumentSnapshotAsync();
-        var codeDocumentReference = await ProcessDocumentAndRetrieveOutputAsync(documentSnapshot);
+        var codeDocumentReference = await ProcessDocumentAndRetrieveOutputAsync(documentSnapshot, DisposalToken);
 
         // Act
         await _projectManager.UpdateAsync(updater =>
@@ -149,7 +149,7 @@ public class CodeDocumentReferenceHolderTest(ITestOutputHelper testOutput) : Lan
     {
         // Arrange
         var documentSnapshot = await CreateDocumentSnapshotAsync();
-        var codeDocumentReference = await ProcessDocumentAndRetrieveOutputAsync(documentSnapshot);
+        var codeDocumentReference = await ProcessDocumentAndRetrieveOutputAsync(documentSnapshot, DisposalToken);
 
         // Act
         await _projectManager.UpdateAsync(updater =>
@@ -176,9 +176,9 @@ public class CodeDocumentReferenceHolderTest(ITestOutputHelper testOutput) : Lan
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private async Task<WeakReference<RazorCodeDocument>> ProcessDocumentAndRetrieveOutputAsync(IDocumentSnapshot documentSnapshot)
+    private async Task<WeakReference<RazorCodeDocument>> ProcessDocumentAndRetrieveOutputAsync(IDocumentSnapshot documentSnapshot, CancellationToken cancellationToken)
     {
-        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync();
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(cancellationToken);
 
         _referenceHolder.DocumentProcessed(codeDocument, documentSnapshot);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentSnapshotTextLoaderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentSnapshotTextLoaderTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -20,7 +21,7 @@ public class DocumentSnapshotTextLoaderTest(ITestOutputHelper testOutput) : Tool
         var expectedSourceText = SourceText.From("Hello World");
         var snapshotMock = new StrictMock<IDocumentSnapshot>();
         snapshotMock
-            .Setup(x => x.GetTextAsync())
+            .Setup(x => x.GetTextAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(expectedSourceText);
         var textLoader = new DocumentSnapshotTextLoader(snapshotMock.Object);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentSnapshotTextLoaderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentSnapshotTextLoaderTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-#nullable disable
-
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -13,24 +11,21 @@ using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
-public class DocumentSnapshotTextLoaderTest : ToolingTestBase
+public class DocumentSnapshotTextLoaderTest(ITestOutputHelper testOutput) : ToolingTestBase(testOutput)
 {
-    public DocumentSnapshotTextLoaderTest(ITestOutputHelper testOutput)
-        : base(testOutput)
-    {
-    }
-
     [Fact]
     public async Task LoadTextAndVersionAsync_CreatesTextAndVersionFromDocumentsText()
     {
         // Arrange
         var expectedSourceText = SourceText.From("Hello World");
-        var result = Task.FromResult(expectedSourceText);
-        var snapshot = Mock.Of<IDocumentSnapshot>(doc => doc.GetTextAsync() == result, MockBehavior.Strict);
-        var textLoader = new DocumentSnapshotTextLoader(snapshot);
+        var snapshotMock = new StrictMock<IDocumentSnapshot>();
+        snapshotMock
+            .Setup(x => x.GetTextAsync())
+            .ReturnsAsync(expectedSourceText);
+        var textLoader = new DocumentSnapshotTextLoader(snapshotMock.Object);
 
         // Act
-        var actual = await textLoader.LoadTextAndVersionAsync(default, default);
+        var actual = await textLoader.LoadTextAndVersionAsync(options: default, DisposalToken);
 
         // Assert
         Assert.Same(expectedSourceText, actual.Text);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingContentValidationPassTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingContentValidationPassTest.cs
@@ -99,9 +99,9 @@ public class FormattingContentValidationPassTest(ITestOutputHelper testOutput) :
         var projectEngine = RazorProjectEngine.Create(builder => builder.SetRootNamespace("Test"));
         var codeDocument = projectEngine.ProcessDesignTime(sourceDocument, fileKind, importSources: default, tagHelpers);
 
-        var documentSnapshot = new Mock<IDocumentSnapshot>(MockBehavior.Strict);
+        var documentSnapshot = new StrictMock<IDocumentSnapshot>();
         documentSnapshot
-            .Setup(d => d.GetGeneratedOutputAsync(It.IsAny<bool>()))
+            .Setup(d => d.GetGeneratedOutputAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(codeDocument);
         documentSnapshot
             .Setup(d => d.TargetPath)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingTestBase.cs
@@ -316,7 +316,7 @@ public class FormattingTestBase : RazorToolingIntegrationTestBase
     {
         var documentSnapshot = new StrictMock<IDocumentSnapshot>();
         documentSnapshot
-            .Setup(d => d.GetGeneratedOutputAsync(It.IsAny<bool>()))
+            .Setup(d => d.GetGeneratedOutputAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(codeDocument);
         documentSnapshot
             .Setup(d => d.FilePath)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingTestBase.cs
@@ -273,9 +273,9 @@ public class FormattingTestBase : RazorToolingIntegrationTestBase
         var importsPath = new Uri("file:///path/to/_Imports.razor").AbsolutePath;
         var importsSourceText = SourceText.From(DefaultImports);
         var importsDocument = RazorSourceDocument.Create(importsSourceText, RazorSourceDocumentProperties.Create(importsPath, importsPath));
-        var importsSnapshot = new Mock<IDocumentSnapshot>(MockBehavior.Strict);
+        var importsSnapshot = new StrictMock<IDocumentSnapshot>();
         importsSnapshot
-            .Setup(d => d.GetTextAsync())
+            .Setup(d => d.GetTextAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(importsSourceText);
         importsSnapshot
             .Setup(d => d.FilePath)
@@ -286,8 +286,7 @@ public class FormattingTestBase : RazorToolingIntegrationTestBase
 
         var projectFileSystem = new TestRazorProjectFileSystem([
             new TestRazorProjectItem(path, fileKind: fileKind),
-            new TestRazorProjectItem(importsPath, fileKind: FileKinds.ComponentImport),
-            ]);
+            new TestRazorProjectItem(importsPath, fileKind: FileKinds.ComponentImport)]);
 
         var projectEngine = RazorProjectEngine.Create(
             new RazorConfiguration(RazorLanguageVersion.Latest, "TestConfiguration", Extensions: [], LanguageServerFlags: new LanguageServerFlags(forceRuntimeCodeGeneration)),
@@ -315,7 +314,7 @@ public class FormattingTestBase : RazorToolingIntegrationTestBase
 
     internal static IDocumentSnapshot CreateDocumentSnapshot(string path, ImmutableArray<TagHelperDescriptor> tagHelpers, string? fileKind, ImmutableArray<RazorSourceDocument> importsDocuments, ImmutableArray<IDocumentSnapshot> imports, RazorProjectEngine projectEngine, RazorCodeDocument codeDocument, bool inGlobalNamespace = false)
     {
-        var documentSnapshot = new Mock<IDocumentSnapshot>(MockBehavior.Strict);
+        var documentSnapshot = new StrictMock<IDocumentSnapshot>();
         documentSnapshot
             .Setup(d => d.GetGeneratedOutputAsync(It.IsAny<bool>()))
             .ReturnsAsync(codeDocument);
@@ -332,7 +331,7 @@ public class FormattingTestBase : RazorToolingIntegrationTestBase
             .Setup(d => d.Project.Configuration)
             .Returns(projectEngine.Configuration);
         documentSnapshot
-            .Setup(d => d.GetTextAsync())
+            .Setup(d => d.GetTextAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(codeDocument.Source.Text);
         documentSnapshot
             .Setup(d => d.Project.GetTagHelpersAsync(It.IsAny<CancellationToken>()))

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverServiceTest.cs
@@ -936,7 +936,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
             .Setup(x => x.GetGeneratedOutputAsync(It.IsAny<bool>()))
             .ReturnsAsync(codeDocument);
         documentSnapshotMock
-            .Setup(x => x.GetTextAsync())
+            .Setup(x => x.GetTextAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(codeDocument.Source.Text);
         documentSnapshotMock
             .SetupGet(x => x.FilePath)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverServiceTest.cs
@@ -933,7 +933,7 @@ public class HoverServiceTest(ITestOutputHelper testOutput) : TagHelperServiceTe
 
         var documentSnapshotMock = new StrictMock<IDocumentSnapshot>();
         documentSnapshotMock
-            .Setup(x => x.GetGeneratedOutputAsync(It.IsAny<bool>()))
+            .Setup(x => x.GetGeneratedOutputAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(codeDocument);
         documentSnapshotMock
             .Setup(x => x.GetTextAsync(It.IsAny<CancellationToken>()))

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/OpenDocumentGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/OpenDocumentGeneratorTest.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
+using Microsoft.AspNetCore.Razor.Test.Common.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -39,7 +40,7 @@ public class OpenDocumentGeneratorTest(ITestOutputHelper testOutput) : LanguageS
         {
             updater.ProjectAdded(_hostProject1);
             updater.ProjectAdded(_hostProject2);
-            updater.DocumentAdded(_hostProject1.Key, _documents[0], null!);
+            updater.DocumentAdded(_hostProject1.Key, _documents[0], _documents[0].CreateEmptyTextLoader());
             updater.DocumentOpened(_hostProject1.Key, _documents[0].FilePath, SourceText.From(string.Empty));
         });
 
@@ -49,7 +50,7 @@ public class OpenDocumentGeneratorTest(ITestOutputHelper testOutput) : LanguageS
         await projectManager.UpdateAsync(updater =>
         {
             updater.DocumentRemoved(_hostProject1.Key, _documents[0]);
-            updater.DocumentAdded(_hostProject2.Key, _documents[0], null!);
+            updater.DocumentAdded(_hostProject2.Key, _documents[0], _documents[0].CreateEmptyTextLoader());
         });
 
         // Assert
@@ -72,7 +73,7 @@ public class OpenDocumentGeneratorTest(ITestOutputHelper testOutput) : LanguageS
             updater.ProjectAdded(_hostProject2);
 
             // Act
-            updater.DocumentAdded(_hostProject1.Key, _documents[0], null!);
+            updater.DocumentAdded(_hostProject1.Key, _documents[0], _documents[0].CreateEmptyTextLoader());
         });
 
         // Assert
@@ -91,7 +92,7 @@ public class OpenDocumentGeneratorTest(ITestOutputHelper testOutput) : LanguageS
         {
             updater.ProjectAdded(_hostProject1);
             updater.ProjectAdded(_hostProject2);
-            updater.DocumentAdded(_hostProject1.Key, _documents[0], null!);
+            updater.DocumentAdded(_hostProject1.Key, _documents[0], _documents[0].CreateEmptyTextLoader());
 
             // Act
             updater.DocumentChanged(_hostProject1.Key, _documents[0].FilePath, SourceText.From("new"));
@@ -113,7 +114,7 @@ public class OpenDocumentGeneratorTest(ITestOutputHelper testOutput) : LanguageS
         {
             updater.ProjectAdded(_hostProject1);
             updater.ProjectAdded(_hostProject2);
-            updater.DocumentAdded(_hostProject1.Key, _documents[0], null!);
+            updater.DocumentAdded(_hostProject1.Key, _documents[0], _documents[0].CreateEmptyTextLoader());
             updater.DocumentOpened(_hostProject1.Key, _documents[0].FilePath, SourceText.From(string.Empty));
 
             // Act
@@ -138,7 +139,7 @@ public class OpenDocumentGeneratorTest(ITestOutputHelper testOutput) : LanguageS
         {
             updater.ProjectAdded(_hostProject1);
             updater.ProjectAdded(_hostProject2);
-            updater.DocumentAdded(_hostProject1.Key, _documents[0], null!);
+            updater.DocumentAdded(_hostProject1.Key, _documents[0], _documents[0].CreateEmptyTextLoader());
 
             // Act
             updater.ProjectWorkspaceStateChanged(_hostProject1.Key,
@@ -161,7 +162,7 @@ public class OpenDocumentGeneratorTest(ITestOutputHelper testOutput) : LanguageS
         {
             updater.ProjectAdded(_hostProject1);
             updater.ProjectAdded(_hostProject2);
-            updater.DocumentAdded(_hostProject1.Key, _documents[0], null!);
+            updater.DocumentAdded(_hostProject1.Key, _documents[0], _documents[0].CreateEmptyTextLoader());
             updater.DocumentOpened(_hostProject1.Key, _documents[0].FilePath, SourceText.From(string.Empty));
 
             // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorComponentSearchEngineTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorComponentSearchEngineTest.cs
@@ -101,8 +101,8 @@ public class RazorComponentSearchEngineTest(ITestOutputHelper testOutput) : Lang
         var searchEngine = new RazorComponentSearchEngine(LoggerFactory);
 
         // Act
-        var documentSnapshot1 = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor1, _projectManager.GetQueryOperations());
-        var documentSnapshot2 = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor2, _projectManager.GetQueryOperations());
+        var documentSnapshot1 = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor1, _projectManager.GetQueryOperations(), DisposalToken);
+        var documentSnapshot2 = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor2, _projectManager.GetQueryOperations(), DisposalToken);
 
         // Assert
         Assert.NotNull(documentSnapshot1);
@@ -120,8 +120,8 @@ public class RazorComponentSearchEngineTest(ITestOutputHelper testOutput) : Lang
         var searchEngine = new RazorComponentSearchEngine(LoggerFactory);
 
         // Act
-        var documentSnapshot1 = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor1, _projectManager.GetQueryOperations());
-        var documentSnapshot2 = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor2, _projectManager.GetQueryOperations());
+        var documentSnapshot1 = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor1, _projectManager.GetQueryOperations(), DisposalToken);
+        var documentSnapshot2 = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor2, _projectManager.GetQueryOperations(), DisposalToken);
 
         // Assert
         Assert.NotNull(documentSnapshot1);
@@ -138,7 +138,7 @@ public class RazorComponentSearchEngineTest(ITestOutputHelper testOutput) : Lang
         var searchEngine = new RazorComponentSearchEngine(LoggerFactory);
 
         // Act
-        var documentSnapshot = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor, _projectManager.GetQueryOperations());
+        var documentSnapshot = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor, _projectManager.GetQueryOperations(), DisposalToken);
 
         // Assert
         Assert.NotNull(documentSnapshot);
@@ -153,7 +153,7 @@ public class RazorComponentSearchEngineTest(ITestOutputHelper testOutput) : Lang
         var searchEngine = new RazorComponentSearchEngine(LoggerFactory);
 
         // Act
-        var documentSnapshot = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor, _projectManager.GetQueryOperations());
+        var documentSnapshot = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor, _projectManager.GetQueryOperations(), DisposalToken);
 
         // Assert
         Assert.Null(documentSnapshot);
@@ -167,7 +167,7 @@ public class RazorComponentSearchEngineTest(ITestOutputHelper testOutput) : Lang
         var searchEngine = new RazorComponentSearchEngine(LoggerFactory);
 
         // Act
-        var documentSnapshot = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor, _projectManager.GetQueryOperations());
+        var documentSnapshot = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor, _projectManager.GetQueryOperations(), DisposalToken);
 
         // Assert
         Assert.Null(documentSnapshot);
@@ -181,7 +181,7 @@ public class RazorComponentSearchEngineTest(ITestOutputHelper testOutput) : Lang
         var searchEngine = new RazorComponentSearchEngine(LoggerFactory);
 
         // Act
-        var documentSnapshot = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor, _projectManager.GetQueryOperations());
+        var documentSnapshot = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor, _projectManager.GetQueryOperations(), DisposalToken);
 
         // Assert
         Assert.Null(documentSnapshot);
@@ -195,7 +195,7 @@ public class RazorComponentSearchEngineTest(ITestOutputHelper testOutput) : Lang
         var searchEngine = new RazorComponentSearchEngine(LoggerFactory);
 
         // Act
-        var documentSnapshot = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor, _projectManager.GetQueryOperations());
+        var documentSnapshot = await searchEngine.TryLocateComponentAsync(tagHelperDescriptor, _projectManager.GetQueryOperations(), DisposalToken);
 
         // Assert
         Assert.NotNull(documentSnapshot);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokensTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokensTest.cs
@@ -958,7 +958,7 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             .Setup(x => x.GetGeneratedOutputAsync(It.IsAny<bool>()))
             .ReturnsAsync(document);
         documentSnapshotMock
-            .Setup(x => x.GetTextAsync())
+            .Setup(x => x.GetTextAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(document.Source.Text);
         documentSnapshotMock
             .SetupGet(x => x.Version)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokensTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Semantic/SemanticTokensTest.cs
@@ -955,7 +955,7 @@ public partial class SemanticTokensTest(ITestOutputHelper testOutput) : TagHelpe
             .SetupGet(x => x.Project)
             .Returns(projectSnapshot.Object);
         documentSnapshotMock
-            .Setup(x => x.GetGeneratedOutputAsync(It.IsAny<bool>()))
+            .Setup(x => x.GetGeneratedOutputAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(document);
         documentSnapshotMock
             .Setup(x => x.GetTextAsync(It.IsAny<CancellationToken>()))

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ProjectSystem/TestDocumentSnapshot.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ProjectSystem/TestDocumentSnapshot.cs
@@ -67,11 +67,11 @@ internal sealed class TestDocumentSnapshot : IDocumentSnapshot
     public IProjectSnapshot Project => RealSnapshot.Project;
     public int Version => RealSnapshot.Version;
 
-    public Task<RazorCodeDocument> GetGeneratedOutputAsync(bool forceDesignTimeGeneratedOutput)
+    public ValueTask<RazorCodeDocument> GetGeneratedOutputAsync(bool forceDesignTimeGeneratedOutput)
     {
         return _codeDocument is null
             ? RealSnapshot.GetGeneratedOutputAsync(forceDesignTimeGeneratedOutput)
-            : Task.FromResult(_codeDocument);
+            : new(_codeDocument);
     }
 
     public ValueTask<SourceText> GetTextAsync(CancellationToken cancellationToken)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ProjectSystem/TestDocumentSnapshot.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ProjectSystem/TestDocumentSnapshot.cs
@@ -90,7 +90,7 @@ internal sealed class TestDocumentSnapshot : IDocumentSnapshot
     {
         return _codeDocument is null
             ? RealSnapshot.GetCSharpSyntaxTreeAsync(cancellationToken)
-            : new(_codeDocument.GetCSharpSyntaxTree(cancellationToken));
+            : new(DocumentSnapshot.GetOrParseCSharpSyntaxTree(_codeDocument, cancellationToken));
     }
 
     public bool TryGetGeneratedOutput([NotNullWhen(true)] out RazorCodeDocument? result)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ProjectSystem/TestDocumentSnapshot.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ProjectSystem/TestDocumentSnapshot.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
 
@@ -85,17 +84,11 @@ internal sealed class TestDocumentSnapshot : IDocumentSnapshot
     public ValueTask<VersionStamp> GetTextVersionAsync(CancellationToken cancellationToken)
         => RealSnapshot.GetTextVersionAsync(cancellationToken);
 
-    public Task<SyntaxTree> GetCSharpSyntaxTreeAsync(CancellationToken cancellationToken)
+    public ValueTask<SyntaxTree> GetCSharpSyntaxTreeAsync(CancellationToken cancellationToken)
     {
-        if (_codeDocument is { } codeDocument)
-        {
-            var csharpText = codeDocument.GetCSharpSourceText();
-            var csharpSyntaxTree = CSharpSyntaxTree.ParseText(csharpText, cancellationToken: cancellationToken);
-
-            return Task.FromResult(csharpSyntaxTree);
-        }
-
-        return RealSnapshot.GetCSharpSyntaxTreeAsync(cancellationToken);
+        return _codeDocument is null
+            ? RealSnapshot.GetCSharpSyntaxTreeAsync(cancellationToken)
+            : new(_codeDocument.GetCSharpSyntaxTree(cancellationToken));
     }
 
     public bool TryGetGeneratedOutput([NotNullWhen(true)] out RazorCodeDocument? result)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ProjectSystem/TestDocumentSnapshot.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ProjectSystem/TestDocumentSnapshot.cs
@@ -75,11 +75,11 @@ internal sealed class TestDocumentSnapshot : IDocumentSnapshot
             : Task.FromResult(_codeDocument);
     }
 
-    public Task<SourceText> GetTextAsync()
+    public ValueTask<SourceText> GetTextAsync()
     {
         return _codeDocument is null
             ? RealSnapshot.GetTextAsync()
-            : Task.FromResult(_codeDocument.Source.Text);
+            : new(_codeDocument.Source.Text);
     }
 
     public ValueTask<VersionStamp> GetTextVersionAsync()

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ProjectSystem/TestDocumentSnapshot.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ProjectSystem/TestDocumentSnapshot.cs
@@ -67,10 +67,12 @@ internal sealed class TestDocumentSnapshot : IDocumentSnapshot
     public IProjectSnapshot Project => RealSnapshot.Project;
     public int Version => RealSnapshot.Version;
 
-    public ValueTask<RazorCodeDocument> GetGeneratedOutputAsync(bool forceDesignTimeGeneratedOutput)
+    public ValueTask<RazorCodeDocument> GetGeneratedOutputAsync(
+        bool forceDesignTimeGeneratedOutput,
+        CancellationToken cancellationToken)
     {
         return _codeDocument is null
-            ? RealSnapshot.GetGeneratedOutputAsync(forceDesignTimeGeneratedOutput)
+            ? RealSnapshot.GetGeneratedOutputAsync(forceDesignTimeGeneratedOutput, cancellationToken)
             : new(_codeDocument);
     }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ProjectSystem/TestDocumentSnapshot.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ProjectSystem/TestDocumentSnapshot.cs
@@ -75,15 +75,15 @@ internal sealed class TestDocumentSnapshot : IDocumentSnapshot
             : Task.FromResult(_codeDocument);
     }
 
-    public ValueTask<SourceText> GetTextAsync()
+    public ValueTask<SourceText> GetTextAsync(CancellationToken cancellationToken)
     {
         return _codeDocument is null
-            ? RealSnapshot.GetTextAsync()
+            ? RealSnapshot.GetTextAsync(cancellationToken)
             : new(_codeDocument.Source.Text);
     }
 
-    public ValueTask<VersionStamp> GetTextVersionAsync()
-        => RealSnapshot.GetTextVersionAsync();
+    public ValueTask<VersionStamp> GetTextVersionAsync(CancellationToken cancellationToken)
+        => RealSnapshot.GetTextVersionAsync(cancellationToken);
 
     public Task<SyntaxTree> GetCSharpSyntaxTreeAsync(CancellationToken cancellationToken)
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ProjectSystem/TestDocumentSnapshot.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ProjectSystem/TestDocumentSnapshot.cs
@@ -39,12 +39,7 @@ internal sealed class TestDocumentSnapshot : IDocumentSnapshot
         var sourceText = SourceText.From(text);
         var textVersion = VersionStamp.Default;
 
-        var documentState = new DocumentState(
-            hostDocument,
-            sourceText,
-            textVersion,
-            version,
-            () => Task.FromResult(TextAndVersion.Create(sourceText, textVersion)));
+        var documentState = new DocumentState(hostDocument, version, sourceText, textVersion);
 
         return new TestDocumentSnapshot(project, documentState);
     }
@@ -60,12 +55,7 @@ internal sealed class TestDocumentSnapshot : IDocumentSnapshot
         var sourceText = codeDocument.Source.Text;
         var textVersion = VersionStamp.Default;
 
-        var documentState = new DocumentState(
-            hostDocument,
-            sourceText,
-            textVersion,
-            version,
-            () => Task.FromResult(TextAndVersion.Create(sourceText, textVersion)));
+        var documentState = new DocumentState(hostDocument, version, sourceText, textVersion);
 
         return new TestDocumentSnapshot(project, documentState, codeDocument);
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ProjectSystem/TestDocumentSnapshot.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ProjectSystem/TestDocumentSnapshot.cs
@@ -82,7 +82,7 @@ internal sealed class TestDocumentSnapshot : IDocumentSnapshot
             : Task.FromResult(_codeDocument.Source.Text);
     }
 
-    public Task<VersionStamp> GetTextVersionAsync()
+    public ValueTask<VersionStamp> GetTextVersionAsync()
         => RealSnapshot.GetTextVersionAsync();
 
     public Task<SyntaxTree> GetCSharpSyntaxTreeAsync(CancellationToken cancellationToken)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/TestMocks.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/TestMocks.cs
@@ -31,6 +31,21 @@ internal static class TestMocks
         return mock.Object;
     }
 
+    public static TextLoader CreateTextLoader(string text, VersionStamp version)
+        => CreateTextLoader(SourceText.From(text), version);
+
+    public static TextLoader CreateTextLoader(SourceText text, VersionStamp version)
+    {
+        var mock = new StrictMock<TextLoader>();
+
+        var textAndVersion = TextAndVersion.Create(text, version);
+
+        mock.Setup(x => x.LoadTextAndVersionAsync(It.IsAny<LoadTextOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(textAndVersion);
+
+        return mock.Object;
+    }
+
     public interface IClientConnectionBuilder
     {
         void SetupSendRequest<TParams, TResponse>(string method, TResponse response, bool verifiable = false);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/DocumentExcerptServiceTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/DocumentExcerptServiceTestBase.cs
@@ -71,7 +71,7 @@ public abstract class DocumentExcerptServiceTestBase(ITestOutputHelper testOutpu
     // that appears in the primary buffer.
     private static async Task<TextSpan> GetSecondarySpanAsync(IDocumentSnapshot primary, TextSpan primarySpan, Document secondary, CancellationToken cancellationToken)
     {
-        var output = await primary.GetGeneratedOutputAsync();
+        var output = await primary.GetGeneratedOutputAsync(cancellationToken);
 
         foreach (var mapping in output.GetCSharpDocument().SourceMappings)
         {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/DocumentExcerptServiceTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/DocumentExcerptServiceTestBase.cs
@@ -40,9 +40,11 @@ public abstract class DocumentExcerptServiceTestBase(ITestOutputHelper testOutpu
     // Adds the text to a ProjectSnapshot, generates code, and updates the workspace.
     private (IDocumentSnapshot primary, Document secondary) InitializeDocument(SourceText sourceText)
     {
-        var project = new ProjectSnapshot(
-            ProjectState.Create(ProjectEngineFactoryProvider, _hostProject, ProjectWorkspaceState.Default)
-            .WithAddedHostDocument(_hostDocument, () => Task.FromResult(TextAndVersion.Create(sourceText, VersionStamp.Create()))));
+        var state = ProjectState
+            .Create(ProjectEngineFactoryProvider, _hostProject, ProjectWorkspaceState.Default)
+            .WithAddedHostDocument(_hostDocument, TestMocks.CreateTextLoader(sourceText, VersionStamp.Create()));
+
+        var project = new ProjectSnapshot(state);
 
         var primary = project.GetDocument(_hostDocument.FilePath).AssumeNotNull();
 

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultDocumentSnapshotTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultDocumentSnapshotTest.cs
@@ -36,18 +36,18 @@ public class DefaultDocumentSnapshotTest : WorkspaceTestBase
         var projectState = ProjectState.Create(ProjectEngineFactoryProvider, TestProjectData.SomeProject, ProjectWorkspaceState.Default);
         var project = new ProjectSnapshot(projectState);
 
-        var textAndVersion = TextAndVersion.Create(_sourceText, _version);
+        var textLoader = TestMocks.CreateTextLoader(_sourceText, _version);
 
-        var documentState = DocumentState.Create(s_legacyHostDocument, () => Task.FromResult(textAndVersion));
+        var documentState = DocumentState.Create(s_legacyHostDocument, textLoader);
         _legacyDocument = new DocumentSnapshot(project, documentState);
 
-        documentState = DocumentState.Create(s_componentHostDocument, () => Task.FromResult(textAndVersion));
+        documentState = DocumentState.Create(s_componentHostDocument, textLoader);
         _componentDocument = new DocumentSnapshot(project, documentState);
 
-        documentState = DocumentState.Create(s_componentCshtmlHostDocument, () => Task.FromResult(textAndVersion));
+        documentState = DocumentState.Create(s_componentCshtmlHostDocument, textLoader);
         _componentCshtmlDocument = new DocumentSnapshot(project, documentState);
 
-        documentState = DocumentState.Create(s_nestedComponentHostDocument, () => Task.FromResult(textAndVersion));
+        documentState = DocumentState.Create(s_nestedComponentHostDocument, textLoader);
         _nestedComponentDocument = new DocumentSnapshot(project, documentState);
     }
 

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultDocumentSnapshotTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultDocumentSnapshotTest.cs
@@ -55,7 +55,7 @@ public class DefaultDocumentSnapshotTest : WorkspaceTestBase
     public async Task GCCollect_OutputIsNoLongerCached()
     {
         // Arrange
-        await Task.Run(async () => { await _legacyDocument.GetGeneratedOutputAsync(); });
+        await Task.Run(async () => { await _legacyDocument.GetGeneratedOutputAsync(DisposalToken); });
 
         // Act
 
@@ -70,7 +70,7 @@ public class DefaultDocumentSnapshotTest : WorkspaceTestBase
     public async Task RegeneratingWithReference_CachesOutput()
     {
         // Arrange
-        var output = await _legacyDocument.GetGeneratedOutputAsync();
+        var output = await _legacyDocument.GetGeneratedOutputAsync(DisposalToken);
 
         // Mostly doing this to ensure "var output" doesn't get optimized out
         Assert.NotNull(output);
@@ -86,7 +86,7 @@ public class DefaultDocumentSnapshotTest : WorkspaceTestBase
     public async Task GetGeneratedOutputAsync_CshtmlComponent_ContainsComponentImports()
     {
         // Act
-        var codeDocument = await _componentCshtmlDocument.GetGeneratedOutputAsync();
+        var codeDocument = await _componentCshtmlDocument.GetGeneratedOutputAsync(DisposalToken);
 
         // Assert
         Assert.Contains("using global::Microsoft.AspNetCore.Components", codeDocument.GetCSharpSourceText().ToString(), StringComparison.Ordinal);
@@ -96,7 +96,7 @@ public class DefaultDocumentSnapshotTest : WorkspaceTestBase
     public async Task GetGeneratedOutputAsync_Component()
     {
         // Act
-        var codeDocument = await _componentDocument.GetGeneratedOutputAsync();
+        var codeDocument = await _componentDocument.GetGeneratedOutputAsync(DisposalToken);
 
         // Assert
         Assert.Contains("ComponentBase", codeDocument.GetCSharpSourceText().ToString(), StringComparison.Ordinal);
@@ -106,7 +106,7 @@ public class DefaultDocumentSnapshotTest : WorkspaceTestBase
     public async Task GetGeneratedOutputAsync_NestedComponentDocument_SetsCorrectNamespaceAndClassName()
     {
         // Act
-        var codeDocument = await _nestedComponentDocument.GetGeneratedOutputAsync();
+        var codeDocument = await _nestedComponentDocument.GetGeneratedOutputAsync(DisposalToken);
 
         // Assert
         Assert.Contains("ComponentBase", codeDocument.GetCSharpSourceText().ToString(), StringComparison.Ordinal);
@@ -120,7 +120,7 @@ public class DefaultDocumentSnapshotTest : WorkspaceTestBase
     public async Task GetGeneratedOutputAsync_Legacy()
     {
         // Act
-        var codeDocument = await _legacyDocument.GetGeneratedOutputAsync();
+        var codeDocument = await _legacyDocument.GetGeneratedOutputAsync(DisposalToken);
 
         // Assert
         Assert.Contains("Template", codeDocument.GetCSharpSourceText().ToString(), StringComparison.Ordinal);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DocumentStateTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DocumentStateTest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Text;
@@ -13,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 public class DocumentStateTest : ToolingTestBase
 {
     private readonly HostDocument _hostDocument;
-    private readonly Func<Task<TextAndVersion>> _textLoader;
+    private readonly TextLoader _textLoader;
     private readonly SourceText _text;
 
     public DocumentStateTest(ITestOutputHelper testOutput)
@@ -21,7 +20,7 @@ public class DocumentStateTest : ToolingTestBase
     {
         _hostDocument = TestProjectData.SomeProjectFile1;
         _text = SourceText.From("Hello, world!");
-        _textLoader = () => Task.FromResult(TextAndVersion.Create(_text, VersionStamp.Create()));
+        _textLoader = TestMocks.CreateTextLoader(_text, VersionStamp.Create());
     }
 
     [Fact]

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DocumentStateTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DocumentStateTest.cs
@@ -30,7 +30,7 @@ public class DocumentStateTest : ToolingTestBase
         var state = DocumentState.Create(_hostDocument, DocumentState.EmptyLoader);
 
         // Assert
-        var text = await state.GetTextAsync();
+        var text = await state.GetTextAsync(DisposalToken);
         Assert.Equal(0, text.Length);
     }
 
@@ -44,7 +44,7 @@ public class DocumentStateTest : ToolingTestBase
         var state = original.WithText(_text, VersionStamp.Create());
 
         // Assert
-        var text = await state.GetTextAsync();
+        var text = await state.GetTextAsync(DisposalToken);
         Assert.Same(_text, text);
     }
 
@@ -58,7 +58,7 @@ public class DocumentStateTest : ToolingTestBase
         var state = original.WithTextLoader(_textLoader);
 
         // Assert
-        var text = await state.GetTextAsync();
+        var text = await state.GetTextAsync(DisposalToken);
         Assert.Same(_text, text);
     }
 
@@ -84,7 +84,7 @@ public class DocumentStateTest : ToolingTestBase
         var original = DocumentState.Create(_hostDocument, DocumentState.EmptyLoader)
             .WithTextLoader(_textLoader);
 
-        await original.GetTextAsync();
+        await original.GetTextAsync(DisposalToken);
 
         // Act
         var state = original.WithConfigurationChange();
@@ -116,7 +116,7 @@ public class DocumentStateTest : ToolingTestBase
         var original = DocumentState.Create(_hostDocument, DocumentState.EmptyLoader)
             .WithTextLoader(_textLoader);
 
-        await original.GetTextAsync();
+        await original.GetTextAsync(DisposalToken);
 
         // Act
         var state = original.WithImportsChange();
@@ -148,7 +148,7 @@ public class DocumentStateTest : ToolingTestBase
         var original = DocumentState.Create(_hostDocument, DocumentState.EmptyLoader)
             .WithTextLoader(_textLoader);
 
-        await original.GetTextAsync();
+        await original.GetTextAsync(DisposalToken);
 
         // Act
         var state = original.WithProjectWorkspaceStateChange();

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/GeneratedDocumentTextLoaderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/GeneratedDocumentTextLoaderTest.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
-using Microsoft.CodeAnalysis.Text;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -32,7 +31,7 @@ public class GeneratedDocumentTextLoaderTest : WorkspaceTestBase
         // Arrange
         var project = new ProjectSnapshot(
             ProjectState.Create(ProjectEngineFactoryProvider, _hostProject, ProjectWorkspaceState.Default)
-            .WithAddedHostDocument(_hostDocument, () => Task.FromResult(TextAndVersion.Create(SourceText.From(""), VersionStamp.Create()))));
+            .WithAddedHostDocument(_hostDocument, TestMocks.CreateTextLoader("", VersionStamp.Create())));
 
         var document = project.GetDocument(_hostDocument.FilePath);
 

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateGeneratedOutputTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateGeneratedOutputTest.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Text;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -81,8 +80,8 @@ public class ProjectStateGeneratedOutputTest : WorkspaceTestBase
     public async Task HostDocumentChanged_DoesNotCacheOutput()
     {
         // Arrange
-        var original =
-            ProjectState.Create(ProjectEngineFactoryProvider, _hostProject, ProjectWorkspaceState.Default)
+        var original = ProjectState
+            .Create(ProjectEngineFactoryProvider, _hostProject, ProjectWorkspaceState.Default)
             .WithAddedHostDocument(_hostDocument, DocumentState.EmptyLoader)
             .WithAddedHostDocument(TestProjectData.SomeProjectImportFile, DocumentState.EmptyLoader);
 
@@ -90,7 +89,7 @@ public class ProjectStateGeneratedOutputTest : WorkspaceTestBase
 
         // Act
         var version = VersionStamp.Create();
-        var state = original.WithChangedHostDocument(_hostDocument, () => Task.FromResult(TextAndVersion.Create(SourceText.From("@using System"), version)));
+        var state = original.WithChangedHostDocument(_hostDocument, TestMocks.CreateTextLoader("@using System", version));
 
         // Assert
         var (actualOutput, actualInputVersion) = await GetOutputAsync(state, _hostDocument);
@@ -103,8 +102,8 @@ public class ProjectStateGeneratedOutputTest : WorkspaceTestBase
     public async Task HostDocumentChanged_Import_DoesNotCacheOutput()
     {
         // Arrange
-        var original =
-            ProjectState.Create(ProjectEngineFactoryProvider, _hostProject, ProjectWorkspaceState.Default)
+        var original = ProjectState
+            .Create(ProjectEngineFactoryProvider, _hostProject, ProjectWorkspaceState.Default)
             .WithAddedHostDocument(_hostDocument, DocumentState.EmptyLoader)
             .WithAddedHostDocument(TestProjectData.SomeProjectImportFile, DocumentState.EmptyLoader);
 
@@ -112,7 +111,7 @@ public class ProjectStateGeneratedOutputTest : WorkspaceTestBase
 
         // Act
         var version = VersionStamp.Create();
-        var state = original.WithChangedHostDocument(TestProjectData.SomeProjectImportFile, () => Task.FromResult(TextAndVersion.Create(SourceText.From("@using System"), version)));
+        var state = original.WithChangedHostDocument(TestProjectData.SomeProjectImportFile, TestMocks.CreateTextLoader("@using System", version));
 
         // Assert
         var (actualOutput, actualInputVersion) = await GetOutputAsync(state, _hostDocument);
@@ -193,7 +192,7 @@ public class ProjectStateGeneratedOutputTest : WorkspaceTestBase
         var originalWorkspaceState = ProjectWorkspaceState.Create(_someTagHelpers, LanguageVersion.CSharp7);
         var original =
             ProjectState.Create(ProjectEngineFactoryProvider, hostProject, originalWorkspaceState)
-            .WithAddedHostDocument(_hostDocument, () => Task.FromResult(TextAndVersion.Create(SourceText.From("@DateTime.Now"), VersionStamp.Default)));
+            .WithAddedHostDocument(_hostDocument, TestMocks.CreateTextLoader("@DateTime.Now", VersionStamp.Default));
         var changedWorkspaceState = ProjectWorkspaceState.Create(_someTagHelpers, LanguageVersion.CSharp8);
 
         var (originalOutput, originalInputVersion) = await GetOutputAsync(original, _hostDocument);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateGeneratedOutputTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateGeneratedOutputTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
@@ -45,13 +46,13 @@ public class ProjectStateGeneratedOutputTest : WorkspaceTestBase
             ProjectState.Create(ProjectEngineFactoryProvider, _hostProject, ProjectWorkspaceState.Default)
             .WithAddedHostDocument(_hostDocument, DocumentState.EmptyLoader);
 
-        var (originalOutput, originalInputVersion) = await GetOutputAsync(original, _hostDocument);
+        var (originalOutput, originalInputVersion) = await GetOutputAsync(original, _hostDocument, DisposalToken);
 
         // Act
         var state = original.WithAddedHostDocument(TestProjectData.AnotherProjectFile1, DocumentState.EmptyLoader);
 
         // Assert
-        var (actualOutput, actualInputVersion) = await GetOutputAsync(state, _hostDocument);
+        var (actualOutput, actualInputVersion) = await GetOutputAsync(state, _hostDocument, DisposalToken);
         Assert.Same(originalOutput, actualOutput);
         Assert.Equal(originalInputVersion, actualInputVersion);
     }
@@ -64,13 +65,13 @@ public class ProjectStateGeneratedOutputTest : WorkspaceTestBase
             ProjectState.Create(ProjectEngineFactoryProvider, _hostProject, ProjectWorkspaceState.Default)
             .WithAddedHostDocument(_hostDocument, DocumentState.EmptyLoader);
 
-        var (originalOutput, originalInputVersion) = await GetOutputAsync(original, _hostDocument);
+        var (originalOutput, originalInputVersion) = await GetOutputAsync(original, _hostDocument, DisposalToken);
 
         // Act
         var state = original.WithAddedHostDocument(TestProjectData.SomeProjectImportFile, DocumentState.EmptyLoader);
 
         // Assert
-        var (actualOutput, actualInputVersion) = await GetOutputAsync(state, _hostDocument);
+        var (actualOutput, actualInputVersion) = await GetOutputAsync(state, _hostDocument, DisposalToken);
         Assert.NotSame(originalOutput, actualOutput);
         Assert.NotEqual(originalInputVersion, actualInputVersion);
         Assert.Equal(state.DocumentCollectionVersion, actualInputVersion);
@@ -85,14 +86,14 @@ public class ProjectStateGeneratedOutputTest : WorkspaceTestBase
             .WithAddedHostDocument(_hostDocument, DocumentState.EmptyLoader)
             .WithAddedHostDocument(TestProjectData.SomeProjectImportFile, DocumentState.EmptyLoader);
 
-        var (originalOutput, originalInputVersion) = await GetOutputAsync(original, _hostDocument);
+        var (originalOutput, originalInputVersion) = await GetOutputAsync(original, _hostDocument, DisposalToken);
 
         // Act
         var version = VersionStamp.Create();
         var state = original.WithChangedHostDocument(_hostDocument, TestMocks.CreateTextLoader("@using System", version));
 
         // Assert
-        var (actualOutput, actualInputVersion) = await GetOutputAsync(state, _hostDocument);
+        var (actualOutput, actualInputVersion) = await GetOutputAsync(state, _hostDocument, DisposalToken);
         Assert.NotSame(originalOutput, actualOutput);
         Assert.NotEqual(originalInputVersion, actualInputVersion);
         Assert.Equal(version, actualInputVersion);
@@ -107,14 +108,14 @@ public class ProjectStateGeneratedOutputTest : WorkspaceTestBase
             .WithAddedHostDocument(_hostDocument, DocumentState.EmptyLoader)
             .WithAddedHostDocument(TestProjectData.SomeProjectImportFile, DocumentState.EmptyLoader);
 
-        var (originalOutput, originalInputVersion) = await GetOutputAsync(original, _hostDocument);
+        var (originalOutput, originalInputVersion) = await GetOutputAsync(original, _hostDocument, DisposalToken);
 
         // Act
         var version = VersionStamp.Create();
         var state = original.WithChangedHostDocument(TestProjectData.SomeProjectImportFile, TestMocks.CreateTextLoader("@using System", version));
 
         // Assert
-        var (actualOutput, actualInputVersion) = await GetOutputAsync(state, _hostDocument);
+        var (actualOutput, actualInputVersion) = await GetOutputAsync(state, _hostDocument, DisposalToken);
         Assert.NotSame(originalOutput, actualOutput);
         Assert.NotEqual(originalInputVersion, actualInputVersion);
         Assert.Equal(version, actualInputVersion);
@@ -129,13 +130,13 @@ public class ProjectStateGeneratedOutputTest : WorkspaceTestBase
             .WithAddedHostDocument(_hostDocument, DocumentState.EmptyLoader)
             .WithAddedHostDocument(TestProjectData.SomeProjectImportFile, DocumentState.EmptyLoader);
 
-        var (originalOutput, originalInputVersion) = await GetOutputAsync(original, _hostDocument);
+        var (originalOutput, originalInputVersion) = await GetOutputAsync(original, _hostDocument, DisposalToken);
 
         // Act
         var state = original.WithRemovedHostDocument(TestProjectData.SomeProjectImportFile);
 
         // Assert
-        var (actualOutput, actualInputVersion) = await GetOutputAsync(state, _hostDocument);
+        var (actualOutput, actualInputVersion) = await GetOutputAsync(state, _hostDocument, DisposalToken);
         Assert.NotSame(originalOutput, actualOutput);
         Assert.NotEqual(originalInputVersion, actualInputVersion);
         Assert.Equal(state.DocumentCollectionVersion, actualInputVersion);
@@ -149,14 +150,14 @@ public class ProjectStateGeneratedOutputTest : WorkspaceTestBase
             ProjectState.Create(ProjectEngineFactoryProvider, _hostProject, ProjectWorkspaceState.Default)
             .WithAddedHostDocument(_hostDocument, DocumentState.EmptyLoader);
 
-        var (originalOutput, originalInputVersion) = await GetOutputAsync(original, _hostDocument);
+        var (originalOutput, originalInputVersion) = await GetOutputAsync(original, _hostDocument, DisposalToken);
         var changed = ProjectWorkspaceState.Default;
 
         // Act
         var state = original.WithProjectWorkspaceState(changed);
 
         // Assert
-        var (actualOutput, actualInputVersion) = await GetOutputAsync(state, _hostDocument);
+        var (actualOutput, actualInputVersion) = await GetOutputAsync(state, _hostDocument, DisposalToken);
         Assert.Same(originalOutput, actualOutput);
         Assert.Equal(originalInputVersion, actualInputVersion);
     }
@@ -170,14 +171,14 @@ public class ProjectStateGeneratedOutputTest : WorkspaceTestBase
             ProjectState.Create(ProjectEngineFactoryProvider, _hostProject, ProjectWorkspaceState.Default)
             .WithAddedHostDocument(_hostDocument, DocumentState.EmptyLoader);
 
-        var (originalOutput, originalInputVersion) = await GetOutputAsync(original, _hostDocument);
+        var (originalOutput, originalInputVersion) = await GetOutputAsync(original, _hostDocument, DisposalToken);
         var changed = ProjectWorkspaceState.Create(_someTagHelpers);
 
         // Act
         var state = original.WithProjectWorkspaceState(changed);
 
         // Assert
-        var (actualOutput, actualInputVersion) = await GetOutputAsync(state, _hostDocument);
+        var (actualOutput, actualInputVersion) = await GetOutputAsync(state, _hostDocument, DisposalToken);
         Assert.NotSame(originalOutput, actualOutput);
         Assert.NotEqual(originalInputVersion, actualInputVersion);
         Assert.Equal(state.ProjectWorkspaceStateVersion, actualInputVersion);
@@ -195,13 +196,13 @@ public class ProjectStateGeneratedOutputTest : WorkspaceTestBase
             .WithAddedHostDocument(_hostDocument, TestMocks.CreateTextLoader("@DateTime.Now", VersionStamp.Default));
         var changedWorkspaceState = ProjectWorkspaceState.Create(_someTagHelpers, LanguageVersion.CSharp8);
 
-        var (originalOutput, originalInputVersion) = await GetOutputAsync(original, _hostDocument);
+        var (originalOutput, originalInputVersion) = await GetOutputAsync(original, _hostDocument, DisposalToken);
 
         // Act
         var state = original.WithProjectWorkspaceState(changedWorkspaceState);
 
         // Assert
-        var (actualOutput, actualInputVersion) = await GetOutputAsync(state, _hostDocument);
+        var (actualOutput, actualInputVersion) = await GetOutputAsync(state, _hostDocument, DisposalToken);
         Assert.NotSame(originalOutput, actualOutput);
         Assert.NotEqual(originalInputVersion, actualInputVersion);
         Assert.Equal(state.ProjectWorkspaceStateVersion, actualInputVersion);
@@ -215,29 +216,28 @@ public class ProjectStateGeneratedOutputTest : WorkspaceTestBase
             ProjectState.Create(ProjectEngineFactoryProvider, _hostProject, ProjectWorkspaceState.Default)
             .WithAddedHostDocument(_hostDocument, DocumentState.EmptyLoader);
 
-        var (originalOutput, originalInputVersion) = await GetOutputAsync(original, _hostDocument);
+        var (originalOutput, originalInputVersion) = await GetOutputAsync(original, _hostDocument, DisposalToken);
 
         // Act
         var state = original.WithHostProject(_hostProjectWithConfigurationChange);
 
         // Assert
-        var (actualOutput, actualInputVersion) = await GetOutputAsync(state, _hostDocument);
+        var (actualOutput, actualInputVersion) = await GetOutputAsync(state, _hostDocument, DisposalToken);
         Assert.NotSame(originalOutput, actualOutput);
         Assert.NotEqual(originalInputVersion, actualInputVersion);
         Assert.NotEqual(state.ProjectWorkspaceStateVersion, actualInputVersion);
     }
 
-    private static Task<(RazorCodeDocument, VersionStamp)> GetOutputAsync(ProjectState project, HostDocument hostDocument)
+    private static Task<(RazorCodeDocument, VersionStamp)> GetOutputAsync(ProjectState project, HostDocument hostDocument, CancellationToken cancellationToken)
     {
         var document = project.Documents[hostDocument.FilePath];
-        return GetOutputAsync(project, document);
+        return GetOutputAsync(project, document, cancellationToken);
     }
 
-    private static Task<(RazorCodeDocument, VersionStamp)> GetOutputAsync(ProjectState project, DocumentState document)
+    private static Task<(RazorCodeDocument, VersionStamp)> GetOutputAsync(ProjectState project, DocumentState document, CancellationToken cancellationToken)
     {
-
         var projectSnapshot = new ProjectSnapshot(project);
         var documentSnapshot = new DocumentSnapshot(projectSnapshot, document);
-        return document.GetGeneratedOutputAndVersionAsync(projectSnapshot, documentSnapshot);
+        return document.GetGeneratedOutputAndVersionAsync(projectSnapshot, documentSnapshot, cancellationToken);
     }
 }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateTest.cs
@@ -106,7 +106,7 @@ public class ProjectStateTest : WorkspaceTestBase
         var state = original.WithAddedHostDocument(_documents[0], DocumentState.EmptyLoader);
 
         // Assert
-        var text = await state.Documents[_documents[0].FilePath].GetTextAsync();
+        var text = await state.Documents[_documents[0].FilePath].GetTextAsync(DisposalToken);
         Assert.Equal(0, text.Length);
     }
 
@@ -278,7 +278,7 @@ public class ProjectStateTest : WorkspaceTestBase
         // Assert
         Assert.NotEqual(original.Version, state.Version);
 
-        var text = await state.Documents[_documents[1].FilePath].GetTextAsync();
+        var text = await state.Documents[_documents[1].FilePath].GetTextAsync(DisposalToken);
         Assert.Same(_text, text);
 
         Assert.Equal(original.DocumentCollectionVersion, state.DocumentCollectionVersion);
@@ -298,7 +298,7 @@ public class ProjectStateTest : WorkspaceTestBase
         // Assert
         Assert.NotEqual(original.Version, state.Version);
 
-        var text = await state.Documents[_documents[1].FilePath].GetTextAsync();
+        var text = await state.Documents[_documents[1].FilePath].GetTextAsync(DisposalToken);
         Assert.Same(_text, text);
 
         Assert.Equal(original.DocumentCollectionVersion, state.DocumentCollectionVersion);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateTest.cs
@@ -22,7 +22,7 @@ public class ProjectStateTest : WorkspaceTestBase
     private readonly HostProject _hostProject;
     private readonly HostProject _hostProjectWithConfigurationChange;
     private readonly ProjectWorkspaceState _projectWorkspaceState;
-    private readonly Func<Task<TextAndVersion>> _textLoader;
+    private readonly TextLoader _textLoader;
     private readonly SourceText _text;
 
     public ProjectStateTest(ITestOutputHelper testOutput)
@@ -44,7 +44,7 @@ public class ProjectStateTest : WorkspaceTestBase
         };
 
         _text = SourceText.From("Hello, world!");
-        _textLoader = () => Task.FromResult(TextAndVersion.Create(_text, VersionStamp.Create()));
+        _textLoader = TestMocks.CreateTextLoader(_text, VersionStamp.Create());
     }
 
     protected override void ConfigureProjectEngine(RazorProjectEngineBuilder builder)
@@ -987,7 +987,7 @@ public class ProjectStateTest : WorkspaceTestBase
     {
         public static TestDocumentState Create(
             HostDocument hostDocument,
-            Func<Task<TextAndVersion>>? loader = null,
+            TextLoader? loader = null,
             Action? onTextChange = null,
             Action? onTextLoaderChange = null,
             Action? onConfigurationChange = null,
@@ -1012,13 +1012,13 @@ public class ProjectStateTest : WorkspaceTestBase
 
         private TestDocumentState(
             HostDocument hostDocument,
-            Func<Task<TextAndVersion>>? loader,
+            TextLoader? loader,
             Action? onTextChange,
             Action? onTextLoaderChange,
             Action? onConfigurationChange,
             Action? onImportsChange,
             Action? onProjectWorkspaceStateChange)
-            : base(hostDocument, text: null, textVersion: null, version: 1, loader)
+            : base(hostDocument, version: 1, loader ?? EmptyLoader)
         {
             _onTextChange = onTextChange;
             _onTextLoaderChange = onTextLoaderChange;
@@ -1033,7 +1033,7 @@ public class ProjectStateTest : WorkspaceTestBase
             return base.WithText(sourceText, textVersion);
         }
 
-        public override DocumentState WithTextLoader(Func<Task<TextAndVersion>> loader)
+        public override DocumentState WithTextLoader(TextLoader loader)
         {
             _onTextLoaderChange?.Invoke();
             return base.WithTextLoader(loader);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostEndpointTestBase.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostEndpointTestBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Basic.Reference.Assemblies;
 using Microsoft.AspNetCore.Razor;
@@ -71,7 +72,11 @@ public abstract class CohostEndpointTestBase(ITestOutputHelper testOutputHelper)
         FeatureOptions.SetOptions(_clientInitializationOptions);
     }
 
-    protected Task<TextDocument> CreateProjectAndRazorDocumentAsync(string contents, string? fileKind = null, (string fileName, string contents)[]? additionalFiles = null, bool createSeparateRemoteAndLocalWorkspaces = false)
+    protected Task<TextDocument> CreateProjectAndRazorDocumentAsync(
+        string contents,
+        string? fileKind = null,
+        (string fileName, string contents)[]? additionalFiles = null,
+        bool createSeparateRemoteAndLocalWorkspaces = false)
     {
         // Using IsLegacy means null == component, so easier for test authors
         var isComponent = !FileKinds.IsLegacy(fileKind);
@@ -95,7 +100,14 @@ public abstract class CohostEndpointTestBase(ITestOutputHelper testOutputHelper)
             // actual solution syncing set up for testing, and don't really use a service broker, but since we also would
             // expect to never make changes to a workspace, it should be fine to simply create duplicated solutions as part
             // of test setup.
-            return CreateLocalProjectAndRazorDocumentAsync(remoteDocument.Project.Solution, projectId, projectName, documentId, documentFilePath, contents, additionalFiles);
+            return CreateLocalProjectAndRazorDocumentAsync(
+                remoteDocument.Project.Solution,
+                projectId,
+                projectName,
+                documentId,
+                documentFilePath,
+                contents,
+                additionalFiles);
         }
 
         // If we're just creating one workspace, then its the remote one and we just return the remote document
@@ -104,7 +116,14 @@ public abstract class CohostEndpointTestBase(ITestOutputHelper testOutputHelper)
         return Task.FromResult(remoteDocument);
     }
 
-    private async Task<TextDocument> CreateLocalProjectAndRazorDocumentAsync(Solution remoteSolution, ProjectId projectId, string projectName, DocumentId documentId, string documentFilePath, string contents, (string fileName, string contents)[]? additionalFiles)
+    private async Task<TextDocument> CreateLocalProjectAndRazorDocumentAsync(
+        Solution remoteSolution,
+        ProjectId projectId,
+        string projectName,
+        DocumentId documentId,
+        string documentFilePath,
+        string contents,
+        (string fileName, string contents)[]? additionalFiles)
     {
         var exportProvider = TestComposition.Roslyn.ExportProviderFactory.CreateExportProvider();
         AddDisposable(exportProvider);
@@ -120,7 +139,7 @@ public abstract class CohostEndpointTestBase(ITestOutputHelper testOutputHelper)
         var snapshotManager = _exportProvider.AssumeNotNull().GetExportedValue<RemoteSnapshotManager>();
         var snapshot = snapshotManager.GetSnapshot(razorDocument);
         // Compile the Razor file
-        var codeDocument = await snapshot.GetGeneratedOutputAsync(false);
+        var codeDocument = await snapshot.GetGeneratedOutputAsync(forceDesignTimeGeneratedOutput: false, DisposalToken);
         // Update the generated doc contents
         var generatedDocumentIds = solution.GetDocumentIdsWithFilePath(documentFilePath + CSharpVirtualDocumentSuffix);
         solution = solution.WithDocumentText(generatedDocumentIds, codeDocument.GetCSharpSourceText());

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/RazorComponentDefinitionServiceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/RazorComponentDefinitionServiceTest.cs
@@ -83,7 +83,7 @@ public class RazorComponentDefinitionServiceTest(ITestOutputHelper testOutputHel
         var documentMappingService = OOPExportProvider.GetExportedValue<IDocumentMappingService>();
 
         var documentSnapshot = snapshotManager.GetSnapshot(document);
-        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync();
+        var codeDocument = await documentSnapshot.GetGeneratedOutputAsync(DisposalToken);
         var positionInfo = documentMappingService.GetPositionInfo(codeDocument, input.Position);
 
         var location = await service.GetDefinitionAsync(

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DocumentGenerator/BackgroundDocumentGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DocumentGenerator/BackgroundDocumentGeneratorTest.cs
@@ -408,12 +408,12 @@ public class BackgroundDocumentGeneratorTest(ITestOutputHelper testOutput) : Vis
             base.Enqueue(project, document);
         }
 
-        protected override Task ProcessDocumentAsync(IProjectSnapshot project, IDocumentSnapshot document)
+        protected override Task ProcessDocumentAsync(IProjectSnapshot project, IDocumentSnapshot document, CancellationToken cancellationToken)
         {
             var key = GetKey(project, document);
             PendingWork.Remove(key);
 
-            var task = base.ProcessDocumentAsync(project, document);
+            var task = base.ProcessDocumentAsync(project, document, cancellationToken);
 
             CompletedWork.Add(key);
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DocumentGenerator/BackgroundDocumentGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DocumentGenerator/BackgroundDocumentGeneratorTest.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.AspNetCore.Razor.Test.Common.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common.VisualStudio;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor;
@@ -186,8 +187,8 @@ public class BackgroundDocumentGeneratorTest(ITestOutputHelper testOutput) : Vis
         {
             updater.ProjectAdded(s_hostProject1);
             updater.ProjectAdded(s_hostProject2);
-            updater.DocumentAdded(s_hostProject1.Key, s_documents[0], null!);
-            updater.DocumentAdded(s_hostProject1.Key, s_documents[1], null!);
+            updater.DocumentAdded(s_hostProject1.Key, s_documents[0], s_documents[0].CreateEmptyTextLoader());
+            updater.DocumentAdded(s_hostProject1.Key, s_documents[1], s_documents[1].CreateEmptyTextLoader());
         });
 
         var project = projectManager.GetLoadedProject(s_hostProject1.Key);
@@ -225,8 +226,8 @@ public class BackgroundDocumentGeneratorTest(ITestOutputHelper testOutput) : Vis
         {
             updater.ProjectAdded(hostProject1);
             updater.ProjectAdded(hostProject2);
-            updater.DocumentAdded(hostProject1.Key, hostDocument1, null!);
-            updater.DocumentAdded(hostProject1.Key, hostDocument2, null!);
+            updater.DocumentAdded(hostProject1.Key, hostDocument1, hostDocument1.CreateEmptyTextLoader());
+            updater.DocumentAdded(hostProject1.Key, hostDocument2, hostDocument2.CreateEmptyTextLoader());
         });
 
         var project = projectManager.GetLoadedProject(hostProject1.Key);
@@ -274,7 +275,7 @@ public class BackgroundDocumentGeneratorTest(ITestOutputHelper testOutput) : Vis
             updater.ProjectAdded(s_hostProject1);
             for (var i = 0; i < documents.Length; i++)
             {
-                updater.DocumentAdded(s_hostProject1.Key, documents[i], null!);
+                updater.DocumentAdded(s_hostProject1.Key, documents[i], documents[i].CreateEmptyTextLoader());
             }
         });
 
@@ -318,8 +319,8 @@ public class BackgroundDocumentGeneratorTest(ITestOutputHelper testOutput) : Vis
         await projectManager.UpdateAsync(updater =>
         {
             updater.ProjectAdded(s_hostProject1);
-            updater.DocumentAdded(s_hostProject1.Key, TestProjectData.SomeProjectComponentFile1, null!);
-            updater.DocumentAdded(s_hostProject1.Key, TestProjectData.SomeProjectImportFile, null!);
+            updater.DocumentAdded(s_hostProject1.Key, TestProjectData.SomeProjectComponentFile1, TestProjectData.SomeProjectComponentFile1.CreateEmptyTextLoader());
+            updater.DocumentAdded(s_hostProject1.Key, TestProjectData.SomeProjectImportFile, TestProjectData.SomeProjectImportFile.CreateEmptyTextLoader());
         });
 
         using var generator = new TestBackgroundDocumentGenerator(projectManager, _dynamicFileInfoProvider, LoggerFactory)

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/CSharpDocumentExcerptServiceTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/CSharpDocumentExcerptServiceTests.cs
@@ -35,7 +35,7 @@ public class CSharpDocumentExcerptServiceTest : DocumentExcerptServiceTestBase
 </html>
 ";
 
-        var (generatedDocument, razorSourceText, primarySpan, generatedSpan) = await InitializeAsync(razorSource);
+        var (generatedDocument, razorSourceText, primarySpan, generatedSpan) = await InitializeAsync(razorSource, DisposalToken);
 
 #pragma warning disable CS0618 // Type or member is obsolete
         var excerptService = new CSharpDocumentExcerptService();
@@ -123,7 +123,7 @@ public class CSharpDocumentExcerptServiceTest : DocumentExcerptServiceTestBase
 </html>
 ";
 
-        var (generatedDocument, razorSourceText, primarySpan, generatedSpan) = await InitializeAsync(razorSource);
+        var (generatedDocument, razorSourceText, primarySpan, generatedSpan) = await InitializeAsync(razorSource, DisposalToken);
 
 #pragma warning disable CS0618 // Type or member is obsolete
         var excerptService = new CSharpDocumentExcerptService();
@@ -169,7 +169,7 @@ public class CSharpDocumentExcerptServiceTest : DocumentExcerptServiceTestBase
 </html>
 ";
 
-        var (generatedDocument, razorSourceText, primarySpan, generatedSpan) = await InitializeAsync(razorSource);
+        var (generatedDocument, razorSourceText, primarySpan, generatedSpan) = await InitializeAsync(razorSource, DisposalToken);
 
 #pragma warning disable CS0618 // Type or member is obsolete
         var excerptService = new CSharpDocumentExcerptService();
@@ -216,7 +216,7 @@ public class CSharpDocumentExcerptServiceTest : DocumentExcerptServiceTestBase
 </html>
 ";
 
-        var (generatedDocument, razorSourceText, primarySpan, generatedSpan) = await InitializeAsync(razorSource);
+        var (generatedDocument, razorSourceText, primarySpan, generatedSpan) = await InitializeAsync(razorSource, DisposalToken);
 
 #pragma warning disable CS0618 // Type or member is obsolete
         var excerptService = new CSharpDocumentExcerptService();
@@ -262,7 +262,7 @@ public class CSharpDocumentExcerptServiceTest : DocumentExcerptServiceTestBase
         // Arrange
         var razorSource = @"@{ var [|foo|] = ""Hello, World!""; }";
 
-        var (generatedDocument, razorSourceText, primarySpan, generatedSpan) = await InitializeAsync(razorSource);
+        var (generatedDocument, razorSourceText, primarySpan, generatedSpan) = await InitializeAsync(razorSource, DisposalToken);
 
 #pragma warning disable CS0618 // Type or member is obsolete
         var excerptService = new CSharpDocumentExcerptService();

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/DynamicFiles/RazorDocumentExcerptServiceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/DynamicFiles/RazorDocumentExcerptServiceTest.cs
@@ -28,7 +28,7 @@ public class RazorDocumentExcerptServiceTest(ITestOutputHelper testOutput) : Doc
 </html>
 ";
 
-        var (primary, secondary, secondarySpan) = await InitializeWithSnapshotAsync(razorSource);
+        var (primary, secondary, secondarySpan) = await InitializeWithSnapshotAsync(razorSource, DisposalToken);
 
         var service = CreateExcerptService(primary);
 
@@ -106,7 +106,7 @@ public class RazorDocumentExcerptServiceTest(ITestOutputHelper testOutput) : Doc
 </html>
 ";
 
-        var (primary, secondary, secondarySpan) = await InitializeWithSnapshotAsync(razorSource);
+        var (primary, secondary, secondarySpan) = await InitializeWithSnapshotAsync(razorSource, DisposalToken);
 
         var service = CreateExcerptService(primary);
 
@@ -159,7 +159,7 @@ public class RazorDocumentExcerptServiceTest(ITestOutputHelper testOutput) : Doc
 </html>
 ";
 
-        var (primary, secondary, secondarySpan) = await InitializeWithSnapshotAsync(razorSource);
+        var (primary, secondary, secondarySpan) = await InitializeWithSnapshotAsync(razorSource, DisposalToken);
 
         var service = CreateExcerptService(primary);
 
@@ -266,7 +266,7 @@ public class RazorDocumentExcerptServiceTest(ITestOutputHelper testOutput) : Doc
             </html>
             """;
 
-        var (primary, secondary, secondarySpan) = await InitializeWithSnapshotAsync(razorSource);
+        var (primary, secondary, secondarySpan) = await InitializeWithSnapshotAsync(razorSource, DisposalToken);
 
         var service = CreateExcerptService(primary);
 
@@ -370,7 +370,7 @@ public class RazorDocumentExcerptServiceTest(ITestOutputHelper testOutput) : Doc
             </html>
             """;
 
-        var (primary, secondary, secondarySpan) = await InitializeWithSnapshotAsync(razorSource);
+        var (primary, secondary, secondarySpan) = await InitializeWithSnapshotAsync(razorSource, DisposalToken);
 
         var service = CreateExcerptService(primary);
 
@@ -444,7 +444,7 @@ public class RazorDocumentExcerptServiceTest(ITestOutputHelper testOutput) : Doc
 </html>
 ";
 
-        var (primary, secondary, secondarySpan) = await InitializeWithSnapshotAsync(razorSource);
+        var (primary, secondary, secondarySpan) = await InitializeWithSnapshotAsync(razorSource, DisposalToken);
 
         var service = CreateExcerptService(primary);
 
@@ -553,7 +553,7 @@ public class RazorDocumentExcerptServiceTest(ITestOutputHelper testOutput) : Doc
         // Arrange
         var razorSource = @"@{ var [|foo|] = ""Hello, World!""; }";
 
-        var (primary, secondary, secondarySpan) = await InitializeWithSnapshotAsync(razorSource);
+        var (primary, secondary, secondarySpan) = await InitializeWithSnapshotAsync(razorSource, DisposalToken);
 
         var service = CreateExcerptService(primary);
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/DynamicFiles/RazorSpanMappingServiceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/DynamicFiles/RazorSpanMappingServiceTest.cs
@@ -29,13 +29,12 @@ public class RazorSpanMappingServiceTest(ITestOutputHelper testOutput) : Workspa
 @SomeProperty
 ");
 
-        var project = new ProjectSnapshot(
-            ProjectState.Create(ProjectEngineFactoryProvider, _hostProject, ProjectWorkspaceState.Default)
-            .WithAddedHostDocument(_hostDocument, () => Task.FromResult(TextAndVersion.Create(sourceText, VersionStamp.Create()))));
+        var project = new ProjectSnapshot(ProjectState
+            .Create(ProjectEngineFactoryProvider, _hostProject, ProjectWorkspaceState.Default)
+            .WithAddedHostDocument(_hostDocument, TestMocks.CreateTextLoader(sourceText, VersionStamp.Create())));
 
         var document = project.GetDocument(_hostDocument.FilePath);
         Assert.NotNull(document);
-        var service = new RazorSpanMappingService(document);
 
         var output = await document.GetGeneratedOutputAsync();
         var generated = output.GetCSharpDocument();
@@ -62,13 +61,12 @@ public class RazorSpanMappingServiceTest(ITestOutputHelper testOutput) : Workspa
 @SomeProperty
 ");
 
-        var project = new ProjectSnapshot(
-            ProjectState.Create(ProjectEngineFactoryProvider, _hostProject, ProjectWorkspaceState.Default)
-            .WithAddedHostDocument(_hostDocument, () => Task.FromResult(TextAndVersion.Create(sourceText, VersionStamp.Create()))));
+        var project = new ProjectSnapshot(ProjectState
+            .Create(ProjectEngineFactoryProvider, _hostProject, ProjectWorkspaceState.Default)
+            .WithAddedHostDocument(_hostDocument, TestMocks.CreateTextLoader(sourceText, VersionStamp.Create())));
 
         var document = project.GetDocument(_hostDocument.FilePath);
         Assert.NotNull(document);
-        var service = new RazorSpanMappingService(document);
 
         var output = await document.GetGeneratedOutputAsync();
         var generated = output.GetCSharpDocument();
@@ -96,13 +94,12 @@ public class RazorSpanMappingServiceTest(ITestOutputHelper testOutput) : Workspa
 }
 ");
 
-        var project = new ProjectSnapshot(
-            ProjectState.Create(ProjectEngineFactoryProvider, _hostProject, ProjectWorkspaceState.Default)
-            .WithAddedHostDocument(_hostDocument, () => Task.FromResult(TextAndVersion.Create(sourceText, VersionStamp.Create()))));
+        var project = new ProjectSnapshot(ProjectState
+            .Create(ProjectEngineFactoryProvider, _hostProject, ProjectWorkspaceState.Default)
+            .WithAddedHostDocument(_hostDocument, TestMocks.CreateTextLoader(sourceText, VersionStamp.Create())));
 
         var document = project.GetDocument(_hostDocument.FilePath);
         Assert.NotNull(document);
-        var service = new RazorSpanMappingService(document);
 
         var output = await document.GetGeneratedOutputAsync();
         var generated = output.GetCSharpDocument();
@@ -129,13 +126,12 @@ public class RazorSpanMappingServiceTest(ITestOutputHelper testOutput) : Workspa
 }
 ");
 
-        var project = new ProjectSnapshot(
-            ProjectState.Create(ProjectEngineFactoryProvider, _hostProject, ProjectWorkspaceState.Default)
-            .WithAddedHostDocument(_hostDocument, () => Task.FromResult(TextAndVersion.Create(sourceText, VersionStamp.Create()))));
+        var project = new ProjectSnapshot(ProjectState
+            .Create(ProjectEngineFactoryProvider, _hostProject, ProjectWorkspaceState.Default)
+            .WithAddedHostDocument(_hostDocument, TestMocks.CreateTextLoader(sourceText, VersionStamp.Create())));
 
         var document = project.GetDocument(_hostDocument.FilePath);
         Assert.NotNull(document);
-        var service = new RazorSpanMappingService(document);
 
         var output = await document.GetGeneratedOutputAsync();
         var generated = output.GetCSharpDocument();
@@ -144,7 +140,7 @@ public class RazorSpanMappingServiceTest(ITestOutputHelper testOutput) : Workspa
         var span = new TextSpan(generated.GeneratedCode.IndexOf(symbol, StringComparison.Ordinal), symbol.Length);
 
         // Act
-        var result = RazorSpanMappingService.TryGetMappedSpans(span, await document.GetTextAsync(), generated, out var mappedLinePositionSpan, out var mappedSpan);
+        var result = RazorSpanMappingService.TryGetMappedSpans(span, await document.GetTextAsync(), generated, out _, out _);
 
         // Assert
         Assert.False(result);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/DynamicFiles/RazorSpanMappingServiceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/DynamicFiles/RazorSpanMappingServiceTest.cs
@@ -36,7 +36,7 @@ public class RazorSpanMappingServiceTest(ITestOutputHelper testOutput) : Workspa
         var document = project.GetDocument(_hostDocument.FilePath);
         Assert.NotNull(document);
 
-        var output = await document.GetGeneratedOutputAsync();
+        var output = await document.GetGeneratedOutputAsync(DisposalToken);
         var generated = output.GetCSharpDocument();
 
         var symbol = "SomeProperty";
@@ -68,7 +68,7 @@ public class RazorSpanMappingServiceTest(ITestOutputHelper testOutput) : Workspa
         var document = project.GetDocument(_hostDocument.FilePath);
         Assert.NotNull(document);
 
-        var output = await document.GetGeneratedOutputAsync();
+        var output = await document.GetGeneratedOutputAsync(DisposalToken);
         var generated = output.GetCSharpDocument();
 
         var symbol = "SomeProperty";
@@ -101,7 +101,7 @@ public class RazorSpanMappingServiceTest(ITestOutputHelper testOutput) : Workspa
         var document = project.GetDocument(_hostDocument.FilePath);
         Assert.NotNull(document);
 
-        var output = await document.GetGeneratedOutputAsync();
+        var output = await document.GetGeneratedOutputAsync(DisposalToken);
         var generated = output.GetCSharpDocument();
 
         var symbol = "SomeProperty";
@@ -133,7 +133,7 @@ public class RazorSpanMappingServiceTest(ITestOutputHelper testOutput) : Workspa
         var document = project.GetDocument(_hostDocument.FilePath);
         Assert.NotNull(document);
 
-        var output = await document.GetGeneratedOutputAsync();
+        var output = await document.GetGeneratedOutputAsync(DisposalToken);
         var generated = output.GetCSharpDocument();
 
         var symbol = "ExecuteAsync";

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/DynamicFiles/RazorSpanMappingServiceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/DynamicFiles/RazorSpanMappingServiceTest.cs
@@ -43,7 +43,7 @@ public class RazorSpanMappingServiceTest(ITestOutputHelper testOutput) : Workspa
         var span = new TextSpan(generated.GeneratedCode.IndexOf(symbol, StringComparison.Ordinal), symbol.Length);
 
         // Act
-        var result = RazorSpanMappingService.TryGetMappedSpans(span, await document.GetTextAsync(), generated, out var mappedLinePositionSpan, out var mappedSpan);
+        var result = RazorSpanMappingService.TryGetMappedSpans(span, await document.GetTextAsync(DisposalToken), generated, out var mappedLinePositionSpan, out var mappedSpan);
 
         // Assert
         Assert.True(result);
@@ -76,7 +76,7 @@ public class RazorSpanMappingServiceTest(ITestOutputHelper testOutput) : Workspa
         var span = new TextSpan(generated.GeneratedCode.IndexOf(symbol, generated.GeneratedCode.IndexOf(symbol, StringComparison.Ordinal) + symbol.Length, StringComparison.Ordinal), symbol.Length);
 
         // Act
-        var result = RazorSpanMappingService.TryGetMappedSpans(span, await document.GetTextAsync(), generated, out var mappedLinePositionSpan, out var mappedSpan);
+        var result = RazorSpanMappingService.TryGetMappedSpans(span, await document.GetTextAsync(DisposalToken), generated, out var mappedLinePositionSpan, out var mappedSpan);
 
         // Assert
         Assert.True(result);
@@ -108,7 +108,7 @@ public class RazorSpanMappingServiceTest(ITestOutputHelper testOutput) : Workspa
         var span = new TextSpan(generated.GeneratedCode.IndexOf(symbol, StringComparison.Ordinal), symbol.Length);
 
         // Act
-        var result = RazorSpanMappingService.TryGetMappedSpans(span, await document.GetTextAsync(), generated, out var mappedLinePositionSpan, out var mappedSpan);
+        var result = RazorSpanMappingService.TryGetMappedSpans(span, await document.GetTextAsync(DisposalToken), generated, out var mappedLinePositionSpan, out var mappedSpan);
 
         // Assert
         Assert.True(result);
@@ -140,7 +140,7 @@ public class RazorSpanMappingServiceTest(ITestOutputHelper testOutput) : Workspa
         var span = new TextSpan(generated.GeneratedCode.IndexOf(symbol, StringComparison.Ordinal), symbol.Length);
 
         // Act
-        var result = RazorSpanMappingService.TryGetMappedSpans(span, await document.GetTextAsync(), generated, out _, out _);
+        var result = RazorSpanMappingService.TryGetMappedSpans(span, await document.GetTextAsync(DisposalToken), generated, out _, out _);
 
         // Assert
         Assert.False(result);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/RazorDocumentOptionsServiceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/RazorDocumentOptionsServiceTest.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
+using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Formatting;
@@ -95,9 +96,9 @@ public class RazorDocumentOptionsServiceTest(ITestOutputHelper testOutput) : Wor
         var hostDocument = new HostDocument(
             Path.Combine(baseDirectory, "SomeProject", "File1.cshtml"), "File1.cshtml", FileKinds.Legacy);
 
-        var project = new ProjectSnapshot(
-            ProjectState.Create(ProjectEngineFactoryProvider, hostProject, ProjectWorkspaceState.Default)
-            .WithAddedHostDocument(hostDocument, () => Task.FromResult(TextAndVersion.Create(sourceText, VersionStamp.Create()))));
+        var project = new ProjectSnapshot(ProjectState
+            .Create(ProjectEngineFactoryProvider, hostProject, ProjectWorkspaceState.Default)
+            .WithAddedHostDocument(hostDocument, TestMocks.CreateTextLoader(sourceText, VersionStamp.Create())));
 
         var documentSnapshot = project.GetDocument(hostDocument.FilePath);
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/RazorDocumentOptionsServiceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/RazorDocumentOptionsServiceTest.cs
@@ -101,6 +101,7 @@ public class RazorDocumentOptionsServiceTest(ITestOutputHelper testOutput) : Wor
             .WithAddedHostDocument(hostDocument, TestMocks.CreateTextLoader(sourceText, VersionStamp.Create())));
 
         var documentSnapshot = project.GetDocument(hostDocument.FilePath);
+        Assert.NotNull(documentSnapshot);
 
         var solution = Workspace.CurrentSolution.AddProject(ProjectInfo.Create(
             ProjectId.CreateNewId(Path.GetFileNameWithoutExtension(hostDocument.FilePath)),

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/ProjectSnapshotManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/ProjectSnapshotManagerTest.cs
@@ -97,7 +97,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         // Act
         await _projectManager.UpdateAsync(updater =>
         {
-            updater.DocumentAdded(s_hostProject.Key, s_documents[0], null!);
+            updater.DocumentAdded(s_hostProject.Key, s_documents[0], s_documents[0].CreateEmptyTextLoader());
         });
 
         // Assert
@@ -123,7 +123,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         // Act
         await _projectManager.UpdateAsync(updater =>
         {
-            updater.DocumentAdded(s_hostProject.Key, s_documents[0], null!);
+            updater.DocumentAdded(s_hostProject.Key, s_documents[0], s_documents[0].CreateEmptyTextLoader());
         });
 
         // Assert
@@ -151,7 +151,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         // Act
         await _projectManager.UpdateAsync(updater =>
         {
-            updater.DocumentAdded(s_hostProject.Key, s_documents[3], null!);
+            updater.DocumentAdded(s_hostProject.Key, s_documents[3], s_documents[3].CreateEmptyTextLoader());
         });
 
         // Assert
@@ -172,7 +172,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         await _projectManager.UpdateAsync(updater =>
         {
             updater.ProjectAdded(s_hostProject);
-            updater.DocumentAdded(s_hostProject.Key, s_documents[0], null!);
+            updater.DocumentAdded(s_hostProject.Key, s_documents[0], s_documents[0].CreateEmptyTextLoader());
         });
 
         using var listener = _projectManager.ListenToNotifications();
@@ -180,7 +180,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         // Act
         await _projectManager.UpdateAsync(updater =>
         {
-            updater.DocumentAdded(s_hostProject.Key, s_documents[0], null!);
+            updater.DocumentAdded(s_hostProject.Key, s_documents[0], s_documents[0].CreateEmptyTextLoader());
         });
 
         // Assert
@@ -210,7 +210,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
     }
 
     [UIFact]
-    public async Task DocumentAdded_NullLoader_HasEmptyText()
+    public async Task DocumentAdded_EmptyLoader_HasEmptyText()
     {
         // Arrange
         await _projectManager.UpdateAsync(updater =>
@@ -221,7 +221,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         // Act
         await _projectManager.UpdateAsync(updater =>
         {
-            updater.DocumentAdded(s_hostProject.Key, s_documents[0], null!);
+            updater.DocumentAdded(s_hostProject.Key, s_documents[0], s_documents[0].CreateEmptyTextLoader());
         });
 
         // Assert
@@ -235,7 +235,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
     }
 
     [UIFact]
-    public async Task DocumentAdded_WithLoader_LoadesText()
+    public async Task DocumentAdded_WithLoader_LoadsText()
     {
         // Arrange
         await _projectManager.UpdateAsync(updater =>
@@ -276,7 +276,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         // Act
         await _projectManager.UpdateAsync(updater =>
         {
-            updater.DocumentAdded(s_hostProject.Key, s_documents[0], null!);
+            updater.DocumentAdded(s_hostProject.Key, s_documents[0], s_documents[0].CreateEmptyTextLoader());
         });
 
         // Assert
@@ -304,7 +304,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         // Act
         await _projectManager.UpdateAsync(updater =>
         {
-            updater.DocumentAdded(s_hostProject.Key, s_documents[0], null!);
+            updater.DocumentAdded(s_hostProject.Key, s_documents[0], s_documents[0].CreateEmptyTextLoader());
         });
 
         // Assert
@@ -319,9 +319,9 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         await _projectManager.UpdateAsync(updater =>
         {
             updater.ProjectAdded(s_hostProject);
-            updater.DocumentAdded(s_hostProject.Key, s_documents[0], null!);
-            updater.DocumentAdded(s_hostProject.Key, s_documents[1], null!);
-            updater.DocumentAdded(s_hostProject.Key, s_documents[2], null!);
+            updater.DocumentAdded(s_hostProject.Key, s_documents[0], s_documents[0].CreateEmptyTextLoader());
+            updater.DocumentAdded(s_hostProject.Key, s_documents[1], s_documents[1].CreateEmptyTextLoader());
+            updater.DocumentAdded(s_hostProject.Key, s_documents[2], s_documents[2].CreateEmptyTextLoader());
         });
 
         using var listener = _projectManager.ListenToNotifications();
@@ -391,9 +391,9 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         {
             updater.ProjectAdded(s_hostProject);
             updater.ProjectWorkspaceStateChanged(s_hostProject.Key, _projectWorkspaceStateWithTagHelpers);
-            updater.DocumentAdded(s_hostProject.Key, s_documents[0], null!);
-            updater.DocumentAdded(s_hostProject.Key, s_documents[1], null!);
-            updater.DocumentAdded(s_hostProject.Key, s_documents[2], null!);
+            updater.DocumentAdded(s_hostProject.Key, s_documents[0], s_documents[0].CreateEmptyTextLoader());
+            updater.DocumentAdded(s_hostProject.Key, s_documents[1], s_documents[1].CreateEmptyTextLoader());
+            updater.DocumentAdded(s_hostProject.Key, s_documents[2], s_documents[2].CreateEmptyTextLoader());
         });
 
         var originalTagHelpers = await _projectManager.GetLoadedProject(s_hostProject.Key).GetTagHelpersAsync(DisposalToken);
@@ -421,9 +421,9 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         await _projectManager.UpdateAsync(updater =>
         {
             updater.ProjectAdded(s_hostProject);
-            updater.DocumentAdded(s_hostProject.Key, s_documents[0], null!);
-            updater.DocumentAdded(s_hostProject.Key, s_documents[1], null!);
-            updater.DocumentAdded(s_hostProject.Key, s_documents[2], null!);
+            updater.DocumentAdded(s_hostProject.Key, s_documents[0], s_documents[0].CreateEmptyTextLoader());
+            updater.DocumentAdded(s_hostProject.Key, s_documents[1], s_documents[1].CreateEmptyTextLoader());
+            updater.DocumentAdded(s_hostProject.Key, s_documents[2], s_documents[2].CreateEmptyTextLoader());
         });
 
         var project = _projectManager.GetLoadedProject(s_hostProject.Key);
@@ -447,7 +447,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         await _projectManager.UpdateAsync(updater =>
         {
             updater.ProjectAdded(s_hostProject);
-            updater.DocumentAdded(s_hostProject.Key, s_documents[0], null!);
+            updater.DocumentAdded(s_hostProject.Key, s_documents[0], s_documents[0].CreateEmptyTextLoader());
         });
 
         using var listener = _projectManager.ListenToNotifications();
@@ -480,7 +480,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         await _projectManager.UpdateAsync(updater =>
         {
             updater.ProjectAdded(s_hostProject);
-            updater.DocumentAdded(s_hostProject.Key, s_documents[0], null!);
+            updater.DocumentAdded(s_hostProject.Key, s_documents[0], s_documents[0].CreateEmptyTextLoader());
             updater.DocumentOpened(s_hostProject.Key, s_documents[0].FilePath, _sourceText);
         });
 
@@ -517,7 +517,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         await _projectManager.UpdateAsync(updater =>
         {
             updater.ProjectAdded(s_hostProject);
-            updater.DocumentAdded(s_hostProject.Key, s_documents[0], null!);
+            updater.DocumentAdded(s_hostProject.Key, s_documents[0], s_documents[0].CreateEmptyTextLoader());
         });
 
         using var listener = _projectManager.ListenToNotifications();
@@ -549,7 +549,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         await _projectManager.UpdateAsync(updater =>
         {
             updater.ProjectAdded(s_hostProject);
-            updater.DocumentAdded(s_hostProject.Key, s_documents[0], null!);
+            updater.DocumentAdded(s_hostProject.Key, s_documents[0], s_documents[0].CreateEmptyTextLoader());
             updater.DocumentOpened(s_hostProject.Key, s_documents[0].FilePath, _sourceText);
         });
 
@@ -582,7 +582,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         await _projectManager.UpdateAsync(updater =>
         {
             updater.ProjectAdded(s_hostProject);
-            updater.DocumentAdded(s_hostProject.Key, s_documents[0], null!);
+            updater.DocumentAdded(s_hostProject.Key, s_documents[0], s_documents[0].CreateEmptyTextLoader());
             updater.DocumentOpened(s_hostProject.Key, s_documents[0].FilePath, _sourceText);
         });
 
@@ -761,7 +761,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         await _projectManager.UpdateAsync(updater =>
         {
             updater.ProjectAdded(s_hostProject);
-            updater.DocumentAdded(s_hostProject.Key, s_documents[0], null!);
+            updater.DocumentAdded(s_hostProject.Key, s_documents[0], s_documents[0].CreateEmptyTextLoader());
         });
 
         // Act
@@ -854,7 +854,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         // Act
         await _projectManager.UpdateAsync(updater =>
         {
-            updater.DocumentAdded(s_hostProject.Key, s_documents[0], null!);
+            updater.DocumentAdded(s_hostProject.Key, s_documents[0], s_documents[0].CreateEmptyTextLoader());
         });
 
         // Assert

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/ProjectSnapshotManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/ProjectSnapshotManagerTest.cs
@@ -230,7 +230,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         var document = project.GetDocument(documentFilePath);
         Assert.NotNull(document);
 
-        var text = await document.GetTextAsync();
+        var text = await document.GetTextAsync(DisposalToken);
         Assert.Equal(0, text.Length);
     }
 
@@ -257,7 +257,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         var document = project.GetDocument(documentFilePath);
         Assert.NotNull(document);
 
-        var actual = await document.GetTextAsync();
+        var actual = await document.GetTextAsync(DisposalToken);
         Assert.Same(expected, actual);
     }
 
@@ -465,7 +465,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         var project = _projectManager.GetLoadedProject(s_hostProject.Key);
         var document = project.GetDocument(s_documents[0].FilePath);
         Assert.NotNull(document);
-        var text = await document.GetTextAsync();
+        var text = await document.GetTextAsync(DisposalToken);
         Assert.Same(_sourceText, text);
 
         Assert.True(_projectManager.IsDocumentOpen(s_documents[0].FilePath));
@@ -504,7 +504,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         var project = _projectManager.GetLoadedProject(s_hostProject.Key);
         var document = project.GetDocument(s_documents[0].FilePath);
         Assert.NotNull(document);
-        var text = await document.GetTextAsync();
+        var text = await document.GetTextAsync(DisposalToken);
         Assert.Same(expected, text);
         Assert.False(_projectManager.IsDocumentOpen(s_documents[0].FilePath));
         Assert.Equal(3, document.Version);
@@ -538,7 +538,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         var project = _projectManager.GetLoadedProject(s_hostProject.Key);
         var document = project.GetDocument(s_documents[0].FilePath);
         Assert.NotNull(document);
-        var text = await document.GetTextAsync();
+        var text = await document.GetTextAsync(DisposalToken);
         Assert.Same(expected, text);
     }
 
@@ -570,7 +570,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         var project = _projectManager.GetLoadedProject(s_hostProject.Key);
         var document = project.GetDocument(s_documents[0].FilePath);
         Assert.NotNull(document);
-        var text = await document.GetTextAsync();
+        var text = await document.GetTextAsync(DisposalToken);
         Assert.Same(expected, text);
         Assert.Equal(3, document.Version);
     }
@@ -604,7 +604,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         var project = _projectManager.GetLoadedProject(s_hostProject.Key);
         var document = project.GetDocument(s_documents[0].FilePath);
         Assert.NotNull(document);
-        var text = await document.GetTextAsync();
+        var text = await document.GetTextAsync(DisposalToken);
         Assert.Same(expected, text);
         Assert.Equal(3, document.Version);
     }


### PR DESCRIPTION
This pull request builds on my last one (https://github.com/dotnet/razor/pull/10995), continuing to make improvements to `IDocumentSnapshot`. The key change is that all of the `Task`-returning methods on `IDocumentSnapshot` now return `ValueTask` and take `CancellationTokens`. I've touched a lot of code to thread `CancellationTokens` everywhere, but it's mostly very mechanical.

There is almost certainly another pull request coming at some point after this one. Next on my list is to tackle the dreaded `ComputedStateTracker`. I've long suspected that most the complexity in that class can just be deleted, and I intend to dig into that soon.