### PR TITLE
Fix nullability to match specification

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/DefinitionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/DefinitionEndpoint.cs
@@ -14,10 +14,10 @@ using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
-using DefinitionResult = Microsoft.VisualStudio.LanguageServer.Protocol.SumType<
+using DefinitionResult = System.Nullable<Microsoft.VisualStudio.LanguageServer.Protocol.SumType<
     Microsoft.VisualStudio.LanguageServer.Protocol.Location,
     Microsoft.VisualStudio.LanguageServer.Protocol.Location[],
-    Microsoft.VisualStudio.LanguageServer.Protocol.DocumentLink[]>;
+    Microsoft.VisualStudio.LanguageServer.Protocol.DocumentLink[]>>;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition;
 
@@ -29,7 +29,7 @@ internal sealed class DefinitionEndpoint(
     LanguageServerFeatureOptions languageServerFeatureOptions,
     IClientConnection clientConnection,
     ILoggerFactory loggerFactory)
-    : AbstractRazorDelegatingEndpoint<TextDocumentPositionParams, DefinitionResult?>(
+    : AbstractRazorDelegatingEndpoint<TextDocumentPositionParams, DefinitionResult>(
         languageServerFeatureOptions,
         documentMappingService,
         clientConnection,
@@ -50,7 +50,7 @@ internal sealed class DefinitionEndpoint(
         serverCapabilities.DefinitionProvider = new DefinitionOptions();
     }
 
-    protected async override Task<DefinitionResult?> TryHandleAsync(
+    protected async override Task<DefinitionResult> TryHandleAsync(
         TextDocumentPositionParams request,
         RazorRequestContext requestContext,
         DocumentPositionInfo positionInfo,
@@ -88,17 +88,19 @@ internal sealed class DefinitionEndpoint(
             positionInfo.LanguageKind));
     }
 
-    protected async override Task<DefinitionResult?> HandleDelegatedResponseAsync(
-        DefinitionResult? response,
+    protected async override Task<DefinitionResult> HandleDelegatedResponseAsync(
+        DefinitionResult response,
         TextDocumentPositionParams originalRequest,
         RazorRequestContext requestContext,
         DocumentPositionInfo positionInfo,
         CancellationToken cancellationToken)
     {
-        if (response is not DefinitionResult result)
+        if (response is null)
         {
             return null;
         }
+
+        var result = response.Value;
 
         if (result.TryGetFirst(out var location))
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/DefinitionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/DefinitionEndpoint.cs
@@ -95,25 +95,21 @@ internal sealed class DefinitionEndpoint(
         DocumentPositionInfo positionInfo,
         CancellationToken cancellationToken)
     {
-        if (response is null)
-        {
-            return null;
-        }
+        var result = response.GetValueOrDefault().Value;
 
-        var result = response.Value;
-
-        if (result.TryGetFirst(out var location))
+        // Not using .TryGetXXX because this does the null check for us too
+        if (result is Location location)
         {
             (location.Uri, location.Range) = await _documentMappingService.MapToHostDocumentUriAndRangeAsync(location.Uri, location.Range, cancellationToken).ConfigureAwait(false);
         }
-        else if (result.TryGetSecond(out var locations))
+        else if (result is Location[] locations)
         {
             foreach (var loc in locations)
             {
                 (loc.Uri, loc.Range) = await _documentMappingService.MapToHostDocumentUriAndRangeAsync(loc.Uri, loc.Range, cancellationToken).ConfigureAwait(false);
             }
         }
-        else if (result.TryGetThird(out var links))
+        else if (result is DocumentLink[] links)
         {
             foreach (var link in links)
             {
@@ -124,6 +120,6 @@ internal sealed class DefinitionEndpoint(
             }
         }
 
-        return result;
+        return response;
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/FindAllReferences/FindAllReferencesEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/FindAllReferences/FindAllReferencesEndpoint.cs
@@ -20,7 +20,7 @@ using Microsoft.VisualStudio.Text.Adornments;
 namespace Microsoft.AspNetCore.Razor.LanguageServer.FindAllReferences;
 
 [RazorLanguageServerEndpoint(Methods.TextDocumentReferencesName)]
-internal sealed class FindAllReferencesEndpoint : AbstractRazorDelegatingEndpoint<ReferenceParams, VSInternalReferenceItem[]>, ICapabilitiesProvider
+internal sealed class FindAllReferencesEndpoint : AbstractRazorDelegatingEndpoint<ReferenceParams, VSInternalReferenceItem[]?>, ICapabilitiesProvider
 {
     private readonly IFilePathService _filePathService;
     private readonly IDocumentMappingService _documentMappingService;
@@ -72,8 +72,18 @@ internal sealed class FindAllReferencesEndpoint : AbstractRazorDelegatingEndpoin
             positionInfo.LanguageKind));
     }
 
-    protected override async Task<VSInternalReferenceItem[]> HandleDelegatedResponseAsync(VSInternalReferenceItem[] delegatedResponse, ReferenceParams originalRequest, RazorRequestContext requestContext, DocumentPositionInfo positionInfo, CancellationToken cancellationToken)
+    protected override async Task<VSInternalReferenceItem[]?> HandleDelegatedResponseAsync(
+        VSInternalReferenceItem[]? delegatedResponse,
+        ReferenceParams originalRequest,
+        RazorRequestContext requestContext,
+        DocumentPositionInfo positionInfo,
+        CancellationToken cancellationToken)
     {
+        if (delegatedResponse is null)
+        {
+            return null;
+        }
+
         using var remappedLocations = new PooledArrayBuilder<VSInternalReferenceItem>();
 
         foreach (var referenceItem in delegatedResponse)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Implementation/ImplementationEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Implementation/ImplementationEndpoint.cs
@@ -60,15 +60,10 @@ internal sealed class ImplementationEndpoint : AbstractRazorDelegatingEndpoint<T
 
     protected async override Task<ImplementationResult> HandleDelegatedResponseAsync(ImplementationResult delegatedResponse, TextDocumentPositionParams request, RazorRequestContext requestContext, DocumentPositionInfo positionInfo, CancellationToken cancellationToken)
     {
-        if (!delegatedResponse.HasValue)
-        {
-            return null;
-        }
-
-        var result = delegatedResponse.Value;
+        var result = delegatedResponse.GetValueOrDefault().Value;
 
         // Not using .TryGetXXX because this does the null check for us too
-        if (result.Value is Location[] locations)
+        if (result is Location[] locations)
         {
             foreach (var loc in locations)
             {
@@ -77,7 +72,7 @@ internal sealed class ImplementationEndpoint : AbstractRazorDelegatingEndpoint<T
 
             return locations;
         }
-        else if (result.Value is VSInternalReferenceItem[] referenceItems)
+        else if (result is VSInternalReferenceItem[] referenceItems)
         {
             foreach (var item in referenceItems)
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Implementation/ImplementationEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Implementation/ImplementationEndpoint.cs
@@ -12,9 +12,9 @@ using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
-using ImplementationResult = Microsoft.VisualStudio.LanguageServer.Protocol.SumType<
+using ImplementationResult = System.Nullable<Microsoft.VisualStudio.LanguageServer.Protocol.SumType<
     Microsoft.VisualStudio.LanguageServer.Protocol.Location[],
-    Microsoft.VisualStudio.LanguageServer.Protocol.VSInternalReferenceItem[]>;
+    Microsoft.VisualStudio.LanguageServer.Protocol.VSInternalReferenceItem[]>>;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Implementation;
 
@@ -60,8 +60,15 @@ internal sealed class ImplementationEndpoint : AbstractRazorDelegatingEndpoint<T
 
     protected async override Task<ImplementationResult> HandleDelegatedResponseAsync(ImplementationResult delegatedResponse, TextDocumentPositionParams request, RazorRequestContext requestContext, DocumentPositionInfo positionInfo, CancellationToken cancellationToken)
     {
+        if (!delegatedResponse.HasValue)
+        {
+            return null;
+        }
+
+        var result = delegatedResponse.Value;
+
         // Not using .TryGetXXX because this does the null check for us too
-        if (delegatedResponse.Value is Location[] locations)
+        if (result.Value is Location[] locations)
         {
             foreach (var loc in locations)
             {
@@ -70,7 +77,7 @@ internal sealed class ImplementationEndpoint : AbstractRazorDelegatingEndpoint<T
 
             return locations;
         }
-        else if (delegatedResponse.Value is VSInternalReferenceItem[] referenceItems)
+        else if (result.Value is VSInternalReferenceItem[] referenceItems)
         {
             foreach (var item in referenceItems)
             {
@@ -80,6 +87,6 @@ internal sealed class ImplementationEndpoint : AbstractRazorDelegatingEndpoint<T
             return referenceItems;
         }
 
-        return default;
+        return null;
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Implementation/ImplementationEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Implementation/ImplementationEndpointTest.cs
@@ -112,8 +112,8 @@ public class ImplementationEndpointTest(ITestOutputHelper testOutput) : SingleSe
         var result = await endpoint.HandleRequestAsync(request, requestContext, DisposalToken);
 
         // Assert
-        Assert.NotNull(result.First);
-        var locations = result.First;
+        Assert.NotNull(result.Value.First);
+        var locations = result.Value.First;
 
         Assert.Equal(expectedSpans.Length, locations.Length);
 


### PR DESCRIPTION
Using SumType doesn't directly allow CLaSP to correctly do a null check via `is null`. This fixes it so that places that allow null use `Nullable<T>` or specificy that the non-value type can be null. Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2136054/
