### PR TITLE
Avoid referencing a test assembly in compilation

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/CodeGenerationIntegrationTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/CodeGenerationIntegrationTest.cs
@@ -10,6 +10,8 @@ using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Mvc.Razor.Extensions;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 
 namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests;
@@ -22,8 +24,15 @@ public class CodeGenerationIntegrationTest : IntegrationTestBase
         : base(layer: TestProject.Layer.Compiler)
     {
         this.designTime = designTime;
-        BaseCompilation = BaseCompilation.AddReferences(
-            MetadataReference.CreateFromFile(typeof(TestTagHelperDescriptors).Assembly.Location));
+        var testTagHelpers = CSharpCompilation.Create(
+            assemblyName: "Microsoft.AspNetCore.Razor.Language.Test",
+            syntaxTrees:
+            [
+                CSharpSyntaxTree.ParseText(TestTagHelperDescriptors.Code),
+            ],
+            references: ReferenceUtil.AspNetLatestAll,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        BaseCompilation = BaseCompilation.AddReferences(testTagHelpers.VerifyDiagnostics().EmitToImageReference());
     }
 
     [IntegrationTestFact]

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/TestTagHelperDescriptors.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/TestTagHelperDescriptors.cs
@@ -215,7 +215,7 @@ public class TestTagHelperDescriptors
                             .Name("catch-all")
                             .Metadata(PropertyName("CatchAll"))
                             .AsEnum()
-                            .TypeName($"{typeof(TestTagHelperDescriptors).FullName}.{nameof(MyEnum)}"),
+                            .TypeName("Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestTagHelperDescriptors.MyEnum"),
                     }),
                 CreateTagHelperDescriptor(
                     tagName: "input",
@@ -227,7 +227,7 @@ public class TestTagHelperDescriptors
                             .Name("value")
                             .Metadata(PropertyName("Value"))
                             .AsEnum()
-                            .TypeName($"{typeof(TestTagHelperDescriptors).FullName}.{nameof(MyEnum)}"),
+                            .TypeName("Microsoft.AspNetCore.Razor.Language.IntegrationTests.TestTagHelperDescriptors.MyEnum"),
                     }),
             };
         }
@@ -644,9 +644,17 @@ public class TestTagHelperDescriptors
         public string BoundProperty { get; set; }
     }
 
-    public enum MyEnum
-    {
-        MyValue,
-        MySecondValue
-    }
+    public static readonly string Code = """
+        namespace Microsoft.AspNetCore.Razor.Language.IntegrationTests
+        {
+            public class TestTagHelperDescriptors
+            {
+                public enum MyEnum
+                {
+                    MyValue,
+                    MySecondValue
+                }
+            }
+        }
+        """;
 }


### PR DESCRIPTION
- Related to https://github.com/dotnet/razor/issues/10343.
- Extracted out of https://github.com/dotnet/razor/pull/11000.