### PR TITLE
Update source-build team references

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,8 @@
 /eng/common/                                   @dotnet/razor-tooling @dotnet/razor-compiler
 /eng/Versions.props                            @dotnet/razor-tooling @dotnet/razor-compiler
 /eng/Version.Details.xml                       @dotnet/razor-tooling @dotnet/razor-compiler
-/eng/SourceBuild*                              @dotnet/source-build-internal
+/eng/DotNetBuild.props                         @dotnet/product-construction
+/eng/SourceBuild*                              @dotnet/source-build
 /src/Razor                                     @dotnet/razor-tooling
 /src/Compiler                                  @dotnet/razor-compiler
 /src/Shared                                    @dotnet/razor-tooling @dotnet/razor-compiler

--- a/eng/DotNetBuild.props
+++ b/eng/DotNetBuild.props
@@ -1,4 +1,4 @@
-﻿<!-- Whenever altering this or other Source Build files, please include @dotnet/source-build-internal as a reviewer. -->
+﻿<!-- When altering this file, include @dotnet/product-construction as a reviewer. -->
 
 <Project>
   <PropertyGroup>

--- a/eng/SourceBuildPrebuiltBaseline.xml
+++ b/eng/SourceBuildPrebuiltBaseline.xml
@@ -1,4 +1,4 @@
-﻿<!-- Whenever altering this or other Source Build files, please include @dotnet/source-build-internal as a reviewer. -->
+﻿<!-- When altering this file or making other Source Build related changes, include @dotnet/source-build as a reviewer. -->
 <!-- See aka.ms/dotnet/prebuilts for guidance on what pre-builts are and how to eliminate them. -->
 
 <UsageData>


### PR DESCRIPTION
The @dotnet/source-build-internal team is being deprecated. All references to it were updated.

Included the renaming of SourceBuild.props to the new naming convention, DotNetBuild.props.

Related to dotnet/source-build#4645

Repo admins, please grant @dotnet/product-construction and @dotnet/source-build write access. You can remove access granted to @dotnet/source-build-internal.