### PR TITLE
Handle EditorRequired *Changed/*Expression parameters

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentCodeGenerationTestBase.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentCodeGenerationTestBase.cs
@@ -1170,6 +1170,41 @@ namespace Test
             Diagnostic("RZ2012").WithLocation(1, 1));
     }
 
+    [IntegrationTestFact, WorkItem("https://github.com/dotnet/razor/issues/10553")]
+    public void Component_WithEditorRequiredParameter_ValueSpecified_ExpressionRequired()
+    {
+        AdditionalSyntaxTrees.Add(Parse("""
+            using System;
+            using System.Linq.Expressions;
+            using Microsoft.AspNetCore.Components;
+
+            namespace Test;
+
+            public class ComponentWithEditorRequiredParameters : ComponentBase
+            {
+                [Parameter, EditorRequired]
+                public bool Property1 { get; set; }
+
+                [Parameter, EditorRequired]
+                public EventCallback<bool> Property1Changed { get; set; }
+
+                [Parameter, EditorRequired]
+                public Expression<Func<bool>> Property1Expression { get; set; }
+            }
+            """));
+
+        var generated = CompileToCSharp("""
+            <ComponentWithEditorRequiredParameters Property1="false" />
+            """);
+
+        CompileToAssembly(generated);
+        generated.RazorDiagnostics.Verify(
+            // x:\dir\subdir\Test\TestComponent.cshtml(1,1): warning RZ2012: Component 'ComponentWithEditorRequiredParameters' expects a value for the parameter 'Property1Changed', but a value may not have been provided.
+            Diagnostic("RZ2012").WithLocation(1, 1),
+            // x:\dir\subdir\Test\TestComponent.cshtml(1,1): warning RZ2012: Component 'ComponentWithEditorRequiredParameters' expects a value for the parameter 'Property1Expression', but a value may not have been provided.
+            Diagnostic("RZ2012").WithLocation(1, 1));
+    }
+
     [IntegrationTestFact]
     public void Component_WithEditorRequiredParameter_ValueSpecified_DifferentCasing()
     {
@@ -1277,6 +1312,41 @@ namespace Test
         generated.RazorDiagnostics.Verify();
     }
 
+    [IntegrationTestFact, WorkItem("https://github.com/dotnet/razor/issues/10553")]
+    public void Component_WithEditorRequiredParameter_ValueSpecifiedUsingBind_ExpressionRequired()
+    {
+        AdditionalSyntaxTrees.Add(Parse("""
+            using System;
+            using System.Linq.Expressions;
+            using Microsoft.AspNetCore.Components;
+
+            namespace Test;
+
+            public class ComponentWithEditorRequiredParameters : ComponentBase
+            {
+                [Parameter, EditorRequired]
+                public string Property1 { get; set; }
+
+                [Parameter, EditorRequired]
+                public EventCallback<string> Property1Changed { get; set; }
+
+                [Parameter, EditorRequired]
+                public Expression<Func<string>> Property1Expression { get; set; }
+            }
+            """));
+
+        var generated = CompileToCSharp("""
+            <ComponentWithEditorRequiredParameters @bind-Property1="myField" />
+
+            @code {
+                private string myField = "Some Value";
+            }
+            """);
+
+        CompileToAssembly(generated);
+        generated.RazorDiagnostics.Verify();
+    }
+
     [IntegrationTestFact]
     public void Component_WithEditorRequiredParameter_ValueSpecifiedUsingBind_DifferentCasing()
     {
@@ -1339,9 +1409,45 @@ namespace Test
             {
                 [Parameter, EditorRequired]
                 public string Property1 { get; set; }
-            
+
                 [Parameter, EditorRequired]
                 public EventCallback<string> Property1Changed { get; set; }
+            }
+            """));
+
+        var generated = CompileToCSharp("""
+            <ComponentWithEditorRequiredParameters @bind-Property1:get="myField" @bind-Property1:set="OnFieldChanged" />
+
+            @code {
+                private string myField = "Some Value";
+                private void OnFieldChanged(string value) { }
+            }
+            """);
+
+        CompileToAssembly(generated);
+        generated.RazorDiagnostics.Verify();
+    }
+
+    [IntegrationTestFact, WorkItem("https://github.com/dotnet/razor/issues/10553")]
+    public void Component_WithEditorRequiredParameter_ValueSpecifiedUsingBindGetSet_ExpressionRequired()
+    {
+        AdditionalSyntaxTrees.Add(Parse("""
+            using System;
+            using System.Linq.Expressions;
+            using Microsoft.AspNetCore.Components;
+
+            namespace Test;
+
+            public class ComponentWithEditorRequiredParameters : ComponentBase
+            {
+                [Parameter, EditorRequired]
+                public string Property1 { get; set; }
+
+                [Parameter, EditorRequired]
+                public EventCallback<string> Property1Changed { get; set; }
+
+                [Parameter, EditorRequired]
+                public Expression<Func<string>> Property1Expression { get; set; }
             }
             """));
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentCodeGenerationTestBase.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentCodeGenerationTestBase.cs
@@ -1141,6 +1141,35 @@ namespace Test
         Assert.Empty(generated.RazorDiagnostics);
     }
 
+    [IntegrationTestFact, WorkItem("https://github.com/dotnet/razor/issues/10553")]
+    public void Component_WithEditorRequiredParameter_ValueSpecified_EventCallbackRequired()
+    {
+        AdditionalSyntaxTrees.Add(Parse("""
+            using System;
+            using Microsoft.AspNetCore.Components;
+
+            namespace Test;
+
+            public class ComponentWithEditorRequiredParameters : ComponentBase
+            {
+                [Parameter, EditorRequired]
+                public bool Property1 { get; set; }
+
+                [Parameter, EditorRequired]
+                public EventCallback<bool> Property1Changed { get; set; }
+            }
+            """));
+
+        var generated = CompileToCSharp("""
+            <ComponentWithEditorRequiredParameters Property1="false" />
+            """);
+
+        CompileToAssembly(generated);
+        generated.RazorDiagnostics.Verify(
+            // x:\dir\subdir\Test\TestComponent.cshtml(1,1): warning RZ2012: Component 'ComponentWithEditorRequiredParameters' expects a value for the parameter 'Property1Changed', but a value may not have been provided.
+            Diagnostic("RZ2012").WithLocation(1, 1));
+    }
+
     [IntegrationTestFact]
     public void Component_WithEditorRequiredParameter_ValueSpecified_DifferentCasing()
     {
@@ -1217,6 +1246,37 @@ namespace Test
         Assert.Empty(generated.RazorDiagnostics);
     }
 
+    [IntegrationTestFact, WorkItem("https://github.com/dotnet/razor/issues/10553")]
+    public void Component_WithEditorRequiredParameter_ValueSpecifiedUsingBind_EventCallbackRequired()
+    {
+        AdditionalSyntaxTrees.Add(Parse("""
+            using System;
+            using Microsoft.AspNetCore.Components;
+
+            namespace Test;
+
+            public class ComponentWithEditorRequiredParameters : ComponentBase
+            {
+                [Parameter, EditorRequired]
+                public string Property1 { get; set; }
+
+                [Parameter, EditorRequired]
+                public EventCallback<string> Property1Changed { get; set; }
+            }
+            """));
+
+        var generated = CompileToCSharp("""
+            <ComponentWithEditorRequiredParameters @bind-Property1="myField" />
+
+            @code {
+                private string myField = "Some Value";
+            }
+            """);
+
+        CompileToAssembly(generated);
+        generated.RazorDiagnostics.Verify();
+    }
+
     [IntegrationTestFact]
     public void Component_WithEditorRequiredParameter_ValueSpecifiedUsingBind_DifferentCasing()
     {
@@ -1264,6 +1324,38 @@ namespace Test
 
         CompileToAssembly(generated);
         Assert.Empty(generated.RazorDiagnostics);
+    }
+
+    [IntegrationTestFact, WorkItem("https://github.com/dotnet/razor/issues/10553")]
+    public void Component_WithEditorRequiredParameter_ValueSpecifiedUsingBindGetSet_EventCallbackRequired()
+    {
+        AdditionalSyntaxTrees.Add(Parse("""
+            using System;
+            using Microsoft.AspNetCore.Components;
+
+            namespace Test;
+
+            public class ComponentWithEditorRequiredParameters : ComponentBase
+            {
+                [Parameter, EditorRequired]
+                public string Property1 { get; set; }
+            
+                [Parameter, EditorRequired]
+                public EventCallback<string> Property1Changed { get; set; }
+            }
+            """));
+
+        var generated = CompileToCSharp("""
+            <ComponentWithEditorRequiredParameters @bind-Property1:get="myField" @bind-Property1:set="OnFieldChanged" />
+
+            @code {
+                private string myField = "Some Value";
+                private void OnFieldChanged(string value) { }
+            }
+            """);
+
+        CompileToAssembly(generated);
+        generated.RazorDiagnostics.Verify();
     }
 
     [IntegrationTestFact, WorkItem("https://github.com/dotnet/razor/issues/10553")]

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentLoweringPass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentLoweringPass.cs
@@ -203,13 +203,13 @@ internal class ComponentLoweringPass : ComponentIntermediateNodePassBase, IRazor
                 const string bindPrefix = "@bind-";
                 if (child is TagHelperDirectiveAttributeIntermediateNode { OriginalAttributeName: { } originalAttributeName } &&
                     originalAttributeName.StartsWith(bindPrefix, StringComparison.Ordinal) &&
-                    originalAttributeName.AsSpan(start: bindPrefix.Length).Equals(attributeName.AsSpan(), StringComparison.Ordinal))
+                    EqualsWithOptionalChangedSuffix(originalAttributeName.AsSpan(start: bindPrefix.Length), attributeName))
                 {
                     return true;
                 }
                 if (child is TagHelperDirectiveAttributeParameterIntermediateNode { OriginalAttributeName: { } originalName, AttributeNameWithoutParameter: { } nameWithoutParameter } &&
                     originalName.StartsWith(bindPrefix, StringComparison.Ordinal) &&
-                    nameWithoutParameter.AsSpan(start: bindPrefix.Length - 1).Equals(attributeName.AsSpan(), StringComparison.Ordinal))
+                    EqualsWithOptionalChangedSuffix(nameWithoutParameter.AsSpan(start: bindPrefix.Length - 1), attributeName))
                 {
                     // `@bind-Value:get` or `@bind-Value:set` is specified.
                     return true;
@@ -217,6 +217,16 @@ internal class ComponentLoweringPass : ComponentIntermediateNodePassBase, IRazor
             }
 
             return false;
+        }
+
+        // True if `specifiedName` is equal to `requiredName` or to `requiredName + "Changed"`.
+        static bool EqualsWithOptionalChangedSuffix(ReadOnlySpan<char> specifiedName, string requiredName)
+        {
+            const string changedSuffix = "Changed";
+            var requiredNameSpan = requiredName.AsSpan();
+            return requiredNameSpan.EndsWith(changedSuffix.AsSpan(), StringComparison.Ordinal)
+                ? specifiedName.Equals(requiredNameSpan[..^changedSuffix.Length], StringComparison.Ordinal)
+                : specifiedName.Equals(requiredNameSpan, StringComparison.Ordinal);
         }
     }
 


### PR DESCRIPTION
Fixes part of https://github.com/dotnet/razor/issues/10553 missed previously - when the `ValueChanged` or `ValueExpression` property is `[EditorRequired]`.