### PR TITLE
Avoid ambiguous `object` reference in generic component recovery

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentCodeGenerationTestBase.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentCodeGenerationTestBase.cs
@@ -9002,6 +9002,29 @@ namespace Test
         CompileToAssembly(generated);
     }
 
+    [IntegrationTestFact]
+    public void GenericComponent_MissingTypeParameter_SystemInNamespace()
+    {
+        // Arrange
+        AdditionalSyntaxTrees.Add(Parse("""
+            using Microsoft.AspNetCore.Components;
+            namespace Test;
+            public class MyComponent<TItem> : ComponentBase;
+            """));
+
+        // Act
+        var generated = CompileToCSharp("""
+            @namespace Test.System
+            <MyComponent />
+            """);
+
+        // Assert
+        CompileToAssembly(generated);
+        generated.RazorDiagnostics.Verify(
+            // x:\dir\subdir\Test\TestComponent.cshtml(2,1): error RZ10001: The type of component 'MyComponent' cannot be inferred based on the values provided. Consider specifying the type arguments directly using the following attributes: 'TItem'.
+            Diagnostic("RZ10001").WithLocation(2, 1));
+    }
+
     [IntegrationTestFact, WorkItem("https://github.com/dotnet/razor/issues/10827")]
     public void GenericTypeCheck()
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/CascadingGenericInference_NotCascaded_CreatesError/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/CascadingGenericInference_NotCascaded_CreatesError/TestComponent.codegen.cs
@@ -77,9 +77,9 @@ namespace __Blazor.Test.TestComponent
         __builder.CloseComponent();
         return default;
         }
-        public static global::Test.Column<System.Object> CreateColumn_1<TItem>(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder, int seq)
+        public static global::Test.Column<object> CreateColumn_1<TItem>(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder, int seq)
         {
-        __builder.OpenComponent<global::Test.Column<System.Object>>(seq);
+        __builder.OpenComponent<global::Test.Column<object>>(seq);
         __builder.CloseComponent();
         return default;
         }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/CascadingGenericInference_NotCascaded_Explicit/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/CascadingGenericInference_NotCascaded_Explicit/TestComponent.codegen.cs
@@ -79,9 +79,9 @@ namespace __Blazor.Test.TestComponent
     #line hidden
     internal static class TypeInference
     {
-        public static global::Test.Column<System.Object> CreateColumn_0<TItem>(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder, int seq)
+        public static global::Test.Column<object> CreateColumn_0<TItem>(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder, int seq)
         {
-        __builder.OpenComponent<global::Test.Column<System.Object>>(seq);
+        __builder.OpenComponent<global::Test.Column<object>>(seq);
         __builder.CloseComponent();
         return default;
         }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/CascadingGenericInference_WithUnrelatedType_CreatesError/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/CascadingGenericInference_WithUnrelatedType_CreatesError/TestComponent.codegen.cs
@@ -85,9 +85,9 @@ namespace __Blazor.Test.TestComponent
         {
             __arg0_out = __arg0;
         }
-        public static global::Test.Column<System.Object> CreateColumn_1<TItem>(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder, int seq)
+        public static global::Test.Column<object> CreateColumn_1<TItem>(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder, int seq)
         {
-        __builder.OpenComponent<global::Test.Column<System.Object>>(seq);
+        __builder.OpenComponent<global::Test.Column<object>>(seq);
         __builder.CloseComponent();
         return default;
         }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallbackOfT_GenericComponent_MissingTypeParameterBinding_01/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallbackOfT_GenericComponent_MissingTypeParameterBinding_01/TestComponent.codegen.cs
@@ -48,9 +48,9 @@ namespace __Blazor.Test.TestComponent
     #line hidden
     internal static class TypeInference
     {
-        public static global::Test.MyComponent<T, System.Object> CreateMyComponent_0<T, T2>(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder, int seq, int __seq0, global::Microsoft.AspNetCore.Components.EventCallback<T> __arg0)
+        public static global::Test.MyComponent<T, object> CreateMyComponent_0<T, T2>(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder, int seq, int __seq0, global::Microsoft.AspNetCore.Components.EventCallback<T> __arg0)
         {
-        __builder.OpenComponent<global::Test.MyComponent<T, System.Object>>(seq);
+        __builder.OpenComponent<global::Test.MyComponent<T, object>>(seq);
         __builder.AddAttribute(__seq0, "OnClick", (object)__arg0);
         __builder.CloseComponent();
         return default;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallbackOfT_GenericComponent_MissingTypeParameterBinding_02/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentDesignTimeCodeGenerationTest/EventCallbackOfT_GenericComponent_MissingTypeParameterBinding_02/TestComponent.codegen.cs
@@ -48,9 +48,9 @@ namespace __Blazor.Test.TestComponent
     #line hidden
     internal static class TypeInference
     {
-        public static global::Test.MyComponent<System.Object, System.Object> CreateMyComponent_0<T, T2>(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder, int seq, int __seq0, global::System.Object __arg0)
+        public static global::Test.MyComponent<object, object> CreateMyComponent_0<T, T2>(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder, int seq, int __seq0, global::System.Object __arg0)
         {
-        __builder.OpenComponent<global::Test.MyComponent<System.Object, System.Object>>(seq);
+        __builder.OpenComponent<global::Test.MyComponent<object, object>>(seq);
         __builder.AddAttribute(__seq0, "OnClick", (object)__arg0);
         __builder.CloseComponent();
         return default;

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_NotCascaded_CreatesError/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_NotCascaded_CreatesError/TestComponent.codegen.cs
@@ -54,7 +54,7 @@ Items
         }
         public static void CreateColumn_1<TItem>(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder, int seq)
         {
-        __builder.OpenComponent<global::Test.Column<System.Object>>(seq);
+        __builder.OpenComponent<global::Test.Column<object>>(seq);
         __builder.CloseComponent();
         }
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_NotCascaded_Explicit/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_NotCascaded_Explicit/TestComponent.codegen.cs
@@ -50,7 +50,7 @@ namespace __Blazor.Test.TestComponent
     {
         public static void CreateColumn_0<TItem>(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder, int seq)
         {
-        __builder.OpenComponent<global::Test.Column<System.Object>>(seq);
+        __builder.OpenComponent<global::Test.Column<object>>(seq);
         __builder.CloseComponent();
         }
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_WithUnrelatedType_CreatesError/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_WithUnrelatedType_CreatesError/TestComponent.codegen.cs
@@ -63,7 +63,7 @@ Items
         }
         public static void CreateColumn_1<TItem>(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder, int seq)
         {
-        __builder.OpenComponent<global::Test.Column<System.Object>>(seq);
+        __builder.OpenComponent<global::Test.Column<object>>(seq);
         __builder.CloseComponent();
         }
     }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallbackOfT_GenericComponent_MissingTypeParameterBinding_01/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallbackOfT_GenericComponent_MissingTypeParameterBinding_01/TestComponent.codegen.cs
@@ -37,8 +37,8 @@ namespace __Blazor.Test.TestComponent
     {
         public static void CreateMyComponent_0<T, T2>(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder, int seq, int __seq0, global::Microsoft.AspNetCore.Components.EventCallback<T> __arg0)
         {
-        __builder.OpenComponent<global::Test.MyComponent<T, System.Object>>(seq);
-        __builder.AddComponentParameter(__seq0, nameof(global::Test.MyComponent<T, System.Object>.
+        __builder.OpenComponent<global::Test.MyComponent<T, object>>(seq);
+        __builder.AddComponentParameter(__seq0, nameof(global::Test.MyComponent<T, object>.
 #nullable restore
 #line (1,14)-(1,21) "x:\dir\subdir\Test\TestComponent.cshtml"
 OnClick

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallbackOfT_GenericComponent_MissingTypeParameterBinding_01/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallbackOfT_GenericComponent_MissingTypeParameterBinding_01/TestComponent.mappings.txt
@@ -9,6 +9,6 @@ Generated Location: (783:23,0 [28] )
 
 Source Location: (13:0,13 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |OnClick|
-Generated Location: (1477:43,0 [7] )
+Generated Location: (1463:43,0 [7] )
 |OnClick|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallbackOfT_GenericComponent_MissingTypeParameterBinding_02/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/EventCallbackOfT_GenericComponent_MissingTypeParameterBinding_02/TestComponent.codegen.cs
@@ -37,7 +37,7 @@ namespace __Blazor.Test.TestComponent
     {
         public static void CreateMyComponent_0<T, T2>(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder, int seq, int __seq0, global::System.Object __arg0)
         {
-        __builder.OpenComponent<global::Test.MyComponent<System.Object, System.Object>>(seq);
+        __builder.OpenComponent<global::Test.MyComponent<object, object>>(seq);
         __builder.AddComponentParameter(__seq0, "OnClick", __arg0);
         __builder.CloseComponent();
         }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/CSharp/GenericTypeNameRewriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/CSharp/GenericTypeNameRewriter.cs
@@ -48,7 +48,7 @@ internal class GenericTypeNameRewriter : TypeNameRewriter
                     // compared to leaving the type parameter in place.
                     //
                     // We add our own diagnostics for missing/invalid type parameters anyway.
-                    var replacement = binding == null ? typeof(object).FullName : binding;
+                    var replacement = binding ?? "object";
                     return identifier.Update(SyntaxFactory.Identifier(replacement).WithTriviaFrom(identifier.Identifier));
                 }
             }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor/test/GenericTypeNameRewriterTest.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor/test/GenericTypeNameRewriterTest.cs
@@ -14,8 +14,8 @@ public class GenericTypeNameRewriterTest
     [Theory]
     [InlineData("TItem2", "Type2")]
 
-    // Unspecified argument -> System.Object
-    [InlineData("TItem3", "System.Object")]
+    // Unspecified argument -> object
+    [InlineData("TItem3", "object")]
 
     // Not a type parameter
     [InlineData("TItem4", "TItem4")]
@@ -24,8 +24,8 @@ public class GenericTypeNameRewriterTest
     [InlineData("TItem1.TItem2", "TItem1.TItem2")]
 
     // Type parameters can't have type parameters
-    [InlineData("TItem1.TItem2<TItem1, TItem2, TItem3>", "TItem1.TItem2<Type1, Type2, System.Object>")]
-    [InlineData("TItem2<TItem1<TItem3>, System.TItem2, RenderFragment<List<TItem1>>", "TItem2<TItem1<System.Object>, System.TItem2, RenderFragment<List<Type1>>")]
+    [InlineData("TItem1.TItem2<TItem1, TItem2, TItem3>", "TItem1.TItem2<Type1, Type2, object>")]
+    [InlineData("TItem2<TItem1<TItem3>, System.TItem2, RenderFragment<List<TItem1>>", "TItem2<TItem1<object>, System.TItem2, RenderFragment<List<Type1>>")]
 
     // Tuples
     [InlineData("List<(TItem1 X, TItem2 Y)>", "List<(Type1 X, Type2 Y)>")]


### PR DESCRIPTION
Similar to https://github.com/dotnet/razor/pull/10999, this time just an error-recovery scenario.