### PR TITLE
Fix resource string

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/TestFiles/ParserTests/CSharpSectionTest/ParserDoesNotOutputErrorOtherNestedDirectives.diag.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/TestFiles/ParserTests/CSharpSectionTest/ParserDoesNotOutputErrorOtherNestedDirectives.diag.txt
@@ -1,2 +1,2 @@
-﻿(1,17): Error RZ2005: The 'inherits` directive must appear at the start of the line.
+﻿(1,17): Error RZ2005: The 'inherits' directive must appear at the start of the line.
 (1,30): Error RZ1017: Unexpected literal following the 'inherits' directive. Expected 'line break'.

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/TestFiles/ParserTests/CSharpSectionTest/ParserOutputsErrorOnMultipleNestedSections.diag.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/TestFiles/ParserTests/CSharpSectionTest/ParserOutputsErrorOnMultipleNestedSections.diag.txt
@@ -1,4 +1,4 @@
 ﻿(1,16): Error RZ2002: Section blocks ("@section Header { ... }") cannot be nested.  Only one level of section blocks are allowed.
-(1,17): Error RZ2005: The 'section` directive must appear at the start of the line.
+(1,17): Error RZ2005: The 'section' directive must appear at the start of the line.
 (1,42): Error RZ2002: Section blocks ("@section Header { ... }") cannot be nested.  Only one level of section blocks are allowed.
-(1,43): Error RZ2005: The 'section` directive must appear at the start of the line.
+(1,43): Error RZ2005: The 'section' directive must appear at the start of the line.

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/TestFiles/ParserTests/CSharpSectionTest/ParserOutputsErrorOnNestedSections.diag.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/TestFiles/ParserTests/CSharpSectionTest/ParserOutputsErrorOnNestedSections.diag.txt
@@ -1,2 +1,2 @@
 ﻿(1,16): Error RZ2002: Section blocks ("@section Header { ... }") cannot be nested.  Only one level of section blocks are allowed.
-(1,17): Error RZ2005: The 'section` directive must appear at the start of the line.
+(1,17): Error RZ2005: The 'section' directive must appear at the start of the line.

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/TestFiles/ParserTests/HtmlToCodeSwitchTest/SectionContextGivesWhitespacePreceedingToCodeIfThereIsNoMarkupOnThatLine.diag.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/TestFiles/ParserTests/HtmlToCodeSwitchTest/SectionContextGivesWhitespacePreceedingToCodeIfThereIsNoMarkupOnThatLine.diag.txt
@@ -1,1 +1,1 @@
-﻿(1,4): Error RZ2005: The 'section` directive must appear at the start of the line.
+﻿(1,4): Error RZ2005: The 'section' directive must appear at the start of the line.

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/TestFiles/ParserTests/RazorDirectivesTest/ExtensibleDirectiveErrorsIfNotAtStartOfLine.diag.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/legacyTest/TestFiles/ParserTests/RazorDirectivesTest/ExtensibleDirectiveErrorsIfNotAtStartOfLine.diag.txt
@@ -1,1 +1,1 @@
-﻿(1,5): Error RZ2005: The 'custom` directive must appear at the start of the line.
+﻿(1,5): Error RZ2005: The 'custom' directive must appear at the start of the line.

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/ParserTests/CSharpSectionTest/ParserDoesNotOutputErrorOtherNestedDirectives.diag.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/ParserTests/CSharpSectionTest/ParserDoesNotOutputErrorOtherNestedDirectives.diag.txt
@@ -1,2 +1,2 @@
-﻿(1,17): Error RZ2005: The 'inherits` directive must appear at the start of the line.
+﻿(1,17): Error RZ2005: The 'inherits' directive must appear at the start of the line.
 (1,30): Error RZ1017: Unexpected literal following the 'inherits' directive. Expected 'line break'.

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/ParserTests/CSharpSectionTest/ParserOutputsErrorOnMultipleNestedSections.diag.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/ParserTests/CSharpSectionTest/ParserOutputsErrorOnMultipleNestedSections.diag.txt
@@ -1,4 +1,4 @@
 ﻿(1,16): Error RZ2002: Section blocks ("@section Header { ... }") cannot be nested.  Only one level of section blocks are allowed.
-(1,17): Error RZ2005: The 'section` directive must appear at the start of the line.
+(1,17): Error RZ2005: The 'section' directive must appear at the start of the line.
 (1,42): Error RZ2002: Section blocks ("@section Header { ... }") cannot be nested.  Only one level of section blocks are allowed.
-(1,43): Error RZ2005: The 'section` directive must appear at the start of the line.
+(1,43): Error RZ2005: The 'section' directive must appear at the start of the line.

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/ParserTests/CSharpSectionTest/ParserOutputsErrorOnNestedSections.diag.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/ParserTests/CSharpSectionTest/ParserOutputsErrorOnNestedSections.diag.txt
@@ -1,2 +1,2 @@
 ﻿(1,16): Error RZ2002: Section blocks ("@section Header { ... }") cannot be nested.  Only one level of section blocks are allowed.
-(1,17): Error RZ2005: The 'section` directive must appear at the start of the line.
+(1,17): Error RZ2005: The 'section' directive must appear at the start of the line.

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/ParserTests/HtmlToCodeSwitchTest/SectionContextGivesWhitespacePreceedingToCodeIfThereIsNoMarkupOnThatLine.diag.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/ParserTests/HtmlToCodeSwitchTest/SectionContextGivesWhitespacePreceedingToCodeIfThereIsNoMarkupOnThatLine.diag.txt
@@ -1,1 +1,1 @@
-﻿(1,4): Error RZ2005: The 'section` directive must appear at the start of the line.
+﻿(1,4): Error RZ2005: The 'section' directive must appear at the start of the line.

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/ParserTests/RazorDirectivesTest/ExtensibleDirectiveErrorsIfNotAtStartOfLine.diag.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/ParserTests/RazorDirectivesTest/ExtensibleDirectiveErrorsIfNotAtStartOfLine.diag.txt
@@ -1,1 +1,1 @@
-﻿(1,5): Error RZ2005: The 'custom` directive must appear at the start of the line.
+﻿(1,5): Error RZ2005: The 'custom' directive must appear at the start of the line.

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Resources.resx
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Resources.resx
@@ -195,7 +195,7 @@
     <value>The '{0}' directive expects a type name.</value>
   </data>
   <data name="DirectiveMustAppearAtStartOfLine" xml:space="preserve">
-    <value>The '{0}` directive must appear at the start of the line.</value>
+    <value>The '{0}' directive must appear at the start of the line.</value>
   </data>
   <data name="DirectiveTokensMustBeSeparatedByWhitespace" xml:space="preserve">
     <value>The '{0}' directives value(s) must be separated by whitespace.</value>


### PR DESCRIPTION
Replace a `` ` ``   with a `'` in the error message.