### PR TITLE
Add flush method and make it implementation detail on how that happens

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/ITelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/ITelemetryReporter.cs
@@ -32,4 +32,9 @@ internal interface ITelemetryReporter
     /// <param name="requestDuration">How long it took to handle the request</param>
     /// <param name="result">The result of handling the request</param>
     void ReportRequestTiming(string name, string? language, TimeSpan queuedDuration, TimeSpan requestDuration, TelemetryResult result);
+
+    /// <summary>
+    /// Flushes any current session data being collected
+    /// </summary>
+    void Flush();
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/NoOpTelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/NoOpTelemetryReporter.cs
@@ -58,4 +58,8 @@ internal class NoOpTelemetryReporter : ITelemetryReporter
     public void ReportRequestTiming(string name, string? language, TimeSpan queuedDuration, TimeSpan requestDuration, TelemetryResult result)
     {
     }
+
+    public void Flush()
+    {
+    }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Telemetry/OutOfProcessTelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Telemetry/OutOfProcessTelemetryReporter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Composition;
 using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.VisualStudio.Razor.Telemetry;
@@ -9,10 +10,10 @@ using Microsoft.VisualStudio.Telemetry;
 namespace Microsoft.CodeAnalysis.Remote.Razor.Telemetry;
 
 [Export(typeof(ITelemetryReporter)), Shared]
-internal class OutOfProcessTelemetryReporter : TelemetryReporter
+internal class OutOfProcessTelemetryReporter() : TelemetryReporter(TelemetryService.DefaultSession), IDisposable
 {
-    public OutOfProcessTelemetryReporter()
-        : base(TelemetryService.DefaultSession)
+    public void Dispose()
     {
+        Flush();
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
@@ -20,7 +20,7 @@ using System.Linq;
 
 namespace Microsoft.VisualStudio.Razor.Telemetry;
 
-internal abstract partial class TelemetryReporter : ITelemetryReporter, IDisposable
+internal abstract partial class TelemetryReporter : ITelemetryReporter
 {
     private const string CodeAnalysisNamespace = nameof(Microsoft) + "." + nameof(CodeAnalysis);
     private const string AspNetCoreNamespace = nameof(Microsoft) + "." + nameof(AspNetCore);
@@ -51,9 +51,9 @@ internal abstract partial class TelemetryReporter : ITelemetryReporter, IDisposa
     public virtual bool IsEnabled => _manager?.Session.IsOptedIn ?? false;
 #endif
 
-    public void Dispose()
+    public void Flush()
     {
-        _manager?.Dispose();
+        _manager?.Flush();
     }
 
     public void ReportEvent(string name, Severity severity)
@@ -215,7 +215,7 @@ internal abstract partial class TelemetryReporter : ITelemetryReporter, IDisposa
 
     protected void SetSession(TelemetrySession session)
     {
-        _manager?.Dispose();
+        _manager?.Flush();
         _manager = TelemetrySessionManager.Create(this, session);
     }
 
@@ -439,7 +439,7 @@ internal abstract partial class TelemetryReporter : ITelemetryReporter, IDisposa
             declaringTypeName.StartsWith(AspNetCoreNamespace) ||
             declaringTypeName.StartsWith(MicrosoftVSRazorNamespace);
 
-    private sealed class TelemetrySessionManager : IDisposable
+    private sealed class TelemetrySessionManager
     {
         /// <summary>
         /// Store request counters in a concurrent dictionary as non-mutating LSP requests can
@@ -463,11 +463,6 @@ internal abstract partial class TelemetryReporter : ITelemetryReporter, IDisposa
                 new AggregatingTelemetryLogManager(telemetryReporter));
 
         public TelemetrySession Session { get; }
-
-        public void Dispose()
-        {
-            Flush();
-        }
 
         public void Flush()
         {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/VSTelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/VSTelemetryReporter.cs
@@ -11,18 +11,14 @@ using StreamJsonRpc;
 namespace Microsoft.VisualStudio.Razor.Telemetry;
 
 [Export(typeof(ITelemetryReporter))]
-internal class VSTelemetryReporter : TelemetryReporter
+[method:ImportingConstructor]
+internal class VSTelemetryReporter(ILoggerFactory loggerFactory) : TelemetryReporter(TelemetryService.DefaultSession), IDisposable
 {
-    private readonly ILogger _logger;
+    private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<VSTelemetryReporter>();
 
-    [ImportingConstructor]
-    public VSTelemetryReporter(ILoggerFactory loggerFactory)
-        // Get the DefaultSession for telemetry. This is set by VS with
-        // TelemetryService.SetDefaultSession and provides the correct
-        // appinsights keys etc
-        : base(TelemetryService.DefaultSession)
+    public void Dispose()
     {
-        _logger = loggerFactory.GetOrCreateLogger<VSTelemetryReporter>();
+        Flush();
     }
 
     protected override bool HandleException(Exception exception, string? message, params object?[] @params)

--- a/src/Razor/src/rzls/Program.cs
+++ b/src/Razor/src/rzls/Program.cs
@@ -102,7 +102,14 @@ public class Program
 
         loggerFactory.GetOrCreateLogger("RZLS").LogInformation($"Razor Language Server started successfully.");
 
-        await host.WaitForExitAsync().ConfigureAwait(true);
+        try
+        {
+            await host.WaitForExitAsync().ConfigureAwait(true);
+        }
+        finally
+        {
+            devKitTelemetryReporter?.Flush();
+        }
     }
 
     private static async Task<ITelemetryReporter?> TryGetTelemetryReporterAsync(string telemetryLevel, string sessionId, string telemetryExtensionPath)


### PR DESCRIPTION
rzls imports telemetry by creating an ExportProvider with the path to devkit telemetry if it's installed and enabled. Unfortunately that means that dispose is being prematurely called when that provider is torn down. To help with this two things are done:

1. Make a flush method on ITelemetryReporter
2. Make when flush happens an implementation detail on the specific providers.

In this case, rzls will flush after the language server host exits. In other cases IDisposable will be used to flush telemetry (VS and OOP)
