### PR TITLE
Update project configuration from Roslyn info

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/CSharp/ParseOptionsExtensions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/CSharp/ParseOptionsExtensions.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.Razor.Compiler.CSharp;
+
+internal static class ParseOptionsExtensions
+{
+    public static bool UseRoslynTokenizer(this ParseOptions parseOptions)
+        => parseOptions.Features.TryGetValue("use-roslyn-tokenizer", out var useRoslynTokenizerValue)
+           && string.Equals(useRoslynTokenizerValue, "true", StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorConfiguration.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorConfiguration.cs
@@ -19,11 +19,7 @@ public sealed record class RazorConfiguration(
     public static readonly RazorConfiguration Default = new(
         RazorLanguageVersion.Latest,
         ConfigurationName: "unnamed",
-        Extensions: [],
-        UseConsolidatedMvcViews: true,
-        SuppressAddComponentParameter: false,
-        LanguageServerFlags: null,
-        UseRoslynTokenizer: false);
+        Extensions: []);
 
     public bool Equals(RazorConfiguration? other)
         => other is not null &&

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorConfiguration.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorConfiguration.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Immutable;
 using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language;
@@ -14,7 +15,8 @@ public sealed record class RazorConfiguration(
     bool UseConsolidatedMvcViews = true,
     bool SuppressAddComponentParameter = false,
     LanguageServerFlags? LanguageServerFlags = null,
-    bool UseRoslynTokenizer = false)
+    bool UseRoslynTokenizer = false,
+    LanguageVersion CSharpLanguageVersion = LanguageVersion.Default)
 {
     public static readonly RazorConfiguration Default = new(
         RazorLanguageVersion.Latest,
@@ -29,6 +31,7 @@ public sealed record class RazorConfiguration(
            LanguageServerFlags == other.LanguageServerFlags &&
            UseConsolidatedMvcViews == other.UseConsolidatedMvcViews &&
            UseRoslynTokenizer == other.UseRoslynTokenizer &&
+           CSharpLanguageVersion == other.CSharpLanguageVersion &&
            Extensions.SequenceEqual(other.Extensions);
 
     public override int GetHashCode()
@@ -41,6 +44,7 @@ public sealed record class RazorConfiguration(
         hash.Add(UseConsolidatedMvcViews);
         hash.Add(LanguageServerFlags);
         hash.Add(UseRoslynTokenizer);
+        hash.Add(CSharpLanguageVersion);
         return hash;
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorConfiguration.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorConfiguration.cs
@@ -13,7 +13,8 @@ public sealed record class RazorConfiguration(
     ImmutableArray<RazorExtension> Extensions,
     bool UseConsolidatedMvcViews = true,
     bool SuppressAddComponentParameter = false,
-    LanguageServerFlags? LanguageServerFlags = null)
+    LanguageServerFlags? LanguageServerFlags = null,
+    bool UseRoslynTokenizer = false)
 {
     public static readonly RazorConfiguration Default = new(
         RazorLanguageVersion.Latest,
@@ -21,7 +22,8 @@ public sealed record class RazorConfiguration(
         Extensions: [],
         UseConsolidatedMvcViews: true,
         SuppressAddComponentParameter: false,
-        LanguageServerFlags: null);
+        LanguageServerFlags: null,
+        UseRoslynTokenizer: false);
 
     public bool Equals(RazorConfiguration? other)
         => other is not null &&
@@ -30,6 +32,7 @@ public sealed record class RazorConfiguration(
            SuppressAddComponentParameter == other.SuppressAddComponentParameter &&
            LanguageServerFlags == other.LanguageServerFlags &&
            UseConsolidatedMvcViews == other.UseConsolidatedMvcViews &&
+           UseRoslynTokenizer == other.UseRoslynTokenizer &&
            Extensions.SequenceEqual(other.Extensions);
 
     public override int GetHashCode()
@@ -41,6 +44,7 @@ public sealed record class RazorConfiguration(
         hash.Add(SuppressAddComponentParameter);
         hash.Add(UseConsolidatedMvcViews);
         hash.Add(LanguageServerFlags);
+        hash.Add(UseRoslynTokenizer);
         return hash;
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/RazorSourceGenerator.RazorProviders.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/RazorSourceGenerator.RazorProviders.cs
@@ -56,8 +56,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
             var razorConfiguration = new RazorConfiguration(razorLanguageVersion, configurationName ?? "default", Extensions: [], UseConsolidatedMvcViews: true, SuppressAddComponentParameter: !isComponentParameterSupported);
 
             // We use the new tokenizer only when requested for now.
-            var useRoslynTokenizer = parseOptions.Features.TryGetValue("use-roslyn-tokenizer", out var useRoslynTokenizerValue)
-                                    && string.Equals(useRoslynTokenizerValue, "true", StringComparison.OrdinalIgnoreCase);
+            var useRoslynTokenizer = parseOptions.UseRoslynTokenizer();
 
             var razorSourceGenerationOptions = new RazorSourceGenerationOptions()
             {

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
@@ -73,7 +73,7 @@ public class RazorLanguageServerBenchmarkBase : ProjectSnapshotManagerBenchmarkB
             {
                 updater.ProjectAdded(hostProject);
                 var tagHelpers = CommonResources.LegacyTagHelpers;
-                var projectWorkspaceState = ProjectWorkspaceState.Create(tagHelpers, CodeAnalysis.CSharp.LanguageVersion.CSharp11);
+                var projectWorkspaceState = ProjectWorkspaceState.Create(tagHelpers);
                 updater.ProjectWorkspaceStateChanged(hostProject.Key, projectWorkspaceState);
                 updater.DocumentAdded(hostProject.Key, hostDocument, textLoader);
             },

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
@@ -73,7 +73,7 @@ public class RazorLanguageServerBenchmarkBase : ProjectSnapshotManagerBenchmarkB
             {
                 updater.ProjectAdded(hostProject);
                 var tagHelpers = CommonResources.LegacyTagHelpers;
-                var projectWorkspaceState = ProjectWorkspaceState.Create(tagHelpers, useRoslynTokenizer: false, CodeAnalysis.CSharp.LanguageVersion.CSharp11);
+                var projectWorkspaceState = ProjectWorkspaceState.Create(tagHelpers, CodeAnalysis.CSharp.LanguageVersion.CSharp11);
                 updater.ProjectWorkspaceStateChanged(hostProject.Key, projectWorkspaceState);
                 updater.DocumentAdded(hostProject.Key, hostDocument, textLoader);
             },

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
@@ -73,7 +73,7 @@ public class RazorLanguageServerBenchmarkBase : ProjectSnapshotManagerBenchmarkB
             {
                 updater.ProjectAdded(hostProject);
                 var tagHelpers = CommonResources.LegacyTagHelpers;
-                var projectWorkspaceState = ProjectWorkspaceState.Create(tagHelpers, CodeAnalysis.CSharp.LanguageVersion.CSharp11);
+                var projectWorkspaceState = ProjectWorkspaceState.Create(tagHelpers, useRoslynTokenizer: false, CodeAnalysis.CSharp.LanguageVersion.CSharp11);
                 updater.ProjectWorkspaceStateChanged(hostProject.Key, projectWorkspaceState);
                 updater.DocumentAdded(hostProject.Key, hostDocument, textLoader);
             },

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Resources/project.razor.json
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Resources/project.razor.json
@@ -5,6 +5,7 @@
   "Configuration": {
     "ConfigurationName": "MVC-3.0",
     "LanguageVersion": "3.0",
+    "UseRoslynTokenizer": true,
     "Extensions": [ "MVC-3.0" ]
   },
   "ProjectWorkspaceState": {
@@ -16126,7 +16127,6 @@
         }
       }
     ],
-    "UseRoslynTokenizer": false,
     "CSharpLanguageVersion": 800
   },
   "RootNamespace": "blazorserver",

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Resources/project.razor.json
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Resources/project.razor.json
@@ -6,6 +6,7 @@
     "ConfigurationName": "MVC-3.0",
     "LanguageVersion": "3.0",
     "UseRoslynTokenizer": true,
+    "CSharpLanguageVersion": 800,
     "Extensions": [ "MVC-3.0" ]
   },
   "ProjectWorkspaceState": {
@@ -16126,8 +16127,7 @@
           "Runtime.Name": "Components.None"
         }
       }
-    ],
-    "CSharpLanguageVersion": 800
+    ]
   },
   "RootNamespace": "blazorserver",
   "Documents": [

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Resources/project.razor.json
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Resources/project.razor.json
@@ -1,5 +1,5 @@
 {
-  "__Version": 6,
+  "__Version": 7,
   "ProjectKey": "C:\\Users\\admin\\location\\blazorserver\\obj\\Debug\\net7.0\\",
   "FilePath": "C:\\Users\\admin\\location\\blazorserver\\blazorserver.csproj",
   "Configuration": {
@@ -16126,6 +16126,7 @@
         }
       }
     ],
+    "UseRoslynTokenizer": false,
     "CSharpLanguageVersion": 800
   },
   "RootNamespace": "blazorserver",

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
@@ -374,7 +374,8 @@ internal partial class RazorProjectService : IRazorProjectService, IRazorProject
                 var currentConfiguration = project.Configuration;
                 var currentRootNamespace = project.RootNamespace;
                 if (currentConfiguration.ConfigurationName == configuration?.ConfigurationName &&
-                    currentRootNamespace == rootNamespace)
+                    currentRootNamespace == rootNamespace &&
+                    currentConfiguration.SuppressAddComponentParameter == configuration?.SuppressAddComponentParameter)
                 {
                     _logger.LogTrace($"Updating project '{project.Key}'. The project is already using configuration '{configuration.ConfigurationName}' and root namespace '{rootNamespace}'.");
                     return;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
@@ -366,7 +366,7 @@ internal partial class RazorProjectService : IRazorProjectService, IRazorProject
 
                 if (!projectWorkspaceState.Equals(ProjectWorkspaceState.Default))
                 {
-                    _logger.LogInformation($"Updating project '{project.Key}' TagHelpers ({projectWorkspaceState.TagHelpers.Length}) and C# Language Version ({projectWorkspaceState.CSharpLanguageVersion}).");
+                    _logger.LogInformation($"Updating project '{project.Key}' TagHelpers ({projectWorkspaceState.TagHelpers.Length}).");
                 }
 
                 updater.ProjectWorkspaceStateChanged(project.Key, projectWorkspaceState);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
@@ -371,13 +371,11 @@ internal partial class RazorProjectService : IRazorProjectService, IRazorProject
 
                 updater.ProjectWorkspaceStateChanged(project.Key, projectWorkspaceState);
 
-                var currentConfiguration = project.Configuration;
                 var currentRootNamespace = project.RootNamespace;
-                if (currentConfiguration.ConfigurationName == configuration?.ConfigurationName &&
-                    currentRootNamespace == rootNamespace &&
-                    currentConfiguration.SuppressAddComponentParameter == configuration?.SuppressAddComponentParameter)
+                if (project.Configuration == configuration &&
+                    currentRootNamespace == rootNamespace)
                 {
-                    _logger.LogTrace($"Updating project '{project.Key}'. The project is already using configuration '{configuration.ConfigurationName}' and root namespace '{rootNamespace}'.");
+                    _logger.LogTrace($"Skipping configuration update for '{project.Key}' as the configuration and root namespace are unchanged.");
                     return;
                 }
 
@@ -386,14 +384,9 @@ internal partial class RazorProjectService : IRazorProjectService, IRazorProject
                     configuration = FallbackRazorConfiguration.Latest;
                     _logger.LogInformation($"Updating project '{project.Key}' to use the latest configuration ('{configuration.ConfigurationName}')'.");
                 }
-                else if (currentConfiguration.ConfigurationName != configuration.ConfigurationName)
+                else
                 {
-                    _logger.LogInformation($"Updating project '{project.Key}' to Razor configuration '{configuration.ConfigurationName}' with language version '{configuration.LanguageVersion}'.");
-                }
-
-                if (currentRootNamespace != rootNamespace)
-                {
-                    _logger.LogInformation($"Updating project '{project.Key}''s root namespace to '{rootNamespace}'.");
+                    _logger.LogInformation($"Updating project '{project.Key}' to Razor configuration '{configuration.ConfigurationName}', namespace '{rootNamespace}', with language version '{configuration.LanguageVersion}'.");
                 }
 
                 var hostProject = new HostProject(project.FilePath, project.IntermediateOutputPath, configuration, rootNamespace, displayName);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/ProjectSystem/ProjectWorkspaceState.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/ProjectSystem/ProjectWorkspaceState.cs
@@ -12,30 +12,34 @@ namespace Microsoft.AspNetCore.Razor.ProjectSystem;
 
 internal sealed class ProjectWorkspaceState : IEquatable<ProjectWorkspaceState>
 {
-    public static readonly ProjectWorkspaceState Default = new(ImmutableArray<TagHelperDescriptor>.Empty, LanguageVersion.Default);
+    public static readonly ProjectWorkspaceState Default = new(ImmutableArray<TagHelperDescriptor>.Empty, useRoslynTokenizer: false, LanguageVersion.Default);
 
     public ImmutableArray<TagHelperDescriptor> TagHelpers { get; }
     public LanguageVersion CSharpLanguageVersion { get; }
+    public bool UseRoslynTokenizer { get; }
 
     private ProjectWorkspaceState(
         ImmutableArray<TagHelperDescriptor> tagHelpers,
+        bool useRoslynTokenizer,
         LanguageVersion csharpLanguageVersion)
     {
         TagHelpers = tagHelpers;
         CSharpLanguageVersion = csharpLanguageVersion;
+        UseRoslynTokenizer = useRoslynTokenizer;
     }
 
     public static ProjectWorkspaceState Create(
         ImmutableArray<TagHelperDescriptor> tagHelpers,
+        bool useRoslynTokenizer,
         LanguageVersion csharpLanguageVersion = LanguageVersion.Default)
         => tagHelpers.IsEmpty && csharpLanguageVersion == LanguageVersion.Default
             ? Default
-            : new(tagHelpers, csharpLanguageVersion);
+            : new(tagHelpers, useRoslynTokenizer, csharpLanguageVersion);
 
-    public static ProjectWorkspaceState Create(LanguageVersion csharpLanguageVersion)
+    public static ProjectWorkspaceState Create(LanguageVersion csharpLanguageVersion, bool useRoslynTokenizer)
         => csharpLanguageVersion == LanguageVersion.Default
             ? Default
-            : new(ImmutableArray<TagHelperDescriptor>.Empty, csharpLanguageVersion);
+            : new(ImmutableArray<TagHelperDescriptor>.Empty, useRoslynTokenizer, csharpLanguageVersion);
 
     public override bool Equals(object? obj)
         => obj is ProjectWorkspaceState other && Equals(other);
@@ -43,7 +47,8 @@ internal sealed class ProjectWorkspaceState : IEquatable<ProjectWorkspaceState>
     public bool Equals(ProjectWorkspaceState? other)
         => other is not null &&
            TagHelpers.SequenceEqual(other.TagHelpers) &&
-           CSharpLanguageVersion == other.CSharpLanguageVersion;
+           CSharpLanguageVersion == other.CSharpLanguageVersion &&
+           UseRoslynTokenizer == other.UseRoslynTokenizer;
 
     public override int GetHashCode()
     {
@@ -51,6 +56,7 @@ internal sealed class ProjectWorkspaceState : IEquatable<ProjectWorkspaceState>
 
         hash.Add(TagHelpers);
         hash.Add(CSharpLanguageVersion);
+        hash.Add(UseRoslynTokenizer);
 
         return hash.CombinedHash;
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/ProjectSystem/ProjectWorkspaceState.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/ProjectSystem/ProjectWorkspaceState.cs
@@ -30,13 +30,13 @@ internal sealed class ProjectWorkspaceState : IEquatable<ProjectWorkspaceState>
 
     public static ProjectWorkspaceState Create(
         ImmutableArray<TagHelperDescriptor> tagHelpers,
-        bool useRoslynTokenizer,
+        bool useRoslynTokenizer = false,
         LanguageVersion csharpLanguageVersion = LanguageVersion.Default)
         => tagHelpers.IsEmpty && csharpLanguageVersion == LanguageVersion.Default
             ? Default
             : new(tagHelpers, useRoslynTokenizer, csharpLanguageVersion);
 
-    public static ProjectWorkspaceState Create(LanguageVersion csharpLanguageVersion, bool useRoslynTokenizer)
+    public static ProjectWorkspaceState Create(LanguageVersion csharpLanguageVersion, bool useRoslynTokenizer = false)
         => csharpLanguageVersion == LanguageVersion.Default
             ? Default
             : new(ImmutableArray<TagHelperDescriptor>.Empty, useRoslynTokenizer, csharpLanguageVersion);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/ProjectSystem/ProjectWorkspaceState.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/ProjectSystem/ProjectWorkspaceState.cs
@@ -5,44 +5,33 @@ using System;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.ProjectSystem;
 
 internal sealed class ProjectWorkspaceState : IEquatable<ProjectWorkspaceState>
 {
-    public static readonly ProjectWorkspaceState Default = new(ImmutableArray<TagHelperDescriptor>.Empty, LanguageVersion.Default);
+    public static readonly ProjectWorkspaceState Default = new(ImmutableArray<TagHelperDescriptor>.Empty);
 
     public ImmutableArray<TagHelperDescriptor> TagHelpers { get; }
-    public LanguageVersion CSharpLanguageVersion { get; }
 
     private ProjectWorkspaceState(
-        ImmutableArray<TagHelperDescriptor> tagHelpers,
-        LanguageVersion csharpLanguageVersion)
+        ImmutableArray<TagHelperDescriptor> tagHelpers)
     {
         TagHelpers = tagHelpers;
-        CSharpLanguageVersion = csharpLanguageVersion;
     }
 
     public static ProjectWorkspaceState Create(
-        ImmutableArray<TagHelperDescriptor> tagHelpers,
-        LanguageVersion csharpLanguageVersion = LanguageVersion.Default)
-        => tagHelpers.IsEmpty && csharpLanguageVersion == LanguageVersion.Default
+        ImmutableArray<TagHelperDescriptor> tagHelpers)
+        => tagHelpers.IsEmpty
             ? Default
-            : new(tagHelpers, csharpLanguageVersion);
-
-    public static ProjectWorkspaceState Create(LanguageVersion csharpLanguageVersion)
-        => csharpLanguageVersion == LanguageVersion.Default
-            ? Default
-            : new(ImmutableArray<TagHelperDescriptor>.Empty, csharpLanguageVersion);
+            : new(tagHelpers);
 
     public override bool Equals(object? obj)
         => obj is ProjectWorkspaceState other && Equals(other);
 
     public bool Equals(ProjectWorkspaceState? other)
         => other is not null &&
-           CSharpLanguageVersion == other.CSharpLanguageVersion &&
            TagHelpers.SequenceEqual(other.TagHelpers);
 
     public override int GetHashCode()
@@ -50,7 +39,6 @@ internal sealed class ProjectWorkspaceState : IEquatable<ProjectWorkspaceState>
         var hash = HashCodeCombiner.Start();
 
         hash.Add(TagHelpers);
-        hash.Add(CSharpLanguageVersion);
 
         return hash.CombinedHash;
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/ProjectSystem/ProjectWorkspaceState.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/ProjectSystem/ProjectWorkspaceState.cs
@@ -46,9 +46,9 @@ internal sealed class ProjectWorkspaceState : IEquatable<ProjectWorkspaceState>
 
     public bool Equals(ProjectWorkspaceState? other)
         => other is not null &&
-           TagHelpers.SequenceEqual(other.TagHelpers) &&
            CSharpLanguageVersion == other.CSharpLanguageVersion &&
-           UseRoslynTokenizer == other.UseRoslynTokenizer;
+           UseRoslynTokenizer == other.UseRoslynTokenizer &&
+           TagHelpers.SequenceEqual(other.TagHelpers);
 
     public override int GetHashCode()
     {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/ProjectSystem/ProjectWorkspaceState.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/ProjectSystem/ProjectWorkspaceState.cs
@@ -12,34 +12,30 @@ namespace Microsoft.AspNetCore.Razor.ProjectSystem;
 
 internal sealed class ProjectWorkspaceState : IEquatable<ProjectWorkspaceState>
 {
-    public static readonly ProjectWorkspaceState Default = new(ImmutableArray<TagHelperDescriptor>.Empty, useRoslynTokenizer: false, LanguageVersion.Default);
+    public static readonly ProjectWorkspaceState Default = new(ImmutableArray<TagHelperDescriptor>.Empty, LanguageVersion.Default);
 
     public ImmutableArray<TagHelperDescriptor> TagHelpers { get; }
     public LanguageVersion CSharpLanguageVersion { get; }
-    public bool UseRoslynTokenizer { get; }
 
     private ProjectWorkspaceState(
         ImmutableArray<TagHelperDescriptor> tagHelpers,
-        bool useRoslynTokenizer,
         LanguageVersion csharpLanguageVersion)
     {
         TagHelpers = tagHelpers;
         CSharpLanguageVersion = csharpLanguageVersion;
-        UseRoslynTokenizer = useRoslynTokenizer;
     }
 
     public static ProjectWorkspaceState Create(
         ImmutableArray<TagHelperDescriptor> tagHelpers,
-        bool useRoslynTokenizer = false,
         LanguageVersion csharpLanguageVersion = LanguageVersion.Default)
         => tagHelpers.IsEmpty && csharpLanguageVersion == LanguageVersion.Default
             ? Default
-            : new(tagHelpers, useRoslynTokenizer, csharpLanguageVersion);
+            : new(tagHelpers, csharpLanguageVersion);
 
-    public static ProjectWorkspaceState Create(LanguageVersion csharpLanguageVersion, bool useRoslynTokenizer = false)
+    public static ProjectWorkspaceState Create(LanguageVersion csharpLanguageVersion)
         => csharpLanguageVersion == LanguageVersion.Default
             ? Default
-            : new(ImmutableArray<TagHelperDescriptor>.Empty, useRoslynTokenizer, csharpLanguageVersion);
+            : new(ImmutableArray<TagHelperDescriptor>.Empty, csharpLanguageVersion);
 
     public override bool Equals(object? obj)
         => obj is ProjectWorkspaceState other && Equals(other);
@@ -47,7 +43,6 @@ internal sealed class ProjectWorkspaceState : IEquatable<ProjectWorkspaceState>
     public bool Equals(ProjectWorkspaceState? other)
         => other is not null &&
            CSharpLanguageVersion == other.CSharpLanguageVersion &&
-           UseRoslynTokenizer == other.UseRoslynTokenizer &&
            TagHelpers.SequenceEqual(other.TagHelpers);
 
     public override int GetHashCode()
@@ -56,7 +51,6 @@ internal sealed class ProjectWorkspaceState : IEquatable<ProjectWorkspaceState>
 
         hash.Add(TagHelpers);
         hash.Add(CSharpLanguageVersion);
-        hash.Add(UseRoslynTokenizer);
 
         return hash.CombinedHash;
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/ProjectWorkspaceStateFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/ProjectWorkspaceStateFormatter.cs
@@ -22,7 +22,7 @@ internal sealed class ProjectWorkspaceStateFormatter : ValueFormatter<ProjectWor
 
     public override ProjectWorkspaceState Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
     {
-        reader.ReadArrayHeaderAndVerify(4);
+        reader.ReadArrayHeaderAndVerify(3);
 
         var checksums = reader.Deserialize<ImmutableArray<Checksum>>(options);
 
@@ -47,21 +47,19 @@ internal sealed class ProjectWorkspaceStateFormatter : ValueFormatter<ProjectWor
         }
 
         var tagHelpers = builder.DrainToImmutable();
-        var useRoslynTokenizer = reader.ReadBoolean();
         var csharpLanguageVersion = (LanguageVersion)reader.ReadInt32();
 
-        return ProjectWorkspaceState.Create(tagHelpers, useRoslynTokenizer, csharpLanguageVersion);
+        return ProjectWorkspaceState.Create(tagHelpers, csharpLanguageVersion);
     }
 
     public override void Serialize(ref MessagePackWriter writer, ProjectWorkspaceState value, SerializerCachingOptions options)
     {
-        writer.WriteArrayHeader(4);
+        writer.WriteArrayHeader(3);
 
         var checksums = value.TagHelpers.SelectAsArray(x => x.Checksum);
 
         writer.Serialize(checksums, options);
         writer.Serialize(value.TagHelpers, options);
-        writer.Write(value.UseRoslynTokenizer);
         writer.Write((int)value.CSharpLanguageVersion);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/ProjectWorkspaceStateFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/ProjectWorkspaceStateFormatter.cs
@@ -22,7 +22,7 @@ internal sealed class ProjectWorkspaceStateFormatter : ValueFormatter<ProjectWor
 
     public override ProjectWorkspaceState Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
     {
-        reader.ReadArrayHeaderAndVerify(3);
+        reader.ReadArrayHeaderAndVerify(4);
 
         var checksums = reader.Deserialize<ImmutableArray<Checksum>>(options);
 
@@ -47,19 +47,21 @@ internal sealed class ProjectWorkspaceStateFormatter : ValueFormatter<ProjectWor
         }
 
         var tagHelpers = builder.DrainToImmutable();
+        var useRoslynTokenizer = reader.ReadBoolean();
         var csharpLanguageVersion = (LanguageVersion)reader.ReadInt32();
 
-        return ProjectWorkspaceState.Create(tagHelpers, csharpLanguageVersion);
+        return ProjectWorkspaceState.Create(tagHelpers, useRoslynTokenizer, csharpLanguageVersion);
     }
 
     public override void Serialize(ref MessagePackWriter writer, ProjectWorkspaceState value, SerializerCachingOptions options)
     {
-        writer.WriteArrayHeader(3);
+        writer.WriteArrayHeader(4);
 
         var checksums = value.TagHelpers.SelectAsArray(x => x.Checksum);
 
         writer.Serialize(checksums, options);
         writer.Serialize(value.TagHelpers, options);
+        writer.Write(value.UseRoslynTokenizer);
         writer.Write((int)value.CSharpLanguageVersion);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/ProjectWorkspaceStateFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/ProjectWorkspaceStateFormatter.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Serialization.MessagePack.Formatters.TagHelpers;
 using Microsoft.AspNetCore.Razor.Utilities;
-using Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.AspNetCore.Razor.Serialization.MessagePack.Formatters;
 
@@ -22,7 +21,7 @@ internal sealed class ProjectWorkspaceStateFormatter : ValueFormatter<ProjectWor
 
     public override ProjectWorkspaceState Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
     {
-        reader.ReadArrayHeaderAndVerify(3);
+        reader.ReadArrayHeaderAndVerify(2);
 
         var checksums = reader.Deserialize<ImmutableArray<Checksum>>(options);
 
@@ -47,19 +46,17 @@ internal sealed class ProjectWorkspaceStateFormatter : ValueFormatter<ProjectWor
         }
 
         var tagHelpers = builder.DrainToImmutable();
-        var csharpLanguageVersion = (LanguageVersion)reader.ReadInt32();
 
-        return ProjectWorkspaceState.Create(tagHelpers, csharpLanguageVersion);
+        return ProjectWorkspaceState.Create(tagHelpers);
     }
 
     public override void Serialize(ref MessagePackWriter writer, ProjectWorkspaceState value, SerializerCachingOptions options)
     {
-        writer.WriteArrayHeader(3);
+        writer.WriteArrayHeader(2);
 
         var checksums = value.TagHelpers.SelectAsArray(x => x.Checksum);
 
         writer.Serialize(checksums, options);
         writer.Serialize(value.TagHelpers, options);
-        writer.Write((int)value.CSharpLanguageVersion);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/RazorConfigurationFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/RazorConfigurationFormatter.cs
@@ -4,6 +4,7 @@
 using MessagePack;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.PooledObjects;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.AspNetCore.Razor.Serialization.MessagePack.Formatters;
 
@@ -13,7 +14,7 @@ internal sealed class RazorConfigurationFormatter : ValueFormatter<RazorConfigur
 
     // The count of properties in RazorConfiguration that are serialized. The number of Extensions will be added
     // to this, for the final serialized value count.
-    private const int SerializedPropertyCount = 5;
+    private const int SerializedPropertyCount = 6;
 
     private RazorConfigurationFormatter()
     {
@@ -29,6 +30,7 @@ internal sealed class RazorConfigurationFormatter : ValueFormatter<RazorConfigur
         var suppressAddComponentParameter = reader.ReadBoolean();
         var useConsolidatedMvcViews = reader.ReadBoolean();
         var useRoslynTokenizer = reader.ReadBoolean();
+        var csharpLanguageVersion = (LanguageVersion)reader.ReadInt32();
 
         count -= SerializedPropertyCount;
 
@@ -52,7 +54,8 @@ internal sealed class RazorConfigurationFormatter : ValueFormatter<RazorConfigur
             extensions,
             UseConsolidatedMvcViews: useConsolidatedMvcViews,
             SuppressAddComponentParameter: suppressAddComponentParameter,
-            UseRoslynTokenizer: useRoslynTokenizer);
+            UseRoslynTokenizer: useRoslynTokenizer,
+            CSharpLanguageVersion: csharpLanguageVersion);
     }
 
     public override void Serialize(ref MessagePackWriter writer, RazorConfiguration value, SerializerCachingOptions options)
@@ -77,6 +80,7 @@ internal sealed class RazorConfigurationFormatter : ValueFormatter<RazorConfigur
         writer.Write(value.SuppressAddComponentParameter);
         writer.Write(value.UseConsolidatedMvcViews);
         writer.Write(value.UseRoslynTokenizer);
+        writer.Write((int)value.CSharpLanguageVersion);
 
         count -= SerializedPropertyCount;
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/SerializationFormat.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/SerializationFormat.cs
@@ -9,5 +9,5 @@ internal static class SerializationFormat
     // or any of the types that compose it changes. This includes: RazorConfiguration,
     // ProjectWorkspaceState, TagHelperDescriptor, and DocumentSnapshotHandle.
     // NOTE: If this version is changed, a coordinated insertion is required between Roslyn and Razor for the C# extension.
-    public const int Version = 6;
+    public const int Version = 7;
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/RazorProjectInfoFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/RazorProjectInfoFactory.cs
@@ -92,7 +92,7 @@ internal static class RazorProjectInfoFactory
 
         var tagHelpers = await project.GetTagHelpersAsync(engine, NoOpTelemetryReporter.Instance, cancellationToken).ConfigureAwait(false);
 
-        var projectWorkspaceState = ProjectWorkspaceState.Create(tagHelpers, csharpLanguageVersion);
+        var projectWorkspaceState = ProjectWorkspaceState.Create(tagHelpers);
 
         return new RazorProjectInfo(
             projectKey: new ProjectKey(intermediateOutputPath),

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/RazorProjectInfoFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/RazorProjectInfoFactory.cs
@@ -92,7 +92,7 @@ internal static class RazorProjectInfoFactory
 
         var tagHelpers = await project.GetTagHelpersAsync(engine, NoOpTelemetryReporter.Instance, cancellationToken).ConfigureAwait(false);
 
-        var projectWorkspaceState = ProjectWorkspaceState.Create(tagHelpers, useRoslynTokenizer, csharpLanguageVersion);
+        var projectWorkspaceState = ProjectWorkspaceState.Create(tagHelpers, csharpLanguageVersion);
 
         return new RazorProjectInfo(
             projectKey: new ProjectKey(intermediateOutputPath),

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/RazorProjectInfoFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/RazorProjectInfoFactory.cs
@@ -57,9 +57,9 @@ internal static class RazorProjectInfoFactory
             return null;
         }
 
-        var cSharpParseOptions = project.ParseOptions as CSharpParseOptions ?? CSharpParseOptions.Default;
-        var csharpLanguageVersion = cSharpParseOptions.LanguageVersion;
-        var useRoslynTokenizer = cSharpParseOptions.UseRoslynTokenizer();
+        var csharpParseOptions = project.ParseOptions as CSharpParseOptions ?? CSharpParseOptions.Default;
+        var csharpLanguageVersion = csharpParseOptions.LanguageVersion;
+        var useRoslynTokenizer = csharpParseOptions.UseRoslynTokenizer();
 
         var compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
         if (compilation is null)
@@ -80,7 +80,7 @@ internal static class RazorProjectInfoFactory
 
             builder.SetCSharpLanguageVersion(csharpLanguageVersion);
             builder.SetSupportLocalizedComponentNames(); // ProjectState in MS.CA.Razor.Workspaces does this, so I'm doing it too!
-            builder.Features.Add(new ConfigureRazorParserOptions(useRoslynTokenizer, cSharpParseOptions));
+            builder.Features.Add(new ConfigureRazorParserOptions(useRoslynTokenizer, csharpParseOptions));
         };
 
         var engineFactory = ProjectEngineFactories.DefaultProvider.GetFactory(configuration);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/StreamExtensions.NetCore.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/StreamExtensions.NetCore.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using Microsoft.AspNetCore.Razor.ProjectSystem;
 using System;
 using System.Buffers;
 using System.Diagnostics;
@@ -9,6 +8,7 @@ using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.ProjectSystem;
 
 namespace Microsoft.AspNetCore.Razor.Utilities;
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshot.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
-using Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
@@ -32,7 +31,6 @@ internal interface IProjectSnapshot
     string? RootNamespace { get; }
     string DisplayName { get; }
     VersionStamp Version { get; }
-    LanguageVersion CSharpLanguageVersion { get; }
     ProjectWorkspaceState ProjectWorkspaceState { get; }
 
     RazorProjectEngine GetProjectEngine();

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshot.cs
@@ -11,7 +11,6 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Utilities;
-using Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
@@ -32,7 +31,6 @@ internal sealed class ProjectSnapshot(ProjectState state) : IProjectSnapshot
     public string? RootNamespace => _state.HostProject.RootNamespace;
     public string DisplayName => _state.HostProject.DisplayName;
     public VersionStamp Version => _state.Version;
-    public LanguageVersion CSharpLanguageVersion => _state.CSharpLanguageVersion;
     public ProjectWorkspaceState ProjectWorkspaceState => _state.ProjectWorkspaceState;
 
     public int DocumentCount => _state.Documents.Count;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Utilities;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.NET.Sdk.Razor.SourceGenerators;
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
@@ -209,6 +210,7 @@ internal class ProjectState
                     builder.SetRootNamespace(HostProject.RootNamespace);
                     builder.SetCSharpLanguageVersion(CSharpLanguageVersion);
                     builder.SetSupportLocalizedComponentNames();
+                    builder.Features.Add(new ConfigureRazorParserOptions(useRoslynTokenizer: ProjectWorkspaceState.UseRoslynTokenizer, CSharpParseOptions.Default));
                 });
             }
         }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
@@ -151,14 +151,15 @@ internal class ProjectState
         else
         {
             ProjectWorkspaceStateVersion = Version;
-        }
 
-        if ((difference & ClearProjectWorkspaceStateVersionMask) != 0 &&
-            CSharpLanguageVersion != older.CSharpLanguageVersion)
-        {
-            // C# language version changed. This impacts the ProjectEngine, reset it.
-            _projectEngine = null;
-            ConfigurationVersion = Version;
+            // CSharpLanguageVersion and UseRoslynTokenizer are part of the ProjectWorkspaceState, but they affect the project engine
+            // so we check for those specifically changing, and clear that.
+            if (CSharpLanguageVersion != older.CSharpLanguageVersion ||
+                ProjectWorkspaceState.UseRoslynTokenizer != older.ProjectWorkspaceState.UseRoslynTokenizer)
+            {
+                _projectEngine = null;
+                ConfigurationVersion = Version;
+            }
         }
     }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
@@ -152,14 +152,6 @@ internal class ProjectState
         {
             ProjectWorkspaceStateVersion = Version;
         }
-
-        if ((difference & ClearProjectWorkspaceStateVersionMask) != 0 &&
-            CSharpLanguageVersion != older.CSharpLanguageVersion)
-        {
-            // C# language version changed. This impacts the ProjectEngine, reset it.
-            _projectEngine = null;
-            ConfigurationVersion = Version;
-        }
     }
 
     // Internal set for testing.
@@ -174,7 +166,7 @@ internal class ProjectState
 
     public ImmutableArray<TagHelperDescriptor> TagHelpers => ProjectWorkspaceState.TagHelpers;
 
-    public LanguageVersion CSharpLanguageVersion => ProjectWorkspaceState.CSharpLanguageVersion;
+    public LanguageVersion CSharpLanguageVersion => HostProject.Configuration.CSharpLanguageVersion;
 
     /// <summary>
     /// Gets the version of this project, INCLUDING content changes. The <see cref="Version"/> is

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
@@ -151,15 +151,14 @@ internal class ProjectState
         else
         {
             ProjectWorkspaceStateVersion = Version;
+        }
 
-            // CSharpLanguageVersion and UseRoslynTokenizer are part of the ProjectWorkspaceState, but they affect the project engine
-            // so we check for those specifically changing, and clear that.
-            if (CSharpLanguageVersion != older.CSharpLanguageVersion ||
-                ProjectWorkspaceState.UseRoslynTokenizer != older.ProjectWorkspaceState.UseRoslynTokenizer)
-            {
-                _projectEngine = null;
-                ConfigurationVersion = Version;
-            }
+        if ((difference & ClearProjectWorkspaceStateVersionMask) != 0 &&
+            CSharpLanguageVersion != older.CSharpLanguageVersion)
+        {
+            // C# language version changed. This impacts the ProjectEngine, reset it.
+            _projectEngine = null;
+            ConfigurationVersion = Version;
         }
     }
 
@@ -211,7 +210,7 @@ internal class ProjectState
                     builder.SetRootNamespace(HostProject.RootNamespace);
                     builder.SetCSharpLanguageVersion(CSharpLanguageVersion);
                     builder.SetSupportLocalizedComponentNames();
-                    builder.Features.Add(new ConfigureRazorParserOptions(useRoslynTokenizer: ProjectWorkspaceState.UseRoslynTokenizer, CSharpParseOptions.Default));
+                    builder.Features.Add(new ConfigureRazorParserOptions(useRoslynTokenizer: configuration.UseRoslynTokenizer, CSharpParseOptions.Default));
                 });
             }
         }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
@@ -166,8 +166,6 @@ internal class ProjectState
 
     public ImmutableArray<TagHelperDescriptor> TagHelpers => ProjectWorkspaceState.TagHelpers;
 
-    public LanguageVersion CSharpLanguageVersion => HostProject.Configuration.CSharpLanguageVersion;
-
     /// <summary>
     /// Gets the version of this project, INCLUDING content changes. The <see cref="Version"/> is
     /// incremented for each new <see cref="ProjectState"/> instance created.
@@ -200,7 +198,7 @@ internal class ProjectState
                 return _projectEngineFactoryProvider.Create(configuration, rootDirectoryPath, builder =>
                 {
                     builder.SetRootNamespace(HostProject.RootNamespace);
-                    builder.SetCSharpLanguageVersion(CSharpLanguageVersion);
+                    builder.SetCSharpLanguageVersion(configuration.CSharpLanguageVersion);
                     builder.SetSupportLocalizedComponentNames();
                     builder.Features.Add(new ConfigureRazorParserOptions(useRoslynTokenizer: configuration.UseRoslynTokenizer, CSharpParseOptions.Default));
                 });

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteProjectSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteProjectSnapshot.cs
@@ -19,6 +19,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Compiler.CSharp;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.NET.Sdk.Razor.SourceGenerators;
 using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
@@ -51,6 +52,7 @@ internal sealed class RemoteProjectSnapshot : IProjectSnapshot
         _lazyProjectEngine = new AsyncLazy<RazorProjectEngine>(async () =>
         {
             var configuration = await _lazyConfiguration.GetValueAsync();
+            var csharpParseOptions = project.ParseOptions as CSharpParseOptions ?? CSharpParseOptions.Default;
             return ProjectEngineFactories.DefaultProvider.Create(
                 configuration,
                 rootDirectoryPath: Path.GetDirectoryName(FilePath).AssumeNotNull(),
@@ -59,6 +61,7 @@ internal sealed class RemoteProjectSnapshot : IProjectSnapshot
                     builder.SetRootNamespace(RootNamespace);
                     builder.SetCSharpLanguageVersion(CSharpLanguageVersion);
                     builder.SetSupportLocalizedComponentNames();
+                    builder.Features.Add(new ConfigureRazorParserOptions(useRoslynTokenizer: csharpParseOptions.UseRoslynTokenizer(), csharpParseOptions));
                 });
         },
         joinableTaskFactory: null);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/IRoslynProjectChangeProcessor.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/IRoslynProjectChangeProcessor.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.VisualStudio.Razor;
 
-internal interface IProjectWorkspaceStateGenerator
+internal interface IRoslynProjectChangeProcessor
 {
     void EnqueueUpdate(Project? workspaceProject, IProjectSnapshot projectSnapshot);
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LiveShare/Host/ProjectSnapshotManagerProxy.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LiveShare/Host/ProjectSnapshotManagerProxy.cs
@@ -101,7 +101,7 @@ internal class ProjectSnapshotManagerProxy : IProjectSnapshotManagerProxy, IColl
         }
 
         var tagHelpers = await project.GetTagHelpersAsync(CancellationToken.None).ConfigureAwait(false);
-        var projectWorkspaceState = ProjectWorkspaceState.Create(tagHelpers, project.CSharpLanguageVersion);
+        var projectWorkspaceState = ProjectWorkspaceState.Create(tagHelpers, project.ProjectWorkspaceState.UseRoslynTokenizer, project.CSharpLanguageVersion);
         var projectFilePath = _session.ConvertLocalPathToSharedUri(project.FilePath);
         var intermediateOutputPath = _session.ConvertLocalPathToSharedUri(project.IntermediateOutputPath);
         var projectHandleProxy = new ProjectSnapshotHandleProxy(projectFilePath, intermediateOutputPath, project.Configuration, project.RootNamespace, projectWorkspaceState);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LiveShare/Host/ProjectSnapshotManagerProxy.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LiveShare/Host/ProjectSnapshotManagerProxy.cs
@@ -101,7 +101,7 @@ internal class ProjectSnapshotManagerProxy : IProjectSnapshotManagerProxy, IColl
         }
 
         var tagHelpers = await project.GetTagHelpersAsync(CancellationToken.None).ConfigureAwait(false);
-        var projectWorkspaceState = ProjectWorkspaceState.Create(tagHelpers, project.CSharpLanguageVersion);
+        var projectWorkspaceState = ProjectWorkspaceState.Create(tagHelpers);
         var projectFilePath = _session.ConvertLocalPathToSharedUri(project.FilePath);
         var intermediateOutputPath = _session.ConvertLocalPathToSharedUri(project.IntermediateOutputPath);
         var projectHandleProxy = new ProjectSnapshotHandleProxy(projectFilePath, intermediateOutputPath, project.Configuration, project.RootNamespace, projectWorkspaceState);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LiveShare/Host/ProjectSnapshotManagerProxy.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LiveShare/Host/ProjectSnapshotManagerProxy.cs
@@ -101,7 +101,7 @@ internal class ProjectSnapshotManagerProxy : IProjectSnapshotManagerProxy, IColl
         }
 
         var tagHelpers = await project.GetTagHelpersAsync(CancellationToken.None).ConfigureAwait(false);
-        var projectWorkspaceState = ProjectWorkspaceState.Create(tagHelpers, project.ProjectWorkspaceState.UseRoslynTokenizer, project.CSharpLanguageVersion);
+        var projectWorkspaceState = ProjectWorkspaceState.Create(tagHelpers, project.CSharpLanguageVersion);
         var projectFilePath = _session.ConvertLocalPathToSharedUri(project.FilePath);
         var intermediateOutputPath = _session.ConvertLocalPathToSharedUri(project.IntermediateOutputPath);
         var projectHandleProxy = new ProjectSnapshotHandleProxy(projectFilePath, intermediateOutputPath, project.Configuration, project.RootNamespace, projectWorkspaceState);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectWorkspaceStateGenerator.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectWorkspaceStateGenerator.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Razor.Compiler.CSharp;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
@@ -279,9 +280,9 @@ internal sealed partial class ProjectWorkspaceStateGenerator(
 
         try
         {
-            var csharpLanguageVersion = workspaceProject.ParseOptions is CSharpParseOptions csharpParseOptions
-                ? csharpParseOptions.LanguageVersion
-                : LanguageVersion.Default;
+            var csharpParseOptions = workspaceProject.ParseOptions as CSharpParseOptions ?? CSharpParseOptions.Default;
+            var csharpLanguageVersion = csharpParseOptions.LanguageVersion;
+            var useRoslynTokenizer = csharpParseOptions.UseRoslynTokenizer();
 
             using var _ = StopwatchPool.GetPooledObject(out var watch);
 
@@ -305,7 +306,7 @@ internal sealed partial class ProjectWorkspaceStateGenerator(
                 Project: {projectSnapshot.FilePath}
                 """);
 
-            return ProjectWorkspaceState.Create(tagHelpers, csharpLanguageVersion);
+            return ProjectWorkspaceState.Create(tagHelpers, useRoslynTokenizer, csharpLanguageVersion);
         }
         catch (OperationCanceledException)
         {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectWorkspaceStateGenerator.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectWorkspaceStateGenerator.cs
@@ -294,6 +294,7 @@ internal sealed partial class ProjectWorkspaceStateGenerator(
             {
                 SuppressAddComponentParameter = suppressAddComponentParameter,
                 UseRoslynTokenizer = useRoslynTokenizer,
+                CSharpLanguageVersion = csharpLanguageVersion
             };
 
             using var _ = StopwatchPool.GetPooledObject(out var watch);
@@ -318,7 +319,7 @@ internal sealed partial class ProjectWorkspaceStateGenerator(
                 Project: {projectSnapshot.FilePath}
                 """);
 
-            return (ProjectWorkspaceState.Create(tagHelpers, csharpLanguageVersion), configuration);
+            return (ProjectWorkspaceState.Create(tagHelpers), configuration);
         }
         catch (OperationCanceledException)
         {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectWorkspaceStateGenerator.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectWorkspaceStateGenerator.cs
@@ -290,7 +290,11 @@ internal sealed partial class ProjectWorkspaceStateGenerator(
 
             var compilation = await workspaceProject.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
             var suppressAddComponentParameter = compilation is not null && !compilation.HasAddComponentParameter();
-            var configuration = projectSnapshot.Configuration with { SuppressAddComponentParameter = suppressAddComponentParameter };
+            var configuration = projectSnapshot.Configuration with
+            {
+                SuppressAddComponentParameter = suppressAddComponentParameter,
+                UseRoslynTokenizer = useRoslynTokenizer,
+            };
 
             using var _ = StopwatchPool.GetPooledObject(out var watch);
 
@@ -314,7 +318,7 @@ internal sealed partial class ProjectWorkspaceStateGenerator(
                 Project: {projectSnapshot.FilePath}
                 """);
 
-            return (ProjectWorkspaceState.Create(tagHelpers, useRoslynTokenizer, csharpLanguageVersion), configuration);
+            return (ProjectWorkspaceState.Create(tagHelpers, csharpLanguageVersion), configuration);
         }
         catch (OperationCanceledException)
         {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RoslynProjectChangeDetector.Comparer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RoslynProjectChangeDetector.Comparer.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.VisualStudio.Razor;
 
-internal partial class WorkspaceProjectStateChangeDetector
+internal partial class RoslynProjectChangeDetector
 {
     private sealed class Comparer : IEqualityComparer<(Project?, IProjectSnapshot)>
     {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RoslynProjectChangeDetector.Comparer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RoslynProjectChangeDetector.Comparer.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.VisualStudio.Razor;
@@ -23,14 +22,14 @@ internal partial class RoslynProjectChangeDetector
             var (_, snapshotX) = x;
             var (_, snapshotY) = y;
 
-            return FilePathComparer.Instance.Equals(snapshotX.Key.Id, snapshotY.Key.Id);
+            return snapshotX.Key.Equals(snapshotY.Key);
         }
 
         public int GetHashCode((Project?, IProjectSnapshot) obj)
         {
             var (_, snapshot) = obj;
 
-            return FilePathComparer.Instance.GetHashCode(snapshot.Key.Id);
+            return snapshot.Key.GetHashCode();
         }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RoslynProjectChangeDetector.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RoslynProjectChangeDetector.cs
@@ -20,11 +20,11 @@ using Microsoft.CodeAnalysis.Razor.Workspaces;
 namespace Microsoft.VisualStudio.Razor;
 
 [Export(typeof(IRazorStartupService))]
-internal partial class WorkspaceProjectStateChangeDetector : IRazorStartupService, IDisposable
+internal partial class RoslynProjectChangeDetector : IRazorStartupService, IDisposable
 {
     private static readonly TimeSpan s_delay = TimeSpan.FromSeconds(1);
 
-    private readonly IProjectWorkspaceStateGenerator _generator;
+    private readonly IRoslynProjectChangeProcessor _generator;
     private readonly IProjectSnapshotManager _projectManager;
     private readonly LanguageServerFeatureOptions _options;
     private readonly CodeAnalysis.Workspace _workspace;
@@ -35,8 +35,8 @@ internal partial class WorkspaceProjectStateChangeDetector : IRazorStartupServic
     private WorkspaceChangedListener? _workspaceChangedListener;
 
     [ImportingConstructor]
-    public WorkspaceProjectStateChangeDetector(
-        IProjectWorkspaceStateGenerator generator,
+    public RoslynProjectChangeDetector(
+        IRoslynProjectChangeProcessor generator,
         IProjectSnapshotManager projectManager,
         LanguageServerFeatureOptions options,
         IWorkspaceProvider workspaceProvider)
@@ -44,8 +44,8 @@ internal partial class WorkspaceProjectStateChangeDetector : IRazorStartupServic
     {
     }
 
-    public WorkspaceProjectStateChangeDetector(
-        IProjectWorkspaceStateGenerator generator,
+    public RoslynProjectChangeDetector(
+        IRoslynProjectChangeProcessor generator,
         IProjectSnapshotManager projectManager,
         LanguageServerFeatureOptions options,
         IWorkspaceProvider workspaceProvider,
@@ -414,7 +414,7 @@ internal partial class WorkspaceProjectStateChangeDetector : IRazorStartupServic
 
     internal TestAccessor GetTestAccessor() => new(this);
 
-    internal sealed class TestAccessor(WorkspaceProjectStateChangeDetector instance)
+    internal sealed class TestAccessor(RoslynProjectChangeDetector instance)
     {
         public void CancelExistingWork()
         {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RoslynProjectChangeDetector.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RoslynProjectChangeDetector.cs
@@ -24,7 +24,7 @@ internal partial class RoslynProjectChangeDetector : IRazorStartupService, IDisp
 {
     private static readonly TimeSpan s_delay = TimeSpan.FromSeconds(1);
 
-    private readonly IRoslynProjectChangeProcessor _generator;
+    private readonly IRoslynProjectChangeProcessor _processor;
     private readonly IProjectSnapshotManager _projectManager;
     private readonly LanguageServerFeatureOptions _options;
     private readonly CodeAnalysis.Workspace _workspace;
@@ -36,22 +36,22 @@ internal partial class RoslynProjectChangeDetector : IRazorStartupService, IDisp
 
     [ImportingConstructor]
     public RoslynProjectChangeDetector(
-        IRoslynProjectChangeProcessor generator,
+        IRoslynProjectChangeProcessor processor,
         IProjectSnapshotManager projectManager,
         LanguageServerFeatureOptions options,
         IWorkspaceProvider workspaceProvider)
-        : this(generator, projectManager, options, workspaceProvider, s_delay)
+        : this(processor, projectManager, options, workspaceProvider, s_delay)
     {
     }
 
     public RoslynProjectChangeDetector(
-        IRoslynProjectChangeProcessor generator,
+        IRoslynProjectChangeProcessor processor,
         IProjectSnapshotManager projectManager,
         LanguageServerFeatureOptions options,
         IWorkspaceProvider workspaceProvider,
         TimeSpan delay)
     {
-        _generator = generator;
+        _processor = processor;
         _projectManager = projectManager;
         _options = options;
 
@@ -94,7 +94,7 @@ internal partial class RoslynProjectChangeDetector : IRazorStartupService, IDisp
                 return default;
             }
 
-            _generator.EnqueueUpdate(project, projectSnapshot);
+            _processor.EnqueueUpdate(project, projectSnapshot);
         }
 
         return default;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RoslynProjectChangeProcessor.TestAccessor.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RoslynProjectChangeProcessor.TestAccessor.cs
@@ -8,11 +8,11 @@ using Microsoft.AspNetCore.Razor.PooledObjects;
 
 namespace Microsoft.VisualStudio.Razor;
 
-internal sealed partial class ProjectWorkspaceStateGenerator
+internal sealed partial class RoslynProjectChangeProcessor
 {
     internal TestAccessor GetTestAccessor() => new(this);
 
-    internal sealed class TestAccessor(ProjectWorkspaceStateGenerator instance)
+    internal sealed class TestAccessor(RoslynProjectChangeProcessor instance)
     {
         public interface IUpdateItem
         {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RoslynProjectChangeProcessor.UpdateItem.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RoslynProjectChangeProcessor.UpdateItem.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.VisualStudio.Razor;
 
-internal sealed partial class ProjectWorkspaceStateGenerator
+internal sealed partial class RoslynProjectChangeProcessor
 {
     private sealed class UpdateItem
     {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RoslynProjectChangeProcessor.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RoslynProjectChangeProcessor.cs
@@ -19,21 +19,21 @@ using Microsoft.CodeAnalysis.Razor.Workspaces;
 
 namespace Microsoft.VisualStudio.Razor;
 
-[Export(typeof(IProjectWorkspaceStateGenerator))]
+[Export(typeof(IRoslynProjectChangeProcessor))]
 [method: ImportingConstructor]
-internal sealed partial class ProjectWorkspaceStateGenerator(
+internal sealed partial class RoslynProjectChangeProcessor(
     IProjectSnapshotManager projectManager,
     ITagHelperResolver tagHelperResolver,
     ILoggerFactory loggerFactory,
     ITelemetryReporter telemetryReporter)
-    : IProjectWorkspaceStateGenerator, IDisposable
+    : IRoslynProjectChangeProcessor, IDisposable
 {
     // SemaphoreSlim is banned. See https://github.com/dotnet/razor/issues/10390 for more info.
 #pragma warning disable RS0030 // Do not use banned APIs
 
     private readonly IProjectSnapshotManager _projectManager = projectManager;
     private readonly ITagHelperResolver _tagHelperResolver = tagHelperResolver;
-    private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<ProjectWorkspaceStateGenerator>();
+    private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<RoslynProjectChangeProcessor>();
     private readonly ITelemetryReporter _telemetryReporter = telemetryReporter;
 
     private readonly SemaphoreSlim _semaphore = new(initialCount: 1);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VsSolutionUpdatesProjectSnapshotChangeTrigger.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VsSolutionUpdatesProjectSnapshotChangeTrigger.cs
@@ -21,7 +21,7 @@ internal class VsSolutionUpdatesProjectSnapshotChangeTrigger : IRazorStartupServ
 {
     private readonly IServiceProvider _serviceProvider;
     private readonly IProjectSnapshotManager _projectManager;
-    private readonly IProjectWorkspaceStateGenerator _workspaceStateGenerator;
+    private readonly IRoslynProjectChangeProcessor _projectChangeProcessor;
     private readonly IWorkspaceProvider _workspaceProvider;
     private readonly JoinableTaskFactory _jtf;
     private readonly CancellationTokenSource _disposeTokenSource;
@@ -36,13 +36,13 @@ internal class VsSolutionUpdatesProjectSnapshotChangeTrigger : IRazorStartupServ
     public VsSolutionUpdatesProjectSnapshotChangeTrigger(
         [Import(typeof(SVsServiceProvider))] IServiceProvider serviceProvider,
         IProjectSnapshotManager projectManager,
-        IProjectWorkspaceStateGenerator workspaceStateGenerator,
+        IRoslynProjectChangeProcessor projectChangeProcessor,
         IWorkspaceProvider workspaceProvider,
         JoinableTaskContext joinableTaskContext)
     {
         _serviceProvider = serviceProvider;
         _projectManager = projectManager;
-        _workspaceStateGenerator = workspaceStateGenerator;
+        _projectChangeProcessor = projectChangeProcessor;
         _workspaceProvider = workspaceProvider;
         _jtf = joinableTaskContext.Factory;
 
@@ -110,7 +110,7 @@ internal class VsSolutionUpdatesProjectSnapshotChangeTrigger : IRazorStartupServ
         if (args.SolutionIsClosing)
         {
             // If the solution is closing, cancel all existing updates.
-            _workspaceStateGenerator.CancelUpdates();
+            _projectChangeProcessor.CancelUpdates();
         }
     }
 
@@ -133,7 +133,7 @@ internal class VsSolutionUpdatesProjectSnapshotChangeTrigger : IRazorStartupServ
                 {
                     // Trigger a tag helper update by forcing the project manager to see the workspace Project
                     // from the current solution.
-                    _workspaceStateGenerator.EnqueueUpdate(workspaceProject, projectSnapshot);
+                    _projectChangeProcessor.EnqueueUpdate(workspaceProject, projectSnapshot);
                 }
             }
         }

--- a/src/Razor/src/Microsoft.VisualStudio.LegacyEditor.Razor/EphemeralProjectSnapshot.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LegacyEditor.Razor/EphemeralProjectSnapshot.cs
@@ -12,7 +12,6 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.ProjectEngineHost;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.VisualStudio.LegacyEditor.Razor;
@@ -49,8 +48,6 @@ internal class EphemeralProjectSnapshot : IProjectSnapshot
     public string DisplayName { get; }
 
     public VersionStamp Version => VersionStamp.Default;
-
-    public LanguageVersion CSharpLanguageVersion => Configuration.CSharpLanguageVersion;
 
     public ValueTask<ImmutableArray<TagHelperDescriptor>> GetTagHelpersAsync(CancellationToken cancellationToken) => new(ProjectWorkspaceState.TagHelpers);
 

--- a/src/Razor/src/Microsoft.VisualStudio.LegacyEditor.Razor/EphemeralProjectSnapshot.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LegacyEditor.Razor/EphemeralProjectSnapshot.cs
@@ -50,7 +50,7 @@ internal class EphemeralProjectSnapshot : IProjectSnapshot
 
     public VersionStamp Version => VersionStamp.Default;
 
-    public LanguageVersion CSharpLanguageVersion => ProjectWorkspaceState.CSharpLanguageVersion;
+    public LanguageVersion CSharpLanguageVersion => Configuration.CSharpLanguageVersion;
 
     public ValueTask<ImmutableArray<TagHelperDescriptor>> GetTagHelpersAsync(CancellationToken cancellationToken) => new(ProjectWorkspaceState.TagHelpers);
 

--- a/src/Razor/src/Microsoft.VisualStudio.LegacyEditor.Razor/Parsing/VisualStudioRazorParser.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LegacyEditor.Razor/Parsing/VisualStudioRazorParser.cs
@@ -494,7 +494,7 @@ internal class VisualStudioRazorParser : IVisualStudioRazorParser, IDisposable
         var projectSnapshot = _documentTracker.ProjectSnapshot;
         if (projectSnapshot != null)
         {
-            builder.SetCSharpLanguageVersion(projectSnapshot.CSharpLanguageVersion);
+            builder.SetCSharpLanguageVersion(projectSnapshot.Configuration.CSharpLanguageVersion);
         }
 
         builder.SetRootNamespace(projectSnapshot?.RootNamespace);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/OpenDocumentGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/OpenDocumentGeneratorTest.cs
@@ -141,7 +141,14 @@ public class OpenDocumentGeneratorTest(ITestOutputHelper testOutput) : LanguageS
             updater.DocumentAdded(_hostProject1.Key, _documents[0], _documents[0].CreateEmptyTextLoader());
 
             // Act
-            updater.ProjectWorkspaceStateChanged(_hostProject1.Key, ProjectWorkspaceState.Default);
+            var changed = _hostProject1 with
+            {
+                Configuration = _hostProject1.Configuration with
+                {
+                    CSharpLanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp8
+                }
+            };
+            updater.ProjectConfigurationChanged(changed);
         });
 
         // Assert
@@ -164,7 +171,14 @@ public class OpenDocumentGeneratorTest(ITestOutputHelper testOutput) : LanguageS
             updater.DocumentOpened(_hostProject1.Key, _documents[0].FilePath, SourceText.From(string.Empty));
 
             // Act
-            updater.ProjectWorkspaceStateChanged(_hostProject1.Key, ProjectWorkspaceState.Default);
+            var changed = _hostProject1 with
+            {
+                Configuration = _hostProject1.Configuration with
+                {
+                    CSharpLanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp8
+                }
+            };
+            updater.ProjectConfigurationChanged(changed);
         });
 
         // Assert

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/OpenDocumentGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/OpenDocumentGeneratorTest.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.AspNetCore.Razor.Test.Common.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
 using Xunit;
@@ -142,8 +141,7 @@ public class OpenDocumentGeneratorTest(ITestOutputHelper testOutput) : LanguageS
             updater.DocumentAdded(_hostProject1.Key, _documents[0], _documents[0].CreateEmptyTextLoader());
 
             // Act
-            updater.ProjectWorkspaceStateChanged(_hostProject1.Key,
-                ProjectWorkspaceState.Create(LanguageVersion.CSharp8));
+            updater.ProjectWorkspaceStateChanged(_hostProject1.Key, ProjectWorkspaceState.Default);
         });
 
         // Assert
@@ -166,8 +164,7 @@ public class OpenDocumentGeneratorTest(ITestOutputHelper testOutput) : LanguageS
             updater.DocumentOpened(_hostProject1.Key, _documents[0].FilePath, SourceText.From(string.Empty));
 
             // Act
-            updater.ProjectWorkspaceStateChanged(_hostProject1.Key,
-                ProjectWorkspaceState.Create(LanguageVersion.CSharp8));
+            updater.ProjectWorkspaceStateChanged(_hostProject1.Key, ProjectWorkspaceState.Default);
         });
 
         // Assert

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectSystem/IProjectSnapshotManagerExtensionsTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectSystem/IProjectSnapshotManagerExtensionsTest.cs
@@ -266,7 +266,7 @@ public class IProjectSnapshotManagerExtensionsTest(ITestOutputHelper testOutput)
     private static void AssertSnapshotsEqual(IProjectSnapshot first, IProjectSnapshot second)
     {
         Assert.Equal(first.FilePath, second.FilePath);
-        Assert.Equal(first.CSharpLanguageVersion, second.CSharpLanguageVersion);
+        Assert.Equal(first.Configuration, second.Configuration);
         Assert.Equal(first.RootNamespace, second.RootNamespace);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
@@ -65,7 +65,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
             updater.ProjectAdded(hostProject);
         });
 
-        var projectWorkspaceState = ProjectWorkspaceState.Default;
+        var projectWorkspaceState = ProjectWorkspaceState.Create([new TagHelperDescriptorBuilder(TagHelperConventions.DefaultKind, "TagHelper", "TagHelperAssembly").Build()]);
 
         // Act
         await _projectInfoListener.UpdatedAsync(new RazorProjectInfo(

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
@@ -13,7 +13,6 @@ using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.AspNetCore.Razor.Test.Common.ProjectSystem;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
 using Moq;
@@ -66,7 +65,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
             updater.ProjectAdded(hostProject);
         });
 
-        var projectWorkspaceState = ProjectWorkspaceState.Create(LanguageVersion.LatestMajor);
+        var projectWorkspaceState = ProjectWorkspaceState.Default;
 
         // Act
         await _projectInfoListener.UpdatedAsync(new RazorProjectInfo(

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/Serialization/SerializerValidationTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/Serialization/SerializerValidationTest.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Immutable;
 using System.IO;
-using System.Reflection;
 using MessagePack;
 using MessagePack.Resolvers;
 using Microsoft.AspNetCore.Razor.Language;
@@ -12,15 +11,13 @@ using Microsoft.AspNetCore.Razor.Serialization;
 using Microsoft.AspNetCore.Razor.Serialization.Json;
 using Microsoft.AspNetCore.Razor.Serialization.MessagePack.Resolvers;
 using Microsoft.AspNetCore.Razor.Test.Common;
-using Microsoft.CodeAnalysis.Razor.Logging;
 using Xunit;
 using Xunit.Abstractions;
-using MessagePackSerializationFormat = Microsoft.AspNetCore.Razor.Serialization.MessagePack.SerializationFormat;
 
 namespace Microsoft.AspNetCore.Razor.ProjectEngineHost.Test.Serialization;
 
 public class SerializerValidationTest(ITestOutputHelper testOutput) : ToolingTestBase(testOutput)
-{
+{   
     [Theory]
     [InlineData("Kendo.Mvc.Examples.project.razor.json")]
     [InlineData("project.razor.json")]

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/Serialization/SerializerValidationTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/Serialization/SerializerValidationTest.cs
@@ -17,7 +17,7 @@ using Xunit.Abstractions;
 namespace Microsoft.AspNetCore.Razor.ProjectEngineHost.Test.Serialization;
 
 public class SerializerValidationTest(ITestOutputHelper testOutput) : ToolingTestBase(testOutput)
-{   
+{
     [Theory]
     [InlineData("Kendo.Mvc.Examples.project.razor.json")]
     [InlineData("project.razor.json")]

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/SerializationTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/SerializationTest.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Serialization;
 using Microsoft.AspNetCore.Razor.Serialization.Json;
 using Microsoft.AspNetCore.Razor.Test.Common;
-using Microsoft.CodeAnalysis.CSharp;
 using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
@@ -26,8 +25,7 @@ public class SerializationTest : ToolingTestBase
 
         _configuration = new(languageVersion, "Custom", [new("TestExtension")]);
         _projectWorkspaceState = ProjectWorkspaceState.Create(
-            tagHelpers: [TagHelperDescriptorBuilder.Create("Test", "TestAssembly").Build()],
-            csharpLanguageVersion: LanguageVersion.LatestMajor);
+            tagHelpers: [TagHelperDescriptorBuilder.Create("Test", "TestAssembly").Build()]);
     }
 
     [Fact]

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/StreamExtensionTests.NetCore.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/StreamExtensionTests.NetCore.cs
@@ -77,7 +77,7 @@ public class StreamExtensionTests
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("tag-name"))
             .Build();
 
-        var projectWorkspaceState = ProjectWorkspaceState.Create([tagHelper], CodeAnalysis.CSharp.LanguageVersion.Latest);
+        var projectWorkspaceState = ProjectWorkspaceState.Create([tagHelper], useRoslynTokenizer: true, CodeAnalysis.CSharp.LanguageVersion.Latest);
 
         var projectInfo = new RazorProjectInfo(
             new ProjectKey("TestProject"),

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/StreamExtensionTests.NetCore.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/StreamExtensionTests.NetCore.cs
@@ -77,7 +77,7 @@ public class StreamExtensionTests
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("tag-name"))
             .Build();
 
-        var projectWorkspaceState = ProjectWorkspaceState.Create([tagHelper], useRoslynTokenizer: true, CodeAnalysis.CSharp.LanguageVersion.Latest);
+        var projectWorkspaceState = ProjectWorkspaceState.Create([tagHelper], CodeAnalysis.CSharp.LanguageVersion.Latest);
 
         var projectInfo = new RazorProjectInfo(
             new ProjectKey("TestProject"),

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/StreamExtensionTests.NetCore.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/StreamExtensionTests.NetCore.cs
@@ -77,7 +77,7 @@ public class StreamExtensionTests
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("tag-name"))
             .Build();
 
-        var projectWorkspaceState = ProjectWorkspaceState.Create([tagHelper], CodeAnalysis.CSharp.LanguageVersion.Latest);
+        var projectWorkspaceState = ProjectWorkspaceState.Create([tagHelper]);
 
         var projectInfo = new RazorProjectInfo(
             new ProjectKey("TestProject"),

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ProjectSystem/TestProjectSnapshot.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ProjectSystem/TestProjectSnapshot.cs
@@ -44,7 +44,6 @@ internal sealed class TestProjectSnapshot : IProjectSnapshot
     public string IntermediateOutputPath => RealSnapshot.IntermediateOutputPath;
     public string? RootNamespace => RealSnapshot.RootNamespace;
     public string DisplayName => RealSnapshot.DisplayName;
-    public LanguageVersion CSharpLanguageVersion => RealSnapshot.CSharpLanguageVersion;
     public ProjectWorkspaceState ProjectWorkspaceState => RealSnapshot.ProjectWorkspaceState;
     public VersionStamp Version => RealSnapshot.Version;
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/TestMocks.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/TestMocks.cs
@@ -116,13 +116,13 @@ internal static class TestMocks
             .Returns(hostProject.RootNamespace);
         mock.SetupGet(x => x.DisplayName)
             .Returns(hostProject.DisplayName);
+        mock.SetupGet(x => x.CSharpLanguageVersion)
+            .Returns(hostProject.Configuration.CSharpLanguageVersion);
 
         if (projectWorkspaceState is not null)
         {
             mock.SetupGet(x => x.ProjectWorkspaceState)
                 .Returns(projectWorkspaceState);
-            mock.SetupGet(x => x.CSharpLanguageVersion)
-                .Returns(projectWorkspaceState.CSharpLanguageVersion);
             mock.Setup(x => x.GetTagHelpersAsync(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(projectWorkspaceState.TagHelpers);
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/TestMocks.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/TestMocks.cs
@@ -116,8 +116,6 @@ internal static class TestMocks
             .Returns(hostProject.RootNamespace);
         mock.SetupGet(x => x.DisplayName)
             .Returns(hostProject.DisplayName);
-        mock.SetupGet(x => x.CSharpLanguageVersion)
-            .Returns(hostProject.Configuration.CSharpLanguageVersion);
 
         if (projectWorkspaceState is not null)
         {

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateGeneratedOutputTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateGeneratedOutputTest.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
-using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -176,30 +175,6 @@ public class ProjectStateGeneratedOutputTest : WorkspaceTestBase
 
         // Act
         var state = original.WithProjectWorkspaceState(changed);
-
-        // Assert
-        var (actualOutput, actualInputVersion) = await GetOutputAsync(state, _hostDocument, DisposalToken);
-        Assert.NotSame(originalOutput, actualOutput);
-        Assert.NotEqual(originalInputVersion, actualInputVersion);
-        Assert.Equal(state.ProjectWorkspaceStateVersion, actualInputVersion);
-    }
-
-    [Fact]
-    public async Task ProjectWorkspaceStateChange_WithProjectWorkspaceState_CSharpLanguageVersionChange_DoesNotCacheOutput()
-    {
-        // Arrange
-        var csharp8ValidConfiguration = new RazorConfiguration(RazorLanguageVersion.Version_3_0, _hostProject.Configuration.ConfigurationName, _hostProject.Configuration.Extensions);
-        var hostProject = TestProjectData.SomeProject with { Configuration = csharp8ValidConfiguration };
-        var originalWorkspaceState = ProjectWorkspaceState.Create(_someTagHelpers, LanguageVersion.CSharp7);
-        var original =
-            ProjectState.Create(ProjectEngineFactoryProvider, hostProject, originalWorkspaceState)
-            .WithAddedHostDocument(_hostDocument, TestMocks.CreateTextLoader("@DateTime.Now", VersionStamp.Default));
-        var changedWorkspaceState = ProjectWorkspaceState.Create(_someTagHelpers, LanguageVersion.CSharp8);
-
-        var (originalOutput, originalInputVersion) = await GetOutputAsync(original, _hostDocument, DisposalToken);
-
-        // Act
-        var state = original.WithProjectWorkspaceState(changedWorkspaceState);
 
         // Assert
         var (actualOutput, actualInputVersion) = await GetOutputAsync(state, _hostDocument, DisposalToken);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateGeneratedOutputTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateGeneratedOutputTest.cs
@@ -190,35 +190,11 @@ public class ProjectStateGeneratedOutputTest : WorkspaceTestBase
         // Arrange
         var csharp8ValidConfiguration = new RazorConfiguration(RazorLanguageVersion.Version_3_0, _hostProject.Configuration.ConfigurationName, _hostProject.Configuration.Extensions);
         var hostProject = TestProjectData.SomeProject with { Configuration = csharp8ValidConfiguration };
-        var originalWorkspaceState = ProjectWorkspaceState.Create(_someTagHelpers, useRoslynTokenizer: false, LanguageVersion.CSharp7);
+        var originalWorkspaceState = ProjectWorkspaceState.Create(_someTagHelpers, LanguageVersion.CSharp7);
         var original =
             ProjectState.Create(ProjectEngineFactoryProvider, hostProject, originalWorkspaceState)
             .WithAddedHostDocument(_hostDocument, TestMocks.CreateTextLoader("@DateTime.Now", VersionStamp.Default));
-        var changedWorkspaceState = ProjectWorkspaceState.Create(_someTagHelpers, useRoslynTokenizer: false, LanguageVersion.CSharp8);
-
-        var (originalOutput, originalInputVersion) = await GetOutputAsync(original, _hostDocument, DisposalToken);
-
-        // Act
-        var state = original.WithProjectWorkspaceState(changedWorkspaceState);
-
-        // Assert
-        var (actualOutput, actualInputVersion) = await GetOutputAsync(state, _hostDocument, DisposalToken);
-        Assert.NotSame(originalOutput, actualOutput);
-        Assert.NotEqual(originalInputVersion, actualInputVersion);
-        Assert.Equal(state.ProjectWorkspaceStateVersion, actualInputVersion);
-    }
-
-    [Fact]
-    public async Task ProjectWorkspaceStateChange_WithProjectWorkspaceState_UseRoslynTokenizerChange_DoesNotCacheOutput()
-    {
-        // Arrange
-        var csharp8ValidConfiguration = new RazorConfiguration(RazorLanguageVersion.Version_3_0, _hostProject.Configuration.ConfigurationName, _hostProject.Configuration.Extensions);
-        var hostProject = TestProjectData.SomeProject with { Configuration = csharp8ValidConfiguration };
-        var originalWorkspaceState = ProjectWorkspaceState.Create(_someTagHelpers, useRoslynTokenizer: false, LanguageVersion.CSharp7);
-        var original =
-            ProjectState.Create(ProjectEngineFactoryProvider, hostProject, originalWorkspaceState)
-            .WithAddedHostDocument(_hostDocument, TestMocks.CreateTextLoader("@DateTime.Now", VersionStamp.Default));
-        var changedWorkspaceState = ProjectWorkspaceState.Create(_someTagHelpers, useRoslynTokenizer: true, LanguageVersion.CSharp7);
+        var changedWorkspaceState = ProjectWorkspaceState.Create(_someTagHelpers, LanguageVersion.CSharp8);
 
         var (originalOutput, originalInputVersion) = await GetOutputAsync(original, _hostDocument, DisposalToken);
 

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateGeneratedOutputTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateGeneratedOutputTest.cs
@@ -190,11 +190,35 @@ public class ProjectStateGeneratedOutputTest : WorkspaceTestBase
         // Arrange
         var csharp8ValidConfiguration = new RazorConfiguration(RazorLanguageVersion.Version_3_0, _hostProject.Configuration.ConfigurationName, _hostProject.Configuration.Extensions);
         var hostProject = TestProjectData.SomeProject with { Configuration = csharp8ValidConfiguration };
-        var originalWorkspaceState = ProjectWorkspaceState.Create(_someTagHelpers, LanguageVersion.CSharp7);
+        var originalWorkspaceState = ProjectWorkspaceState.Create(_someTagHelpers, useRoslynTokenizer: false, LanguageVersion.CSharp7);
         var original =
             ProjectState.Create(ProjectEngineFactoryProvider, hostProject, originalWorkspaceState)
             .WithAddedHostDocument(_hostDocument, TestMocks.CreateTextLoader("@DateTime.Now", VersionStamp.Default));
-        var changedWorkspaceState = ProjectWorkspaceState.Create(_someTagHelpers, LanguageVersion.CSharp8);
+        var changedWorkspaceState = ProjectWorkspaceState.Create(_someTagHelpers, useRoslynTokenizer: false, LanguageVersion.CSharp8);
+
+        var (originalOutput, originalInputVersion) = await GetOutputAsync(original, _hostDocument, DisposalToken);
+
+        // Act
+        var state = original.WithProjectWorkspaceState(changedWorkspaceState);
+
+        // Assert
+        var (actualOutput, actualInputVersion) = await GetOutputAsync(state, _hostDocument, DisposalToken);
+        Assert.NotSame(originalOutput, actualOutput);
+        Assert.NotEqual(originalInputVersion, actualInputVersion);
+        Assert.Equal(state.ProjectWorkspaceStateVersion, actualInputVersion);
+    }
+
+    [Fact]
+    public async Task ProjectWorkspaceStateChange_WithProjectWorkspaceState_UseRoslynTokenizerChange_DoesNotCacheOutput()
+    {
+        // Arrange
+        var csharp8ValidConfiguration = new RazorConfiguration(RazorLanguageVersion.Version_3_0, _hostProject.Configuration.ConfigurationName, _hostProject.Configuration.Extensions);
+        var hostProject = TestProjectData.SomeProject with { Configuration = csharp8ValidConfiguration };
+        var originalWorkspaceState = ProjectWorkspaceState.Create(_someTagHelpers, useRoslynTokenizer: false, LanguageVersion.CSharp7);
+        var original =
+            ProjectState.Create(ProjectEngineFactoryProvider, hostProject, originalWorkspaceState)
+            .WithAddedHostDocument(_hostDocument, TestMocks.CreateTextLoader("@DateTime.Now", VersionStamp.Default));
+        var changedWorkspaceState = ProjectWorkspaceState.Create(_someTagHelpers, useRoslynTokenizer: true, LanguageVersion.CSharp7);
 
         var (originalOutput, originalInputVersion) = await GetOutputAsync(original, _hostDocument, DisposalToken);
 

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateTest.cs
@@ -9,7 +9,6 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
 using Xunit;
 using Xunit.Abstractions;
@@ -643,45 +642,6 @@ public class ProjectStateTest : WorkspaceTestBase
     }
 
     [Fact]
-    public void ProjectState_WithProjectWorkspaceState_Changed()
-    {
-        // Arrange
-        var original = ProjectState.Create(ProjectEngineFactoryProvider, _hostProject, _projectWorkspaceState)
-            .WithAddedHostDocument(_documents[2], DocumentState.EmptyLoader)
-            .WithAddedHostDocument(_documents[1], DocumentState.EmptyLoader);
-
-        // Force init
-        var originalTagHelpers = original.TagHelpers;
-        var originalProjectWorkspaceStateVersion = original.ProjectWorkspaceStateVersion;
-
-        var changed = ProjectWorkspaceState.Create(_projectWorkspaceState.TagHelpers, LanguageVersion.CSharp6);
-
-        // Act
-        var state = original.WithProjectWorkspaceState(changed);
-
-        // Assert
-        Assert.NotEqual(original.Version, state.Version);
-        Assert.Same(changed, state.ProjectWorkspaceState);
-
-        var actualTagHelpers = state.TagHelpers;
-        var actualProjectWorkspaceStateVersion = state.ProjectWorkspaceStateVersion;
-
-        // The C# language version changed, and the tag helpers didn't change
-        Assert.NotSame(original.ProjectEngine, state.ProjectEngine);
-
-        Assert.Equal(originalTagHelpers.Length, actualTagHelpers.Length);
-        for (var i = 0; i < originalTagHelpers.Length; i++)
-        {
-            Assert.Same(originalTagHelpers[i], actualTagHelpers[i]);
-        }
-
-        Assert.NotEqual(originalProjectWorkspaceStateVersion, actualProjectWorkspaceStateVersion);
-
-        Assert.NotSame(original.Documents[_documents[1].FilePath], state.Documents[_documents[1].FilePath]);
-        Assert.NotSame(original.Documents[_documents[2].FilePath], state.Documents[_documents[2].FilePath]);
-    }
-
-    [Fact]
     public void ProjectState_WithProjectWorkspaceState_Changed_TagHelpersChanged()
     {
         // Arrange
@@ -727,7 +687,7 @@ public class ProjectStateTest : WorkspaceTestBase
         _ = original.TagHelpers;
         _ = original.ProjectWorkspaceStateVersion;
 
-        var changed = ProjectWorkspaceState.Create(original.TagHelpers, original.CSharpLanguageVersion);
+        var changed = ProjectWorkspaceState.Create(original.TagHelpers);
 
         // Act
         var state = original.WithProjectWorkspaceState(changed);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateTest.cs
@@ -654,7 +654,7 @@ public class ProjectStateTest : WorkspaceTestBase
         var originalTagHelpers = original.TagHelpers;
         var originalProjectWorkspaceStateVersion = original.ProjectWorkspaceStateVersion;
 
-        var changed = ProjectWorkspaceState.Create(_projectWorkspaceState.TagHelpers, LanguageVersion.CSharp6);
+        var changed = ProjectWorkspaceState.Create(_projectWorkspaceState.TagHelpers, useRoslynTokenizer: false, LanguageVersion.CSharp6);
 
         // Act
         var state = original.WithProjectWorkspaceState(changed);
@@ -727,7 +727,7 @@ public class ProjectStateTest : WorkspaceTestBase
         _ = original.TagHelpers;
         _ = original.ProjectWorkspaceStateVersion;
 
-        var changed = ProjectWorkspaceState.Create(original.TagHelpers, original.CSharpLanguageVersion);
+        var changed = ProjectWorkspaceState.Create(original.TagHelpers, original.ProjectWorkspaceState.UseRoslynTokenizer, original.CSharpLanguageVersion);
 
         // Act
         var state = original.WithProjectWorkspaceState(changed);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateTest.cs
@@ -654,7 +654,7 @@ public class ProjectStateTest : WorkspaceTestBase
         var originalTagHelpers = original.TagHelpers;
         var originalProjectWorkspaceStateVersion = original.ProjectWorkspaceStateVersion;
 
-        var changed = ProjectWorkspaceState.Create(_projectWorkspaceState.TagHelpers, useRoslynTokenizer: false, LanguageVersion.CSharp6);
+        var changed = ProjectWorkspaceState.Create(_projectWorkspaceState.TagHelpers, LanguageVersion.CSharp6);
 
         // Act
         var state = original.WithProjectWorkspaceState(changed);
@@ -727,7 +727,7 @@ public class ProjectStateTest : WorkspaceTestBase
         _ = original.TagHelpers;
         _ = original.ProjectWorkspaceStateVersion;
 
-        var changed = ProjectWorkspaceState.Create(original.TagHelpers, original.ProjectWorkspaceState.UseRoslynTokenizer, original.CSharpLanguageVersion);
+        var changed = ProjectWorkspaceState.Create(original.TagHelpers, original.CSharpLanguageVersion);
 
         // Act
         var state = original.WithProjectWorkspaceState(changed);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/RoslynProjectChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/RoslynProjectChangeDetectorTest.cs
@@ -122,9 +122,9 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
     public async Task SolutionClosing_StopsActiveWork()
     {
         // Arrange
-        var generator = new TestRoslynProjectChangeProcessor();
+        var processor = new TestRoslynProjectChangeProcessor();
         var projectManager = CreateProjectSnapshotManager();
-        using var detector = CreateDetector(generator, projectManager);
+        using var detector = CreateDetector(processor, projectManager);
         var detectorAccessor = detector.GetTestAccessor();
 
         var workspaceChangedTask = detectorAccessor.ListenForWorkspaceChangesAsync(
@@ -141,7 +141,7 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
         await workspaceChangedTask;
         await detectorAccessor.WaitUntilCurrentBatchCompletesAsync();
 
-        generator.Clear();
+        processor.Clear();
 
         // Act
         await projectManager.UpdateAsync(updater =>
@@ -154,7 +154,7 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
 
         // Assert
 
-        Assert.Empty(generator.Updates);
+        Assert.Empty(processor.Updates);
     }
 
     [UITheory]
@@ -164,9 +164,9 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
     public async Task WorkspaceChanged_DocumentEvents_EnqueuesUpdatesForDependentProjects(WorkspaceChangeKind kind)
     {
         // Arrange
-        var generator = new TestRoslynProjectChangeProcessor();
+        var processor = new TestRoslynProjectChangeProcessor();
         var projectManager = CreateProjectSnapshotManager();
-        using var detector = CreateDetector(generator, projectManager);
+        using var detector = CreateDetector(processor, projectManager);
         var detectorAccessor = detector.GetTestAccessor();
 
         await projectManager.UpdateAsync(updater =>
@@ -192,10 +192,10 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
         await detectorAccessor.WaitUntilCurrentBatchCompletesAsync();
 
         // Assert
-        Assert.Equal(3, generator.Updates.Count);
-        Assert.Contains(generator.Updates, u => u.ProjectSnapshot.Key == _projectNumberOne.ToProjectKey());
-        Assert.Contains(generator.Updates, u => u.ProjectSnapshot.Key == _projectNumberTwo.ToProjectKey());
-        Assert.Contains(generator.Updates, u => u.ProjectSnapshot.Key == _projectNumberThree.ToProjectKey());
+        Assert.Equal(3, processor.Updates.Count);
+        Assert.Contains(processor.Updates, u => u.ProjectSnapshot.Key == _projectNumberOne.ToProjectKey());
+        Assert.Contains(processor.Updates, u => u.ProjectSnapshot.Key == _projectNumberTwo.ToProjectKey());
+        Assert.Contains(processor.Updates, u => u.ProjectSnapshot.Key == _projectNumberThree.ToProjectKey());
     }
 
     [UITheory]
@@ -205,9 +205,9 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
     public async Task WorkspaceChanged_ProjectEvents_EnqueuesUpdatesForDependentProjects(WorkspaceChangeKind kind)
     {
         // Arrange
-        var generator = new TestRoslynProjectChangeProcessor();
+        var processor = new TestRoslynProjectChangeProcessor();
         var projectManager = CreateProjectSnapshotManager();
-        using var detector = CreateDetector(generator, projectManager);
+        using var detector = CreateDetector(processor, projectManager);
         var detectorAccessor = detector.GetTestAccessor();
 
         await projectManager.UpdateAsync(updater =>
@@ -233,10 +233,10 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
         await detectorAccessor.WaitUntilCurrentBatchCompletesAsync();
 
         // Assert
-        Assert.Equal(3, generator.Updates.Count);
-        Assert.Contains(generator.Updates, u => u.ProjectSnapshot.Key == _projectNumberOne.ToProjectKey());
-        Assert.Contains(generator.Updates, u => u.ProjectSnapshot.Key == _projectNumberTwo.ToProjectKey());
-        Assert.Contains(generator.Updates, u => u.ProjectSnapshot.Key == _projectNumberThree.ToProjectKey());
+        Assert.Equal(3, processor.Updates.Count);
+        Assert.Contains(processor.Updates, u => u.ProjectSnapshot.Key == _projectNumberOne.ToProjectKey());
+        Assert.Contains(processor.Updates, u => u.ProjectSnapshot.Key == _projectNumberTwo.ToProjectKey());
+        Assert.Contains(processor.Updates, u => u.ProjectSnapshot.Key == _projectNumberThree.ToProjectKey());
     }
 
     [UITheory]
@@ -248,9 +248,9 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
     public async Task WorkspaceChanged_SolutionEvents_EnqueuesUpdatesForProjectsInSolution(WorkspaceChangeKind kind)
     {
         // Arrange
-        var generator = new TestRoslynProjectChangeProcessor();
+        var processor = new TestRoslynProjectChangeProcessor();
         var projectManager = CreateProjectSnapshotManager();
-        using var detector = CreateDetector(generator, projectManager);
+        using var detector = CreateDetector(processor, projectManager);
         var detectorAccessor = detector.GetTestAccessor();
 
         await projectManager.UpdateAsync(updater =>
@@ -268,7 +268,7 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
 
         // Assert
         Assert.Collection(
-            generator.Updates,
+            processor.Updates,
             p => Assert.Equal(_projectNumberOne.Id, p.WorkspaceProject?.Id),
             p => Assert.Equal(_projectNumberTwo.Id, p.WorkspaceProject?.Id));
     }
@@ -282,9 +282,9 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
     public async Task WorkspaceChanged_SolutionEvents_EnqueuesStateClear_EnqueuesSolutionProjectUpdates(WorkspaceChangeKind kind)
     {
         // Arrange
-        var generator = new TestRoslynProjectChangeProcessor();
+        var processor = new TestRoslynProjectChangeProcessor();
         var projectManager = CreateProjectSnapshotManager();
-        using var detector = CreateDetector(generator, projectManager);
+        using var detector = CreateDetector(processor, projectManager);
         var detectorAccessor = detector.GetTestAccessor();
 
         await projectManager.UpdateAsync(updater =>
@@ -309,7 +309,7 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
 
         // Assert
         Assert.Collection(
-            generator.Updates,
+            processor.Updates,
             p => Assert.Equal(_projectNumberThree.Id, p.WorkspaceProject?.Id),
             p => Assert.Null(p.WorkspaceProject),
             p => Assert.Equal(_projectNumberOne.Id, p.WorkspaceProject?.Id),
@@ -322,9 +322,9 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
     public async Task WorkspaceChanged_ProjectChangeEvents_UpdatesProjectState_AfterDelay(WorkspaceChangeKind kind)
     {
         // Arrange
-        var generator = new TestRoslynProjectChangeProcessor();
+        var processor = new TestRoslynProjectChangeProcessor();
         var projectManager = CreateProjectSnapshotManager();
-        using var detector = CreateDetector(generator, projectManager);
+        using var detector = CreateDetector(processor, projectManager);
         var detectorAccessor = detector.GetTestAccessor();
 
         await projectManager.UpdateAsync(updater =>
@@ -334,7 +334,7 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
 
         // Stop any existing work and clear out any updates that we might have received.
         detectorAccessor.CancelExistingWork();
-        generator.Clear();
+        processor.Clear();
 
         // Create a listener for the workspace change we're about to send.
         var listenerTask = detectorAccessor.ListenForWorkspaceChangesAsync(kind);
@@ -349,7 +349,7 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
         await detectorAccessor.WaitUntilCurrentBatchCompletesAsync();
 
         // Assert
-        var update = Assert.Single(generator.Updates);
+        var update = Assert.Single(processor.Updates);
         Assert.Equal(_projectNumberOne.Id, update.WorkspaceProject?.Id);
         Assert.Equal(_hostProjectOne.FilePath, update.ProjectSnapshot.FilePath);
     }
@@ -358,9 +358,9 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
     public async Task WorkspaceChanged_DocumentChanged_BackgroundVirtualCS_UpdatesProjectState_AfterDelay()
     {
         // Arrange
-        var generator = new TestRoslynProjectChangeProcessor();
+        var processor = new TestRoslynProjectChangeProcessor();
         var projectManager = CreateProjectSnapshotManager();
-        using var detector = CreateDetector(generator, projectManager);
+        using var detector = CreateDetector(processor, projectManager);
         var detectorAccessor = detector.GetTestAccessor();
 
         Workspace.TryApplyChanges(_solutionWithTwoProjects);
@@ -370,7 +370,7 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
             updater.ProjectAdded(_hostProjectOne);
         });
 
-        generator.Clear();
+        processor.Clear();
 
         var solution = _solutionWithTwoProjects.WithDocumentText(_backgroundVirtualCSharpDocumentId, SourceText.From("public class Foo{}"));
         var e = new WorkspaceChangeEventArgs(WorkspaceChangeKind.DocumentChanged, oldSolution: _solutionWithTwoProjects, newSolution: solution, projectId: _projectNumberOne.Id, _backgroundVirtualCSharpDocumentId);
@@ -381,7 +381,7 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
         await detectorAccessor.WaitUntilCurrentBatchCompletesAsync();
 
         // Assert
-        var update = Assert.Single(generator.Updates);
+        var update = Assert.Single(processor.Updates);
         Assert.Equal(_projectNumberOne.Id, update.WorkspaceProject?.Id);
         Assert.Equal(_hostProjectOne.FilePath, update.ProjectSnapshot.FilePath);
     }
@@ -390,9 +390,9 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
     public async Task WorkspaceChanged_DocumentChanged_CSHTML_UpdatesProjectState_AfterDelay()
     {
         // Arrange
-        var generator = new TestRoslynProjectChangeProcessor();
+        var processor = new TestRoslynProjectChangeProcessor();
         var projectManager = CreateProjectSnapshotManager();
-        using var detector = CreateDetector(generator, projectManager);
+        using var detector = CreateDetector(processor, projectManager);
         var detectorAccessor = detector.GetTestAccessor();
 
         Workspace.TryApplyChanges(_solutionWithTwoProjects);
@@ -402,7 +402,7 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
             updater.ProjectAdded(_hostProjectOne);
         });
 
-        generator.Clear();
+        processor.Clear();
 
         var solution = _solutionWithTwoProjects.WithDocumentText(_cshtmlDocumentId, SourceText.From("Hello World"));
         var e = new WorkspaceChangeEventArgs(WorkspaceChangeKind.DocumentChanged, oldSolution: _solutionWithTwoProjects, newSolution: solution, projectId: _projectNumberOne.Id, _cshtmlDocumentId);
@@ -413,7 +413,7 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
         await detectorAccessor.WaitUntilCurrentBatchCompletesAsync();
 
         // Assert
-        var update = Assert.Single(generator.Updates);
+        var update = Assert.Single(processor.Updates);
         Assert.Equal(_projectNumberOne.Id, update.WorkspaceProject?.Id);
         Assert.Equal(_hostProjectOne.FilePath, update.ProjectSnapshot.FilePath);
     }
@@ -422,9 +422,9 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
     public async Task WorkspaceChanged_DocumentChanged_Razor_UpdatesProjectState_AfterDelay()
     {
         // Arrange
-        var generator = new TestRoslynProjectChangeProcessor();
+        var processor = new TestRoslynProjectChangeProcessor();
         var projectManager = CreateProjectSnapshotManager();
-        using var detector = CreateDetector(generator, projectManager);
+        using var detector = CreateDetector(processor, projectManager);
         var detectorAccessor = detector.GetTestAccessor();
 
         Workspace.TryApplyChanges(_solutionWithTwoProjects);
@@ -434,7 +434,7 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
             updater.ProjectAdded(_hostProjectOne);
         });
 
-        generator.Clear();
+        processor.Clear();
 
         var solution = _solutionWithTwoProjects.WithDocumentText(_razorDocumentId, SourceText.From("Hello World"));
         var e = new WorkspaceChangeEventArgs(WorkspaceChangeKind.DocumentChanged, oldSolution: _solutionWithTwoProjects, newSolution: solution, projectId: _projectNumberOne.Id, _razorDocumentId);
@@ -445,7 +445,7 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
         await detectorAccessor.WaitUntilCurrentBatchCompletesAsync();
 
         // Assert
-        var update = Assert.Single(generator.Updates);
+        var update = Assert.Single(processor.Updates);
         Assert.Equal(_projectNumberOne.Id, update.WorkspaceProject?.Id);
         Assert.Equal(_hostProjectOne.FilePath, update.ProjectSnapshot.FilePath);
     }
@@ -454,9 +454,9 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
     public async Task WorkspaceChanged_DocumentChanged_PartialComponent_UpdatesProjectState_AfterDelay()
     {
         // Arrange
-        var generator = new TestRoslynProjectChangeProcessor();
+        var processor = new TestRoslynProjectChangeProcessor();
         var projectManager = CreateProjectSnapshotManager();
-        using var detector = CreateDetector(generator, projectManager);
+        using var detector = CreateDetector(processor, projectManager);
         var detectorAccessor = detector.GetTestAccessor();
 
         Workspace.TryApplyChanges(_solutionWithTwoProjects);
@@ -467,7 +467,7 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
         });
 
         await detectorAccessor.WaitUntilCurrentBatchCompletesAsync();
-        generator.Clear();
+        processor.Clear();
 
         var sourceText = SourceText.From($$"""
             public partial class TestComponent : {{ComponentsApi.IComponent.MetadataName}} {}
@@ -495,7 +495,7 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
         await detectorAccessor.WaitUntilCurrentBatchCompletesAsync();
 
         // Assert
-        var update = Assert.Single(generator.Updates);
+        var update = Assert.Single(processor.Updates);
         Assert.Equal(_projectNumberOne.Id, update.WorkspaceProject?.Id);
         Assert.Equal(_hostProjectOne.FilePath, update.ProjectSnapshot.FilePath);
     }
@@ -504,9 +504,9 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
     public async Task WorkspaceChanged_ProjectRemovedEvent_QueuesProjectStateRemoval()
     {
         // Arrange
-        var generator = new TestRoslynProjectChangeProcessor();
+        var processor = new TestRoslynProjectChangeProcessor();
         var projectManager = CreateProjectSnapshotManager();
-        using var detector = CreateDetector(generator, projectManager);
+        using var detector = CreateDetector(processor, projectManager);
         var detectorAccessor = detector.GetTestAccessor();
 
         await projectManager.UpdateAsync(updater =>
@@ -524,7 +524,7 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
 
         // Assert
         Assert.Single(
-            generator.Updates,
+            processor.Updates,
             p => p.WorkspaceProject is null);
     }
 
@@ -532,9 +532,9 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
     public async Task WorkspaceChanged_ProjectAddedEvent_AddsProject()
     {
         // Arrange
-        var generator = new TestRoslynProjectChangeProcessor();
+        var processor = new TestRoslynProjectChangeProcessor();
         var projectManager = CreateProjectSnapshotManager();
-        using var detector = CreateDetector(generator, projectManager);
+        using var detector = CreateDetector(processor, projectManager);
         var detectorAccessor = detector.GetTestAccessor();
 
         await projectManager.UpdateAsync(updater =>
@@ -553,7 +553,7 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
 
         // Assert
         Assert.Single(
-            generator.Updates,
+            processor.Updates,
             p => p.WorkspaceProject?.Id == _projectNumberThree.Id);
     }
 
@@ -751,6 +751,6 @@ public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
         Assert.False(result);
     }
 
-    private RoslynProjectChangeDetector CreateDetector(IRoslynProjectChangeProcessor generator, IProjectSnapshotManager projectManager)
-        => new(generator, projectManager, TestLanguageServerFeatureOptions.Instance, WorkspaceProvider, TimeSpan.FromMilliseconds(10));
+    private RoslynProjectChangeDetector CreateDetector(IRoslynProjectChangeProcessor processor, IProjectSnapshotManager projectManager)
+        => new(processor, projectManager, TestLanguageServerFeatureOptions.Instance, WorkspaceProvider, TimeSpan.FromMilliseconds(10));
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/RoslynProjectChangeDetectorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/RoslynProjectChangeDetectorTest.cs
@@ -18,7 +18,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.VisualStudio.Razor.ProjectSystem;
 
-public class WorkspaceProjectStateChangeDetectorTest : VisualStudioWorkspaceTestBase
+public class RoslynProjectChangeDetectorTest : VisualStudioWorkspaceTestBase
 {
     private readonly HostProject _hostProjectOne;
     private readonly HostProject _hostProjectTwo;
@@ -36,7 +36,7 @@ public class WorkspaceProjectStateChangeDetectorTest : VisualStudioWorkspaceTest
     private readonly DocumentId _backgroundVirtualCSharpDocumentId;
     private readonly DocumentId _partialComponentClassDocumentId;
 
-    public WorkspaceProjectStateChangeDetectorTest(ITestOutputHelper testOutput)
+    public RoslynProjectChangeDetectorTest(ITestOutputHelper testOutput)
         : base(testOutput)
     {
         _emptySolution = Workspace.CurrentSolution;
@@ -122,7 +122,7 @@ public class WorkspaceProjectStateChangeDetectorTest : VisualStudioWorkspaceTest
     public async Task SolutionClosing_StopsActiveWork()
     {
         // Arrange
-        var generator = new TestProjectWorkspaceStateGenerator();
+        var generator = new TestRoslynProjectChangeProcessor();
         var projectManager = CreateProjectSnapshotManager();
         using var detector = CreateDetector(generator, projectManager);
         var detectorAccessor = detector.GetTestAccessor();
@@ -164,7 +164,7 @@ public class WorkspaceProjectStateChangeDetectorTest : VisualStudioWorkspaceTest
     public async Task WorkspaceChanged_DocumentEvents_EnqueuesUpdatesForDependentProjects(WorkspaceChangeKind kind)
     {
         // Arrange
-        var generator = new TestProjectWorkspaceStateGenerator();
+        var generator = new TestRoslynProjectChangeProcessor();
         var projectManager = CreateProjectSnapshotManager();
         using var detector = CreateDetector(generator, projectManager);
         var detectorAccessor = detector.GetTestAccessor();
@@ -205,7 +205,7 @@ public class WorkspaceProjectStateChangeDetectorTest : VisualStudioWorkspaceTest
     public async Task WorkspaceChanged_ProjectEvents_EnqueuesUpdatesForDependentProjects(WorkspaceChangeKind kind)
     {
         // Arrange
-        var generator = new TestProjectWorkspaceStateGenerator();
+        var generator = new TestRoslynProjectChangeProcessor();
         var projectManager = CreateProjectSnapshotManager();
         using var detector = CreateDetector(generator, projectManager);
         var detectorAccessor = detector.GetTestAccessor();
@@ -248,7 +248,7 @@ public class WorkspaceProjectStateChangeDetectorTest : VisualStudioWorkspaceTest
     public async Task WorkspaceChanged_SolutionEvents_EnqueuesUpdatesForProjectsInSolution(WorkspaceChangeKind kind)
     {
         // Arrange
-        var generator = new TestProjectWorkspaceStateGenerator();
+        var generator = new TestRoslynProjectChangeProcessor();
         var projectManager = CreateProjectSnapshotManager();
         using var detector = CreateDetector(generator, projectManager);
         var detectorAccessor = detector.GetTestAccessor();
@@ -282,7 +282,7 @@ public class WorkspaceProjectStateChangeDetectorTest : VisualStudioWorkspaceTest
     public async Task WorkspaceChanged_SolutionEvents_EnqueuesStateClear_EnqueuesSolutionProjectUpdates(WorkspaceChangeKind kind)
     {
         // Arrange
-        var generator = new TestProjectWorkspaceStateGenerator();
+        var generator = new TestRoslynProjectChangeProcessor();
         var projectManager = CreateProjectSnapshotManager();
         using var detector = CreateDetector(generator, projectManager);
         var detectorAccessor = detector.GetTestAccessor();
@@ -322,7 +322,7 @@ public class WorkspaceProjectStateChangeDetectorTest : VisualStudioWorkspaceTest
     public async Task WorkspaceChanged_ProjectChangeEvents_UpdatesProjectState_AfterDelay(WorkspaceChangeKind kind)
     {
         // Arrange
-        var generator = new TestProjectWorkspaceStateGenerator();
+        var generator = new TestRoslynProjectChangeProcessor();
         var projectManager = CreateProjectSnapshotManager();
         using var detector = CreateDetector(generator, projectManager);
         var detectorAccessor = detector.GetTestAccessor();
@@ -358,7 +358,7 @@ public class WorkspaceProjectStateChangeDetectorTest : VisualStudioWorkspaceTest
     public async Task WorkspaceChanged_DocumentChanged_BackgroundVirtualCS_UpdatesProjectState_AfterDelay()
     {
         // Arrange
-        var generator = new TestProjectWorkspaceStateGenerator();
+        var generator = new TestRoslynProjectChangeProcessor();
         var projectManager = CreateProjectSnapshotManager();
         using var detector = CreateDetector(generator, projectManager);
         var detectorAccessor = detector.GetTestAccessor();
@@ -390,7 +390,7 @@ public class WorkspaceProjectStateChangeDetectorTest : VisualStudioWorkspaceTest
     public async Task WorkspaceChanged_DocumentChanged_CSHTML_UpdatesProjectState_AfterDelay()
     {
         // Arrange
-        var generator = new TestProjectWorkspaceStateGenerator();
+        var generator = new TestRoslynProjectChangeProcessor();
         var projectManager = CreateProjectSnapshotManager();
         using var detector = CreateDetector(generator, projectManager);
         var detectorAccessor = detector.GetTestAccessor();
@@ -422,7 +422,7 @@ public class WorkspaceProjectStateChangeDetectorTest : VisualStudioWorkspaceTest
     public async Task WorkspaceChanged_DocumentChanged_Razor_UpdatesProjectState_AfterDelay()
     {
         // Arrange
-        var generator = new TestProjectWorkspaceStateGenerator();
+        var generator = new TestRoslynProjectChangeProcessor();
         var projectManager = CreateProjectSnapshotManager();
         using var detector = CreateDetector(generator, projectManager);
         var detectorAccessor = detector.GetTestAccessor();
@@ -454,7 +454,7 @@ public class WorkspaceProjectStateChangeDetectorTest : VisualStudioWorkspaceTest
     public async Task WorkspaceChanged_DocumentChanged_PartialComponent_UpdatesProjectState_AfterDelay()
     {
         // Arrange
-        var generator = new TestProjectWorkspaceStateGenerator();
+        var generator = new TestRoslynProjectChangeProcessor();
         var projectManager = CreateProjectSnapshotManager();
         using var detector = CreateDetector(generator, projectManager);
         var detectorAccessor = detector.GetTestAccessor();
@@ -504,7 +504,7 @@ public class WorkspaceProjectStateChangeDetectorTest : VisualStudioWorkspaceTest
     public async Task WorkspaceChanged_ProjectRemovedEvent_QueuesProjectStateRemoval()
     {
         // Arrange
-        var generator = new TestProjectWorkspaceStateGenerator();
+        var generator = new TestRoslynProjectChangeProcessor();
         var projectManager = CreateProjectSnapshotManager();
         using var detector = CreateDetector(generator, projectManager);
         var detectorAccessor = detector.GetTestAccessor();
@@ -532,7 +532,7 @@ public class WorkspaceProjectStateChangeDetectorTest : VisualStudioWorkspaceTest
     public async Task WorkspaceChanged_ProjectAddedEvent_AddsProject()
     {
         // Arrange
-        var generator = new TestProjectWorkspaceStateGenerator();
+        var generator = new TestRoslynProjectChangeProcessor();
         var projectManager = CreateProjectSnapshotManager();
         using var detector = CreateDetector(generator, projectManager);
         var detectorAccessor = detector.GetTestAccessor();
@@ -576,7 +576,7 @@ public class WorkspaceProjectStateChangeDetectorTest : VisualStudioWorkspaceTest
         await document.GetSemanticModelAsync();
 
         // Act
-        var result = WorkspaceProjectStateChangeDetector.IsPartialComponentClass(document);
+        var result = RoslynProjectChangeDetector.IsPartialComponentClass(document);
 
         // Assert
         Assert.False(result);
@@ -605,7 +605,7 @@ public class WorkspaceProjectStateChangeDetectorTest : VisualStudioWorkspaceTest
         await document.GetSemanticModelAsync();
 
         // Act
-        var result = WorkspaceProjectStateChangeDetector.IsPartialComponentClass(document);
+        var result = RoslynProjectChangeDetector.IsPartialComponentClass(document);
 
         // Assert
         Assert.True(result);
@@ -630,7 +630,7 @@ public class WorkspaceProjectStateChangeDetectorTest : VisualStudioWorkspaceTest
         Assert.NotNull(document);
 
         // Act
-        var result = WorkspaceProjectStateChangeDetector.IsPartialComponentClass(document);
+        var result = RoslynProjectChangeDetector.IsPartialComponentClass(document);
 
         // Assert
         Assert.False(result);
@@ -657,7 +657,7 @@ public class WorkspaceProjectStateChangeDetectorTest : VisualStudioWorkspaceTest
         await document.GetSyntaxRootAsync();
 
         // Act
-        var result = WorkspaceProjectStateChangeDetector.IsPartialComponentClass(document);
+        var result = RoslynProjectChangeDetector.IsPartialComponentClass(document);
 
         // Assert
         Assert.False(result);
@@ -680,7 +680,7 @@ public class WorkspaceProjectStateChangeDetectorTest : VisualStudioWorkspaceTest
         await document.GetSemanticModelAsync();
 
         // Act
-        var result = WorkspaceProjectStateChangeDetector.IsPartialComponentClass(document);
+        var result = RoslynProjectChangeDetector.IsPartialComponentClass(document);
 
         // Assert
         Assert.False(result);
@@ -713,7 +713,7 @@ public class WorkspaceProjectStateChangeDetectorTest : VisualStudioWorkspaceTest
         await document.GetSemanticModelAsync();
 
         // Act
-        var result = WorkspaceProjectStateChangeDetector.IsPartialComponentClass(document);
+        var result = RoslynProjectChangeDetector.IsPartialComponentClass(document);
 
         // Assert
         Assert.True(result);
@@ -745,12 +745,12 @@ public class WorkspaceProjectStateChangeDetectorTest : VisualStudioWorkspaceTest
         await document.GetSemanticModelAsync();
 
         // Act
-        var result = WorkspaceProjectStateChangeDetector.IsPartialComponentClass(document);
+        var result = RoslynProjectChangeDetector.IsPartialComponentClass(document);
 
         // Assert
         Assert.False(result);
     }
 
-    private WorkspaceProjectStateChangeDetector CreateDetector(IProjectWorkspaceStateGenerator generator, IProjectSnapshotManager projectManager)
+    private RoslynProjectChangeDetector CreateDetector(IRoslynProjectChangeProcessor generator, IProjectSnapshotManager projectManager)
         => new(generator, projectManager, TestLanguageServerFeatureOptions.Instance, WorkspaceProvider, TimeSpan.FromMilliseconds(10));
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/TestRoslynProjectChangeProcessor.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/TestRoslynProjectChangeProcessor.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.VisualStudio.Razor.ProjectSystem;
 
-internal class TestProjectWorkspaceStateGenerator : IProjectWorkspaceStateGenerator
+internal class TestRoslynProjectChangeProcessor : IRoslynProjectChangeProcessor
 {
     private readonly List<TestUpdate> _updates = [];
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/RoslynProjectChangeProcessorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/RoslynProjectChangeProcessorTest.cs
@@ -53,36 +53,36 @@ public class RoslynProjectChangeProcessorTest : VisualStudioWorkspaceTestBase
     public void Dispose_MakesUpdateNoop()
     {
         // Arrange
-        using var generator = new RoslynProjectChangeProcessor(
+        using var processor = new RoslynProjectChangeProcessor(
             _projectManager, _tagHelperResolver, LoggerFactory, NoOpTelemetryReporter.Instance);
 
-        var generatorAccessor = generator.GetTestAccessor();
-        generatorAccessor.BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false);
+        var processorAccessor = processor.GetTestAccessor();
+        processorAccessor.BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false);
 
         // Act
-        generator.Dispose();
+        processor.Dispose();
 
-        generator.EnqueueUpdate(_workspaceProject, _projectSnapshot);
+        processor.EnqueueUpdate(_workspaceProject, _projectSnapshot);
 
         // Assert
-        Assert.Empty(generatorAccessor.GetUpdates());
+        Assert.Empty(processorAccessor.GetUpdates());
     }
 
     [UIFact]
     public void Update_StartsUpdateTask()
     {
         // Arrange
-        using var generator = new RoslynProjectChangeProcessor(
+        using var processor = new RoslynProjectChangeProcessor(
             _projectManager, _tagHelperResolver, LoggerFactory, NoOpTelemetryReporter.Instance);
 
-        var generatorAccessor = generator.GetTestAccessor();
-        generatorAccessor.BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false);
+        var processorAccessor = processor.GetTestAccessor();
+        processorAccessor.BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false);
 
         // Act
-        generator.EnqueueUpdate(_workspaceProject, _projectSnapshot);
+        processor.EnqueueUpdate(_workspaceProject, _projectSnapshot);
 
         // Assert
-        var update = Assert.Single(generatorAccessor.GetUpdates());
+        var update = Assert.Single(processorAccessor.GetUpdates());
         Assert.False(update.IsCompleted);
     }
 
@@ -90,18 +90,18 @@ public class RoslynProjectChangeProcessorTest : VisualStudioWorkspaceTestBase
     public void Update_SoftCancelsIncompleteTaskForSameProject()
     {
         // Arrange
-        using var generator = new RoslynProjectChangeProcessor(
+        using var processor = new RoslynProjectChangeProcessor(
             _projectManager, _tagHelperResolver, LoggerFactory, NoOpTelemetryReporter.Instance);
 
-        var generatorAccessor = generator.GetTestAccessor();
-        generatorAccessor.BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false);
+        var processorAccessor = processor.GetTestAccessor();
+        processorAccessor.BlockBackgroundWorkStart = new ManualResetEventSlim(initialState: false);
 
-        generator.EnqueueUpdate(_workspaceProject, _projectSnapshot);
+        processor.EnqueueUpdate(_workspaceProject, _projectSnapshot);
 
-        var initialUpdate = Assert.Single(generatorAccessor.GetUpdates());
+        var initialUpdate = Assert.Single(processorAccessor.GetUpdates());
 
         // Act
-        generator.EnqueueUpdate(_workspaceProject, _projectSnapshot);
+        processor.EnqueueUpdate(_workspaceProject, _projectSnapshot);
 
         // Assert
         Assert.True(initialUpdate.IsCancellationRequested);
@@ -111,11 +111,11 @@ public class RoslynProjectChangeProcessorTest : VisualStudioWorkspaceTestBase
     public async Task Update_NullWorkspaceProject_ClearsProjectWorkspaceState()
     {
         // Arrange
-        using var generator = new RoslynProjectChangeProcessor(
+        using var processor = new RoslynProjectChangeProcessor(
             _projectManager, _tagHelperResolver, LoggerFactory, NoOpTelemetryReporter.Instance);
 
-        var generatorAccessor = generator.GetTestAccessor();
-        generatorAccessor.NotifyBackgroundWorkCompleted = new ManualResetEventSlim(initialState: false);
+        var processorAccessor = processor.GetTestAccessor();
+        processorAccessor.NotifyBackgroundWorkCompleted = new ManualResetEventSlim(initialState: false);
 
         await _projectManager.UpdateAsync(updater =>
         {
@@ -124,10 +124,10 @@ public class RoslynProjectChangeProcessorTest : VisualStudioWorkspaceTestBase
         });
 
         // Act
-        generator.EnqueueUpdate(workspaceProject: null, _projectSnapshot);
+        processor.EnqueueUpdate(workspaceProject: null, _projectSnapshot);
 
         // Jump off the UI thread so the background work can complete.
-        await Task.Run(() => generatorAccessor.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3)));
+        await Task.Run(() => processorAccessor.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3)));
 
         // Assert
         var newProjectSnapshot = _projectManager.GetLoadedProject(_projectSnapshot.Key);
@@ -139,11 +139,11 @@ public class RoslynProjectChangeProcessorTest : VisualStudioWorkspaceTestBase
     public async Task Update_ResolvesTagHelpersAndUpdatesWorkspaceState()
     {
         // Arrange
-        using var generator = new RoslynProjectChangeProcessor(
+        using var processor = new RoslynProjectChangeProcessor(
             _projectManager, _tagHelperResolver, LoggerFactory, NoOpTelemetryReporter.Instance);
 
-        var generatorAccessor = generator.GetTestAccessor();
-        generatorAccessor.NotifyBackgroundWorkCompleted = new ManualResetEventSlim(initialState: false);
+        var processorAccessor = processor.GetTestAccessor();
+        processorAccessor.NotifyBackgroundWorkCompleted = new ManualResetEventSlim(initialState: false);
 
         await _projectManager.UpdateAsync(updater =>
         {
@@ -151,10 +151,10 @@ public class RoslynProjectChangeProcessorTest : VisualStudioWorkspaceTestBase
         });
 
         // Act
-        generator.EnqueueUpdate(_workspaceProject, _projectSnapshot);
+        processor.EnqueueUpdate(_workspaceProject, _projectSnapshot);
 
         // Jump off the UI thread so the background work can complete.
-        await Task.Run(() => generatorAccessor.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3)));
+        await Task.Run(() => processorAccessor.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3)));
 
         // Assert
         var newProjectSnapshot = _projectManager.GetLoadedProject(_projectSnapshot.Key);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/RoslynProjectChangeProcessorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/RoslynProjectChangeProcessorTest.cs
@@ -18,7 +18,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.VisualStudio.Razor;
 
-public class ProjectWorkspaceStateGeneratorTest : VisualStudioWorkspaceTestBase
+public class RoslynProjectChangeProcessorTest : VisualStudioWorkspaceTestBase
 {
     private readonly TestTagHelperResolver _tagHelperResolver;
     private readonly Project _workspaceProject;
@@ -26,7 +26,7 @@ public class ProjectWorkspaceStateGeneratorTest : VisualStudioWorkspaceTestBase
     private readonly ProjectWorkspaceState _projectWorkspaceStateWithTagHelpers;
     private readonly TestProjectSnapshotManager _projectManager;
 
-    public ProjectWorkspaceStateGeneratorTest(ITestOutputHelper testOutput)
+    public RoslynProjectChangeProcessorTest(ITestOutputHelper testOutput)
         : base(testOutput)
     {
         _tagHelperResolver = new TestTagHelperResolver(
@@ -53,7 +53,7 @@ public class ProjectWorkspaceStateGeneratorTest : VisualStudioWorkspaceTestBase
     public void Dispose_MakesUpdateNoop()
     {
         // Arrange
-        using var generator = new ProjectWorkspaceStateGenerator(
+        using var generator = new RoslynProjectChangeProcessor(
             _projectManager, _tagHelperResolver, LoggerFactory, NoOpTelemetryReporter.Instance);
 
         var generatorAccessor = generator.GetTestAccessor();
@@ -72,7 +72,7 @@ public class ProjectWorkspaceStateGeneratorTest : VisualStudioWorkspaceTestBase
     public void Update_StartsUpdateTask()
     {
         // Arrange
-        using var generator = new ProjectWorkspaceStateGenerator(
+        using var generator = new RoslynProjectChangeProcessor(
             _projectManager, _tagHelperResolver, LoggerFactory, NoOpTelemetryReporter.Instance);
 
         var generatorAccessor = generator.GetTestAccessor();
@@ -90,7 +90,7 @@ public class ProjectWorkspaceStateGeneratorTest : VisualStudioWorkspaceTestBase
     public void Update_SoftCancelsIncompleteTaskForSameProject()
     {
         // Arrange
-        using var generator = new ProjectWorkspaceStateGenerator(
+        using var generator = new RoslynProjectChangeProcessor(
             _projectManager, _tagHelperResolver, LoggerFactory, NoOpTelemetryReporter.Instance);
 
         var generatorAccessor = generator.GetTestAccessor();
@@ -111,7 +111,7 @@ public class ProjectWorkspaceStateGeneratorTest : VisualStudioWorkspaceTestBase
     public async Task Update_NullWorkspaceProject_ClearsProjectWorkspaceState()
     {
         // Arrange
-        using var generator = new ProjectWorkspaceStateGenerator(
+        using var generator = new RoslynProjectChangeProcessor(
             _projectManager, _tagHelperResolver, LoggerFactory, NoOpTelemetryReporter.Instance);
 
         var generatorAccessor = generator.GetTestAccessor();
@@ -139,7 +139,7 @@ public class ProjectWorkspaceStateGeneratorTest : VisualStudioWorkspaceTestBase
     public async Task Update_ResolvesTagHelpersAndUpdatesWorkspaceState()
     {
         // Arrange
-        using var generator = new ProjectWorkspaceStateGenerator(
+        using var generator = new RoslynProjectChangeProcessor(
             _projectManager, _tagHelperResolver, LoggerFactory, NoOpTelemetryReporter.Instance);
 
         var generatorAccessor = generator.GetTestAccessor();

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/VsSolutionUpdatesProjectSnapshotChangeTriggerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/VsSolutionUpdatesProjectSnapshotChangeTriggerTest.cs
@@ -89,7 +89,7 @@ public class VsSolutionUpdatesProjectSnapshotChangeTriggerTest : VisualStudioTes
         using (var trigger = new VsSolutionUpdatesProjectSnapshotChangeTrigger(
             serviceProvider,
             projectManager,
-            StrictMock.Of<IProjectWorkspaceStateGenerator>(),
+            StrictMock.Of<IRoslynProjectChangeProcessor>(),
             _workspaceProvider,
             JoinableTaskContext))
         {
@@ -128,7 +128,7 @@ public class VsSolutionUpdatesProjectSnapshotChangeTriggerTest : VisualStudioTes
         using var trigger = new VsSolutionUpdatesProjectSnapshotChangeTrigger(
             serviceProvider,
             projectManager,
-            StrictMock.Of<IProjectWorkspaceStateGenerator>(),
+            StrictMock.Of<IRoslynProjectChangeProcessor>(),
             _workspaceProvider,
             JoinableTaskContext);
 
@@ -158,7 +158,7 @@ public class VsSolutionUpdatesProjectSnapshotChangeTriggerTest : VisualStudioTes
         });
 
         var serviceProvider = VsMocks.CreateServiceProvider();
-        var workspaceStateGenerator = new TestProjectWorkspaceStateGenerator();
+        var workspaceStateGenerator = new TestRoslynProjectChangeProcessor();
 
         var vsHierarchyMock = new StrictMock<IVsHierarchy>();
         var vsProjectMock = vsHierarchyMock.As<IVsProject>();
@@ -211,7 +211,7 @@ public class VsSolutionUpdatesProjectSnapshotChangeTriggerTest : VisualStudioTes
         });
 
         var serviceProvider = VsMocks.CreateServiceProvider();
-        var workspaceStateGenerator = new TestProjectWorkspaceStateGenerator();
+        var workspaceStateGenerator = new TestRoslynProjectChangeProcessor();
 
         using var trigger = new VsSolutionUpdatesProjectSnapshotChangeTrigger(
             serviceProvider,
@@ -262,7 +262,7 @@ public class VsSolutionUpdatesProjectSnapshotChangeTriggerTest : VisualStudioTes
                 new HostProject("/Some/Unknown/Path.csproj", "/Some/Unknown/obj", RazorConfiguration.Default, "Path"));
         });
 
-        var workspaceStateGenerator = new TestProjectWorkspaceStateGenerator();
+        var workspaceStateGenerator = new TestRoslynProjectChangeProcessor();
 
         using var trigger = new VsSolutionUpdatesProjectSnapshotChangeTrigger(
             serviceProvider,
@@ -298,7 +298,7 @@ public class VsSolutionUpdatesProjectSnapshotChangeTriggerTest : VisualStudioTes
 
         var projectManager = CreateProjectSnapshotManager();
 
-        var workspaceStateGenerator = new TestProjectWorkspaceStateGenerator();
+        var workspaceStateGenerator = new TestRoslynProjectChangeProcessor();
 
         using var trigger = new VsSolutionUpdatesProjectSnapshotChangeTrigger(
             serviceProvider,

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/VsSolutionUpdatesProjectSnapshotChangeTriggerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/VsSolutionUpdatesProjectSnapshotChangeTriggerTest.cs
@@ -158,7 +158,7 @@ public class VsSolutionUpdatesProjectSnapshotChangeTriggerTest : VisualStudioTes
         });
 
         var serviceProvider = VsMocks.CreateServiceProvider();
-        var workspaceStateGenerator = new TestRoslynProjectChangeProcessor();
+        var roslynProjectChangeProcessor = new TestRoslynProjectChangeProcessor();
 
         var vsHierarchyMock = new StrictMock<IVsHierarchy>();
         var vsProjectMock = vsHierarchyMock.As<IVsProject>();
@@ -169,7 +169,7 @@ public class VsSolutionUpdatesProjectSnapshotChangeTriggerTest : VisualStudioTes
         using var trigger = new VsSolutionUpdatesProjectSnapshotChangeTrigger(
             serviceProvider,
             projectManager,
-            workspaceStateGenerator,
+            roslynProjectChangeProcessor,
             _workspaceProvider,
             JoinableTaskContext);
 
@@ -187,7 +187,7 @@ public class VsSolutionUpdatesProjectSnapshotChangeTriggerTest : VisualStudioTes
             updater.ProjectRemoved(s_someProject.Key);
         });
 
-        var update = Assert.Single(workspaceStateGenerator.Updates);
+        var update = Assert.Single(roslynProjectChangeProcessor.Updates);
         Assert.NotNull(update.WorkspaceProject);
         Assert.Equal(update.WorkspaceProject.Id, _someWorkspaceProject.Id);
         Assert.Same(expectedProjectSnapshot, update.ProjectSnapshot);
@@ -211,12 +211,12 @@ public class VsSolutionUpdatesProjectSnapshotChangeTriggerTest : VisualStudioTes
         });
 
         var serviceProvider = VsMocks.CreateServiceProvider();
-        var workspaceStateGenerator = new TestRoslynProjectChangeProcessor();
+        var roslynProjectChangeProcessor = new TestRoslynProjectChangeProcessor();
 
         using var trigger = new VsSolutionUpdatesProjectSnapshotChangeTrigger(
             serviceProvider,
             projectManager,
-            workspaceStateGenerator,
+            roslynProjectChangeProcessor,
             _workspaceProvider,
             JoinableTaskContext);
 
@@ -232,7 +232,7 @@ public class VsSolutionUpdatesProjectSnapshotChangeTriggerTest : VisualStudioTes
         await testAccessor.OnProjectBuiltAsync(vsHierarchyMock.Object, DisposalToken);
 
         // Assert
-        var update = Assert.Single(workspaceStateGenerator.Updates);
+        var update = Assert.Single(roslynProjectChangeProcessor.Updates);
         Assert.NotNull(update.WorkspaceProject);
         Assert.Equal(update.WorkspaceProject.Id, _someWorkspaceProject.Id);
         Assert.Same(expectedProjectSnapshot, update.ProjectSnapshot);
@@ -262,12 +262,12 @@ public class VsSolutionUpdatesProjectSnapshotChangeTriggerTest : VisualStudioTes
                 new HostProject("/Some/Unknown/Path.csproj", "/Some/Unknown/obj", RazorConfiguration.Default, "Path"));
         });
 
-        var workspaceStateGenerator = new TestRoslynProjectChangeProcessor();
+        var roslynProjectChangeProcessor = new TestRoslynProjectChangeProcessor();
 
         using var trigger = new VsSolutionUpdatesProjectSnapshotChangeTrigger(
             serviceProvider,
             projectManager,
-            workspaceStateGenerator,
+            roslynProjectChangeProcessor,
             _workspaceProvider,
             JoinableTaskContext);
 
@@ -277,7 +277,7 @@ public class VsSolutionUpdatesProjectSnapshotChangeTriggerTest : VisualStudioTes
         await testAccessor.OnProjectBuiltAsync(StrictMock.Of<IVsHierarchy>(), DisposalToken);
 
         // Assert
-        Assert.Empty(workspaceStateGenerator.Updates);
+        Assert.Empty(roslynProjectChangeProcessor.Updates);
     }
 
     [UIFact]
@@ -298,12 +298,12 @@ public class VsSolutionUpdatesProjectSnapshotChangeTriggerTest : VisualStudioTes
 
         var projectManager = CreateProjectSnapshotManager();
 
-        var workspaceStateGenerator = new TestRoslynProjectChangeProcessor();
+        var roslynProjectChangeProcessor = new TestRoslynProjectChangeProcessor();
 
         using var trigger = new VsSolutionUpdatesProjectSnapshotChangeTrigger(
             serviceProvider,
             projectManager,
-            workspaceStateGenerator,
+            roslynProjectChangeProcessor,
             _workspaceProvider,
             JoinableTaskContext);
 
@@ -313,6 +313,6 @@ public class VsSolutionUpdatesProjectSnapshotChangeTriggerTest : VisualStudioTes
         await testAccessor.OnProjectBuiltAsync(StrictMock.Of<IVsHierarchy>(), DisposalToken);
 
         // Assert
-        Assert.Empty(workspaceStateGenerator.Updates);
+        Assert.Empty(roslynProjectChangeProcessor.Updates);
     }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectReaders.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectReaders.cs
@@ -102,9 +102,10 @@ internal static partial class ObjectReaders
     public static ProjectWorkspaceState ReadProjectWorkspaceStateFromProperties(JsonDataReader reader)
     {
         var tagHelpers = reader.ReadImmutableArrayOrEmpty(nameof(ProjectWorkspaceState.TagHelpers), static r => ReadTagHelper(r, useCache: true));
+        var useRoslynTokenizer = reader.ReadBooleanOrFalse(nameof(ProjectWorkspaceState.UseRoslynTokenizer));
         var csharpLanguageVersion = (LanguageVersion)reader.ReadInt32OrZero(nameof(ProjectWorkspaceState.CSharpLanguageVersion));
 
-        return ProjectWorkspaceState.Create(tagHelpers, csharpLanguageVersion);
+        return ProjectWorkspaceState.Create(tagHelpers, useRoslynTokenizer, csharpLanguageVersion);
     }
 
     public static TagHelperDescriptor ReadTagHelper(JsonDataReader reader, bool useCache)

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectReaders.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectReaders.cs
@@ -44,6 +44,7 @@ internal static partial class ObjectReaders
         var languageVersionText = reader.ReadNonNullString(nameof(RazorConfiguration.LanguageVersion));
         var suppressAddComponentParameter = reader.ReadBooleanOrFalse(nameof(RazorConfiguration.SuppressAddComponentParameter));
         var useConsolidatedMvcViews = reader.ReadBooleanOrTrue(nameof(RazorConfiguration.UseConsolidatedMvcViews));
+        var useRoslynTokenizer = reader.ReadBooleanOrFalse(nameof(RazorConfiguration.UseRoslynTokenizer));
         var extensions = reader.ReadImmutableArrayOrEmpty(nameof(RazorConfiguration.Extensions),
             static r =>
             {
@@ -55,7 +56,7 @@ internal static partial class ObjectReaders
             ? version
             : RazorLanguageVersion.Version_2_1;
 
-        return new(languageVersion, configurationName, extensions, SuppressAddComponentParameter: suppressAddComponentParameter);
+        return new(languageVersion, configurationName, extensions, SuppressAddComponentParameter: suppressAddComponentParameter, UseRoslynTokenizer: useRoslynTokenizer);
     }
 
     public static RazorDiagnostic ReadDiagnostic(JsonDataReader reader)
@@ -102,10 +103,9 @@ internal static partial class ObjectReaders
     public static ProjectWorkspaceState ReadProjectWorkspaceStateFromProperties(JsonDataReader reader)
     {
         var tagHelpers = reader.ReadImmutableArrayOrEmpty(nameof(ProjectWorkspaceState.TagHelpers), static r => ReadTagHelper(r, useCache: true));
-        var useRoslynTokenizer = reader.ReadBooleanOrFalse(nameof(ProjectWorkspaceState.UseRoslynTokenizer));
         var csharpLanguageVersion = (LanguageVersion)reader.ReadInt32OrZero(nameof(ProjectWorkspaceState.CSharpLanguageVersion));
 
-        return ProjectWorkspaceState.Create(tagHelpers, useRoslynTokenizer, csharpLanguageVersion);
+        return ProjectWorkspaceState.Create(tagHelpers, csharpLanguageVersion);
     }
 
     public static TagHelperDescriptor ReadTagHelper(JsonDataReader reader, bool useCache)

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectReaders.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectReaders.cs
@@ -45,6 +45,7 @@ internal static partial class ObjectReaders
         var suppressAddComponentParameter = reader.ReadBooleanOrFalse(nameof(RazorConfiguration.SuppressAddComponentParameter));
         var useConsolidatedMvcViews = reader.ReadBooleanOrTrue(nameof(RazorConfiguration.UseConsolidatedMvcViews));
         var useRoslynTokenizer = reader.ReadBooleanOrFalse(nameof(RazorConfiguration.UseRoslynTokenizer));
+        var csharpLanguageVersion = (LanguageVersion)reader.ReadInt32OrZero(nameof(RazorConfiguration.CSharpLanguageVersion));
         var extensions = reader.ReadImmutableArrayOrEmpty(nameof(RazorConfiguration.Extensions),
             static r =>
             {
@@ -103,9 +104,8 @@ internal static partial class ObjectReaders
     public static ProjectWorkspaceState ReadProjectWorkspaceStateFromProperties(JsonDataReader reader)
     {
         var tagHelpers = reader.ReadImmutableArrayOrEmpty(nameof(ProjectWorkspaceState.TagHelpers), static r => ReadTagHelper(r, useCache: true));
-        var csharpLanguageVersion = (LanguageVersion)reader.ReadInt32OrZero(nameof(ProjectWorkspaceState.CSharpLanguageVersion));
 
-        return ProjectWorkspaceState.Create(tagHelpers, csharpLanguageVersion);
+        return ProjectWorkspaceState.Create(tagHelpers);
     }
 
     public static TagHelperDescriptor ReadTagHelper(JsonDataReader reader, bool useCache)

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectWriters.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectWriters.cs
@@ -84,6 +84,7 @@ internal static class ObjectWriters
     public static void WriteProperties(JsonDataWriter writer, ProjectWorkspaceState value)
     {
         writer.WriteArrayIfNotDefaultOrEmpty(nameof(value.TagHelpers), value.TagHelpers, Write);
+        writer.WriteIfNotFalse(nameof(value.UseRoslynTokenizer), value.UseRoslynTokenizer);
         writer.WriteIfNotZero(nameof(value.CSharpLanguageVersion), (int)value.CSharpLanguageVersion);
     }
 

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectWriters.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectWriters.cs
@@ -37,6 +37,7 @@ internal static class ObjectWriters
 
         writer.WriteIfNotFalse(nameof(value.SuppressAddComponentParameter), value.SuppressAddComponentParameter);
         writer.WriteIfNotTrue(nameof(value.UseConsolidatedMvcViews), value.UseConsolidatedMvcViews);
+        writer.WriteIfNotFalse(nameof(value.UseRoslynTokenizer), value.UseRoslynTokenizer);
 
         writer.WriteArrayIfNotNullOrEmpty(nameof(value.Extensions), value.Extensions, static (w, v) => w.Write(v.ExtensionName));
     }
@@ -84,8 +85,6 @@ internal static class ObjectWriters
     public static void WriteProperties(JsonDataWriter writer, ProjectWorkspaceState value)
     {
         writer.WriteArrayIfNotDefaultOrEmpty(nameof(value.TagHelpers), value.TagHelpers, Write);
-        writer.WriteIfNotFalse(nameof(value.UseRoslynTokenizer), value.UseRoslynTokenizer);
-        writer.WriteIfNotZero(nameof(value.CSharpLanguageVersion), (int)value.CSharpLanguageVersion);
     }
 
     public static void Write(JsonDataWriter writer, TagHelperDescriptor? value)

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectWriters.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectWriters.cs
@@ -38,6 +38,7 @@ internal static class ObjectWriters
         writer.WriteIfNotFalse(nameof(value.SuppressAddComponentParameter), value.SuppressAddComponentParameter);
         writer.WriteIfNotTrue(nameof(value.UseConsolidatedMvcViews), value.UseConsolidatedMvcViews);
         writer.WriteIfNotFalse(nameof(value.UseRoslynTokenizer), value.UseRoslynTokenizer);
+        writer.WriteIfNotZero(nameof(value.CSharpLanguageVersion), (int)value.CSharpLanguageVersion);
 
         writer.WriteArrayIfNotNullOrEmpty(nameof(value.Extensions), value.Extensions, static (w, v) => w.Write(v.ExtensionName));
     }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/SerializationFormat.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/SerializationFormat.cs
@@ -9,5 +9,5 @@ internal static class SerializationFormat
     // or any of the types that compose it changes. This includes: RazorConfiguration,
     // ProjectWorkspaceState, TagHelperDescriptor, and DocumentSnapshotHandle.
     // NOTE: If this version is changed, a coordinated insertion is required between Roslyn and Razor for the C# extension.
-    public const int Version = 6;
+    public const int Version = 7;
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/10736 and brings in IDE support for the new Roslyn tokenizer, which makes this work:

![Image](https://github.com/user-attachments/assets/3f3647d3-5089-4750-96a0-a80c498db97b)