### PR TITLE
Reduce the amount of telemetry emitted

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
@@ -58,7 +58,7 @@ internal sealed class CodeActionEndpoint(
         }
 
         var correlationId = Guid.NewGuid();
-        using var __ = _telemetryReporter.TrackLspRequest(LspEndpointName, LanguageServerConstants.RazorLanguageServerName, TimeSpan.FromMilliseconds(TelemetryThresholds.CodeActionRazorTelemetryThresholdMS), correlationId);
+        using var __ = _telemetryReporter.TrackLspRequest(LspEndpointName, LanguageServerConstants.RazorLanguageServerName, TelemetryThresholds.CodeActionRazorTelemetryThreshold, correlationId);
         cancellationToken.ThrowIfCancellationRequested();
 
         return await _codeActionsService.GetCodeActionsAsync(request, documentContext, _supportsCodeActionResolve, correlationId, cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.CodeAnalysis.Razor.CodeActions;
 using Microsoft.CodeAnalysis.Razor.Protocol.CodeActions;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Telemetry;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
@@ -57,7 +58,7 @@ internal sealed class CodeActionEndpoint(
         }
 
         var correlationId = Guid.NewGuid();
-        using var __ = _telemetryReporter.TrackLspRequest(LspEndpointName, LanguageServerConstants.RazorLanguageServerName, correlationId);
+        using var __ = _telemetryReporter.TrackLspRequest(LspEndpointName, LanguageServerConstants.RazorLanguageServerName, TimeSpan.FromMilliseconds(TelemetryThresholds.CodeActionRazorTelemetryThresholdMS), correlationId);
         cancellationToken.ThrowIfCancellationRequested();
 
         return await _codeActionsService.GetCodeActionsAsync(request, documentContext, _supportsCodeActionResolve, correlationId, cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -78,7 +78,7 @@ internal class RazorCompletionEndpoint(
         }
 
         var correlationId = Guid.NewGuid();
-        using var _ = _telemetryReporter?.TrackLspRequest(Methods.TextDocumentCompletionName, LanguageServerConstants.RazorLanguageServerName, TimeSpan.FromMilliseconds(TelemetryThresholds.CompletionRazorTelemetryThresholdMS), correlationId);
+        using var _ = _telemetryReporter?.TrackLspRequest(Methods.TextDocumentCompletionName, LanguageServerConstants.RazorLanguageServerName, TelemetryThresholds.CompletionRazorTelemetryThreshold, correlationId);
         var completionList = await _completionListProvider.GetCompletionListAsync(
             hostDocumentIndex,
             completionContext,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.Telemetry;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Telemetry;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -77,7 +78,7 @@ internal class RazorCompletionEndpoint(
         }
 
         var correlationId = Guid.NewGuid();
-        using var _ = _telemetryReporter?.TrackLspRequest(Methods.TextDocumentCompletionName, LanguageServerConstants.RazorLanguageServerName, correlationId);
+        using var _ = _telemetryReporter?.TrackLspRequest(Methods.TextDocumentCompletionName, LanguageServerConstants.RazorLanguageServerName, TimeSpan.FromMilliseconds(TelemetryThresholds.CompletionRazorTelemetryThresholdMS), correlationId);
         var completionList = await _completionListProvider.GetCompletionListAsync(
             hostDocumentIndex,
             completionContext,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/DocumentPullDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/DocumentPullDiagnosticsEndpoint.cs
@@ -72,7 +72,7 @@ internal class DocumentPullDiagnosticsEndpoint : IRazorRequestHandler<VSInternal
         }
 
         var correlationId = Guid.NewGuid();
-        using var __ = _telemetryReporter?.TrackLspRequest(VSInternalMethods.DocumentPullDiagnosticName, LanguageServerConstants.RazorLanguageServerName, TimeSpan.FromMilliseconds(TelemetryThresholds.DiagnosticsRazorTelemetryThresholdMS), correlationId);
+        using var __ = _telemetryReporter?.TrackLspRequest(VSInternalMethods.DocumentPullDiagnosticName, LanguageServerConstants.RazorLanguageServerName, TelemetryThresholds.DiagnosticsRazorTelemetryThreshold, correlationId);
         var documentContext = context.DocumentContext;
         if (documentContext is null)
         {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/DocumentPullDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Diagnostics/DocumentPullDiagnosticsEndpoint.cs
@@ -19,6 +19,7 @@ using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Protocol.Diagnostics;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Telemetry;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics;
@@ -30,7 +31,7 @@ internal class DocumentPullDiagnosticsEndpoint : IRazorRequestHandler<VSInternal
     private readonly IClientConnection _clientConnection;
     private readonly RazorTranslateDiagnosticsService _translateDiagnosticsService;
     private readonly ITelemetryReporter? _telemetryReporter;
-    private ImmutableDictionary<ProjectKey, int> _lastReporedProjectTagHelperCount = ImmutableDictionary<ProjectKey, int>.Empty;
+    private ImmutableDictionary<ProjectKey, int> _lastReportedProjectTagHelperCount = ImmutableDictionary<ProjectKey, int>.Empty;
 
     public DocumentPullDiagnosticsEndpoint(
         LanguageServerFeatureOptions languageServerFeatureOptions,
@@ -71,7 +72,7 @@ internal class DocumentPullDiagnosticsEndpoint : IRazorRequestHandler<VSInternal
         }
 
         var correlationId = Guid.NewGuid();
-        using var __ = _telemetryReporter?.TrackLspRequest(VSInternalMethods.DocumentPullDiagnosticName, LanguageServerConstants.RazorLanguageServerName, correlationId);
+        using var __ = _telemetryReporter?.TrackLspRequest(VSInternalMethods.DocumentPullDiagnosticName, LanguageServerConstants.RazorLanguageServerName, TimeSpan.FromMilliseconds(TelemetryThresholds.DiagnosticsRazorTelemetryThresholdMS), correlationId);
         var documentContext = context.DocumentContext;
         if (documentContext is null)
         {
@@ -202,7 +203,7 @@ internal class DocumentPullDiagnosticsEndpoint : IRazorRequestHandler<VSInternal
         var shouldReport = false;
 
         ImmutableInterlocked.AddOrUpdate(
-            ref _lastReporedProjectTagHelperCount,
+            ref _lastReportedProjectTagHelperCount,
             documentContext.Project.Key,
             (k) =>
             {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MapCode/MapCodeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MapCode/MapCodeEndpoint.cs
@@ -21,6 +21,7 @@ using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Telemetry;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Location = Microsoft.VisualStudio.LanguageServer.Protocol.Location;
@@ -70,7 +71,7 @@ internal sealed class MapCodeEndpoint(
         }
 
         var mapCodeCorrelationId = mapperParams.MapCodeCorrelationId ?? Guid.NewGuid();
-        using var ts = _telemetryReporter.TrackLspRequest(VSInternalMethods.WorkspaceMapCodeName, LanguageServerConstants.RazorLanguageServerName, mapCodeCorrelationId);
+        using var ts = _telemetryReporter.TrackLspRequest(VSInternalMethods.WorkspaceMapCodeName, LanguageServerConstants.RazorLanguageServerName, TimeSpan.FromMilliseconds(TelemetryThresholds.MapCodeRazorTelemetryThresholdMS), mapCodeCorrelationId);
 
         return await HandleMappingsAsync(mapperParams.Mappings, mapCodeCorrelationId, cancellationToken).ConfigureAwait(false);
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MapCode/MapCodeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/MapCode/MapCodeEndpoint.cs
@@ -71,7 +71,7 @@ internal sealed class MapCodeEndpoint(
         }
 
         var mapCodeCorrelationId = mapperParams.MapCodeCorrelationId ?? Guid.NewGuid();
-        using var ts = _telemetryReporter.TrackLspRequest(VSInternalMethods.WorkspaceMapCodeName, LanguageServerConstants.RazorLanguageServerName, TimeSpan.FromMilliseconds(TelemetryThresholds.MapCodeRazorTelemetryThresholdMS), mapCodeCorrelationId);
+        using var ts = _telemetryReporter.TrackLspRequest(VSInternalMethods.WorkspaceMapCodeName, LanguageServerConstants.RazorLanguageServerName, TelemetryThresholds.MapCodeRazorTelemetryThreshold, mapCodeCorrelationId);
 
         return await HandleMappingsAsync(mapperParams.Mappings, mapCodeCorrelationId, cancellationToken).ConfigureAwait(false);
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/SemanticTokensRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/SemanticTokensRangeEndpoint.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
 using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.CodeAnalysis.Razor.SemanticTokens;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Telemetry;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Semantic;
@@ -49,7 +50,7 @@ internal sealed class SemanticTokensRangeEndpoint(
         var colorBackground = _razorLSPOptionsMonitor.CurrentValue.ColorBackground;
 
         var correlationId = Guid.NewGuid();
-        using var _ = _telemetryReporter?.TrackLspRequest(Methods.TextDocumentSemanticTokensRangeName, LanguageServerConstants.RazorLanguageServerName, correlationId);
+        using var _ = _telemetryReporter?.TrackLspRequest(Methods.TextDocumentSemanticTokensRangeName, LanguageServerConstants.RazorLanguageServerName, TimeSpan.FromMilliseconds(TelemetryThresholds.SemanticTokensRazorTelemetryThresholdMS), correlationId);
 
         var data = await _semanticTokensInfoService.GetSemanticTokensAsync(documentContext, request.Range.ToLinePositionSpan(), colorBackground, correlationId, cancellationToken).ConfigureAwait(false);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/SemanticTokensRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Semantic/SemanticTokensRangeEndpoint.cs
@@ -50,7 +50,7 @@ internal sealed class SemanticTokensRangeEndpoint(
         var colorBackground = _razorLSPOptionsMonitor.CurrentValue.ColorBackground;
 
         var correlationId = Guid.NewGuid();
-        using var _ = _telemetryReporter?.TrackLspRequest(Methods.TextDocumentSemanticTokensRangeName, LanguageServerConstants.RazorLanguageServerName, TimeSpan.FromMilliseconds(TelemetryThresholds.SemanticTokensRazorTelemetryThresholdMS), correlationId);
+        using var _ = _telemetryReporter?.TrackLspRequest(Methods.TextDocumentSemanticTokensRangeName, LanguageServerConstants.RazorLanguageServerName, TelemetryThresholds.SemanticTokensRazorTelemetryThreshold, correlationId);
 
         var data = await _semanticTokensInfoService.GetSemanticTokensAsync(documentContext, request.Range.ToLinePositionSpan(), colorBackground, correlationId, cancellationToken).ConfigureAwait(false);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/ITelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/ITelemetryReporter.cs
@@ -7,11 +7,11 @@ namespace Microsoft.AspNetCore.Razor.Telemetry;
 
 internal interface ITelemetryReporter
 {
-    TelemetryScope BeginBlock(string name, Severity severity);
-    TelemetryScope BeginBlock(string name, Severity severity, Property property);
-    TelemetryScope BeginBlock(string name, Severity severity, Property property1, Property property2);
-    TelemetryScope BeginBlock(string name, Severity severity, Property property1, Property property2, Property property3);
-    TelemetryScope BeginBlock(string name, Severity severity, TimeSpan minTimeToReport, params Property[] properties);
+    TelemetryScope BeginBlock(string name, Severity severity, TimeSpan minTimeToReport);
+    TelemetryScope BeginBlock(string name, Severity severity, TimeSpan minTimeToReport, Property property);
+    TelemetryScope BeginBlock(string name, Severity severity, TimeSpan minTimeToReport, Property property1, Property property2);
+    TelemetryScope BeginBlock(string name, Severity severity, TimeSpan minTimeToReport, Property property1, Property property2, Property property3);
+    TelemetryScope BeginBlock(string name, Severity severity, TimeSpan minTimeToReport, params ReadOnlySpan<Property> properties);
 
     TelemetryScope TrackLspRequest(string lspMethodName, string lspServerName, TimeSpan minTimeToReport, Guid correlationId);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/ITelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/ITelemetryReporter.cs
@@ -11,9 +11,9 @@ internal interface ITelemetryReporter
     TelemetryScope BeginBlock(string name, Severity severity, Property property);
     TelemetryScope BeginBlock(string name, Severity severity, Property property1, Property property2);
     TelemetryScope BeginBlock(string name, Severity severity, Property property1, Property property2, Property property3);
-    TelemetryScope BeginBlock(string name, Severity severity, params Property[] properties);
+    TelemetryScope BeginBlock(string name, Severity severity, TimeSpan minTimeToReport, params Property[] properties);
 
-    TelemetryScope TrackLspRequest(string lspMethodName, string lspServerName, Guid correlationId);
+    TelemetryScope TrackLspRequest(string lspMethodName, string lspServerName, TimeSpan minTimeToReport, Guid correlationId);
 
     void ReportEvent(string name, Severity severity);
     void ReportEvent(string name, Severity severity, Property property);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/ITelemetryReporterExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/ITelemetryReporterExtensions.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.AspNetCore.Razor.Telemetry;
+
+internal static class ITelemetryReporterExtensions
+{
+    // These extensions effectively make TimeSpan an optional parameter on BeginBlock
+    internal static TelemetryScope BeginBlock(this ITelemetryReporter self, string name, Severity severity) { return self.BeginBlock(name, severity, TimeSpan.Zero); }
+    internal static TelemetryScope BeginBlock(this ITelemetryReporter self, string name, Severity severity, Property property) { return self.BeginBlock(name, severity, TimeSpan.Zero, property); }
+    internal static TelemetryScope BeginBlock(this ITelemetryReporter self, string name, Severity severity, Property property1, Property property2) { return self.BeginBlock(name, severity, TimeSpan.Zero, property1, property2); }
+    internal static TelemetryScope BeginBlock(this ITelemetryReporter self, string name, Severity severity, Property property1, Property property2, Property property3) { return self.BeginBlock(name, severity, TimeSpan.Zero, property1, property2 , property3); }
+    internal static TelemetryScope BeginBlock(this ITelemetryReporter self, string name, Severity severity, params ReadOnlySpan<Property> properties) { return self.BeginBlock(name, severity, TimeSpan.Zero, properties); }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/ITelemetryReporterExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/ITelemetryReporterExtensions.cs
@@ -8,9 +8,18 @@ namespace Microsoft.AspNetCore.Razor.Telemetry;
 internal static class ITelemetryReporterExtensions
 {
     // These extensions effectively make TimeSpan an optional parameter on BeginBlock
-    internal static TelemetryScope BeginBlock(this ITelemetryReporter self, string name, Severity severity) { return self.BeginBlock(name, severity, TimeSpan.Zero); }
-    internal static TelemetryScope BeginBlock(this ITelemetryReporter self, string name, Severity severity, Property property) { return self.BeginBlock(name, severity, TimeSpan.Zero, property); }
-    internal static TelemetryScope BeginBlock(this ITelemetryReporter self, string name, Severity severity, Property property1, Property property2) { return self.BeginBlock(name, severity, TimeSpan.Zero, property1, property2); }
-    internal static TelemetryScope BeginBlock(this ITelemetryReporter self, string name, Severity severity, Property property1, Property property2, Property property3) { return self.BeginBlock(name, severity, TimeSpan.Zero, property1, property2 , property3); }
-    internal static TelemetryScope BeginBlock(this ITelemetryReporter self, string name, Severity severity, params ReadOnlySpan<Property> properties) { return self.BeginBlock(name, severity, TimeSpan.Zero, properties); }
+    public static TelemetryScope BeginBlock(this ITelemetryReporter reporter, string name, Severity severity)
+          => reporter.BeginBlock(name, severity, minTimeToReport: TimeSpan.Zero);
+
+    public static TelemetryScope BeginBlock(this ITelemetryReporter reporter, string name, Severity severity, Property property)
+        => reporter.BeginBlock(name, severity, minTimeToReport: TimeSpan.Zero, property);
+
+    public static TelemetryScope BeginBlock(this ITelemetryReporter reporter, string name, Severity severity, Property property1, Property property2)
+        => reporter.BeginBlock(name, severity, minTimeToReport: TimeSpan.Zero, property1, property2);
+
+    public static TelemetryScope BeginBlock(this ITelemetryReporter reporter, string name, Severity severity, Property property1, Property property2, Property property3)
+        => reporter.BeginBlock(name, severity, minTimeToReport: TimeSpan.Zero, property1, property2, property3);
+
+    public static TelemetryScope BeginBlock(this ITelemetryReporter reporter, string name, Severity severity, params ReadOnlySpan<Property> properties)
+        => reporter.BeginBlock(name, severity, minTimeToReport: TimeSpan.Zero, properties);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/NoOpTelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/NoOpTelemetryReporter.cs
@@ -25,7 +25,7 @@ internal class NoOpTelemetryReporter : ITelemetryReporter
     public TelemetryScope BeginBlock(string name, Severity severity, Property property1, Property property2, Property property3)
         => TelemetryScope.Null;
 
-    public TelemetryScope BeginBlock(string name, Severity severity, params Property[] properties)
+    public TelemetryScope BeginBlock(string name, Severity severity, TimeSpan minTimeToReport, params Property[] properties)
         => TelemetryScope.Null;
 
     public void ReportEvent(string name, Severity severity)
@@ -52,7 +52,7 @@ internal class NoOpTelemetryReporter : ITelemetryReporter
     {
     }
 
-    public TelemetryScope TrackLspRequest(string lspMethodName, string lspServerName, Guid correlationId)
+    public TelemetryScope TrackLspRequest(string lspMethodName, string lspServerName, TimeSpan minTimeToReport, Guid correlationId)
         => TelemetryScope.Null;
 
     public void ReportRequestTiming(string name, string? language, TimeSpan queuedDuration, TimeSpan requestDuration, TelemetryResult result)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/NoOpTelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/NoOpTelemetryReporter.cs
@@ -13,19 +13,19 @@ internal class NoOpTelemetryReporter : ITelemetryReporter
     {
     }
 
-    public TelemetryScope BeginBlock(string name, Severity severity)
+    public TelemetryScope BeginBlock(string name, Severity severity, TimeSpan minTimeToReport)
         => TelemetryScope.Null;
 
-    public TelemetryScope BeginBlock(string name, Severity severity, Property property)
+    public TelemetryScope BeginBlock(string name, Severity severity, TimeSpan minTimeToReport, Property property)
         => TelemetryScope.Null;
 
-    public TelemetryScope BeginBlock(string name, Severity severity, Property property1, Property property2)
+    public TelemetryScope BeginBlock(string name, Severity severity, TimeSpan minTimeToReport, Property property1, Property property2)
         => TelemetryScope.Null;
 
-    public TelemetryScope BeginBlock(string name, Severity severity, Property property1, Property property2, Property property3)
+    public TelemetryScope BeginBlock(string name, Severity severity, TimeSpan minTimeToReport, Property property1, Property property2, Property property3)
         => TelemetryScope.Null;
 
-    public TelemetryScope BeginBlock(string name, Severity severity, TimeSpan minTimeToReport, params Property[] properties)
+    public TelemetryScope BeginBlock(string name, Severity severity, TimeSpan minTimeToReport, params ReadOnlySpan<Property> properties)
         => TelemetryScope.Null;
 
     public void ReportEvent(string name, Severity severity)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/TelemetryScope.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/TelemetryScope.cs
@@ -74,46 +74,45 @@ internal sealed class TelemetryScope : IDisposable
         StopwatchPool.Default.Return(_stopwatch);
     }
 
-    public static TelemetryScope Create(ITelemetryReporter reporter, string name, Severity severity)
+    public static TelemetryScope Create(ITelemetryReporter reporter, string name, Severity severity, TimeSpan minTimeToReport)
     {
         var array = new Property[1];
 
-        return new(reporter, name, TimeSpan.Zero, severity, array);
+        return new(reporter, name, minTimeToReport, severity, array);
     }
 
-    public static TelemetryScope Create(ITelemetryReporter reporter, string name, Severity severity, Property property)
+    public static TelemetryScope Create(ITelemetryReporter reporter, string name, Severity severity, TimeSpan minTimeToReport, Property property)
     {
         var array = new Property[2];
         array[0] = property;
 
-        return new(reporter, name, TimeSpan.Zero, severity, array);
+        return new(reporter, name, minTimeToReport, severity, array);
     }
 
-    public static TelemetryScope Create(ITelemetryReporter reporter, string name, Severity severity, Property property1, Property property2)
+    public static TelemetryScope Create(ITelemetryReporter reporter, string name, Severity severity, TimeSpan minTimeToReport, Property property1, Property property2)
     {
         var array = new Property[3];
         array[0] = property1;
         array[1] = property2;
 
-        return new(reporter, name, TimeSpan.Zero, severity,  array);
+        return new(reporter, name, minTimeToReport, severity,  array);
     }
 
-    public static TelemetryScope Create(ITelemetryReporter reporter, string name, Severity severity, Property property1, Property property2, Property property3)
+    public static TelemetryScope Create(ITelemetryReporter reporter, string name, Severity severity, TimeSpan minTimeToReport, Property property1, Property property2, Property property3)
     {
         var array = new Property[4];
         array[0] = property1;
         array[1] = property2;
         array[2] = property3;
 
-        return new(reporter, name, TimeSpan.Zero, severity, array);
+        return new(reporter, name, minTimeToReport, severity, array);
     }
 
-    public static TelemetryScope Create(ITelemetryReporter reporter, string name, Severity severity, TimeSpan minTimeToReport, Property[] properties)
+    public static TelemetryScope Create(ITelemetryReporter reporter, string name, Severity severity, TimeSpan minTimeToReport, ReadOnlySpan<Property> properties)
     {
         var array = new Property[properties.Length + 1];
-
-        Array.Copy(properties, array, properties.Length);
-
+        properties.CopyTo(array);
+        
         return new(reporter, name, minTimeToReport, severity, array);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/TelemetryScope.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/TelemetryScope.cs
@@ -4,12 +4,10 @@
 using System;
 using System.Diagnostics;
 using Microsoft.AspNetCore.Razor.PooledObjects;
-using Microsoft.AspNetCore.Razor.Utilities;
 
 namespace Microsoft.AspNetCore.Razor.Telemetry;
 
-[NonCopyable]
-internal struct TelemetryScope : IDisposable
+internal sealed class TelemetryScope : IDisposable
 {
     public static readonly TelemetryScope Null = new();
 
@@ -21,9 +19,9 @@ internal struct TelemetryScope : IDisposable
     private readonly TimeSpan _minTimeToReport;
     private bool _disposed;
 
-    public TelemetryScope()
+    private TelemetryScope()
     {
-        // This constructor should be called only to initialize the Null instance
+        // This constructor is only called to initialize the Null instance
         // above. Rather than make _name, _properties, and _stopwatch
         // nullable, we use a ! to initialize them to null for this case only.
         _reporter = null;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/TelemetryScope.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/TelemetryScope.cs
@@ -4,10 +4,12 @@
 using System;
 using System.Diagnostics;
 using Microsoft.AspNetCore.Razor.PooledObjects;
+using Microsoft.AspNetCore.Razor.Utilities;
 
 namespace Microsoft.AspNetCore.Razor.Telemetry;
 
-internal sealed class TelemetryScope : IDisposable
+[NonCopyable]
+internal struct TelemetryScope : IDisposable
 {
     public static readonly TelemetryScope Null = new();
 
@@ -19,9 +21,9 @@ internal sealed class TelemetryScope : IDisposable
     private readonly TimeSpan _minTimeToReport;
     private bool _disposed;
 
-    private TelemetryScope()
+    public TelemetryScope()
     {
-        // This constructor is only called to initialize the Null instance
+        // This constructor should be called only to initialize the Null instance
         // above. Rather than make _name, _properties, and _stopwatch
         // nullable, we use a ! to initialize them to null for this case only.
         _reporter = null;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Telemetry/TelemetryThresholds.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Telemetry/TelemetryThresholds.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Razor.Workspaces.Telemetry;
+
+/// <summary>
+/// A set of constants used to reduce the telemetry emitted to the set that help us understand
+/// which LSP is taking the most time in the case that the overall call is lengthy.
+/// </summary>
+internal class TelemetryThresholds
+{
+    internal const int CodeActionRazorTelemetryThresholdMS = 2000;
+    internal const int CodeActionSubLSPTelemetryThresholdMS = 1000;
+
+    internal const int CompletionRazorTelemetryThresholdMS = 4000;
+    internal const int CompletionSubLSPTelemetryThresholdMS = 2000;
+
+    internal const int DiagnosticsRazorTelemetryThresholdMS = 4000;
+    internal const int DiagnosticsSubLSPTelemetryThresholdMS = 2000;
+
+    internal const int MapCodeRazorTelemetryThresholdMS = 2000;
+    internal const int MapCodeSubLSPTelemetryThresholdMS = 1000;
+
+    internal const int SemanticTokensRazorTelemetryThresholdMS = 2000;
+    internal const int SemanticTokensSubLSPTelemetryThresholdMS = 1000;
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Telemetry/TelemetryThresholds.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Telemetry/TelemetryThresholds.cs
@@ -1,26 +1,28 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.CodeAnalysis.Razor.Workspaces.Telemetry;
 
 /// <summary>
 /// A set of constants used to reduce the telemetry emitted to the set that help us understand
 /// which LSP is taking the most time in the case that the overall call is lengthy.
 /// </summary>
-internal class TelemetryThresholds
+internal static class TelemetryThresholds
 {
-    internal const int CodeActionRazorTelemetryThresholdMS = 2000;
-    internal const int CodeActionSubLSPTelemetryThresholdMS = 1000;
+    internal static readonly TimeSpan CodeActionRazorTelemetryThreshold = TimeSpan.FromMilliseconds(2000);
+    internal static readonly TimeSpan CodeActionSubLSPTelemetryThreshold = TimeSpan.FromMilliseconds(1000);
 
-    internal const int CompletionRazorTelemetryThresholdMS = 4000;
-    internal const int CompletionSubLSPTelemetryThresholdMS = 2000;
+    internal static readonly TimeSpan CompletionRazorTelemetryThreshold = TimeSpan.FromMilliseconds(4000);
+    internal static readonly TimeSpan CompletionSubLSPTelemetryThreshold = TimeSpan.FromMilliseconds(2000);
 
-    internal const int DiagnosticsRazorTelemetryThresholdMS = 4000;
-    internal const int DiagnosticsSubLSPTelemetryThresholdMS = 2000;
+    internal static readonly TimeSpan DiagnosticsRazorTelemetryThreshold = TimeSpan.FromMilliseconds(4000);
+    internal static readonly TimeSpan DiagnosticsSubLSPTelemetryThreshold = TimeSpan.FromMilliseconds(2000);
 
-    internal const int MapCodeRazorTelemetryThresholdMS = 2000;
-    internal const int MapCodeSubLSPTelemetryThresholdMS = 1000;
+    internal static readonly TimeSpan MapCodeRazorTelemetryThreshold = TimeSpan.FromMilliseconds(2000);
+    internal static readonly TimeSpan MapCodeSubLSPTelemetryThreshold = TimeSpan.FromMilliseconds(1000);
 
-    internal const int SemanticTokensRazorTelemetryThresholdMS = 2000;
-    internal const int SemanticTokensSubLSPTelemetryThresholdMS = 1000;
+    internal static readonly TimeSpan SemanticTokensRazorTelemetryThreshold = TimeSpan.FromMilliseconds(2000);
+    internal static readonly TimeSpan SemanticTokensSubLSPTelemetryThreshold = TimeSpan.FromMilliseconds(1000);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SemanticTokens/RemoteCSharpSemanticTokensProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SemanticTokens/RemoteCSharpSemanticTokensProvider.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost.Handlers;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.SemanticTokens;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Telemetry;
 using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
 
@@ -26,7 +27,10 @@ internal class RemoteCSharpSemanticTokensProvider(IFilePathService filePathServi
 
     public async Task<int[]?> GetCSharpSemanticTokensResponseAsync(DocumentContext documentContext, ImmutableArray<LinePositionSpan> csharpRanges, Guid correlationId, CancellationToken cancellationToken)
     {
-        using var _ = _telemetryReporter.TrackLspRequest(nameof(SemanticTokensRange.GetSemanticTokensAsync), Constants.ExternalAccessServerName, correlationId);
+        using var _ = _telemetryReporter.TrackLspRequest(nameof(SemanticTokensRange.GetSemanticTokensAsync),
+            Constants.ExternalAccessServerName,
+            TimeSpan.FromMilliseconds(TelemetryThresholds.SemanticTokensRazorTelemetryThresholdMS),
+            correlationId);
 
         // We have a razor document, lets find the generated C# document
         Debug.Assert(documentContext is RemoteDocumentContext, "This method only works on document snapshots created in the OOP process");

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SemanticTokens/RemoteCSharpSemanticTokensProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/SemanticTokens/RemoteCSharpSemanticTokensProvider.cs
@@ -29,7 +29,7 @@ internal class RemoteCSharpSemanticTokensProvider(IFilePathService filePathServi
     {
         using var _ = _telemetryReporter.TrackLspRequest(nameof(SemanticTokensRange.GetSemanticTokensAsync),
             Constants.ExternalAccessServerName,
-            TimeSpan.FromMilliseconds(TelemetryThresholds.SemanticTokensRazorTelemetryThresholdMS),
+            TelemetryThresholds.SemanticTokensRazorTelemetryThreshold,
             correlationId);
 
         // We have a razor document, lets find the generated C# document

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostSemanticTokensRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostSemanticTokensRangeEndpoint.cs
@@ -80,7 +80,7 @@ internal sealed class CohostSemanticTokensRangeEndpoint(
         var colorBackground = _clientSettingsManager.GetClientSettings().AdvancedSettings.ColorBackground;
 
         var correlationId = Guid.NewGuid();
-        using var _ = _telemetryReporter.TrackLspRequest(Methods.TextDocumentSemanticTokensRangeName, RazorLSPConstants.CohostLanguageServerName, TimeSpan.FromMilliseconds(TelemetryThresholds.SemanticTokensRazorTelemetryThresholdMS), correlationId);
+        using var _ = _telemetryReporter.TrackLspRequest(Methods.TextDocumentSemanticTokensRangeName, RazorLSPConstants.CohostLanguageServerName, TelemetryThresholds.SemanticTokensRazorTelemetryThreshold, correlationId);
 
         var tokens = await _remoteServiceInvoker.TryInvokeAsync<IRemoteSemanticTokensService, int[]?>(
             razorDocument.Project.Solution,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostSemanticTokensRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostSemanticTokensRangeEndpoint.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
 using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.CodeAnalysis.Razor.SemanticTokens;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Telemetry;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Razor.Settings;
@@ -79,7 +80,7 @@ internal sealed class CohostSemanticTokensRangeEndpoint(
         var colorBackground = _clientSettingsManager.GetClientSettings().AdvancedSettings.ColorBackground;
 
         var correlationId = Guid.NewGuid();
-        using var _ = _telemetryReporter.TrackLspRequest(Methods.TextDocumentSemanticTokensRangeName, RazorLSPConstants.CohostLanguageServerName, correlationId);
+        using var _ = _telemetryReporter.TrackLspRequest(Methods.TextDocumentSemanticTokensRangeName, RazorLSPConstants.CohostLanguageServerName, TimeSpan.FromMilliseconds(TelemetryThresholds.SemanticTokensRazorTelemetryThresholdMS), correlationId);
 
         var tokens = await _remoteServiceInvoker.TryInvokeAsync<IRemoteSemanticTokensService, int[]?>(
             razorDocument.Project.Solution,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_CodeActions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_CodeActions.cs
@@ -57,7 +57,7 @@ internal partial class RazorCustomMessageTarget
 
         var textBuffer = virtualDocumentSnapshot.Snapshot.TextBuffer;
         var lspMethodName = Methods.TextDocumentCodeActionName;
-        using var _ = _telemetryReporter.TrackLspRequest(lspMethodName, languageServerName, TimeSpan.FromMilliseconds(TelemetryThresholds.CodeActionSubLSPTelemetryThresholdMS), codeActionParams.CorrelationId);
+        using var _ = _telemetryReporter.TrackLspRequest(lspMethodName, languageServerName, TelemetryThresholds.CodeActionSubLSPTelemetryThreshold, codeActionParams.CorrelationId);
         var requests = _requestInvoker.ReinvokeRequestOnMultipleServersAsync<VSCodeActionParams, IReadOnlyList<VSInternalCodeAction>>(
             textBuffer,
             lspMethodName,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_CodeActions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_CodeActions.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Protocol.CodeActions;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Telemetry;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Threading;
@@ -56,7 +57,7 @@ internal partial class RazorCustomMessageTarget
 
         var textBuffer = virtualDocumentSnapshot.Snapshot.TextBuffer;
         var lspMethodName = Methods.TextDocumentCodeActionName;
-        using var _ = _telemetryReporter.TrackLspRequest(lspMethodName, languageServerName, codeActionParams.CorrelationId);
+        using var _ = _telemetryReporter.TrackLspRequest(lspMethodName, languageServerName, TimeSpan.FromMilliseconds(TelemetryThresholds.CodeActionSubLSPTelemetryThresholdMS), codeActionParams.CorrelationId);
         var requests = _requestInvoker.ReinvokeRequestOnMultipleServersAsync<VSCodeActionParams, IReadOnlyList<VSInternalCodeAction>>(
             textBuffer,
             lspMethodName,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_Completion.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_Completion.cs
@@ -122,7 +122,7 @@ internal partial class RazorCustomMessageTarget
             var textBuffer = virtualDocumentSnapshot.Snapshot.TextBuffer;
             var lspMethodName = Methods.TextDocumentCompletion.Name;
             ReinvocationResponse<VSInternalCompletionList?>? response;
-            using (_telemetryReporter.TrackLspRequest(lspMethodName, languageServerName, TimeSpan.FromMilliseconds(TelemetryThresholds.CompletionSubLSPTelemetryThresholdMS), request.CorrelationId))
+            using (_telemetryReporter.TrackLspRequest(lspMethodName, languageServerName, TelemetryThresholds.CompletionSubLSPTelemetryThreshold, request.CorrelationId))
             {
                 response = await _requestInvoker.ReinvokeRequestOnServerAsync<CompletionParams, VSInternalCompletionList?>(
                     textBuffer,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_Completion.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_Completion.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Protocol.Completion;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Telemetry;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Razor.Snippets;
@@ -121,7 +122,7 @@ internal partial class RazorCustomMessageTarget
             var textBuffer = virtualDocumentSnapshot.Snapshot.TextBuffer;
             var lspMethodName = Methods.TextDocumentCompletion.Name;
             ReinvocationResponse<VSInternalCompletionList?>? response;
-            using (_telemetryReporter.TrackLspRequest(lspMethodName, languageServerName, request.CorrelationId))
+            using (_telemetryReporter.TrackLspRequest(lspMethodName, languageServerName, TimeSpan.FromMilliseconds(TelemetryThresholds.CompletionSubLSPTelemetryThresholdMS), request.CorrelationId))
             {
                 response = await _requestInvoker.ReinvokeRequestOnServerAsync<CompletionParams, VSInternalCompletionList?>(
                     textBuffer,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_Diagnostics.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_Diagnostics.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Protocol.Diagnostics;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Telemetry;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using StreamJsonRpc;
@@ -78,7 +79,7 @@ internal partial class RazorCustomMessageTarget
         };
 
         var lspMethodName = VSInternalMethods.DocumentPullDiagnosticName;
-        using var _ = _telemetryReporter.TrackLspRequest(lspMethodName, delegatedLanguageServerName, correlationId);
+        using var _ = _telemetryReporter.TrackLspRequest(lspMethodName, delegatedLanguageServerName,        TimeSpan.FromMilliseconds(TelemetryThresholds.DiagnosticsSubLSPTelemetryThresholdMS), correlationId);
         var response = await _requestInvoker.ReinvokeRequestOnServerAsync<VSInternalDocumentDiagnosticsParams, VSInternalDiagnosticReport[]?>(
             virtualDocument.Snapshot.TextBuffer,
             lspMethodName,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_Diagnostics.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_Diagnostics.cs
@@ -79,7 +79,7 @@ internal partial class RazorCustomMessageTarget
         };
 
         var lspMethodName = VSInternalMethods.DocumentPullDiagnosticName;
-        using var _ = _telemetryReporter.TrackLspRequest(lspMethodName, delegatedLanguageServerName,        TimeSpan.FromMilliseconds(TelemetryThresholds.DiagnosticsSubLSPTelemetryThresholdMS), correlationId);
+        using var _ = _telemetryReporter.TrackLspRequest(lspMethodName, delegatedLanguageServerName, TelemetryThresholds.DiagnosticsSubLSPTelemetryThreshold, correlationId);
         var response = await _requestInvoker.ReinvokeRequestOnServerAsync<VSInternalDocumentDiagnosticsParams, VSInternalDiagnosticReport[]?>(
             virtualDocument.Snapshot.TextBuffer,
             lspMethodName,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_MapCode.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_MapCode.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Razor.Protocol;
@@ -41,7 +40,7 @@ internal partial class RazorCustomMessageTarget
         var textBuffer = delegationDetails.Value.TextBuffer;
         var lspMethodName = VSInternalMethods.WorkspaceMapCodeName;
         var languageServerName = delegationDetails.Value.LanguageServerName;
-        using var _ = _telemetryReporter.TrackLspRequest(lspMethodName, languageServerName, TimeSpan.FromMilliseconds(TelemetryThresholds.MapCodeSubLSPTelemetryThresholdMS), request.MapCodeCorrelationId);
+        using var _ = _telemetryReporter.TrackLspRequest(lspMethodName, languageServerName, TelemetryThresholds.MapCodeSubLSPTelemetryThreshold, request.MapCodeCorrelationId);
 
         var response = await _requestInvoker.ReinvokeRequestOnServerAsync<VSInternalMapCodeParams, WorkspaceEdit?>(
             textBuffer,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_MapCode.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_MapCode.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Razor.Protocol;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Telemetry;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using StreamJsonRpc;
 
@@ -39,7 +41,7 @@ internal partial class RazorCustomMessageTarget
         var textBuffer = delegationDetails.Value.TextBuffer;
         var lspMethodName = VSInternalMethods.WorkspaceMapCodeName;
         var languageServerName = delegationDetails.Value.LanguageServerName;
-        using var _ = _telemetryReporter.TrackLspRequest(lspMethodName, languageServerName, request.MapCodeCorrelationId);
+        using var _ = _telemetryReporter.TrackLspRequest(lspMethodName, languageServerName, TimeSpan.FromMilliseconds(TelemetryThresholds.MapCodeSubLSPTelemetryThresholdMS), request.MapCodeCorrelationId);
 
         var response = await _requestInvoker.ReinvokeRequestOnServerAsync<VSInternalMapCodeParams, WorkspaceEdit?>(
             textBuffer,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_SemanticTokens.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_SemanticTokens.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -86,7 +85,7 @@ internal partial class RazorCustomMessageTarget
         var languageServerName = RazorLSPConstants.RazorCSharpLanguageServerName;
 
         SemanticTokens? response;
-        using (var disposable = _telemetryReporter.TrackLspRequest(lspMethodName, languageServerName, TimeSpan.FromMilliseconds(TelemetryThresholds.SemanticTokensSubLSPTelemetryThresholdMS), semanticTokensParams.CorrelationId))
+        using (var disposable = _telemetryReporter.TrackLspRequest(lspMethodName, languageServerName, TelemetryThresholds.SemanticTokensSubLSPTelemetryThreshold, semanticTokensParams.CorrelationId))
         {
             try
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_SemanticTokens.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_SemanticTokens.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -8,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Protocol.SemanticTokens;
+using Microsoft.CodeAnalysis.Razor.Workspaces.Telemetry;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using StreamJsonRpc;
 
@@ -84,7 +86,7 @@ internal partial class RazorCustomMessageTarget
         var languageServerName = RazorLSPConstants.RazorCSharpLanguageServerName;
 
         SemanticTokens? response;
-        using (var disposable = _telemetryReporter.TrackLspRequest(lspMethodName, languageServerName, semanticTokensParams.CorrelationId))
+        using (var disposable = _telemetryReporter.TrackLspRequest(lspMethodName, languageServerName, TimeSpan.FromMilliseconds(TelemetryThresholds.SemanticTokensSubLSPTelemetryThresholdMS), semanticTokensParams.CorrelationId))
         {
             try
             {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
@@ -260,22 +260,18 @@ internal abstract partial class TelemetryReporter : ITelemetryReporter
     public TelemetryScope BeginBlock(string name, Severity severity, Property property1, Property property2, Property property3)
         => TelemetryScope.Create(this, name, severity, property1, property2, property3);
 
-    public TelemetryScope BeginBlock(string name, Severity severity, params Property[] properties)
-        => TelemetryScope.Create(this, name, severity, properties);
+    public TelemetryScope BeginBlock(string name, Severity severity, TimeSpan minTimeToReport, params Property[] properties)
+        => TelemetryScope.Create(this, name, severity, minTimeToReport, properties);
 
-    public TelemetryScope TrackLspRequest(string lspMethodName, string languageServerName, Guid correlationId)
+    public TelemetryScope TrackLspRequest(string lspMethodName, string languageServerName, TimeSpan minTimeToReport, Guid correlationId)
     {
         if (correlationId == Guid.Empty)
         {
             return TelemetryScope.Null;
         }
 
-        ReportEvent("BeginLspRequest", Severity.Normal,
-            new("eventscope.method", lspMethodName),
-            new("eventscope.languageservername", languageServerName),
-            new("eventscope.correlationid", correlationId));
-
         return BeginBlock("TrackLspRequest", Severity.Normal,
+            minTimeToReport,
             new("eventscope.method", lspMethodName),
             new("eventscope.languageservername", languageServerName),
             new("eventscope.correlationid", correlationId));

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
@@ -237,7 +237,7 @@ internal abstract partial class TelemetryReporter : ITelemetryReporter
         }
     }
 
-    protected virtual bool HandleException(Exception exception, string? message, params object?[] @params)
+    protected virtual bool HandleException(Exception exception, string? message, params ReadOnlySpan<object?> @params)
         => false;
 
     protected virtual void LogTrace(string message)
@@ -248,19 +248,19 @@ internal abstract partial class TelemetryReporter : ITelemetryReporter
     {
     }
 
-    public TelemetryScope BeginBlock(string name, Severity severity)
-        => TelemetryScope.Create(this, name, severity);
+    public TelemetryScope BeginBlock(string name, Severity severity, TimeSpan minTimeToReport)
+        => TelemetryScope.Create(this, name, severity, minTimeToReport);
 
-    public TelemetryScope BeginBlock(string name, Severity severity, Property property)
-        => TelemetryScope.Create(this, name, severity, property);
+    public TelemetryScope BeginBlock(string name, Severity severity, TimeSpan minTimeToReport, Property property)
+        => TelemetryScope.Create(this, name, severity, minTimeToReport, property);
 
-    public TelemetryScope BeginBlock(string name, Severity severity, Property property1, Property property2)
-        => TelemetryScope.Create(this, name, severity, property1, property2);
+    public TelemetryScope BeginBlock(string name, Severity severity, TimeSpan minTimeToReport, Property property1, Property property2)
+        => TelemetryScope.Create(this, name, severity, minTimeToReport, property1, property2);
 
-    public TelemetryScope BeginBlock(string name, Severity severity, Property property1, Property property2, Property property3)
-        => TelemetryScope.Create(this, name, severity, property1, property2, property3);
+    public TelemetryScope BeginBlock(string name, Severity severity, TimeSpan minTimeToReport, Property property1, Property property2, Property property3)
+        => TelemetryScope.Create(this, name, severity, minTimeToReport, property1, property2, property3);
 
-    public TelemetryScope BeginBlock(string name, Severity severity, TimeSpan minTimeToReport, params Property[] properties)
+    public TelemetryScope BeginBlock(string name, Severity severity, TimeSpan minTimeToReport, params ReadOnlySpan<Property> properties)
         => TelemetryScope.Create(this, name, severity, minTimeToReport, properties);
 
     public TelemetryScope TrackLspRequest(string lspMethodName, string languageServerName, TimeSpan minTimeToReport, Guid correlationId)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/VSTelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/VSTelemetryReporter.cs
@@ -21,7 +21,7 @@ internal class VSTelemetryReporter(ILoggerFactory loggerFactory) : TelemetryRepo
         Flush();
     }
 
-    protected override bool HandleException(Exception exception, string? message, params object?[] @params)
+    protected override bool HandleException(Exception exception, string? message, params ReadOnlySpan<object?> @params)
     {
         if (exception is RemoteInvocationException remoteInvocationException)
         {
@@ -34,7 +34,7 @@ internal class VSTelemetryReporter(ILoggerFactory loggerFactory) : TelemetryRepo
         return false;
     }
 
-    private bool ReportRemoteInvocationException(RemoteInvocationException remoteInvocationException, object?[] @params)
+    private bool ReportRemoteInvocationException(RemoteInvocationException remoteInvocationException, ReadOnlySpan<object?> @params)
     {
         if (remoteInvocationException.InnerException is Exception innerException)
         {

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/RazorCustomMessageTargetTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/RazorCustomMessageTargetTest.cs
@@ -266,7 +266,9 @@ public class RazorCustomMessageTargetTest : ToolingTestBase
 
         var documentSynchronizer = GetDocumentSynchronizer(GetCSharpSnapshot());
         var telemetryReporter = new Mock<ITelemetryReporter>(MockBehavior.Strict);
-        telemetryReporter.Setup(r => r.TrackLspRequest(It.IsAny<string>(), It.IsAny<string>(), TimeSpan.FromSeconds(1), It.IsAny<Guid>())).Returns(TelemetryScope.Null);
+        telemetryReporter.Setup(r => r.TrackLspRequest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<Guid>()))
+            .Callback<string, string, TimeSpan, Guid>((s1, s2, ts, g) => Assert.NotEqual(TimeSpan.Zero, ts))
+            .Returns(TelemetryScope.Null);
         var csharpVirtualDocumentAddListener = new CSharpVirtualDocumentAddListener(LoggerFactory);
 
         var target = new RazorCustomMessageTarget(
@@ -520,8 +522,13 @@ public class RazorCustomMessageTargetTest : ToolingTestBase
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new DefaultLSPDocumentSynchronizer.SynchronizedResult<CSharpVirtualDocumentSnapshot>(true, csharpVirtualDocument));
         var telemetryReporter = new Mock<ITelemetryReporter>(MockBehavior.Strict);
-        telemetryReporter.Setup(r => r.BeginBlock(It.IsAny<string>(), It.IsAny<Severity>(), It.IsAny<TimeSpan>(), It.IsAny<Property>())).Returns(TelemetryScope.Null);
-        telemetryReporter.Setup(r => r.TrackLspRequest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<Guid>())).Returns(TelemetryScope.Null);
+        telemetryReporter.Setup(r => r.BeginBlock(It.IsAny<string>(), It.IsAny<Severity>(), It.IsAny<TimeSpan>(), It.IsAny<Property>()))
+            .Callback<string, Severity, TimeSpan, Property>((s1, s2, ts, g) => Assert.NotEqual(TimeSpan.Zero, ts))
+            .Returns(TelemetryScope.Null);
+
+        telemetryReporter.Setup(r => r.TrackLspRequest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<Guid>()))
+            .Callback<string, string, TimeSpan, Guid>((s1, s2, ts, g) => Assert.NotEqual(TimeSpan.Zero, ts))
+            .Returns(TelemetryScope.Null);
         var csharpVirtualDocumentAddListener = new CSharpVirtualDocumentAddListener(LoggerFactory);
 
         var target = new RazorCustomMessageTarget(
@@ -598,8 +605,13 @@ public class RazorCustomMessageTargetTest : ToolingTestBase
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new DefaultLSPDocumentSynchronizer.SynchronizedResult<CSharpVirtualDocumentSnapshot>(true, csharpVirtualDocument));
         var telemetryReporter = new Mock<ITelemetryReporter>(MockBehavior.Strict);
-        telemetryReporter.Setup(r => r.BeginBlock(It.IsAny<string>(), It.IsAny<Severity>(), It.IsAny<TimeSpan>(), It.IsAny<Property>())).Returns(TelemetryScope.Null);
-        telemetryReporter.Setup(r => r.TrackLspRequest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<Guid>())).Returns(TelemetryScope.Null);
+        telemetryReporter.Setup(r => r.BeginBlock(It.IsAny<string>(), It.IsAny<Severity>(), It.IsAny<TimeSpan>(), It.IsAny<Property>()))
+            .Callback<string, Severity, TimeSpan, Property>((s, sev, ts, p) => Assert.NotEqual(TimeSpan.Zero, ts))
+            .Returns(TelemetryScope.Null);
+
+        telemetryReporter.Setup(r => r.TrackLspRequest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<Guid>()))
+            .Callback<string, string, TimeSpan, Guid>((s1, s2, ts, g) => Assert.NotEqual(TimeSpan.Zero, ts))
+            .Returns(TelemetryScope.Null);
         var csharpVirtualDocumentAddListener = new CSharpVirtualDocumentAddListener(LoggerFactory);
 
         var target = new RazorCustomMessageTarget(

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/RazorCustomMessageTargetTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/RazorCustomMessageTargetTest.cs
@@ -520,8 +520,8 @@ public class RazorCustomMessageTargetTest : ToolingTestBase
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new DefaultLSPDocumentSynchronizer.SynchronizedResult<CSharpVirtualDocumentSnapshot>(true, csharpVirtualDocument));
         var telemetryReporter = new Mock<ITelemetryReporter>(MockBehavior.Strict);
-        telemetryReporter.Setup(r => r.BeginBlock(It.IsAny<string>(), It.IsAny<Severity>(), TimeSpan.FromSeconds(1), It.IsAny<Property[]>())).Returns(TelemetryScope.Null);
-        telemetryReporter.Setup(r => r.TrackLspRequest(It.IsAny<string>(), It.IsAny<string>(), TimeSpan.FromSeconds(1), It.IsAny<Guid>())).Returns(TelemetryScope.Null);
+        telemetryReporter.Setup(r => r.BeginBlock(It.IsAny<string>(), It.IsAny<Severity>(), It.IsAny<TimeSpan>(), It.IsAny<Property>())).Returns(TelemetryScope.Null);
+        telemetryReporter.Setup(r => r.TrackLspRequest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<Guid>())).Returns(TelemetryScope.Null);
         var csharpVirtualDocumentAddListener = new CSharpVirtualDocumentAddListener(LoggerFactory);
 
         var target = new RazorCustomMessageTarget(
@@ -598,8 +598,8 @@ public class RazorCustomMessageTargetTest : ToolingTestBase
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new DefaultLSPDocumentSynchronizer.SynchronizedResult<CSharpVirtualDocumentSnapshot>(true, csharpVirtualDocument));
         var telemetryReporter = new Mock<ITelemetryReporter>(MockBehavior.Strict);
-        telemetryReporter.Setup(r => r.BeginBlock(It.IsAny<string>(), It.IsAny<Severity>(), TimeSpan.FromSeconds(1),It.IsAny<Property[]>())).Returns(TelemetryScope.Null);
-        telemetryReporter.Setup(r => r.TrackLspRequest(It.IsAny<string>(), It.IsAny<string>(), TimeSpan.FromSeconds(1), It.IsAny<Guid>())).Returns(TelemetryScope.Null);
+        telemetryReporter.Setup(r => r.BeginBlock(It.IsAny<string>(), It.IsAny<Severity>(), It.IsAny<TimeSpan>(), It.IsAny<Property>())).Returns(TelemetryScope.Null);
+        telemetryReporter.Setup(r => r.TrackLspRequest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<Guid>())).Returns(TelemetryScope.Null);
         var csharpVirtualDocumentAddListener = new CSharpVirtualDocumentAddListener(LoggerFactory);
 
         var target = new RazorCustomMessageTarget(

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/RazorCustomMessageTargetTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/RazorCustomMessageTargetTest.cs
@@ -266,7 +266,7 @@ public class RazorCustomMessageTargetTest : ToolingTestBase
 
         var documentSynchronizer = GetDocumentSynchronizer(GetCSharpSnapshot());
         var telemetryReporter = new Mock<ITelemetryReporter>(MockBehavior.Strict);
-        telemetryReporter.Setup(r => r.TrackLspRequest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>())).Returns(TelemetryScope.Null);
+        telemetryReporter.Setup(r => r.TrackLspRequest(It.IsAny<string>(), It.IsAny<string>(), TimeSpan.FromSeconds(1), It.IsAny<Guid>())).Returns(TelemetryScope.Null);
         var csharpVirtualDocumentAddListener = new CSharpVirtualDocumentAddListener(LoggerFactory);
 
         var target = new RazorCustomMessageTarget(
@@ -520,8 +520,8 @@ public class RazorCustomMessageTargetTest : ToolingTestBase
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new DefaultLSPDocumentSynchronizer.SynchronizedResult<CSharpVirtualDocumentSnapshot>(true, csharpVirtualDocument));
         var telemetryReporter = new Mock<ITelemetryReporter>(MockBehavior.Strict);
-        telemetryReporter.Setup(r => r.BeginBlock(It.IsAny<string>(), It.IsAny<Severity>(), It.IsAny<Property[]>())).Returns(TelemetryScope.Null);
-        telemetryReporter.Setup(r => r.TrackLspRequest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>())).Returns(TelemetryScope.Null);
+        telemetryReporter.Setup(r => r.BeginBlock(It.IsAny<string>(), It.IsAny<Severity>(), TimeSpan.FromSeconds(1), It.IsAny<Property[]>())).Returns(TelemetryScope.Null);
+        telemetryReporter.Setup(r => r.TrackLspRequest(It.IsAny<string>(), It.IsAny<string>(), TimeSpan.FromSeconds(1), It.IsAny<Guid>())).Returns(TelemetryScope.Null);
         var csharpVirtualDocumentAddListener = new CSharpVirtualDocumentAddListener(LoggerFactory);
 
         var target = new RazorCustomMessageTarget(
@@ -598,8 +598,8 @@ public class RazorCustomMessageTargetTest : ToolingTestBase
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new DefaultLSPDocumentSynchronizer.SynchronizedResult<CSharpVirtualDocumentSnapshot>(true, csharpVirtualDocument));
         var telemetryReporter = new Mock<ITelemetryReporter>(MockBehavior.Strict);
-        telemetryReporter.Setup(r => r.BeginBlock(It.IsAny<string>(), It.IsAny<Severity>(), It.IsAny<Property[]>())).Returns(TelemetryScope.Null);
-        telemetryReporter.Setup(r => r.TrackLspRequest(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>())).Returns(TelemetryScope.Null);
+        telemetryReporter.Setup(r => r.BeginBlock(It.IsAny<string>(), It.IsAny<Severity>(), TimeSpan.FromSeconds(1),It.IsAny<Property[]>())).Returns(TelemetryScope.Null);
+        telemetryReporter.Setup(r => r.TrackLspRequest(It.IsAny<string>(), It.IsAny<string>(), TimeSpan.FromSeconds(1), It.IsAny<Guid>())).Returns(TelemetryScope.Null);
         var csharpVirtualDocumentAddListener = new CSharpVirtualDocumentAddListener(LoggerFactory);
 
         var target = new RazorCustomMessageTarget(

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Telemetry/TelemetryReporterTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Telemetry/TelemetryReporterTests.cs
@@ -168,7 +168,7 @@ public class TelemetryReporterTests(ITestOutputHelper testOutput) : ToolingTestB
     public void Block_TwoArguments()
     {
         using var reporter = new TestTelemetryReporter(LoggerFactory);
-        using (reporter.BeginBlock("EventName", Severity.Normal, new("P1", false), new("P2", "test")))
+        using (reporter.BeginBlock("EventName", Severity.Normal, TimeSpan.Zero, new("P1", false), new("P2", "test")))
         {
         }
 
@@ -192,6 +192,7 @@ public class TelemetryReporterTests(ITestOutputHelper testOutput) : ToolingTestB
         var p3Value = Guid.NewGuid();
         using (reporter.BeginBlock("EventName",
             Severity.Normal,
+            TimeSpan.Zero,
             new("P1", false),
             new("P2", "test"),
             new("P3", p3Value)))
@@ -222,6 +223,7 @@ public class TelemetryReporterTests(ITestOutputHelper testOutput) : ToolingTestB
         var p3Value = Guid.NewGuid();
         using (reporter.BeginBlock("EventName",
             Severity.Normal,
+            TimeSpan.Zero,
             new("P1", false),
             new("P2", "test"),
             new("P3", p3Value),
@@ -296,7 +298,7 @@ public class TelemetryReporterTests(ITestOutputHelper testOutput) : ToolingTestB
     {
         using var reporter = new TestTelemetryReporter(LoggerFactory);
         var correlationId = Guid.NewGuid();
-        using (reporter.TrackLspRequest("MethodName", "ServerName", correlationId))
+        using (reporter.TrackLspRequest("MethodName", "ServerName", TimeSpan.Zero, correlationId))
         {
         }
 
@@ -304,27 +306,14 @@ public class TelemetryReporterTests(ITestOutputHelper testOutput) : ToolingTestB
             e1 =>
             {
                 Assert.Equal(TelemetrySeverity.Normal, e1.Severity);
-                Assert.Equal("dotnet/razor/beginlsprequest", e1.Name);
+                Assert.Equal("dotnet/razor/tracklsprequest", e1.Name);
                 Assert.True(e1.HasProperties);
 
+                Assert.True(e1.Properties["dotnet.razor.eventscope.ellapsedms"] is long);
                 Assert.Equal("MethodName", e1.Properties["dotnet.razor.eventscope.method"]);
                 Assert.Equal("ServerName", e1.Properties["dotnet.razor.eventscope.languageservername"]);
 
                 var correlationProperty = e1.Properties["dotnet.razor.eventscope.correlationid"] as TelemetryComplexProperty;
-                Assert.NotNull(correlationProperty);
-                Assert.Equal(correlationId, correlationProperty.Value);
-            },
-            e2 =>
-            {
-                Assert.Equal(TelemetrySeverity.Normal, e2.Severity);
-                Assert.Equal("dotnet/razor/tracklsprequest", e2.Name);
-                Assert.True(e2.HasProperties);
-
-                Assert.True(e2.Properties["dotnet.razor.eventscope.ellapsedms"] is long);
-                Assert.Equal("MethodName", e2.Properties["dotnet.razor.eventscope.method"]);
-                Assert.Equal("ServerName", e2.Properties["dotnet.razor.eventscope.languageservername"]);
-
-                var correlationProperty = e2.Properties["dotnet.razor.eventscope.correlationid"] as TelemetryComplexProperty;
                 Assert.NotNull(correlationProperty);
                 Assert.Equal(correlationId, correlationProperty.Value);
             });


### PR DESCRIPTION
Reduce the amount of telemetry emitted

The beginLspRequest event is removed, and the trackLspRequest event is only emitted if the amount of time is over a certain threshold.  This allows analysis of cases in which the amount of taken is significantly over expectations while reducing the total telemetry significantly.

