### PR TITLE
Update Roslyn package references to latest available and do minor fixup

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,7 @@
     <_MicrosoftCodeAnalysisAnalyzersPackageVersion>3.11.0</_MicrosoftCodeAnalysisAnalyzersPackageVersion>
     <_RoslynDiagnosticAnalyzersPackageVersion>3.11.0-beta1.24508.2</_RoslynDiagnosticAnalyzersPackageVersion>
     <_MicrosoftVisualStudioLanguageServicesPackageVersion>$(MicrosoftVisualStudioLanguageServicesPackageVersion)</_MicrosoftVisualStudioLanguageServicesPackageVersion>
-    <_XunitPackageVersion>2.6.3</_XunitPackageVersion>
+    <_XunitPackageVersion>2.6.6</_XunitPackageVersion>
     <_MicrosoftBuildPackageVersion>17.11.0-preview-24309-01</_MicrosoftBuildPackageVersion>
   </PropertyGroup>
 
@@ -117,7 +117,7 @@
     <PackageVersion Include="System.Text.Json" Version="8.0.4" />
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     <PackageVersion Include="xunit" Version="$(_XunitPackageVersion)" />
-    <PackageVersion Include="Xunit.Combinatorial" Version="1.5.25" />
+    <PackageVersion Include="Xunit.Combinatorial" Version="1.6.24" />
     <PackageVersion Include="xunit.extensibility.execution" Version="$(_XunitPackageVersion)" />
     <PackageVersion Include="xunit.runner.utility" Version="2.4.1" />
     <PackageVersion Include="Xunit.StaFact" Version="1.2.46-alpha" />

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -11,82 +11,82 @@
       <Sha>4660d88cf953fbbd14192c787053a20246ce1aeb</Sha>
       <SourceBuild RepoName="source-build-reference-packages" ManagedOnly="true" />
     </Dependency>
-    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.12.0-3.24466.4">
+    <Dependency Name="Microsoft.Net.Compilers.Toolset" Version="4.13.0-1.24522.7">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>7b7951aa13c50ad768538e58ed3805898b058928</Sha>
+      <Sha>77c6704c42b162e89095631f12e2661398a75ba7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CommonLanguageServerProtocol.Framework" Version="4.12.0-3.24466.4">
+    <Dependency Name="Microsoft.CommonLanguageServerProtocol.Framework" Version="4.13.0-1.24522.7">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>7b7951aa13c50ad768538e58ed3805898b058928</Sha>
+      <Sha>77c6704c42b162e89095631f12e2661398a75ba7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.ExternalAccess.Razor" Version="4.12.0-3.24466.4">
+    <Dependency Name="Microsoft.CodeAnalysis.ExternalAccess.Razor" Version="4.13.0-1.24522.7">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>7b7951aa13c50ad768538e58ed3805898b058928</Sha>
+      <Sha>77c6704c42b162e89095631f12e2661398a75ba7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Common" Version="4.12.0-3.24466.4">
+    <Dependency Name="Microsoft.CodeAnalysis.Common" Version="4.13.0-1.24522.7">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>7b7951aa13c50ad768538e58ed3805898b058928</Sha>
+      <Sha>77c6704c42b162e89095631f12e2661398a75ba7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.12.0-3.24466.4">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp" Version="4.13.0-1.24522.7">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>7b7951aa13c50ad768538e58ed3805898b058928</Sha>
+      <Sha>77c6704c42b162e89095631f12e2661398a75ba7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.EditorFeatures" Version="4.12.0-3.24466.4">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.EditorFeatures" Version="4.13.0-1.24522.7">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>7b7951aa13c50ad768538e58ed3805898b058928</Sha>
+      <Sha>77c6704c42b162e89095631f12e2661398a75ba7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="4.12.0-3.24466.4">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Features" Version="4.13.0-1.24522.7">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>7b7951aa13c50ad768538e58ed3805898b058928</Sha>
+      <Sha>77c6704c42b162e89095631f12e2661398a75ba7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0-3.24466.4">
+    <Dependency Name="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.13.0-1.24522.7">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>7b7951aa13c50ad768538e58ed3805898b058928</Sha>
+      <Sha>77c6704c42b162e89095631f12e2661398a75ba7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures" Version="4.12.0-3.24466.4">
+    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures" Version="4.13.0-1.24522.7">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>7b7951aa13c50ad768538e58ed3805898b058928</Sha>
+      <Sha>77c6704c42b162e89095631f12e2661398a75ba7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Common" Version="4.12.0-3.24466.4">
+    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Common" Version="4.13.0-1.24522.7">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>7b7951aa13c50ad768538e58ed3805898b058928</Sha>
+      <Sha>77c6704c42b162e89095631f12e2661398a75ba7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Text" Version="4.12.0-3.24466.4">
+    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Text" Version="4.13.0-1.24522.7">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>7b7951aa13c50ad768538e58ed3805898b058928</Sha>
+      <Sha>77c6704c42b162e89095631f12e2661398a75ba7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Wpf" Version="4.12.0-3.24466.4">
+    <Dependency Name="Microsoft.CodeAnalysis.EditorFeatures.Wpf" Version="4.13.0-1.24522.7">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>7b7951aa13c50ad768538e58ed3805898b058928</Sha>
+      <Sha>77c6704c42b162e89095631f12e2661398a75ba7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Remote.ServiceHub" Version="4.12.0-3.24466.4">
+    <Dependency Name="Microsoft.CodeAnalysis.Remote.ServiceHub" Version="4.13.0-1.24522.7">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>7b7951aa13c50ad768538e58ed3805898b058928</Sha>
+      <Sha>77c6704c42b162e89095631f12e2661398a75ba7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.12.0-3.24466.4">
+    <Dependency Name="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="4.13.0-1.24522.7">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>7b7951aa13c50ad768538e58ed3805898b058928</Sha>
+      <Sha>77c6704c42b162e89095631f12e2661398a75ba7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.12.0-3.24466.4">
+    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.13.0-1.24522.7">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>7b7951aa13c50ad768538e58ed3805898b058928</Sha>
+      <Sha>77c6704c42b162e89095631f12e2661398a75ba7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.12.0-3.24466.4">
+    <Dependency Name="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.13.0-1.24522.7">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>7b7951aa13c50ad768538e58ed3805898b058928</Sha>
+      <Sha>77c6704c42b162e89095631f12e2661398a75ba7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.VisualStudio.LanguageServices" Version="4.12.0-3.24466.4">
+    <Dependency Name="Microsoft.VisualStudio.LanguageServices" Version="4.13.0-1.24522.7">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>7b7951aa13c50ad768538e58ed3805898b058928</Sha>
+      <Sha>77c6704c42b162e89095631f12e2661398a75ba7</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.CodeAnalysis.Test.Utilities" Version="4.12.0-3.24466.4">
+    <Dependency Name="Microsoft.CodeAnalysis.Test.Utilities" Version="4.13.0-1.24522.7">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>7b7951aa13c50ad768538e58ed3805898b058928</Sha>
+      <Sha>77c6704c42b162e89095631f12e2661398a75ba7</Sha>
     </Dependency>
     <!-- Intermediate is necessary for source build. -->
-    <Dependency Name="Microsoft.SourceBuild.Intermediate.roslyn" Version="4.12.0-3.24466.4">
+    <Dependency Name="Microsoft.SourceBuild.Intermediate.roslyn" Version="4.13.0-1.24522.7">
       <Uri>https://github.com/dotnet/roslyn</Uri>
-      <Sha>7b7951aa13c50ad768538e58ed3805898b058928</Sha>
+      <Sha>77c6704c42b162e89095631f12e2661398a75ba7</Sha>
       <SourceBuild RepoName="roslyn" ManagedOnly="true" />
     </Dependency>
   </ProductDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -53,25 +53,25 @@
     <MicrosoftSourceBuildIntermediatearcadePackageVersion>9.0.0-beta.24516.2</MicrosoftSourceBuildIntermediatearcadePackageVersion>
     <MicrosoftDotNetXliffTasksPackageVersion>1.0.0-beta.23475.1</MicrosoftDotNetXliffTasksPackageVersion>
     <MicrosoftSourceBuildIntermediatexlifftasksPackageVersion>1.0.0-beta.23475.1</MicrosoftSourceBuildIntermediatexlifftasksPackageVersion>
-    <MicrosoftNetCompilersToolsetPackageVersion>4.12.0-3.24466.4</MicrosoftNetCompilersToolsetPackageVersion>
-    <MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>4.12.0-3.24466.4</MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>
-    <MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>4.12.0-3.24466.4</MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>
-    <MicrosoftCodeAnalysisCommonPackageVersion>4.12.0-3.24466.4</MicrosoftCodeAnalysisCommonPackageVersion>
-    <MicrosoftCodeAnalysisCSharpPackageVersion>4.12.0-3.24466.4</MicrosoftCodeAnalysisCSharpPackageVersion>
-    <MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion>4.12.0-3.24466.4</MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.12.0-3.24466.4</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>4.12.0-3.24466.4</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
-    <MicrosoftCodeAnalysisEditorFeaturesPackageVersion>4.12.0-3.24466.4</MicrosoftCodeAnalysisEditorFeaturesPackageVersion>
-    <MicrosoftCodeAnalysisEditorFeaturesCommonPackageVersion>4.12.0-3.24466.4</MicrosoftCodeAnalysisEditorFeaturesCommonPackageVersion>
-    <MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>4.12.0-3.24466.4</MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>
-    <MicrosoftCodeAnalysisEditorFeaturesWpfPackageVersion>4.12.0-3.24466.4</MicrosoftCodeAnalysisEditorFeaturesWpfPackageVersion>
-    <MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>4.12.0-3.24466.4</MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>
-    <MicrosoftCodeAnalysisTestUtilitiesPackageVersion>4.12.0-3.24466.4</MicrosoftCodeAnalysisTestUtilitiesPackageVersion>
-    <MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>4.12.0-3.24466.4</MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>
-    <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>4.12.0-3.24466.4</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
-    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.12.0-3.24466.4</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
-    <MicrosoftSourceBuildIntermediateroslynPackageVersion>4.12.0-3.24466.4</MicrosoftSourceBuildIntermediateroslynPackageVersion>
-    <MicrosoftVisualStudioLanguageServicesPackageVersion>4.12.0-3.24466.4</MicrosoftVisualStudioLanguageServicesPackageVersion>
+    <MicrosoftNetCompilersToolsetPackageVersion>4.13.0-1.24522.7</MicrosoftNetCompilersToolsetPackageVersion>
+    <MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>4.13.0-1.24522.7</MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion>
+    <MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>4.13.0-1.24522.7</MicrosoftCodeAnalysisExternalAccessRazorPackageVersion>
+    <MicrosoftCodeAnalysisCommonPackageVersion>4.13.0-1.24522.7</MicrosoftCodeAnalysisCommonPackageVersion>
+    <MicrosoftCodeAnalysisCSharpPackageVersion>4.13.0-1.24522.7</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion>4.13.0-1.24522.7</MicrosoftCodeAnalysisCSharpEditorFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>4.13.0-1.24522.7</MicrosoftCodeAnalysisCSharpFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>4.13.0-1.24522.7</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisEditorFeaturesPackageVersion>4.13.0-1.24522.7</MicrosoftCodeAnalysisEditorFeaturesPackageVersion>
+    <MicrosoftCodeAnalysisEditorFeaturesCommonPackageVersion>4.13.0-1.24522.7</MicrosoftCodeAnalysisEditorFeaturesCommonPackageVersion>
+    <MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>4.13.0-1.24522.7</MicrosoftCodeAnalysisEditorFeaturesTextPackageVersion>
+    <MicrosoftCodeAnalysisEditorFeaturesWpfPackageVersion>4.13.0-1.24522.7</MicrosoftCodeAnalysisEditorFeaturesWpfPackageVersion>
+    <MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>4.13.0-1.24522.7</MicrosoftCodeAnalysisRemoteServiceHubPackageVersion>
+    <MicrosoftCodeAnalysisTestUtilitiesPackageVersion>4.13.0-1.24522.7</MicrosoftCodeAnalysisTestUtilitiesPackageVersion>
+    <MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>4.13.0-1.24522.7</MicrosoftCodeAnalysisVisualBasicWorkspacesPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>4.13.0-1.24522.7</MicrosoftCodeAnalysisWorkspacesCommonPackageVersion>
+    <MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>4.13.0-1.24522.7</MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion>
+    <MicrosoftSourceBuildIntermediateroslynPackageVersion>4.13.0-1.24522.7</MicrosoftSourceBuildIntermediateroslynPackageVersion>
+    <MicrosoftVisualStudioLanguageServicesPackageVersion>4.13.0-1.24522.7</MicrosoftVisualStudioLanguageServicesPackageVersion>
     <!--
       Exception - Microsoft.Extensions.ObjectPool and System.Collections.Immutable packages are not updated by automation,
       but are present in Version.Details.xml for source-build PVP flow. See the comment in Version.Details.xml for more information.
@@ -97,7 +97,7 @@
       PackageReference versions directly in arcade.
     -->
     <MicrosoftNetCompilersToolsetVersion>$(MicrosoftNetCompilersToolsetPackageVersion)</MicrosoftNetCompilersToolsetVersion>
-    <XUnitVersion>2.6.3</XUnitVersion>
+    <XUnitVersion>2.6.6</XUnitVersion>
     <XUnitAnalyzersVersion>1.7.0</XUnitAnalyzersVersion>
   </PropertyGroup>
 </Project>

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/MetadataCollectionTests.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/MetadataCollectionTests.cs
@@ -35,7 +35,9 @@ public class MetadataCollectionTests
         }
 
         var collection1 = MetadataCollection.Create(pairs.ToArray());
-        var collection2 = MetadataCollection.Create(pairs.ToArray().Reverse().ToArray());
+        // force conversion to IEnumerable so Linq Reverse method gets called instead of the new System.MemoryExtensions.Reverse
+        var enumerableCollection = (IEnumerable<KeyValuePair<string, string?>>)pairs;
+        var collection2 = MetadataCollection.Create(enumerableCollection.Reverse().ToArray());
 
         Assert.Equal(collection1, collection2);
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/MetadataCollectionTests.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/MetadataCollectionTests.cs
@@ -35,9 +35,8 @@ public class MetadataCollectionTests
         }
 
         var collection1 = MetadataCollection.Create(pairs.ToArray());
-        // force conversion to IEnumerable so Linq Reverse method gets called instead of the new System.MemoryExtensions.Reverse
-        var enumerableCollection = (IEnumerable<KeyValuePair<string, string?>>)pairs;
-        var collection2 = MetadataCollection.Create(enumerableCollection.Reverse().ToArray());
+        var reversed = Enumerable.Reverse(pairs.ToArray());
+        var collection2 = MetadataCollection.Create(reversed.ToArray());
 
         Assert.Equal(collection1, collection2);
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentSymbols/RemoteDocumentSymbolService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentSymbols/RemoteDocumentSymbolService.cs
@@ -38,7 +38,11 @@ internal sealed partial class RemoteDocumentSymbolService(in ServiceArgs args) :
             .ConfigureAwait(false);
 
         var csharpSymbols = await ExternalHandlers.DocumentSymbols.GetDocumentSymbolsAsync(
-            generatedDocument, useHierarchicalSymbols, supportsVSExtensions: true, cancellationToken).ConfigureAwait(false);
+            generatedDocument,
+            useHierarchicalSymbols,
+            // TODO: use correct value from client capabilities when https://github.com/dotnet/razor/issues/11102
+            supportsVSExtensions: true,
+            cancellationToken).ConfigureAwait(false);
 
         var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
         var csharpDocument = codeDocument.GetCSharpDocument();

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentSymbols/RemoteDocumentSymbolService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentSymbols/RemoteDocumentSymbolService.cs
@@ -37,7 +37,8 @@ internal sealed partial class RemoteDocumentSymbolService(in ServiceArgs args) :
             .GetGeneratedDocumentAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        var csharpSymbols = await ExternalHandlers.DocumentSymbols.GetDocumentSymbolsAsync(generatedDocument, useHierarchicalSymbols, cancellationToken).ConfigureAwait(false);
+        var csharpSymbols = await ExternalHandlers.DocumentSymbols.GetDocumentSymbolsAsync(
+            generatedDocument, useHierarchicalSymbols, supportsVSExtensions: true, cancellationToken).ConfigureAwait(false);
 
         var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
         var csharpDocument = codeDocument.GetCSharpDocument();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/TestRazorDocumentServiceProvider.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/TestRazorDocumentServiceProvider.cs
@@ -14,18 +14,23 @@ internal class TestRazorDocumentServiceProvider(IRazorSpanMappingService spanMap
 
     public bool SupportDiagnostics => true;
 
-    TService IRazorDocumentServiceProvider.GetService<TService>()
+    TService? IRazorDocumentServiceProvider.GetService<TService>() where TService : class
     {
         var serviceType = typeof(TService);
 
         if (serviceType == typeof(IRazorSpanMappingService))
         {
-            return (TService)_spanMappingService;
+            return (TService?)_spanMappingService;
         }
 
         if (serviceType == typeof(IRazorDocumentPropertiesService))
         {
-            return (TService)(IRazorDocumentPropertiesService)new TestRazorDocumentPropertiesService();
+            return (TService?)(IRazorDocumentPropertiesService)new TestRazorDocumentPropertiesService();
+        }
+
+        if (serviceType == typeof(IRazorMappingService))
+        {
+            return null;
         }
 
         return (this as TService).AssumeNotNull();


### PR DESCRIPTION
﻿### Summary of the changes

- Update Roslyn package references to the latest in VS main
- Minor fixup due to ambiguous extension method Reverse() - there is now one in System.MemoryExtensions, so we need to force type we are invoking the method on to be IEnumerable to get the Linq reverse method we want.
- Roslyn GetDocumentSymbolAsync method now requires supportsVSExtensions parameter. Hardcoding to true for now until we plumb VSInternalClientCapabilities through init of the remote client (see https://github.com/dotnet/razor/issues/11102)
