### PR TITLE
Make "add using" code actions high priority

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/Razor/RazorCodeActionFactory.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/Razor/RazorCodeActionFactory.cs
@@ -28,6 +28,7 @@ internal static class RazorCodeActionFactory
             Title = newTagName is null ? title : $"{newTagName} - {title}",
             Data = data,
             TelemetryId = s_addComponentUsingTelemetryId,
+            Priority = VSInternalPriorityLevel.High
         };
         return codeAction;
     }
@@ -39,6 +40,7 @@ internal static class RazorCodeActionFactory
             Title = fullyQualifiedName,
             Edit = workspaceEdit,
             TelemetryId = s_fullyQualifyComponentTelemetryId,
+            Priority = VSInternalPriorityLevel.High
         };
         return codeAction;
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/11049

Turns out https://github.com/dotnet/razor/pull/11069 meant the ordering of Razor and C# code actions is no longer a problem, so all we need to do is make sure the code actions that introduce new `@using` directives comes first.