### PR TITLE
Pre co-hosting Hover tweaks

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/HoverEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/HoverEndpoint.cs
@@ -90,7 +90,6 @@ internal sealed class HoverEndpoint(
 
         return await HoverFactory.GetHoverAsync(
             codeDocument,
-            documentContext.FilePath,
             positionInfo.HostDocumentIndex,
             options,
             _projectManager.GetQueryOperations(),

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/HoverEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/HoverEndpoint.cs
@@ -16,6 +16,7 @@ using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using LspHover = Microsoft.VisualStudio.LanguageServer.Protocol.Hover;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover;
 
@@ -27,7 +28,7 @@ internal sealed class HoverEndpoint(
     IDocumentMappingService documentMappingService,
     IClientConnection clientConnection,
     ILoggerFactory loggerFactory)
-    : AbstractRazorDelegatingEndpoint<TextDocumentPositionParams, VSInternalHover?>(
+    : AbstractRazorDelegatingEndpoint<TextDocumentPositionParams, LspHover?>(
         languageServerFeatureOptions,
         documentMappingService,
         clientConnection,
@@ -61,7 +62,7 @@ internal sealed class HoverEndpoint(
             positionInfo.LanguageKind));
     }
 
-    protected override async Task<VSInternalHover?> TryHandleAsync(TextDocumentPositionParams request, RazorRequestContext requestContext, DocumentPositionInfo positionInfo, CancellationToken cancellationToken)
+    protected override async Task<LspHover?> TryHandleAsync(TextDocumentPositionParams request, RazorRequestContext requestContext, DocumentPositionInfo positionInfo, CancellationToken cancellationToken)
     {
         var documentContext = requestContext.DocumentContext;
         if (documentContext is null)
@@ -97,7 +98,7 @@ internal sealed class HoverEndpoint(
             .ConfigureAwait(false);
     }
 
-    protected override async Task<VSInternalHover?> HandleDelegatedResponseAsync(VSInternalHover? response, TextDocumentPositionParams originalRequest, RazorRequestContext requestContext, DocumentPositionInfo positionInfo, CancellationToken cancellationToken)
+    protected override async Task<LspHover?> HandleDelegatedResponseAsync(LspHover? response, TextDocumentPositionParams originalRequest, RazorRequestContext requestContext, DocumentPositionInfo positionInfo, CancellationToken cancellationToken)
     {
         var documentContext = requestContext.DocumentContext;
         if (documentContext is null)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Hover/HoverFactory.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Hover/HoverFactory.cs
@@ -19,12 +19,13 @@ using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Editor.Razor;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Text.Adornments;
+using LspHover = Microsoft.VisualStudio.LanguageServer.Protocol.Hover;
 
 namespace Microsoft.CodeAnalysis.Razor.Hover;
 
 internal static class HoverFactory
 {
-    public static Task<VSInternalHover?> GetHoverAsync(
+    public static Task<LspHover?> GetHoverAsync(
         RazorCodeDocument codeDocument,
         string documentFilePath,
         int absoluteIndex,
@@ -38,7 +39,7 @@ internal static class HoverFactory
         if (owner is null)
         {
             Debug.Fail("Owner should never be null.");
-            return SpecializedTasks.Null<VSInternalHover>();
+            return SpecializedTasks.Null<LspHover>();
         }
 
         // For cases where the point in the middle of an attribute,
@@ -59,7 +60,7 @@ internal static class HoverFactory
             {
                 // It's possible for there to be a <Text> component that is in scope, and would be found by the GetTagHelperBinding
                 // call below, but a text tag, regardless of casing, inside C# code, is always just a text tag, not a component.
-                return SpecializedTasks.Null<VSInternalHover>();
+                return SpecializedTasks.Null<LspHover>();
             }
 
             // We want to find the parent tag, but looking up ancestors in the tree can find other things,
@@ -82,12 +83,12 @@ internal static class HoverFactory
             if (binding is null)
             {
                 // No matching tagHelpers, it's just HTML
-                return SpecializedTasks.Null<VSInternalHover>();
+                return SpecializedTasks.Null<LspHover>();
             }
             else if (binding.IsAttributeMatch)
             {
                 // Hovered over a HTML tag name but the binding matches an attribute
-                return SpecializedTasks.Null<VSInternalHover>();
+                return SpecializedTasks.Null<LspHover>();
             }
 
             Debug.Assert(binding.Descriptors.Any());
@@ -120,7 +121,7 @@ internal static class HoverFactory
             if (binding is null)
             {
                 // No matching TagHelpers, it's just HTML
-                return SpecializedTasks.Null<VSInternalHover>();
+                return SpecializedTasks.Null<LspHover>();
             }
 
             Debug.Assert(binding.Descriptors.Any());
@@ -172,10 +173,10 @@ internal static class HoverFactory
             return Task.FromResult(AttributeInfoToHover(tagHelperAttributes, attributeName, span, options));
         }
 
-        return SpecializedTasks.Null<VSInternalHover>();
+        return SpecializedTasks.Null<LspHover>();
     }
 
-    private static VSInternalHover? AttributeInfoToHover(
+    private static LspHover? AttributeInfoToHover(
         ImmutableArray<BoundAttributeDescriptor> boundAttributes,
         string attributeName,
         LinePositionSpan span,
@@ -205,7 +206,7 @@ internal static class HoverFactory
             return null;
         }
 
-        return new VSInternalHover
+        return new LspHover
         {
             Contents = new MarkupContent()
             {
@@ -216,7 +217,7 @@ internal static class HoverFactory
         };
     }
 
-    private static async Task<VSInternalHover?> ElementInfoToHoverAsync(
+    private static async Task<LspHover?> ElementInfoToHoverAsync(
         string documentFilePath,
         ImmutableArray<TagHelperDescriptor> descriptors,
         LinePositionSpan span,
@@ -253,7 +254,7 @@ internal static class HoverFactory
             return null;
         }
 
-        return new VSInternalHover
+        return new LspHover
         {
             Contents = new MarkupContent()
             {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Hover/HoverFactory.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Hover/HoverFactory.cs
@@ -27,7 +27,6 @@ internal static class HoverFactory
 {
     public static Task<LspHover?> GetHoverAsync(
         RazorCodeDocument codeDocument,
-        string documentFilePath,
         int absoluteIndex,
         HoverDisplayOptions options,
         ISolutionQueryOperations solutionQueryOperations,
@@ -96,7 +95,7 @@ internal static class HoverFactory
             var span = containingTagNameToken.GetLinePositionSpan(codeDocument.Source);
 
             return ElementInfoToHoverAsync(
-                documentFilePath, binding.Descriptors, span, options, solutionQueryOperations, cancellationToken);
+                codeDocument.Source.FilePath, binding.Descriptors, span, options, solutionQueryOperations, cancellationToken);
         }
 
         if (HtmlFacts.TryGetAttributeInfo(owner, out containingTagNameToken, out _, out var selectedAttributeName, out var selectedAttributeNameLocation, out attributes) &&
@@ -218,7 +217,7 @@ internal static class HoverFactory
     }
 
     private static async Task<LspHover?> ElementInfoToHoverAsync(
-        string documentFilePath,
+        string? documentFilePath,
         ImmutableArray<TagHelperDescriptor> descriptors,
         LinePositionSpan span,
         HoverDisplayOptions options,

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Tooltip/ClassifiedTagHelperTooltipFactory.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Tooltip/ClassifiedTagHelperTooltipFactory.cs
@@ -58,7 +58,7 @@ internal static class ClassifiedTagHelperTooltipFactory
     private static readonly ClassifiedTextRun s_nullableType = new(ClassificationTypeNames.Punctuation, "?");
 
     public static async Task<ContainerElement?> TryCreateTooltipContainerAsync(
-        string documentFilePath,
+        string? documentFilePath,
         AggregateBoundElementDescription elementDescriptionInfo,
         ISolutionQueryOperations solutionQueryOperations,
         CancellationToken cancellationToken)
@@ -140,7 +140,7 @@ internal static class ClassifiedTagHelperTooltipFactory
     }
 
     private static async Task<ImmutableArray<DescriptionClassification>> TryClassifyElementAsync(
-        string documentFilePath,
+        string? documentFilePath,
         AggregateBoundElementDescription elementInfo,
         ISolutionQueryOperations solutionQueryOperations,
         CancellationToken cancellationToken)
@@ -169,8 +169,11 @@ internal static class ClassifiedTagHelperTooltipFactory
             TryClassifySummary(documentationRuns, descriptionInfo.Documentation);
 
             // 3. Project availability
-            await AddProjectAvailabilityInfoAsync(
-                documentFilePath, descriptionInfo.TagHelperTypeName, solutionQueryOperations, documentationRuns, cancellationToken).ConfigureAwait(false);
+            if (documentFilePath is not null)
+            {
+                await AddProjectAvailabilityInfoAsync(
+                    documentFilePath, descriptionInfo.TagHelperTypeName, solutionQueryOperations, documentationRuns, cancellationToken).ConfigureAwait(false);
+            }
 
             // 4. Combine type + summary information
             descriptions.Add(new DescriptionClassification(typeRuns, documentationRuns));

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Tooltip/MarkupTagHelperTooltipFactory.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Tooltip/MarkupTagHelperTooltipFactory.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Razor.Tooltip;
 internal static class MarkupTagHelperTooltipFactory
 {
     public static async Task<MarkupContent?> TryCreateTooltipAsync(
-        string documentFilePath,
+        string? documentFilePath,
         AggregateBoundElementDescription elementDescriptionInfo,
         ISolutionQueryOperations solutionQueryOperations,
         MarkupKind markupKind,
@@ -73,14 +73,17 @@ internal static class MarkupTagHelperTooltipFactory
                 descriptionBuilder.Append(finalSummaryContent);
             }
 
-            var availability = await solutionQueryOperations
-                .GetProjectAvailabilityTextAsync(documentFilePath, tagHelperType, cancellationToken)
-                .ConfigureAwait(false);
-
-            if (availability is not null)
+            if (documentFilePath is not null)
             {
-                descriptionBuilder.AppendLine();
-                descriptionBuilder.Append(availability);
+                var availability = await solutionQueryOperations
+                    .GetProjectAvailabilityTextAsync(documentFilePath, tagHelperType, cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (availability is not null)
+                {
+                    descriptionBuilder.AppendLine();
+                    descriptionBuilder.Append(availability);
+                }
             }
         }
 

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Hover/HoverFactoryTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Hover/HoverFactoryTest.cs
@@ -44,7 +44,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, "file.cshtml", code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -68,7 +68,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, "file.cshtml", code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -92,7 +92,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, "file.cshtml", code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -114,7 +114,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, "file.cshtml", code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -136,7 +136,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, "file.cshtml", code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -159,7 +159,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, "file.cshtml", code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -182,7 +182,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, "file.cshtml", code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
 
         // Assert
         Assert.Null(hover);
@@ -200,7 +200,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, "file.cshtml", code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
 
         // Assert
         Assert.Null(hover);
@@ -218,7 +218,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, "file.cshtml", code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
 
         // Assert
         Assert.Null(hover);
@@ -236,7 +236,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, "file.cshtml", code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -263,7 +263,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, "text.razor", SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, "file.cshtml", code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -285,7 +285,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, "file.cshtml", code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -307,7 +307,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, "file.cshtml", code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -330,7 +330,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, "file.cshtml", code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
 
         // Assert
         Assert.Null(hover);
@@ -348,7 +348,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, "file.cshtml", code.Position, UsePlainText, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UsePlainText, CreateSolutionQueryOperations(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -371,7 +371,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, "file.cshtml", code.Position, UsePlainText, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UsePlainText, CreateSolutionQueryOperations(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -393,7 +393,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: true, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, "file.razor", code.Position, UsePlainText, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UsePlainText, CreateSolutionQueryOperations(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -417,7 +417,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: true, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, "file.razor", code.Position, UsePlainText, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UsePlainText, CreateSolutionQueryOperations(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -442,7 +442,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: true, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, "file.razor", code.Position, UsePlainText, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UsePlainText, CreateSolutionQueryOperations(), DisposalToken);
 
         // Assert
         Assert.Null(hover);
@@ -464,7 +464,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: true, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, "file.razor", code.Position, UsePlainText, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UsePlainText, CreateSolutionQueryOperations(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -487,7 +487,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, "file.cshtml", code.Position, UsePlainText, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UsePlainText, CreateSolutionQueryOperations(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -511,7 +511,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, "file.cshtml", code.Position, UsePlainText, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UsePlainText, CreateSolutionQueryOperations(), DisposalToken);
 
         // Assert
         Assert.Null(hover);
@@ -529,7 +529,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, "file.cshtml", code.Position, UsePlainText, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UsePlainText, CreateSolutionQueryOperations(), DisposalToken);
 
         // Assert
         Assert.Null(hover);
@@ -547,7 +547,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, "file.cshtml", code.Position, UseVisualStudio, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseVisualStudio, CreateSolutionQueryOperations(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -585,7 +585,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, "file.cshtml", code.Position, UseVisualStudio, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseVisualStudio, CreateSolutionQueryOperations(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Hover/HoverFactoryTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Hover/HoverFactoryTest.cs
@@ -547,16 +547,17 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var vsHover = await HoverFactory.GetHoverAsync(codeDocument, "file.cshtml", code.Position, UseVisualStudio, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, "file.cshtml", code.Position, UseVisualStudio, CreateSolutionQueryOperations(), DisposalToken);
 
         // Assert
-        Assert.NotNull(vsHover);
-        Assert.NotNull(vsHover.Contents);
-        Assert.False(vsHover.Contents.Value.TryGetFourth(out var _));
-        Assert.True(vsHover.Contents.Value.TryGetThird(out var _) && !vsHover.Contents.Value.Third.Any());
+        Assert.NotNull(hover);
+        Assert.NotNull(hover.Contents);
+        Assert.False(hover.Contents.Value.TryGetFourth(out var _));
+        Assert.True(hover.Contents.Value.TryGetThird(out var _) && !hover.Contents.Value.Third.Any());
         var expectedRange = VsLspFactory.CreateSingleLineRange(line: 1, character: 1, length: 5);
-        Assert.Equal(expectedRange, vsHover.Range);
+        Assert.Equal(expectedRange, hover.Range);
 
+        var vsHover = Assert.IsType<VSInternalHover>(hover);
         Assert.NotNull(vsHover.RawContent);
         var container = (ContainerElement)vsHover.RawContent;
         var containerElements = container.Elements.ToList();
@@ -584,16 +585,17 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var vsHover = await HoverFactory.GetHoverAsync(codeDocument, "file.cshtml", code.Position, UseVisualStudio, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, "file.cshtml", code.Position, UseVisualStudio, CreateSolutionQueryOperations(), DisposalToken);
 
         // Assert
-        Assert.NotNull(vsHover);
-        Assert.NotNull(vsHover.Contents);
-        Assert.False(vsHover.Contents.Value.TryGetFourth(out _));
-        Assert.True(vsHover.Contents.Value.TryGetThird(out var markedStrings) && !markedStrings.Any());
+        Assert.NotNull(hover);
+        Assert.NotNull(hover.Contents);
+        Assert.False(hover.Contents.Value.TryGetFourth(out _));
+        Assert.True(hover.Contents.Value.TryGetThird(out var markedStrings) && !markedStrings.Any());
         var expectedRange = VsLspFactory.CreateSingleLineRange(line: 1, character: 7, length: 8);
-        Assert.Equal(expectedRange, vsHover.Range);
+        Assert.Equal(expectedRange, hover.Range);
 
+        var vsHover = Assert.IsType<VSInternalHover>(hover);
         Assert.NotNull(vsHover.RawContent);
         var container = (ContainerElement)vsHover.RawContent;
         var containerElements = container.Elements.ToList();


### PR DESCRIPTION
This pull request makes a couple of changes to `HoverFactory.GetHoverAsync(...)` to prepare for co-hosting:

1. `HoverFactory.GetHoverAsync(...)` returns an LSP `Hover` rather than `VSInternalHover`.
2. `HoverFactory.GetHoverAsync(...)` no longer takes a document file path. It already takes a `RazorCodeDocument`, and the file path can be retrieved from that.