### PR TITLE
Fix aggregate telemetry reliability

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/ITelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/ITelemetryReporter.cs
@@ -32,9 +32,4 @@ internal interface ITelemetryReporter
     /// <param name="requestDuration">How long it took to handle the request</param>
     /// <param name="result">The result of handling the request</param>
     void ReportRequestTiming(string name, string? language, TimeSpan queuedDuration, TimeSpan requestDuration, TelemetryResult result);
-
-    /// <summary>
-    /// Flushes any current session data being collected
-    /// </summary>
-    void Flush();
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/NoOpTelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/NoOpTelemetryReporter.cs
@@ -58,8 +58,4 @@ internal class NoOpTelemetryReporter : ITelemetryReporter
     public void ReportRequestTiming(string name, string? language, TimeSpan queuedDuration, TimeSpan requestDuration, TelemetryResult result)
     {
     }
-
-    public void Flush()
-    {
-    }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Telemetry/OutOfProcessTelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Telemetry/OutOfProcessTelemetryReporter.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
 using System.Composition;
 using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.VisualStudio.Razor.Telemetry;
@@ -10,10 +9,6 @@ using Microsoft.VisualStudio.Telemetry;
 namespace Microsoft.CodeAnalysis.Remote.Razor.Telemetry;
 
 [Export(typeof(ITelemetryReporter)), Shared]
-internal class OutOfProcessTelemetryReporter() : TelemetryReporter(TelemetryService.DefaultSession), IDisposable
+internal class OutOfProcessTelemetryReporter() : TelemetryReporter(TelemetryService.DefaultSession)
 {
-    public void Dispose()
-    {
-        Flush();
-    }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
@@ -20,7 +20,7 @@ using System.Linq;
 
 namespace Microsoft.VisualStudio.Razor.Telemetry;
 
-internal abstract partial class TelemetryReporter : ITelemetryReporter
+internal abstract partial class TelemetryReporter : ITelemetryReporter, IDisposable
 {
     private const string CodeAnalysisNamespace = nameof(Microsoft) + "." + nameof(CodeAnalysis);
     private const string AspNetCoreNamespace = nameof(Microsoft) + "." + nameof(AspNetCore);
@@ -42,6 +42,11 @@ internal abstract partial class TelemetryReporter : ITelemetryReporter
         }
     }
 
+    public void Dispose()
+    {
+        _manager?.Dispose();
+    }
+
     internal static string GetEventName(string name) => "dotnet/razor/" + name;
     internal static string GetPropertyName(string name) => "dotnet.razor." + name;
 
@@ -50,11 +55,6 @@ internal abstract partial class TelemetryReporter : ITelemetryReporter
 #else
     public virtual bool IsEnabled => _manager?.Session.IsOptedIn ?? false;
 #endif
-
-    public void Flush()
-    {
-        _manager?.Flush();
-    }
 
     public void ReportEvent(string name, Severity severity)
     {
@@ -215,7 +215,7 @@ internal abstract partial class TelemetryReporter : ITelemetryReporter
 
     protected void SetSession(TelemetrySession session)
     {
-        _manager?.Flush();
+        _manager?.Dispose();
         _manager = TelemetrySessionManager.Create(this, session);
     }
 
@@ -435,7 +435,7 @@ internal abstract partial class TelemetryReporter : ITelemetryReporter
             declaringTypeName.StartsWith(AspNetCoreNamespace) ||
             declaringTypeName.StartsWith(MicrosoftVSRazorNamespace);
 
-    private sealed class TelemetrySessionManager
+    private sealed class TelemetrySessionManager: IDisposable
     {
         /// <summary>
         /// Store request counters in a concurrent dictionary as non-mutating LSP requests can
@@ -452,6 +452,12 @@ internal abstract partial class TelemetryReporter : ITelemetryReporter
             Session = session;
         }
 
+        public void Dispose()
+        {
+            Flush();
+            Session.Dispose();
+        }
+
         public static TelemetrySessionManager Create(TelemetryReporter telemetryReporter, TelemetrySession session)
             => new(
                 telemetryReporter,
@@ -460,7 +466,7 @@ internal abstract partial class TelemetryReporter : ITelemetryReporter
 
         public TelemetrySession Session { get; }
 
-        public void Flush()
+        private void Flush()
         {
             _aggregatingManager.Flush();
             LogRequestCounters();

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/VSTelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/VSTelemetryReporter.cs
@@ -12,14 +12,9 @@ namespace Microsoft.VisualStudio.Razor.Telemetry;
 
 [Export(typeof(ITelemetryReporter))]
 [method:ImportingConstructor]
-internal class VSTelemetryReporter(ILoggerFactory loggerFactory) : TelemetryReporter(TelemetryService.DefaultSession), IDisposable
+internal class VSTelemetryReporter(ILoggerFactory loggerFactory) : TelemetryReporter(TelemetryService.DefaultSession)
 {
     private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<VSTelemetryReporter>();
-
-    public void Dispose()
-    {
-        Flush();
-    }
 
     protected override bool HandleException(Exception exception, string? message, params ReadOnlySpan<object?> @params)
     {

--- a/src/Razor/src/rzls/Program.cs
+++ b/src/Razor/src/rzls/Program.cs
@@ -141,7 +141,7 @@ public class Program
         return null;
     }
 
-    private record struct TelemetryContext(IDisposable ExportProvider, ITelemetryReporter TelemetryReporter) : IDisposable
+    private readonly record struct TelemetryContext(IDisposable ExportProvider, ITelemetryReporter TelemetryReporter) : IDisposable
     {
         public void Dispose()
         {

--- a/src/Razor/src/rzls/Program.cs
+++ b/src/Razor/src/rzls/Program.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Razor.Utilities;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.Composition;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
@@ -77,7 +78,7 @@ public class Program
 
         var languageServerFeatureOptions = new ConfigurableLanguageServerFeatureOptions(args);
 
-        var devKitTelemetryReporter = await TryGetTelemetryReporterAsync(telemetryLevel, sessionId, telemetryExtensionPath).ConfigureAwait(true);
+        using var telemetryContext = await TryGetTelemetryReporterAsync(telemetryLevel, sessionId, telemetryExtensionPath).ConfigureAwait(true);
 
         // Have to create a logger factory to give to the server, but can't create any logger providers until we have
         // a server.
@@ -87,7 +88,7 @@ public class Program
             Console.OpenStandardInput(),
             Console.OpenStandardOutput(),
             loggerFactory,
-            devKitTelemetryReporter ?? NoOpTelemetryReporter.Instance,
+            telemetryContext?.TelemetryReporter ?? NoOpTelemetryReporter.Instance,
             featureOptions: languageServerFeatureOptions,
             configureServices: static services =>
             {
@@ -102,42 +103,49 @@ public class Program
 
         loggerFactory.GetOrCreateLogger("RZLS").LogInformation($"Razor Language Server started successfully.");
 
-        try
-        {
-            await host.WaitForExitAsync().ConfigureAwait(true);
-        }
-        finally
-        {
-            devKitTelemetryReporter?.Flush();
-        }
+        await host.WaitForExitAsync().ConfigureAwait(true);
     }
 
-    private static async Task<ITelemetryReporter?> TryGetTelemetryReporterAsync(string telemetryLevel, string sessionId, string telemetryExtensionPath)
+    private static async Task<TelemetryContext?> TryGetTelemetryReporterAsync(string telemetryLevel, string sessionId, string telemetryExtensionPath)
     {
-        ITelemetryReporter? devKitTelemetryReporter = null;
+        ExportProvider? exportProvider = null;
         if (!telemetryExtensionPath.IsNullOrEmpty())
         {
             try
             {
-                using var exportProvider = await ExportProviderBuilder
+                exportProvider = await ExportProviderBuilder
                     .CreateExportProviderAsync(telemetryExtensionPath)
                     .ConfigureAwait(true);
 
                 // Initialize the telemetry reporter if available
-                devKitTelemetryReporter = exportProvider.GetExports<ITelemetryReporter>().SingleOrDefault()?.Value;
+                var devKitTelemetryReporter = exportProvider.GetExports<ITelemetryReporter>().SingleOrDefault()?.Value;
 
                 if (devKitTelemetryReporter is ITelemetryReporterInitializer initializer)
                 {
                     initializer.InitializeSession(telemetryLevel, sessionId, isDefaultSession: true);
+                    return new TelemetryContext(exportProvider, devKitTelemetryReporter);
+                }
+                else
+                {
+                    exportProvider.Dispose();
                 }
             }
             catch (Exception ex)
             {
                 await Console.Error.WriteLineAsync($"Failed to load telemetry extension in {telemetryExtensionPath}.").ConfigureAwait(true);
                 await Console.Error.WriteLineAsync(ex.ToString()).ConfigureAwait(true);
+                exportProvider?.Dispose();
             }
         }
 
-        return devKitTelemetryReporter;
+        return null;
+    }
+
+    private record struct TelemetryContext(IDisposable ExportProvider, ITelemetryReporter TelemetryReporter) : IDisposable
+    {
+        public void Dispose()
+        {
+            ExportProvider.Dispose();
+        }
     }
 }

--- a/src/Razor/src/rzls/Program.cs
+++ b/src/Razor/src/rzls/Program.cs
@@ -145,6 +145,8 @@ public class Program
     {
         public void Dispose()
         {
+            // No need to explicitly dispose of the telemetry reporter. The lifetime
+            // is managed by the ExportProvider and will be disposed with it.
             ExportProvider.Dispose();
         }
     }


### PR DESCRIPTION
Currently telemetry is flushed after the language server host exits in VS Code. This is correctly flushing to the telemetry session, but can miss actually reporting the telemetry. In VS the lifetime of the TelemetrySession is managed centrally, but in VS Code it is up to each process to make sure it gets disposed properly. Without this telemetry that is fired could be dropped. This change addresses this by doing the following: 

1. Removing the flush method on ITelemetryReporter
2. Making TelemetryReporter IDisposable (again). This will be disposed by the DI container.
3. Keep the DI container (ExportProvider) alive in rzls until the language server host exits.

This should fix the reliability of some telemetry getting dropped. It still won't fix the scenario where the user force closes the process but better aligns VS and VS Code in expectation of lifetime management. 

I noticed this while trying to set up dashboards. There are not nearly as many events as would be expected. If this still continues to be an issue one more option would be to flush on a timer. The data itself is aggregated and should handle that nicely. 
