### PR TITLE
More CodeAction moves in preparation for cohosting

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCodeActionsBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCodeActionsBenchmark.cs
@@ -48,6 +48,7 @@ public class RazorCodeActionsBenchmark : RazorLanguageServerBenchmarkBase
     {
         CodeActionEndpoint = new CodeActionEndpoint(
             codeActionsService: RazorLanguageServerHost.GetRequiredService<ICodeActionsService>(),
+            delegatedCodeActionProvider: RazorLanguageServerHost.GetRequiredService<IDelegatedCodeActionsProvider>(),
             telemetryReporter: NoOpTelemetryReporter.Instance);
 
         var projectRoot = Path.Combine(Helpers.GetTestAppsPath(), "ComponentApp");

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
+using Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
 using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.CodeAnalysis.Razor.CodeActions;
 using Microsoft.CodeAnalysis.Razor.Protocol.CodeActions;
@@ -32,16 +33,7 @@ internal sealed class CodeActionEndpoint(
     {
         _supportsCodeActionResolve = clientCapabilities.TextDocument?.CodeAction?.ResolveSupport is not null;
 
-        serverCapabilities.CodeActionProvider = new CodeActionOptions
-        {
-            CodeActionKinds =
-            [
-                CodeActionKind.RefactorExtract,
-                CodeActionKind.QuickFix,
-                CodeActionKind.Refactor
-            ],
-            ResolveProvider = true,
-        };
+        serverCapabilities.EnableCodeActions();
     }
 
     public TextDocumentIdentifier GetTextDocumentIdentifier(VSCodeActionParams request)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
@@ -25,7 +25,7 @@ internal sealed class CodeActionEndpoint(
     private readonly ICodeActionsService _codeActionsService = codeActionsService;
     private readonly ITelemetryReporter _telemetryReporter = telemetryReporter;
 
-    internal bool _supportsCodeActionResolve = false;
+    private bool _supportsCodeActionResolve = false;
 
     public bool MutatesSolutionState { get; } = false;
 
@@ -54,5 +54,15 @@ internal sealed class CodeActionEndpoint(
         cancellationToken.ThrowIfCancellationRequested();
 
         return await _codeActionsService.GetCodeActionsAsync(request, documentContext, _supportsCodeActionResolve, correlationId, cancellationToken).ConfigureAwait(false);
+    }
+
+    internal TestAccessor GetTestAccessor() => new(this);
+
+    internal readonly struct TestAccessor(CodeActionEndpoint instance)
+    {
+        public void SetSupportsCodeActionResolve(bool value)
+        {
+            instance._supportsCodeActionResolve = value;
+        }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
@@ -4,10 +4,14 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
 using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.CodeAnalysis.Razor.CodeActions;
+using Microsoft.CodeAnalysis.Razor.CodeActions.Models;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Protocol.CodeActions;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Telemetry;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -17,12 +21,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
 [RazorLanguageServerEndpoint(LspEndpointName)]
 internal sealed class CodeActionEndpoint(
     ICodeActionsService codeActionsService,
+    IDelegatedCodeActionsProvider delegatedCodeActionProvider,
     ITelemetryReporter telemetryReporter)
     : IRazorRequestHandler<VSCodeActionParams, SumType<Command, CodeAction>[]?>, ICapabilitiesProvider
 {
     private const string LspEndpointName = Methods.TextDocumentCodeActionName;
 
     private readonly ICodeActionsService _codeActionsService = codeActionsService;
+    private readonly IDelegatedCodeActionsProvider _delegatedCodeActionProvider = delegatedCodeActionProvider;
     private readonly ITelemetryReporter _telemetryReporter = telemetryReporter;
 
     private bool _supportsCodeActionResolve = false;
@@ -53,7 +59,41 @@ internal sealed class CodeActionEndpoint(
         using var __ = _telemetryReporter.TrackLspRequest(LspEndpointName, LanguageServerConstants.RazorLanguageServerName, TelemetryThresholds.CodeActionRazorTelemetryThreshold, correlationId);
         cancellationToken.ThrowIfCancellationRequested();
 
-        return await _codeActionsService.GetCodeActionsAsync(request, documentContext, _supportsCodeActionResolve, correlationId, cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        if (!codeDocument.Source.Text.TryGetAbsoluteIndex(request.Range.Start, out var absoluteIndex))
+        {
+            return null;
+        }
+
+        var languageKind = codeDocument.GetLanguageKind(absoluteIndex, rightAssociative: false);
+        var documentSnapshot = documentContext.Snapshot;
+
+        var delegatedCodeActions = languageKind switch
+        {
+            RazorLanguageKind.Html => await GetHtmlCodeActionsAsync(documentSnapshot, request, correlationId, cancellationToken).ConfigureAwait(false),
+            RazorLanguageKind.CSharp => await GetCSharpCodeActionsAsync(documentSnapshot, request, correlationId, cancellationToken).ConfigureAwait(false),
+            _ => []
+        };
+
+        return await _codeActionsService.GetCodeActionsAsync(request, documentSnapshot, delegatedCodeActions, _supportsCodeActionResolve, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<RazorVSInternalCodeAction[]> GetHtmlCodeActionsAsync(IDocumentSnapshot documentSnapshot, VSCodeActionParams request, Guid correlationId, CancellationToken cancellationToken)
+    {
+        var htmlCodeActions = await _delegatedCodeActionProvider.GetDelegatedCodeActionsAsync(RazorLanguageKind.Html, request, documentSnapshot.Version, correlationId, cancellationToken).ConfigureAwait(false);
+        return htmlCodeActions ?? [];
+    }
+
+    private async Task<RazorVSInternalCodeAction[]> GetCSharpCodeActionsAsync(IDocumentSnapshot documentSnapshot, VSCodeActionParams request, Guid correlationId, CancellationToken cancellationToken)
+    {
+        var csharpRequest = await _codeActionsService.GetCSharpCodeActionsRequestAsync(documentSnapshot, request, cancellationToken).ConfigureAwait(false);
+        if (csharpRequest is null)
+        {
+            return [];
+        }
+
+        var csharpCodeActions = await _delegatedCodeActionProvider.GetDelegatedCodeActionsAsync(RazorLanguageKind.CSharp, csharpRequest, documentSnapshot.Version, correlationId, cancellationToken).ConfigureAwait(false);
+        return csharpCodeActions ?? [];
     }
 
     internal TestAccessor GetTestAccessor() => new(this);
@@ -64,5 +104,8 @@ internal sealed class CodeActionEndpoint(
         {
             instance._supportsCodeActionResolve = value;
         }
+
+        public Task<RazorVSInternalCodeAction[]> GetCSharpCodeActionsAsync(IDocumentSnapshot documentSnapshot, VSCodeActionParams request, Guid correlationId, CancellationToken cancellationToken)
+            => instance.GetCSharpCodeActionsAsync(documentSnapshot, request, correlationId, cancellationToken);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionResolveEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionResolveEndpoint.cs
@@ -1,11 +1,15 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.CodeAnalysis.Razor.CodeActions;
+using Microsoft.CodeAnalysis.Razor.CodeActions.Models;
 using Microsoft.CodeAnalysis.Razor.Formatting;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
@@ -13,9 +17,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
 [RazorLanguageServerEndpoint(Methods.CodeActionResolveName)]
 internal sealed class CodeActionResolveEndpoint(
     ICodeActionResolveService codeActionResolveService,
+    IDelegatedCodeActionResolver delegatedCodeActionResolver,
     RazorLSPOptionsMonitor razorLSPOptionsMonitor) : IRazorRequestHandler<CodeAction, CodeAction>
 {
     private readonly ICodeActionResolveService _codeActionResolveService = codeActionResolveService;
+    private readonly IDelegatedCodeActionResolver _delegatedCodeActionResolver = delegatedCodeActionResolver;
     private readonly RazorLSPOptionsMonitor _razorLSPOptionsMonitor = razorLSPOptionsMonitor;
 
     public bool MutatesSolutionState => false;
@@ -33,7 +39,28 @@ internal sealed class CodeActionResolveEndpoint(
         };
         var documentContext = requestContext.DocumentContext.AssumeNotNull();
 
-        return await _codeActionResolveService.ResolveCodeActionAsync(documentContext, request, options, cancellationToken).ConfigureAwait(false);
+        var context = CodeActionResolveService.GetRazorCodeActionResolutionParams(request);
 
+        var resolvedDelegatedCodeAction = context.Language != RazorLanguageKind.Razor
+            ? await ResolveDelegatedCodeActionAsync(documentContext, request, context, cancellationToken).ConfigureAwait(false)
+            : null;
+
+        return await _codeActionResolveService.ResolveCodeActionAsync(documentContext, request, resolvedDelegatedCodeAction, options, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<CodeAction> ResolveDelegatedCodeActionAsync(DocumentContext documentContext, CodeAction request, RazorCodeActionResolutionParams context, CancellationToken cancellationToken)
+    {
+        var originalData = request.Data;
+        request.Data = context.Data;
+
+        try
+        {
+            var resolvedCodeAction = await _delegatedCodeActionResolver.ResolveCodeActionAsync(documentContext.GetTextDocumentIdentifier(), documentContext.Snapshot.Version, context.Language, request, cancellationToken).ConfigureAwait(false);
+            return resolvedCodeAction ?? request;
+        }
+        finally
+        {
+            request.Data = originalData;
+        }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionResolveEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionResolveEndpoint.cs
@@ -21,7 +21,7 @@ internal sealed class CodeActionResolveEndpoint(
     public bool MutatesSolutionState => false;
 
     public TextDocumentIdentifier GetTextDocumentIdentifier(CodeAction request)
-        => _codeActionResolveService.GetRazorCodeActionResolutionParams(request).TextDocument;
+        => CodeActionResolveService.GetRazorCodeActionResolutionParams(request).TextDocument;
 
     public async Task<CodeAction> HandleRequestAsync(CodeAction request, RazorRequestContext requestContext, CancellationToken cancellationToken)
     {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/IDelegatedCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/IDelegatedCodeActionResolver.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
-namespace Microsoft.CodeAnalysis.Razor.CodeActions;
+namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
 
 internal interface IDelegatedCodeActionResolver
 {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/IDelegatedCodeActionsProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/IDelegatedCodeActionsProvider.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.Razor.CodeActions.Models;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Protocol.CodeActions;
 
-namespace Microsoft.CodeAnalysis.Razor.CodeActions;
+namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
 
 internal interface IDelegatedCodeActionsProvider
 {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hosting/LspInitializationHelpers.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hosting/LspInitializationHelpers.cs
@@ -20,6 +20,24 @@ internal static class LspInitializationHelpers
         };
     }
 
+    public static void EnableCodeActions(this VSInternalServerCapabilities serverCapabilities)
+    {
+        serverCapabilities.CodeActionProvider = new CodeActionOptions().EnableCodeActions();
+    }
+
+    public static CodeActionOptions EnableCodeActions(this CodeActionOptions options)
+    {
+        options.CodeActionKinds =
+        [
+            CodeActionKind.RefactorExtract,
+            CodeActionKind.QuickFix,
+            CodeActionKind.Refactor
+        ];
+        options.ResolveProvider = true;
+
+        return options;
+    }
+
     public static void EnableSemanticTokens(this VSInternalServerCapabilities serverCapabilities, ISemanticTokensLegendService legend)
     {
         serverCapabilities.SemanticTokensOptions = new SemanticTokensOptions().EnableSemanticTokens(legend);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/CodeActionResolveService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/CodeActionResolveService.cs
@@ -9,6 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.Razor.CodeActions.Models;
 using Microsoft.CodeAnalysis.Razor.Formatting;
@@ -31,7 +32,7 @@ internal sealed class CodeActionResolveService(
     private readonly FrozenDictionary<string, IHtmlCodeActionResolver> _htmlCodeActionResolvers = CreateResolverMap(htmlCodeActionResolvers);
     private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<CodeActionResolveService>();
 
-    public async Task<CodeAction> ResolveCodeActionAsync(DocumentContext documentContext, CodeAction request, RazorFormattingOptions options, CancellationToken cancellationToken)
+    public async Task<CodeAction> ResolveCodeActionAsync(DocumentContext documentContext, CodeAction request, CodeAction? resolvedDelegatedCodeAction, RazorFormattingOptions options, CancellationToken cancellationToken)
     {
         var resolutionParams = GetRazorCodeActionResolutionParams(request);
 
@@ -47,8 +48,6 @@ internal sealed class CodeActionResolveService(
             return request;
         }
 
-        request.Data = resolutionParams.Data;
-
         switch (resolutionParams.Language)
         {
             case RazorLanguageKind.Razor:
@@ -61,13 +60,13 @@ internal sealed class CodeActionResolveService(
             case RazorLanguageKind.CSharp:
                 return await ResolveCSharpCodeActionAsync(
                     documentContext,
-                    request,
+                    resolvedDelegatedCodeAction.AssumeNotNull(),
                     resolutionParams,
                     cancellationToken).ConfigureAwait(false);
             case RazorLanguageKind.Html:
                 return await ResolveHtmlCodeActionAsync(
                     documentContext,
-                    request,
+                    resolvedDelegatedCodeAction.AssumeNotNull(),
                     resolutionParams,
                     cancellationToken).ConfigureAwait(false);
             default:

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/CodeActionResolveService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/CodeActionResolveService.cs
@@ -76,7 +76,7 @@ internal sealed class CodeActionResolveService(
         }
     }
 
-    public RazorCodeActionResolutionParams GetRazorCodeActionResolutionParams(CodeAction request)
+    public static RazorCodeActionResolutionParams GetRazorCodeActionResolutionParams(CodeAction request)
     {
         if (request.Data is not JsonElement paramsObj)
         {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/ICodeActionResolveService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/ICodeActionResolveService.cs
@@ -3,7 +3,6 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Razor.CodeActions.Models;
 using Microsoft.CodeAnalysis.Razor.Formatting;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -12,6 +11,5 @@ namespace Microsoft.CodeAnalysis.Razor.CodeActions;
 
 internal interface ICodeActionResolveService
 {
-    RazorCodeActionResolutionParams GetRazorCodeActionResolutionParams(CodeAction request);
     Task<CodeAction> ResolveCodeActionAsync(DocumentContext documentContext, CodeAction request, RazorFormattingOptions options, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/ICodeActionResolveService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/ICodeActionResolveService.cs
@@ -11,5 +11,5 @@ namespace Microsoft.CodeAnalysis.Razor.CodeActions;
 
 internal interface ICodeActionResolveService
 {
-    Task<CodeAction> ResolveCodeActionAsync(DocumentContext documentContext, CodeAction request, RazorFormattingOptions options, CancellationToken cancellationToken);
+    Task<CodeAction> ResolveCodeActionAsync(DocumentContext documentContext, CodeAction request, CodeAction? resolvedDelegatedCodeAction, RazorFormattingOptions options, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/ICodeActionsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/ICodeActionsService.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Razor.CodeActions.Models;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol.CodeActions;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -12,5 +12,7 @@ namespace Microsoft.CodeAnalysis.Razor.CodeActions;
 
 internal interface ICodeActionsService
 {
-    Task<SumType<Command, CodeAction>[]?> GetCodeActionsAsync(VSCodeActionParams request, DocumentContext documentContext, bool supportsCodeActionResolve, Guid correlationId, CancellationToken cancellationToken);
+    Task<SumType<Command, CodeAction>[]?> GetCodeActionsAsync(VSCodeActionParams request, IDocumentSnapshot documentSnapshot, RazorVSInternalCodeAction[] delegatedCodeActions, bool supportsCodeActionResolve, CancellationToken cancellationToken);
+
+    Task<VSCodeActionParams?> GetCSharpCodeActionsRequestAsync(IDocumentSnapshot documentSnapshot, VSCodeActionParams request, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/RazorCodeActionContext.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/RazorCodeActionContext.cs
@@ -14,6 +14,7 @@ internal sealed record class RazorCodeActionContext(
     RazorCodeDocument CodeDocument,
     int StartAbsoluteIndex,
     int EndAbsoluteIndex,
+    Protocol.RazorLanguageKind LanguageKind,
     SourceText SourceText,
     bool SupportsFileCreation,
     bool SupportsCodeActionResolve);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/CSharpCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/CSharpCodeActionProviderTest.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Razor.CodeActions;
 using Microsoft.CodeAnalysis.Razor.CodeActions.Models;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Protocol.CodeActions;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.NET.Sdk.Razor.SourceGenerators;
@@ -348,6 +349,7 @@ $$Path;
             codeDocument,
             StartAbsoluteIndex: absoluteIndex,
             EndAbsoluteIndex: absoluteIndex,
+            RazorLanguageKind.CSharp,
             codeDocument.Source.Text,
             supportsFileCreation,
             supportsCodeActionResolve);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/TypeAccessibilityCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/TypeAccessibilityCodeActionProviderTest.cs
@@ -476,6 +476,7 @@ public class TypeAccessibilityCodeActionProviderTest(ITestOutputHelper testOutpu
             codeDocument,
             StartAbsoluteIndex: absoluteIndex,
             EndAbsoluteIndex: absoluteIndex,
+            RazorLanguageKind.Razor,
             codeDocument.Source.Text,
             supportsFileCreation,
             supportsCodeActionResolve);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndToEndTest.NetFx.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndToEndTest.NetFx.cs
@@ -1217,14 +1217,14 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : SingleServer
         var delegatedCodeActionResolver = new DelegatedCodeActionResolver(clientConnection);
         var csharpResolvers = new ICSharpCodeActionResolver[]
         {
-            new CSharpCodeActionResolver(delegatedCodeActionResolver, formattingService)
+            new CSharpCodeActionResolver(formattingService)
         };
 
         var htmlResolvers = Array.Empty<IHtmlCodeActionResolver>();
 
         optionsMonitor ??= TestRazorLSPOptionsMonitor.Create();
         var codeActionResolveService = new CodeActionResolveService(razorResolvers, csharpResolvers, htmlResolvers, LoggerFactory);
-        var resolveEndpoint = new CodeActionResolveEndpoint(codeActionResolveService, optionsMonitor);
+        var resolveEndpoint = new CodeActionResolveEndpoint(codeActionResolveService, delegatedCodeActionResolver, optionsMonitor);
 
         var resolveResult = await resolveEndpoint.HandleRequestAsync(codeActionToRun, requestContext, DisposalToken);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndToEndTest.NetFx.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndToEndTest.NetFx.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Components;
@@ -1175,11 +1174,11 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : SingleServer
                 new TypeAccessibilityCodeActionProvider()
             ],
             htmlCodeActionProviders: [],
-            delegatedCodeActionsProvider,
             LanguageServerFeatureOptions.AssumeNotNull());
 
         var endpoint = new CodeActionEndpoint(
             codeActionsService,
+            delegatedCodeActionsProvider,
             NoOpTelemetryReporter.Instance);
 
         // Call GetRegistration, so the endpoint knows we support resolve

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndpointTest.cs
@@ -603,12 +603,10 @@ public class CodeActionEndpointTest(ITestOutputHelper testOutput) : LanguageServ
             clientConnection,
             languageServerFeatureOptions);
 
-        return new CodeActionEndpoint(
-            codeActionsService,
-            NoOpTelemetryReporter.Instance)
-        {
-            _supportsCodeActionResolve = supportsCodeActionResolve
-        };
+        var endpoint = new CodeActionEndpoint(codeActionsService, NoOpTelemetryReporter.Instance);
+        endpoint.GetTestAccessor().SetSupportsCodeActionResolve(supportsCodeActionResolve);
+
+        return endpoint;
     }
 
     private CodeActionsService CreateService(

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionResolutionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionResolutionEndpointTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.AspNetCore.Razor.Threading;
 using Microsoft.CodeAnalysis.Razor.CodeActions;
@@ -32,6 +33,7 @@ public class CodeActionResolutionEndpointTest(ITestOutputHelper testOutput) : La
             LoggerFactory);
         var codeActionEndpoint = new CodeActionResolveEndpoint(
             codeActionResolveService,
+            StrictMock.Of<IDelegatedCodeActionResolver>(),
             TestRazorLSPOptionsMonitor.Create());
         var requestParams = new RazorCodeActionResolutionParams()
         {
@@ -69,6 +71,7 @@ public class CodeActionResolutionEndpointTest(ITestOutputHelper testOutput) : La
             LoggerFactory);
         var codeActionEndpoint = new CodeActionResolveEndpoint(
             codeActionResolveService,
+            new NoOpDelegatedCodeActionResolver(),
             TestRazorLSPOptionsMonitor.Create());
         var requestParams = new RazorCodeActionResolutionParams()
         {
@@ -102,6 +105,7 @@ public class CodeActionResolutionEndpointTest(ITestOutputHelper testOutput) : La
             LoggerFactory);
         var codeActionEndpoint = new CodeActionResolveEndpoint(
             codeActionResolveService,
+            new NoOpDelegatedCodeActionResolver(),
             TestRazorLSPOptionsMonitor.Create());
         var requestParams = new RazorCodeActionResolutionParams()
         {
@@ -135,6 +139,7 @@ public class CodeActionResolutionEndpointTest(ITestOutputHelper testOutput) : La
             LoggerFactory);
         var codeActionEndpoint = new CodeActionResolveEndpoint(
             codeActionResolveService,
+            StrictMock.Of<IDelegatedCodeActionResolver>(),
             TestRazorLSPOptionsMonitor.Create());
         var requestParams = new RazorCodeActionResolutionParams()
         {
@@ -177,6 +182,7 @@ public class CodeActionResolutionEndpointTest(ITestOutputHelper testOutput) : La
             LoggerFactory);
         var codeActionEndpoint = new CodeActionResolveEndpoint(
             codeActionResolveService,
+            StrictMock.Of<IDelegatedCodeActionResolver>(),
             TestRazorLSPOptionsMonitor.Create());
         var requestParams = new RazorCodeActionResolutionParams()
         {
@@ -215,6 +221,7 @@ public class CodeActionResolutionEndpointTest(ITestOutputHelper testOutput) : La
             LoggerFactory);
         var codeActionEndpoint = new CodeActionResolveEndpoint(
             codeActionResolveService,
+            StrictMock.Of<IDelegatedCodeActionResolver>(),
             TestRazorLSPOptionsMonitor.Create());
         var requestParams = new RazorCodeActionResolutionParams()
         {
@@ -257,6 +264,7 @@ public class CodeActionResolutionEndpointTest(ITestOutputHelper testOutput) : La
             LoggerFactory);
         var codeActionEndpoint = new CodeActionResolveEndpoint(
             codeActionResolveService,
+            StrictMock.Of<IDelegatedCodeActionResolver>(),
             TestRazorLSPOptionsMonitor.Create());
         var requestParams = new RazorCodeActionResolutionParams()
         {
@@ -446,6 +454,7 @@ public class CodeActionResolutionEndpointTest(ITestOutputHelper testOutput) : La
             LoggerFactory);
         var codeActionEndpoint = new CodeActionResolveEndpoint(
             codeActionResolveService,
+            StrictMock.Of<IDelegatedCodeActionResolver>(),
             TestRazorLSPOptionsMonitor.Create());
         var requestParams = new RazorCodeActionResolutionParams()
         {
@@ -467,6 +476,14 @@ public class CodeActionResolutionEndpointTest(ITestOutputHelper testOutput) : La
 
         // Assert
         Assert.NotNull(razorCodeAction.Edit);
+    }
+
+    private class NoOpDelegatedCodeActionResolver : IDelegatedCodeActionResolver
+    {
+        public Task<CodeAction?> ResolveCodeActionAsync(TextDocumentIdentifier razorFileIdentifier, int hostDocumentVersion, RazorLanguageKind languageKind, CodeAction codeAction, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<CodeAction?>(codeAction);
+        }
     }
 
     private class MockRazorCodeActionResolver : IRazorCodeActionResolver

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Html/HtmlCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Html/HtmlCodeActionProviderTest.cs
@@ -173,6 +173,7 @@ public class HtmlCodeActionProviderTest(ITestOutputHelper testOutput) : Language
             codeDocument,
             StartAbsoluteIndex: absoluteIndex,
             EndAbsoluteIndex: absoluteIndex,
+            RazorLanguageKind.Html,
             codeDocument.Source.Text,
             supportsFileCreation,
             supportsCodeActionResolve);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Html/HtmlCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Html/HtmlCodeActionResolverTest.cs
@@ -4,15 +4,12 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.CodeAnalysis.Razor.CodeActions;
 using Microsoft.CodeAnalysis.Razor.CodeActions.Models;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
-using Microsoft.CodeAnalysis.Razor.Protocol;
-using Microsoft.CodeAnalysis.Razor.Protocol.CodeActions;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Moq;
@@ -59,8 +56,7 @@ public class HtmlCodeActionResolverTest(ITestOutputHelper testOutput) : Language
             .Setup(x => x.RemapWorkspaceEditAsync(It.IsAny<IDocumentSnapshot>(), It.IsAny<WorkspaceEdit>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(remappedEdit);
 
-        var delegatedCodeActionResolver = new DelegatedCodeActionResolver(CreateLanguageServer(resolvedCodeAction));
-        var resolver = new HtmlCodeActionResolver(delegatedCodeActionResolver, editMappingServiceMock.Object);
+        var resolver = new HtmlCodeActionResolver(editMappingServiceMock.Object);
 
         var codeAction = new RazorVSInternalCodeAction()
         {
@@ -98,17 +94,5 @@ public class HtmlCodeActionResolverTest(ITestOutputHelper testOutput) : Language
             {
                 Assert.Equal("", e.NewText);
             });
-    }
-
-    private static IClientConnection CreateLanguageServer(CodeAction resolvedCodeAction)
-    {
-        var response = resolvedCodeAction;
-
-        var clientConnection = new Mock<IClientConnection>(MockBehavior.Strict);
-        clientConnection
-            .Setup(l => l.SendRequestAsync<RazorResolveCodeActionParams, CodeAction>(CustomMessageNames.RazorResolveCodeActionsEndpoint, It.IsAny<RazorResolveCodeActionParams>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(response);
-
-        return clientConnection.Object;
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ComponentAccessibilityCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ComponentAccessibilityCodeActionProviderTest.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Razor.CodeActions;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Protocol.CodeActions;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.NET.Sdk.Razor.SourceGenerators;
@@ -476,6 +477,7 @@ public class ComponentAccessibilityCodeActionProviderTest(ITestOutputHelper test
             codeDocument,
             StartAbsoluteIndex: absoluteIndex,
             EndAbsoluteIndex: absoluteIndex,
+            RazorLanguageKind.Razor,
             codeDocument.Source.Text,
             supportsFileCreation,
             SupportsCodeActionResolve: true);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionProviderTest.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.CodeAnalysis.Razor.CodeActions;
 using Microsoft.CodeAnalysis.Razor.CodeActions.Models;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Protocol.CodeActions;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
@@ -402,6 +403,7 @@ public class ExtractToCodeBehindCodeActionProviderTest(ITestOutputHelper testOut
             codeDocument,
             StartAbsoluteIndex: absoluteIndex,
             EndAbsoluteIndex: absoluteIndex,
+            RazorLanguageKind.Razor,
             codeDocument.Source.Text,
             supportsFileCreation,
             SupportsCodeActionResolve: true);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToComponentCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToComponentCodeActionProviderTest.cs
@@ -16,6 +16,7 @@ using Microsoft.CodeAnalysis.Razor.CodeActions;
 using Microsoft.CodeAnalysis.Razor.CodeActions.Models;
 using Microsoft.CodeAnalysis.Razor.CodeActions.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Protocol.CodeActions;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
@@ -441,6 +442,7 @@ public class ExtractToComponentCodeActionProviderTest(ITestOutputHelper testOutp
             codeDocument,
             selectionSpan.Start,
             selectionSpan.End,
+            RazorLanguageKind.Razor,
             sourceText,
             supportsFileCreation,
             SupportsCodeActionResolve: true);


### PR DESCRIPTION
Okay, I was wrong when I said the last PR was the final piece before cohosting actually gets implemented, but this one is, I swear!

Code actions have to run in devenv for Roslyn, so the main thing here is re-architecting so that the endpoints call the delegated servers, because calling into the service. Each commit is an isolated step on the way.