### PR TITLE
Don't get compilations in devenv

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RoslynProjectChangeProcessor.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RoslynProjectChangeProcessor.cs
@@ -288,11 +288,8 @@ internal sealed partial class RoslynProjectChangeProcessor(
             var csharpLanguageVersion = csharpParseOptions.LanguageVersion;
             var useRoslynTokenizer = csharpParseOptions.UseRoslynTokenizer();
 
-            var compilation = await workspaceProject.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
-            var suppressAddComponentParameter = compilation is not null && !compilation.HasAddComponentParameter();
             var configuration = projectSnapshot.Configuration with
             {
-                SuppressAddComponentParameter = suppressAddComponentParameter,
                 UseRoslynTokenizer = useRoslynTokenizer,
                 CSharpLanguageVersion = csharpLanguageVersion
             };


### PR DESCRIPTION
This should avoid RPS/Speedometer issues, but it does also disable the SupppressHasComponentParameter fix for a bit. I think I'm the only one who ever ran into it.