### PR TITLE
Improvements for Assumed.Unreachable(...)

### DIFF
--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Assumed.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Assumed.cs
@@ -45,17 +45,32 @@ internal static class Assumed
     /// </summary>
     /// <exception cref="InvalidOperationException"/>
     [DoesNotReturn]
+    public static void Unreachable(string message, [CallerFilePath] string? path = null, [CallerLineNumber] int line = 0)
+        => ThrowInvalidOperation(message, path, line);
+
+    /// <summary>
+    ///  Can be called at points that are assumed to be unreachable at runtime.
+    /// </summary>
+    /// <exception cref="InvalidOperationException"/>
+    [DoesNotReturn]
     public static T Unreachable<T>([CallerFilePath] string? path = null, [CallerLineNumber] int line = 0)
-    {
-        ThrowInvalidOperation(SR.This_program_location_is_thought_to_be_unreachable, path, line);
-        return default;
-    }
+        => ThrowInvalidOperation<T>(SR.This_program_location_is_thought_to_be_unreachable, path, line);
+
+    /// <summary>
+    ///  Can be called at points that are assumed to be unreachable at runtime.
+    /// </summary>
+    /// <exception cref="InvalidOperationException"/>
+    [DoesNotReturn]
+    public static T Unreachable<T>(string message, [CallerFilePath] string? path = null, [CallerLineNumber] int line = 0)
+        => ThrowInvalidOperation<T>(message, path, line);
 
     [DebuggerHidden]
     [DoesNotReturn]
-    [MethodImpl(MethodImplOptions.NoInlining)]
     private static void ThrowInvalidOperation(string message, string? path, int line)
-    {
-        throw new InvalidOperationException(message);
-    }
+        => ThrowHelper.ThrowInvalidOperationException(message + Environment.NewLine + SR.FormatFile_0_Line_1(path, line));
+
+    [DebuggerHidden]
+    [DoesNotReturn]
+    private static T ThrowInvalidOperation<T>(string message, string? path, int line)
+        => ThrowHelper.ThrowInvalidOperationException<T>(message + Environment.NewLine + SR.FormatFile_0_Line_1(path, line));
 }


### PR DESCRIPTION
This change is a follow-up to https://github.com/dotnet/razor/pull/11144#discussion_r1828602406 that addresses two issues that may help with diagnosis:

1. `Assumed.Unreachable(...)`captures the `[CallerFilePath]` and `[CallerLineNumber]` but didn't do anything with them. Now, those values are appended to the exception message.
2. Two `Assumed.Unreachable(...)` overloads have been added to allow a custom exception message to be provided that can be used to add more detail about a failure.
