### PR TITLE
Add cohosting Hover test for component attribute

### DIFF
--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/HoverAssertions.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/HoverAssertions.cs
@@ -79,11 +79,17 @@ internal static class HoverAssertions
             Assert.Equal(text, run.Text);
         };
 
+    public static Action<ClassifiedTextRun> ClassName (string text)
+        => Run(text, ClassificationTypeNames.ClassName);
+
     public static Action<ClassifiedTextRun> Keyword(string text)
         => Run(text, ClassificationTypeNames.Keyword);
 
     public static Action<ClassifiedTextRun> LocalName(string text)
         => Run(text, ClassificationTypeNames.LocalName);
+
+    public static Action<ClassifiedTextRun> PropertyName(string text)
+        => Run(text, ClassificationTypeNames.PropertyName);
 
     public static Action<ClassifiedTextRun> Punctuation(string text)
         => Run(text, ClassificationTypeNames.Punctuation);


### PR DESCRIPTION
Even though component attributes look like HTML they map to generated C#. In this case, Hover prefers C# over HTML and requests hover data from Roslyn. This adds a test for that scenario.
