### PR TITLE
Fixing html snippet completion and integration tests

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_Completion.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_Completion.cs
@@ -150,7 +150,11 @@ internal partial class RazorCustomMessageTarget
                 };
             }
 
-            _snippetCompletionItemProvider.AddSnippetCompletions(request.ProjectedKind, request.Context.InvokeKind, request.Context.TriggerCharacter, ref builder.AsRef());
+            if (request.ShouldIncludeSnippets)
+            {
+                _snippetCompletionItemProvider.AddSnippetCompletions(request.ProjectedKind, request.Context.InvokeKind, request.Context.TriggerCharacter, ref builder.AsRef());
+            }
+
             completionList.Items = builder.ToArray();
 
             completionList.Data = JsonHelpers.TryConvertFromJObject(completionList.Data);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentCompletionEndpointTest.cs
@@ -290,6 +290,29 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
              snippetLabels: ["snippet1", "snippet2"]);
     }
 
+    [Fact]
+    public async Task HtmlSnippetsCompletion_NotInStartTag()
+    {
+        await VerifyCompletionListAsync(
+            input: """
+                This is a Razor document.
+
+                <div $$></div>
+
+                The end.
+                """,
+             completionContext: new RoslynVSInternalCompletionContext()
+             {
+                 InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
+                 TriggerCharacter = " ",
+                 TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
+             },
+             expectedItemLabels: ["style", "dir"],
+             unexpectedItemLabels: ["snippet1", "snippet2"],
+             delegatedItemLabels: ["style", "dir"],
+             snippetLabels: ["snippet1", "snippet2"]);
+    }
+
     // Tests HTML attributes and DirectiveAttributeTransitionCompletionItemProvider
     [Fact]
     public async Task HtmlAndDirectiveAttributeTransitionNamesCompletion()
@@ -402,6 +425,7 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
         TestCode input,
         RoslynVSInternalCompletionContext completionContext,
         string[] expectedItemLabels,
+        string[]? unexpectedItemLabels = null,
         string[]? delegatedItemLabels = null,
         string[]? delegatedItemCommitCharacters = null,
         string[]? snippetLabels = null,
@@ -467,6 +491,14 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
         foreach (var expectedItemLabel in expectedItemLabels)
         {
             Assert.Contains(expectedItemLabel, labelSet);
+        }
+
+        if (unexpectedItemLabels is not null)
+        {
+            foreach (var unexpectedItemLabel in unexpectedItemLabels)
+            {
+                Assert.DoesNotContain(unexpectedItemLabel, labelSet);
+            }
         }
 
         if (!commitElementsWithSpace)


### PR DESCRIPTION
HTML snippet completions were being included when they shouldn't have been

﻿### Summary of the changes

- Include HTML snippet completions only when they request flag indicates they should be
- Also added a cohosting test, though this was not broken in cohosting

Fixes:
- Integration tests
- Snippets included when they shouldn't be (e.g. in a start tag)