### PR TITLE
Fix format on paste data readon from request

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DocumentRangeFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DocumentRangeFormattingEndpoint.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
@@ -56,8 +58,9 @@ internal class DocumentRangeFormattingEndpoint(
 
         if (request.Options.OtherOptions is not null &&
             request.Options.OtherOptions.TryGetValue("fromPaste", out var fromPasteObj) &&
-            fromPasteObj is bool fromPaste)
+            fromPasteObj is JsonElement fromPasteElement)
         {
+            var fromPaste = fromPasteElement.Deserialize<bool>();
             if (fromPaste && !_optionsMonitor.CurrentValue.Formatting.IsOnPasteEnabled())
             {
                 return null;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/DocumentRangeFormattingEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/DocumentRangeFormattingEndpointTest.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -116,13 +118,15 @@ public class DocumentRangeFormattingEndpointTest(ITestOutputHelper testOutput) :
         var optionsMonitor = GetOptionsMonitor(formatOnPaste: false);
         var htmlFormatter = new TestHtmlFormatter();
         var endpoint = new DocumentRangeFormattingEndpoint(formattingService, htmlFormatter, optionsMonitor);
+        var bytes = Encoding.UTF8.GetBytes("\"True\"");
+        var reader = new Utf8JsonReader(bytes);
         var @params = new DocumentRangeFormattingParams()
         {
             Options = new()
             {
                 OtherOptions = new()
                 {
-                    { "fromPaste", true }
+                    { "fromPaste", JsonElement.ParseValue(ref reader) }
                 }
             }
         };


### PR DESCRIPTION
It turns out the value comes back as a JsonElement instead of the underlying type 🤷