### PR TITLE
Fix request duration logging

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/AggregatingTelemetryLog.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/AggregatingTelemetryLog.cs
@@ -54,20 +54,20 @@ internal sealed class AggregatingTelemetryLog
     /// Adds aggregated information for the metric and value passed in via <paramref name="name"/>. The Name/Value properties
     /// are used as the metric name and value to record.
     /// </summary>
-    public void Log(string name,
+    public void Log(string keyName,
         int value,
-        string metricName,
         string method)
     {
         if (!IsEnabled)
             return;
 
-        (var histogram, _, var histogramLock) = ImmutableInterlocked.GetOrAdd(ref _histograms, name, name =>
+        (var histogram, _, var histogramLock) = ImmutableInterlocked.GetOrAdd(ref _histograms, keyName, keyName =>
         {
             var telemetryEvent = new TelemetryEvent(_eventName);
+
             TelemetryReporter.AddToProperties(telemetryEvent.Properties, new Property("method", method));
 
-            var histogram = _meter.CreateHistogram<long>(metricName, _histogramConfiguration);
+            var histogram = _meter.CreateHistogram<long>(keyName, _histogramConfiguration);
             var histogramLock = new object();
 
             return (histogram, telemetryEvent, histogramLock);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/AggregatingTelemetryLog.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/AggregatingTelemetryLog.cs
@@ -51,10 +51,11 @@ internal sealed class AggregatingTelemetryLog
     }
 
     /// <summary>
-    /// Adds aggregated information for the metric and value passed in via <paramref name="name"/>. The Name/Value properties
-    /// are used as the metric name and value to record.
+    /// Adds aggregated information for the <paramref name="histogramKey"/> and <paramref name="value"/>. Method name is tacked onto
+    /// to the first <paramref name="histogramKey"/> used for convenience.
     /// </summary>
-    public void Log(string histogramKey,
+    public void Log(
+        string histogramKey,
         int value,
         string method)
     {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/AggregatingTelemetryLog.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/AggregatingTelemetryLog.cs
@@ -54,20 +54,20 @@ internal sealed class AggregatingTelemetryLog
     /// Adds aggregated information for the metric and value passed in via <paramref name="name"/>. The Name/Value properties
     /// are used as the metric name and value to record.
     /// </summary>
-    public void Log(string keyName,
+    public void Log(string histogramKey,
         int value,
         string method)
     {
         if (!IsEnabled)
             return;
 
-        (var histogram, _, var histogramLock) = ImmutableInterlocked.GetOrAdd(ref _histograms, keyName, keyName =>
+        (var histogram, _, var histogramLock) = ImmutableInterlocked.GetOrAdd(ref _histograms, histogramKey, histogramKey =>
         {
             var telemetryEvent = new TelemetryEvent(_eventName);
 
             TelemetryReporter.AddToProperties(telemetryEvent.Properties, new Property("method", method));
 
-            var histogram = _meter.CreateHistogram<long>(keyName, _histogramConfiguration);
+            var histogram = _meter.CreateHistogram<long>(histogramKey, _histogramConfiguration);
             var histogramLock = new object();
 
             return (histogram, telemetryEvent, histogramLock);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
@@ -503,13 +503,13 @@ internal abstract partial class TelemetryReporter : ITelemetryReporter, IDisposa
         }
 
         private void LogAggregated(
-            string eventName,
-            string keyName,
+            string managerKey,
+            string histogramKey,
             int value,
             string method)
         {
-            var aggregatingLog = _aggregatingManager?.GetLog(eventName);
-            aggregatingLog?.Log(keyName, value, method);
+            var aggregatingLog = _aggregatingManager?.GetLog(managerKey);
+            aggregatingLog?.Log(histogramKey, value, method);
         }
 
         private sealed class Counter

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
@@ -475,13 +475,13 @@ internal abstract partial class TelemetryReporter : ITelemetryReporter, IDisposa
         public void LogRequestTelemetry(string name, string? language, TimeSpan queuedDuration, TimeSpan requestDuration, TelemetryResult result)
         {
             LogAggregated("LSP_TimeInQueue",
+                "",  // All time in queue events use the same histogram, no need for separate keys
                 (int)queuedDuration.TotalMilliseconds,
-                "TimeInQueue",
                 name);
 
             LogAggregated("LSP_RequestDuration",
+                name, // RequestDuration requests are histogrammed by their unique name
                 (int)requestDuration.TotalMilliseconds,
-                "RequestDuration",
                 name);
 
             _requestCounters.GetOrAdd((name, language), (_) => new Counter()).IncrementCount(result);
@@ -503,13 +503,13 @@ internal abstract partial class TelemetryReporter : ITelemetryReporter, IDisposa
         }
 
         private void LogAggregated(
-            string name,
+            string eventName,
+            string keyName,
             int value,
-            string metricName,
             string method)
         {
-            var aggregatingLog = _aggregatingManager?.GetLog(name);
-            aggregatingLog?.Log(name, value, metricName, method);
+            var aggregatingLog = _aggregatingManager?.GetLog(eventName);
+            aggregatingLog?.Log(keyName, value, method);
         }
 
         private sealed class Counter

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
@@ -475,7 +475,7 @@ internal abstract partial class TelemetryReporter : ITelemetryReporter, IDisposa
         public void LogRequestTelemetry(string name, string? language, TimeSpan queuedDuration, TimeSpan requestDuration, TelemetryResult result)
         {
             LogAggregated("LSP_TimeInQueue",
-                "",  // All time in queue events use the same histogram, no need for separate keys
+                "TimeInQueue",  // All time in queue events use the same histogram, no need for separate keys
                 (int)queuedDuration.TotalMilliseconds,
                 name);
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Telemetry/TelemetryReporterTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Telemetry/TelemetryReporterTests.cs
@@ -443,7 +443,7 @@ public class TelemetryReporterTests(ITestOutputHelper testOutput) : ToolingTestB
             static evt =>
             {
                 var histogram = Assert.IsAssignableFrom<IHistogram<long>>(evt.Instrument);
-                Assert.Equal("", histogram.Name);
+                Assert.Equal("TimeInQueue", histogram.Name);
 
                 var telemetryEvent = evt.Event;
                 Assert.Equal("dotnet/razor/lsp_timeinqueue", telemetryEvent.Name);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Telemetry/TelemetryReporterTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Telemetry/TelemetryReporterTests.cs
@@ -415,6 +415,27 @@ public class TelemetryReporterTests(ITestOutputHelper testOutput) : ToolingTestB
             TimeSpan.FromMilliseconds(300),
             AspNetCore.Razor.Telemetry.TelemetryResult.Failed);
 
+        reporter.ReportRequestTiming(
+            Methods.TextDocumentCompletionName,
+             WellKnownLspServerKinds.RazorLspServer.GetContractName(),
+            TimeSpan.FromMilliseconds(100),
+            TimeSpan.FromMilliseconds(100),
+            AspNetCore.Razor.Telemetry.TelemetryResult.Succeeded);
+
+        reporter.ReportRequestTiming(
+            Methods.TextDocumentCompletionName,
+             WellKnownLspServerKinds.RazorLspServer.GetContractName(),
+            TimeSpan.FromMilliseconds(200),
+            TimeSpan.FromMilliseconds(200),
+            AspNetCore.Razor.Telemetry.TelemetryResult.Cancelled);
+
+        reporter.ReportRequestTiming(
+            Methods.TextDocumentCompletionName,
+             WellKnownLspServerKinds.RazorLspServer.GetContractName(),
+            TimeSpan.FromMilliseconds(300),
+            TimeSpan.FromMilliseconds(300),
+            AspNetCore.Razor.Telemetry.TelemetryResult.Failed);
+
         reporter.Dispose();
 
         // Assert
@@ -422,7 +443,7 @@ public class TelemetryReporterTests(ITestOutputHelper testOutput) : ToolingTestB
             static evt =>
             {
                 var histogram = Assert.IsAssignableFrom<IHistogram<long>>(evt.Instrument);
-                Assert.Equal("TimeInQueue", histogram.Name);
+                Assert.Equal("", histogram.Name);
 
                 var telemetryEvent = evt.Event;
                 Assert.Equal("dotnet/razor/lsp_timeinqueue", telemetryEvent.Name);
@@ -436,7 +457,7 @@ public class TelemetryReporterTests(ITestOutputHelper testOutput) : ToolingTestB
             static evt =>
             {
                 var histogram = Assert.IsAssignableFrom<IHistogram<long>>(evt.Instrument);
-                Assert.Equal("RequestDuration", histogram.Name);
+                Assert.Equal(Methods.TextDocumentCodeActionName, histogram.Name);
 
                 var telemetryEvent = evt.Event;
                 Assert.Equal("dotnet/razor/lsp_requestduration", telemetryEvent.Name);
@@ -445,6 +466,20 @@ public class TelemetryReporterTests(ITestOutputHelper testOutput) : ToolingTestB
                     {
                         Assert.Equal("dotnet.razor.method", prop.Key);
                         Assert.Equal(Methods.TextDocumentCodeActionName, prop.Value);
+                    });
+            },
+            static evt =>
+            {
+                var histogram = Assert.IsAssignableFrom<IHistogram<long>>(evt.Instrument);
+                Assert.Equal(Methods.TextDocumentCompletionName, histogram.Name);
+
+                var telemetryEvent = evt.Event;
+                Assert.Equal("dotnet/razor/lsp_requestduration", telemetryEvent.Name);
+                Assert.Collection(telemetryEvent.Properties,
+                    static prop =>
+                    {
+                        Assert.Equal("dotnet.razor.method", prop.Key);
+                        Assert.Equal(Methods.TextDocumentCompletionName, prop.Value);
                     });
             });
 
@@ -457,6 +492,31 @@ public class TelemetryReporterTests(ITestOutputHelper testOutput) : ToolingTestB
                     {
                         Assert.Equal("dotnet.razor.method", prop.Key);
                         Assert.Equal(Methods.TextDocumentCodeActionName, prop.Value);
+                    },
+                    static prop =>
+                    {
+                        Assert.Equal("dotnet.razor.successful", prop.Key);
+                        Assert.Equal(1, prop.Value);
+                    },
+                    static prop =>
+                    {
+                        Assert.Equal("dotnet.razor.failed", prop.Key);
+                        Assert.Equal(1, prop.Value);
+                    },
+                    static prop =>
+                    {
+                        Assert.Equal("dotnet.razor.cancelled", prop.Key);
+                        Assert.Equal(1, prop.Value);
+                    });
+            },
+            static evt =>
+            {
+                Assert.Equal("dotnet/razor/lsp_requestcounter", evt.Name);
+                Assert.Collection(evt.Properties,
+                    static prop =>
+                    {
+                        Assert.Equal("dotnet.razor.method", prop.Key);
+                        Assert.Equal(Methods.TextDocumentCompletionName, prop.Value);
                     },
                     static prop =>
                     {


### PR DESCRIPTION
When first introduced there was an error in assumption of how histogram telemetry worked. This fixes this by correctly reporting a unique histogram even per lsp method name rather than the first one that comes in (which, as it turns out, was always initialize)

Also cleaned up the wording so it was a little easier to understand. 