### PR TITLE
Remove GetTagHelpersSynchronously extension method

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshotExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshotExtensions.cs
@@ -3,9 +3,6 @@
 
 using System;
 using System.Collections.Immutable;
-using System.Diagnostics;
-using System.Threading;
-using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Serialization;
@@ -36,20 +33,6 @@ internal static class IProjectSnapshotExtensions
             displayName: project.DisplayName,
             projectWorkspaceState: project.ProjectWorkspaceState,
             documents: documents.DrainToImmutable());
-    }
-
-    public static ImmutableArray<TagHelperDescriptor> GetTagHelpersSynchronously(this IProjectSnapshot projectSnapshot)
-    {
-        var canResolveTagHelpersSynchronously = projectSnapshot is ProjectSnapshot ||
-            projectSnapshot.GetType().FullName == "Microsoft.VisualStudio.LegacyEditor.Razor.EphemeralProjectSnapshot";
-
-        Debug.Assert(canResolveTagHelpersSynchronously, "The ProjectSnapshot in the VisualStudioDocumentTracker should not be a cohosted project.");
-        var tagHelperTask = projectSnapshot.GetTagHelpersAsync(CancellationToken.None);
-        Debug.Assert(tagHelperTask.IsCompleted, "GetTagHelpersAsync should be synchronous for non-cohosted projects.");
-
-#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
-        return tagHelperTask.Result;
-#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
     }
 
     public static ImmutableArray<IDocumentSnapshot> GetRelatedDocuments(this IProjectSnapshot projectSnapshot, IDocumentSnapshot document)

--- a/src/Razor/src/Microsoft.VisualStudio.LegacyEditor.Razor/VisualStudioDocumentTracker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LegacyEditor.Razor/VisualStudioDocumentTracker.cs
@@ -70,17 +70,9 @@ internal sealed class VisualStudioDocumentTracker : IVisualStudioDocumentTracker
     public ClientSpaceSettings EditorSettings => _workspaceEditorSettings.Current.ClientSpaceSettings;
 
     public ImmutableArray<TagHelperDescriptor> TagHelpers
-    {
-        get
-        {
-            if (ProjectSnapshot is null)
-            {
-                return ImmutableArray<TagHelperDescriptor>.Empty;
-            }
-
-            return ProjectSnapshot.GetTagHelpersSynchronously();
-        }
-    }
+        => _projectSnapshot is { ProjectWorkspaceState.TagHelpers: var tagHelpers }
+            ? tagHelpers
+            : [];
 
     public bool IsSupportedProject => _isSupportedProject;
 
@@ -231,7 +223,7 @@ internal sealed class VisualStudioDocumentTracker : IVisualStudioDocumentTracker
                     _ = OnContextChangedAsync(ContextChangeKind.ProjectChanged);
 
                     if (e.Older is null ||
-                        !e.Older.GetTagHelpersSynchronously().SequenceEqual(e.Newer!.GetTagHelpersSynchronously()))
+                        !e.Older.ProjectWorkspaceState.TagHelpers.SequenceEqual(e.Newer!.ProjectWorkspaceState.TagHelpers))
                     {
                         _ = OnContextChangedAsync(ContextChangeKind.TagHelpersChanged);
                     }


### PR DESCRIPTION
Fixes #9878

It turns out that this extension method isn't necessary. It's only used by the legacy editor, which can just access `IProjectSnaphshot.ProjectWorkspaceState.TagHelpers`. That property is always implemented by any project snapshot that the legacy editor encounters, namely `ProjectSnapshot` or `EphemeralProjectSnapshot`.
