### PR TITLE
Fine tuning of what types of project update affect what state

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentState.cs
@@ -160,12 +160,14 @@ internal partial class DocumentState
         return state;
     }
 
-    public virtual DocumentState WithProjectChange()
+    public virtual DocumentState WithProjectChange(bool cacheComputedState)
     {
         var state = new DocumentState(HostDocument, Version + 1, _textAndVersion, _textLoader);
 
-        // Optimistically cache the computed state
-        state._computedState = new ComputedStateTracker(_computedState);
+        if (cacheComputedState)
+        {
+            state._computedState = new ComputedStateTracker(_computedState);
+        }
 
         return state;
     }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
@@ -274,26 +274,36 @@ internal class ProjectState
 
     public ProjectState WithHostProjectAndWorkspaceState(HostProject hostProject, ProjectWorkspaceState projectWorkspaceState)
     {
-        if (HostProject.Configuration.Equals(hostProject.Configuration) &&
-            HostProject.RootNamespace == hostProject.RootNamespace &&
-            ProjectWorkspaceState.Equals(projectWorkspaceState))
+        var configUnchanged = (HostProject.Configuration.Equals(hostProject.Configuration) &&
+            HostProject.RootNamespace == hostProject.RootNamespace);
+
+        if (configUnchanged && ProjectWorkspaceState.Equals(projectWorkspaceState))
         {
             return this;
         }
 
-        var documents = Documents.ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.WithProjectChange(), FilePathNormalizingComparer.Instance);
+        var documents = Documents.ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.WithProjectChange(cacheComputedState: configUnchanged), FilePathNormalizingComparer.Instance);
 
-        // If the host project has changed then we need to recompute the imports map
-        var importsToRelatedDocuments = s_emptyImportsToRelatedDocuments;
+        var importsToRelatedDocuments = configUnchanged
+            ? ImportsToRelatedDocuments
+            : ComputeImportsToRelatedDocuments(documents);
 
-        foreach (var document in documents)
-        {
-            var importTargetPaths = GetImportDocumentTargetPaths(document.Value.HostDocument);
-            importsToRelatedDocuments = AddToImportsToRelatedDocuments(importsToRelatedDocuments, document.Value.HostDocument.FilePath, importTargetPaths);
-        }
-
-        var state = new ProjectState(this, numberOfDocumentsMayHaveChanged: true, hostProject, projectWorkspaceState, documents, importsToRelatedDocuments);
+        var state = new ProjectState(this, numberOfDocumentsMayHaveChanged: !configUnchanged, hostProject, projectWorkspaceState, documents, importsToRelatedDocuments);
         return state;
+
+        ImmutableDictionary<string, ImmutableArray<string>> ComputeImportsToRelatedDocuments(ImmutableDictionary<string, DocumentState> documents)
+        {
+            // If the host project has changed then we need to recompute the imports map
+            var importsToRelatedDocuments = s_emptyImportsToRelatedDocuments;
+
+            foreach (var document in documents)
+            {
+                var importTargetPaths = GetImportDocumentTargetPaths(document.Value.HostDocument);
+                importsToRelatedDocuments = AddToImportsToRelatedDocuments(importsToRelatedDocuments, document.Value.HostDocument.FilePath, importTargetPaths);
+            }
+
+            return importsToRelatedDocuments;
+        }
     }
 
     internal static ImmutableDictionary<string, ImmutableArray<string>> AddToImportsToRelatedDocuments(

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
@@ -284,6 +284,7 @@ internal class ProjectState
 
         var documents = Documents.ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value.WithProjectChange(cacheComputedState: configUnchanged), FilePathNormalizingComparer.Instance);
 
+        // If the host project has changed then we need to recompute the imports map
         var importsToRelatedDocuments = configUnchanged
             ? ImportsToRelatedDocuments
             : ComputeImportsToRelatedDocuments(documents);
@@ -293,7 +294,6 @@ internal class ProjectState
 
         ImmutableDictionary<string, ImmutableArray<string>> ComputeImportsToRelatedDocuments(ImmutableDictionary<string, DocumentState> documents)
         {
-            // If the host project has changed then we need to recompute the imports map
             var importsToRelatedDocuments = s_emptyImportsToRelatedDocuments;
 
             foreach (var document in documents)

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DocumentStateTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DocumentStateTest.cs
@@ -70,7 +70,7 @@ public class DocumentStateTest : ToolingTestBase
             .WithText(_text, VersionStamp.Create());
 
         // Act
-        var state = original.WithProjectChange();
+        var state = original.WithProjectChange(cacheComputedState: false);
 
         // Assert
         Assert.True(state.TryGetText(out _));
@@ -87,7 +87,7 @@ public class DocumentStateTest : ToolingTestBase
         await original.GetTextAsync(DisposalToken);
 
         // Act
-        var state = original.WithProjectChange();
+        var state = original.WithProjectChange(cacheComputedState: false);
 
         // Assert
         Assert.True(state.TryGetText(out _));


### PR DESCRIPTION
Follow up to https://github.com/dotnet/razor/pull/11191 which caused RPS regressions.

There were some edge-y things I papered over in that PR, assuming they were unnecessary over-complications, but given the RPS regression I had a closer look, and they could have caused re-compilation of closed documents when only tag helpers changed, which would be new behaviour. Not _entirely_ convinced the re-compilation is all unnecessary (if a document used a Tag Helper that has only just been discovered, then its code gen would legitimately change) but it's hard to justify when I can't point to any tooling for the closed files that would actually benefit from the extra work.

The key thing is not changing `DocumentCollectionVersion` when only `ProjectWorkspaceState` changes. Not re-calculating import documents was just a little extra amuse-bouche, and not caching the computed state tracker is pure paranoia.