### PR TITLE
[Fuse] bind-Value:attribute support

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.codegen.cs
@@ -36,6 +36,15 @@ ParentValue
 #nullable disable
             ));
             __builder.AddComponentParameter(2, nameof(global::Test.MyComponent.OnChanged), (global::System.Action<global::System.Int32>)(__value => ParentValue = __value));
+             _ = nameof(global::Test.MyComponent.
+#nullable restore
+#line (1,46)-(1,51) "x:\dir\subdir\Test\TestComponent.cshtml"
+Value
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_SpecifiesValueAndChangeEvent_WithMatchingProperties/TestComponent.mappings.txt
@@ -8,11 +8,16 @@ Source Location: (26:0,26 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1144:31,0 [11] )
 |ParentValue|
 
+Source Location: (45:0,45 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (1531:41,0 [5] )
+|Value|
+
 Source Location: (80:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1568:43,0 [50] )
+Generated Location: (1774:52,0 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_Action/TestComponent.codegen.cs
@@ -44,6 +44,15 @@ Update
 #line hidden
 #nullable disable
             ); }));
+             _ = nameof(global::Test.MyComponent.
+#nullable restore
+#line (1,50)-(1,55) "x:\dir\subdir\Test\TestComponent.cshtml"
+Value
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_Action/TestComponent.mappings.txt
@@ -13,13 +13,18 @@ Source Location: (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1583:40,0 [6] )
 |Update|
 
+Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (1795:49,0 [5] )
+|Value|
+
 Source Location: (81:1,7 [82] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 
     public void Update() { }
 |
-Generated Location: (1832:51,0 [82] )
+Generated Location: (2038:60,0 [82] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_ActionLambda/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_ActionLambda/TestComponent.codegen.cs
@@ -44,6 +44,15 @@ ParentValue
 #line hidden
 #nullable disable
             ); }));
+             _ = nameof(global::Test.MyComponent.
+#nullable restore
+#line (1,50)-(1,55) "x:\dir\subdir\Test\TestComponent.cshtml"
+Value
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_ActionLambda/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_ActionLambda/TestComponent.mappings.txt
@@ -13,11 +13,16 @@ Source Location: (62:0,62 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1583:40,0 [9] )
 |() => { }|
 
+Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (1798:49,0 [5] )
+|Value|
+
 Source Location: (84:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1835:51,0 [50] )
+Generated Location: (2041:60,0 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_AsyncLambdaProducesError/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_AsyncLambdaProducesError/TestComponent.codegen.cs
@@ -44,6 +44,15 @@ ParentValue
 #line hidden
 #nullable disable
             ));
+             _ = nameof(global::Test.MyComponent.
+#nullable restore
+#line (1,50)-(1,55) "x:\dir\subdir\Test\TestComponent.cshtml"
+Value
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_AsyncLambdaProducesError/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_AsyncLambdaProducesError/TestComponent.mappings.txt
@@ -13,11 +13,16 @@ Source Location: (60:0,60 [62] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1449:40,0 [62] )
 |(value => { ParentValue = value; return Task.CompletedTask; })|
 
+Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (1713:49,0 [5] )
+|Value|
+
 Source Location: (135:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1750:51,0 [50] )
+Generated Location: (1956:60,0 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback/TestComponent.codegen.cs
@@ -44,6 +44,15 @@ UpdateValue
 #line hidden
 #nullable disable
             ); }, value: ParentValue), ParentValue))));
+             _ = nameof(global::Test.MyComponent.
+#nullable restore
+#line (1,50)-(1,55) "x:\dir\subdir\Test\TestComponent.cshtml"
+Value
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback/TestComponent.mappings.txt
@@ -13,12 +13,17 @@ Source Location: (62:0,62 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (2023:40,0 [11] )
 |UpdateValue|
 
+Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (2276:49,0 [5] )
+|Value|
+
 Source Location: (86:1,7 [102] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
     public EventCallback UpdateValue { get; set; }
 |
-Generated Location: (2313:51,0 [102] )
+Generated Location: (2519:60,0 [102] )
 |
     public int ParentValue { get; set; } = 42;
     public EventCallback UpdateValue { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesAction/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesAction/TestComponent.codegen.cs
@@ -44,6 +44,15 @@ ParentValue
 #line hidden
 #nullable disable
             ); }, value: ParentValue), ParentValue))));
+             _ = nameof(global::Test.MyComponent.
+#nullable restore
+#line (1,50)-(1,55) "x:\dir\subdir\Test\TestComponent.cshtml"
+Value
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesAction/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesAction/TestComponent.mappings.txt
@@ -13,11 +13,16 @@ Source Location: (62:0,62 [9] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (2023:40,0 [9] )
 |() => { }|
 
+Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (2274:49,0 [5] )
+|Value|
+
 Source Location: (84:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (2311:51,0 [50] )
+Generated Location: (2517:60,0 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesFunction/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesFunction/TestComponent.codegen.cs
@@ -44,6 +44,15 @@ UpdateValue
 #line hidden
 #nullable disable
             ); }, value: ParentValue), ParentValue))));
+             _ = nameof(global::Test.MyComponent.
+#nullable restore
+#line (1,50)-(1,55) "x:\dir\subdir\Test\TestComponent.cshtml"
+Value
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesFunction/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_EventCallback_ReceivesFunction/TestComponent.mappings.txt
@@ -13,13 +13,18 @@ Source Location: (62:0,62 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (2023:40,0 [11] )
 |UpdateValue|
 
+Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (2276:49,0 [5] )
+|Value|
+
 Source Location: (86:1,7 [106] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 
     public Task UpdateValue() => Task.CompletedTask;
 |
-Generated Location: (2313:51,0 [106] )
+Generated Location: (2519:60,0 [106] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningDelegate/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningDelegate/TestComponent.codegen.cs
@@ -44,6 +44,15 @@ Update
 #line hidden
 #nullable disable
             ); }));
+             _ = nameof(global::Test.MyComponent.
+#nullable restore
+#line (1,50)-(1,55) "x:\dir\subdir\Test\TestComponent.cshtml"
+Value
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningDelegate/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningDelegate/TestComponent.mappings.txt
@@ -13,13 +13,18 @@ Source Location: (62:0,62 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1631:40,0 [6] )
 |Update|
 
+Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (1843:49,0 [5] )
+|Value|
+
 Source Location: (81:1,7 [101] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 
     public Task Update() => Task.CompletedTask;
 |
-Generated Location: (1880:51,0 [101] )
+Generated Location: (2086:60,0 [101] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningLambda/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningLambda/TestComponent.codegen.cs
@@ -44,6 +44,15 @@ ParentValue
 #line hidden
 #nullable disable
             ); }));
+             _ = nameof(global::Test.MyComponent.
+#nullable restore
+#line (1,50)-(1,55) "x:\dir\subdir\Test\TestComponent.cshtml"
+Value
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningLambda/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithAfter_TaskReturningLambda/TestComponent.mappings.txt
@@ -13,11 +13,16 @@ Source Location: (62:0,62 [36] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1631:40,0 [36] )
 |() => { return Task.CompletedTask; }|
 
+Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (1873:49,0 [5] )
+|Value|
+
 Source Location: (111:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1910:51,0 [50] )
+Generated Location: (2116:60,0 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_Action/TestComponent.codegen.cs
@@ -44,6 +44,15 @@ UpdateValue
 #line hidden
 #nullable disable
             ));
+             _ = nameof(global::Test.MyComponent.
+#nullable restore
+#line (1,50)-(1,55) "x:\dir\subdir\Test\TestComponent.cshtml"
+Value
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_Action/TestComponent.mappings.txt
@@ -13,13 +13,18 @@ Source Location: (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1448:40,0 [11] )
 |UpdateValue|
 
+Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (1661:49,0 [5] )
+|Value|
+
 Source Location: (84:1,7 [116] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 
     public void UpdateValue(int value) => ParentValue = value;
 |
-Generated Location: (1698:51,0 [116] )
+Generated Location: (1904:60,0 [116] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_ActionLambda/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_ActionLambda/TestComponent.codegen.cs
@@ -44,6 +44,15 @@ value => ParentValue = value
 #line hidden
 #nullable disable
             ));
+             _ = nameof(global::Test.MyComponent.
+#nullable restore
+#line (1,50)-(1,55) "x:\dir\subdir\Test\TestComponent.cshtml"
+Value
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_ActionLambda/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_ActionLambda/TestComponent.mappings.txt
@@ -13,11 +13,16 @@ Source Location: (60:0,60 [28] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1448:40,0 [28] )
 |value => ParentValue = value|
 
+Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (1678:49,0 [5] )
+|Value|
+
 Source Location: (101:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1715:51,0 [50] )
+Generated Location: (1921:60,0 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback/TestComponent.codegen.cs
@@ -44,6 +44,15 @@ UpdateValue
 #line hidden
 #nullable disable
             , ParentValue))));
+             _ = nameof(global::Test.MyComponent.
+#nullable restore
+#line (1,50)-(1,55) "x:\dir\subdir\Test\TestComponent.cshtml"
+Value
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback/TestComponent.mappings.txt
@@ -13,12 +13,17 @@ Source Location: (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1764:40,0 [11] )
 |UpdateValue|
 
+Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (1992:49,0 [5] )
+|Value|
+
 Source Location: (84:1,7 [107] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
     public EventCallback<int> UpdateValue { get; set; }
 |
-Generated Location: (2029:51,0 [107] )
+Generated Location: (2235:60,0 [107] )
 |
     public int ParentValue { get; set; } = 42;
     public EventCallback<int> UpdateValue { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesAction/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesAction/TestComponent.codegen.cs
@@ -44,6 +44,15 @@ value => ParentValue = value
 #line hidden
 #nullable disable
             , ParentValue))));
+             _ = nameof(global::Test.MyComponent.
+#nullable restore
+#line (1,50)-(1,55) "x:\dir\subdir\Test\TestComponent.cshtml"
+Value
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesAction/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesAction/TestComponent.mappings.txt
@@ -13,11 +13,16 @@ Source Location: (60:0,60 [28] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1764:40,0 [28] )
 |value => ParentValue = value|
 
+Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (2009:49,0 [5] )
+|Value|
+
 Source Location: (101:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (2046:51,0 [50] )
+Generated Location: (2252:60,0 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesFunction/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesFunction/TestComponent.codegen.cs
@@ -44,6 +44,15 @@ UpdateValue
 #line hidden
 #nullable disable
             , ParentValue))));
+             _ = nameof(global::Test.MyComponent.
+#nullable restore
+#line (1,50)-(1,55) "x:\dir\subdir\Test\TestComponent.cshtml"
+Value
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesFunction/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_EventCallback_ReceivesFunction/TestComponent.mappings.txt
@@ -13,13 +13,18 @@ Source Location: (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1764:40,0 [11] )
 |UpdateValue|
 
+Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (1992:49,0 [5] )
+|Value|
+
 Source Location: (84:1,7 [144] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 
     public Task UpdateValue(int value) { ParentValue = value; return Task.CompletedTask; }
 |
-Generated Location: (2029:51,0 [144] )
+Generated Location: (2235:60,0 [144] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_ProducesErrorOnOlderLanguageVersions/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_ProducesErrorOnOlderLanguageVersions/TestComponent.codegen.cs
@@ -44,6 +44,15 @@ UpdateValue
 #line hidden
 #nullable disable
             )));
+             _ = nameof(global::Test.MyComponent.
+#nullable restore
+#line (1,50)-(1,55) "x:\dir\subdir\Test\TestComponent.cshtml"
+Value
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_ProducesErrorOnOlderLanguageVersions/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_ProducesErrorOnOlderLanguageVersions/TestComponent.mappings.txt
@@ -13,13 +13,18 @@ Source Location: (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1449:40,0 [11] )
 |UpdateValue|
 
+Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (1663:49,0 [5] )
+|Value|
+
 Source Location: (84:1,7 [116] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 
     public void UpdateValue(int value) => ParentValue = value;
 |
-Generated Location: (1700:51,0 [116] )
+Generated Location: (1906:60,0 [116] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningDelegate/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningDelegate/TestComponent.codegen.cs
@@ -44,6 +44,15 @@ UpdateValue
 #line hidden
 #nullable disable
             ));
+             _ = nameof(global::Test.MyComponent.
+#nullable restore
+#line (1,50)-(1,55) "x:\dir\subdir\Test\TestComponent.cshtml"
+Value
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningDelegate/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningDelegate/TestComponent.mappings.txt
@@ -13,13 +13,18 @@ Source Location: (60:0,60 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1483:40,0 [11] )
 |UpdateValue|
 
+Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (1696:49,0 [5] )
+|Value|
+
 Source Location: (84:1,7 [144] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 
     public Task UpdateValue(int value) { ParentValue = value; return Task.CompletedTask; }
 |
-Generated Location: (1733:51,0 [144] )
+Generated Location: (1939:60,0 [144] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningLambda/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningLambda/TestComponent.codegen.cs
@@ -44,6 +44,15 @@ value => { ParentValue = value; return Task.CompletedTask; }
 #line hidden
 #nullable disable
             ));
+             _ = nameof(global::Test.MyComponent.
+#nullable restore
+#line (1,50)-(1,55) "x:\dir\subdir\Test\TestComponent.cshtml"
+Value
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningLambda/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToComponent_WithGetSet_TaskReturningLambda/TestComponent.mappings.txt
@@ -13,11 +13,16 @@ Source Location: (60:0,60 [60] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1484:40,0 [60] )
 |value => { ParentValue = value; return Task.CompletedTask; }|
 
+Source Location: (49:0,49 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (1746:49,0 [5] )
+|Value|
+
 Source Location: (133:1,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 |
-Generated Location: (1783:51,0 [50] )
+Generated Location: (1989:60,0 [50] )
 |
     public int ParentValue { get; set; } = 42;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.codegen.cs
@@ -44,6 +44,15 @@ Update
 #line hidden
 #nullable disable
             ); }));
+             _ = nameof(global::Test.MyComponent<int>.
+#nullable restore
+#line (1,63)-(1,68) "x:\dir\subdir\Test\TestComponent.cshtml"
+Value
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.mappings.txt
@@ -13,13 +13,18 @@ Source Location: (75:0,75 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1564:40,0 [6] )
 |Update|
 
+Source Location: (62:0,62 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (1781:49,0 [5] )
+|Value|
+
 Source Location: (94:1,7 [82] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public int ParentValue { get; set; } = 42;
 
     public void Update() { }
 |
-Generated Location: (1813:51,0 [82] )
+Generated Location: (2024:60,0 [82] )
 |
     public int ParentValue { get; set; } = 42;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.codegen.cs
@@ -44,6 +44,15 @@ UpdateValue
 #line hidden
 #nullable disable
             , ParentValue))));
+             _ = nameof(global::Test.MyComponent<CustomValue>.
+#nullable restore
+#line (1,71)-(1,76) "x:\dir\subdir\Test\TestComponent.cshtml"
+Value
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.mappings.txt
@@ -13,13 +13,18 @@ Source Location: (81:0,81 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1776:40,0 [11] )
 |UpdateValue|
 
+Source Location: (70:0,70 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (2017:49,0 [5] )
+|Value|
+
 Source Location: (105:1,7 [147] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public CustomValue ParentValue { get; set; } = new CustomValue();
 
     public void UpdateValue(CustomValue value) => ParentValue = value;
 |
-Generated Location: (2041:51,0 [147] )
+Generated Location: (2260:60,0 [147] )
 |
     public CustomValue ParentValue { get; set; } = new CustomValue();
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.codegen.cs
@@ -44,6 +44,15 @@ UpdateValue
 #line hidden
 #nullable disable
             , ParentValue))));
+             _ = nameof(global::Test.MyComponent<CustomValue>.
+#nullable restore
+#line (1,71)-(1,76) "x:\dir\subdir\Test\TestComponent.cshtml"
+Value
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.mappings.txt
@@ -13,12 +13,17 @@ Source Location: (81:0,81 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1776:40,0 [11] )
 |UpdateValue|
 
+Source Location: (70:0,70 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (2017:49,0 [5] )
+|Value|
+
 Source Location: (105:1,7 [138] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public CustomValue ParentValue { get; set; } = new CustomValue();
     public EventCallback<CustomValue> UpdateValue { get; set; }
 |
-Generated Location: (2041:51,0 [138] )
+Generated Location: (2260:60,0 [138] )
 |
     public CustomValue ParentValue { get; set; } = new CustomValue();
     public EventCallback<CustomValue> UpdateValue { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.codegen.cs
@@ -44,6 +44,15 @@ UpdateValue
 #line hidden
 #nullable disable
             , ParentValue))));
+             _ = nameof(global::Test.MyComponent<CustomValue>.
+#nullable restore
+#line (1,71)-(1,76) "x:\dir\subdir\Test\TestComponent.cshtml"
+Value
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.mappings.txt
@@ -13,13 +13,18 @@ Source Location: (81:0,81 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1776:40,0 [11] )
 |UpdateValue|
 
+Source Location: (70:0,70 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (2017:49,0 [5] )
+|Value|
+
 Source Location: (105:1,7 [179] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public CustomValue ParentValue { get; set; } = new CustomValue();
 
         public Task UpdateValue(CustomValue value) { ParentValue = value; return Task.CompletedTask; }
 |
-Generated Location: (2041:51,0 [179] )
+Generated Location: (2260:60,0 [179] )
 |
     public CustomValue ParentValue { get; set; } = new CustomValue();
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.codegen.cs
@@ -52,6 +52,15 @@ UpdateValue
 #line hidden
 #nullable disable
             , ParentValue))));
+             _ = nameof(global::Test.MyComponent<TParam>.
+#nullable restore
+#line (2,66)-(2,71) "x:\dir\subdir\Test\TestComponent.cshtml"
+Value
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Action/TestComponent.mappings.txt
@@ -18,13 +18,18 @@ Source Location: (95:1,76 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1894:48,0 [11] )
 |UpdateValue|
 
+Source Location: (84:1,65 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (2130:57,0 [5] )
+|Value|
+
 Source Location: (119:2,7 [128] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public TParam ParentValue { get; set; } = default;
 
     public void UpdateValue(TParam value) { ParentValue = value; }
 |
-Generated Location: (2159:59,0 [128] )
+Generated Location: (2373:68,0 [128] )
 |
     public TParam ParentValue { get; set; } = default;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.codegen.cs
@@ -52,6 +52,15 @@ UpdateValue
 #line hidden
 #nullable disable
             , ParentValue))));
+             _ = nameof(global::Test.MyComponent<TParam>.
+#nullable restore
+#line (2,66)-(2,71) "x:\dir\subdir\Test\TestComponent.cshtml"
+Value
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_EventCallback/TestComponent.mappings.txt
@@ -18,12 +18,17 @@ Source Location: (95:1,76 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1894:48,0 [11] )
 |UpdateValue|
 
+Source Location: (84:1,65 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (2130:57,0 [5] )
+|Value|
+
 Source Location: (119:2,7 [118] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public TParam ParentValue { get; set; } = default;
     public EventCallback<TParam> UpdateValue { get; set; }
 |
-Generated Location: (2159:59,0 [118] )
+Generated Location: (2373:68,0 [118] )
 |
     public TParam ParentValue { get; set; } = default;
     public EventCallback<TParam> UpdateValue { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.codegen.cs
@@ -52,6 +52,15 @@ UpdateValue
 #line hidden
 #nullable disable
             , ParentValue))));
+             _ = nameof(global::Test.MyComponent<TParam>.
+#nullable restore
+#line (2,66)-(2,71) "x:\dir\subdir\Test\TestComponent.cshtml"
+Value
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericBindToGenericComponent_ExplicitType_WithGetSet_Function/TestComponent.mappings.txt
@@ -18,13 +18,18 @@ Source Location: (95:1,76 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1894:48,0 [11] )
 |UpdateValue|
 
+Source Location: (84:1,65 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (2130:57,0 [5] )
+|Value|
+
 Source Location: (119:2,7 [155] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public TParam ParentValue { get; set; } = default;
 
     public Task UpdateValue(TParam value) { ParentValue = value; return Task.CompletedTask; }
 |
-Generated Location: (2159:59,0 [155] )
+Generated Location: (2373:68,0 [155] )
 |
     public TParam ParentValue { get; set; } = default;
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.codegen.cs
@@ -52,6 +52,15 @@ Update
 #line hidden
 #nullable disable
             ); }));
+             _ = nameof(global::Test.MyComponent<TParam>.
+#nullable restore
+#line (2,66)-(2,71) "x:\dir\subdir\Test\TestComponent.cshtml"
+Value
+
+#line default
+#line hidden
+#nullable disable
+            );
             __builder.CloseComponent();
         }
         #pragma warning restore 1998

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponentBindToGenericComponent_ExplicitType_WithAfter_Action/TestComponent.mappings.txt
@@ -18,13 +18,18 @@ Source Location: (97:1,78 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 Generated Location: (1727:48,0 [6] )
 |Update|
 
+Source Location: (84:1,65 [5] x:\dir\subdir\Test\TestComponent.cshtml)
+|Value|
+Generated Location: (1947:57,0 [5] )
+|Value|
+
 Source Location: (116:2,7 [79] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     public TParam ParentValue { get; set; }
 
     public void Update() { }
 |
-Generated Location: (1976:59,0 [79] )
+Generated Location: (2190:68,0 [79] )
 |
     public TParam ParentValue { get; set; }
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/CSharp/BindTagHelperDescriptorProvider.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/CSharp/BindTagHelperDescriptorProvider.cs
@@ -667,6 +667,7 @@ internal sealed class BindTagHelperDescriptorProvider() : TagHelperDescriptorPro
                     attribute.Name = "@bind-" + valueAttribute.Name;
                     attribute.TypeName = changeAttribute.TypeName;
                     attribute.IsEnum = valueAttribute.IsEnum;
+                    attribute.ContainingType = valueAttribute.ContainingType;
 
                     attribute.SetMetadata(
                         PropertyName(valueAttribute.GetPropertyName()),

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentRuntimeNodeWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentRuntimeNodeWriter.cs
@@ -593,6 +593,7 @@ internal class ComponentRuntimeNodeWriter : ComponentNodeWriter
 
         if (node.IsDesignTimePropertyAccessHelper())
         {
+            WriteDesignTimePropertyAccessor(context, node);
             return;
         }
 
@@ -623,6 +624,17 @@ internal class ComponentRuntimeNodeWriter : ComponentNodeWriter
 
         context.CodeWriter.Write(");");
         context.CodeWriter.WriteLine();
+    }
+
+    private static void WriteDesignTimePropertyAccessor(CodeRenderingContext context, ComponentAttributeIntermediateNode attribute)
+    {
+        // These attributes don't really exist in the emitted code, but have a representation in the razor document.
+        // We emit a small piece of empty code that is elided by the compiler, so that the IDE has something to reference
+        // for Find All References etc.
+        Debug.Assert(attribute.BoundAttribute?.ContainingType is not null);
+        context.CodeWriter.Write(" _ = ");
+        WriteComponentAttributeName(context, attribute);
+        context.CodeWriter.WriteLine(";");
     }
 
     private void WriteComponentAttributeInnards(CodeRenderingContext context, ComponentAttributeIntermediateNode node, bool canTypeCheck)

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/GoToDefinitionTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/GoToDefinitionTests.cs
@@ -367,8 +367,8 @@ public class GoToDefinitionTests(ITestOutputHelper testOutputHelper) : AbstractR
 
     [IdeTheory]
     [InlineData("MyProperty:get")]
-    [InlineData("MyProperty:set", Skip = "https://github.com/dotnet/razor/issues/10966")]
-    [InlineData("MyProperty:after", Skip = "https://github.com/dotnet/razor/issues/10966")]
+    [InlineData("MyProperty:set")]
+    [InlineData("MyProperty:after")]
     public async Task GoToDefinition_ComponentAttribute_BindSet(string attribute)
     {
         // Create the file


### PR DESCRIPTION
The various `@bind-Value:get` `@bind-Value:set`, `@bind-Value:event` tag helpers are mostly macro based, meaning that what they expand into isn't represented in the document. 

For the IDE to enable Hover, FAR etc on the `Value` part of the attribute, we need to emit something that we can map (we can't map the same piece of text twice).

This PR takes the approach of emitting a simple discard expression of the `nameof` the referenced value so we have something to map for the IDE, but is completely elided by the compiler at build time, so has no runtime effect.

We already had the machinery to correctly emit the `nameof` including on generic types, so this PR just re-uses that. 

Fixes: https://github.com/dotnet/razor/issues/10966