### PR TITLE
Publish package artifacts on PR builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -182,7 +182,7 @@ stages:
         - publish: artifacts\packages\$(_BuildConfig)
           artifact: Packages_$(Agent.Os)_$(_BuildConfig)
           displayName: Publish package artifacts
-          condition: and(succeeded(), eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
+          condition: succeeded()
 
   # Unix jobs done as a group since they share the same test results format.
   - template: /eng/common/templates/jobs/jobs.yml


### PR DESCRIPTION
This will allow https://lab.razor.fyi to be used on PR builds of the compiler. Including Debug configurations (useful for seeing asserts). Note that Roslyn also publishes packages and DLLs on PR builds (both Debug and Release configurations).