### PR TITLE
Completion resolve endpoint skeleton

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostDocumentCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostDocumentCompletionEndpoint.cs
@@ -64,7 +64,7 @@ internal sealed class CohostDocumentCompletionEndpoint(
                 Method = Methods.TextDocumentCompletionName,
                 RegisterOptions = new CompletionRegistrationOptions()
                 {
-                    ResolveProvider = false, // TODO - change to true when Resolve is implemented
+                    ResolveProvider = true, // TODO - change to true when Resolve is implemented
                     TriggerCharacters = CompletionTriggerAndCommitCharacters.AllTriggerCharacters,
                     AllCommitCharacters = CompletionTriggerAndCommitCharacters.AllCommitCharacters
                 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostDocumentCompletionResolveEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostDocumentCompletionResolveEndpoint.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using RoslynVSInternalCompletionItem = Roslyn.LanguageServer.Protocol.VSInternalCompletionItem;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+
+#pragma warning disable RS0030 // Do not use banned APIs
+[Shared]
+[CohostEndpoint(Methods.TextDocumentCompletionResolveName)]
+[Export(typeof(IDynamicRegistrationProvider))]
+[ExportCohostStatelessLspService(typeof(CohostDocumentCompletionResolveEndpoint))]
+#pragma warning restore RS0030 // Do not use banned APIs
+internal sealed class CohostDocumentCompletionResolveEndpoint : AbstractRazorCohostRequestHandler<RoslynVSInternalCompletionItem, RoslynVSInternalCompletionItem>, IDynamicRegistrationProvider
+{
+    protected override bool MutatesSolutionState => false;
+
+    protected override bool RequiresLSPSolution => true;
+
+    public ImmutableArray<Registration> GetRegistrations(VSInternalClientCapabilities clientCapabilities, RazorCohostRequestContext requestContext)
+    {
+        if (clientCapabilities.TextDocument?.Completion?.DynamicRegistration is true)
+        {
+            return [new Registration()
+            {
+                Method = Methods.TextDocumentCompletionResolveName
+            }];
+        }
+
+        return [];
+    }
+
+    protected override Task<RoslynVSInternalCompletionItem> HandleRequestAsync(RoslynVSInternalCompletionItem request, RazorCohostRequestContext context, CancellationToken cancellationToken)
+        => HandleRequestAsync(request);
+
+    private Task<RoslynVSInternalCompletionItem> HandleRequestAsync(RoslynVSInternalCompletionItem request)
+    {
+        return Task.FromResult(request);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostDocumentCompletionResolveParams.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostDocumentCompletionResolveParams.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Text.Json;
+using System;
+using System.Text.Json.Serialization;
+using Roslyn.LanguageServer.Protocol;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+
+// Data that's getting sent with each completion item so that we can provide document ID
+// to Roslyn language server which will use the URI to figure out that language of the request
+// and forward the request to us. It gets serialized as Data member of the completion item.
+// Without it, Roslyn won't forward the completion resolve request to us.
+internal sealed class CohostDocumentCompletionResolveParams
+{
+    // NOTE: Capital T here is required to match Roslyn's DocumentResolveData structure, so that the Roslyn
+    //       language server can correctly route requests to us in cohosting. In future when we normalize
+    //       on to Roslyn types, we should inherit from that class so we don't have to remember to do this.
+    [JsonPropertyName("TextDocument")]
+    public required VSTextDocumentIdentifier TextDocument { get; set; }
+
+    public static CohostDocumentCompletionResolveParams Create(TextDocumentIdentifier textDocumentIdentifier)
+    {
+        var vsTextDocumentIdentifier = textDocumentIdentifier is VSTextDocumentIdentifier vsTextDocumentIdentifierValue
+        ? vsTextDocumentIdentifierValue
+            : new VSTextDocumentIdentifier() { Uri = textDocumentIdentifier.Uri };
+
+        var resolutionParams = new CohostDocumentCompletionResolveParams()
+        {
+            TextDocument = vsTextDocumentIdentifier
+        };
+
+        return resolutionParams;
+    }
+
+    public static CohostDocumentCompletionResolveParams GetCohostDocumentCompletionResolveParams(VSInternalCompletionItem request)
+    {
+        if (request.Data is not JsonElement paramsObj)
+        {
+            throw new InvalidOperationException($"Invalid Completion Resolve Request Received");
+        }
+
+        var resolutionParams = paramsObj.Deserialize<CohostDocumentCompletionResolveParams>();
+        if (resolutionParams is null)
+        {
+            throw new InvalidOperationException($"request.Data should be convertible to {nameof(CohostDocumentCompletionResolveParams)}");
+        }
+
+        return resolutionParams;
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentCompletionResolveEndpointTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentCompletionResolveEndpointTest.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Xunit;
+using Xunit.Abstractions;
+using RoslynTextDocumentIdentifier = Roslyn.LanguageServer.Protocol.TextDocumentIdentifier;
+using RoslynVSInternalCompletionItem = Roslyn.LanguageServer.Protocol.VSInternalCompletionItem;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+
+public class CohostDocumentCompletionResolveEndpointTest(ITestOutputHelper testOutputHelper) : CohostEndpointTestBase(testOutputHelper)
+{
+    [Fact]
+    public async Task ResolveReturnsSelf()
+    {
+        await VerifyCompletionItemResolveAsync(
+            input: """
+                This is a Razor document.
+
+                <div st$$></div>
+
+                The end.
+                """,
+             initialItemLabel: "TestItem1",
+             expectedItemLabel: "TestItem1");
+    }
+
+    private async Task VerifyCompletionItemResolveAsync(
+        TestCode input,
+        string initialItemLabel,
+        string expectedItemLabel)
+    {
+        var document = await CreateProjectAndRazorDocumentAsync(input.Text);
+
+        var endpoint = new CohostDocumentCompletionResolveEndpoint();
+
+        var textDocumentIdentifier = new RoslynTextDocumentIdentifier()
+        {
+            Uri = document.CreateUri()
+        };
+
+        var resolutionParams = CohostDocumentCompletionResolveParams.Create(textDocumentIdentifier);
+
+        var request = new RoslynVSInternalCompletionItem()
+        {
+            Data = JsonSerializer.SerializeToElement(resolutionParams),
+            Label = initialItemLabel
+        };
+
+        var result = await endpoint.GetTestAccessor().HandleRequestAsync(request, DisposalToken);
+
+        Assert.Equal(result.Label, expectedItemLabel);
+    }
+}


### PR DESCRIPTION
﻿### Summary of the changes

- Adds skeleton for the cohosting completion resolve request handler
- Adds TextDocument identifier data to the completion item so that resolve request handler is now callable by Roslyn (Roslyn uses that data to figure out that request should go to Razor)

Fixes:
Partial fix for https://github.com/dotnet/razor/issues/11101