### PR TITLE
Fire an ETW event when the background document generator queue is empty

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/RazorEventSource.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/RazorEventSource.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Diagnostics.Tracing;
+
+namespace Microsoft.AspNetCore.Razor;
+
+[EventSource(Name = "RazorEventSource")]
+internal sealed class RazorEventSource : EventSource
+{
+    public static readonly RazorEventSource Instance = new();
+
+    private RazorEventSource()
+    {
+    }
+
+    [Event(1, Level = EventLevel.Informational)]
+    public void BackgroundDocumentGeneratorIdle() => WriteEvent(1);
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/AsyncBatchingWorkQueue`1.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/AsyncBatchingWorkQueue`1.cs
@@ -17,7 +17,8 @@ internal class AsyncBatchingWorkQueue<TItem>(
     TimeSpan delay,
     Func<ImmutableArray<TItem>, CancellationToken, ValueTask> processBatchAsync,
     IEqualityComparer<TItem>? equalityComparer,
-    CancellationToken cancellationToken) : AsyncBatchingWorkQueue<TItem, VoidResult>(delay, Convert(processBatchAsync), equalityComparer, cancellationToken)
+    Action? idleAction,
+    CancellationToken cancellationToken) : AsyncBatchingWorkQueue<TItem, VoidResult>(delay, Convert(processBatchAsync), equalityComparer, idleAction, cancellationToken)
 {
     public AsyncBatchingWorkQueue(
         TimeSpan delay,
@@ -27,6 +28,19 @@ internal class AsyncBatchingWorkQueue<TItem>(
                processBatchAsync,
                equalityComparer: null,
                cancellationToken)
+    {
+    }
+
+    public AsyncBatchingWorkQueue(
+        TimeSpan delay,
+        Func<ImmutableArray<TItem>, CancellationToken, ValueTask> processBatchAsync,
+        IEqualityComparer<TItem>? equalityComparer,
+        CancellationToken cancellationToken)
+        : this(delay,
+              processBatchAsync,
+              equalityComparer,
+              idleAction: null,
+              cancellationToken)
     {
     }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/DynamicFiles/BackgroundDocumentGenerator.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/DynamicFiles/BackgroundDocumentGenerator.cs
@@ -54,8 +54,12 @@ internal partial class BackgroundDocumentGenerator : IRazorStartupService, IDisp
         _logger = loggerFactory.GetOrCreateLogger<BackgroundDocumentGenerator>();
 
         _disposeTokenSource = new();
-        _workQueue = new AsyncBatchingWorkQueue<(IProjectSnapshot, IDocumentSnapshot)>(delay, ProcessBatchAsync, _disposeTokenSource.Token);
-        _workQueue.Idle += (_, _) => RazorEventSource.Instance.BackgroundDocumentGeneratorIdle();
+        _workQueue = new AsyncBatchingWorkQueue<(IProjectSnapshot, IDocumentSnapshot)>(
+            delay,
+            processBatchAsync: ProcessBatchAsync,
+            equalityComparer: null,
+            idleAction: () => RazorEventSource.Instance.BackgroundDocumentGeneratorIdle(),
+            _disposeTokenSource.Token);
         _suppressedDocuments = ImmutableHashSet<string>.Empty.WithComparer(FilePathComparer.Instance);
         _projectManager.Changed += ProjectManager_Changed;
     }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/DynamicFiles/BackgroundDocumentGenerator.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/DynamicFiles/BackgroundDocumentGenerator.cs
@@ -55,6 +55,7 @@ internal partial class BackgroundDocumentGenerator : IRazorStartupService, IDisp
 
         _disposeTokenSource = new();
         _workQueue = new AsyncBatchingWorkQueue<(IProjectSnapshot, IDocumentSnapshot)>(delay, ProcessBatchAsync, _disposeTokenSource.Token);
+        _workQueue.Idle += (_, _) => RazorEventSource.Instance.BackgroundDocumentGeneratorIdle();
         _suppressedDocuments = ImmutableHashSet<string>.Empty.WithComparer(FilePathComparer.Instance);
         _projectManager.Changed += ProjectManager_Changed;
     }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/DynamicFiles/BackgroundDocumentGenerator.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/DynamicFiles/BackgroundDocumentGenerator.cs
@@ -58,7 +58,7 @@ internal partial class BackgroundDocumentGenerator : IRazorStartupService, IDisp
             delay,
             processBatchAsync: ProcessBatchAsync,
             equalityComparer: null,
-            idleAction: () => RazorEventSource.Instance.BackgroundDocumentGeneratorIdle(),
+            idleAction: RazorEventSource.Instance.BackgroundDocumentGeneratorIdle,
             _disposeTokenSource.Token);
         _suppressedDocuments = ImmutableHashSet<string>.Empty.WithComparer(FilePathComparer.Instance);
         _projectManager.Changed += ProjectManager_Changed;


### PR DESCRIPTION
I was musing the other day about ETW events possibly being useful in tracking down the Speedometer regression I was looking in to, and then along comes https://github.com/dotnet/razor/issues/11232 which is a great excuse to add some ETW event infrastructure to our lives.

The idea here is that RPS/Speedometer tests can wait for Razor to be "ready" by looking for this event, rather than `Thread.Sleep`ing. Anecdotally on my machine, when loading OrchardCore, this event fires once a couple of minutes after solution load, so seems like a reasonable candidate.

Once this is in @WardenGnaw will try it out and if it's not good, we'll pop some more events somewhere.

Will need to follow up with PR(s?) to add this event source name to the list, but I need to work out where to do that first :)