### PR TITLE
Adding a setting to .editorconfig to enforce formatting

### DIFF
--- a/src/Razor/src/.editorconfig
+++ b/src/Razor/src/.editorconfig
@@ -2,3 +2,5 @@
 
 # Call ConfigureAwait
 dotnet_diagnostic.CA2007.severity = warning
+# Fix Formatting
+dotnet_diagnostic.IDE0055.severity = warning

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace/RazorWorkspaceListener.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace/RazorWorkspaceListener.cs
@@ -10,7 +10,7 @@ namespace Microsoft.AspNetCore.Razor.ExternalAccess.RoslynWorkspace;
 public sealed class RazorWorkspaceListener : RazorWorkspaceListenerBase
 {
     public RazorWorkspaceListener(ILoggerFactory loggerFactory) : base(loggerFactory.CreateLogger(nameof(RazorWorkspaceListener)))
-    { 
+    {
     }
 
     /// <summary>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionResolveEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionResolveEndpoint.cs
@@ -58,9 +58,10 @@ internal class RazorCompletionResolveEndpoint
 
             // See if this is the right completion list for this corresponding completion item. We cross-check this based on label only given that
             // is what users interact with.
-            if (cacheEntry.CompletionList.Items.Any(completion => completionItem.Label == completion.Label &&
-              // Check the Kind as well, e.g. we may have a Razor snippet and a C# keyword with the same label, etc.
-                                                                  completionItem.Kind == completion.Kind))
+            if (cacheEntry.CompletionList.Items.Any(completion =>
+                completionItem.Label == completion.Label
+                // Check the Kind as well, e.g. we may have a Razor snippet and a C# keyword with the same label, etc.
+                && completionItem.Kind == completion.Kind))
             {
                 originalRequestContext = cacheEntry.Context;
                 containingCompletionList = cacheEntry.CompletionList;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hosting/FormattingFlags.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hosting/FormattingFlags.cs
@@ -8,11 +8,9 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
 [Flags]
 internal enum FormattingFlags
 {
-#pragma warning disable format
     Disabled = 0,
-    Enabled  = 1,
-    OnPaste  = 1 << 1,
-    OnType   = 1 << 2,
-    All      = Enabled | OnPaste | OnType
-#pragma warning restore format
+    Enabled = 1,
+    OnPaste = 1 << 1,
+    OnType = 1 << 2,
+    All = Enabled | OnPaste | OnType
 };

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hosting/FormattingFlags.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hosting/FormattingFlags.cs
@@ -8,9 +8,11 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
 [Flags]
 internal enum FormattingFlags
 {
+#pragma warning disable format
     Disabled = 0,
     Enabled  = 1,
     OnPaste  = 1 << 1,
     OnType   = 1 << 2,
     All      = Enabled | OnPaste | OnType
+#pragma warning restore format
 };

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/TelemetryScope.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Telemetry/TelemetryScope.cs
@@ -95,7 +95,7 @@ internal sealed class TelemetryScope : IDisposable
         array[0] = property1;
         array[1] = property2;
 
-        return new(reporter, name, minTimeToReport, severity,  array);
+        return new(reporter, name, minTimeToReport, severity, array);
     }
 
     public static TelemetryScope Create(ITelemetryReporter reporter, string name, Severity severity, TimeSpan minTimeToReport, Property property1, Property property2, Property property3)
@@ -112,7 +112,7 @@ internal sealed class TelemetryScope : IDisposable
     {
         var array = new Property[properties.Length + 1];
         properties.CopyTo(array);
-        
+
         return new(reporter, name, minTimeToReport, severity, array);
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/Models/RazorCodeActionResolutionParams.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/Models/RazorCodeActionResolutionParams.cs
@@ -8,7 +8,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.Razor.CodeActions.Models;
 
-internal sealed class RazorCodeActionResolutionParams 
+internal sealed class RazorCodeActionResolutionParams
 {
     // NOTE: Capital T here is required to match Roslyn's DocumentResolveData structure, so that the Roslyn
     //       language server can correctly route requests to us in cohosting. In future when we normalize

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/SnippetResponseRewriter.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/SnippetResponseRewriter.cs
@@ -24,7 +24,7 @@ internal class SnippetResponseRewriter : IDelegatedCSharpCompletionResponseRewri
         // Modifying label of the C# using snippet to "using statement" to disambiguate from
         // Razor @using directive, and also appending a space to sort text to make sure it's sorted
         // after Razor "using" keyword and "using directive ..." entries (which use "using" as sort text)
-        ["using"] = (Label:$"using {SR.Statement}", SortText:"using ")
+        ["using"] = (Label: $"using {SR.Statement}", SortText: "using ")
     }
     .ToFrozenDictionary();
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Logging/LogLevel.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Logging/LogLevel.cs
@@ -5,13 +5,11 @@ namespace Microsoft.CodeAnalysis.Razor.Logging;
 
 internal enum LogLevel
 {
-#pragma warning disable format
-    None        = 0,
-    Trace       = 1,
-    Debug       = 2,
+    None = 0,
+    Trace = 1,
+    Debug = 2,
     Information = 3,
-    Warning     = 4,
-    Error       = 5,
-    Critical    = 6,
-#pragma warning restore format
+    Warning = 4,
+    Error = 5,
+    Critical = 6,
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Logging/LogLevel.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Logging/LogLevel.cs
@@ -5,6 +5,7 @@ namespace Microsoft.CodeAnalysis.Razor.Logging;
 
 internal enum LogLevel
 {
+#pragma warning disable format
     None        = 0,
     Trace       = 1,
     Debug       = 2,
@@ -12,4 +13,5 @@ internal enum LogLevel
     Warning     = 4,
     Error       = 5,
     Critical    = 6,
+#pragma warning restore format
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/AutoInsert/RemoteAutoInsertTextEdit.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/AutoInsert/RemoteAutoInsertTextEdit.cs
@@ -17,7 +17,7 @@ internal readonly record struct RemoteAutoInsertTextEdit(
     [property: DataMember(Order = 2)] RoslynInsertTextFormat InsertTextFormat)
 {
     public static RemoteAutoInsertTextEdit FromLspInsertTextEdit(VSInternalDocumentOnAutoInsertResponseItem edit)
-        => new (
+        => new(
             edit.TextEdit.Range.ToLinePositionSpan(),
             edit.TextEdit.NewText,
             (RoslynInsertTextFormat)edit.TextEditFormat);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/Competion/CompletionPositionInfo.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/Competion/CompletionPositionInfo.cs
@@ -20,6 +20,6 @@ namespace Microsoft.CodeAnalysis.Razor.Protocol.Completion;
 /// <param name="DocumentPositionInfo">Document position mapping data for language mappings</param>
 /// <param name="ShouldIncludeDelegationSnippets">Indicates that snippets should be added to delegated completion list (currently for HTML only)</param>
 internal record struct CompletionPositionInfo(
-    [property:JsonPropertyName("provisionalTextEdit")] TextEdit? ProvisionalTextEdit,
-    [property:JsonPropertyName("documentPositionInfo")] DocumentPositionInfo DocumentPositionInfo,
-    [property:JsonPropertyName("shouldIncludeDelegationSnippets")] bool ShouldIncludeDelegationSnippets);
+    [property: JsonPropertyName("provisionalTextEdit")] TextEdit? ProvisionalTextEdit,
+    [property: JsonPropertyName("documentPositionInfo")] DocumentPositionInfo DocumentPositionInfo,
+    [property: JsonPropertyName("shouldIncludeDelegationSnippets")] bool ShouldIncludeDelegationSnippets);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/TextDocumentIdentifierAndVersion.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/TextDocumentIdentifierAndVersion.cs
@@ -13,5 +13,5 @@ namespace Microsoft.CodeAnalysis.Razor.Protocol;
 /// it will lose the project context information.
 /// </summary>
 internal record class TextDocumentIdentifierAndVersion(
-    [property:JsonPropertyName("textDocumentIdentifier")] TextDocumentIdentifier TextDocumentIdentifier,
-    [property:JsonPropertyName("version")] int Version);
+    [property: JsonPropertyName("textDocumentIdentifier")] TextDocumentIdentifier TextDocumentIdentifier,
+    [property: JsonPropertyName("version")] int Version);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostDocumentCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostDocumentCompletionEndpoint.cs
@@ -89,7 +89,7 @@ internal sealed class CohostDocumentCompletionEndpoint(
         }
 
         // Return immediately if this is auto-shown completion but auto-shown completion is disallowed in settings
-        var clientSettings =  _clientSettingsManager.GetClientSettings();
+        var clientSettings = _clientSettingsManager.GetClientSettings();
         var autoShownCompletion = completionContext.TriggerKind != CompletionTriggerKind.Invoked;
         if (autoShownCompletion && !clientSettings.ClientCompletionSettings.AutoShowCompletion)
         {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LiveShare/Guest/RazorGuestInitializationService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LiveShare/Guest/RazorGuestInitializationService.cs
@@ -96,11 +96,11 @@ internal class RazorGuestInitializationService(
 
 internal class SessionActiveDetector(Action onDispose) : ICollaborationService, IDisposable
 {
-private readonly Action _onDispose = onDispose ?? throw new ArgumentNullException(nameof(onDispose));
+    private readonly Action _onDispose = onDispose ?? throw new ArgumentNullException(nameof(onDispose));
 
-[SuppressMessage("Usage", "CA1816:Dispose methods should call SuppressFinalize", Justification = "https://github.com/dotnet/roslyn-analyzers/issues/4801")]
-public virtual void Dispose()
-{
-    _onDispose();
-}
+    [SuppressMessage("Usage", "CA1816:Dispose methods should call SuppressFinalize", Justification = "https://github.com/dotnet/roslyn-analyzers/issues/4801")]
+    public virtual void Dispose()
+    {
+        _onDispose();
+    }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/TelemetryReporter.cs
@@ -435,7 +435,7 @@ internal abstract partial class TelemetryReporter : ITelemetryReporter, IDisposa
             declaringTypeName.StartsWith(AspNetCoreNamespace) ||
             declaringTypeName.StartsWith(MicrosoftVSRazorNamespace);
 
-    private sealed class TelemetrySessionManager: IDisposable
+    private sealed class TelemetrySessionManager : IDisposable
     {
         /// <summary>
         /// Store request counters in a concurrent dictionary as non-mutating LSP requests can

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/VSTelemetryReporter.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Telemetry/VSTelemetryReporter.cs
@@ -11,7 +11,7 @@ using StreamJsonRpc;
 namespace Microsoft.VisualStudio.Razor.Telemetry;
 
 [Export(typeof(ITelemetryReporter))]
-[method:ImportingConstructor]
+[method: ImportingConstructor]
 internal class VSTelemetryReporter(ILoggerFactory loggerFactory) : TelemetryReporter(TelemetryService.DefaultSession)
 {
     private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<VSTelemetryReporter>();

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/SyntaxVisualizer/IntraTextAdornmentTagger.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/SyntaxVisualizer/IntraTextAdornmentTagger.cs
@@ -141,12 +141,9 @@ internal abstract class IntraTextAdornmentTagger<TData, TAdornment>
         var visibleSpan = view.TextViewLines.FormattedSpan;
 
         // Filter out the adornments that are no longer visible.
-        var toRemove = from keyValuePair
-            in _adornmentCache
-#pragma warning disable format
-            where !keyValuePair.Key.TranslateTo(visibleSpan.Snapshot, SpanTrackingMode.EdgeExclusive).IntersectsWith(visibleSpan)
-            select keyValuePair.Key;
-#pragma warning restore format
+        var toRemove = from keyValuePair in _adornmentCache
+                       where !keyValuePair.Key.TranslateTo(visibleSpan.Snapshot, SpanTrackingMode.EdgeExclusive).IntersectsWith(visibleSpan)
+                       select keyValuePair.Key;
 
         foreach (var span in toRemove)
         {

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/SyntaxVisualizer/IntraTextAdornmentTagger.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/SyntaxVisualizer/IntraTextAdornmentTagger.cs
@@ -143,8 +143,10 @@ internal abstract class IntraTextAdornmentTagger<TData, TAdornment>
         // Filter out the adornments that are no longer visible.
         var toRemove = from keyValuePair
             in _adornmentCache
+#pragma warning disable format
             where !keyValuePair.Key.TranslateTo(visibleSpan.Snapshot, SpanTrackingMode.EdgeExclusive).IntersectsWith(visibleSpan)
             select keyValuePair.Key;
+#pragma warning restore format
 
         foreach (var span in toRemove)
         {


### PR DESCRIPTION
﻿### Summary of the changes

- Adding .editorconfig setting to flag formatting issues as warnings during build

Fixes: https://github.com/orgs/dotnet/projects/197?pane=issue&itemId=88054220