### PR TITLE
[17.12] Add back null check to allow merge editor to load

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectCapabilityResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectCapabilityResolver.cs
@@ -111,6 +111,15 @@ internal sealed class ProjectCapabilityResolver : IProjectCapabilityResolver, ID
             return false;
         }
 
+        // vsHierarchy can be null here if the document is not included in a project.
+        // In this scenario, the IVsUIShellOpenDocument.IsDocumentInAProject(..., ..., ..., ..., out int pDocInProj) call succeeds,
+        // but pDocInProj == __VSDOCINPROJECT.DOCINPROJ_DocNotInProject.
+        if (vsHierarchy is null)
+        {
+            _logger.LogWarning($"LSP Editor is not supported for file because it is not in a project: {documentFilePath}");
+            return false;
+        }
+
         try
         {
             return vsHierarchy.IsCapabilityMatch(capability);


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2302211

This change adds a null check to ProjectCapabilityResolver.ContainingProjectHasCapability(...) that was incorrectly removed by 6cd5bd4ba6fe57dee7454e8b4d6a33ddaea5514b. Without this null check, it is impossible to open a merge editor for a razor or cshtml file. The merge editor has a few editors within it, and some of them are not included in a project, so they have a null IVsHIerarchy.
