### PR TITLE
Use correct serializer options when serializing and deserializing

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hosting/RazorLanguageServerHost.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hosting/RazorLanguageServerHost.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -77,8 +78,7 @@ internal sealed partial class RazorLanguageServerHost : IDisposable
     {
         var messageFormatter = new SystemTextJsonFormatter();
 
-        // In its infinite wisdom, the LSP client has a public method that takes Newtonsoft.Json types, but an internal method that takes System.Text.Json types.
-        typeof(VSInternalExtensionUtilities).GetMethod("AddVSInternalExtensionConverters", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)!.Invoke(null, [messageFormatter.JsonSerializerOptions]);
+        JsonHelpers.AddVSInternalExtensionConverters(messageFormatter.JsonSerializerOptions);
 
         var jsonRpc = new JsonRpc(new HeaderDelimitedMessageHandler(output, input, messageFormatter));
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/JsonHelpers.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/JsonHelpers.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Text.Json;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.CodeAnalysis.Razor.Protocol;
@@ -9,6 +12,8 @@ namespace Microsoft.CodeAnalysis.Razor.Protocol;
 internal static class JsonHelpers
 {
     private const string s_convertedFlag = "__convertedFromJObject";
+    private static readonly Lazy<JsonSerializerOptions> s_roslynLspJsonSerializerOptions = new(CreateRoslynLspJsonSerializerOptions);
+    private static readonly Lazy<JsonSerializerOptions> s_vsLspJsonSerializerOptions = new(CreateVsLspJsonSerializerOptions);
 
     /// <summary>
     /// Normalizes data from JObject to JsonElement as thats what we expect to process
@@ -36,5 +41,77 @@ internal static class JsonHelpers
         }
 
         return data;
+    }
+
+    /// <summary>
+    /// Serializer options to use when serializing or deserializing a Roslyn LSP type
+    /// </summary>
+    internal static JsonSerializerOptions RoslynLspJsonSerializerOptions => s_roslynLspJsonSerializerOptions.Value;
+
+    /// <summary>
+    /// Serializer options to use when serializing or deserializing a VS Platform LSP type
+    /// </summary>
+    internal static JsonSerializerOptions VsLspJsonSerializerOptions => s_vsLspJsonSerializerOptions.Value;
+
+    /// <summary>
+    /// Converts a Roslyn LSP object to a VS Platform LSP object via serializing to text and deserializing to VS LSP type
+    /// </summary>
+    internal static TVsLspResult? ToVsLSP<TVsLspResult, TRoslynLspSource>(TRoslynLspSource source)
+    {
+        // This is, to say the least, not ideal. In future we're going to normalize on to Roslyn LSP types, and this can go.
+        if (JsonSerializer.Deserialize<TVsLspResult>(JsonSerializer.SerializeToDocument(source, RoslynLspJsonSerializerOptions), VsLspJsonSerializerOptions) is not { } target)
+        {
+            return default;
+        }
+
+        return target;
+    }
+
+    /// <summary>
+    /// Converts a VS Platform LSP object to a Roslyn LSP object via serializing to text and deserializing to Roslyn LSP type
+    /// </summary>
+    internal static TRoslynLspResult? ToRoslynLSP<TRoslynLspResult, TVsLspSource>(TVsLspSource? source)
+    {
+        if (source is null)
+        {
+            return default;
+        }
+
+        // This is, to say the least, not ideal. In future we're going to normalize on to Roslyn LSP types, and this can go.
+        if (JsonSerializer.Deserialize<TRoslynLspResult>(JsonSerializer.SerializeToDocument(source, VsLspJsonSerializerOptions), RoslynLspJsonSerializerOptions) is not { } target)
+        {
+            return default;
+        }
+
+        return target;
+    }
+
+    /// <summary>
+    /// Adds VS Platform LSP converters for VSInternal variation of types (e.g. VSInternalClientCapability from ClientCapability)
+    /// </summary>
+    internal static void AddVSInternalExtensionConverters(JsonSerializerOptions serializerOptions)
+    {
+        // In its infinite wisdom, the LSP client has a public method that takes Newtonsoft.Json types, but an internal method that takes System.Text.Json types.
+        typeof(VSInternalExtensionUtilities).GetMethod("AddVSInternalExtensionConverters", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)!.Invoke(null, [serializerOptions]);
+    }
+
+    private static JsonSerializerOptions CreateRoslynLspJsonSerializerOptions()
+    {
+        var serializerOptions = new JsonSerializerOptions();
+
+        foreach (var converter in RazorServiceDescriptorsWrapper.GetLspConverters())
+        {
+            serializerOptions.Converters.Add(converter);
+        }
+
+        return serializerOptions;
+    }
+
+    private static JsonSerializerOptions CreateVsLspJsonSerializerOptions()
+    {
+        var serializerOptions = new JsonSerializerOptions();
+
+        AddVSInternalExtensionConverters(serializerOptions);
+        return serializerOptions;
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/JsonHelpers.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/JsonHelpers.cs
@@ -58,13 +58,7 @@ internal static class JsonHelpers
     /// </summary>
     internal static TVsLspResult? ToVsLSP<TVsLspResult, TRoslynLspSource>(TRoslynLspSource source)
     {
-        // This is, to say the least, not ideal. In future we're going to normalize on to Roslyn LSP types, and this can go.
-        if (JsonSerializer.Deserialize<TVsLspResult>(JsonSerializer.SerializeToDocument(source, RoslynLspJsonSerializerOptions), VsLspJsonSerializerOptions) is not { } target)
-        {
-            return default;
-        }
-
-        return target;
+        return JsonSerializer.Deserialize<TVsLspResult>(JsonSerializer.SerializeToDocument(source, RoslynLspJsonSerializerOptions), VsLspJsonSerializerOptions);
     }
 
     /// <summary>
@@ -72,18 +66,7 @@ internal static class JsonHelpers
     /// </summary>
     internal static TRoslynLspResult? ToRoslynLSP<TRoslynLspResult, TVsLspSource>(TVsLspSource? source)
     {
-        if (source is null)
-        {
-            return default;
-        }
-
-        // This is, to say the least, not ideal. In future we're going to normalize on to Roslyn LSP types, and this can go.
-        if (JsonSerializer.Deserialize<TRoslynLspResult>(JsonSerializer.SerializeToDocument(source, VsLspJsonSerializerOptions), RoslynLspJsonSerializerOptions) is not { } target)
-        {
-            return default;
-        }
-
-        return target;
+        return JsonSerializer.Deserialize<TRoslynLspResult>(JsonSerializer.SerializeToDocument(source, VsLspJsonSerializerOptions), RoslynLspJsonSerializerOptions);
     }
 
     /// <summary>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentSymbols/RemoteDocumentSymbolService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentSymbols/RemoteDocumentSymbolService.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
@@ -12,6 +11,7 @@ using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using ExternalHandlers = Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost.Handlers;
+using RoslynSymbolSumType = Roslyn.LanguageServer.Protocol.SumType<Roslyn.LanguageServer.Protocol.DocumentSymbol[], Roslyn.LanguageServer.Protocol.SymbolInformation[]>;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor;
 
@@ -49,13 +49,7 @@ internal sealed partial class RemoteDocumentSymbolService(in ServiceArgs args) :
         var csharpDocument = codeDocument.GetCSharpDocument();
 
         // This is, to say the least, not ideal. In future we're going to normalize on to Roslyn LSP types, and this can go.
-        var options = new JsonSerializerOptions();
-        foreach (var converter in RazorServiceDescriptorsWrapper.GetLspConverters())
-        {
-            options.Converters.Add(converter);
-        }
-
-        var vsCSharpSymbols = JsonSerializer.Deserialize<SumType<DocumentSymbol[], SymbolInformation[]>?>(JsonSerializer.SerializeToDocument(csharpSymbols), options);
+        var vsCSharpSymbols = JsonHelpers.ToVsLSP<SumType<DocumentSymbol[], SymbolInformation[]>?, RoslynSymbolSumType>(csharpSymbols);
         if (vsCSharpSymbols is not { } convertedSymbols)
         {
             return null;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostDocumentCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostDocumentCompletionEndpoint.cs
@@ -4,13 +4,11 @@
 using System.Collections.Immutable;
 using System.Composition;
 using System.Linq;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
 using Microsoft.CodeAnalysis.Razor.Completion;
 using Microsoft.CodeAnalysis.Razor.Completion.Delegation;
@@ -25,6 +23,8 @@ using Microsoft.VisualStudio.Razor.Snippets;
 using Response = Microsoft.CodeAnalysis.Razor.Remote.RemoteResponse<Microsoft.VisualStudio.LanguageServer.Protocol.VSInternalCompletionList?>;
 using RoslynCompletionParams = Roslyn.LanguageServer.Protocol.CompletionParams;
 using RoslynLspExtensions = Roslyn.LanguageServer.Protocol.RoslynLspExtensions;
+using RoslynPosition = Roslyn.LanguageServer.Protocol.Position;
+using RoslynCompletionContext = Roslyn.LanguageServer.Protocol.CompletionContext;
 
 namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 
@@ -82,7 +82,7 @@ internal sealed class CohostDocumentCompletionEndpoint(
 
     private async Task<VSInternalCompletionList?> HandleRequestAsync(RoslynCompletionParams request, TextDocument razorDocument, CancellationToken cancellationToken)
     {
-        if (request.Context is null || ToVsLSP<VSInternalCompletionContext>(request.Context) is not VSInternalCompletionContext completionContext)
+        if (request.Context is null || JsonHelpers.ToVsLSP<VSInternalCompletionContext, RoslynCompletionContext>(request.Context) is not VSInternalCompletionContext completionContext)
         {
             _logger.LogError("Completion request context is null");
             return null;
@@ -105,7 +105,7 @@ internal sealed class CohostDocumentCompletionEndpoint(
                             solutionInfo,
                             razorDocument.Id,
                             completionContext,
-                            ToVsLSP<Position>(request.Position).AssumeNotNull(),
+                            JsonHelpers.ToVsLSP<Position, RoslynPosition>(request.Position).AssumeNotNull(),
                             cancellationToken),
                 cancellationToken).ConfigureAwait(false) is not { } completionPositionInfo)
         {
@@ -216,23 +216,6 @@ internal sealed class CohostDocumentCompletionEndpoint(
         var rewrittenResponse = DelegatedCompletionHelper.RewriteHtmlResponse(result?.Response, razorCompletionOptions);
 
         return rewrittenResponse;
-    }
-
-    private static T? ToVsLSP<T>(object source) where T : class
-    {
-        // This is, to say the least, not ideal. In future we're going to normalize on to Roslyn LSP types, and this can go.
-        var options = new JsonSerializerOptions();
-        foreach (var converter in RazorServiceDescriptorsWrapper.GetLspConverters())
-        {
-            options.Converters.Add(converter);
-        }
-
-        if (JsonSerializer.Deserialize<T>(JsonSerializer.SerializeToDocument(source), options) is not { } target)
-        {
-            return null;
-        }
-
-        return target;
     }
 
     private VSInternalCompletionList? AddSnippets(

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/RazorCohostDynamicRegistrationService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/RazorCohostDynamicRegistrationService.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -40,7 +41,7 @@ internal class RazorCohostDynamicRegistrationService(
             return;
         }
 
-        var clientCapabilities = JsonSerializer.Deserialize<VSInternalClientCapabilities>(clientCapabilitiesString) ?? new();
+        var clientCapabilities = JsonSerializer.Deserialize<VSInternalClientCapabilities>(clientCapabilitiesString, JsonHelpers.VsLspJsonSerializerOptions) ?? new();
 
         _lazyRazorCohostClientCapabilitiesService.Value.SetCapabilities(clientCapabilities);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/LanguageServerTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/LanguageServerTestBase.cs
@@ -21,11 +21,11 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.NET.Sdk.Razor.SourceGenerators;
-using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
@@ -41,10 +41,7 @@ public abstract class LanguageServerTestBase : ToolingTestBase
     {
         SpanMappingService = new ThrowingRazorSpanMappingService();
 
-        SerializerOptions = new JsonSerializerOptions();
-        // In its infinite wisdom, the LSP client has a public method that takes Newtonsoft.Json types, but an internal method that takes System.Text.Json types.
-        typeof(VSInternalExtensionUtilities).GetMethod("AddVSInternalExtensionConverters", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)!.Invoke(null, [SerializerOptions]);
-
+        SerializerOptions = JsonHelpers.VsLspJsonSerializerOptions;
         FilePathService = new LSPFilePathService(TestLanguageServerFeatureOptions.Instance);
     }
 


### PR DESCRIPTION
We weren't always using correct serializer options when serializing and deserializing in cohosting. E.g. deserializing to VS LSP types should use VS LSP converters, and deserializing to Roslyn LSP types should use Roslyn LSP converters. Otherwise, things mostly work, but you can end up with base versions of the types instead of VSInternal subtypes.

I found this issue when I realized that VSInternalClientCapabilities wasn't getting deserialized quite right - top level was VSInternal version, but all fields (and their fields) were not properly deserialized to their VSInternal versions. 

Also adding a couple of common helper methods to make serialization/deserializion code easier to keep consistent. 

﻿### Summary of the changes

-Common helpers for serialization and deserialization
-Make sure correct converters are used for both VL LSP and Roslyn LSP types

