### PR TITLE
Switch PDB from 'embedded' to 'portable' for rzls

### DIFF
--- a/src/Razor/src/rzls/rzls.csproj
+++ b/src/Razor/src/rzls/rzls.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(DefaultNetCoreTargetFramework)</TargetFramework>
     <OutputType>Exe</OutputType>
+    <DebugType>portable</DebugType>
     <Description>Razor is a markup syntax for adding server-side logic to web pages. This package
       contains a Razor language server.</Description>
     <RootNamespace>Microsoft.AspNetCore.Razor.LanguageServer</RootNamespace>


### PR DESCRIPTION
﻿### Summary of the changes

-
Switch PDB from 'embedded' to 'portable' for rzls

This is an attempt to make builds more reliable, so that conversion from Windows to Portable is unnecessary for Linux and Mac.

