### PR TITLE
Enable long paths before building on test machines

### DIFF
--- a/eng/pipelines/test-integration-job.yml
+++ b/eng/pipelines/test-integration-job.yml
@@ -36,7 +36,6 @@ steps:
       -PropertyType DWORD
       -Force
     displayName: Enable Long Paths
-    condition: succeeded()
 
   - script: eng\cibuild.cmd
       -configuration ${{ parameters.configuration }}

--- a/eng/pipelines/test-integration-job.yml
+++ b/eng/pipelines/test-integration-job.yml
@@ -29,6 +29,15 @@ steps:
     displayName: Set Feature Flags
     condition: and(succeeded(), ne(variables['FeatureFlag'], ''))
 
+  - powershell: New-ItemProperty
+      -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem"
+      -Name "LongPathsEnabled"
+      -Value "1"
+      -PropertyType DWORD
+      -Force
+    displayName: Enable Long Paths
+    condition: succeeded()
+
   - script: eng\cibuild.cmd
       -configuration ${{ parameters.configuration }}
       -msbuildEngine vs


### PR DESCRIPTION
Seems to work:
https://devdiv.visualstudio.com/DevDiv/_build?definitionId=15591&_a=summary