### PR TITLE
Improve Find All Refs results

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/FindAllReferences/FindAllReferencesHelper.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/FindAllReferences/FindAllReferencesHelper.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.Razor.DocumentMapping;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Razor.FindAllReferences;
+
+internal static class FindAllReferencesHelper
+{
+    public static async Task<string?> GetResultTextAsync(IDocumentMappingService documentMappingService, ISolutionQueryOperations solutionQueryOperations, int lineNumber, string filePath, CancellationToken cancellationToken)
+    {
+        // Roslyn will have sent us back text that comes from the .g.cs file, but that is often not helpful. For example give:
+        //
+        // <SurveyPrompt Title="Blah" />
+        //
+        // A FAR for the Title property will return just the word "Title" in the Text of the reference item, which does not
+        // help the user reason about the result. For such cases, its better to return the text from the Razor file, even
+        // though it will be unclassified, as it will help the user.
+        //
+        // However, for cases where the result comes from a C# block, for example:
+        //
+        // @code {
+        //    public string Title { get; set; }
+        // }
+        //
+        // A FAR for the Title property here will return the full line of code, classified by Roslyn, so we don't want to
+        // do anything for those.
+        //
+        // To identify which situation we're in, we try to map the start and the end of the line to C#, as an indicator. If
+        // either start or end fail to map, it means the entire line is not C#
+
+        if (solutionQueryOperations.GetProjectsContainingDocument(filePath).FirstOrDefault() is { } project &&
+            project.GetDocument(filePath) is { } document)
+        {
+            var codeDoc = await document.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
+            var line = codeDoc.Source.Text.Lines[lineNumber];
+            var csharpDocument = codeDoc.GetCSharpDocument();
+            if (!documentMappingService.TryMapToGeneratedDocumentPosition(csharpDocument, line.Start, out _, out _) ||
+                !documentMappingService.TryMapToGeneratedDocumentPosition(csharpDocument, line.End, out _, out _))
+            {
+                var start = line.GetFirstNonWhitespacePosition() ?? line.Start;
+                return codeDoc.Source.Text.GetSubTextString(TextSpan.FromBounds(start, line.End));
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/FindReferences/FindAllReferencesEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/FindReferences/FindAllReferencesEndpointTest.cs
@@ -5,10 +5,14 @@ using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.AspNetCore.Razor.Test.Common.ProjectSystem;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.Text.Adornments;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -46,9 +50,18 @@ public class FindAllReferencesEndpointTest(ITestOutputHelper testOutput) : Singl
         var razorFilePath = "C:/path/to/file.razor";
 
         var languageServer = await CreateLanguageServerAsync(codeDocument, razorFilePath, multiTargetProject: false);
+        var projectManager = CreateProjectSnapshotManager();
+        var hostProject = TestHostProject.Create("C:/path/to/project.csproj");
+        var hostDocument = TestHostDocument.Create(TestProjectData.SomeProject, razorFilePath);
+
+        await projectManager.UpdateAsync(updater =>
+        {
+            updater.ProjectAdded(hostProject);
+            updater.DocumentAdded(hostProject.Key, hostDocument, TextLoader.From(TextAndVersion.Create(codeDocument.Source.Text, VersionStamp.Default)));
+        });
 
         var endpoint = new FindAllReferencesEndpoint(
-            LanguageServerFeatureOptions, DocumentMappingService, languageServer, LoggerFactory, FilePathService);
+            LanguageServerFeatureOptions, DocumentMappingService, languageServer, LoggerFactory, FilePathService, projectManager);
 
         var sourceText = codeDocument.Source.Text;
 
@@ -83,7 +96,20 @@ public class FindAllReferencesEndpointTest(ITestOutputHelper testOutput) : Singl
             var expectedRange = codeDocument.Source.Text.GetRange(expectedSpans[i]);
             Assert.Equal(expectedRange, referenceItem.Location.Range);
 
+            var expected = codeDocument.Source.Text.Lines[referenceItem.Location.Range.Start.Line].ToString();
+            Assert.Equal(expected.Trim(), GetText(referenceItem));
+
             i++;
         }
+    }
+
+    private static string GetText(VSInternalReferenceItem referenceItem)
+    {
+        if (referenceItem.Text is ClassifiedTextElement classifiedText)
+        {
+            return string.Join("", classifiedText.Runs.Select(s => s.Text));
+        }
+
+        return referenceItem.Text.AssumeNotNull().ToString().AssumeNotNull();
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/11278
Fixes https://github.com/dotnet/razor/issues/4611

We lose classification, but get more context. Worthy trade off I think

Before:
![image](https://github.com/user-attachments/assets/1fd57f57-e1d9-4ea4-881d-26afa5d5a547)

After:
![image](https://github.com/user-attachments/assets/f0a803c9-b947-42a9-8e78-d0b20f317a6d)

