### PR TITLE
Rationalize ProjectSnapshotManager methods

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
@@ -81,9 +81,9 @@ public class RazorLanguageServerBenchmarkBase : ProjectSnapshotManagerBenchmarkB
             },
             CancellationToken.None);
 
-        var projectSnapshot = projectManager.GetLoadedProject(hostProject.Key);
-
-        return projectSnapshot.GetDocument(filePath);
+        return projectManager
+            .GetLoadedProject(hostProject.Key)
+            .GetRequiredDocument(filePath);
     }
 
     private sealed class NoOpClientNotifierService : IClientConnection, IOnInitialized

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
@@ -82,7 +82,7 @@ public class RazorLanguageServerBenchmarkBase : ProjectSnapshotManagerBenchmarkB
             CancellationToken.None);
 
         return projectManager
-            .GetLoadedProject(hostProject.Key)
+            .GetRequiredProject(hostProject.Key)
             .GetRequiredDocument(filePath);
     }
 

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
@@ -81,9 +81,7 @@ public class RazorLanguageServerBenchmarkBase : ProjectSnapshotManagerBenchmarkB
             },
             CancellationToken.None);
 
-        return projectManager
-            .GetRequiredProject(hostProject.Key)
-            .GetRequiredDocument(filePath);
+        return projectManager.GetRequiredDocument(hostProject.Key, filePath);
     }
 
     private sealed class NoOpClientNotifierService : IClientConnection, IOnInitialized

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/ProjectSystem/BackgroundCodeGenerationBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/ProjectSystem/BackgroundCodeGenerationBenchmark.cs
@@ -57,7 +57,7 @@ public class BackgroundCodeGenerationBenchmark : ProjectSnapshotManagerBenchmark
     {
         // The real work happens here.
         var document = ProjectManager
-            .GetLoadedProject(e.ProjectKey)
+            .GetRequiredProject(e.ProjectKey)
             .GetRequiredDocument(e.DocumentFilePath);
 
         Tasks.Add(document.GetGeneratedOutputAsync(CancellationToken.None).AsTask());

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/ProjectSystem/BackgroundCodeGenerationBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/ProjectSystem/BackgroundCodeGenerationBenchmark.cs
@@ -56,9 +56,7 @@ public class BackgroundCodeGenerationBenchmark : ProjectSnapshotManagerBenchmark
     private void SnapshotManager_Changed(object sender, ProjectChangeEventArgs e)
     {
         // The real work happens here.
-        var document = ProjectManager
-            .GetRequiredProject(e.ProjectKey)
-            .GetRequiredDocument(e.DocumentFilePath);
+        var document = ProjectManager.GetRequiredDocument(e.ProjectKey, e.DocumentFilePath);
 
         Tasks.Add(document.GetGeneratedOutputAsync(CancellationToken.None).AsTask());
     }

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/ProjectSystem/BackgroundCodeGenerationBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/ProjectSystem/BackgroundCodeGenerationBenchmark.cs
@@ -56,8 +56,9 @@ public class BackgroundCodeGenerationBenchmark : ProjectSnapshotManagerBenchmark
     private void SnapshotManager_Changed(object sender, ProjectChangeEventArgs e)
     {
         // The real work happens here.
-        var project = ProjectManager.GetLoadedProject(e.ProjectKey);
-        var document = project.GetDocument(e.DocumentFilePath);
+        var document = ProjectManager
+            .GetLoadedProject(e.ProjectKey)
+            .GetRequiredDocument(e.DocumentFilePath);
 
         Tasks.Add(document.GetGeneratedOutputAsync(CancellationToken.None).AsTask());
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentContextFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DocumentContextFactory.cs
@@ -48,7 +48,7 @@ internal sealed class DocumentContextFactory(
             return _projectManager.TryResolveDocumentInAnyProject(filePath, _logger, out documentSnapshot);
         }
 
-        if (_projectManager.TryGetLoadedProject(projectContext.ToProjectKey(), out var project) &&
+        if (_projectManager.TryGetProject(projectContext.ToProjectKey(), out var project) &&
             project.TryGetDocument(filePath, out documentSnapshot))
         {
             return true;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/GeneratedDocumentSynchronizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/GeneratedDocumentSynchronizer.cs
@@ -29,7 +29,7 @@ internal class GeneratedDocumentSynchronizer(
         }
 
         // If the document has been removed from the project, then don't do anything, or version numbers will be thrown off
-        if (!_projectManager.TryGetLoadedProject(document.Project.Key, out var project) ||
+        if (!_projectManager.TryGetProject(document.Project.Key, out var project) ||
             !project.ContainsDocument(filePath))
         {
             return;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/GeneratedDocumentSynchronizer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/GeneratedDocumentSynchronizer.cs
@@ -29,8 +29,7 @@ internal class GeneratedDocumentSynchronizer(
         }
 
         // If the document has been removed from the project, then don't do anything, or version numbers will be thrown off
-        if (!_projectManager.TryGetProject(document.Project.Key, out var project) ||
-            !project.ContainsDocument(filePath))
+        if (!_projectManager.ContainsDocument(document.Project.Key, filePath))
         {
             return;
         }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/IProjectSnapshotManagerExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/IProjectSnapshotManagerExtensions.cs
@@ -16,7 +16,7 @@ internal static partial class IProjectSnapshotManagerExtensions
 {
     public static IProjectSnapshot GetMiscellaneousProject(this IProjectSnapshotManager projectManager)
     {
-        return projectManager.GetLoadedProject(MiscFilesHostProject.Instance.Key);
+        return projectManager.GetRequiredProject(MiscFilesHostProject.Instance.Key);
     }
 
     /// <summary>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
@@ -359,7 +359,7 @@ internal partial class RazorProjectService : IRazorProjectService, IRazorProject
                     var newKey = AddProjectCore(updater, filePath, intermediateOutputPath, configuration, rootNamespace, displayName);
                     Debug.Assert(newKey == projectKey);
 
-                    project = _projectManager.GetLoadedProject(projectKey);
+                    project = _projectManager.GetRequiredProject(projectKey);
                 }
 
                 UpdateProjectDocuments(updater, documents, project.Key);
@@ -408,7 +408,7 @@ internal partial class RazorProjectService : IRazorProjectService, IRazorProject
     {
         _logger.LogDebug($"UpdateProjectDocuments for {projectKey} with {documents.Length} documents: {string.Join(", ", documents.Select(d => d.FilePath))}");
 
-        var project = _projectManager.GetLoadedProject(projectKey);
+        var project = _projectManager.GetRequiredProject(projectKey);
         var currentProjectKey = project.Key;
         var projectDirectory = FilePathNormalizer.GetNormalizedDirectoryName(project.FilePath);
         var documentMap = documents.ToDictionary(document => EnsureFullPath(document.FilePath, projectDirectory), FilePathComparer.Instance);
@@ -428,7 +428,7 @@ internal partial class RazorProjectService : IRazorProjectService, IRazorProject
             MoveDocument(updater, documentFilePath, fromProject: project, toProject: miscellaneousProject);
         }
 
-        project = _projectManager.GetLoadedProject(projectKey);
+        project = _projectManager.GetRequiredProject(projectKey);
 
         // Update existing documents
         foreach (var documentFilePath in project.DocumentFilePaths)
@@ -468,7 +468,7 @@ internal partial class RazorProjectService : IRazorProjectService, IRazorProject
             updater.DocumentAdded(currentProjectKey, newHostDocument, textLoader);
         }
 
-        project = _projectManager.GetLoadedProject(project.Key);
+        project = _projectManager.GetRequiredProject(project.Key);
         miscellaneousProject = _projectManager.GetMiscellaneousProject();
 
         // Add (or migrate from misc) any new documents

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
@@ -343,7 +343,7 @@ internal partial class RazorProjectService : IRazorProjectService, IRazorProject
         return _projectManager.UpdateAsync(
             updater =>
             {
-                if (!_projectManager.TryGetLoadedProject(projectKey, out var project))
+                if (!_projectManager.TryGetProject(projectKey, out var project))
                 {
                     if (filePath is null)
                     {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/FindAllReferences/FindAllReferencesHelper.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/FindAllReferences/FindAllReferencesHelper.cs
@@ -36,7 +36,7 @@ internal static class FindAllReferencesHelper
         // either start or end fail to map, it means the entire line is not C#
 
         if (solutionQueryOperations.GetProjectsContainingDocument(filePath).FirstOrDefault() is { } project &&
-            project.GetDocument(filePath) is { } document)
+            project.TryGetDocument(filePath, out var document))
         {
             var codeDoc = await document.GetGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
             var line = codeDoc.Source.Text.Lines[lineNumber];

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshot.cs
@@ -39,6 +39,5 @@ internal interface IProjectSnapshot
     ValueTask<ImmutableArray<TagHelperDescriptor>> GetTagHelpersAsync(CancellationToken cancellationToken);
 
     bool ContainsDocument(string filePath);
-    IDocumentSnapshot? GetDocument(string filePath);
     bool TryGetDocument(string filePath, [NotNullWhen(true)] out IDocumentSnapshot? document);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshotExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshotExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Immutable;
+using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Serialization;
@@ -15,6 +16,9 @@ internal static class IProjectSnapshotExtensions
         => project.TryGetDocument(filePath, out var result)
             ? result
             : null;
+
+    public static IDocumentSnapshot GetRequiredDocument(this IProjectSnapshot project, string filePath)
+        => project.GetDocument(filePath).AssumeNotNull();
 
     public static RazorProjectInfo ToRazorProjectInfo(this IProjectSnapshot project)
     {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshotExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshotExtensions.cs
@@ -11,6 +11,11 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 internal static class IProjectSnapshotExtensions
 {
+    public static IDocumentSnapshot? GetDocument(this IProjectSnapshot project, string filePath)
+        => project.TryGetDocument(filePath, out var result)
+            ? result
+            : null;
+
     public static RazorProjectInfo ToRazorProjectInfo(this IProjectSnapshot project)
     {
         using var documents = new PooledArrayBuilder<DocumentSnapshotHandle>();

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshotManager.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshotManager.cs
@@ -19,7 +19,7 @@ internal interface IProjectSnapshotManager
 
     ImmutableArray<ProjectKey> GetAllProjectKeys(string projectFileName);
     ImmutableArray<IProjectSnapshot> GetProjects();
-    IProjectSnapshot GetLoadedProject(ProjectKey projectKey);
+
     bool TryGetProject(ProjectKey projectKey, [NotNullWhen(true)] out IProjectSnapshot? project);
 
     bool IsDocumentOpen(string documentFilePath);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshotManager.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshotManager.cs
@@ -20,7 +20,7 @@ internal interface IProjectSnapshotManager
     ImmutableArray<ProjectKey> GetAllProjectKeys(string projectFileName);
     ImmutableArray<IProjectSnapshot> GetProjects();
     IProjectSnapshot GetLoadedProject(ProjectKey projectKey);
-    bool TryGetLoadedProject(ProjectKey projectKey, [NotNullWhen(true)] out IProjectSnapshot? project);
+    bool TryGetProject(ProjectKey projectKey, [NotNullWhen(true)] out IProjectSnapshot? project);
 
     bool IsDocumentOpen(string documentFilePath);
     ImmutableArray<string> GetOpenDocuments();

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshotManager.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshotManager.cs
@@ -17,7 +17,7 @@ internal interface IProjectSnapshotManager
 
     bool IsSolutionClosing { get; }
 
-    ImmutableArray<ProjectKey> GetAllProjectKeys(string projectFileName);
+    ImmutableArray<ProjectKey> GetProjectKeysWithFilePath(string projectFileName);
     ImmutableArray<IProjectSnapshot> GetProjects();
 
     bool ContainsProject(ProjectKey projectKey);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshotManager.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshotManager.cs
@@ -20,6 +20,7 @@ internal interface IProjectSnapshotManager
     ImmutableArray<ProjectKey> GetAllProjectKeys(string projectFileName);
     ImmutableArray<IProjectSnapshot> GetProjects();
 
+    bool ContainsProject(ProjectKey projectKey);
     bool TryGetProject(ProjectKey projectKey, [NotNullWhen(true)] out IProjectSnapshot? project);
 
     bool IsDocumentOpen(string documentFilePath);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshotManagerExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshotManagerExtensions.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Razor;
+using Microsoft.AspNetCore.Razor.ProjectSystem;
+
+namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+internal static class IProjectSnapshotManagerExtensions
+{
+    public static IProjectSnapshot? GetProject(this IProjectSnapshotManager projectManager, ProjectKey projectKey)
+        => projectManager.TryGetProject(projectKey, out var result)
+            ? result
+            : null;
+
+    public static IProjectSnapshot GetRequiredProject(this IProjectSnapshotManager projectManager, ProjectKey projectKey)
+        => projectManager.GetProject(projectKey).AssumeNotNull();
+
+    public static IProjectSnapshot? GetProject(this ProjectSnapshotManager.Updater updater, ProjectKey projectKey)
+        => updater.TryGetProject(projectKey, out var result)
+            ? result
+            : null;
+
+    public static IProjectSnapshot GetRequiredProject(this ProjectSnapshotManager.Updater updater, ProjectKey projectKey)
+        => updater.GetProject(projectKey).AssumeNotNull();
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshotManagerExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshotManagerExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
 
@@ -16,6 +17,27 @@ internal static class IProjectSnapshotManagerExtensions
     public static IProjectSnapshot GetRequiredProject(this IProjectSnapshotManager projectManager, ProjectKey projectKey)
         => projectManager.GetProject(projectKey).AssumeNotNull();
 
+    public static bool TryGetDocument(
+        this IProjectSnapshotManager projectManager,
+        ProjectKey projectKey,
+        string documentFilePath,
+        [NotNullWhen(true)] out IDocumentSnapshot? document)
+    {
+        document = projectManager.TryGetProject(projectKey, out var project)
+            ? project.GetDocument(documentFilePath)
+            : null;
+
+        return document is not null;
+    }
+
+    public static IDocumentSnapshot? GetDocument(this IProjectSnapshotManager projectManager, ProjectKey projectKey, string documentFilePath)
+        => projectManager.TryGetDocument(projectKey, documentFilePath, out var result)
+            ? result
+            : null;
+
+    public static IDocumentSnapshot GetRequiredDocument(this IProjectSnapshotManager projectManager, ProjectKey projectKey, string documentFilePath)
+        => projectManager.GetDocument(projectKey, documentFilePath).AssumeNotNull();
+
     public static IProjectSnapshot? GetProject(this ProjectSnapshotManager.Updater updater, ProjectKey projectKey)
         => updater.TryGetProject(projectKey, out var result)
             ? result
@@ -23,4 +45,25 @@ internal static class IProjectSnapshotManagerExtensions
 
     public static IProjectSnapshot GetRequiredProject(this ProjectSnapshotManager.Updater updater, ProjectKey projectKey)
         => updater.GetProject(projectKey).AssumeNotNull();
+
+    public static bool TryGetDocument(
+        this ProjectSnapshotManager.Updater updater,
+        ProjectKey projectKey,
+        string documentFilePath,
+        [NotNullWhen(true)] out IDocumentSnapshot? document)
+    {
+        document = updater.TryGetProject(projectKey, out var project)
+            ? project.GetDocument(documentFilePath)
+            : null;
+
+        return document is not null;
+    }
+
+    public static IDocumentSnapshot? GetDocument(this ProjectSnapshotManager.Updater updater, ProjectKey projectKey, string documentFilePath)
+        => updater.TryGetDocument(projectKey, documentFilePath, out var result)
+            ? result
+            : null;
+
+    public static IDocumentSnapshot GetRequiredDocument(this ProjectSnapshotManager.Updater updater, ProjectKey projectKey, string documentFilePath)
+        => updater.GetDocument(projectKey, documentFilePath).AssumeNotNull();
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshotManagerExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IProjectSnapshotManagerExtensions.cs
@@ -17,6 +17,10 @@ internal static class IProjectSnapshotManagerExtensions
     public static IProjectSnapshot GetRequiredProject(this IProjectSnapshotManager projectManager, ProjectKey projectKey)
         => projectManager.GetProject(projectKey).AssumeNotNull();
 
+    public static bool ContainsDocument(this IProjectSnapshotManager projectManager, ProjectKey projectKey, string documentFilePath)
+        => projectManager.TryGetProject(projectKey, out var project) &&
+           project.ContainsDocument(documentFilePath);
+
     public static bool TryGetDocument(
         this IProjectSnapshotManager projectManager,
         ProjectKey projectKey,
@@ -45,6 +49,10 @@ internal static class IProjectSnapshotManagerExtensions
 
     public static IProjectSnapshot GetRequiredProject(this ProjectSnapshotManager.Updater updater, ProjectKey projectKey)
         => updater.GetProject(projectKey).AssumeNotNull();
+
+    public static bool ContainsDocument(this ProjectSnapshotManager.Updater updater, ProjectKey projectKey, string documentFilePath)
+        => updater.TryGetProject(projectKey, out var project) &&
+           project.ContainsDocument(documentFilePath);
 
     public static bool TryGetDocument(
         this ProjectSnapshotManager.Updater updater,

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshot.cs
@@ -64,11 +64,6 @@ internal sealed class ProjectSnapshot(ProjectState state) : IProjectSnapshot
         }
     }
 
-    public IDocumentSnapshot? GetDocument(string filePath)
-        => TryGetDocument(filePath, out var document)
-            ? document
-            : null;
-
     public bool TryGetDocument(string filePath, [NotNullWhen(true)] out IDocumentSnapshot? document)
     {
         lock (_gate)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshotManager.Updater.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshotManager.Updater.cs
@@ -16,8 +16,7 @@ internal partial class ProjectSnapshotManager
             => instance.GetAllProjectKeys(projectFileName);
         public ImmutableArray<IProjectSnapshot> GetProjects()
             => instance.GetProjects();
-        public IProjectSnapshot GetLoadedProject(ProjectKey projectKey)
-            => instance.GetLoadedProject(projectKey);
+
         public bool TryGetProject(ProjectKey projectKey, [NotNullWhen(true)] out IProjectSnapshot? project)
             => instance.TryGetProject(projectKey, out project);
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshotManager.Updater.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshotManager.Updater.cs
@@ -12,8 +12,9 @@ internal partial class ProjectSnapshotManager
 {
     public readonly struct Updater(ProjectSnapshotManager instance)
     {
-        public ImmutableArray<ProjectKey> GetAllProjectKeys(string projectFileName)
-            => instance.GetAllProjectKeys(projectFileName);
+        public ImmutableArray<ProjectKey> GetProjectKeysWithFilePath(string filePath)
+            => instance.GetProjectKeysWithFilePath(filePath);
+
         public ImmutableArray<IProjectSnapshot> GetProjects()
             => instance.GetProjects();
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshotManager.Updater.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshotManager.Updater.cs
@@ -17,6 +17,9 @@ internal partial class ProjectSnapshotManager
         public ImmutableArray<IProjectSnapshot> GetProjects()
             => instance.GetProjects();
 
+        public bool ContainsProject(ProjectKey projectKey)
+            => instance.ContainsProject(projectKey);
+
         public bool TryGetProject(ProjectKey projectKey, [NotNullWhen(true)] out IProjectSnapshot? project)
             => instance.TryGetProject(projectKey, out project);
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshotManager.Updater.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshotManager.Updater.cs
@@ -18,8 +18,8 @@ internal partial class ProjectSnapshotManager
             => instance.GetProjects();
         public IProjectSnapshot GetLoadedProject(ProjectKey projectKey)
             => instance.GetLoadedProject(projectKey);
-        public bool TryGetLoadedProject(ProjectKey projectKey, [NotNullWhen(true)] out IProjectSnapshot? project)
-            => instance.TryGetLoadedProject(projectKey, out project);
+        public bool TryGetProject(ProjectKey projectKey, [NotNullWhen(true)] out IProjectSnapshot? project)
+            => instance.TryGetProject(projectKey, out project);
 
         public bool IsDocumentOpen(string documentFilePath)
             => instance.IsDocumentOpen(documentFilePath);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshotManager.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshotManager.cs
@@ -126,6 +126,14 @@ internal partial class ProjectSnapshotManager : IProjectSnapshotManager, IDispos
         }
     }
 
+    public bool ContainsProject(ProjectKey projectKey)
+    {
+        using (_readerWriterLock.DisposableRead())
+        {
+            return _projectMap.ContainsKey(projectKey);
+        }
+    }
+
     public bool TryGetProject(ProjectKey projectKey, [NotNullWhen(true)] out IProjectSnapshot? project)
     {
         using (_readerWriterLock.DisposableRead())

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshotManager.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshotManager.cs
@@ -126,19 +126,6 @@ internal partial class ProjectSnapshotManager : IProjectSnapshotManager, IDispos
         }
     }
 
-    public IProjectSnapshot GetLoadedProject(ProjectKey projectKey)
-    {
-        using (_readerWriterLock.DisposableRead())
-        {
-            if (_projectMap.TryGetValue(projectKey, out var entry))
-            {
-                return entry.GetSnapshot();
-            }
-        }
-
-        throw new InvalidOperationException($"No project snapshot exists with the key, '{projectKey}'");
-    }
-
     public bool TryGetProject(ProjectKey projectKey, [NotNullWhen(true)] out IProjectSnapshot? project)
     {
         using (_readerWriterLock.DisposableRead())

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshotManager.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshotManager.cs
@@ -139,7 +139,7 @@ internal partial class ProjectSnapshotManager : IProjectSnapshotManager, IDispos
         throw new InvalidOperationException($"No project snapshot exists with the key, '{projectKey}'");
     }
 
-    public bool TryGetLoadedProject(ProjectKey projectKey, [NotNullWhen(true)] out IProjectSnapshot? project)
+    public bool TryGetProject(ProjectKey projectKey, [NotNullWhen(true)] out IProjectSnapshot? project)
     {
         using (_readerWriterLock.DisposableRead())
         {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshotManager.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshotManager.cs
@@ -149,7 +149,7 @@ internal partial class ProjectSnapshotManager : IProjectSnapshotManager, IDispos
         return false;
     }
 
-    public ImmutableArray<ProjectKey> GetAllProjectKeys(string projectFileName)
+    public ImmutableArray<ProjectKey> GetProjectKeysWithFilePath(string filePath)
     {
         using (_readerWriterLock.DisposableRead())
         {
@@ -157,7 +157,7 @@ internal partial class ProjectSnapshotManager : IProjectSnapshotManager, IDispos
 
             foreach (var (key, entry) in _projectMap)
             {
-                if (FilePathComparer.Instance.Equals(entry.State.HostProject.FilePath, projectFileName))
+                if (FilePathComparer.Instance.Equals(entry.State.HostProject.FilePath, filePath))
                 {
                     projects.Add(key);
                 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteProjectSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteProjectSnapshot.cs
@@ -164,11 +164,6 @@ internal sealed class RemoteProjectSnapshot : IProjectSnapshot
         return false;
     }
 
-    public IDocumentSnapshot? GetDocument(string filePath)
-        => TryGetDocument(filePath, out var document)
-            ? document
-            : null;
-
     public bool TryGetDocument(string filePath, [NotNullWhen(true)] out IDocumentSnapshot? document)
     {
         if (!filePath.IsRazorFilePath())

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Documents/EditorDocumentManagerListener.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Documents/EditorDocumentManagerListener.cs
@@ -245,7 +245,7 @@ internal partial class EditorDocumentManagerListener : IRazorStartupService, IDi
                 {
                     var (document, telemetryReporter, cancellationToken) = state;
 
-                    if (updater.TryGetLoadedProject(document.ProjectKey, out var project) &&
+                    if (updater.TryGetProject(document.ProjectKey, out var project) &&
                         project is ProjectSnapshot { HostProject: FallbackHostProject } projectSnapshot)
                     {
                         // The user is opening a document that is part of a fallback project. This is a scenario we are very interested in knowing more about

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Documents/RazorCodeDocumentProvidingSnapshotChangeTrigger.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Documents/RazorCodeDocumentProvidingSnapshotChangeTrigger.cs
@@ -70,7 +70,7 @@ internal class RazorCodeDocumentProvidingSnapshotChangeTrigger : IRazorStartupSe
             return null;
         }
 
-        if (!_projectManager.TryGetLoadedProject(projectKey, out var project))
+        if (!_projectManager.TryGetProject(projectKey, out var project))
         {
             return null;
         }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/CSharpVirtualDocumentFactory.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/CSharpVirtualDocumentFactory.cs
@@ -197,12 +197,13 @@ internal class CSharpVirtualDocumentFactory : VirtualDocumentFactoryBase
 
         var inAny = false;
         var normalizedDocumentPath = RazorDynamicFileInfoProvider.GetProjectSystemFilePath(hostDocumentUri);
-        foreach (var projectSnapshot in projects)
+
+        foreach (var project in projects)
         {
-            if (projectSnapshot.ContainsDocument(normalizedDocumentPath))
+            if (project.ContainsDocument(normalizedDocumentPath))
             {
                 inAny = true;
-                yield return projectSnapshot.Key;
+                yield return project.Key;
             }
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LiveShare/Guest/ProjectSnapshotSynchronizationService.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LiveShare/Guest/ProjectSnapshotSynchronizationService.cs
@@ -97,7 +97,7 @@ internal class ProjectSnapshotSynchronizationService(
             await _projectManager.UpdateAsync(
                 static (updater, guestPath) =>
                 {
-                    var projectKeys = updater.GetAllProjectKeys(guestPath);
+                    var projectKeys = updater.GetProjectKeysWithFilePath(guestPath);
                     foreach (var projectKey in projectKeys)
                     {
                         updater.ProjectRemoved(projectKey);
@@ -125,7 +125,7 @@ internal class ProjectSnapshotSynchronizationService(
                 await _projectManager.UpdateAsync(
                     static (updater, state) =>
                     {
-                        var projectKeys = updater.GetAllProjectKeys(state.guestPath);
+                        var projectKeys = updater.GetProjectKeysWithFilePath(state.guestPath);
 
                         foreach (var projectKey in projectKeys)
                         {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/DefaultWindowsRazorProjectHost.cs
@@ -111,7 +111,7 @@ internal class DefaultWindowsRazorProjectHost(
             await UpdateAsync(
                 updater =>
                 {
-                    var projectKeys = GetAllProjectKeys(CommonServices.UnconfiguredProject.FullPath);
+                    var projectKeys = GetProjectKeysWithFilePath(CommonServices.UnconfiguredProject.FullPath);
                     foreach (var projectKey in projectKeys)
                     {
                         RemoveProject(updater, projectKey);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackProjectManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackProjectManager.cs
@@ -44,7 +44,7 @@ internal sealed class FallbackProjectManager(
     {
         try
         {
-            if (_projectManager.TryGetLoadedProject(razorProjectKey, out var project))
+            if (_projectManager.TryGetProject(razorProjectKey, out var project))
             {
                 if (project is ProjectSnapshot { HostProject: FallbackHostProject })
                 {
@@ -76,7 +76,7 @@ internal sealed class FallbackProjectManager(
     {
         try
         {
-            if (_projectManager.TryGetLoadedProject(razorProjectKey, out var project) &&
+            if (_projectManager.TryGetProject(razorProjectKey, out var project) &&
                 project is ProjectSnapshot { HostProject: FallbackHostProject })
             {
                 // If this is a fallback project, then Roslyn may not track documents in the project, so these dynamic file notifications

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/FallbackWindowsRazorProjectHost.cs
@@ -73,7 +73,7 @@ internal class FallbackWindowsRazorProjectHost : WindowsRazorProjectHostBase
             await UpdateAsync(
                 updater =>
                 {
-                    var projectKeys = GetAllProjectKeys(CommonServices.UnconfiguredProject.FullPath);
+                    var projectKeys = GetProjectKeysWithFilePath(CommonServices.UnconfiguredProject.FullPath);
                     foreach (var projectKey in projectKeys)
                     {
                         RemoveProject(updater, projectKey);
@@ -91,7 +91,7 @@ internal class FallbackWindowsRazorProjectHost : WindowsRazorProjectHostBase
             await UpdateAsync(
                 updater =>
                 {
-                    var projectKeys = GetAllProjectKeys(CommonServices.UnconfiguredProject.FullPath);
+                    var projectKeys = GetProjectKeysWithFilePath(CommonServices.UnconfiguredProject.FullPath);
                     foreach (var projectKey in projectKeys)
                     {
                         RemoveProject(updater, projectKey);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
@@ -217,17 +217,17 @@ internal abstract partial class WindowsRazorProjectHostBase : OnceInitializedOnc
             var projectKeys = updater.GetAllProjectKeys(oldProjectFilePath);
             foreach (var projectKey in projectKeys)
             {
-                if (updater.TryGetLoadedProject(projectKey, out var current))
+                if (updater.TryGetProject(projectKey, out var project))
                 {
                     RemoveProject(updater, projectKey);
 
-                    var hostProject = new HostProject(newProjectFilePath, current.IntermediateOutputPath, current.Configuration, current.RootNamespace);
+                    var hostProject = new HostProject(newProjectFilePath, project.IntermediateOutputPath, project.Configuration, project.RootNamespace);
                     UpdateProject(updater, hostProject);
 
                     // This should no-op in the common case, just putting it here for insurance.
-                    foreach (var documentFilePath in current.DocumentFilePaths)
+                    foreach (var documentFilePath in project.DocumentFilePaths)
                     {
-                        var documentSnapshot = current.GetRequiredDocument(documentFilePath);
+                        var documentSnapshot = project.GetRequiredDocument(documentFilePath);
 
                         var hostDocument = new HostDocument(
                             documentSnapshot.FilePath,
@@ -264,7 +264,7 @@ internal abstract partial class WindowsRazorProjectHostBase : OnceInitializedOnc
 
     protected static void UpdateProject(ProjectSnapshotManager.Updater updater, HostProject project)
     {
-        if (!updater.TryGetLoadedProject(project.Key, out _))
+        if (!updater.TryGetProject(project.Key, out _))
         {
             // Just in case we somehow got in a state where VS didn't tell us that solution close was finished, lets just
             // ensure we're going to actually do something with the new project that we've just been told about.

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
@@ -214,7 +214,7 @@ internal abstract partial class WindowsRazorProjectHostBase : OnceInitializedOnc
         // FilePath.
         return ExecuteWithLockAsync(() => UpdateAsync(updater =>
         {
-            var projectKeys = updater.GetAllProjectKeys(oldProjectFilePath);
+            var projectKeys = updater.GetProjectKeysWithFilePath(oldProjectFilePath);
             foreach (var projectKey in projectKeys)
             {
                 if (updater.TryGetProject(projectKey, out var project))
@@ -240,10 +240,8 @@ internal abstract partial class WindowsRazorProjectHostBase : OnceInitializedOnc
         }, CancellationToken.None));
     }
 
-    protected ImmutableArray<ProjectKey> GetAllProjectKeys(string projectFilePath)
-    {
-        return _projectManager.GetAllProjectKeys(projectFilePath);
-    }
+    protected ImmutableArray<ProjectKey> GetProjectKeysWithFilePath(string projectFilePath)
+        => _projectManager.GetProjectKeysWithFilePath(projectFilePath);
 
     protected Task UpdateAsync(Action<ProjectSnapshotManager.Updater> action, CancellationToken cancellationToken)
     {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
@@ -264,7 +264,7 @@ internal abstract partial class WindowsRazorProjectHostBase : OnceInitializedOnc
 
     protected static void UpdateProject(ProjectSnapshotManager.Updater updater, HostProject project)
     {
-        if (!updater.TryGetProject(project.Key, out _))
+        if (!updater.ContainsProject(project.Key))
         {
             // Just in case we somehow got in a state where VS didn't tell us that solution close was finished, lets just
             // ensure we're going to actually do something with the new project that we've just been told about.

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
@@ -227,8 +227,7 @@ internal abstract partial class WindowsRazorProjectHostBase : OnceInitializedOnc
                     // This should no-op in the common case, just putting it here for insurance.
                     foreach (var documentFilePath in current.DocumentFilePaths)
                     {
-                        var documentSnapshot = current.GetDocument(documentFilePath);
-                        Assumes.NotNull(documentSnapshot);
+                        var documentSnapshot = current.GetRequiredDocument(documentFilePath);
 
                         var hostDocument = new HostDocument(
                             documentSnapshot.FilePath,

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VsSolutionUpdatesProjectSnapshotChangeTrigger.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VsSolutionUpdatesProjectSnapshotChangeTrigger.cs
@@ -125,15 +125,15 @@ internal class VsSolutionUpdatesProjectSnapshotChangeTrigger : IRazorStartupServ
         var projectKeys = _projectManager.GetAllProjectKeys(projectFilePath);
         foreach (var projectKey in projectKeys)
         {
-            if (_projectManager.TryGetLoadedProject(projectKey, out var projectSnapshot))
+            if (_projectManager.TryGetProject(projectKey, out var project))
             {
                 var workspace = _workspaceProvider.GetWorkspace();
-                var workspaceProject = workspace.CurrentSolution.Projects.FirstOrDefault(wp => wp.ToProjectKey() == projectSnapshot.Key);
+                var workspaceProject = workspace.CurrentSolution.Projects.FirstOrDefault(wp => wp.ToProjectKey() == project.Key);
                 if (workspaceProject is not null)
                 {
                     // Trigger a tag helper update by forcing the project manager to see the workspace Project
                     // from the current solution.
-                    _workspaceStateGenerator.EnqueueUpdate(workspaceProject, projectSnapshot);
+                    _workspaceStateGenerator.EnqueueUpdate(workspaceProject, project);
                 }
             }
         }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VsSolutionUpdatesProjectSnapshotChangeTrigger.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VsSolutionUpdatesProjectSnapshotChangeTrigger.cs
@@ -122,7 +122,7 @@ internal class VsSolutionUpdatesProjectSnapshotChangeTrigger : IRazorStartupServ
             return;
         }
 
-        var projectKeys = _projectManager.GetAllProjectKeys(projectFilePath);
+        var projectKeys = _projectManager.GetProjectKeysWithFilePath(projectFilePath);
         foreach (var projectKey in projectKeys)
         {
             if (_projectManager.TryGetProject(projectKey, out var project))

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/WorkspaceProjectStateChangeDetector.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/WorkspaceProjectStateChangeDetector.cs
@@ -409,7 +409,7 @@ internal partial class WorkspaceProjectStateChangeDetector : IRazorStartupServic
 
         var projectKey = project.ToProjectKey();
 
-        return _projectManager.TryGetLoadedProject(projectKey, out projectSnapshot);
+        return _projectManager.TryGetProject(projectKey, out projectSnapshot);
     }
 
     internal TestAccessor GetTestAccessor() => new(this);

--- a/src/Razor/src/Microsoft.VisualStudio.LegacyEditor.Razor/EphemeralProjectSnapshot.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LegacyEditor.Razor/EphemeralProjectSnapshot.cs
@@ -59,16 +59,6 @@ internal class EphemeralProjectSnapshot : IProjectSnapshot
     public bool ContainsDocument(string filePath)
         => false;
 
-    public IDocumentSnapshot? GetDocument(string filePath)
-    {
-        if (filePath is null)
-        {
-            throw new ArgumentNullException(nameof(filePath));
-        }
-
-        return null;
-    }
-
     public bool TryGetDocument(string filePath, [NotNullWhen(true)] out IDocumentSnapshot? document)
     {
         document = null;

--- a/src/Razor/src/Microsoft.VisualStudio.LegacyEditor.Razor/Parsing/VisualStudioRazorParser.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LegacyEditor.Razor/Parsing/VisualStudioRazorParser.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.AspNetCore.Razor.ProjectEngineHost;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Logging;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Settings;
 using Microsoft.Extensions.Internal;
 using Microsoft.VisualStudio.Language.Intellisense;

--- a/src/Razor/src/Microsoft.VisualStudio.LegacyEditor.Razor/VisualStudioDocumentTracker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LegacyEditor.Razor/VisualStudioDocumentTracker.cs
@@ -155,7 +155,7 @@ internal sealed class VisualStudioDocumentTracker : IVisualStudioDocumentTracker
         var projectKeys = _projectManager.GetAllProjectKeys(projectPath);
 
         if (projectKeys.Length == 0 ||
-            !_projectManager.TryGetLoadedProject(projectKeys[0], out var project))
+            !_projectManager.TryGetProject(projectKeys[0], out var project))
         {
             return new EphemeralProjectSnapshot(_projectEngineFactoryProvider, projectPath);
         }
@@ -202,7 +202,7 @@ internal sealed class VisualStudioDocumentTracker : IVisualStudioDocumentTracker
             string.Equals(_projectPath, e.ProjectFilePath, StringComparison.OrdinalIgnoreCase))
         {
             // This will be the new snapshot unless the project was removed.
-            if (!_projectManager.TryGetLoadedProject(e.ProjectKey, out _projectSnapshot))
+            if (!_projectManager.TryGetProject(e.ProjectKey, out _projectSnapshot))
             {
                 _projectSnapshot = null;
             }

--- a/src/Razor/src/Microsoft.VisualStudio.LegacyEditor.Razor/VisualStudioDocumentTracker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LegacyEditor.Razor/VisualStudioDocumentTracker.cs
@@ -150,17 +150,16 @@ internal sealed class VisualStudioDocumentTracker : IVisualStudioDocumentTracker
         _ = OnContextChangedAsync(ContextChangeKind.ProjectChanged);
     }
 
-    private IProjectSnapshot GetOrCreateProject(string projectPath)
+    private IProjectSnapshot GetOrCreateProject(string projectFilePath)
     {
-        var projectKeys = _projectManager.GetAllProjectKeys(projectPath);
+        var projectKeys = _projectManager.GetProjectKeysWithFilePath(projectFilePath);
 
-        if (projectKeys.Length == 0 ||
-            !_projectManager.TryGetProject(projectKeys[0], out var project))
+        if (projectKeys is [var projectKey, ..] && _projectManager.TryGetProject(projectKey, out var project))
         {
-            return new EphemeralProjectSnapshot(_projectEngineFactoryProvider, projectPath);
+            return project;
         }
 
-        return project;
+        return new EphemeralProjectSnapshot(_projectEngineFactoryProvider, projectFilePath);
     }
 
     public void Unsubscribe()

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeDocumentReferenceHolderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeDocumentReferenceHolderTest.cs
@@ -64,7 +64,7 @@ public class CodeDocumentReferenceHolderTest(ITestOutputHelper testOutput) : Lan
             var unrelatedTextLoader = new SourceTextLoader("<p>Unrelated</p>", unrelatedHostDocument.FilePath);
             updater.DocumentAdded(s_hostProject.Key, unrelatedHostDocument, unrelatedTextLoader);
 
-            return updater.GetRequiredProject(s_hostProject.Key).GetRequiredDocument(unrelatedHostDocument.FilePath);
+            return updater.GetRequiredDocument(s_hostProject.Key, unrelatedHostDocument.FilePath);
         });
 
         Assert.NotNull(unrelatedDocumentSnapshot);
@@ -170,7 +170,7 @@ public class CodeDocumentReferenceHolderTest(ITestOutputHelper testOutput) : Lan
             var textLoader = new SourceTextLoader("<p>Hello World</p>", s_hostDocument.FilePath);
             updater.DocumentAdded(s_hostProject.Key, s_hostDocument, textLoader);
 
-            return updater.GetRequiredProject(s_hostProject.Key).GetRequiredDocument(s_hostDocument.FilePath);
+            return updater.GetRequiredDocument(s_hostProject.Key, s_hostDocument.FilePath);
         });
     }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeDocumentReferenceHolderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeDocumentReferenceHolderTest.cs
@@ -64,7 +64,7 @@ public class CodeDocumentReferenceHolderTest(ITestOutputHelper testOutput) : Lan
             var unrelatedTextLoader = new SourceTextLoader("<p>Unrelated</p>", unrelatedHostDocument.FilePath);
             updater.DocumentAdded(s_hostProject.Key, unrelatedHostDocument, unrelatedTextLoader);
 
-            return updater.GetLoadedProject(s_hostProject.Key).GetRequiredDocument(unrelatedHostDocument.FilePath);
+            return updater.GetRequiredProject(s_hostProject.Key).GetRequiredDocument(unrelatedHostDocument.FilePath);
         });
 
         Assert.NotNull(unrelatedDocumentSnapshot);
@@ -170,7 +170,7 @@ public class CodeDocumentReferenceHolderTest(ITestOutputHelper testOutput) : Lan
             var textLoader = new SourceTextLoader("<p>Hello World</p>", s_hostDocument.FilePath);
             updater.DocumentAdded(s_hostProject.Key, s_hostDocument, textLoader);
 
-            return updater.GetLoadedProject(s_hostProject.Key).GetRequiredDocument(s_hostDocument.FilePath);
+            return updater.GetRequiredProject(s_hostProject.Key).GetRequiredDocument(s_hostDocument.FilePath);
         });
     }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeDocumentReferenceHolderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeDocumentReferenceHolderTest.cs
@@ -63,9 +63,8 @@ public class CodeDocumentReferenceHolderTest(ITestOutputHelper testOutput) : Lan
         {
             var unrelatedTextLoader = new SourceTextLoader("<p>Unrelated</p>", unrelatedHostDocument.FilePath);
             updater.DocumentAdded(s_hostProject.Key, unrelatedHostDocument, unrelatedTextLoader);
-            var project = updater.GetLoadedProject(s_hostProject.Key);
 
-            return project.GetDocument(unrelatedHostDocument.FilePath);
+            return updater.GetLoadedProject(s_hostProject.Key).GetRequiredDocument(unrelatedHostDocument.FilePath);
         });
 
         Assert.NotNull(unrelatedDocumentSnapshot);
@@ -170,8 +169,8 @@ public class CodeDocumentReferenceHolderTest(ITestOutputHelper testOutput) : Lan
             updater.ProjectAdded(s_hostProject);
             var textLoader = new SourceTextLoader("<p>Hello World</p>", s_hostDocument.FilePath);
             updater.DocumentAdded(s_hostProject.Key, s_hostDocument, textLoader);
-            var project = updater.GetLoadedProject(s_hostProject.Key);
-            return project.GetDocument(s_hostDocument.FilePath).AssumeNotNull();
+
+            return updater.GetLoadedProject(s_hostProject.Key).GetRequiredDocument(s_hostDocument.FilePath);
         });
     }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsPublisherTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsPublisherTest.cs
@@ -77,12 +77,10 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
 
         var project = testProjectManager.GetLoadedProject(hostProject.Key);
 
-        var openedDocument = project.GetDocument(openedHostDocument.FilePath).AssumeNotNull();
-        _openedDocument = openedDocument;
+        _openedDocument = project.GetRequiredDocument(openedHostDocument.FilePath);
         _openedDocumentUri = new Uri("C:/project/open_document.cshtml");
 
-        var closedDocument = project.GetDocument(closedHostDocument.FilePath).AssumeNotNull();
-        _closedDocument = closedDocument;
+        _closedDocument = project.GetRequiredDocument(closedHostDocument.FilePath);
 
         _projectManager = testProjectManager;
         _testCodeDocument = TestRazorCodeDocument.CreateEmpty();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsPublisherTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsPublisherTest.cs
@@ -60,14 +60,14 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
 
     protected override async Task InitializeAsync()
     {
-        var testProjectManager = CreateProjectSnapshotManager();
+        var projectManager = CreateProjectSnapshotManager();
         var hostProject = new HostProject("C:/project/project.csproj", "C:/project/obj", RazorConfiguration.Default, "TestRootNamespace");
         var sourceText = SourceText.From(string.Empty);
         var textAndVersion = TextAndVersion.Create(sourceText, VersionStamp.Default);
         var openedHostDocument = new HostDocument("C:/project/open_document.cshtml", "C:/project/open_document.cshtml");
         var closedHostDocument = new HostDocument("C:/project/closed_document.cshtml", "C:/project/closed_document.cshtml");
 
-        await testProjectManager.UpdateAsync(updater =>
+        await projectManager.UpdateAsync(updater =>
         {
             updater.ProjectAdded(hostProject);
             updater.DocumentAdded(hostProject.Key, openedHostDocument, TextLoader.From(textAndVersion));
@@ -75,14 +75,14 @@ public class RazorDiagnosticsPublisherTest(ITestOutputHelper testOutput) : Langu
             updater.DocumentAdded(hostProject.Key, closedHostDocument, TextLoader.From(textAndVersion));
         });
 
-        var project = testProjectManager.GetLoadedProject(hostProject.Key);
+        var project = projectManager.GetRequiredProject(hostProject.Key);
 
         _openedDocument = project.GetRequiredDocument(openedHostDocument.FilePath);
         _openedDocumentUri = new Uri("C:/project/open_document.cshtml");
 
         _closedDocument = project.GetRequiredDocument(closedHostDocument.FilePath);
 
-        _projectManager = testProjectManager;
+        _projectManager = projectManager;
         _testCodeDocument = TestRazorCodeDocument.CreateEmpty();
     }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentContextFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentContextFactoryTest.cs
@@ -69,8 +69,7 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
         });
 
         var miscFilesProject = _projectManager.GetMiscellaneousProject();
-        var documentSnapshot = miscFilesProject.GetDocument(filePath);
-        Assert.NotNull(documentSnapshot);
+        var documentSnapshot = miscFilesProject.GetRequiredDocument(filePath);
 
         var factory = new DocumentContextFactory(_projectManager, LoggerFactory);
 
@@ -124,8 +123,7 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
         });
 
         var miscFilesProject = _projectManager.GetMiscellaneousProject();
-        var documentSnapshot = miscFilesProject.GetDocument(filePath);
-        Assert.NotNull(documentSnapshot);
+        var documentSnapshot = miscFilesProject.GetRequiredDocument(filePath);
 
         var factory = new DocumentContextFactory(_projectManager, LoggerFactory);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentContextFactoryTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentContextFactoryTest.cs
@@ -68,8 +68,9 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
             updater.DocumentAdded(MiscFilesHostProject.Instance.Key, hostDocument, TestMocks.CreateTextLoader(filePath, ""));
         });
 
-        var miscFilesProject = _projectManager.GetMiscellaneousProject();
-        var documentSnapshot = miscFilesProject.GetRequiredDocument(filePath);
+        var documentSnapshot = _projectManager
+            .GetMiscellaneousProject()
+            .GetRequiredDocument(filePath);
 
         var factory = new DocumentContextFactory(_projectManager, LoggerFactory);
 
@@ -122,8 +123,9 @@ public class DocumentContextFactoryTest : LanguageServerTestBase
             updater.DocumentAdded(MiscFilesHostProject.Instance.Key, hostDocument, TestMocks.CreateTextLoader(filePath, ""));
         });
 
-        var miscFilesProject = _projectManager.GetMiscellaneousProject();
-        var documentSnapshot = miscFilesProject.GetRequiredDocument(filePath);
+        var documentSnapshot = _projectManager
+            .GetMiscellaneousProject()
+            .GetRequiredDocument(filePath);
 
         var factory = new DocumentContextFactory(_projectManager, LoggerFactory);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentPresentation/TextDocumentUriPresentationEndpointTests.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DocumentPresentation/TextDocumentUriPresentationEndpointTests.cs
@@ -342,11 +342,6 @@ public class TextDocumentUriPresentationEndpointTests(ITestOutputHelper testOutp
             updater.DocumentOpened(hostProject.Key, hostDocument1.FilePath, SourceText.From("<div></div>"));
         });
 
-        var documentSnapshot = projectManager
-            .GetLoadedProject(hostProject.Key)
-            .GetDocument(hostDocument1.FilePath);
-        Assert.NotNull(documentSnapshot);
-
         var documentContextFactory = new DocumentContextFactory(projectManager, LoggerFactory);
         Assert.True(documentContextFactory.TryCreate(uri, projectContext: null, out var documentContext));
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectSystem/IProjectSnapshotManagerExtensionsTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/ProjectSystem/IProjectSnapshotManagerExtensionsTest.cs
@@ -137,7 +137,7 @@ public class IProjectSnapshotManagerExtensionsTest(ITestOutputHelper testOutput)
             updater.ProjectAdded(otherHostProject);
             updater.DocumentAdded(hostProject.Key, hostDocument, hostDocument.CreateEmptyTextLoader());
 
-            return updater.GetLoadedProject(hostProject.Key);
+            return updater.GetRequiredProject(hostProject.Key);
         });
 
         // Act
@@ -166,7 +166,7 @@ public class IProjectSnapshotManagerExtensionsTest(ITestOutputHelper testOutput)
             updater.DocumentAdded(miscFilesHostProject.Key, hostDocument, hostDocument.CreateEmptyTextLoader());
             updater.ProjectAdded(hostProject);
 
-            return updater.GetLoadedProject(miscFilesHostProject.Key);
+            return updater.GetRequiredProject(miscFilesHostProject.Key);
         });
 
         // Act
@@ -191,7 +191,7 @@ public class IProjectSnapshotManagerExtensionsTest(ITestOutputHelper testOutput)
             updater.ProjectAdded(hostProject);
             updater.DocumentAdded(hostProject.Key, hostDocument, hostDocument.CreateEmptyTextLoader());
 
-            return updater.GetLoadedProject(hostProject.Key);
+            return updater.GetRequiredProject(hostProject.Key);
         });
 
         // Act
@@ -210,7 +210,7 @@ public class IProjectSnapshotManagerExtensionsTest(ITestOutputHelper testOutput)
 
         // Act
         var project = projectManager.GetMiscellaneousProject();
-        var inManager = projectManager.GetLoadedProject(MiscFilesHostProject.Instance.Key);
+        var inManager = projectManager.GetRequiredProject(MiscFilesHostProject.Instance.Key);
 
         // Assert
         Assert.Same(inManager, project);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
@@ -111,9 +111,10 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
             DisposalToken);
 
         // Assert
-        var project = _projectManager.GetLoadedProject(hostProject.Key);
-        var document = project.GetDocument(hostDocument.FilePath);
-        Assert.NotNull(document);
+        var document = _projectManager
+            .GetLoadedProject(hostProject.Key)
+            .GetRequiredDocument(hostDocument.FilePath);
+
         Assert.Equal(FileKinds.Component, document.FileKind);
     }
 
@@ -325,9 +326,10 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
             DisposalToken);
 
         // Assert
-        var project = _projectManager.GetLoadedProject(hostProject.Key);
-        var document = project.GetDocument(newDocument.FilePath);
-        Assert.NotNull(document);
+        var document = _projectManager
+            .GetLoadedProject(hostProject.Key)
+            .GetRequiredDocument(newDocument.FilePath);
+
         Assert.Equal(FileKinds.Component, document.FileKind);
     }
 
@@ -992,7 +994,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         listener.AssertNotifications(
             x => x.DocumentChanged(DocumentFilePath, ownerProject.Key));
 
-        var latestVersion = _projectManager.GetLoadedProject(ownerProjectKey).GetDocument(DocumentFilePath)!.Version;
+        var latestVersion = _projectManager.GetLoadedProject(ownerProjectKey).GetRequiredDocument(DocumentFilePath).Version;
         Assert.Equal(2, latestVersion);
     }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
@@ -111,9 +111,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
             DisposalToken);
 
         // Assert
-        var document = _projectManager
-            .GetRequiredProject(hostProject.Key)
-            .GetRequiredDocument(hostDocument.FilePath);
+        var document = _projectManager.GetRequiredDocument(hostProject.Key, hostDocument.FilePath);
 
         Assert.Equal(FileKinds.Component, document.FileKind);
     }
@@ -316,9 +314,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
             DisposalToken);
 
         // Assert
-        var document = _projectManager
-            .GetRequiredProject(hostProject.Key)
-            .GetRequiredDocument(newDocument.FilePath);
+        var document = _projectManager.GetRequiredDocument(hostProject.Key, newDocument.FilePath);
 
         Assert.Equal(FileKinds.Component, document.FileKind);
     }
@@ -959,9 +955,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
         listener.AssertNotifications(
             x => x.DocumentChanged(DocumentFilePath, ownerProjectKey));
 
-        var latestVersion = _projectManager
-            .GetRequiredProject(ownerProjectKey)
-            .GetRequiredDocument(DocumentFilePath).Version;
+        var latestVersion = _projectManager.GetRequiredDocument(ownerProjectKey, DocumentFilePath).Version;
 
         Assert.Equal(2, latestVersion);
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ProjectSystem/TestProjectSnapshot.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ProjectSystem/TestProjectSnapshot.cs
@@ -61,9 +61,6 @@ internal sealed class TestProjectSnapshot : IProjectSnapshot
     public bool ContainsDocument(string filePath)
         => RealSnapshot.ContainsDocument(filePath);
 
-    public IDocumentSnapshot? GetDocument(string filePath)
-        => RealSnapshot.GetDocument(filePath);
-
     public bool TryGetDocument(string filePath, [NotNullWhen(true)] out IDocumentSnapshot? document)
         => RealSnapshot.TryGetDocument(filePath, out document);
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/DocumentExcerptServiceTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/DocumentExcerptServiceTestBase.cs
@@ -47,7 +47,7 @@ public abstract class DocumentExcerptServiceTestBase(ITestOutputHelper testOutpu
 
         var project = new ProjectSnapshot(state);
 
-        var primary = project.GetDocument(_hostDocument.FilePath).AssumeNotNull();
+        var primary = project.GetRequiredDocument(_hostDocument.FilePath);
 
         var solution = Workspace.CurrentSolution.AddProject(ProjectInfo.Create(
             ProjectId.CreateNewId(Path.GetFileNameWithoutExtension(_hostDocument.FilePath)),

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultProjectSnapshotTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/DefaultProjectSnapshotTest.cs
@@ -51,14 +51,14 @@ public class DefaultProjectSnapshotTest : WorkspaceTestBase
         var snapshot = new ProjectSnapshot(state);
 
         // Act
-        var documents = snapshot.DocumentFilePaths.ToDictionary(f => f, f => snapshot.GetDocument(f));
+        var documents = snapshot.DocumentFilePaths.ToDictionary(f => f, snapshot.GetRequiredDocument);
 
         // Assert
         Assert.Collection(
             documents,
-            d => Assert.Same(d.Value, snapshot.GetDocument(d.Key)),
-            d => Assert.Same(d.Value, snapshot.GetDocument(d.Key)),
-            d => Assert.Same(d.Value, snapshot.GetDocument(d.Key)));
+            d => Assert.Same(d.Value, snapshot.GetRequiredDocument(d.Key)),
+            d => Assert.Same(d.Value, snapshot.GetRequiredDocument(d.Key)),
+            d => Assert.Same(d.Value, snapshot.GetRequiredDocument(d.Key)));
     }
 
     [Fact]
@@ -69,8 +69,7 @@ public class DefaultProjectSnapshotTest : WorkspaceTestBase
             .WithAddedHostDocument(_documents[0], DocumentState.EmptyLoader);
         var snapshot = new ProjectSnapshot(state);
 
-        var document = snapshot.GetDocument(_documents[0].FilePath);
-        Assert.NotNull(document);
+        var document = snapshot.GetRequiredDocument(_documents[0].FilePath);
 
         // Act
         var documents = snapshot.GetRelatedDocuments(document);
@@ -89,8 +88,7 @@ public class DefaultProjectSnapshotTest : WorkspaceTestBase
             .WithAddedHostDocument(TestProjectData.SomeProjectImportFile, DocumentState.EmptyLoader);
         var snapshot = new ProjectSnapshot(state);
 
-        var document = snapshot.GetDocument(TestProjectData.SomeProjectImportFile.FilePath);
-        Assert.NotNull(document);
+        var document = snapshot.GetRequiredDocument(TestProjectData.SomeProjectImportFile.FilePath);
 
         // Act
         var documents = snapshot.GetRelatedDocuments(document);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/GeneratedDocumentTextLoaderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/GeneratedDocumentTextLoaderTest.cs
@@ -33,7 +33,7 @@ public class GeneratedDocumentTextLoaderTest : WorkspaceTestBase
             ProjectState.Create(ProjectEngineFactoryProvider, LanguageServerFeatureOptions, _hostProject, ProjectWorkspaceState.Default)
             .WithAddedHostDocument(_hostDocument, TestMocks.CreateTextLoader("", VersionStamp.Create())));
 
-        var document = project.GetDocument(_hostDocument.FilePath);
+        var document = project.GetRequiredDocument(_hostDocument.FilePath);
 
         var loader = new GeneratedDocumentTextLoader(document, "file.cshtml");
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DocumentGenerator/BackgroundDocumentGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DocumentGenerator/BackgroundDocumentGeneratorTest.cs
@@ -9,7 +9,6 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common;
@@ -131,7 +130,7 @@ public class BackgroundDocumentGeneratorTest(ITestOutputHelper testOutput) : Vis
         using var generator = new TestBackgroundDocumentGenerator(projectManager, _dynamicFileInfoProvider, loggerFactoryMock.Object);
 
         // Act & Assert
-        generator.Enqueue(project, project.GetDocument(s_documents[0].FilePath).AssumeNotNull());
+        generator.Enqueue(project, project.GetRequiredDocument(s_documents[0].FilePath));
 
         await generator.WaitUntilCurrentBatchCompletesAsync();
     }
@@ -172,7 +171,7 @@ public class BackgroundDocumentGeneratorTest(ITestOutputHelper testOutput) : Vis
         using var generator = new TestBackgroundDocumentGenerator(projectManager, _dynamicFileInfoProvider, loggerFactoryMock.Object);
 
         // Act & Assert
-        generator.Enqueue(project, project.GetDocument(s_documents[0].FilePath).AssumeNotNull());
+        generator.Enqueue(project, project.GetRequiredDocument(s_documents[0].FilePath));
 
         await generator.WaitUntilCurrentBatchCompletesAsync();
     }
@@ -199,7 +198,7 @@ public class BackgroundDocumentGeneratorTest(ITestOutputHelper testOutput) : Vis
         // Act & Assert
 
         // Enqueue some work.
-        generator.Enqueue(project, project.GetDocument(s_documents[0].FilePath).AssumeNotNull());
+        generator.Enqueue(project, project.GetRequiredDocument(s_documents[0].FilePath));
 
         // Wait for the work to complete.
         await generator.WaitUntilCurrentBatchCompletesAsync();
@@ -239,7 +238,7 @@ public class BackgroundDocumentGeneratorTest(ITestOutputHelper testOutput) : Vis
         // Act & Assert
 
         // First, enqueue some work.
-        generator.Enqueue(project, project.GetDocument(hostDocument1.FilePath).AssumeNotNull());
+        generator.Enqueue(project, project.GetRequiredDocument(hostDocument1.FilePath));
 
         // Wait for the work to complete.
         await generator.WaitUntilCurrentBatchCompletesAsync();
@@ -248,7 +247,7 @@ public class BackgroundDocumentGeneratorTest(ITestOutputHelper testOutput) : Vis
         Assert.Single(generator.CompletedWork, documentKey1);
 
         // Enqueue more work.
-        generator.Enqueue(project, project.GetDocument(hostDocument2.FilePath).AssumeNotNull());
+        generator.Enqueue(project, project.GetRequiredDocument(hostDocument2.FilePath));
 
         // Wait for the work to complete.
         await generator.WaitUntilCurrentBatchCompletesAsync();

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DocumentGenerator/BackgroundDocumentGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/DocumentGenerator/BackgroundDocumentGeneratorTest.cs
@@ -61,7 +61,7 @@ public class BackgroundDocumentGeneratorTest(ITestOutputHelper testOutput) : Vis
             .Returns(tcs.Task);
         var hostDocument = s_documents[0];
 
-        var project = projectManager.GetLoadedProject(s_hostProject1.Key);
+        var project = projectManager.GetRequiredProject(s_hostProject1.Key);
         using var generator = new TestBackgroundDocumentGenerator(projectManager, _dynamicFileInfoProvider, LoggerFactory)
         {
             NotifyBackgroundWorkStarting = new ManualResetEventSlim(initialState: false)
@@ -125,7 +125,7 @@ public class BackgroundDocumentGeneratorTest(ITestOutputHelper testOutput) : Vis
             updater.DocumentAdded(s_hostProject1.Key, s_documents[0], textLoader.Object);
         });
 
-        var project = projectManager.GetLoadedProject(s_hostProject1.Key);
+        var project = projectManager.GetRequiredProject(s_hostProject1.Key);
 
         using var generator = new TestBackgroundDocumentGenerator(projectManager, _dynamicFileInfoProvider, loggerFactoryMock.Object);
 
@@ -166,7 +166,7 @@ public class BackgroundDocumentGeneratorTest(ITestOutputHelper testOutput) : Vis
             updater.DocumentAdded(s_hostProject1.Key, s_documents[0], textLoaderMock.Object);
         });
 
-        var project = projectManager.GetLoadedProject(s_hostProject1.Key);
+        var project = projectManager.GetRequiredProject(s_hostProject1.Key);
 
         using var generator = new TestBackgroundDocumentGenerator(projectManager, _dynamicFileInfoProvider, loggerFactoryMock.Object);
 
@@ -190,7 +190,7 @@ public class BackgroundDocumentGeneratorTest(ITestOutputHelper testOutput) : Vis
             updater.DocumentAdded(s_hostProject1.Key, s_documents[1], s_documents[1].CreateEmptyTextLoader());
         });
 
-        var project = projectManager.GetLoadedProject(s_hostProject1.Key);
+        var project = projectManager.GetRequiredProject(s_hostProject1.Key);
         var documentKey1 = new DocumentKey(project.Key, s_documents[0].FilePath);
 
         using var generator = new TestBackgroundDocumentGenerator(projectManager, _dynamicFileInfoProvider, LoggerFactory);
@@ -229,7 +229,7 @@ public class BackgroundDocumentGeneratorTest(ITestOutputHelper testOutput) : Vis
             updater.DocumentAdded(hostProject1.Key, hostDocument2, hostDocument2.CreateEmptyTextLoader());
         });
 
-        var project = projectManager.GetLoadedProject(hostProject1.Key);
+        var project = projectManager.GetRequiredProject(hostProject1.Key);
         var documentKey1 = new DocumentKey(project.Key, hostDocument1.FilePath);
         var documentKey2 = new DocumentKey(project.Key, hostDocument2.FilePath);
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/DynamicFiles/RazorSpanMappingServiceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/DynamicFiles/RazorSpanMappingServiceTest.cs
@@ -33,8 +33,7 @@ public class RazorSpanMappingServiceTest(ITestOutputHelper testOutput) : Workspa
             .Create(ProjectEngineFactoryProvider, LanguageServerFeatureOptions, _hostProject, ProjectWorkspaceState.Default)
             .WithAddedHostDocument(_hostDocument, TestMocks.CreateTextLoader(sourceText, VersionStamp.Create())));
 
-        var document = project.GetDocument(_hostDocument.FilePath);
-        Assert.NotNull(document);
+        var document = project.GetRequiredDocument(_hostDocument.FilePath);
 
         var output = await document.GetGeneratedOutputAsync(DisposalToken);
         var generated = output.GetCSharpDocument();
@@ -65,8 +64,7 @@ public class RazorSpanMappingServiceTest(ITestOutputHelper testOutput) : Workspa
             .Create(ProjectEngineFactoryProvider, LanguageServerFeatureOptions, _hostProject, ProjectWorkspaceState.Default)
             .WithAddedHostDocument(_hostDocument, TestMocks.CreateTextLoader(sourceText, VersionStamp.Create())));
 
-        var document = project.GetDocument(_hostDocument.FilePath);
-        Assert.NotNull(document);
+        var document = project.GetRequiredDocument(_hostDocument.FilePath);
 
         var output = await document.GetGeneratedOutputAsync(DisposalToken);
         var generated = output.GetCSharpDocument();
@@ -98,8 +96,7 @@ public class RazorSpanMappingServiceTest(ITestOutputHelper testOutput) : Workspa
             .Create(ProjectEngineFactoryProvider, LanguageServerFeatureOptions, _hostProject, ProjectWorkspaceState.Default)
             .WithAddedHostDocument(_hostDocument, TestMocks.CreateTextLoader(sourceText, VersionStamp.Create())));
 
-        var document = project.GetDocument(_hostDocument.FilePath);
-        Assert.NotNull(document);
+        var document = project.GetRequiredDocument(_hostDocument.FilePath);
 
         var output = await document.GetGeneratedOutputAsync(DisposalToken);
         var generated = output.GetCSharpDocument();
@@ -130,8 +127,7 @@ public class RazorSpanMappingServiceTest(ITestOutputHelper testOutput) : Workspa
             .Create(ProjectEngineFactoryProvider, LanguageServerFeatureOptions, _hostProject, ProjectWorkspaceState.Default)
             .WithAddedHostDocument(_hostDocument, TestMocks.CreateTextLoader(sourceText, VersionStamp.Create())));
 
-        var document = project.GetDocument(_hostDocument.FilePath);
-        Assert.NotNull(document);
+        var document = project.GetRequiredDocument(_hostDocument.FilePath);
 
         var output = await document.GetGeneratedOutputAsync(DisposalToken);
         var generated = output.GetCSharpDocument();

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/RazorDocumentOptionsServiceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/RazorDocumentOptionsServiceTest.cs
@@ -100,8 +100,7 @@ public class RazorDocumentOptionsServiceTest(ITestOutputHelper testOutput) : Wor
             .Create(ProjectEngineFactoryProvider, LanguageServerFeatureOptions, hostProject, ProjectWorkspaceState.Default)
             .WithAddedHostDocument(hostDocument, TestMocks.CreateTextLoader(sourceText, VersionStamp.Create())));
 
-        var documentSnapshot = project.GetDocument(hostDocument.FilePath);
-        Assert.NotNull(documentSnapshot);
+        var document = project.GetRequiredDocument(hostDocument.FilePath);
 
         var solution = Workspace.CurrentSolution.AddProject(ProjectInfo.Create(
             ProjectId.CreateNewId(Path.GetFileNameWithoutExtension(hostDocument.FilePath)),
@@ -114,9 +113,8 @@ public class RazorDocumentOptionsServiceTest(ITestOutputHelper testOutput) : Wor
         solution = solution.AddDocument(
             DocumentId.CreateNewId(solution.ProjectIds.Single(), hostDocument.FilePath),
             hostDocument.FilePath,
-            new GeneratedDocumentTextLoader(documentSnapshot, hostDocument.FilePath));
+            new GeneratedDocumentTextLoader(document, hostDocument.FilePath));
 
-        var document = solution.Projects.Single().Documents.Single();
-        return document;
+        return solution.Projects.Single().Documents.Single();
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LiveShare/Host/ProjectSnapshotManagerProxyTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LiveShare/Host/ProjectSnapshotManagerProxyTest.cs
@@ -59,8 +59,13 @@ public class ProjectSnapshotManagerProxyTest(ITestOutputHelper testOutput) : Vis
         var state = await JoinableTaskFactory.RunAsync(() => proxy.CalculateUpdatedStateAsync(projectManager.GetProjects()));
 
         // Assert
-        var project1TagHelpers = await projectManager.GetLoadedProject(_hostProject1.Key).GetTagHelpersAsync(DisposalToken);
-        var project2TagHelpers = await projectManager.GetLoadedProject(_hostProject2.Key).GetTagHelpersAsync(DisposalToken);
+        var project1TagHelpers = await projectManager
+            .GetRequiredProject(_hostProject1.Key)
+            .GetTagHelpersAsync(DisposalToken);
+
+        var project2TagHelpers = await projectManager
+            .GetRequiredProject(_hostProject2.Key)
+            .GetTagHelpersAsync(DisposalToken);
 
         Assert.Collection(
             state.ProjectHandles,
@@ -101,7 +106,7 @@ public class ProjectSnapshotManagerProxyTest(ITestOutputHelper testOutput) : Vis
         await projectManager.UpdateAsync(updater =>
         {
             // Change the project's configuration to force a changed event to be raised.
-            var project = updater.GetLoadedProject(_hostProject1.Key);
+            var project = updater.GetRequiredProject(_hostProject1.Key);
             updater.ProjectConfigurationChanged(new(
                 project.FilePath,
                 project.IntermediateOutputPath,
@@ -142,7 +147,7 @@ public class ProjectSnapshotManagerProxyTest(ITestOutputHelper testOutput) : Vis
         await projectManager.UpdateAsync(updater =>
         {
             // Change the project's configuration to force a changed event to be raised.
-            var project = updater.GetLoadedProject(_hostProject1.Key);
+            var project = updater.GetRequiredProject(_hostProject1.Key);
             updater.ProjectConfigurationChanged(new(
                 project.FilePath,
                 project.IntermediateOutputPath,
@@ -211,8 +216,13 @@ public class ProjectSnapshotManagerProxyTest(ITestOutputHelper testOutput) : Vis
         var state = await JoinableTaskFactory.RunAsync(() => proxy.GetProjectManagerStateAsync(DisposalToken));
 
         // Assert
-        var project1TagHelpers = await projectManager.GetLoadedProject(_hostProject1.Key).GetTagHelpersAsync(DisposalToken);
-        var project2TagHelpers = await projectManager.GetLoadedProject(_hostProject2.Key).GetTagHelpersAsync(DisposalToken);
+        var project1TagHelpers = await projectManager
+            .GetRequiredProject(_hostProject1.Key)
+            .GetTagHelpersAsync(DisposalToken);
+
+        var project2TagHelpers = await projectManager
+            .GetRequiredProject(_hostProject2.Key)
+            .GetTagHelpersAsync(DisposalToken);
 
         Assert.Collection(
             state.ProjectHandles,

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
@@ -13,6 +13,7 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common.VisualStudio;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 using Xunit;
 using Xunit.Abstractions;

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
@@ -726,14 +726,14 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
             snapshot.DocumentFilePaths.OrderBy(d => d),
             d =>
             {
-                var document = snapshot.GetDocument(d);
+                var document = snapshot.GetRequiredDocument(d);
                 Assert.Equal(TestProjectData.SomeProjectFile1.FilePath, document.FilePath);
                 Assert.Equal(TestProjectData.SomeProjectFile1.TargetPath, document.TargetPath);
                 Assert.Equal(FileKinds.Legacy, document.FileKind);
             },
             d =>
             {
-                var document = snapshot.GetDocument(d);
+                var document = snapshot.GetRequiredDocument(d);
                 Assert.Equal(TestProjectData.SomeProjectComponentFile1.FilePath, document.FilePath);
                 Assert.Equal(TestProjectData.SomeProjectComponentFile1.TargetPath, document.TargetPath);
                 Assert.Equal(FileKinds.Component, document.FileKind);
@@ -927,20 +927,20 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
             snapshot.DocumentFilePaths.OrderBy(d => d),
             d =>
             {
-                var document = snapshot.GetDocument(d);
+                var document = snapshot.GetRequiredDocument(d);
                 Assert.Equal(TestProjectData.SomeProjectComponentImportFile1.FilePath, document.FilePath);
                 Assert.Equal(TestProjectData.SomeProjectComponentImportFile1.TargetPath, document.TargetPath);
                 Assert.Equal(FileKinds.ComponentImport, document.FileKind);
             },
             d =>
             {
-                var document = snapshot.GetDocument(d);
+                var document = snapshot.GetRequiredDocument(d);
                 Assert.Equal(TestProjectData.SomeProjectFile1.FilePath, document.FilePath);
                 Assert.Equal(TestProjectData.SomeProjectFile1.TargetPath, document.TargetPath);
             },
             d =>
             {
-                var document = snapshot.GetDocument(d);
+                var document = snapshot.GetRequiredDocument(d);
                 Assert.Equal(TestProjectData.SomeProjectComponentFile1.FilePath, document.FilePath);
                 Assert.Equal(TestProjectData.SomeProjectComponentFile1.TargetPath, document.TargetPath);
                 Assert.Equal(FileKinds.Component, document.FileKind);
@@ -988,35 +988,35 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
             snapshot.DocumentFilePaths.OrderBy(d => d),
             d =>
             {
-                var document = snapshot.GetDocument(d);
+                var document = snapshot.GetRequiredDocument(d);
                 Assert.Equal(TestProjectData.AnotherProjectNestedFile3.FilePath, document.FilePath);
                 Assert.Equal(TestProjectData.AnotherProjectNestedFile3.TargetPath, document.TargetPath);
                 Assert.Equal(FileKinds.Legacy, document.FileKind);
             },
             d =>
             {
-                var document = snapshot.GetDocument(d);
+                var document = snapshot.GetRequiredDocument(d);
                 Assert.Equal(TestProjectData.AnotherProjectNestedComponentFile3.FilePath, document.FilePath);
                 Assert.Equal(TestProjectData.AnotherProjectNestedComponentFile3.TargetPath, document.TargetPath);
                 Assert.Equal(FileKinds.Component, document.FileKind);
             },
             d =>
             {
-                var document = snapshot.GetDocument(d);
+                var document = snapshot.GetRequiredDocument(d);
                 Assert.Equal(TestProjectData.SomeProjectComponentImportFile1.FilePath, document.FilePath);
                 Assert.Equal(TestProjectData.SomeProjectComponentImportFile1.TargetPath, document.TargetPath);
                 Assert.Equal(FileKinds.ComponentImport, document.FileKind);
             },
             d =>
             {
-                var document = snapshot.GetDocument(d);
+                var document = snapshot.GetRequiredDocument(d);
                 Assert.Equal(TestProjectData.SomeProjectFile1.FilePath, document.FilePath);
                 Assert.Equal(TestProjectData.SomeProjectFile1.TargetPath, document.TargetPath);
                 Assert.Equal(FileKinds.Legacy, document.FileKind);
             },
             d =>
             {
-                var document = snapshot.GetDocument(d);
+                var document = snapshot.GetRequiredDocument(d);
                 Assert.Equal(TestProjectData.SomeProjectComponentFile1.FilePath, document.FilePath);
                 Assert.Equal(TestProjectData.SomeProjectComponentFile1.TargetPath, document.TargetPath);
                 Assert.Equal(FileKinds.Component, document.FileKind);
@@ -1232,14 +1232,14 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
            snapshot.DocumentFilePaths.OrderBy(d => d),
            d =>
            {
-               var document = snapshot.GetDocument(d);
+               var document = snapshot.GetRequiredDocument(d);
                Assert.Equal(TestProjectData.SomeProjectFile1.FilePath, document.FilePath);
                Assert.Equal(TestProjectData.SomeProjectFile1.TargetPath, document.TargetPath);
                Assert.Equal(FileKinds.Legacy, document.FileKind);
            },
            d =>
            {
-               var document = snapshot.GetDocument(d);
+               var document = snapshot.GetRequiredDocument(d);
                Assert.Equal(TestProjectData.SomeProjectComponentFile1.FilePath, document.FilePath);
                Assert.Equal(TestProjectData.SomeProjectComponentFile1.TargetPath, document.TargetPath);
                Assert.Equal(FileKinds.Component, document.FileKind);
@@ -1258,14 +1258,14 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
            snapshot.DocumentFilePaths.OrderBy(d => d),
            d =>
            {
-               var document = snapshot.GetDocument(d);
+               var document = snapshot.GetRequiredDocument(d);
                Assert.Equal(TestProjectData.SomeProjectFile1.FilePath, document.FilePath);
                Assert.Equal(TestProjectData.SomeProjectFile1.TargetPath, document.TargetPath);
                Assert.Equal(FileKinds.Legacy, document.FileKind);
            },
            d =>
            {
-               var document = snapshot.GetDocument(d);
+               var document = snapshot.GetRequiredDocument(d);
                Assert.Equal(TestProjectData.SomeProjectComponentFile1.FilePath, document.FilePath);
                Assert.Equal(TestProjectData.SomeProjectComponentFile1.TargetPath, document.TargetPath);
                Assert.Equal(FileKinds.Component, document.FileKind);
@@ -1335,20 +1335,20 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
             snapshot.DocumentFilePaths.OrderBy(d => d),
             d =>
             {
-                var document = snapshot.GetDocument(d);
+                var document = snapshot.GetRequiredDocument(d);
                 Assert.Equal(TestProjectData.SomeProjectComponentImportFile1.FilePath, document.FilePath);
                 Assert.Equal(TestProjectData.SomeProjectComponentImportFile1.TargetPath, document.TargetPath);
                 Assert.Equal(FileKinds.ComponentImport, document.FileKind);
             },
             d =>
             {
-                var document = snapshot.GetDocument(d);
+                var document = snapshot.GetRequiredDocument(d);
                 Assert.Equal(TestProjectData.SomeProjectFile1.FilePath, document.FilePath);
                 Assert.Equal(TestProjectData.SomeProjectFile1.TargetPath, document.TargetPath);
             },
             d =>
             {
-                var document = snapshot.GetDocument(d);
+                var document = snapshot.GetRequiredDocument(d);
                 Assert.Equal(TestProjectData.SomeProjectComponentFile1.FilePath, document.FilePath);
                 Assert.Equal(TestProjectData.SomeProjectComponentFile1.TargetPath, document.TargetPath);
                 Assert.Equal(FileKinds.Component, document.FileKind);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
@@ -712,28 +712,28 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
         await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
 
         // Assert
-        var snapshot = Assert.Single(_projectManager.GetProjects());
-        Assert.Equal(TestProjectData.SomeProject.FilePath, snapshot.FilePath);
+        var project = Assert.Single(_projectManager.GetProjects());
+        Assert.Equal(TestProjectData.SomeProject.FilePath, project.FilePath);
 
-        Assert.Equal(RazorLanguageVersion.Version_2_1, snapshot.Configuration.LanguageVersion);
-        Assert.Equal("MVC-2.1", snapshot.Configuration.ConfigurationName);
+        Assert.Equal(RazorLanguageVersion.Version_2_1, project.Configuration.LanguageVersion);
+        Assert.Equal("MVC-2.1", project.Configuration.ConfigurationName);
         Assert.Collection(
-            snapshot.Configuration.Extensions.OrderBy(e => e.ExtensionName),
+            project.Configuration.Extensions.OrderBy(e => e.ExtensionName),
             e => Assert.Equal("Another-Thing", e.ExtensionName),
             e => Assert.Equal("MVC-2.1", e.ExtensionName));
 
         Assert.Collection(
-            snapshot.DocumentFilePaths.OrderBy(d => d),
+            project.DocumentFilePaths.OrderBy(d => d),
             d =>
             {
-                var document = snapshot.GetRequiredDocument(d);
+                var document = project.GetRequiredDocument(d);
                 Assert.Equal(TestProjectData.SomeProjectFile1.FilePath, document.FilePath);
                 Assert.Equal(TestProjectData.SomeProjectFile1.TargetPath, document.TargetPath);
                 Assert.Equal(FileKinds.Legacy, document.FileKind);
             },
             d =>
             {
-                var document = snapshot.GetRequiredDocument(d);
+                var document = project.GetRequiredDocument(d);
                 Assert.Equal(TestProjectData.SomeProjectComponentFile1.FilePath, document.FilePath);
                 Assert.Equal(TestProjectData.SomeProjectComponentFile1.TargetPath, document.TargetPath);
                 Assert.Equal(FileKinds.Component, document.FileKind);
@@ -913,34 +913,34 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
         await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
 
         // Assert - 1
-        var snapshot = Assert.Single(_projectManager.GetProjects());
-        Assert.Equal(TestProjectData.SomeProject.FilePath, snapshot.FilePath);
+        var project = Assert.Single(_projectManager.GetProjects());
+        Assert.Equal(TestProjectData.SomeProject.FilePath, project.FilePath);
 
-        Assert.Equal(RazorLanguageVersion.Version_2_1, snapshot.Configuration.LanguageVersion);
-        Assert.Equal("MVC-2.1", snapshot.Configuration.ConfigurationName);
+        Assert.Equal(RazorLanguageVersion.Version_2_1, project.Configuration.LanguageVersion);
+        Assert.Equal("MVC-2.1", project.Configuration.ConfigurationName);
         Assert.Collection(
-            snapshot.Configuration.Extensions.OrderBy(e => e.ExtensionName),
+            project.Configuration.Extensions.OrderBy(e => e.ExtensionName),
             e => Assert.Equal("Another-Thing", e.ExtensionName),
             e => Assert.Equal("MVC-2.1", e.ExtensionName));
 
         Assert.Collection(
-            snapshot.DocumentFilePaths.OrderBy(d => d),
+            project.DocumentFilePaths.OrderBy(d => d),
             d =>
             {
-                var document = snapshot.GetRequiredDocument(d);
+                var document = project.GetRequiredDocument(d);
                 Assert.Equal(TestProjectData.SomeProjectComponentImportFile1.FilePath, document.FilePath);
                 Assert.Equal(TestProjectData.SomeProjectComponentImportFile1.TargetPath, document.TargetPath);
                 Assert.Equal(FileKinds.ComponentImport, document.FileKind);
             },
             d =>
             {
-                var document = snapshot.GetRequiredDocument(d);
+                var document = project.GetRequiredDocument(d);
                 Assert.Equal(TestProjectData.SomeProjectFile1.FilePath, document.FilePath);
                 Assert.Equal(TestProjectData.SomeProjectFile1.TargetPath, document.TargetPath);
             },
             d =>
             {
-                var document = snapshot.GetRequiredDocument(d);
+                var document = project.GetRequiredDocument(d);
                 Assert.Equal(TestProjectData.SomeProjectComponentFile1.FilePath, document.FilePath);
                 Assert.Equal(TestProjectData.SomeProjectComponentFile1.TargetPath, document.TargetPath);
                 Assert.Equal(FileKinds.Component, document.FileKind);
@@ -974,49 +974,49 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
         await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
 
         // Assert - 2
-        snapshot = Assert.Single(_projectManager.GetProjects());
-        Assert.Equal(TestProjectData.SomeProject.FilePath, snapshot.FilePath);
+        project = Assert.Single(_projectManager.GetProjects());
+        Assert.Equal(TestProjectData.SomeProject.FilePath, project.FilePath);
 
-        Assert.Equal(RazorLanguageVersion.Version_2_0, snapshot.Configuration.LanguageVersion);
-        Assert.Equal("MVC-2.0", snapshot.Configuration.ConfigurationName);
+        Assert.Equal(RazorLanguageVersion.Version_2_0, project.Configuration.LanguageVersion);
+        Assert.Equal("MVC-2.0", project.Configuration.ConfigurationName);
         Assert.Collection(
-            snapshot.Configuration.Extensions.OrderBy(e => e.ExtensionName),
+            project.Configuration.Extensions.OrderBy(e => e.ExtensionName),
             e => Assert.Equal("Another-Thing", e.ExtensionName),
             e => Assert.Equal("MVC-2.0", e.ExtensionName));
 
         Assert.Collection(
-            snapshot.DocumentFilePaths.OrderBy(d => d),
+            project.DocumentFilePaths.OrderBy(d => d),
             d =>
             {
-                var document = snapshot.GetRequiredDocument(d);
+                var document = project.GetRequiredDocument(d);
                 Assert.Equal(TestProjectData.AnotherProjectNestedFile3.FilePath, document.FilePath);
                 Assert.Equal(TestProjectData.AnotherProjectNestedFile3.TargetPath, document.TargetPath);
                 Assert.Equal(FileKinds.Legacy, document.FileKind);
             },
             d =>
             {
-                var document = snapshot.GetRequiredDocument(d);
+                var document = project.GetRequiredDocument(d);
                 Assert.Equal(TestProjectData.AnotherProjectNestedComponentFile3.FilePath, document.FilePath);
                 Assert.Equal(TestProjectData.AnotherProjectNestedComponentFile3.TargetPath, document.TargetPath);
                 Assert.Equal(FileKinds.Component, document.FileKind);
             },
             d =>
             {
-                var document = snapshot.GetRequiredDocument(d);
+                var document = project.GetRequiredDocument(d);
                 Assert.Equal(TestProjectData.SomeProjectComponentImportFile1.FilePath, document.FilePath);
                 Assert.Equal(TestProjectData.SomeProjectComponentImportFile1.TargetPath, document.TargetPath);
                 Assert.Equal(FileKinds.ComponentImport, document.FileKind);
             },
             d =>
             {
-                var document = snapshot.GetRequiredDocument(d);
+                var document = project.GetRequiredDocument(d);
                 Assert.Equal(TestProjectData.SomeProjectFile1.FilePath, document.FilePath);
                 Assert.Equal(TestProjectData.SomeProjectFile1.TargetPath, document.TargetPath);
                 Assert.Equal(FileKinds.Legacy, document.FileKind);
             },
             d =>
             {
-                var document = snapshot.GetRequiredDocument(d);
+                var document = project.GetRequiredDocument(d);
                 Assert.Equal(TestProjectData.SomeProjectComponentFile1.FilePath, document.FilePath);
                 Assert.Equal(TestProjectData.SomeProjectComponentFile1.TargetPath, document.TargetPath);
                 Assert.Equal(FileKinds.Component, document.FileKind);
@@ -1224,22 +1224,22 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
         await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
 
         // Assert - 1
-        var snapshot = Assert.Single(_projectManager.GetProjects());
-        Assert.Equal(TestProjectData.SomeProject.FilePath, snapshot.FilePath);
-        Assert.Same("MVC-2.1", snapshot.Configuration.ConfigurationName);
+        var project = Assert.Single(_projectManager.GetProjects());
+        Assert.Equal(TestProjectData.SomeProject.FilePath, project.FilePath);
+        Assert.Same("MVC-2.1", project.Configuration.ConfigurationName);
 
         Assert.Collection(
-           snapshot.DocumentFilePaths.OrderBy(d => d),
+           project.DocumentFilePaths.OrderBy(d => d),
            d =>
            {
-               var document = snapshot.GetRequiredDocument(d);
+               var document = project.GetRequiredDocument(d);
                Assert.Equal(TestProjectData.SomeProjectFile1.FilePath, document.FilePath);
                Assert.Equal(TestProjectData.SomeProjectFile1.TargetPath, document.TargetPath);
                Assert.Equal(FileKinds.Legacy, document.FileKind);
            },
            d =>
            {
-               var document = snapshot.GetRequiredDocument(d);
+               var document = project.GetRequiredDocument(d);
                Assert.Equal(TestProjectData.SomeProjectComponentFile1.FilePath, document.FilePath);
                Assert.Equal(TestProjectData.SomeProjectComponentFile1.TargetPath, document.TargetPath);
                Assert.Equal(FileKinds.Component, document.FileKind);
@@ -1250,22 +1250,22 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
         await Task.Run(async () => await host.OnProjectRenamingAsync(TestProjectData.SomeProject.FilePath, TestProjectData.AnotherProject.FilePath));
 
         // Assert - 1
-        snapshot = Assert.Single(_projectManager.GetProjects());
-        Assert.Equal(TestProjectData.AnotherProject.FilePath, snapshot.FilePath);
-        Assert.Same("MVC-2.1", snapshot.Configuration.ConfigurationName);
+        project = Assert.Single(_projectManager.GetProjects());
+        Assert.Equal(TestProjectData.AnotherProject.FilePath, project.FilePath);
+        Assert.Same("MVC-2.1", project.Configuration.ConfigurationName);
 
         Assert.Collection(
-           snapshot.DocumentFilePaths.OrderBy(d => d),
+           project.DocumentFilePaths.OrderBy(d => d),
            d =>
            {
-               var document = snapshot.GetRequiredDocument(d);
+               var document = project.GetRequiredDocument(d);
                Assert.Equal(TestProjectData.SomeProjectFile1.FilePath, document.FilePath);
                Assert.Equal(TestProjectData.SomeProjectFile1.TargetPath, document.TargetPath);
                Assert.Equal(FileKinds.Legacy, document.FileKind);
            },
            d =>
            {
-               var document = snapshot.GetRequiredDocument(d);
+               var document = project.GetRequiredDocument(d);
                Assert.Equal(TestProjectData.SomeProjectComponentFile1.FilePath, document.FilePath);
                Assert.Equal(TestProjectData.SomeProjectComponentFile1.TargetPath, document.TargetPath);
                Assert.Equal(FileKinds.Component, document.FileKind);
@@ -1321,34 +1321,34 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
         await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
 
         // Assert - 1
-        var snapshot = Assert.Single(_projectManager.GetProjects());
-        Assert.Equal(TestProjectData.SomeProject.FilePath, snapshot.FilePath);
+        var project = Assert.Single(_projectManager.GetProjects());
+        Assert.Equal(TestProjectData.SomeProject.FilePath, project.FilePath);
 
-        Assert.Equal(RazorLanguageVersion.Version_2_1, snapshot.Configuration.LanguageVersion);
-        Assert.Equal("MVC-2.1", snapshot.Configuration.ConfigurationName);
+        Assert.Equal(RazorLanguageVersion.Version_2_1, project.Configuration.LanguageVersion);
+        Assert.Equal("MVC-2.1", project.Configuration.ConfigurationName);
         Assert.Collection(
-            snapshot.Configuration.Extensions.OrderBy(e => e.ExtensionName),
+            project.Configuration.Extensions.OrderBy(e => e.ExtensionName),
             e => Assert.Equal("Another-Thing", e.ExtensionName),
             e => Assert.Equal("MVC-2.1", e.ExtensionName));
 
         Assert.Collection(
-            snapshot.DocumentFilePaths.OrderBy(d => d),
+            project.DocumentFilePaths.OrderBy(d => d),
             d =>
             {
-                var document = snapshot.GetRequiredDocument(d);
+                var document = project.GetRequiredDocument(d);
                 Assert.Equal(TestProjectData.SomeProjectComponentImportFile1.FilePath, document.FilePath);
                 Assert.Equal(TestProjectData.SomeProjectComponentImportFile1.TargetPath, document.TargetPath);
                 Assert.Equal(FileKinds.ComponentImport, document.FileKind);
             },
             d =>
             {
-                var document = snapshot.GetRequiredDocument(d);
+                var document = project.GetRequiredDocument(d);
                 Assert.Equal(TestProjectData.SomeProjectFile1.FilePath, document.FilePath);
                 Assert.Equal(TestProjectData.SomeProjectFile1.TargetPath, document.TargetPath);
             },
             d =>
             {
-                var document = snapshot.GetRequiredDocument(d);
+                var document = project.GetRequiredDocument(d);
                 Assert.Equal(TestProjectData.SomeProjectComponentFile1.FilePath, document.FilePath);
                 Assert.Equal(TestProjectData.SomeProjectComponentFile1.TargetPath, document.TargetPath);
                 Assert.Equal(FileKinds.Component, document.FileKind);
@@ -1371,9 +1371,9 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
 
         // Assert - 2
         // Changing intermediate output path is effectively removing the old project and adding a new one.
-        snapshot = Assert.Single(_projectManager.GetProjects());
-        Assert.Equal(TestProjectData.SomeProject.FilePath, snapshot.FilePath);
-        Assert.Equal(TestProjectData.SomeProject.IntermediateOutputPath + "2", snapshot.IntermediateOutputPath);
+        project = Assert.Single(_projectManager.GetProjects());
+        Assert.Equal(TestProjectData.SomeProject.FilePath, project.FilePath);
+        Assert.Equal(TestProjectData.SomeProject.IntermediateOutputPath + "2", project.IntermediateOutputPath);
 
         await Task.Run(async () => await host.DisposeAsync());
         Assert.Empty(_projectManager.GetProjects());

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/FallbackProjectManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/FallbackProjectManagerTest.cs
@@ -107,7 +107,7 @@ public class FallbackProjectManagerTest : VisualStudioWorkspaceTestBase
 
         var documentFilePath = Assert.Single(project.DocumentFilePaths);
         Assert.Equal(SomeProjectFile1.FilePath, documentFilePath);
-        Assert.Equal(SomeProjectFile1.TargetPath, project.GetDocument(documentFilePath)!.TargetPath);
+        Assert.Equal(SomeProjectFile1.TargetPath, project.GetRequiredDocument(documentFilePath).TargetPath);
     }
 
     [UIFact]
@@ -190,10 +190,12 @@ public class FallbackProjectManagerTest : VisualStudioWorkspaceTestBase
             f => Assert.Equal(SomeProjectFile2.FilePath, f),
             f => Assert.Equal(SomeProjectNestedComponentFile3.FilePath, f));
 
-        Assert.Equal(SomeProjectFile1.TargetPath, project.GetDocument(SomeProjectFile1.FilePath)!.TargetPath);
-        Assert.Equal(SomeProjectFile2.TargetPath, project.GetDocument(SomeProjectFile2.FilePath)!.TargetPath);
+        Assert.Equal(SomeProjectFile1.TargetPath, project.GetRequiredDocument(SomeProjectFile1.FilePath).TargetPath);
+        Assert.Equal(SomeProjectFile2.TargetPath, project.GetRequiredDocument(SomeProjectFile2.FilePath).TargetPath);
         // The test data is created with a "\" so when the test runs on Linux, and direct string comparison wouldn't work
-        Assert.True(FilePathNormalizer.AreFilePathsEquivalent(SomeProjectNestedComponentFile3.TargetPath, project.GetDocument(SomeProjectNestedComponentFile3.FilePath)!.TargetPath));
+        Assert.True(FilePathNormalizer.AreFilePathsEquivalent(
+            SomeProjectNestedComponentFile3.TargetPath,
+            project.GetRequiredDocument(SomeProjectNestedComponentFile3.FilePath).TargetPath));
     }
 
     [UIFact]
@@ -236,7 +238,7 @@ public class FallbackProjectManagerTest : VisualStudioWorkspaceTestBase
         Assert.Single(project.DocumentFilePaths,
             filePath => filePath == SomeProjectFile1.FilePath);
 
-        Assert.Equal(SomeProjectFile1.TargetPath, project.GetDocument(SomeProjectFile1.FilePath)!.TargetPath);
+        Assert.Equal(SomeProjectFile1.TargetPath, project.GetRequiredDocument(SomeProjectFile1.FilePath).TargetPath);
     }
 
     private Task WaitForProjectManagerUpdatesAsync()

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/ProjectSnapshotManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/ProjectSnapshotManagerTest.cs
@@ -6,7 +6,6 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common;
@@ -131,7 +130,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         Assert.Single(
             project.DocumentFilePaths,
             filePath => filePath == s_documents[0].FilePath &&
-                        project.GetDocument(filePath).AssumeNotNull().FileKind == FileKinds.Legacy);
+                        project.GetRequiredDocument(filePath).FileKind == FileKinds.Legacy);
 
         listener.AssertNotifications(
             x => x.DocumentAdded());
@@ -159,7 +158,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         Assert.Single(
             project.DocumentFilePaths,
             filePath => filePath == s_documents[3].FilePath &&
-                        project.GetDocument(filePath).AssumeNotNull().FileKind == FileKinds.Component);
+                        project.GetRequiredDocument(filePath).FileKind == FileKinds.Component);
 
         listener.AssertNotifications(
             x => x.DocumentAdded());
@@ -190,7 +189,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
 
         listener.AssertNoNotifications();
 
-        Assert.Equal(1, project.GetDocument(s_documents[0].FilePath)!.Version);
+        Assert.Equal(1, project.GetRequiredDocument(s_documents[0].FilePath).Version);
     }
 
     [UIFact]
@@ -227,8 +226,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         // Assert
         var project = _projectManager.GetLoadedProject(s_hostProject.Key);
         var documentFilePath = Assert.Single(project.DocumentFilePaths);
-        var document = project.GetDocument(documentFilePath);
-        Assert.NotNull(document);
+        var document = project.GetRequiredDocument(documentFilePath);
 
         var text = await document.GetTextAsync(DisposalToken);
         Assert.Equal(0, text.Length);
@@ -254,8 +252,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         // Assert
         var project = _projectManager.GetLoadedProject(s_hostProject.Key);
         var documentFilePath = Assert.Single(project.DocumentFilePaths);
-        var document = project.GetDocument(documentFilePath);
-        Assert.NotNull(document);
+        var document = project.GetRequiredDocument(documentFilePath);
 
         var actual = await document.GetTextAsync(DisposalToken);
         Assert.Same(expected, actual);
@@ -462,9 +459,10 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         listener.AssertNotifications(
             x => x.DocumentChanged());
 
-        var project = _projectManager.GetLoadedProject(s_hostProject.Key);
-        var document = project.GetDocument(s_documents[0].FilePath);
-        Assert.NotNull(document);
+        var document = _projectManager
+            .GetLoadedProject(s_hostProject.Key)
+            .GetRequiredDocument(s_documents[0].FilePath);
+
         var text = await document.GetTextAsync(DisposalToken);
         Assert.Same(_sourceText, text);
 
@@ -501,9 +499,10 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         listener.AssertNotifications(
             x => x.DocumentChanged());
 
-        var project = _projectManager.GetLoadedProject(s_hostProject.Key);
-        var document = project.GetDocument(s_documents[0].FilePath);
-        Assert.NotNull(document);
+        var document = _projectManager
+            .GetLoadedProject(s_hostProject.Key)
+            .GetRequiredDocument(s_documents[0].FilePath);
+
         var text = await document.GetTextAsync(DisposalToken);
         Assert.Same(expected, text);
         Assert.False(_projectManager.IsDocumentOpen(s_documents[0].FilePath));
@@ -535,9 +534,10 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         listener.AssertNotifications(
             x => x.DocumentChanged());
 
-        var project = _projectManager.GetLoadedProject(s_hostProject.Key);
-        var document = project.GetDocument(s_documents[0].FilePath);
-        Assert.NotNull(document);
+        var document = _projectManager
+            .GetLoadedProject(s_hostProject.Key)
+            .GetRequiredDocument(s_documents[0].FilePath);
+
         var text = await document.GetTextAsync(DisposalToken);
         Assert.Same(expected, text);
     }
@@ -567,9 +567,10 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         listener.AssertNotifications(
             x => x.DocumentChanged());
 
-        var project = _projectManager.GetLoadedProject(s_hostProject.Key);
-        var document = project.GetDocument(s_documents[0].FilePath);
-        Assert.NotNull(document);
+        var document = _projectManager
+            .GetLoadedProject(s_hostProject.Key)
+            .GetRequiredDocument(s_documents[0].FilePath);
+
         var text = await document.GetTextAsync(DisposalToken);
         Assert.Same(expected, text);
         Assert.Equal(3, document.Version);
@@ -601,9 +602,10 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         listener.AssertNotifications(
             x => x.DocumentChanged());
 
-        var project = _projectManager.GetLoadedProject(s_hostProject.Key);
-        var document = project.GetDocument(s_documents[0].FilePath);
-        Assert.NotNull(document);
+        var document = _projectManager
+            .GetLoadedProject(s_hostProject.Key)
+            .GetRequiredDocument(s_documents[0].FilePath);
+
         var text = await document.GetTextAsync(DisposalToken);
         Assert.Same(expected, text);
         Assert.Equal(3, document.Version);
@@ -771,9 +773,8 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         });
 
         // Assert
-        var document = _projectManager.GetLoadedProject(s_hostProject.Key).GetDocument(s_documents[0].FilePath);
+        var document = _projectManager.GetLoadedProject(s_hostProject.Key).GetRequiredDocument(s_documents[0].FilePath);
 
-        Assert.NotNull(document);
         Assert.Equal(2, document.Version);
     }
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/ProjectSnapshotManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/ProjectSnapshotManagerTest.cs
@@ -467,9 +467,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         listener.AssertNotifications(
             x => x.DocumentChanged());
 
-        var document = _projectManager
-            .GetRequiredProject(s_hostProject.Key)
-            .GetRequiredDocument(s_documents[0].FilePath);
+        var document = _projectManager.GetRequiredDocument(s_hostProject.Key, s_documents[0].FilePath);
 
         var text = await document.GetTextAsync(DisposalToken);
         Assert.Same(_sourceText, text);
@@ -507,9 +505,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         listener.AssertNotifications(
             x => x.DocumentChanged());
 
-        var document = _projectManager
-            .GetRequiredProject(s_hostProject.Key)
-            .GetRequiredDocument(s_documents[0].FilePath);
+        var document = _projectManager.GetRequiredDocument(s_hostProject.Key, s_documents[0].FilePath);
 
         var text = await document.GetTextAsync(DisposalToken);
         Assert.Same(expected, text);
@@ -542,9 +538,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         listener.AssertNotifications(
             x => x.DocumentChanged());
 
-        var document = _projectManager
-            .GetRequiredProject(s_hostProject.Key)
-            .GetRequiredDocument(s_documents[0].FilePath);
+        var document = _projectManager.GetRequiredDocument(s_hostProject.Key, s_documents[0].FilePath);
 
         var text = await document.GetTextAsync(DisposalToken);
         Assert.Same(expected, text);
@@ -575,9 +569,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         listener.AssertNotifications(
             x => x.DocumentChanged());
 
-        var document = _projectManager
-            .GetRequiredProject(s_hostProject.Key)
-            .GetRequiredDocument(s_documents[0].FilePath);
+        var document = _projectManager.GetRequiredDocument(s_hostProject.Key, s_documents[0].FilePath);
 
         var text = await document.GetTextAsync(DisposalToken);
         Assert.Same(expected, text);
@@ -610,9 +602,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         listener.AssertNotifications(
             x => x.DocumentChanged());
 
-        var document = _projectManager
-            .GetRequiredProject(s_hostProject.Key)
-            .GetRequiredDocument(s_documents[0].FilePath);
+        var document = _projectManager.GetRequiredDocument(s_hostProject.Key, s_documents[0].FilePath);
 
         var text = await document.GetTextAsync(DisposalToken);
         Assert.Same(expected, text);
@@ -781,9 +771,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         });
 
         // Assert
-        var document = _projectManager
-            .GetRequiredProject(s_hostProject.Key)
-            .GetRequiredDocument(s_documents[0].FilePath);
+        var document = _projectManager.GetRequiredDocument(s_hostProject.Key, s_documents[0].FilePath);
 
         Assert.Equal(2, document.Version);
     }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/ProjectSnapshotManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/ProjectSnapshotManagerTest.cs
@@ -100,7 +100,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         });
 
         // Assert
-        var project = _projectManager.GetLoadedProject(s_hostProject.Key);
+        var project = _projectManager.GetRequiredProject(s_hostProject.Key);
         Assert.Single(project.DocumentFilePaths,
             filePath => filePath == s_documents[0].FilePath);
 
@@ -126,7 +126,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         });
 
         // Assert
-        var project = _projectManager.GetLoadedProject(s_hostProject.Key);
+        var project = _projectManager.GetRequiredProject(s_hostProject.Key);
         Assert.Single(
             project.DocumentFilePaths,
             filePath => filePath == s_documents[0].FilePath &&
@@ -154,7 +154,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         });
 
         // Assert
-        var project = _projectManager.GetLoadedProject(s_hostProject.Key);
+        var project = _projectManager.GetRequiredProject(s_hostProject.Key);
         Assert.Single(
             project.DocumentFilePaths,
             filePath => filePath == s_documents[3].FilePath &&
@@ -183,7 +183,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         });
 
         // Assert
-        var project = _projectManager.GetLoadedProject(s_hostProject.Key);
+        var project = _projectManager.GetRequiredProject(s_hostProject.Key);
         Assert.Single(project.DocumentFilePaths,
             filePath => filePath == s_documents[0].FilePath);
 
@@ -224,7 +224,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         });
 
         // Assert
-        var project = _projectManager.GetLoadedProject(s_hostProject.Key);
+        var project = _projectManager.GetRequiredProject(s_hostProject.Key);
         var documentFilePath = Assert.Single(project.DocumentFilePaths);
         var document = project.GetRequiredDocument(documentFilePath);
 
@@ -250,7 +250,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         });
 
         // Assert
-        var project = _projectManager.GetLoadedProject(s_hostProject.Key);
+        var project = _projectManager.GetRequiredProject(s_hostProject.Key);
         var documentFilePath = Assert.Single(project.DocumentFilePaths);
         var document = project.GetRequiredDocument(documentFilePath);
 
@@ -268,7 +268,9 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
             updater.ProjectWorkspaceStateChanged(s_hostProject.Key, _projectWorkspaceStateWithTagHelpers);
         });
 
-        var originalTagHelpers = await _projectManager.GetLoadedProject(s_hostProject.Key).GetTagHelpersAsync(DisposalToken);
+        var originalTagHelpers = await _projectManager
+            .GetRequiredProject(s_hostProject.Key)
+            .GetTagHelpersAsync(DisposalToken);
 
         // Act
         await _projectManager.UpdateAsync(updater =>
@@ -277,7 +279,9 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         });
 
         // Assert
-        var newTagHelpers = await _projectManager.GetLoadedProject(s_hostProject.Key).GetTagHelpersAsync(DisposalToken);
+        var newTagHelpers = await _projectManager
+            .GetRequiredProject(s_hostProject.Key)
+            .GetTagHelpersAsync(DisposalToken);
 
         Assert.Equal(originalTagHelpers.Length, newTagHelpers.Length);
         for (var i = 0; i < originalTagHelpers.Length; i++)
@@ -295,7 +299,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
             updater.ProjectAdded(s_hostProject);
         });
 
-        var project = _projectManager.GetLoadedProject(s_hostProject.Key);
+        var project = _projectManager.GetRequiredProject(s_hostProject.Key);
         var projectEngine = project.GetProjectEngine();
 
         // Act
@@ -305,7 +309,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         });
 
         // Assert
-        project = _projectManager.GetLoadedProject(s_hostProject.Key);
+        project = _projectManager.GetRequiredProject(s_hostProject.Key);
         Assert.Same(projectEngine, project.GetProjectEngine());
     }
 
@@ -330,7 +334,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         });
 
         // Assert
-        var project = _projectManager.GetLoadedProject(s_hostProject.Key);
+        var project = _projectManager.GetRequiredProject(s_hostProject.Key);
         Assert.Collection(
             project.DocumentFilePaths.OrderBy(f => f),
             f => Assert.Equal(s_documents[2].FilePath, f),
@@ -358,7 +362,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         });
 
         // Assert
-        var project = _projectManager.GetLoadedProject(s_hostProject.Key);
+        var project = _projectManager.GetRequiredProject(s_hostProject.Key);
         Assert.Empty(project.DocumentFilePaths);
 
         listener.AssertNoNotifications();
@@ -393,7 +397,9 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
             updater.DocumentAdded(s_hostProject.Key, s_documents[2], s_documents[2].CreateEmptyTextLoader());
         });
 
-        var originalTagHelpers = await _projectManager.GetLoadedProject(s_hostProject.Key).GetTagHelpersAsync(DisposalToken);
+        var originalTagHelpers = await _projectManager
+            .GetRequiredProject(s_hostProject.Key)
+            .GetTagHelpersAsync(DisposalToken);
 
         // Act
         await _projectManager.UpdateAsync(updater =>
@@ -402,7 +408,9 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         });
 
         // Assert
-        var newTagHelpers = await _projectManager.GetLoadedProject(s_hostProject.Key).GetTagHelpersAsync(DisposalToken);
+        var newTagHelpers = await _projectManager
+            .GetRequiredProject(s_hostProject.Key)
+            .GetTagHelpersAsync(DisposalToken);
 
         Assert.Equal(originalTagHelpers.Length, newTagHelpers.Length);
         for (var i = 0; i < originalTagHelpers.Length; i++)
@@ -423,7 +431,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
             updater.DocumentAdded(s_hostProject.Key, s_documents[2], s_documents[2].CreateEmptyTextLoader());
         });
 
-        var project = _projectManager.GetLoadedProject(s_hostProject.Key);
+        var project = _projectManager.GetRequiredProject(s_hostProject.Key);
         var projectEngine = project.GetProjectEngine();
 
         // Act
@@ -433,7 +441,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         });
 
         // Assert
-        project = _projectManager.GetLoadedProject(s_hostProject.Key);
+        project = _projectManager.GetRequiredProject(s_hostProject.Key);
         Assert.Same(projectEngine, project.GetProjectEngine());
     }
 
@@ -460,7 +468,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
             x => x.DocumentChanged());
 
         var document = _projectManager
-            .GetLoadedProject(s_hostProject.Key)
+            .GetRequiredProject(s_hostProject.Key)
             .GetRequiredDocument(s_documents[0].FilePath);
 
         var text = await document.GetTextAsync(DisposalToken);
@@ -500,7 +508,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
             x => x.DocumentChanged());
 
         var document = _projectManager
-            .GetLoadedProject(s_hostProject.Key)
+            .GetRequiredProject(s_hostProject.Key)
             .GetRequiredDocument(s_documents[0].FilePath);
 
         var text = await document.GetTextAsync(DisposalToken);
@@ -535,7 +543,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
             x => x.DocumentChanged());
 
         var document = _projectManager
-            .GetLoadedProject(s_hostProject.Key)
+            .GetRequiredProject(s_hostProject.Key)
             .GetRequiredDocument(s_documents[0].FilePath);
 
         var text = await document.GetTextAsync(DisposalToken);
@@ -568,7 +576,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
             x => x.DocumentChanged());
 
         var document = _projectManager
-            .GetLoadedProject(s_hostProject.Key)
+            .GetRequiredProject(s_hostProject.Key)
             .GetRequiredDocument(s_documents[0].FilePath);
 
         var text = await document.GetTextAsync(DisposalToken);
@@ -603,7 +611,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
             x => x.DocumentChanged());
 
         var document = _projectManager
-            .GetLoadedProject(s_hostProject.Key)
+            .GetRequiredProject(s_hostProject.Key)
             .GetRequiredDocument(s_documents[0].FilePath);
 
         var text = await document.GetTextAsync(DisposalToken);
@@ -682,7 +690,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
             updater.ProjectAdded(s_hostProject);
         });
 
-        var project = _projectManager.GetLoadedProject(s_hostProject.Key);
+        var project = _projectManager.GetRequiredProject(s_hostProject.Key);
         var projectEngine = project.GetProjectEngine();
 
         // Act
@@ -692,7 +700,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         });
 
         // Assert
-        project = _projectManager.GetLoadedProject(s_hostProjectWithConfigurationChange.Key);
+        project = _projectManager.GetRequiredProject(s_hostProjectWithConfigurationChange.Key);
         Assert.NotSame(projectEngine, project.GetProjectEngine());
     }
 
@@ -773,7 +781,9 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         });
 
         // Assert
-        var document = _projectManager.GetLoadedProject(s_hostProject.Key).GetRequiredDocument(s_documents[0].FilePath);
+        var document = _projectManager
+            .GetRequiredProject(s_hostProject.Key)
+            .GetRequiredDocument(s_documents[0].FilePath);
 
         Assert.Equal(2, document.Version);
     }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/ProjectSnapshotManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/ProjectSnapshotManagerTest.cs
@@ -204,7 +204,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         });
 
         // Assert
-        var projectKeys = _projectManager.GetAllProjectKeys(s_hostProject.FilePath);
+        var projectKeys = _projectManager.GetProjectKeysWithFilePath(s_hostProject.FilePath);
         Assert.Empty(projectKeys);
     }
 
@@ -380,7 +380,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
         });
 
         // Assert
-        var projectKeys = _projectManager.GetAllProjectKeys(s_hostProject.FilePath);
+        var projectKeys = _projectManager.GetProjectKeysWithFilePath(s_hostProject.FilePath);
         Assert.Empty(projectKeys);
     }
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/RazorDynamicFileInfoProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/RazorDynamicFileInfoProviderTest.cs
@@ -56,7 +56,7 @@ public class RazorDynamicFileInfoProviderTest(ITestOutputHelper testOutput) : Vi
         });
 
         var projectKey = _projectManager.GetAllProjectKeys(hostProject.FilePath).Single();
-        _project = _projectManager.GetLoadedProject(projectKey);
+        _project = _projectManager.GetRequiredProject(projectKey);
         _document1 = _project.GetRequiredDocument(hostDocument1.FilePath);
         _document2 = _project.GetRequiredDocument(hostDocument2.FilePath);
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/RazorDynamicFileInfoProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/RazorDynamicFileInfoProviderTest.cs
@@ -5,7 +5,6 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.AspNetCore.Razor.Test.Common;
@@ -58,8 +57,8 @@ public class RazorDynamicFileInfoProviderTest(ITestOutputHelper testOutput) : Vi
 
         var projectKey = _projectManager.GetAllProjectKeys(hostProject.FilePath).Single();
         _project = _projectManager.GetLoadedProject(projectKey);
-        _document1 = _project.GetDocument(hostDocument1.FilePath).AssumeNotNull();
-        _document2 = _project.GetDocument(hostDocument2.FilePath).AssumeNotNull();
+        _document1 = _project.GetRequiredDocument(hostDocument1.FilePath);
+        _document2 = _project.GetRequiredDocument(hostDocument2.FilePath);
 
         var languageServerFeatureOptions = new TestLanguageServerFeatureOptions(includeProjectKeyInGeneratedFilePath: true);
         var filePathService = new VisualStudioFilePathService(languageServerFeatureOptions);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/RazorDynamicFileInfoProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/RazorDynamicFileInfoProviderTest.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Telemetry;
@@ -55,8 +54,7 @@ public class RazorDynamicFileInfoProviderTest(ITestOutputHelper testOutput) : Vi
             updater.DocumentAdded(hostProject.Key, hostDocument2, new EmptyTextLoader(hostDocument2.FilePath));
         });
 
-        var projectKey = _projectManager.GetAllProjectKeys(hostProject.FilePath).Single();
-        _project = _projectManager.GetRequiredProject(projectKey);
+        _project = _projectManager.GetRequiredProject(hostProject.Key);
         _document1 = _project.GetRequiredDocument(hostDocument1.FilePath);
         _document2 = _project.GetRequiredDocument(hostDocument2.FilePath);
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectWorkspaceStateGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectWorkspaceStateGeneratorTest.cs
@@ -130,8 +130,8 @@ public class ProjectWorkspaceStateGeneratorTest : VisualStudioWorkspaceTestBase
         await Task.Run(() => generatorAccessor.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3)));
 
         // Assert
-        var newProjectSnapshot = _projectManager.GetLoadedProject(_projectSnapshot.Key);
-        Assert.NotNull(newProjectSnapshot);
+        var newProjectSnapshot = _projectManager.GetRequiredProject(_projectSnapshot.Key);
+
         Assert.Empty(await newProjectSnapshot.GetTagHelpersAsync(DisposalToken));
     }
 
@@ -157,8 +157,8 @@ public class ProjectWorkspaceStateGeneratorTest : VisualStudioWorkspaceTestBase
         await Task.Run(() => generatorAccessor.NotifyBackgroundWorkCompleted.Wait(TimeSpan.FromSeconds(3)));
 
         // Assert
-        var newProjectSnapshot = _projectManager.GetLoadedProject(_projectSnapshot.Key);
-        Assert.NotNull(newProjectSnapshot);
+        var newProjectSnapshot = _projectManager.GetRequiredProject(_projectSnapshot.Key);
+
         Assert.Equal<TagHelperDescriptor>(_tagHelperResolver.TagHelpers, await newProjectSnapshot.GetTagHelpersAsync(DisposalToken));
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Remote/OutOfProcTagHelperResolverTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Remote/OutOfProcTagHelperResolverTest.cs
@@ -81,7 +81,7 @@ public partial class OutOfProcTagHelperResolverTest : VisualStudioTestBase
             updater.ProjectAdded(s_hostProject_For_2_0);
         });
 
-        var projectSnapshot = _projectManager.GetLoadedProject(s_hostProject_For_2_0.Key);
+        var projectSnapshot = _projectManager.GetRequiredProject(s_hostProject_For_2_0.Key);
 
         var calledOutOfProcess = false;
 
@@ -113,7 +113,7 @@ public partial class OutOfProcTagHelperResolverTest : VisualStudioTestBase
             updater.ProjectAdded(s_hostProject_For_NonSerializableConfiguration);
         });
 
-        var projectSnapshot = _projectManager.GetLoadedProject(s_hostProject_For_2_0.Key);
+        var projectSnapshot = _projectManager.GetRequiredProject(s_hostProject_For_2_0.Key);
 
         var calledInProcess = false;
 
@@ -145,7 +145,7 @@ public partial class OutOfProcTagHelperResolverTest : VisualStudioTestBase
             updater.ProjectAdded(s_hostProject_For_2_0);
         });
 
-        var projectSnapshot = _projectManager.GetLoadedProject(s_hostProject_For_2_0.Key);
+        var projectSnapshot = _projectManager.GetRequiredProject(s_hostProject_For_2_0.Key);
 
         var calledOutOfProcess = false;
         var calledInProcess = false;

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/VsSolutionUpdatesProjectSnapshotChangeTriggerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/VsSolutionUpdatesProjectSnapshotChangeTriggerTest.cs
@@ -154,7 +154,7 @@ public class VsSolutionUpdatesProjectSnapshotChangeTriggerTest : VisualStudioTes
             updater.ProjectAdded(s_someProject);
             updater.ProjectAdded(s_someOtherProject);
 
-            return updater.GetLoadedProject(s_someProject.Key);
+            return updater.GetRequiredProject(s_someProject.Key);
         });
 
         var serviceProvider = VsMocks.CreateServiceProvider();
@@ -207,7 +207,7 @@ public class VsSolutionUpdatesProjectSnapshotChangeTriggerTest : VisualStudioTes
             updater.ProjectAdded(s_someProject);
             updater.ProjectAdded(s_someOtherProject);
 
-            return updater.GetLoadedProject(s_someProject.Key);
+            return updater.GetRequiredProject(s_someProject.Key);
         });
 
         var serviceProvider = VsMocks.CreateServiceProvider();

--- a/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/ImportDocumentManagerIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/ImportDocumentManagerIntegrationTest.cs
@@ -45,14 +45,14 @@ public class ImportDocumentManagerIntegrationTest : VisualStudioTestBase
             t.ProjectPath == _projectPath &&
             t.ProjectSnapshot == StrictMock.Of<IProjectSnapshot>(p =>
                 p.GetProjectEngine() == _projectEngine &&
-                p.GetDocument(It.IsAny<string>()) == null));
+                p.TryGetDocument(It.IsAny<string>(), out It.Ref<IDocumentSnapshot?>.IsAny) == false));
 
         var anotherTracker = StrictMock.Of<IVisualStudioDocumentTracker>(t =>
             t.FilePath == Path.Combine(_directoryPath, "anotherFile.cshtml") &&
             t.ProjectPath == _projectPath &&
             t.ProjectSnapshot == StrictMock.Of<IProjectSnapshot>(p =>
                 p.GetProjectEngine() == _projectEngine &&
-                p.GetDocument(It.IsAny<string>()) == null));
+                p.TryGetDocument(It.IsAny<string>(), out It.Ref<IDocumentSnapshot?>.IsAny) == false));
 
         var fileChangeTrackerFactoryMock = new StrictMock<IFileChangeTrackerFactory>();
         var fileChangeTracker1Mock = new StrictMock<IFileChangeTracker>();

--- a/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/ImportDocumentManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/ImportDocumentManagerTest.cs
@@ -44,7 +44,7 @@ public class ImportDocumentManagerTest : VisualStudioTestBase
             t.ProjectPath == _projectPath &&
             t.ProjectSnapshot == StrictMock.Of<IProjectSnapshot>(p =>
                 p.GetProjectEngine() == _projectEngine &&
-                p.GetDocument(It.IsAny<string>()) == null));
+                p.TryGetDocument(It.IsAny<string>(), out It.Ref<IDocumentSnapshot?>.IsAny) == false));
 
         var fileChangeTrackerFactoryMock = new StrictMock<IFileChangeTrackerFactory>();
         var fileChangeTracker1Mock = new StrictMock<IFileChangeTracker>();
@@ -91,14 +91,14 @@ public class ImportDocumentManagerTest : VisualStudioTestBase
             t.ProjectPath == _projectPath &&
             t.ProjectSnapshot == StrictMock.Of<IProjectSnapshot>(p =>
                 p.GetProjectEngine() == _projectEngine &&
-                p.GetDocument(It.IsAny<string>()) == null));
+                p.TryGetDocument(It.IsAny<string>(), out It.Ref<IDocumentSnapshot?>.IsAny) == false));
 
         var anotherTracker = StrictMock.Of<IVisualStudioDocumentTracker>(t =>
             t.FilePath == Path.Combine(_directoryPath, "anotherFile.cshtml") &&
             t.ProjectPath == _projectPath &&
             t.ProjectSnapshot == StrictMock.Of<IProjectSnapshot>(p =>
                 p.GetProjectEngine() == _projectEngine &&
-                p.GetDocument(It.IsAny<string>()) == null));
+                p.TryGetDocument(It.IsAny<string>(), out It.Ref<IDocumentSnapshot?>.IsAny) == false));
 
         var callCount = 0;
         var fileChangeTrackerFactoryMock = new StrictMock<IFileChangeTrackerFactory>();
@@ -129,7 +129,7 @@ public class ImportDocumentManagerTest : VisualStudioTestBase
             t.ProjectPath == _projectPath &&
             t.ProjectSnapshot == StrictMock.Of<IProjectSnapshot>(p =>
                 p.GetProjectEngine() == _projectEngine &&
-                p.GetDocument(It.IsAny<string>()) == null));
+                p.TryGetDocument(It.IsAny<string>(), out It.Ref<IDocumentSnapshot?>.IsAny) == false));
 
         var fileChangeTrackerFactoryMock = new StrictMock<IFileChangeTrackerFactory>();
         var fileChangeTrackerMock = new StrictMock<IFileChangeTracker>();
@@ -163,14 +163,14 @@ public class ImportDocumentManagerTest : VisualStudioTestBase
             t.ProjectPath == _projectPath &&
             t.ProjectSnapshot == StrictMock.Of<IProjectSnapshot>(p =>
                 p.GetProjectEngine() == _projectEngine &&
-                p.GetDocument(It.IsAny<string>()) == null));
+                p.TryGetDocument(It.IsAny<string>(), out It.Ref<IDocumentSnapshot?>.IsAny) == false));
 
         var anotherTracker = StrictMock.Of<IVisualStudioDocumentTracker>(t =>
             t.FilePath == Path.Combine(_directoryPath, "anotherFile.cshtml") &&
             t.ProjectPath == _projectPath &&
             t.ProjectSnapshot == StrictMock.Of<IProjectSnapshot>(p =>
                 p.GetProjectEngine() == _projectEngine &&
-                p.GetDocument(It.IsAny<string>()) == null));
+                p.TryGetDocument(It.IsAny<string>(), out It.Ref<IDocumentSnapshot?>.IsAny) == false));
 
         var fileChangeTrackerFactoryMock = new StrictMock<IFileChangeTrackerFactory>();
         var fileChangeTrackerMock = new StrictMock<IFileChangeTracker>();

--- a/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/VisualStudioDocumentTrackerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/VisualStudioDocumentTrackerTest.cs
@@ -159,14 +159,14 @@ public class VisualStudioDocumentTrackerTest : VisualStudioWorkspaceTestBase
             updater.ProjectAdded(_hostProject);
         });
 
-        var e = new ProjectChangeEventArgs(null!, _projectManager.GetLoadedProject(_hostProject.Key), ProjectChangeKind.ProjectAdded);
+        var e = new ProjectChangeEventArgs(null!, _projectManager.GetRequiredProject(_hostProject.Key), ProjectChangeKind.ProjectAdded);
 
         var called = false;
         _documentTracker.ContextChanged += (sender, args) =>
         {
             called = true;
 
-            Assert.Same(_projectManager.GetLoadedProject(_hostProject.Key), _documentTracker.ProjectSnapshot);
+            Assert.Same(_projectManager.GetRequiredProject(_hostProject.Key), _documentTracker.ProjectSnapshot);
         };
 
         // Act
@@ -185,14 +185,14 @@ public class VisualStudioDocumentTrackerTest : VisualStudioWorkspaceTestBase
             updater.ProjectAdded(_hostProject);
         });
 
-        var e = new ProjectChangeEventArgs(null!, _projectManager.GetLoadedProject(_hostProject.Key), ProjectChangeKind.ProjectChanged);
+        var e = new ProjectChangeEventArgs(null!, _projectManager.GetRequiredProject(_hostProject.Key), ProjectChangeKind.ProjectChanged);
 
         var called = false;
         _documentTracker.ContextChanged += (sender, args) =>
         {
             called = true;
 
-            Assert.Same(_projectManager.GetLoadedProject(_hostProject.Key), _documentTracker.ProjectSnapshot);
+            Assert.Same(_projectManager.GetRequiredProject(_hostProject.Key), _documentTracker.ProjectSnapshot);
         };
 
         // Act
@@ -211,14 +211,14 @@ public class VisualStudioDocumentTrackerTest : VisualStudioWorkspaceTestBase
             updater.ProjectAdded(_hostProject);
         });
 
-        var project = _projectManager.GetLoadedProject(_hostProject.Key);
+        var project = _projectManager.GetRequiredProject(_hostProject.Key);
 
         await _projectManager.UpdateAsync(updater =>
         {
             updater.ProjectRemoved(_hostProject.Key);
         });
 
-        var e = new ProjectChangeEventArgs(project!, null!, ProjectChangeKind.ProjectRemoved);
+        var e = new ProjectChangeEventArgs(project, null!, ProjectChangeKind.ProjectRemoved);
 
         var called = false;
         _documentTracker.ContextChanged += (sender, args) =>
@@ -245,7 +245,7 @@ public class VisualStudioDocumentTrackerTest : VisualStudioWorkspaceTestBase
             updater.ProjectAdded(_otherHostProject);
         });
 
-        var e = new ProjectChangeEventArgs(null!, _projectManager.GetLoadedProject(_otherHostProject.Key), ProjectChangeKind.ProjectChanged);
+        var e = new ProjectChangeEventArgs(null!, _projectManager.GetRequiredProject(_otherHostProject.Key), ProjectChangeKind.ProjectChanged);
 
         var called = false;
         _documentTracker.ContextChanged += (sender, args) => called = true;

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/RazorProjectSystemInProcess.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/RazorProjectSystemInProcess.cs
@@ -2,17 +2,17 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Threading;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.Razor.IntegrationTests.InProcess;
-using Xunit;
 using Microsoft.VisualStudio.Razor.LanguageClient;
-using Microsoft.AspNetCore.Razor.Threading;
-using System.Collections.Immutable;
-using System.Linq;
+using Xunit;
 
 namespace Microsoft.VisualStudio.Extensibility.Testing;
 
@@ -50,7 +50,7 @@ internal partial class RazorProjectSystemInProcess
                 return SpecializedTasks.False;
             }
 
-            return Task.FromResult(projectManager.TryGetProject(projectKeys[0], out _));
+            return Task.FromResult(projectManager.ContainsProject(projectKeys[0]));
         }, TimeSpan.FromMilliseconds(100), cancellationToken);
     }
 

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/RazorProjectSystemInProcess.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/RazorProjectSystemInProcess.cs
@@ -86,14 +86,9 @@ internal partial class RazorProjectSystemInProcess
         {
             var projectKeys = projectManager.GetAllProjectKeys(projectFilePath);
 
-            if (projectKeys is [var projectKey, ..] &&
-                projectManager.TryGetProject(projectKey, out var project) &&
-                project.ContainsDocument(filePath))
-            {
-                return SpecializedTasks.True;
-            }
-
-            return SpecializedTasks.False;
+            return projectKeys is [var projectKey, ..] && projectManager.ContainsDocument(projectKey, filePath)
+                ? SpecializedTasks.True
+                : SpecializedTasks.False;
         }, TimeSpan.FromMilliseconds(100), cancellationToken);
     }
 

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/RazorProjectSystemInProcess.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/InProcess/RazorProjectSystemInProcess.cs
@@ -50,7 +50,7 @@ internal partial class RazorProjectSystemInProcess
                 return SpecializedTasks.False;
             }
 
-            return Task.FromResult(projectManager.TryGetLoadedProject(projectKeys[0], out _));
+            return Task.FromResult(projectManager.TryGetProject(projectKeys[0], out _));
         }, TimeSpan.FromMilliseconds(100), cancellationToken);
     }
 
@@ -67,7 +67,7 @@ internal partial class RazorProjectSystemInProcess
                 return false;
             }
 
-            if (!projectManager.TryGetLoadedProject(projectKeys[0], out var project))
+            if (!projectManager.TryGetProject(projectKeys[0], out var project))
             {
                 return false;
             }
@@ -87,7 +87,7 @@ internal partial class RazorProjectSystemInProcess
             var projectKeys = projectManager.GetAllProjectKeys(projectFilePath);
 
             if (projectKeys is [var projectKey, ..] &&
-                projectManager.TryGetLoadedProject(projectKey, out var project) &&
+                projectManager.TryGetProject(projectKey, out var project) &&
                 project.ContainsDocument(filePath))
             {
                 return SpecializedTasks.True;


### PR DESCRIPTION
This pull request is an attempt to rationalize and normalize the "Get" methods on `IProjectSnapshotManger` and `IProjectSnapshot`. The goal here is to try and match common naming conventions (e.g. GetLoadedProject becomes GetRequiredProejct) and match Roslyn where appropriate. In addition, some methods have been converted to or introduced as extension methods. This allows the interfaces to stay light a bit lighter and exclude members that have the same implementation across the code base. This is especially useful for `IProjectSnapshot`, which is implemented as `ProjectSnapshot` and `RemoteProjectSnapshot`.

Reviewing commit-by-commit might be helpful.