### PR TITLE
Formatting engine changes to allow it to (mostly) run on runtime code-gen

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/RazorSyntaxNodeExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/RazorSyntaxNodeExtensions.cs
@@ -166,7 +166,9 @@ internal static class RazorSyntaxNodeExtensions
             {
                 var previousToken = token.GetPreviousToken(includeWhitespace);
 
-                if (previousToken.Kind != SyntaxKind.Marker || previousToken.Position != foundPosition)
+                if (previousToken is null ||
+                    previousToken.Kind != SyntaxKind.Marker ||
+                    previousToken.Position != foundPosition)
                 {
                     break;
                 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/FormattingVisitor.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/FormattingVisitor.cs
@@ -408,7 +408,20 @@ internal class FormattingVisitor : RazorSyntaxWalker
 
     public override void VisitCSharpStatementLiteral(CSharpStatementLiteralSyntax node)
     {
-        WriteSpan(node, FormattingSpanKind.Code);
+        // Workaround for a quirk of runtime code gen, where an empty marker is inserted before the close brace
+        // of an explicit expression. ie, at the $$ below:
+        //
+        // @{
+        //     something
+        // $$}
+        //
+        // Writing a span for this empty marker will cause the close brace to be incorrectly indented, because its seen as
+        // being "inside" the block.
+        if (node.LiteralTokens is not [{ Kind: SyntaxKind.Marker }])
+        {
+            WriteSpan(node, FormattingSpanKind.Code);
+        }
+
         base.VisitCSharpStatementLiteral(node);
     }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpFormattingPass.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpFormattingPass.cs
@@ -55,7 +55,7 @@ internal sealed class CSharpFormattingPass(
 
         cancellationToken.ThrowIfCancellationRequested();
 
-        var indentationChanges = await AdjustIndentationAsync(changedContext, startLine: 0, endLineInclusive: changedText.Lines.Count - 1, roslynWorkspaceHelper.HostWorkspaceServices, cancellationToken).ConfigureAwait(false);
+        var indentationChanges = await AdjustIndentationAsync(changedContext, startLine: 0, endLineInclusive: changedText.Lines.Count - 1, roslynWorkspaceHelper.HostWorkspaceServices, _logger, cancellationToken).ConfigureAwait(false);
         if (indentationChanges.Length > 0)
         {
             // Apply the edits that modify indentation.
@@ -63,6 +63,8 @@ internal sealed class CSharpFormattingPass(
 
             _logger.LogTestOnly($"After AdjustIndentationAsync:\r\n{changedText}");
         }
+
+        _logger.LogTestOnly($"Source Mappings:\r\n{string.Join(Environment.NewLine, context.CodeDocument.GetCSharpDocument().SourceMappings)}");
 
         _logger.LogTestOnly($"Generated C#:\r\n{context.CSharpSourceText}");
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpFormattingPassBase.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpFormattingPassBase.cs
@@ -164,8 +164,6 @@ internal abstract partial class CSharpFormattingPassBase(IDocumentMappingService
             }
         }
 
-        logger.LogTestOnly($"Significant locations:\r\n{string.Join(",", significantLocations)}");
-
         // Now, invoke the C# formatter to obtain the CSharpDesiredIndentation for all significant locations.
         var significantLocationIndentation = await CSharpFormatter.GetCSharpIndentationAsync(context, significantLocations, hostWorkspaceServices, cancellationToken).ConfigureAwait(false);
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpOnTypeFormattingPass.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpOnTypeFormattingPass.cs
@@ -167,7 +167,7 @@ internal sealed class CSharpOnTypeFormattingPass(
 
         Debug.Assert(cleanedText.Lines.Count > endLineInclusive, "Invalid range. This is unexpected.");
 
-        var indentationChanges = await AdjustIndentationAsync(changedContext, startLine, endLineInclusive, roslynWorkspaceHelper.HostWorkspaceServices, cancellationToken).ConfigureAwait(false);
+        var indentationChanges = await AdjustIndentationAsync(changedContext, startLine, endLineInclusive, roslynWorkspaceHelper.HostWorkspaceServices, _logger, cancellationToken).ConfigureAwait(false);
         if (indentationChanges.Length > 0)
         {
             // Apply the edits that modify indentation.

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/RazorFormattingPass.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/RazorFormattingPass.cs
@@ -93,13 +93,13 @@ internal sealed class RazorFormattingPass(ILoggerFactory loggerFactory) : IForma
         if (node is CSharpCodeBlockSyntax directiveCode &&
             directiveCode.Children is [RazorDirectiveSyntax directive, ..] &&
             directive.DirectiveDescriptor?.Directive == SectionDirective.Directive.Directive &&
-            directive.Body is RazorDirectiveBodySyntax { CSharpCode: { } code })
+            directive.Body is RazorDirectiveBodySyntax { CSharpCode: { Children: var children } })
         {
             // Section directives are really annoying in their implementation, and we have some code in the C# formatting pass
             // to work around those annoyances, but if the section content has no C# mappings then that code won't get hit.
             // Fortunately for a Html-only section block, the indentation is entirely handled by the Html formatter, and we
             // just need to push it out one level, because the Html formatter will have pushed it back to position 0.
-            if (code.Children is [.., MarkupBlockSyntax block, RazorMetaCodeSyntax /* close brace */] &&
+            if (children is [.., MarkupBlockSyntax block, RazorMetaCodeSyntax /* close brace */] &&
                 !context.CodeDocument.GetCSharpDocument().SourceMappings.Any(m => block.Span.Contains(m.OriginalSpan.AbsoluteIndex)))
             {
                 // The Html formatter will have "collapsed" the @section block contents to 0 indent, so we push it back out
@@ -114,7 +114,6 @@ internal sealed class RazorFormattingPass(ILoggerFactory loggerFactory) : IForma
                 }
             }
 
-            var children = code.Children;
             if (TryGetWhitespace(children, out var whitespaceBeforeSectionName, out var whitespaceAfterSectionName))
             {
                 // For whitespace we normalize it differently depending on if its multi-line or not

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/RazorFormattingPass.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/RazorFormattingPass.cs
@@ -146,7 +146,10 @@ internal sealed class RazorFormattingPass(ILoggerFactory loggerFactory) : IForma
         // @code
         // {
         // }
-        if (node is CSharpCodeBlockSyntax { Children: [RazorDirectiveSyntax { Body: RazorDirectiveBodySyntax body } directive] })
+
+        // In design time code gen, there is only one child of a node like this, but at runtime any leading whitespace is included
+        // as a child, so we handle both cases by just checking the last child.
+        if (node is CSharpCodeBlockSyntax { Children: [.., RazorDirectiveSyntax { Body: RazorDirectiveBodySyntax body } directive] })
         {
             if (!IsCodeOrFunctionsBlock(body.Keyword))
             {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/RazorFormattingPass.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/RazorFormattingPass.cs
@@ -392,7 +392,8 @@ internal sealed class RazorFormattingPass(ILoggerFactory loggerFactory) : IForma
                 changes.Add(new TextChange(source.Text.GetTextSpan(span), newText));
                 didFormat = true;
             }
-            else if (codeRange.End.Line == closeBraceRange.Start.Line)
+            else if (codeRange.End.Line == closeBraceRange.Start.Line &&
+                codeNode.GetLastToken(includeZeroWidth: false) is not { Kind: SyntaxKind.NewLine })
             {
                 // Add a Newline between the content and the "}" if one doesn't already exist.
                 changes.Add(new TextChange(source.Text.GetTextSpan(codeRange.End, codeRange.End), context.NewLineString));

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/RazorFormattingPass.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/RazorFormattingPass.cs
@@ -183,8 +183,9 @@ internal sealed class RazorFormattingPass(ILoggerFactory loggerFactory) : IForma
         // @{
         //     var x = 1;
         // }
+        // Using LastOrDefault because runtime code-gen puts whitespace before the statement
         if (node is CSharpCodeBlockSyntax explicitCode &&
-            explicitCode.Children.FirstOrDefault() is CSharpStatementSyntax statement &&
+            explicitCode.Children.LastOrDefault() is CSharpStatementSyntax statement &&
             statement.Body is CSharpStatementBodySyntax csharpStatementBody)
         {
             var openBraceNode = csharpStatementBody.OpenBrace;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/RazorFormattingService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/RazorFormattingService.cs
@@ -49,7 +49,7 @@ internal class RazorFormattingService : IRazorFormattingService
         _documentFormattingPasses =
         [
             new HtmlFormattingPass(loggerFactory),
-            new RazorFormattingPass(),
+            new RazorFormattingPass(loggerFactory),
             new CSharpFormattingPass(documentMappingService, hostServicesProvider, loggerFactory),
             .. _validationPasses
         ];

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/DocumentFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/DocumentFormattingTest.cs
@@ -1147,6 +1147,22 @@ public class DocumentFormattingTest(FormattingTestContext context, HtmlFormattin
                     </div>
                     }
 
+                    @{
+                    <div class="FF"
+                        id="ERT">
+                        @{
+                    <div class="FF"
+                        id="ERT">
+                        asdf
+                        <div class="3"
+                            id="3">
+                                @if(true){<p></p>}
+                            </div>
+                    </div>
+                    }
+                    </div>
+                    }
+
                     @functions {
                             public class Foo
                         {
@@ -1187,6 +1203,25 @@ public class DocumentFormattingTest(FormattingTestContext context, HtmlFormattin
                                     <p></p>
                                 }
                             </div>
+                        </div>
+                    }
+
+                    @{
+                        <div class="FF"
+                             id="ERT">
+                            @{
+                                <div class="FF"
+                                     id="ERT">
+                                    asdf
+                                    <div class="3"
+                                         id="3">
+                                        @if (true)
+                                        {
+                                            <p></p>
+                                        }
+                                    </div>
+                                </div>
+                            }
                         </div>
                     }
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/DocumentFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/DocumentFormattingTest.cs
@@ -4128,6 +4128,93 @@ public class DocumentFormattingTest(FormattingTestContext context, HtmlFormattin
 
     [FormattingTestFact]
     [WorkItem("https://github.com/dotnet/aspnetcore/issues/4498")]
+    public async Task IfBlock_TopLevel_WithOtherCode2()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                    @{
+
+                        // foo
+
+                            // foo
+
+                    }
+
+                            @if (true)
+                    {
+                    }
+                    """,
+            expected: """
+                    @{
+
+                        // foo
+
+                        // foo
+
+                    }
+
+                    @if (true)
+                    {
+                    }
+                    """);
+    }
+
+    [FormattingTestFact]
+    [WorkItem("https://github.com/dotnet/aspnetcore/issues/4498")]
+    public async Task IfBlock_TopLevel_WithOtherCode3()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                    @{
+                        var x = 3;
+
+                        // foo
+                    }
+
+                            @if (true)
+                    {
+                    }
+                    """,
+            expected: """
+                    @{
+                        var x = 3;
+
+                        // foo
+                    }
+
+                    @if (true)
+                    {
+                    }
+                    """);
+    }
+
+    [FormattingTestFact]
+    [WorkItem("https://github.com/dotnet/aspnetcore/issues/4498")]
+    public async Task IfBlock_TopLevel_WithOtherCode4()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                    @{
+                        var x = 3;
+                    }
+
+                            @if (true)
+                    {
+                    }
+                    """,
+            expected: """
+                    @{
+                        var x = 3;
+                    }
+
+                    @if (true)
+                    {
+                    }
+                    """);
+    }
+
+    [FormattingTestFact]
+    [WorkItem("https://github.com/dotnet/aspnetcore/issues/4498")]
     public async Task IfBlock_Nested()
     {
         await RunFormattingTestAsync(

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/DocumentFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/DocumentFormattingTest.cs
@@ -2972,6 +2972,103 @@ public class DocumentFormattingTest(FormattingTestContext context, HtmlFormattin
     }
 
     [FormattingTestFact]
+    public async Task Format_SectionDirectiveBlock8()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                    @functions {
+                     public class Foo{
+                    void Method() {  }
+                        }
+                    }
+
+                    @section Scripts {
+                    <p>this is a para</p>
+                    @if(true)
+                    {
+                    <p>and so is this</p>
+                    }
+                    <p>and finally this</p>
+                    }
+                    """,
+            expected: """
+                    @functions {
+                        public class Foo
+                        {
+                            void Method() { }
+                        }
+                    }
+
+                    @section Scripts {
+                        <p>this is a para</p>
+                        @if (true)
+                        {
+                            <p>and so is this</p>
+                        }
+                        <p>and finally this</p>
+                    }
+                    """,
+            fileKind: FileKinds.Legacy);
+    }
+
+    [FormattingTestFact]
+    public async Task Format_SectionDirectiveBlock9()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                    @functions {
+                     public class Foo{
+                    void Method() {  }
+                        }
+                    }
+
+                    @section Scripts {
+                    <p>this is a para</p>
+                    @if(true)
+                    {
+                    <p>and so is this</p>
+                    }
+                    <p>and finally this</p>
+                    }
+
+                    <p>I lied when I said finally</p>
+
+                    @functions {
+                     public class Foo2{
+                    void Method() {  }
+                        }
+                    }
+                    """,
+            expected: """
+                    @functions {
+                        public class Foo
+                        {
+                            void Method() { }
+                        }
+                    }
+
+                    @section Scripts {
+                        <p>this is a para</p>
+                        @if (true)
+                        {
+                            <p>and so is this</p>
+                        }
+                        <p>and finally this</p>
+                    }
+
+                    <p>I lied when I said finally</p>
+
+                    @functions {
+                        public class Foo2
+                        {
+                            void Method() { }
+                        }
+                    }
+                    """,
+            fileKind: FileKinds.Legacy);
+    }
+
+    [FormattingTestFact]
     public async Task Formats_CodeBlockDirectiveWithRazorComments()
     {
         await RunFormattingTestAsync(


### PR DESCRIPTION
Part of https://github.com/dotnet/razor/issues/10402

This PR makes various updates to our formatting engine to allow it to run on runtime code-gen. After this PR there are still 5 formatting tests that fail, representing two different bugs (the one in the issue, and a cascading value parameter issue), but those are proving very stubborn, so thought I'd put this up first. Plus it's Friday afternoon :)

Comments in the code hopefully explain what is going on, but honestly, it doesn't matter if anyone understands the formatting engine, as long as the tests pass :D

Each commit is a self-contained change for those who are extra curious about which bit fixes which failure.