### PR TITLE
Filter out CSS002 when it appears in an "@@"

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Diagnostics/CSSErrorCodes.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Diagnostics/CSSErrorCodes.cs
@@ -6,6 +6,7 @@ namespace Microsoft.CodeAnalysis.Razor.Diagnostics;
 // Note: This type should be kept in sync with WTE's ErrorCodes.cs
 internal static class CSSErrorCodes
 {
+    public const string UnrecognizedBlockType = "CSS002";
     public const string MissingOpeningBrace = "CSS023";
     public const string MissingSelectorAfterCombinator = "CSS029";
     public const string MissingSelectorBeforeCombinatorCode = "CSS031";


### PR DESCRIPTION
Filters out the main user frustration arising from https://github.com/dotnet/razor/issues/7349