### PR TITLE
Only show element hover information when hovering over an element in a `.razor` file

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Hover/HoverFactory.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Hover/HoverFactory.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.Threading;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Tooltip;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Editor.Razor;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -224,7 +225,11 @@ internal static class HoverFactory
         ISolutionQueryOperations solutionQueryOperations,
         CancellationToken cancellationToken)
     {
-        var descriptionInfos = descriptors.SelectAsArray(BoundElementDescriptionInfo.From);
+        // Filter out attribute descriptors since we're creating an element hover
+        var keepAttributeInfo = FileKinds.GetFileKindFromFilePath(documentFilePath) == FileKinds.Legacy;
+        var descriptionInfos = descriptors
+            .Where(d => keepAttributeInfo || !d.IsAttributeDescriptor())
+            .SelectAsArray(BoundElementDescriptionInfo.From);
         var elementDescriptionInfo = new AggregateBoundElementDescription(descriptionInfos);
 
         if (options.SupportsVisualStudioExtensions)

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostHoverEndpointTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostHoverEndpointTest.cs
@@ -145,6 +145,44 @@ public class CohostHoverEndpointTest(ITestOutputHelper testOutputHelper) : Cohos
         });
     }
 
+    [Fact]
+    public async Task Component_WithCallbacks()
+    {
+        TestCode code = """
+            <[|Inpu$$tText|] ValueChanged="Foo"
+                       DisplayName="Foo"
+                       @onchange="Foo"
+                       @onfocus="Foo"
+                       @onblur="Foo" />
+
+            @code {
+                private void Foo()
+                {
+                }
+            }
+            """;
+
+        await VerifyHoverAsync(code, async (hover, document) =>
+        {
+            await hover.VerifyRangeAsync(code.Span, document);
+
+            hover.VerifyRawContent(
+                Container(
+                    Container(
+                        Image,
+                        ClassifiedText( // Microsoft.ApsNetCore.Components.Forms.InputText
+                            Text("Microsoft"),
+                            Punctuation("."),
+                            Text("AspNetCore"),
+                            Punctuation("."),
+                            Text("Components"),
+                            Punctuation("."),
+                            Text("Forms"),
+                            Punctuation("."),
+                            Type("InputText")))));
+        });
+    }
+
     private async Task VerifyHoverAsync(TestCode input, Func<RoslynHover, TextDocument, Task> verifyHover)
     {
         var document = await CreateProjectAndRazorDocumentAsync(input.Text);


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/11335

Event callbacks on components use the tag helper infrastructure internally in the compiler, but it makes sense to me to have different rules applied to them when it comes to showing hover info. Leaving the existing code as is for `.cshtml` files is entirely deliberate.

Before:
![Before](https://github.com/user-attachments/assets/d8d9c17f-04a2-48a6-aef3-343a54dd14b9)

After:
![image](https://github.com/user-attachments/assets/047e1804-5c71-48df-97c0-0ddf6e488148)
