### PR TITLE
Fix completion at end of document

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/DelegatedCompletionHelper.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/DelegatedCompletionHelper.cs
@@ -207,6 +207,15 @@ internal static class DelegatedCompletionHelper
         var tree = razorCodeDocument.GetSyntaxTree();
 
         var token = tree.Root.FindToken(absoluteIndex, includeWhitespace: false);
+        if (token.Kind == SyntaxKind.EndOfFile &&
+            absoluteIndex > 0)
+        {
+            // If we're at the end of the file, we check if the previous token is an open angle (ie, we're in <$$[EOF])
+            // because even though the tree won't match our expectations for an incomplete start tag, thats what it is.
+            token = tree.Root.FindToken(absoluteIndex - 1, includeWhitespace: false);
+            return token.Kind is not SyntaxKind.OpenAngle;
+        }
+
         var node = token.Parent;
         var startOrEndTag = node?.FirstAncestorOrSelf<SyntaxNode>(n => RazorSyntaxFacts.IsAnyStartTag(n) || RazorSyntaxFacts.IsAnyEndTag(n));
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionListProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionListProviderTest.cs
@@ -292,7 +292,7 @@ public class DelegatedCompletionListProviderTest : LanguageServerTestBase
 
     [Theory]
     [InlineData("$$", true)]
-    [InlineData("<$$", true)]
+    [InlineData("<$$", false)]
     [InlineData(">$$", true)]
     [InlineData("$$<", true)]
     [InlineData("$$>", false)] // This is the only case that returns false but should return true. It's unlikely a user will type this, but it's complex to solve. Consider this a known and acceptable bug.

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentCompletionEndpointTest.cs
@@ -329,7 +329,8 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
                  TriggerCharacter = null,
                  TriggerKind = RoslynCompletionTriggerKind.Invoked
              },
-             expectedItemLabels: ["snippet1", "snippet2"]);
+             expectedItemLabels: ["snippet1", "snippet2"],
+             snippetLabels: ["snippet1", "snippet2"]);
     }
 
     [Fact]
@@ -351,7 +352,8 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
              },
              expectedItemLabels: ["style", "dir"],
              unexpectedItemLabels: ["snippet1", "snippet2"],
-             delegatedItemLabels: ["style", "dir"]);
+             delegatedItemLabels: ["style", "dir"],
+             snippetLabels: ["snippet1", "snippet2"]);
     }
 
     // Tests HTML attributes and DirectiveAttributeTransitionCompletionItemProvider
@@ -520,9 +522,11 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
         var requestInvoker = new TestLSPRequestInvoker([(Methods.TextDocumentCompletionName, response)]);
 
         var snippetCompletionItemProvider = new SnippetCompletionItemProvider(new SnippetCache());
-        snippetCompletionItemProvider.SnippetCache.Update(SnippetLanguage.Html, [
-            new SnippetInfo("snippet1", "snippet1", "snippet1", string.Empty, SnippetLanguage.Html),
-            new SnippetInfo("snippet2", "snippet2", "snippet2", string.Empty, SnippetLanguage.Html)]);
+        if (snippetLabels is not null)
+        {
+            var snippetInfos = snippetLabels.Select(label => new SnippetInfo(label, label, label, string.Empty, SnippetLanguage.Html)).ToImmutableArray();
+            snippetCompletionItemProvider.SnippetCache.Update(SnippetLanguage.Html, snippetInfos);
+        }
 
         var endpoint = new CohostDocumentCompletionEndpoint(
             RemoteServiceInvoker,

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentCompletionEndpointTest.cs
@@ -26,9 +26,6 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 
 public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHelper) : CohostEndpointTestBase(testOutputHelper)
 {
-    private const string HtmlSnippet1 = "snippet1";
-    private const string HtmlSnippet2 = "snippet2";
-
     [Theory]
     [CombinatorialData]
     public async Task CSharpInEmptyExplicitStatement(bool fuse)
@@ -289,7 +286,7 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
              },
              expectedItemLabels: ["div", "h1", "LayoutView", "EditForm", "ValidationMessage"],
              delegatedItemLabels: ["div", "h1"],
-             unexpectedItemLabels: [HtmlSnippet1, HtmlSnippet2]);
+             unexpectedItemLabels: ["snippet1", "snippet2"]);
     }
 
     [Fact]
@@ -332,7 +329,7 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
                  TriggerCharacter = null,
                  TriggerKind = RoslynCompletionTriggerKind.Invoked
              },
-             expectedItemLabels: [HtmlSnippet1, HtmlSnippet2]);
+             expectedItemLabels: ["snippet1", "snippet2"]);
     }
 
     [Fact]
@@ -353,7 +350,7 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
                  TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
              },
              expectedItemLabels: ["style", "dir"],
-             unexpectedItemLabels: [HtmlSnippet1, HtmlSnippet2],
+             unexpectedItemLabels: ["snippet1", "snippet2"],
              delegatedItemLabels: ["style", "dir"]);
     }
 
@@ -524,8 +521,8 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
 
         var snippetCompletionItemProvider = new SnippetCompletionItemProvider(new SnippetCache());
         snippetCompletionItemProvider.SnippetCache.Update(SnippetLanguage.Html, [
-            new SnippetInfo(HtmlSnippet1, "snippet1", "snippet1", string.Empty, SnippetLanguage.Html),
-            new SnippetInfo(HtmlSnippet2, "snippet2", "snippet2", string.Empty, SnippetLanguage.Html)]);
+            new SnippetInfo("snippet1", "snippet1", "snippet1", string.Empty, SnippetLanguage.Html),
+            new SnippetInfo("snippet2", "snippet2", "snippet2", string.Empty, SnippetLanguage.Html)]);
 
         var endpoint = new CohostDocumentCompletionEndpoint(
             RemoteServiceInvoker,

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentCompletionEndpointTest.cs
@@ -26,6 +26,9 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 
 public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHelper) : CohostEndpointTestBase(testOutputHelper)
 {
+    private const string HtmlSnippet1 = "snippet1";
+    private const string HtmlSnippet2 = "snippet2";
+
     [Theory]
     [CombinatorialData]
     public async Task CSharpInEmptyExplicitStatement(bool fuse)
@@ -286,7 +289,7 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
              },
              expectedItemLabels: ["div", "h1", "LayoutView", "EditForm", "ValidationMessage"],
              delegatedItemLabels: ["div", "h1"],
-             unexpectedItemLabels: ["snippet1", "snippet2"]);
+             unexpectedItemLabels: [HtmlSnippet1, HtmlSnippet2]);
     }
 
     [Fact]
@@ -329,7 +332,7 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
                  TriggerCharacter = null,
                  TriggerKind = RoslynCompletionTriggerKind.Invoked
              },
-             expectedItemLabels: ["snippet1", "snippet2"]);
+             expectedItemLabels: [HtmlSnippet1, HtmlSnippet2]);
     }
 
     [Fact]
@@ -350,7 +353,7 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
                  TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
              },
              expectedItemLabels: ["style", "dir"],
-             unexpectedItemLabels: ["snippet1", "snippet2"],
+             unexpectedItemLabels: [HtmlSnippet1, HtmlSnippet2],
              delegatedItemLabels: ["style", "dir"]);
     }
 
@@ -521,8 +524,8 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
 
         var snippetCompletionItemProvider = new SnippetCompletionItemProvider(new SnippetCache());
         snippetCompletionItemProvider.SnippetCache.Update(SnippetLanguage.Html, [
-            new SnippetInfo("snippet1", "snippet1", "snippet1", string.Empty, SnippetLanguage.Html),
-            new SnippetInfo("snippet2", "snippet2", "snippet2", string.Empty, SnippetLanguage.Html)]);
+            new SnippetInfo(HtmlSnippet1, "snippet1", "snippet1", string.Empty, SnippetLanguage.Html),
+            new SnippetInfo(HtmlSnippet2, "snippet2", "snippet2", string.Empty, SnippetLanguage.Html)]);
 
         var endpoint = new CohostDocumentCompletionEndpoint(
             RemoteServiceInvoker,

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentCompletionEndpointTest.cs
@@ -442,6 +442,25 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
     }
 
     [Fact]
+    public async Task HtmlAttributeNamesAndTagHelpersCompletion_EndOfDocument()
+    {
+        await VerifyCompletionListAsync(
+            input: """
+                This is a Razor document.
+
+                <EditForm $$
+                """,
+             completionContext: new RoslynVSInternalCompletionContext()
+             {
+                 InvokeKind = RoslynVSInternalCompletionInvokeKind.Explicit,
+                 TriggerCharacter = null,
+                 TriggerKind = RoslynCompletionTriggerKind.Invoked
+             },
+             expectedItemLabels: ["style", "dir", "FormName", "OnValidSubmit", "@..."],
+             delegatedItemLabels: ["style", "dir"]);
+    }
+
+    [Fact]
     public async Task TagHelperAttributes_NoAutoInsertQuotes_Completion()
     {
         await VerifyCompletionListAsync(
@@ -469,7 +488,6 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
         string[]? unexpectedItemLabels = null,
         string[]? delegatedItemLabels = null,
         string[]? delegatedItemCommitCharacters = null,
-        string[]? snippetLabels = null,
         bool autoInsertAttributeQuotes = true,
         bool commitElementsWithSpace = true,
         bool fuse = false)

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentCompletionEndpointTest.cs
@@ -40,13 +40,13 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
 
                 The end.
                 """,
-             completionContext: new RoslynVSInternalCompletionContext()
-             {
-                 InvokeKind = RoslynVSInternalCompletionInvokeKind.Explicit,
-                 TriggerKind = RoslynCompletionTriggerKind.Invoked
-             },
-             expectedItemLabels: ["var", "char", "DateTime", "Exception"],
-             fuse: fuse);
+            completionContext: new RoslynVSInternalCompletionContext()
+            {
+                InvokeKind = RoslynVSInternalCompletionInvokeKind.Explicit,
+                TriggerKind = RoslynCompletionTriggerKind.Invoked
+            },
+            expectedItemLabels: ["var", "char", "DateTime", "Exception"],
+            fuse: fuse);
     }
 
     [Fact]
@@ -60,13 +60,13 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
 
                 The end.
                 """,
-             completionContext: new RoslynVSInternalCompletionContext()
-             {
-                 InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
-                 TriggerCharacter = "@",
-                 TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
-             },
-             expectedItemLabels: ["char", "DateTime", "Exception"]);
+            completionContext: new RoslynVSInternalCompletionContext()
+            {
+                InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
+                TriggerCharacter = "@",
+                TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
+            },
+            expectedItemLabels: ["char", "DateTime", "Exception"]);
     }
 
     [Fact]
@@ -80,13 +80,13 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
 
                 The end.
                 """,
-             completionContext: new RoslynVSInternalCompletionContext()
-             {
-                 InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
-                 TriggerCharacter = ".",
-                 TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
-             },
-             expectedItemLabels: ["DaysInMonth", "IsLeapYear", "Now"]);
+            completionContext: new RoslynVSInternalCompletionContext()
+            {
+                InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
+                TriggerCharacter = ".",
+                TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
+            },
+            expectedItemLabels: ["DaysInMonth", "IsLeapYear", "Now"]);
     }
 
     [Fact]
@@ -102,13 +102,13 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
 
                 The end.
                 """,
-             completionContext: new RoslynVSInternalCompletionContext()
-             {
-                 InvokeKind = RoslynVSInternalCompletionInvokeKind.Explicit,
-                 TriggerCharacter = null,
-                 TriggerKind = RoslynCompletionTriggerKind.Invoked
-             },
-             expectedItemLabels: ["char", "DateTime", "Exception"]);
+            completionContext: new RoslynVSInternalCompletionContext()
+            {
+                InvokeKind = RoslynVSInternalCompletionInvokeKind.Explicit,
+                TriggerCharacter = null,
+                TriggerKind = RoslynCompletionTriggerKind.Invoked
+            },
+            expectedItemLabels: ["char", "DateTime", "Exception"]);
     }
 
     [Fact]
@@ -129,13 +129,13 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
 
                 The end.
                 """,
-             completionContext: new RoslynVSInternalCompletionContext()
-             {
-                 InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
-                 TriggerCharacter = ".",
-                 TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
-             },
-             expectedItemLabels: ["DaysInMonth", "IsLeapYear", "Now"]);
+            completionContext: new RoslynVSInternalCompletionContext()
+            {
+                InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
+                TriggerCharacter = ".",
+                TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
+            },
+            expectedItemLabels: ["DaysInMonth", "IsLeapYear", "Now"]);
     }
 
     [Fact]
@@ -151,13 +151,13 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
 
                 The end.
                 """,
-             completionContext: new RoslynVSInternalCompletionContext()
-             {
-                 InvokeKind = RoslynVSInternalCompletionInvokeKind.Explicit,
-                 TriggerCharacter = null,
-                 TriggerKind = RoslynCompletionTriggerKind.Invoked
-             },
-             expectedItemLabels: ["Equals(object? obj)", "GetHashCode()", "SetParametersAsync(ParameterView parameters)", "ToString()"]);
+            completionContext: new RoslynVSInternalCompletionContext()
+            {
+                InvokeKind = RoslynVSInternalCompletionInvokeKind.Explicit,
+                TriggerCharacter = null,
+                TriggerKind = RoslynCompletionTriggerKind.Invoked
+            },
+            expectedItemLabels: ["Equals(object? obj)", "GetHashCode()", "SetParametersAsync(ParameterView parameters)", "ToString()"]);
     }
 
     // Tests MarkupTransitionCompletionItemProvider
@@ -179,14 +179,14 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
 
                 The end.
                 """,
-             completionContext: new RoslynVSInternalCompletionContext()
-             {
-                 InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
-                 TriggerCharacter = "<",
-                 TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
-             },
-             expectedItemLabels: ["text", "EditForm", "InputDate", "div"],
-             delegatedItemLabels: ["div"]);
+            completionContext: new RoslynVSInternalCompletionContext()
+            {
+                InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
+                TriggerCharacter = "<",
+                TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
+            },
+            expectedItemLabels: ["text", "EditForm", "InputDate", "div"],
+            delegatedItemLabels: ["div"]);
     }
 
     [Fact]
@@ -220,13 +220,13 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
 
                 The end.
                 """,
-             completionContext: new RoslynVSInternalCompletionContext()
-             {
-                 InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
-                 TriggerCharacter = "@",
-                 TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
-             },
-             expectedItemLabels: expectedLabels);
+            completionContext: new RoslynVSInternalCompletionContext()
+            {
+                InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
+                TriggerCharacter = "@",
+                TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
+            },
+            expectedItemLabels: expectedLabels);
     }
 
     [Fact]
@@ -240,14 +240,14 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
 
                 The end.
                 """,
-             completionContext: new RoslynVSInternalCompletionContext()
-             {
-                 InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
-                 TriggerCharacter = "<",
-                 TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
-             },
-             expectedItemLabels: ["LayoutView", "EditForm", "ValidationMessage", "div"],
-             delegatedItemLabels: ["div"]);
+            completionContext: new RoslynVSInternalCompletionContext()
+            {
+                InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
+                TriggerCharacter = "<",
+                TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
+            },
+            expectedItemLabels: ["LayoutView", "EditForm", "ValidationMessage", "div"],
+            delegatedItemLabels: ["div"]);
     }
 
     [Fact]
@@ -261,14 +261,14 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
 
                 The end.
                 """,
-             completionContext: new RoslynVSInternalCompletionContext()
-             {
-                 InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
-                 TriggerCharacter = "<",
-                 TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
-             },
-             expectedItemLabels: ["div", "h1", "LayoutView", "EditForm", "ValidationMessage"],
-             delegatedItemLabels: ["div", "h1"]);
+            completionContext: new RoslynVSInternalCompletionContext()
+            {
+                InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
+                TriggerCharacter = "<",
+                TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
+            },
+            expectedItemLabels: ["div", "h1", "LayoutView", "EditForm", "ValidationMessage"],
+            delegatedItemLabels: ["div", "h1"]);
     }
 
     [Fact]
@@ -280,15 +280,15 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
 
                 <$$
                 """,
-             completionContext: new RoslynVSInternalCompletionContext()
-             {
-                 InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
-                 TriggerCharacter = "<",
-                 TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
-             },
-             expectedItemLabels: ["div", "h1", "LayoutView", "EditForm", "ValidationMessage"],
-             delegatedItemLabels: ["div", "h1"],
-             unexpectedItemLabels: ["snippet1", "snippet2"]);
+            completionContext: new RoslynVSInternalCompletionContext()
+            {
+                InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
+                TriggerCharacter = "<",
+                TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
+            },
+            expectedItemLabels: ["div", "h1", "LayoutView", "EditForm", "ValidationMessage"],
+            delegatedItemLabels: ["div", "h1"],
+            unexpectedItemLabels: ["snippet1", "snippet2"]);
     }
 
     [Fact]
@@ -302,16 +302,16 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
 
                 The end.
                 """,
-             completionContext: new RoslynVSInternalCompletionContext()
-             {
-                 InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
-                 TriggerCharacter = "<",
-                 TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
-             },
-             expectedItemLabels: ["div", "h1", "LayoutView", "EditForm", "ValidationMessage"],
-             delegatedItemLabels: ["div", "h1"],
-             delegatedItemCommitCharacters: [" ", ">"],
-             commitElementsWithSpace: false);
+            completionContext: new RoslynVSInternalCompletionContext()
+            {
+                InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
+                TriggerCharacter = "<",
+                TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
+            },
+            expectedItemLabels: ["div", "h1", "LayoutView", "EditForm", "ValidationMessage"],
+            delegatedItemLabels: ["div", "h1"],
+            delegatedItemCommitCharacters: [" ", ">"],
+            commitElementsWithSpace: false);
     }
 
     [Fact]
@@ -325,15 +325,15 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
 
                 The end.
                 """,
-             completionContext: new RoslynVSInternalCompletionContext()
-             {
-                 InvokeKind = RoslynVSInternalCompletionInvokeKind.Explicit,
-                 TriggerCharacter = null,
-                 TriggerKind = RoslynCompletionTriggerKind.Invoked
-             },
-             expectedItemLabels: ["snippet1", "snippet2"],
-             delegatedItemLabels: [],
-             snippetLabels: ["snippet1", "snippet2"]);
+            completionContext: new RoslynVSInternalCompletionContext()
+            {
+                InvokeKind = RoslynVSInternalCompletionInvokeKind.Explicit,
+                TriggerCharacter = null,
+                TriggerKind = RoslynCompletionTriggerKind.Invoked
+            },
+            expectedItemLabels: ["snippet1", "snippet2"],
+            delegatedItemLabels: [],
+            snippetLabels: ["snippet1", "snippet2"]);
     }
 
     [Fact]
@@ -343,14 +343,15 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
             input: """
                 $$
                 """,
-             completionContext: new RoslynVSInternalCompletionContext()
-             {
-                 InvokeKind = RoslynVSInternalCompletionInvokeKind.Explicit,
-                 TriggerCharacter = null,
-                 TriggerKind = RoslynCompletionTriggerKind.Invoked
-             },
-             expectedItemLabels: ["snippet1", "snippet2"],
-             snippetLabels: ["snippet1", "snippet2"]);
+            completionContext: new RoslynVSInternalCompletionContext()
+            {
+                InvokeKind = RoslynVSInternalCompletionInvokeKind.Explicit,
+                TriggerCharacter = null,
+                TriggerKind = RoslynCompletionTriggerKind.Invoked
+            },
+            expectedItemLabels: ["snippet1", "snippet2"],
+            delegatedItemLabels: [],
+            snippetLabels: ["snippet1", "snippet2"]);
     }
 
     [Fact]
@@ -361,14 +362,15 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
 
                 $$
                 """,
-             completionContext: new RoslynVSInternalCompletionContext()
-             {
-                 InvokeKind = RoslynVSInternalCompletionInvokeKind.Explicit,
-                 TriggerCharacter = null,
-                 TriggerKind = RoslynCompletionTriggerKind.Invoked
-             },
-             expectedItemLabels: ["snippet1", "snippet2"],
-             snippetLabels: ["snippet1", "snippet2"]);
+            completionContext: new RoslynVSInternalCompletionContext()
+            {
+                InvokeKind = RoslynVSInternalCompletionInvokeKind.Explicit,
+                TriggerCharacter = null,
+                TriggerKind = RoslynCompletionTriggerKind.Invoked
+            },
+            expectedItemLabels: ["snippet1", "snippet2"],
+            delegatedItemLabels: [],
+            snippetLabels: ["snippet1", "snippet2"]);
     }
 
     [Fact]
@@ -379,14 +381,15 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
                 $$
 
                 """,
-             completionContext: new RoslynVSInternalCompletionContext()
-             {
-                 InvokeKind = RoslynVSInternalCompletionInvokeKind.Explicit,
-                 TriggerCharacter = null,
-                 TriggerKind = RoslynCompletionTriggerKind.Invoked
-             },
-             expectedItemLabels: ["snippet1", "snippet2"],
-             snippetLabels: ["snippet1", "snippet2"]);
+            completionContext: new RoslynVSInternalCompletionContext()
+            {
+                InvokeKind = RoslynVSInternalCompletionInvokeKind.Explicit,
+                TriggerCharacter = null,
+                TriggerKind = RoslynCompletionTriggerKind.Invoked
+            },
+            expectedItemLabels: ["snippet1", "snippet2"],
+            delegatedItemLabels: [],
+            snippetLabels: ["snippet1", "snippet2"]);
     }
 
     [Fact]
@@ -400,16 +403,16 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
 
                 The end.
                 """,
-             completionContext: new RoslynVSInternalCompletionContext()
-             {
-                 InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
-                 TriggerCharacter = " ",
-                 TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
-             },
-             expectedItemLabels: ["style", "dir"],
-             unexpectedItemLabels: ["snippet1", "snippet2"],
-             delegatedItemLabels: ["style", "dir"],
-             snippetLabels: ["snippet1", "snippet2"]);
+            completionContext: new RoslynVSInternalCompletionContext()
+            {
+                InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
+                TriggerCharacter = " ",
+                TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
+            },
+            expectedItemLabels: ["style", "dir"],
+            unexpectedItemLabels: ["snippet1", "snippet2"],
+            delegatedItemLabels: ["style", "dir"],
+            snippetLabels: ["snippet1", "snippet2"]);
     }
 
     // Tests HTML attributes and DirectiveAttributeTransitionCompletionItemProvider
@@ -424,14 +427,14 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
 
                 The end.
                 """,
-             completionContext: new RoslynVSInternalCompletionContext()
-             {
-                 InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
-                 TriggerCharacter = " ",
-                 TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
-             },
-             expectedItemLabels: ["style", "dir", "@..."],
-             delegatedItemLabels: ["style", "dir"]);
+            completionContext: new RoslynVSInternalCompletionContext()
+            {
+                InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
+                TriggerCharacter = " ",
+                TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
+            },
+            expectedItemLabels: ["style", "dir", "@..."],
+            delegatedItemLabels: ["style", "dir"]);
     }
 
     // Tests HTML attributes and DirectiveAttributeCompletionItemProvider
@@ -446,14 +449,14 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
 
                 The end.
                 """,
-             completionContext: new RoslynVSInternalCompletionContext()
-             {
-                 InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
-                 TriggerCharacter = "@",
-                 TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
-             },
-             expectedItemLabels: ["style", "dir", "@rendermode", "@bind-..."],
-             delegatedItemLabels: ["style", "dir"]);
+            completionContext: new RoslynVSInternalCompletionContext()
+            {
+                InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
+                TriggerCharacter = "@",
+                TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
+            },
+            expectedItemLabels: ["style", "dir", "@rendermode", "@bind-..."],
+            delegatedItemLabels: ["style", "dir"]);
     }
 
     // Tests HTML attributes and DirectiveAttributeParameterCompletionItemProvider
@@ -468,14 +471,14 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
 
                 The end.
                 """,
-             completionContext: new RoslynVSInternalCompletionContext()
-             {
-                 InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
-                 TriggerCharacter = "f",
-                 TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
-             },
-             expectedItemLabels: ["style", "dir", "culture", "event", "format", "get", "set", "after"],
-             delegatedItemLabels: ["style", "dir"]);
+            completionContext: new RoslynVSInternalCompletionContext()
+            {
+                InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
+                TriggerCharacter = "f",
+                TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
+            },
+            expectedItemLabels: ["style", "dir", "culture", "event", "format", "get", "set", "after"],
+            delegatedItemLabels: ["style", "dir"]);
     }
 
     [Fact]
@@ -489,14 +492,14 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
 
                 The end.
                 """,
-             completionContext: new RoslynVSInternalCompletionContext()
-             {
-                 InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
-                 TriggerCharacter = " ",
-                 TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
-             },
-             expectedItemLabels: ["style", "dir", "FormName", "OnValidSubmit", "@..."],
-             delegatedItemLabels: ["style", "dir"]);
+            completionContext: new RoslynVSInternalCompletionContext()
+            {
+                InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
+                TriggerCharacter = " ",
+                TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
+            },
+            expectedItemLabels: ["style", "dir", "FormName", "OnValidSubmit", "@..."],
+            delegatedItemLabels: ["style", "dir"]);
     }
 
     [Fact]
@@ -508,14 +511,14 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
 
                 <EditForm $$
                 """,
-             completionContext: new RoslynVSInternalCompletionContext()
-             {
-                 InvokeKind = RoslynVSInternalCompletionInvokeKind.Explicit,
-                 TriggerCharacter = null,
-                 TriggerKind = RoslynCompletionTriggerKind.Invoked
-             },
-             expectedItemLabels: ["style", "dir", "FormName", "OnValidSubmit", "@..."],
-             delegatedItemLabels: ["style", "dir"]);
+            completionContext: new RoslynVSInternalCompletionContext()
+            {
+                InvokeKind = RoslynVSInternalCompletionInvokeKind.Explicit,
+                TriggerCharacter = null,
+                TriggerKind = RoslynCompletionTriggerKind.Invoked
+            },
+            expectedItemLabels: ["style", "dir", "FormName", "OnValidSubmit", "@..."],
+            delegatedItemLabels: ["style", "dir"]);
     }
 
     [Fact]
@@ -529,15 +532,15 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
 
                 The end.
                 """,
-             completionContext: new RoslynVSInternalCompletionContext()
-             {
-                 InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
-                 TriggerCharacter = " ",
-                 TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
-             },
-             expectedItemLabels: ["FormName", "OnValidSubmit", "@...", "style"],
-             delegatedItemLabels: ["style"],
-             autoInsertAttributeQuotes: false);
+            completionContext: new RoslynVSInternalCompletionContext()
+            {
+                InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
+                TriggerCharacter = " ",
+                TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
+            },
+            expectedItemLabels: ["FormName", "OnValidSubmit", "@...", "style"],
+            delegatedItemLabels: ["style"],
+            autoInsertAttributeQuotes: false);
     }
 
     private async Task VerifyCompletionListAsync(

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentCompletionEndpointTest.cs
@@ -329,8 +329,7 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
                  TriggerCharacter = null,
                  TriggerKind = RoslynCompletionTriggerKind.Invoked
              },
-             expectedItemLabels: ["snippet1", "snippet2"],
-             snippetLabels: ["snippet1", "snippet2"]);
+             expectedItemLabels: ["snippet1", "snippet2"]);
     }
 
     [Fact]
@@ -352,8 +351,7 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
              },
              expectedItemLabels: ["style", "dir"],
              unexpectedItemLabels: ["snippet1", "snippet2"],
-             delegatedItemLabels: ["style", "dir"],
-             snippetLabels: ["snippet1", "snippet2"]);
+             delegatedItemLabels: ["style", "dir"]);
     }
 
     // Tests HTML attributes and DirectiveAttributeTransitionCompletionItemProvider
@@ -504,11 +502,9 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
         var requestInvoker = new TestLSPRequestInvoker([(Methods.TextDocumentCompletionName, response)]);
 
         var snippetCompletionItemProvider = new SnippetCompletionItemProvider(new SnippetCache());
-        if (snippetLabels is not null)
-        {
-            var snippetInfos = snippetLabels.Select(label => new SnippetInfo(label, label, label, string.Empty, SnippetLanguage.Html)).ToImmutableArray();
-            snippetCompletionItemProvider.SnippetCache.Update(SnippetLanguage.Html, snippetInfos);
-        }
+        snippetCompletionItemProvider.SnippetCache.Update(SnippetLanguage.Html, [
+            new SnippetInfo("snippet1", "snippet1", "snippet1", string.Empty, SnippetLanguage.Html),
+            new SnippetInfo("snippet2", "snippet2", "snippet2", string.Empty, SnippetLanguage.Html)]);
 
         var endpoint = new CohostDocumentCompletionEndpoint(
             RemoteServiceInvoker,

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentCompletionEndpointTest.cs
@@ -270,6 +270,26 @@ public class CohostDocumentCompletionEndpointTest(ITestOutputHelper testOutputHe
     }
 
     [Fact]
+    public async Task HtmlElementNamesAndTagHelpersCompletion_EndOfDocument()
+    {
+        await VerifyCompletionListAsync(
+            input: """
+                This is a Razor document.
+
+                <$$
+                """,
+             completionContext: new RoslynVSInternalCompletionContext()
+             {
+                 InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
+                 TriggerCharacter = "<",
+                 TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
+             },
+             expectedItemLabels: ["div", "h1", "LayoutView", "EditForm", "ValidationMessage"],
+             delegatedItemLabels: ["div", "h1"],
+             unexpectedItemLabels: ["snippet1", "snippet2"]);
+    }
+
+    [Fact]
     public async Task HtmlElementDoNotCommitWithSpace()
     {
         await VerifyCompletionListAsync(


### PR DESCRIPTION
Fixes element completion at the end of a document.
Also closes https://github.com/dotnet/razor/issues/4622 by adding a test to prove it doesn't repro.