### PR TITLE
Allow on-type formatting to run on runtime code-gen

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpFormattingPass.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpFormattingPass.cs
@@ -71,26 +71,6 @@ internal sealed class CSharpFormattingPass(
         return changedText.GetTextChangesArray(originalText);
     }
 
-    private static string RenderSourceMappings(RazorCodeDocument codeDocument)
-    {
-        var markers = codeDocument.GetCSharpDocument().SourceMappings.SelectMany(mapping =>
-            new[]
-            {
-                (index: mapping.OriginalSpan.AbsoluteIndex, text: "<#" ),
-                (index: mapping.OriginalSpan.AbsoluteIndex + mapping.OriginalSpan.Length, text: "#>"),
-            })
-            .OrderByDescending(mapping => mapping.index)
-            .ThenBy(mapping => mapping.text);
-
-        var output = codeDocument.Source.Text.ToString();
-        foreach (var (index, text) in markers)
-        {
-            output = output.Insert(index, text);
-        }
-
-        return output;
-    }
-
     private async Task<ImmutableArray<TextChange>> FormatCSharpAsync(FormattingContext context, HostWorkspaceServices hostWorkspaceServices, Document csharpDocument, CancellationToken cancellationToken)
     {
         var sourceText = context.SourceText;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpFormattingPassBase.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpFormattingPassBase.cs
@@ -627,6 +627,26 @@ internal abstract partial class CSharpFormattingPassBase(IDocumentMappingService
         }
     }
 
+    protected static string RenderSourceMappings(RazorCodeDocument codeDocument)
+    {
+        var markers = codeDocument.GetCSharpDocument().SourceMappings.SelectMany(mapping =>
+            new[]
+            {
+                (index: mapping.OriginalSpan.AbsoluteIndex, text: "<#" ),
+                (index: mapping.OriginalSpan.AbsoluteIndex + mapping.OriginalSpan.Length, text: "#>"),
+            })
+            .OrderByDescending(mapping => mapping.index)
+            .ThenBy(mapping => mapping.text);
+
+        var output = codeDocument.Source.Text.ToString();
+        foreach (var (index, text) in markers)
+        {
+            output = output.Insert(index, text);
+        }
+
+        return output;
+    }
+
     private record struct ShouldFormatOptions(bool AllowImplicitStatements, bool AllowImplicitExpressions, bool AllowSingleLineExplicitExpressions, bool IsLineRequest)
     {
         public ShouldFormatOptions(bool allowImplicitStatements, bool isLineRequest)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpOnTypeFormattingPass.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpOnTypeFormattingPass.cs
@@ -233,7 +233,36 @@ internal sealed class CSharpOnTypeFormattingPass(
 
     private static ImmutableArray<TextChange> FilterCSharpTextChanges(FormattingContext context, ImmutableArray<TextChange> changes)
     {
-        return changes.WhereAsArray(e => ShouldFormat(context, e.Span, allowImplicitStatements: false));
+        var indent = context.GetIndentationLevelString(1);
+
+        using var filteredChanges = new PooledArrayBuilder<TextChange>();
+
+        foreach (var change in changes)
+        {
+            if (!ShouldFormat(context, change.Span, allowImplicitStatements: false))
+            {
+                continue;
+            }
+
+            // One extra bit of filtering we do here, is to guard against quirks in runtime code-gen, where source mappings
+            // end after whitespace, rather than design time where they end before. This results in the C# formatter wanting
+            // to insert an indent in what ends up being the middle of a line of Razor code. Since there is no reason to ever
+            // insert anything but a single space in the middle of a line, it's easy to filter them out.
+            if (change.Span.Length == 0 &&
+                change.NewText == indent)
+            {
+                var linePosition = context.SourceText.GetLinePosition(change.Span.Start);
+                var first = context.SourceText.Lines[linePosition.Line].GetFirstNonWhitespaceOffset();
+                if (linePosition.Character > first)
+                {
+                    continue;
+                }
+            }
+
+            filteredChanges.Add(change);
+        }
+
+        return filteredChanges.ToImmutable();
     }
 
     private static int LineDelta(SourceText text, IEnumerable<TextChange> changes, out int firstLine, out int lastLine)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpOnTypeFormattingPass.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpOnTypeFormattingPass.cs
@@ -87,7 +87,12 @@ internal sealed class CSharpOnTypeFormattingPass(
             }
         }
 
+        _logger.LogTestOnly($"Original C#:\r\n{csharpText}");
+
         var normalizedChanges = csharpText.MinimizeTextChanges(changes, out var originalTextWithChanges);
+
+        _logger.LogTestOnly($"Formatted C#:\r\n{originalTextWithChanges}");
+
         var mappedChanges = RemapTextChanges(codeDocument, normalizedChanges);
         var filteredChanges = FilterCSharpTextChanges(context, mappedChanges);
         if (filteredChanges.Length == 0)
@@ -104,6 +109,8 @@ internal sealed class CSharpOnTypeFormattingPass(
         // Find the lines that were affected by these edits.
         var originalText = codeDocument.Source.Text;
         _logger.LogTestOnly($"Original text:\r\n{originalText}");
+
+        _logger.LogTestOnly($"Source Mappings:\r\n{RenderSourceMappings(context.CodeDocument)}");
 
         // Apply the format on type edits sent over by the client.
         var formattedText = ApplyChangesAndTrackChange(originalText, filteredChanges, out _, out var spanAfterFormatting);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Microsoft.CodeAnalysis.Razor.Workspaces.csproj
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Microsoft.CodeAnalysis.Razor.Workspaces.csproj
@@ -7,6 +7,9 @@
     <IsShippingPackage>false</IsShippingPackage>
     <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
     <IsPackable Condition="'$(OS)' != 'Windows_NT'">false</IsPackable>
+
+    <!-- Uncomment this line to run formatting on runtime code-gen if FUSE is turned on -->
+    <!--<DefineConstants>$(DefineConstants);FORMAT_FUSE</DefineConstants>-->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentSnapshot.cs
@@ -70,10 +70,12 @@ internal sealed class DocumentSnapshot(ProjectSnapshot project, DocumentState st
 
     public async ValueTask<RazorCodeDocument> GetGeneratedOutputAsync(bool forceDesignTimeGeneratedOutput, CancellationToken cancellationToken)
     {
+#if !FORMAT_FUSE
         if (forceDesignTimeGeneratedOutput)
         {
             return await GetDesignTimeGeneratedOutputAsync(cancellationToken).ConfigureAwait(false);
         }
+#endif
 
         var (output, _) = await _state
             .GetGeneratedOutputAndVersionAsync(_project, this, cancellationToken)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Microsoft.CodeAnalysis.Remote.Razor.csproj
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Microsoft.CodeAnalysis.Remote.Razor.csproj
@@ -8,6 +8,9 @@
     <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
     <IsPackable Condition="'$(OS)' != 'Windows_NT'">false</IsPackable>
 
+    <!-- Uncomment this line to run formatting on runtime code-gen if FUSE is turned on -->
+    <!--<DefineConstants>$(DefineConstants);FORMAT_FUSE</DefineConstants>-->
+
     <!--
       Razor.ServiceHub won't always match the other packages Roslyn ships. This is ignorable.
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteDocumentSnapshot.cs
@@ -67,10 +67,12 @@ internal sealed class RemoteDocumentSnapshot : IDocumentSnapshot
         CancellationToken cancellationToken)
     {
         // We don't cache if we're forcing, as that would break everything else
+#if !FORMAT_FUSE
         if (forceDesignTimeGeneratedOutput)
         {
             return new ValueTask<RazorCodeDocument>(GetRazorCodeDocumentAsync(forceRuntimeCodeGeneration: false, cancellationToken));
         }
+#endif
 
         var forceRuntimeCodeGeneration = ProjectSnapshot.SolutionSnapshot.SnapshotManager.LanguageServerFeatureOptions.ForceRuntimeCodeGeneration;
 


### PR DESCRIPTION
There was only one slight tweak that needed to be made to on type formatting in order for all of our tests to pass on runtime code-gen, so this is that.

Extracted out of the new formatting engine PR.