### PR TITLE
Port validate breakpoint endpoint to cohostingN

### DIFF
--- a/eng/targets/Services.props
+++ b/eng/targets/Services.props
@@ -38,5 +38,6 @@
     <ServiceHubService Include="Microsoft.VisualStudio.Razor.CodeActions" ClassName="Microsoft.CodeAnalysis.Remote.Razor.RemoteCodeActionsService+Factory" />
     <ServiceHubService Include="Microsoft.VisualStudio.Razor.FindAllReferences" ClassName="Microsoft.CodeAnalysis.Remote.Razor.RemoteFindAllReferencesService+Factory" />
     <ServiceHubService Include="Microsoft.VisualStudio.Razor.InlineCompletion" ClassName="Microsoft.CodeAnalysis.Remote.Razor.RemoteInlineCompletionService+Factory" />
+    <ServiceHubService Include="Microsoft.VisualStudio.Razor.DebugInfo" ClassName="Microsoft.CodeAnalysis.Remote.Razor.RemoteDebugInfoService+Factory" />
   </ItemGroup>
 </Project>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -214,13 +214,14 @@ internal partial class RazorLanguageServer : SystemTextJsonLanguageServer<RazorR
                 services.AddHandlerWithCapabilities<ProjectContextsEndpoint>();
 
                 services.AddHandlerWithCapabilities<FindAllReferencesEndpoint>();
+
+                services.AddHandlerWithCapabilities<ValidateBreakpointRangeEndpoint>();
+                services.AddHandler<RazorBreakpointSpanEndpoint>();
+                services.AddHandler<RazorProximityExpressionsEndpoint>();
             }
 
             services.AddHandler<WrapWithTagEndpoint>();
-            services.AddHandler<RazorBreakpointSpanEndpoint>();
-            services.AddHandler<RazorProximityExpressionsEndpoint>();
 
-            services.AddHandlerWithCapabilities<ValidateBreakpointRangeEndpoint>();
             services.AddHandlerWithCapabilities<MapCodeEndpoint>();
         }
     }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/IRemoteDebugInfoService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/IRemoteDebugInfoService.cs
@@ -10,6 +10,18 @@ namespace Microsoft.CodeAnalysis.Razor.Remote;
 
 internal interface IRemoteDebugInfoService
 {
+    ValueTask<LinePositionSpan?> ResolveBreakpointRangeAsync(
+        RazorPinnedSolutionInfoWrapper solutionInfo,
+        DocumentId documentId,
+        LinePosition position,
+        CancellationToken cancellationToken);
+
+    ValueTask<string[]?> ResolveProximityExpressionsAsync(
+        RazorPinnedSolutionInfoWrapper solutionInfo,
+        DocumentId documentId,
+        LinePosition position,
+        CancellationToken cancellationToken);
+
     ValueTask<LinePositionSpan?> ValidateBreakableRangeAsync(
         RazorPinnedSolutionInfoWrapper solutionInfo,
         DocumentId documentId,

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/IRemoteDebugInfoService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/IRemoteDebugInfoService.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Razor.Remote;
+
+internal interface IRemoteDebugInfoService
+{
+    ValueTask<LinePositionSpan?> ValidateBreakableRangeAsync(
+        RazorPinnedSolutionInfoWrapper solutionInfo,
+        DocumentId documentId,
+        LinePositionSpan span,
+        CancellationToken cancellationToken);
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RazorServices.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RazorServices.cs
@@ -24,6 +24,7 @@ internal static class RazorServices
             (typeof(IRemoteFormattingService), null),
             (typeof(IRemoteSpellCheckService), null),
             (typeof(IRemoteInlineCompletionService), null),
+            (typeof(IRemoteDebugInfoService), null),
         ];
 
     // Internal for testing

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Debugging/RemoteDebugInfoService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Debugging/RemoteDebugInfoService.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.Razor.DocumentMapping;
+using Microsoft.CodeAnalysis.Razor.Protocol;
+using Microsoft.CodeAnalysis.Razor.Remote;
+using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.Remote.Razor;
+
+internal sealed class RemoteDebugInfoService(in ServiceArgs args) : RazorDocumentServiceBase(in args), IRemoteDebugInfoService
+{
+    internal sealed class Factory : FactoryBase<IRemoteDebugInfoService>
+    {
+        protected override IRemoteDebugInfoService CreateService(in ServiceArgs args)
+            => new RemoteDebugInfoService(in args);
+    }
+
+    private readonly IDocumentMappingService _documentMappingService = args.ExportProvider.GetExportedValue<IDocumentMappingService>();
+
+    public ValueTask<LinePositionSpan?> ValidateBreakableRangeAsync(RazorPinnedSolutionInfoWrapper solutionInfo, DocumentId documentId, LinePositionSpan span, CancellationToken cancellationToken)
+        => RunServiceAsync(
+            solutionInfo,
+            documentId,
+            context => ValidateBreakableRangeAsync(context, span, cancellationToken),
+            cancellationToken);
+
+    public async ValueTask<LinePositionSpan?> ValidateBreakableRangeAsync(RemoteDocumentContext context, LinePositionSpan span, CancellationToken cancellationToken)
+    {
+        var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var csharpDocument = codeDocument.GetCSharpDocument();
+
+        if (!_documentMappingService.TryMapToGeneratedDocumentRange(csharpDocument, span, out var mappedSpan))
+        {
+            return null;
+        }
+
+        var generatedDocument = await context.Snapshot.GetGeneratedDocumentAsync(cancellationToken).ConfigureAwait(false);
+
+        var result = await ExternalAccess.Razor.Cohost.Handlers.ValidateBreakableRange.GetBreakableRangeAsync(generatedDocument, mappedSpan, cancellationToken).ConfigureAwait(false);
+        if (result is { } csharpSpan &&
+            _documentMappingService.TryMapToHostDocumentRange(codeDocument.GetCSharpDocument(), csharpSpan, MappingBehavior.Inclusive, out var hostSpan))
+        {
+            return hostSpan;
+        }
+
+        return null;
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostValidateBreakableRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostValidateBreakableRangeEndpoint.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+using Microsoft.CodeAnalysis.Razor.Remote;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.LanguageServer.Protocol;
+using VSLSP = Microsoft.VisualStudio.LanguageServer.Protocol;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+
+#pragma warning disable RS0030 // Do not use banned APIs
+[Shared]
+[CohostEndpoint(VSInternalMethods.TextDocumentValidateBreakableRangeName)]
+[Export(typeof(IDynamicRegistrationProvider))]
+[ExportCohostStatelessLspService(typeof(CohostValidateBreakableRangeEndpoint))]
+[method: ImportingConstructor]
+#pragma warning restore RS0030 // Do not use banned APIs
+internal sealed class CohostValidateBreakableRangeEndpoint(
+    IRemoteServiceInvoker remoteServiceInvoker)
+    : AbstractRazorCohostDocumentRequestHandler<VSInternalValidateBreakableRangeParams, Range?>, IDynamicRegistrationProvider
+{
+    private readonly IRemoteServiceInvoker _remoteServiceInvoker = remoteServiceInvoker;
+
+    protected override bool MutatesSolutionState => false;
+
+    protected override bool RequiresLSPSolution => true;
+
+    public ImmutableArray<VSLSP.Registration> GetRegistrations(VSLSP.VSInternalClientCapabilities clientCapabilities, RazorCohostRequestContext requestContext)
+    {
+        return [new VSLSP.Registration
+        {
+            Method = VSInternalMethods.TextDocumentValidateBreakableRangeName,
+            RegisterOptions = new VSLSP.TextDocumentRegistrationOptions()
+        }];
+    }
+
+    protected override RazorTextDocumentIdentifier? GetRazorTextDocumentIdentifier(VSInternalValidateBreakableRangeParams request)
+        => request.TextDocument.ToRazorTextDocumentIdentifier();
+
+    protected override Task<Range?> HandleRequestAsync(VSInternalValidateBreakableRangeParams request, RazorCohostRequestContext context, CancellationToken cancellationToken)
+        => HandleRequestAsync(
+            context.TextDocument.AssumeNotNull(),
+            request.Range.ToLinePositionSpan(),
+            cancellationToken);
+
+    private async Task<Range?> HandleRequestAsync(TextDocument razorDocument, LinePositionSpan span, CancellationToken cancellationToken)
+    {
+        var response = await _remoteServiceInvoker
+            .TryInvokeAsync<IRemoteDebugInfoService, LinePositionSpan?>(
+                razorDocument.Project.Solution,
+                (service, solutionInfo, cancellationToken) =>
+                    service.ValidateBreakableRangeAsync(solutionInfo, razorDocument.Id, span, cancellationToken),
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        return response?.ToRange();
+    }
+
+    internal TestAccessor GetTestAccessor() => new(this);
+
+    internal readonly struct TestAccessor(CohostValidateBreakableRangeEndpoint instance)
+    {
+        public Task<Range?> HandleRequestAsync(TextDocument razorDocument, LinePositionSpan span, CancellationToken cancellationToken)
+            => instance.HandleRequestAsync(razorDocument, span, cancellationToken);
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Debugging/RazorBreakpointResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Debugging/RazorBreakpointResolver.cs
@@ -7,6 +7,11 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Utilities;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.Razor.Remote;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Razor.Debugging;
@@ -20,20 +25,80 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Debugging;
 internal class RazorBreakpointResolver(
     FileUriProvider fileUriProvider,
     LSPDocumentManager documentManager,
-    ILSPBreakpointSpanProvider breakpointSpanProvider) : IRazorBreakpointResolver
+    ILSPBreakpointSpanProvider breakpointSpanProvider,
+    LanguageServerFeatureOptions languageServerFeatureOptions,
+    IRemoteServiceInvoker remoteServiceInvoker) : IRazorBreakpointResolver
 {
-    private record CacheKey(Uri DocumentUri, long? HostDocumentSyncVersion, int Line, int Character);
+    private record CohostCacheKey(DocumentId DocumentId, VersionStamp Version, int Line, int Character) : CacheKey;
+    private record LspCacheKey(Uri DocumentUri, long? HostDocumentSyncVersion, int Line, int Character) : CacheKey;
+    private record CacheKey;
 
     private readonly FileUriProvider _fileUriProvider = fileUriProvider;
     private readonly LSPDocumentManager _documentManager = documentManager;
     private readonly ILSPBreakpointSpanProvider _breakpointSpanProvider = breakpointSpanProvider;
+    private readonly LanguageServerFeatureOptions _languageServerFeatureOptions = languageServerFeatureOptions;
+    private readonly IRemoteServiceInvoker _remoteServiceInvoker = remoteServiceInvoker;
 
     // 4 is a magic number that was determined based on the functionality of VisualStudio. Currently when you set or edit a breakpoint
     // we get called with two different locations for the same breakpoint. Because of this 2 time call our size must be at least 2,
     // we grow it to 4 just to be safe for lesser known scenarios.
     private readonly MemoryCache<CacheKey, Range> _cache = new(sizeLimit: 4);
 
-    public async Task<Range?> TryResolveBreakpointRangeAsync(ITextBuffer textBuffer, int lineIndex, int characterIndex, CancellationToken cancellationToken)
+    public Task<Range?> TryResolveBreakpointRangeAsync(ITextBuffer textBuffer, int lineIndex, int characterIndex, CancellationToken cancellationToken)
+    {
+        if (_languageServerFeatureOptions.UseRazorCohostServer)
+        {
+            return TryResolveBreakpointRangeViaCohostingAsync(textBuffer, lineIndex, characterIndex, cancellationToken);
+        }
+
+        return TryResolveBreakpointRangeViaLspAsync(textBuffer, lineIndex, characterIndex, cancellationToken);
+    }
+
+    private async Task<Range?> TryResolveBreakpointRangeViaCohostingAsync(ITextBuffer textBuffer, int lineIndex, int characterIndex, CancellationToken cancellationToken)
+    {
+        if (!textBuffer.TryGetTextDocument(out var razorDocument))
+        {
+            // Razor document is not in the Roslyn workspace.
+            return null;
+        }
+
+        if (razorDocument!.TryGetTextVersion(out var version))
+        {
+            version = await razorDocument.GetTextVersionAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        var cacheKey = new CohostCacheKey(razorDocument.Id, version, lineIndex, characterIndex);
+        if (_cache.TryGetValue(cacheKey, out var cachedRange))
+        {
+            // We've seen this request before. Hopefully the TryGetTextVersion call above was successful so this whole path
+            // will have been sync, and the cache will have been useful.
+            return cachedRange;
+        }
+
+        var response = await _remoteServiceInvoker
+           .TryInvokeAsync<IRemoteDebugInfoService, LinePositionSpan?>(
+               razorDocument.Project.Solution,
+               (service, solutionInfo, cancellationToken) =>
+                   service.ResolveBreakpointRangeAsync(solutionInfo, razorDocument.Id, new(lineIndex, characterIndex), cancellationToken),
+               cancellationToken)
+           .ConfigureAwait(false);
+
+        if (response is not { } responseSpan)
+        {
+            // can't map the position, invalid breakpoint location.
+            return null;
+        }
+
+        var hostDocumentRange = responseSpan.ToRange();
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Cache range so if we're asked again for this document/line/character we don't have to go async.
+        _cache.Set(cacheKey, hostDocumentRange);
+
+        return hostDocumentRange;
+    }
+
+    private async Task<Range?> TryResolveBreakpointRangeViaLspAsync(ITextBuffer textBuffer, int lineIndex, int characterIndex, CancellationToken cancellationToken)
     {
         if (!_fileUriProvider.TryGet(textBuffer, out var documentUri))
         {
@@ -55,7 +120,7 @@ internal class RazorBreakpointResolver(
             return null;
         }
 
-        var cacheKey = new CacheKey(documentSnapshot.Uri, virtualDocument.HostDocumentSyncVersion, lineIndex, characterIndex);
+        var cacheKey = new LspCacheKey(documentSnapshot.Uri, virtualDocument.HostDocumentSyncVersion, lineIndex, characterIndex);
         if (_cache.TryGetValue(cacheKey, out var cachedRange))
         {
             // We've seen this request before, no need to go async.

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Debugging/RazorProximityExpressionResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Debugging/RazorProximityExpressionResolver.cs
@@ -8,6 +8,10 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Utilities;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.Razor.Remote;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Razor.Debugging;
@@ -20,19 +24,78 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Debugging;
 internal class RazorProximityExpressionResolver(
     FileUriProvider fileUriProvider,
     LSPDocumentManager documentManager,
-    ILSPProximityExpressionsProvider proximityExpressionsProvider) : IRazorProximityExpressionResolver
+    ILSPProximityExpressionsProvider proximityExpressionsProvider,
+    LanguageServerFeatureOptions languageServerFeatureOptions,
+    IRemoteServiceInvoker remoteServiceInvoker) : IRazorProximityExpressionResolver
 {
-    private record CacheKey(Uri DocumentUri, long? HostDocumentSyncVersion, int Line, int Character);
+    private record CohostCacheKey(DocumentId DocumentId, VersionStamp Version, int Line, int Character) : CacheKey;
+    private record LspCacheKey(Uri DocumentUri, long? HostDocumentSyncVersion, int Line, int Character) : CacheKey;
+    private record CacheKey;
 
     private readonly FileUriProvider _fileUriProvider = fileUriProvider;
     private readonly LSPDocumentManager _documentManager = documentManager;
     private readonly ILSPProximityExpressionsProvider _proximityExpressionsProvider = proximityExpressionsProvider;
+    private readonly LanguageServerFeatureOptions _languageServerFeatureOptions = languageServerFeatureOptions;
+    private readonly IRemoteServiceInvoker _remoteServiceInvoker = remoteServiceInvoker;
 
     // 10 is a magic number where this effectively represents our ability to cache the last 10 "hit" breakpoint locations
     // corresponding proximity expressions which enables us not to go "async" in those re-hit scenarios.
     private readonly MemoryCache<CacheKey, IReadOnlyList<string>> _cache = new(sizeLimit: 10);
 
-    public async Task<IReadOnlyList<string>?> TryResolveProximityExpressionsAsync(ITextBuffer textBuffer, int lineIndex, int characterIndex, CancellationToken cancellationToken)
+    public Task<IReadOnlyList<string>?> TryResolveProximityExpressionsAsync(ITextBuffer textBuffer, int lineIndex, int characterIndex, CancellationToken cancellationToken)
+    {
+        if (_languageServerFeatureOptions.UseRazorCohostServer)
+        {
+            return TryResolveProximityExpressionsViaCohostingAsync(textBuffer, lineIndex, characterIndex, cancellationToken);
+        }
+
+        return TryResolveProximityExpressionsViaLspAsync(textBuffer, lineIndex, characterIndex, cancellationToken);
+
+    }
+
+    private async Task<IReadOnlyList<string>?> TryResolveProximityExpressionsViaCohostingAsync(ITextBuffer textBuffer, int lineIndex, int characterIndex, CancellationToken cancellationToken)
+    {
+        if (!textBuffer.TryGetTextDocument(out var razorDocument))
+        {
+            // Razor document is not in the Roslyn workspace.
+            return null;
+        }
+
+        if (razorDocument!.TryGetTextVersion(out var version))
+        {
+            version = await razorDocument.GetTextVersionAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        var cacheKey = new CohostCacheKey(razorDocument.Id, version, lineIndex, characterIndex);
+        if (_cache.TryGetValue(cacheKey, out var cachedRange))
+        {
+            // We've seen this request before. Hopefully the TryGetTextVersion call above was successful so this whole path
+            // will have been sync, and the cache will have been useful.
+            return cachedRange;
+        }
+
+        var response = await _remoteServiceInvoker
+           .TryInvokeAsync<IRemoteDebugInfoService, string[]?>(
+               razorDocument.Project.Solution,
+               (service, solutionInfo, cancellationToken) =>
+                   service.ResolveProximityExpressionsAsync(solutionInfo, razorDocument.Id, new(lineIndex, characterIndex), cancellationToken),
+               cancellationToken)
+           .ConfigureAwait(false);
+
+        if (response is null)
+        {
+            return null;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        // Cache range so if we're asked again for this document/line/character we don't have to go async.
+        _cache.Set(cacheKey, response);
+
+        return response;
+    }
+
+    private async Task<IReadOnlyList<string>?> TryResolveProximityExpressionsViaLspAsync(ITextBuffer textBuffer, int lineIndex, int characterIndex, CancellationToken cancellationToken)
     {
         if (!_fileUriProvider.TryGet(textBuffer, out var documentUri))
         {
@@ -54,7 +117,7 @@ internal class RazorProximityExpressionResolver(
             return null;
         }
 
-        var cacheKey = new CacheKey(documentSnapshot.Uri, virtualDocument.HostDocumentSyncVersion, lineIndex, characterIndex);
+        var cacheKey = new LspCacheKey(documentSnapshot.Uri, virtualDocument.HostDocumentSyncVersion, lineIndex, characterIndex);
         if (_cache.TryGetValue(cacheKey, out var cachedExpressions))
         {
             // We've seen this request before, no need to go async.

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/TestCode.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/TestCode.cs
@@ -41,6 +41,9 @@ internal readonly struct TestCode
     public int Position
         => Positions.Single();
 
+    public bool HasSpans
+        => TryGetNamedSpans(string.Empty, out _);
+
     public TextSpan Span
         => Spans.Single();
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostValidateBreakableRangeEndpointTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostValidateBreakableRangeEndpointTest.cs
@@ -1,0 +1,132 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.LanguageServer.Protocol;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+
+public class CohostValidateBreakableRangeEndpointTest(ITestOutputHelper testOutputHelper) : CohostEndpointTestBase(testOutputHelper)
+{
+    [Fact]
+    public async Task Handle_CSharpInHtml_ValidBreakpoint()
+    {
+        var input = """
+                <div></div>
+
+                @{
+                    var currentCount = 1;
+                }
+
+                <p>@{|breakpoint:{|expected:currentCount|}|}</p>
+                """;
+
+        await VerifyBreakableRangeAsync(input);
+    }
+
+    [Fact]
+    public async Task Handle_CSharpInAttribute_ValidBreakpoint()
+    {
+        var input = """
+                <div></div>
+
+                @{
+                    var currentCount = 1;
+                }
+
+                <button class="btn btn-primary" disabled="@({|breakpoint:{|expected:currentCount > 3|}|})">Click me</button>
+                """;
+
+        await VerifyBreakableRangeAsync(input);
+    }
+
+    [Fact]
+    public async Task Handle_CSharp_ValidBreakpoint()
+    {
+        var input = """
+                <div></div>
+
+                @{
+                    {|breakpoint:{|expected:var x = GetX();|}|}
+                }
+                """;
+
+        await VerifyBreakableRangeAsync(input);
+    }
+
+    [Fact]
+    public async Task Handle_CSharp_InvalidBreakpointRemoved()
+    {
+        var input = """
+                <div></div>
+
+                @{
+                    //{|breakpoint:var x = GetX();|}
+                }
+                """;
+
+        await VerifyBreakableRangeAsync(input);
+    }
+
+    [Fact]
+    public async Task Handle_CSharp_ValidBreakpointMoved()
+    {
+        var input = """
+                <div></div>
+
+                @{
+                    {|breakpoint:var x = Goo;
+                    {|expected:Goo;|}|}
+                }
+                """;
+
+        await VerifyBreakableRangeAsync(input);
+    }
+
+    [Fact]
+    public async Task Handle_Html_BreakpointRemoved()
+    {
+        var input = """
+                {|breakpoint:<div></div>|}
+
+                @{
+                    var x = GetX();
+                }
+                """;
+
+        await VerifyBreakableRangeAsync(input);
+    }
+
+    private async Task VerifyBreakableRangeAsync(TestCode input)
+    {
+        var document = await CreateProjectAndRazorDocumentAsync(input.Text);
+        var inputText = await document.GetTextAsync(DisposalToken);
+
+        Assert.True(input.TryGetNamedSpans("breakpoint", out var breakpointSpans), "Test authoring failure: Expected at least one span named 'breakpoint'.");
+        Assert.True(breakpointSpans.Length == 1, "Test authoring failure: Expected only one 'breakpoint' span.");
+
+        var span = inputText.GetLinePositionSpan(breakpointSpans.Single());
+
+        var endpoint = new CohostValidateBreakableRangeEndpoint(RemoteServiceInvoker);
+
+        var result = await endpoint.GetTestAccessor().HandleRequestAsync(document, span, DisposalToken);
+
+        if (!input.TryGetNamedSpans("expected", out var expected))
+        {
+            Assert.Null(result);
+            return;
+        }
+
+        Assert.NotNull(result);
+
+        var expectedRange = inputText.GetRange(expected.Single());
+        Assert.Equal(expectedRange, result);
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/RemoteDebugInfoServiceTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/RemoteDebugInfoServiceTest.cs
@@ -1,0 +1,226 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Razor.Remote;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Test.Utilities;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+
+public class RemoveDebugInfoServiceTest(ITestOutputHelper testOutputHelper) : CohostEndpointTestBase(testOutputHelper)
+{
+    [Fact]
+    public async Task ResolveProximityExpressionsAsync_Html()
+    {
+        var input = """
+                $$<div></div>
+
+                @{
+                    var currentCount = 1;
+                }
+
+                <p>@currentCount</p>
+                """;
+
+        await VerifyProximityExpressionsAsync(input, ["__builder", "this"]);
+    }
+
+    [Fact]
+    public async Task ResolveProximityExpressionsAsync_ExplicitExpression()
+    {
+        var input = """
+                <div></div>
+
+                @{
+                    var currentC$$ount = 1;
+                }
+
+                <p>@[|currentCount|]</p>
+                """;
+
+        await VerifyProximityExpressionsAsync(input, ["__builder", "this"]);
+    }
+
+    [Fact]
+    public async Task ResolveProximityExpressionsAsync_OutsideImplicitExpression()
+    {
+        var input = """
+                <div></div>
+
+                @{
+                    var [|currentCount|] = 1;
+                }
+
+                $$<p>@currentCount</p>
+                """;
+
+        await VerifyProximityExpressionsAsync(input, ["__o", "this"]);
+    }
+
+    [Fact]
+    public async Task ResolveProximityExpressionsAsync_ImplicitExpression()
+    {
+        var input = """
+                <div></div>
+
+                @{
+                    var [|currentCount|] = 1;
+                }
+
+                <p>@curr$$entCount</p>
+                """;
+
+        await VerifyProximityExpressionsAsync(input, ["__o", "this"]);
+    }
+
+    [Fact]
+    public async Task ResolveProximityExpressionsAsync_CodeBlock()
+    {
+        var input = """
+                <div></div>
+
+                <p>@currentCount</p>
+
+                @code
+                {
+                    private int [|currentCount|];
+                    private bool hasBeenClicked;
+
+                    private void M()
+                    {
+                        current$$Count++;
+                    }
+                }
+                """;
+
+        await VerifyProximityExpressionsAsync(input, ["this"]);
+    }
+
+    [Fact]
+    public async Task ResolveBreakpointRangeAsync_Html()
+    {
+        var input = """
+                $$<div></div>
+
+                @{
+                    var currentCount = 1;
+                }
+
+                <p>@currentCount</p>
+                """;
+
+        await VerifyBreakpointRangeAsync(input);
+    }
+
+    [Fact]
+    public async Task ResolveBreakpointRangeAsync_CodeBlock()
+    {
+        var input = """
+                <div></div>
+
+                <p>@currentCount</p>
+
+                @code
+                {
+                    private int currentCount;
+
+                    private void M()
+                    {
+                        [|current$$Count++;|]
+                    }
+                }
+                """;
+
+        await VerifyBreakpointRangeAsync(input);
+    }
+
+    [Fact]
+    public async Task ResolveBreakpointRangeAsync_CodeBlock_InvalidLocation()
+    {
+        var input = """
+                <div></div>
+
+                <p>@currentCount</p>
+
+                @code
+                {
+                    private bool hasBeen$$Clicked;
+                }
+                """;
+
+        await VerifyBreakpointRangeAsync(input);
+    }
+
+    [Fact]
+    public async Task ResolveBreakpointRangeAsync_OutsideImplicitExpression()
+    {
+        var input = """
+                <div></div>
+
+                @{
+                    var currentCount = 1;
+                }
+
+                $$<p>@[|currentCount|]</p>
+                """;
+
+        await VerifyBreakpointRangeAsync(input);
+    }
+
+    private async Task VerifyProximityExpressionsAsync(TestCode input, string[] extraExpressions)
+    {
+        var document = await CreateProjectAndRazorDocumentAsync(input.Text);
+        var inputText = await document.GetTextAsync(DisposalToken);
+
+        var span = inputText.GetLinePosition(input.Position);
+
+        var result = await RemoteServiceInvoker
+           .TryInvokeAsync<IRemoteDebugInfoService, string[]?>(
+               document.Project.Solution,
+               (service, solutionInfo, cancellationToken) =>
+                   service.ResolveProximityExpressionsAsync(solutionInfo, document.Id, span, cancellationToken),
+               DisposalToken);
+
+        if (!input.HasSpans)
+        {
+            Assert.Null(result);
+            return;
+        }
+
+        Assert.NotNull(result);
+
+        var expected = input.Spans.Select(inputText.GetSubTextString).Concat(extraExpressions).OrderAsArray();
+        AssertEx.SequenceEqual(expected, result.OrderAsArray());
+    }
+
+    private async Task VerifyBreakpointRangeAsync(TestCode input)
+    {
+        var document = await CreateProjectAndRazorDocumentAsync(input.Text);
+        var inputText = await document.GetTextAsync(DisposalToken);
+
+        var span = inputText.GetLinePosition(input.Position);
+
+        var result = await RemoteServiceInvoker
+           .TryInvokeAsync<IRemoteDebugInfoService, LinePositionSpan?>(
+               document.Project.Solution,
+               (service, solutionInfo, cancellationToken) =>
+                   service.ResolveBreakpointRangeAsync(solutionInfo, document.Id, span, cancellationToken),
+               DisposalToken);
+
+        if (result is not { } breakpoint)
+        {
+            Assert.False(input.HasSpans);
+            return;
+        }
+
+        var expected = inputText.GetLinePositionSpan(input.Span);
+        Assert.Equal(expected, breakpoint);
+    }
+}

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/Debugging/RazorBreakpointResolverTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/Debugging/RazorBreakpointResolverTest.cs
@@ -8,6 +8,8 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.Editor;
+using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
+using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Razor.Debugging;
@@ -169,8 +171,9 @@ public class RazorBreakpointResolverTest : ToolingTestBase
                     DisposalToken))
                 .ReturnsAsync(value: null);
         }
+        var remoteServiceInvoker = StrictMock.Of<IRemoteServiceInvoker>();
 
-        var razorBreakpointResolver = new RazorBreakpointResolver(uriProvider, documentManager, projectionProvider);
+        var razorBreakpointResolver = new RazorBreakpointResolver(uriProvider, documentManager, projectionProvider, TestLanguageServerFeatureOptions.Instance, remoteServiceInvoker);
 
         return razorBreakpointResolver;
     }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/Debugging/RazorProximityExpressionResolverTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/Debugging/RazorProximityExpressionResolverTest.cs
@@ -9,7 +9,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.Editor;
+using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 using Microsoft.AspNetCore.Razor.Threading;
+using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Razor.Debugging;
@@ -113,11 +115,14 @@ public class RazorProximityExpressionResolverTest : ToolingTestBase
         documentManager ??= Mock.Of<LSPDocumentManager>(
             manager => manager.TryGetDocument(_documentUri, out documentSnapshot) == true,
             MockBehavior.Strict);
+        var remoteServiceInvoker = StrictMock.Of<IRemoteServiceInvoker>();
 
         var razorProximityExpressionResolver = new RazorProximityExpressionResolver(
             uriProvider,
             documentManager,
-            TestLSPProximityExpressionProvider.Instance);
+            TestLSPProximityExpressionProvider.Instance,
+            TestLanguageServerFeatureOptions.Instance,
+            remoteServiceInvoker);
 
         return razorProximityExpressionResolver;
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/11337
Needs https://github.com/dotnet/roslyn/pull/76629

Ports one endpoint to cohosting
Updates two `IVsLanguageInfo` entry points to call cohosting in OOP rather than making LSP calls.

These mostly just call Roslyn and don't do anything interesting with the results. I thought about making some changes here (eg, does `__o` need to be a proximity expression?) but given the very low test coverage of our existing code, I didn't want to rock the boat.