### PR TITLE
Remove unused field in LspServices

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LspServices.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LspServices.cs
@@ -20,6 +20,8 @@ internal class LspServices : ILspServices
     {
         serviceCollection.AddSingleton<ILspServices>(this);
         _serviceProvider = serviceCollection.BuildServiceProvider();
+        // Create all startup services
+        _serviceProvider.GetServices<IRazorStartupService>();
     }
 
     public ImmutableArray<Type> GetRegisteredServices()

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LspServices.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LspServices.cs
@@ -14,16 +14,12 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer;
 internal class LspServices : ILspServices
 {
     private readonly IServiceProvider _serviceProvider;
-    private readonly IEnumerable<IRazorStartupService> _startupServices;
     public bool IsDisposed = false;
 
     public LspServices(IServiceCollection serviceCollection)
     {
         serviceCollection.AddSingleton<ILspServices>(this);
         _serviceProvider = serviceCollection.BuildServiceProvider();
-
-        // Create all startup services
-        _startupServices = _serviceProvider.GetServices<IRazorStartupService>();
     }
 
     public ImmutableArray<Type> GetRegisteredServices()

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/AutoInsert/RemoteAutoInsertService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/AutoInsert/RemoteAutoInsertService.cs
@@ -32,7 +32,6 @@ internal sealed class RemoteAutoInsertService(in ServiceArgs args)
     }
 
     private readonly IAutoInsertService _autoInsertService = args.ExportProvider.GetExportedValue<IAutoInsertService>();
-    private readonly IFilePathService _filePathService = args.ExportProvider.GetExportedValue<IFilePathService>();
     private readonly IRazorFormattingService _razorFormattingService = args.ExportProvider.GetExportedValue<IRazorFormattingService>();
 
     protected override IDocumentPositionInfoStrategy DocumentPositionInfoStrategy => PreferHtmlInAttributeValuesDocumentPositionInfoStrategy.Instance;


### PR DESCRIPTION
When using the latest daily build of the .NET 10 SDK to build this repo, it results in the following errors:

```
/__w/1/vmr/src/razor/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LspServices.cs(17,56): error IDE0052: Private member 'LspServices._startupServices' can be removed as the value assigned to it is never read (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0052) [/__w/1/vmr/src/razor/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Microsoft.AspNetCore.Razor.LanguageServer.csproj]

/__w/1/vmr/src/razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/AutoInsert/RemoteAutoInsertService.cs(35,39): error IDE0052: Private member 'RemoteAutoInsertService._filePathService' can be removed as the value assigned to it is never read (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0052) [/__w/1/vmr/src/razor/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Microsoft.CodeAnalysis.Remote.Razor.csproj]
```

This is fixed by removing these unused fields.