### PR TITLE
Remove unused field in RazorContentTypeChangeListener

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/RazorContentTypeChangeListener.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/RazorContentTypeChangeListener.cs
@@ -18,7 +18,6 @@ internal class RazorContentTypeChangeListener : ITextBufferContentTypeListener
     private readonly TrackingLSPDocumentManager _lspDocumentManager;
     private readonly ITextDocumentFactoryService _textDocumentFactory;
     private readonly ILspEditorFeatureDetector _lspEditorFeatureDetector;
-    private readonly IEditorOptionsFactoryService _editorOptionsFactory;
     private readonly IFileToContentTypeService _fileToContentTypeService;
 
     [ImportingConstructor]
@@ -26,7 +25,6 @@ internal class RazorContentTypeChangeListener : ITextBufferContentTypeListener
         ITextDocumentFactoryService textDocumentFactory,
         LSPDocumentManager lspDocumentManager,
         ILspEditorFeatureDetector lspEditorFeatureDetector,
-        IEditorOptionsFactoryService editorOptionsFactory,
         IFileToContentTypeService fileToContentTypeService)
     {
         if (textDocumentFactory is null)
@@ -44,11 +42,6 @@ internal class RazorContentTypeChangeListener : ITextBufferContentTypeListener
             throw new ArgumentNullException(nameof(lspEditorFeatureDetector));
         }
 
-        if (editorOptionsFactory is null)
-        {
-            throw new ArgumentNullException(nameof(editorOptionsFactory));
-        }
-
         if (fileToContentTypeService is null)
         {
             throw new ArgumentNullException(nameof(fileToContentTypeService));
@@ -63,7 +56,6 @@ internal class RazorContentTypeChangeListener : ITextBufferContentTypeListener
 
         _textDocumentFactory = textDocumentFactory;
         _lspEditorFeatureDetector = lspEditorFeatureDetector;
-        _editorOptionsFactory = editorOptionsFactory;
         _fileToContentTypeService = fileToContentTypeService;
     }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/RazorContentTypeChangeListener.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/RazorContentTypeChangeListener.cs
@@ -5,7 +5,6 @@ using System;
 using System.ComponentModel.Composition;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.Text;
-using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.VisualStudio.Razor.LanguageClient;

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/RazorContentTypeChangeListenerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/LanguageClient/RazorContentTypeChangeListenerTest.cs
@@ -226,7 +226,6 @@ public class RazorContentTypeChangeListenerTest : ToolingTestBase
             textDocumentFactory,
             lspDocumentManager,
             lspEditorFeatureDetector,
-            Mock.Of<IEditorOptionsFactoryService>(s => s.GetOptions(It.IsAny<ITextBuffer>()) == Mock.Of<IEditorOptions>(MockBehavior.Strict), MockBehavior.Strict),
             fileToContentTypeService);
 
         return listener;


### PR DESCRIPTION
Related to https://github.com/dotnet/razor/pull/11358

Discovered another unused field to be removed.