### PR TITLE
Enforce IDE0052 across the repo

### DIFF
--- a/eng/config/globalconfigs/Common.globalconfig
+++ b/eng/config/globalconfigs/Common.globalconfig
@@ -75,6 +75,9 @@ dotnet_diagnostic.IDE0048.severity = suggestion
 # IDE0051: Remove unused private members
 dotnet_diagnostic.IDE0051.severity = warning
 
+# IDE0052: Remove unread private members
+dotnet_diagnostic.IDE0052.severity = warning
+
 # IDE0053: Use expression body for lambda expressions
 dotnet_diagnostic.IDE0053.severity = suggestion
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentMarkupBlockPass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentMarkupBlockPass.cs
@@ -264,15 +264,11 @@ internal class ComponentMarkupBlockPass : ComponentIntermediateNodePassBase, IRa
 
     private class RewriteVisitor : IntermediateNodeWalker
     {
-        private readonly StringBuilder _encodingBuilder;
-
         private readonly List<IntermediateNodeReference> _trees;
 
         public RewriteVisitor(List<IntermediateNodeReference> trees)
         {
             _trees = trees;
-
-            _encodingBuilder = new StringBuilder();
         }
 
         public StringBuilder Builder { get; } = new StringBuilder();

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DocumentClassifierPassBase.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DocumentClassifierPassBase.cs
@@ -73,7 +73,7 @@ public abstract class DocumentClassifierPassBase : IntermediateNodePassBase, IRa
         var methodBuilder = IntermediateNodeBuilder.Create(classBuilder.Current);
         methodBuilder.Push(method);
 
-        var visitor = new Visitor(documentBuilder, namespaceBuilder, classBuilder, methodBuilder);
+        var visitor = new Visitor(namespaceBuilder, classBuilder, methodBuilder);
 
         for (var i = 0; i < children.Count; i++)
         {
@@ -117,14 +117,12 @@ public abstract class DocumentClassifierPassBase : IntermediateNodePassBase, IRa
 
     private class Visitor : IntermediateNodeVisitor
     {
-        private readonly IntermediateNodeBuilder _document;
         private readonly IntermediateNodeBuilder _namespace;
         private readonly IntermediateNodeBuilder _class;
         private readonly IntermediateNodeBuilder _method;
 
-        public Visitor(IntermediateNodeBuilder document, IntermediateNodeBuilder @namespace, IntermediateNodeBuilder @class, IntermediateNodeBuilder method)
+        public Visitor(IntermediateNodeBuilder @namespace, IntermediateNodeBuilder @class, IntermediateNodeBuilder method)
         {
-            _document = document;
             _namespace = @namespace;
             _class = @class;
             _method = method;


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/11359

IDE0052 wasn't being enforced in CI which means we broke the VMR build (see https://github.com/dotnet/razor/pull/11358 and https://github.com/dotnet/razor/pull/11361). This change makes sure this rule is turned on and enforced in command line builds, and fixes a couple of violations in the compiler. Should prevent future breakages too.

Not sure why out existing .editorconfig for this diagnostic didn't work, but I suspect its because the compiler has its own .editorconfig marked as root.