### PR TITLE
Fix a couple of exceptions encountered when formatting documents with preprocessor directives

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/RazorSyntaxNodeExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/RazorSyntaxNodeExtensions.cs
@@ -380,6 +380,12 @@ internal static class RazorSyntaxNodeExtensions
         var startPositionSpan = GetLinePositionSpan(firstToken, source, node.SpanStart);
         var endPositionSpan = GetLinePositionSpan(lastToken, source, node.SpanStart);
 
+        if (endPositionSpan.End < startPositionSpan.Start)
+        {
+            linePositionSpan = default;
+            return false;
+        }
+
         linePositionSpan = new LinePositionSpan(startPositionSpan.Start, endPositionSpan.End);
         return true;
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/CSharpFormatter.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/CSharpFormatter.cs
@@ -106,9 +106,15 @@ internal sealed class CSharpFormatter(IDocumentMappingService documentMappingSer
             var formattedTriviaList = formattedRoot.GetAnnotatedTrivia(MarkerId);
             foreach (var trivia in formattedTriviaList)
             {
-                // We only expect one annotation because we built the entire trivia with a single annotation.
-                var annotation = trivia.GetAnnotations(MarkerId).Single();
-                if (!int.TryParse(annotation.Data, out var projectedIndex))
+                // We only expect one annotation because we built the entire trivia with a single annotation, but
+                // we need to be defensive here. Annotations are a little hard to work with though, so apologies for
+                // the slightly odd method of validation.
+                using var enumerator = trivia.GetAnnotations(MarkerId).GetEnumerator();
+                enumerator.MoveNext();
+                var annotation = enumerator.Current;
+                // We shouldn't be able to enumerate any more, and we should be able to parse our data out of the annotation.
+                if (enumerator.MoveNext() ||
+                    !int.TryParse(annotation.Data, out var projectedIndex))
                 {
                     // This shouldn't happen realistically unless someone messed with the annotations we added.
                     // Let's ignore this annotation.

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/HtmlFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/HtmlFormattingTest.cs
@@ -440,6 +440,46 @@ public class HtmlFormattingTest(FormattingTestContext context, HtmlFormattingFix
         }
     }
 
+    [FormattingTestFact]
+    public async Task PreprocessorDirectives()
+    {
+        await RunFormattingTestAsync(
+            input: """
+            <div Model="SomeModel">
+            <div />
+            @{
+            #if DEBUG
+            }
+             <div />
+            @{
+            #endif
+            }
+            </div>
+
+            @code {
+                private object SomeModel {get;set;}
+            }
+            """,
+            expected: """
+            <div Model="SomeModel">
+                <div />
+                @{
+            #if DEBUG
+                    }
+                    <div />
+                    @{
+            #endif
+
+                }
+            </div>
+
+            @code {
+                private object SomeModel { get; set; }
+            }
+            """,
+            allowDiagnostics: true);
+    }
+
     private ImmutableArray<TagHelperDescriptor> GetComponents()
     {
         AdditionalSyntaxTrees.Add(Parse("""


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/11372

When you assume, you make a fool out of people who use the `.Single()` method and expect a good time.