### PR TITLE
Replace ISolutionQueryOperations in hover with a dedicated service

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionItemResolver.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionItemResolver.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.Razor.Completion;
 using Microsoft.CodeAnalysis.Razor.Formatting;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol;
+using Microsoft.CodeAnalysis.Razor.Tooltip;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation;
@@ -32,7 +33,7 @@ internal class DelegatedCompletionItemResolver(
         VSInternalCompletionList containingCompletionList,
         object? originalRequestContext,
         VSInternalClientCapabilities? clientCapabilities,
-        ISolutionQueryOperations solutionQueryOperations,
+        IComponentAvailabilityService componentAvailabilityService,
         CancellationToken cancellationToken)
     {
         if (originalRequestContext is not DelegatedCompletionResolutionContext resolutionContext)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionResolveEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionResolveEndpoint.cs
@@ -5,32 +5,24 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
-using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Completion;
-using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Tooltip;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion;
 
 [RazorLanguageServerEndpoint(Methods.TextDocumentCompletionResolveName)]
-internal class RazorCompletionResolveEndpoint
-    : IRazorDocumentlessRequestHandler<VSInternalCompletionItem, VSInternalCompletionItem>,
-      ICapabilitiesProvider
+internal class RazorCompletionResolveEndpoint(
+    AggregateCompletionItemResolver completionItemResolver,
+    CompletionListCache completionListCache,
+    IComponentAvailabilityService componentAvailabilityService)
+    : IRazorDocumentlessRequestHandler<VSInternalCompletionItem, VSInternalCompletionItem>, ICapabilitiesProvider
 {
-    private readonly AggregateCompletionItemResolver _completionItemResolver;
-    private readonly CompletionListCache _completionListCache;
-    private readonly ProjectSnapshotManager _projectSnapshotManager;
-    private VSInternalClientCapabilities? _clientCapabilities;
+    private readonly AggregateCompletionItemResolver _completionItemResolver = completionItemResolver;
+    private readonly CompletionListCache _completionListCache = completionListCache;
+    private readonly IComponentAvailabilityService _componentAvailabilityService = componentAvailabilityService;
 
-    public RazorCompletionResolveEndpoint(
-        AggregateCompletionItemResolver completionItemResolver,
-        CompletionListCache completionListCache,
-        ProjectSnapshotManager projectSnapshotManager)
-    {
-        _completionItemResolver = completionItemResolver;
-        _completionListCache = completionListCache;
-        _projectSnapshotManager = projectSnapshotManager;
-    }
+    private VSInternalClientCapabilities? _clientCapabilities;
 
     public bool MutatesSolutionState => false;
 
@@ -75,13 +67,16 @@ internal class RazorCompletionResolveEndpoint
             return completionItem;
         }
 
-        var resolvedCompletionItem = await _completionItemResolver.ResolveAsync(
-            completionItem,
-            containingCompletionList,
-            originalRequestContext,
-            _clientCapabilities,
-            _projectSnapshotManager.GetQueryOperations(),
-            cancellationToken).ConfigureAwait(false);
+        var resolvedCompletionItem = await _completionItemResolver
+            .ResolveAsync(
+                completionItem,
+                containingCompletionList,
+                originalRequestContext,
+                _clientCapabilities,
+                _componentAvailabilityService,
+                cancellationToken)
+            .ConfigureAwait(false);
+
         resolvedCompletionItem ??= completionItem;
 
         return resolvedCompletionItem;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
@@ -22,7 +22,6 @@ using Microsoft.AspNetCore.Razor.ProjectEngineHost;
 using Microsoft.CodeAnalysis.Razor.CodeActions;
 using Microsoft.CodeAnalysis.Razor.CodeActions.Razor;
 using Microsoft.CodeAnalysis.Razor.Completion;
-using Microsoft.CodeAnalysis.Razor.Completion.Delegation;
 using Microsoft.CodeAnalysis.Razor.Diagnostics;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.Formatting;
@@ -30,6 +29,7 @@ using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.SemanticTokens;
 using Microsoft.CodeAnalysis.Razor.SpellCheck;
+using Microsoft.CodeAnalysis.Razor.Tooltip;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.Extensions.DependencyInjection;
@@ -107,6 +107,7 @@ internal static class IServiceCollectionExtensions
 
     public static void AddHoverServices(this IServiceCollection services)
     {
+        services.AddSingleton<IComponentAvailabilityService, ComponentAvailabilityService>();
         services.AddHandlerWithCapabilities<HoverEndpoint>();
     }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/ComponentAvailabilityService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/ComponentAvailabilityService.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
+using Microsoft.AspNetCore.Razor.PooledObjects;
+using Microsoft.AspNetCore.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Tooltip;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover;
+
+internal sealed class ComponentAvailabilityService(ProjectSnapshotManager projectManager) : AbstractComponentAvailabilityService
+{
+    private readonly ProjectSnapshotManager _projectManager = projectManager;
+
+    protected override ImmutableArray<IProjectSnapshot> GetProjectsContainingDocument(string documentFilePath)
+    {
+        using var projects = new PooledArrayBuilder<IProjectSnapshot>();
+
+        foreach (var project in _projectManager.GetProjects())
+        {
+            // Always exclude the miscellaneous project.
+            if (project.Key == MiscFilesProject.Key)
+            {
+                continue;
+            }
+
+            if (project.ContainsDocument(documentFilePath))
+            {
+                projects.Add(project);
+            }
+        }
+
+        return projects.DrainToImmutable();
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/HoverEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hover/HoverEndpoint.cs
@@ -14,6 +14,7 @@ using Microsoft.CodeAnalysis.Razor.Hover;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol;
+using Microsoft.CodeAnalysis.Razor.Tooltip;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using LspHover = Microsoft.VisualStudio.LanguageServer.Protocol.Hover;
@@ -22,7 +23,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Hover;
 
 [RazorLanguageServerEndpoint(Methods.TextDocumentHoverName)]
 internal sealed class HoverEndpoint(
-    ProjectSnapshotManager projectManager,
+    IComponentAvailabilityService componentAvailabilityService,
     IClientCapabilitiesService clientCapabilitiesService,
     LanguageServerFeatureOptions languageServerFeatureOptions,
     IDocumentMappingService documentMappingService,
@@ -34,7 +35,7 @@ internal sealed class HoverEndpoint(
         clientConnection,
         loggerFactory.GetOrCreateLogger<HoverEndpoint>()), ICapabilitiesProvider
 {
-    private readonly ProjectSnapshotManager _projectManager = projectManager;
+    private readonly IComponentAvailabilityService _componentAvailabilityService = componentAvailabilityService;
     private readonly IClientCapabilitiesService _clientCapabilitiesService = clientCapabilitiesService;
 
     public void ApplyCapabilities(VSInternalServerCapabilities serverCapabilities, VSInternalClientCapabilities clientCapabilities)
@@ -92,7 +93,7 @@ internal sealed class HoverEndpoint(
             codeDocument,
             positionInfo.HostDocumentIndex,
             options,
-            _projectManager.GetQueryOperations(),
+            _componentAvailabilityService,
             cancellationToken)
             .ConfigureAwait(false);
     }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/AggregateCompletionItemResolver.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/AggregateCompletionItemResolver.cs
@@ -9,7 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.Razor.Logging;
-using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Tooltip;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.Razor.Completion;
@@ -30,7 +30,7 @@ internal class AggregateCompletionItemResolver
         VSInternalCompletionList containingCompletionList,
         object? originalRequestContext,
         VSInternalClientCapabilities? clientCapabilities,
-        ISolutionQueryOperations solutionQueryOperations,
+        IComponentAvailabilityService componentAvailabilityService,
         CancellationToken cancellationToken)
     {
         using var completionItemResolverTasks = new PooledArrayBuilder<Task<VSInternalCompletionItem?>>(_completionItemResolvers.Count);
@@ -39,7 +39,7 @@ internal class AggregateCompletionItemResolver
         {
             try
             {
-                var task = completionItemResolver.ResolveAsync(item, containingCompletionList, originalRequestContext, clientCapabilities, solutionQueryOperations, cancellationToken);
+                var task = completionItemResolver.ResolveAsync(item, containingCompletionList, originalRequestContext, clientCapabilities, componentAvailabilityService, cancellationToken);
                 completionItemResolverTasks.Add(task);
             }
             catch (Exception ex) when (ex is not TaskCanceledException)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionItemResolver.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionItemResolver.cs
@@ -3,7 +3,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Tooltip;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.Razor.Completion;
@@ -15,6 +15,6 @@ internal abstract class CompletionItemResolver
         VSInternalCompletionList containingCompletionList,
         object? originalRequestContext,
         VSInternalClientCapabilities? clientCapabilities,
-        ISolutionQueryOperations solutionQueryOperations,
+        IComponentAvailabilityService componentAvailabilityService,
         CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItemResolver.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItemResolver.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Tooltip;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Text.Adornments;
@@ -20,7 +19,7 @@ internal class RazorCompletionItemResolver : CompletionItemResolver
         VSInternalCompletionList containingCompletionList,
         object? originalRequestContext,
         VSInternalClientCapabilities? clientCapabilities,
-        ISolutionQueryOperations solutionQueryOperations,
+        IComponentAvailabilityService componentAvailabilityService,
         CancellationToken cancellationToken)
     {
         if (originalRequestContext is not RazorCompletionResolveContext razorCompletionResolveContext)
@@ -52,6 +51,7 @@ internal class RazorCompletionItemResolver : CompletionItemResolver
             // do what previous version of the code did and return true.
             return true;
         });
+
         if (associatedRazorCompletion is null)
         {
             return null;
@@ -115,13 +115,13 @@ internal class RazorCompletionItemResolver : CompletionItemResolver
                     if (useDescriptionProperty)
                     {
                         tagHelperClassifiedTextTooltip = await ClassifiedTagHelperTooltipFactory
-                            .TryCreateTooltipAsync(razorCompletionResolveContext.FilePath, descriptionInfo, solutionQueryOperations, cancellationToken)
+                            .TryCreateTooltipAsync(razorCompletionResolveContext.FilePath, descriptionInfo, componentAvailabilityService, cancellationToken)
                             .ConfigureAwait(false);
                     }
                     else
                     {
                         tagHelperMarkupTooltip = await MarkupTagHelperTooltipFactory
-                            .TryCreateTooltipAsync(razorCompletionResolveContext.FilePath, descriptionInfo, solutionQueryOperations, documentationKind, cancellationToken)
+                            .TryCreateTooltipAsync(razorCompletionResolveContext.FilePath, descriptionInfo, componentAvailabilityService, documentationKind, cancellationToken)
                             .ConfigureAwait(false);
                     }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/FindAllReferences/FindAllReferencesHelper.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/FindAllReferences/FindAllReferencesHelper.cs
@@ -35,6 +35,7 @@ internal static class FindAllReferencesHelper
         // To identify which situation we're in, we try to map the start and the end of the line to C#, as an indicator. If
         // either start or end fail to map, it means the entire line is not C#
 
+        // TODO: Note the call to ISolutionQueryOperations.GetProjectsContainingDocument(...) will be removed with the introduction of solution snapshots.
         if (solutionQueryOperations.GetProjectsContainingDocument(filePath).FirstOrDefault() is { } project &&
             project.TryGetDocument(filePath, out var document))
         {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Hover/HoverFactory.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Hover/HoverFactory.cs
@@ -13,7 +13,6 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Legacy;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.Threading;
-using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Tooltip;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Text;
@@ -30,7 +29,7 @@ internal static class HoverFactory
         RazorCodeDocument codeDocument,
         int absoluteIndex,
         HoverDisplayOptions options,
-        ISolutionQueryOperations solutionQueryOperations,
+        IComponentAvailabilityService componentAvailabilityService,
         CancellationToken cancellationToken)
     {
         var syntaxTree = codeDocument.GetSyntaxTree();
@@ -96,7 +95,7 @@ internal static class HoverFactory
             var span = containingTagNameToken.GetLinePositionSpan(codeDocument.Source);
 
             return ElementInfoToHoverAsync(
-                codeDocument.Source.FilePath, binding.Descriptors, span, options, solutionQueryOperations, cancellationToken);
+                codeDocument.Source.FilePath, binding.Descriptors, span, options, componentAvailabilityService, cancellationToken);
         }
 
         if (HtmlFacts.TryGetAttributeInfo(owner, out containingTagNameToken, out _, out var selectedAttributeName, out var selectedAttributeNameLocation, out attributes) &&
@@ -222,7 +221,7 @@ internal static class HoverFactory
         ImmutableArray<TagHelperDescriptor> descriptors,
         LinePositionSpan span,
         HoverDisplayOptions options,
-        ISolutionQueryOperations solutionQueryOperations,
+        IComponentAvailabilityService componentAvailabilityService,
         CancellationToken cancellationToken)
     {
         // Filter out attribute descriptors since we're creating an element hover
@@ -235,7 +234,7 @@ internal static class HoverFactory
         if (options.SupportsVisualStudioExtensions)
         {
             var classifiedTextElement = await ClassifiedTagHelperTooltipFactory
-                .TryCreateTooltipContainerAsync(documentFilePath, elementDescriptionInfo, solutionQueryOperations, cancellationToken)
+                .TryCreateTooltipContainerAsync(documentFilePath, elementDescriptionInfo, componentAvailabilityService, cancellationToken)
                 .ConfigureAwait(false);
 
             if (classifiedTextElement is not null)
@@ -250,7 +249,7 @@ internal static class HoverFactory
         }
 
         var tooltipContent = await MarkupTagHelperTooltipFactory
-            .TryCreateTooltipAsync(documentFilePath, elementDescriptionInfo, solutionQueryOperations, options.MarkupKind, cancellationToken)
+            .TryCreateTooltipAsync(documentFilePath, elementDescriptionInfo, componentAvailabilityService, options.MarkupKind, cancellationToken)
             .ConfigureAwait(false);
 
         if (tooltipContent is null)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Tooltip/AbstractComponentAvailabilityService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Tooltip/AbstractComponentAvailabilityService.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.PooledObjects;
+using Microsoft.AspNetCore.Razor.ProjectSystem;
+
+namespace Microsoft.CodeAnalysis.Razor.Tooltip;
+
+internal abstract class AbstractComponentAvailabilityService : IComponentAvailabilityService
+{
+    public async Task<ImmutableArray<(IProjectSnapshot Project, bool IsAvailable)>> GetComponentAvailabilityAsync(
+        string documentFilePath,
+        string typeName,
+        CancellationToken cancellationToken)
+    {
+        var projects = GetProjectsContainingDocument(documentFilePath);
+        if (projects.IsEmpty)
+        {
+            return [];
+        }
+
+        using var result = new PooledArrayBuilder<(IProjectSnapshot, bool IsAvailable)>(capacity: projects.Length);
+
+        foreach (var project in projects)
+        {
+            var containsTagHelper = await ContainsTagHelperAsync(project, typeName, cancellationToken).ConfigureAwait(false);
+
+            result.Add((project, IsAvailable: containsTagHelper));
+        }
+
+        return result.DrainToImmutable();
+    }
+
+    protected abstract ImmutableArray<IProjectSnapshot> GetProjectsContainingDocument(string documentFilePath);
+
+    private static async Task<bool> ContainsTagHelperAsync(
+        IProjectSnapshot projectSnapshot,
+        string typeName,
+        CancellationToken cancellationToken)
+    {
+        var tagHelpers = await projectSnapshot.GetTagHelpersAsync(cancellationToken).ConfigureAwait(false);
+
+        foreach (var tagHelper in tagHelpers)
+        {
+            if (tagHelper.GetTypeName() == typeName)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Tooltip/ClassifiedTagHelperTooltipFactory.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Tooltip/ClassifiedTagHelperTooltipFactory.cs
@@ -12,7 +12,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.Classification;
-using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.VisualStudio.Core.Imaging;
 using Microsoft.VisualStudio.Text.Adornments;
 
@@ -60,7 +59,7 @@ internal static class ClassifiedTagHelperTooltipFactory
     public static async Task<ContainerElement?> TryCreateTooltipContainerAsync(
         string? documentFilePath,
         AggregateBoundElementDescription elementDescriptionInfo,
-        ISolutionQueryOperations solutionQueryOperations,
+        IComponentAvailabilityService componentAvailabilityService,
         CancellationToken cancellationToken)
     {
         if (elementDescriptionInfo is null)
@@ -69,7 +68,7 @@ internal static class ClassifiedTagHelperTooltipFactory
         }
 
         var descriptionClassifications = await TryClassifyElementAsync(
-            documentFilePath, elementDescriptionInfo, solutionQueryOperations, cancellationToken).ConfigureAwait(false);
+            documentFilePath, elementDescriptionInfo, componentAvailabilityService, cancellationToken).ConfigureAwait(false);
 
         if (descriptionClassifications.IsDefaultOrEmpty)
         {
@@ -101,7 +100,7 @@ internal static class ClassifiedTagHelperTooltipFactory
     public static async Task<ClassifiedTextElement?> TryCreateTooltipAsync(
         string documentFilePath,
         AggregateBoundElementDescription elementDescriptionInfo,
-        ISolutionQueryOperations solutionQueryOperations,
+        IComponentAvailabilityService componentAvailabilityService,
         CancellationToken cancellationToken)
     {
         if (elementDescriptionInfo is null)
@@ -110,7 +109,7 @@ internal static class ClassifiedTagHelperTooltipFactory
         }
 
         var descriptionClassifications = await TryClassifyElementAsync(
-            documentFilePath, elementDescriptionInfo, solutionQueryOperations, cancellationToken).ConfigureAwait(false);
+            documentFilePath, elementDescriptionInfo, componentAvailabilityService, cancellationToken).ConfigureAwait(false);
 
         if (descriptionClassifications.IsDefaultOrEmpty)
         {
@@ -142,7 +141,7 @@ internal static class ClassifiedTagHelperTooltipFactory
     private static async Task<ImmutableArray<DescriptionClassification>> TryClassifyElementAsync(
         string? documentFilePath,
         AggregateBoundElementDescription elementInfo,
-        ISolutionQueryOperations solutionQueryOperations,
+        IComponentAvailabilityService componentAvailabilityService,
         CancellationToken cancellationToken)
     {
         var associatedTagHelperInfos = elementInfo.DescriptionInfos;
@@ -172,7 +171,7 @@ internal static class ClassifiedTagHelperTooltipFactory
             if (documentFilePath is not null)
             {
                 await AddProjectAvailabilityInfoAsync(
-                    documentFilePath, descriptionInfo.TagHelperTypeName, solutionQueryOperations, documentationRuns, cancellationToken).ConfigureAwait(false);
+                    documentFilePath, descriptionInfo.TagHelperTypeName, componentAvailabilityService, documentationRuns, cancellationToken).ConfigureAwait(false);
             }
 
             // 4. Combine type + summary information
@@ -185,11 +184,11 @@ internal static class ClassifiedTagHelperTooltipFactory
     private static async Task AddProjectAvailabilityInfoAsync(
         string documentFilePath,
         string tagHelperTypeName,
-        ISolutionQueryOperations solutionQueryOperations,
+        IComponentAvailabilityService componentAvailabilityService,
         List<ClassifiedTextRun> documentationRuns,
         CancellationToken cancellationToken)
     {
-        var availability = await solutionQueryOperations
+        var availability = await componentAvailabilityService
             .GetProjectAvailabilityTextAsync(documentFilePath, tagHelperTypeName, cancellationToken)
             .ConfigureAwait(false);
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Tooltip/Extensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Tooltip/Extensions.cs
@@ -1,26 +1,22 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System.Collections.Immutable;
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.Language;
+using System.Threading;
 using Microsoft.AspNetCore.Razor.PooledObjects;
-using Microsoft.AspNetCore.Razor.ProjectSystem;
-using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 namespace Microsoft.CodeAnalysis.Razor.Tooltip;
 
 internal static class Extensions
 {
     internal static async Task<string?> GetProjectAvailabilityTextAsync(
-        this ISolutionQueryOperations solutionQueryOperations,
+        this IComponentAvailabilityService componentAvailabilityService,
         string documentFilePath,
         string tagHelperTypeName,
         CancellationToken cancellationToken)
     {
-        var projects = await solutionQueryOperations
-            .GetProjectAvailabilityAsync(documentFilePath, tagHelperTypeName, cancellationToken)
+        var projects = await componentAvailabilityService
+            .GetComponentAvailabilityAsync(documentFilePath, tagHelperTypeName, cancellationToken)
             .ConfigureAwait(false);
 
         if (projects.IsEmpty)
@@ -54,51 +50,5 @@ internal static class Extensions
         }
 
         return builder.ToString();
-    }
-
-    /// <summary>
-    ///  Returns the Razor projects that contain the document specified by file path and a <see cref="bool"/>
-    ///  that indicates whether or not the given tag helper is available within a project.
-    /// </summary>
-    internal static async Task<ImmutableArray<(IProjectSnapshot, bool IsAvailable)>> GetProjectAvailabilityAsync(
-        this ISolutionQueryOperations solutionQueryOperations,
-        string documentFilePath,
-        string tagHelperTypeName,
-        CancellationToken cancellationToken)
-    {
-        var projects = solutionQueryOperations.GetProjectsContainingDocument(documentFilePath);
-        if (projects.IsEmpty)
-        {
-            return [];
-        }
-
-        using var result = new PooledArrayBuilder<(IProjectSnapshot, bool IsAvailable)>(capacity: projects.Length);
-
-        foreach (var project in projects)
-        {
-            var containsTagHelper = await project.ContainsTagHelperAsync(tagHelperTypeName, cancellationToken).ConfigureAwait(false);
-
-            result.Add((project, IsAvailable: containsTagHelper));
-        }
-
-        return result.DrainToImmutable();
-    }
-
-    internal static async Task<bool> ContainsTagHelperAsync(
-        this IProjectSnapshot projectSnapshot,
-        string tagHelperTypeName,
-        CancellationToken cancellationToken)
-    {
-        var tagHelpers = await projectSnapshot.GetTagHelpersAsync(cancellationToken).ConfigureAwait(false);
-
-        foreach (var tagHelper in tagHelpers)
-        {
-            if (tagHelper.GetTypeName() == tagHelperTypeName)
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Tooltip/IComponentAvailabilityService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Tooltip/IComponentAvailabilityService.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.ProjectSystem;
+
+namespace Microsoft.CodeAnalysis.Razor.Tooltip;
+
+internal interface IComponentAvailabilityService
+{
+    /// <summary>
+    ///  Returns an array of projects that contain the specified document and whether the
+    ///  given component or tag helper type name is available within it.
+    /// </summary>
+    Task<ImmutableArray<(IProjectSnapshot Project, bool IsAvailable)>> GetComponentAvailabilityAsync(
+        string documentFilePath,
+        string typeName,
+        CancellationToken cancellationToken);
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Tooltip/MarkupTagHelperTooltipFactory.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Tooltip/MarkupTagHelperTooltipFactory.cs
@@ -8,7 +8,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.PooledObjects;
-using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.Razor.Tooltip;
@@ -18,7 +17,7 @@ internal static class MarkupTagHelperTooltipFactory
     public static async Task<MarkupContent?> TryCreateTooltipAsync(
         string? documentFilePath,
         AggregateBoundElementDescription elementDescriptionInfo,
-        ISolutionQueryOperations solutionQueryOperations,
+        IComponentAvailabilityService componentAvailabilityService,
         MarkupKind markupKind,
         CancellationToken cancellationToken)
     {
@@ -75,7 +74,7 @@ internal static class MarkupTagHelperTooltipFactory
 
             if (documentFilePath is not null)
             {
-                var availability = await solutionQueryOperations
+                var availability = await componentAvailabilityService
                     .GetProjectAvailabilityTextAsync(documentFilePath, tagHelperType, cancellationToken)
                     .ConfigureAwait(false);
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Hover/ComponentAvailabilityService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Hover/ComponentAvailabilityService.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Microsoft.AspNetCore.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Tooltip;
+using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
+
+namespace Microsoft.CodeAnalysis.Remote.Razor;
+
+internal sealed class ComponentAvailabilityService(RemoteSolutionSnapshot solutionSnapshot) : AbstractComponentAvailabilityService
+{
+    private readonly RemoteSolutionSnapshot _solutionSnapshot = solutionSnapshot;
+
+    protected override ImmutableArray<IProjectSnapshot> GetProjectsContainingDocument(string documentFilePath)
+        => _solutionSnapshot.GetProjectsContainingDocument(documentFilePath);
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Hover/RemoteHoverService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Hover/RemoteHoverService.cs
@@ -102,8 +102,15 @@ internal sealed class RemoteHoverService(in ServiceArgs args) : RazorDocumentSer
         // If this is Html or Razor, try to retrieve a hover from Razor.
         var options = HoverDisplayOptions.From(clientCapabilities);
 
+        // In co-hosting, there isn't a singleton IComponentAvailabilityService in the MEF composition.
+        // So, we construct one using the current solution snapshot.
+        // All of this will change when solution snapshots are available in the core Razor project model.
+
+        // TODO: Remove this when solution snapshots are available in the core Razor project model.
+        var componentAvailabilityService = new ComponentAvailabilityService(context.Snapshot.ProjectSnapshot.SolutionSnapshot);
+
         var razorHover = await HoverFactory
-            .GetHoverAsync(codeDocument, hostDocumentIndex, options, context.GetSolutionQueryOperations(), cancellationToken)
+            .GetHoverAsync(codeDocument, hostDocumentIndex, options, componentAvailabilityService, cancellationToken)
             .ConfigureAwait(false);
 
         // Roslyn couldn't provide a hover, so we're done.

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionResolveEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionResolveEndpointTest.cs
@@ -8,9 +8,10 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.LanguageServer.Hover;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.CodeAnalysis.Razor.Completion;
-using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Tooltip;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Xunit;
 using Xunit.Abstractions;
@@ -27,12 +28,16 @@ public class RazorCompletionResolveEndpointTest : LanguageServerTestBase
         : base(testOutput)
     {
         _completionListCache = new CompletionListCache();
+
+        var projectManager = CreateProjectSnapshotManager();
+        var componentAvailabilityService = new ComponentAvailabilityService(projectManager);
+
         _endpoint = new RazorCompletionResolveEndpoint(
             new AggregateCompletionItemResolver(
                 new[] { new TestCompletionItemResolver() },
                 LoggerFactory),
             _completionListCache,
-            CreateProjectSnapshotManager());
+            componentAvailabilityService);
         _clientCapabilities = new VSInternalClientCapabilities()
         {
             TextDocument = new TextDocumentClientCapabilities()
@@ -163,7 +168,7 @@ public class RazorCompletionResolveEndpointTest : LanguageServerTestBase
             VSInternalCompletionList containingCompletionList,
             object originalRequestContext,
             VSInternalClientCapabilities clientCapabilities,
-            ISolutionQueryOperations solutionQueryOperations,
+            IComponentAvailabilityService componentAvailabilityService,
             CancellationToken cancellationToken)
         {
             var completionSupportedKinds = clientCapabilities?.TextDocument?.Completion?.CompletionItem?.DocumentationFormat;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverEndpointTest.cs
@@ -201,6 +201,7 @@ public class HoverEndpointTest(ITestOutputHelper testOutput) : TagHelperServiceT
         var documentMappingService = new LspDocumentMappingService(FilePathService, documentContextFactory, LoggerFactory);
 
         var projectManager = CreateProjectSnapshotManager();
+        var componentAvailabilityService = new ComponentAvailabilityService(projectManager);
 
         var clientCapabilities = new VSInternalClientCapabilities()
         {
@@ -211,7 +212,7 @@ public class HoverEndpointTest(ITestOutputHelper testOutput) : TagHelperServiceT
         var clientCapabilitiesService = new TestClientCapabilitiesService(clientCapabilities);
 
         var endpoint = new HoverEndpoint(
-            projectManager,
+            componentAvailabilityService,
             clientCapabilitiesService,
             languageServerFeatureOptions,
             documentMappingService,
@@ -293,6 +294,7 @@ public class HoverEndpointTest(ITestOutputHelper testOutput) : TagHelperServiceT
         clientConnection ??= StrictMock.Of<IClientConnection>();
 
         var projectManager = CreateProjectSnapshotManager();
+        var componentAvailabilityService = new ComponentAvailabilityService(projectManager);
 
         var clientCapabilities = new VSInternalClientCapabilities()
         {
@@ -303,7 +305,7 @@ public class HoverEndpointTest(ITestOutputHelper testOutput) : TagHelperServiceT
         var clientCapabilitiesService = new TestClientCapabilitiesService(clientCapabilities);
 
         var endpoint = new HoverEndpoint(
-            projectManager,
+            componentAvailabilityService,
             clientCapabilitiesService,
             languageServerFeatureOptions,
             documentMappingService,

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Hover/HoverFactoryTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Hover/HoverFactoryTest.cs
@@ -3,10 +3,10 @@
 
 using System;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Classification;
-using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Tooltip;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Text.Adornments;
@@ -23,11 +23,11 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
 
     private static HoverDisplayOptions UseVisualStudio => new(MarkupKind.Markdown, SupportsVisualStudioExtensions: true);
 
-    private static ISolutionQueryOperations CreateSolutionQueryOperations()
+    private static IComponentAvailabilityService CreateComponentAvailabilityService()
     {
-        var mock = new StrictMock<ISolutionQueryOperations>();
-        mock.Setup(x => x.GetProjectsContainingDocument(It.IsAny<string>()))
-            .Returns([]);
+        var mock = new StrictMock<IComponentAvailabilityService>();
+        mock.Setup(x => x.GetComponentAvailabilityAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
 
         return mock.Object;
     }
@@ -44,7 +44,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateComponentAvailabilityService(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -68,7 +68,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateComponentAvailabilityService(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -92,7 +92,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateComponentAvailabilityService(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -114,7 +114,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateComponentAvailabilityService(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -136,7 +136,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateComponentAvailabilityService(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -159,7 +159,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateComponentAvailabilityService(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -182,7 +182,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateComponentAvailabilityService(), DisposalToken);
 
         // Assert
         Assert.Null(hover);
@@ -200,7 +200,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateComponentAvailabilityService(), DisposalToken);
 
         // Assert
         Assert.Null(hover);
@@ -218,7 +218,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateComponentAvailabilityService(), DisposalToken);
 
         // Assert
         Assert.Null(hover);
@@ -236,7 +236,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateComponentAvailabilityService(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -263,7 +263,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, "text.razor", SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateComponentAvailabilityService(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -285,7 +285,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateComponentAvailabilityService(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -307,7 +307,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateComponentAvailabilityService(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -330,7 +330,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseMarkdown, CreateComponentAvailabilityService(), DisposalToken);
 
         // Assert
         Assert.Null(hover);
@@ -348,7 +348,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UsePlainText, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UsePlainText, CreateComponentAvailabilityService(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -371,7 +371,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UsePlainText, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UsePlainText, CreateComponentAvailabilityService(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -393,7 +393,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: true, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UsePlainText, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UsePlainText, CreateComponentAvailabilityService(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -417,7 +417,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: true, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UsePlainText, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UsePlainText, CreateComponentAvailabilityService(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -442,7 +442,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: true, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UsePlainText, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UsePlainText, CreateComponentAvailabilityService(), DisposalToken);
 
         // Assert
         Assert.Null(hover);
@@ -464,7 +464,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: true, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UsePlainText, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UsePlainText, CreateComponentAvailabilityService(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -487,7 +487,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UsePlainText, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UsePlainText, CreateComponentAvailabilityService(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -511,7 +511,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UsePlainText, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UsePlainText, CreateComponentAvailabilityService(), DisposalToken);
 
         // Assert
         Assert.Null(hover);
@@ -529,7 +529,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UsePlainText, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UsePlainText, CreateComponentAvailabilityService(), DisposalToken);
 
         // Assert
         Assert.Null(hover);
@@ -547,7 +547,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseVisualStudio, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseVisualStudio, CreateComponentAvailabilityService(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);
@@ -585,7 +585,7 @@ public class HoverFactoryTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         var codeDocument = RazorCodeDocumentFactory.CreateCodeDocument(code.Text, isRazorFile: false, SimpleTagHelpers.Default);
 
         // Act
-        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseVisualStudio, CreateSolutionQueryOperations(), DisposalToken);
+        var hover = await HoverFactory.GetHoverAsync(codeDocument, code.Position, UseVisualStudio, CreateComponentAvailabilityService(), DisposalToken);
 
         // Assert
         Assert.NotNull(hover);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Tooltip/ClassifiedTagHelperTooltipFactoryTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Tooltip/ClassifiedTagHelperTooltipFactoryTest.cs
@@ -7,12 +7,9 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Classification;
-using Microsoft.CodeAnalysis.Razor.Workspaces.Test;
 using Microsoft.VisualStudio.Text.Adornments;
 using Xunit;
 using Xunit.Abstractions;
@@ -172,10 +169,11 @@ End summary description.";
     {
         // Arrange
         var projectManager = CreateProjectSnapshotManager();
+        var componentAvailabilityService = new TestComponentAvailabilityService(projectManager);
         var elementDescription = AggregateBoundElementDescription.Empty;
 
         // Act
-        var classifiedTextElement = await ClassifiedTagHelperTooltipFactory.TryCreateTooltipAsync("file.razor", elementDescription, projectManager.GetQueryOperations(), DisposalToken);
+        var classifiedTextElement = await ClassifiedTagHelperTooltipFactory.TryCreateTooltipAsync("file.razor", elementDescription, componentAvailabilityService, DisposalToken);
 
         // Assert
         Assert.Null(classifiedTextElement);
@@ -186,16 +184,19 @@ End summary description.";
     {
         // Arrange
         var projectManager = CreateProjectSnapshotManager();
+        var componentAvailabilityService = new TestComponentAvailabilityService(projectManager);
+
         var associatedTagHelperInfos = new[]
         {
             new BoundElementDescriptionInfo(
                 "Microsoft.AspNetCore.SomeTagHelper",
                 "<summary>Uses <see cref=\"T:System.Collections.List{System.Collections.List{System.String}}\" />s</summary>"),
         };
+
         var elementDescription = new AggregateBoundElementDescription(associatedTagHelperInfos.ToImmutableArray());
 
         // Act
-        var classifiedTextElement = await ClassifiedTagHelperTooltipFactory.TryCreateTooltipAsync("file.razor", elementDescription, projectManager.GetQueryOperations(), DisposalToken);
+        var classifiedTextElement = await ClassifiedTagHelperTooltipFactory.TryCreateTooltipAsync("file.razor", elementDescription, componentAvailabilityService, DisposalToken);
 
         // Assert
         Assert.NotNull(classifiedTextElement);
@@ -226,16 +227,19 @@ End summary description.";
     {
         // Arrange
         var projectManager = CreateProjectSnapshotManager();
+        var componentAvailabilityService = new TestComponentAvailabilityService(projectManager);
+
         var associatedTagHelperInfos = new[]
         {
             new BoundElementDescriptionInfo(
                 "Microsoft.AspNetCore.SomeTagHelper.SomeTagHelper",
                 "<summary>Uses <see cref=\"T:A.B.C{C.B}\" />s</summary>"),
         };
+
         var elementDescription = new AggregateBoundElementDescription(associatedTagHelperInfos.ToImmutableArray());
 
         // Act
-        var classifiedTextElement = await ClassifiedTagHelperTooltipFactory.TryCreateTooltipAsync("file.razor", elementDescription, projectManager.GetQueryOperations(), DisposalToken);
+        var classifiedTextElement = await ClassifiedTagHelperTooltipFactory.TryCreateTooltipAsync("file.razor", elementDescription, componentAvailabilityService, DisposalToken);
 
         // Assert
         Assert.NotNull(classifiedTextElement);
@@ -265,6 +269,8 @@ End summary description.";
     {
         // Arrange
         var projectManager = CreateProjectSnapshotManager();
+        var componentAvailabilityService = new TestComponentAvailabilityService(projectManager);
+
         var associatedTagHelperInfos = new[]
         {
             new BoundElementDescriptionInfo("Microsoft.AspNetCore.SomeTagHelper", "<summary>\nUses <see cref=\"T:System.Collections.List{System.String}\" />s\n</summary>"),
@@ -273,7 +279,7 @@ End summary description.";
         var elementDescription = new AggregateBoundElementDescription(associatedTagHelperInfos.ToImmutableArray());
 
         // Act
-        var classifiedTextElement = await ClassifiedTagHelperTooltipFactory.TryCreateTooltipAsync("file.razor", elementDescription, projectManager.GetQueryOperations(), DisposalToken);
+        var classifiedTextElement = await ClassifiedTagHelperTooltipFactory.TryCreateTooltipAsync("file.razor", elementDescription, componentAvailabilityService, DisposalToken);
 
         // Assert
         Assert.NotNull(classifiedTextElement);
@@ -445,10 +451,12 @@ End summary description.";
     {
         // Arrange
         var projectManager = CreateProjectSnapshotManager();
+        var componentAvailabilityService = new TestComponentAvailabilityService(projectManager);
+
         var elementDescription = AggregateBoundElementDescription.Empty;
 
         // Act
-        var containerElement = await ClassifiedTagHelperTooltipFactory.TryCreateTooltipContainerAsync("file.razor", elementDescription, projectManager.GetQueryOperations(), DisposalToken);
+        var containerElement = await ClassifiedTagHelperTooltipFactory.TryCreateTooltipContainerAsync("file.razor", elementDescription, componentAvailabilityService, DisposalToken);
 
         // Assert
         Assert.Null(containerElement);
@@ -459,15 +467,18 @@ End summary description.";
     {
         // Arrange
         var projectManager = CreateProjectSnapshotManager();
+        var componentAvailabilityService = new TestComponentAvailabilityService(projectManager);
+
         var associatedTagHelperInfos = new[]
         {
             new BoundElementDescriptionInfo("Microsoft.AspNetCore.SomeTagHelper", "<summary>\nUses <see cref=\"T:System.Collections.List{System.String}\" />s\n</summary>"),
             new BoundElementDescriptionInfo("Microsoft.AspNetCore.OtherTagHelper", "<summary>\nAlso uses <see cref=\"T:System.Collections.List{System.String}\" />s\n\r\n\r\r</summary>"),
         };
+
         var elementDescription = new AggregateBoundElementDescription(associatedTagHelperInfos.ToImmutableArray());
 
         // Act
-        var container = await ClassifiedTagHelperTooltipFactory.TryCreateTooltipContainerAsync("file.razor", elementDescription, projectManager.GetQueryOperations(), DisposalToken);
+        var container = await ClassifiedTagHelperTooltipFactory.TryCreateTooltipContainerAsync("file.razor", elementDescription, componentAvailabilityService, DisposalToken);
 
         // Assert
         Assert.NotNull(container);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Tooltip/MarkupTagHelperTooltipFactoryTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Tooltip/MarkupTagHelperTooltipFactoryTest.cs
@@ -4,11 +4,8 @@
 #nullable disable
 
 using System.Collections.Immutable;
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common;
-using Microsoft.CodeAnalysis.Razor.Workspaces.Test;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Xunit;
 using Xunit.Abstractions;
@@ -68,10 +65,11 @@ World", cleanedSummary);
     {
         // Arrange
         var projectManager = CreateProjectSnapshotManager();
+        var componentAvailabilityService = new TestComponentAvailabilityService(projectManager);
         var elementDescription = AggregateBoundElementDescription.Empty;
 
         // Act
-        var markdown = await MarkupTagHelperTooltipFactory.TryCreateTooltipAsync("file.razor", elementDescription, projectManager.GetQueryOperations(), MarkupKind.Markdown, DisposalToken);
+        var markdown = await MarkupTagHelperTooltipFactory.TryCreateTooltipAsync("file.razor", elementDescription, componentAvailabilityService, MarkupKind.Markdown, DisposalToken);
 
         // Assert
         Assert.Null(markdown);
@@ -82,13 +80,16 @@ World", cleanedSummary);
     {
         // Arrange
         var projectManager = CreateProjectSnapshotManager();
+        var componentAvailabilityService = new TestComponentAvailabilityService(projectManager);
+
         var associatedTagHelperInfos = new[]
         {
             new BoundElementDescriptionInfo("Microsoft.AspNetCore.SomeTagHelper", "<summary>Uses <see cref=\"T:System.Collections.List{System.String}\" />s</summary>"),
         };
+
         var elementDescription = new AggregateBoundElementDescription(associatedTagHelperInfos.ToImmutableArray());
         // Act
-        var markdown = await MarkupTagHelperTooltipFactory.TryCreateTooltipAsync("file.razor", elementDescription, projectManager.GetQueryOperations(), MarkupKind.Markdown, DisposalToken);
+        var markdown = await MarkupTagHelperTooltipFactory.TryCreateTooltipAsync("file.razor", elementDescription, componentAvailabilityService, MarkupKind.Markdown, DisposalToken);
 
         // Assert
         Assert.NotNull(markdown);
@@ -103,14 +104,17 @@ Uses `List<System.String>`s", markdown.Value);
     {
         // Arrange
         var projectManager = CreateProjectSnapshotManager();
+        var componentAvailabilityService = new TestComponentAvailabilityService(projectManager);
+
         var associatedTagHelperInfos = new[]
         {
             new BoundElementDescriptionInfo("Microsoft.AspNetCore.SomeTagHelper", "<summary>Uses <see cref=\"T:System.Collections.List{System.String}\" />s</summary>"),
         };
+
         var elementDescription = new AggregateBoundElementDescription(associatedTagHelperInfos.ToImmutableArray());
 
         // Act
-        var markdown = await MarkupTagHelperTooltipFactory.TryCreateTooltipAsync("file.razor", elementDescription, projectManager.GetQueryOperations(), MarkupKind.PlainText, DisposalToken);
+        var markdown = await MarkupTagHelperTooltipFactory.TryCreateTooltipAsync("file.razor", elementDescription, componentAvailabilityService, MarkupKind.PlainText, DisposalToken);
 
         // Assert
         Assert.NotNull(markdown);
@@ -132,6 +136,7 @@ Uses `List<System.String>`s", markdown.Value);
                 PropertyName: "SomeProperty",
                 Documentation: "<summary>Uses <see cref=\"T:System.Collections.List{System.String}\" />s</summary>")
         };
+
         var attributeDescription = new AggregateBoundAttributeDescription(associatedAttributeDescriptions.ToImmutableArray());
 
         // Act
@@ -150,15 +155,18 @@ Uses `List<System.String>`s", markdown.Value);
     {
         // Arrange
         var projectManager = CreateProjectSnapshotManager();
+        var componentAvailabilityService = new TestComponentAvailabilityService(projectManager);
+
         var associatedTagHelperInfos = new[]
         {
             new BoundElementDescriptionInfo("Microsoft.AspNetCore.SomeTagHelper", "<summary>\nUses <see cref=\"T:System.Collections.List{System.String}\" />s\n</summary>"),
             new BoundElementDescriptionInfo("Microsoft.AspNetCore.OtherTagHelper", "<summary>\nAlso uses <see cref=\"T:System.Collections.List{System.String}\" />s\n\r\n\r\r</summary>"),
         };
+
         var elementDescription = new AggregateBoundElementDescription(associatedTagHelperInfos.ToImmutableArray());
 
         // Act
-        var markdown = await MarkupTagHelperTooltipFactory.TryCreateTooltipAsync("file.razor", elementDescription, projectManager.GetQueryOperations(), MarkupKind.Markdown, DisposalToken);
+        var markdown = await MarkupTagHelperTooltipFactory.TryCreateTooltipAsync("file.razor", elementDescription, componentAvailabilityService, MarkupKind.Markdown, DisposalToken);
 
         // Assert
         Assert.NotNull(markdown);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Tooltip/ProjectAvailabilityTests.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Tooltip/ProjectAvailabilityTests.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
-using Microsoft.CodeAnalysis.Razor.Workspaces.Test;
 using Roslyn.Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
@@ -22,9 +21,9 @@ public class ProjectAvailabilityTests(ITestOutputHelper testOutput) : ToolingTes
     public async Task GetProjectAvailabilityText_NoProjects_ReturnsNull()
     {
         var projectManager = CreateProjectSnapshotManager();
-        var solutionQueryOperations = projectManager.GetQueryOperations();
+        var componentAvailabilityService = new TestComponentAvailabilityService(projectManager);
 
-        var availability = await solutionQueryOperations.GetProjectAvailabilityTextAsync("file.razor", "MyTagHelper", DisposalToken);
+        var availability = await componentAvailabilityService.GetProjectAvailabilityTextAsync("file.razor", "MyTagHelper", DisposalToken);
 
         Assert.Null(availability);
     }
@@ -60,9 +59,9 @@ public class ProjectAvailabilityTests(ITestOutputHelper testOutput) : ToolingTes
             updater.AddDocument(hostProject.Key, hostDocument, EmptyTextLoader.Instance);
         });
 
-        var solutionQueryOperations = projectManager.GetQueryOperations();
+        var componentAvailabilityService = new TestComponentAvailabilityService(projectManager);
 
-        var availability = await solutionQueryOperations.GetProjectAvailabilityTextAsync(hostDocument.FilePath, tagHelperTypeName, DisposalToken);
+        var availability = await componentAvailabilityService.GetProjectAvailabilityTextAsync(hostDocument.FilePath, tagHelperTypeName, DisposalToken);
 
         Assert.Null(availability);
     }
@@ -109,9 +108,9 @@ public class ProjectAvailabilityTests(ITestOutputHelper testOutput) : ToolingTes
             updater.AddDocument(hostProject2.Key, hostDocument, EmptyTextLoader.Instance);
         });
 
-        var solutionQueryOperations = projectManager.GetQueryOperations();
+        var componentAvailabilityService = new TestComponentAvailabilityService(projectManager);
 
-        var availability = await solutionQueryOperations.GetProjectAvailabilityTextAsync(hostDocument.FilePath, tagHelperTypeName, DisposalToken);
+        var availability = await componentAvailabilityService.GetProjectAvailabilityTextAsync(hostDocument.FilePath, tagHelperTypeName, DisposalToken);
 
         Assert.Null(availability);
     }
@@ -157,9 +156,9 @@ public class ProjectAvailabilityTests(ITestOutputHelper testOutput) : ToolingTes
             updater.AddDocument(hostProject2.Key, hostDocument, EmptyTextLoader.Instance);
         });
 
-        var solutionQueryOperations = projectManager.GetQueryOperations();
+        var componentAvailabilityService = new TestComponentAvailabilityService(projectManager);
 
-        var availability = await solutionQueryOperations.GetProjectAvailabilityTextAsync(hostDocument.FilePath, tagHelperTypeName, DisposalToken);
+        var availability = await componentAvailabilityService.GetProjectAvailabilityTextAsync(hostDocument.FilePath, tagHelperTypeName, DisposalToken);
 
         AssertEx.EqualOrDiff("""
 
@@ -201,9 +200,9 @@ public class ProjectAvailabilityTests(ITestOutputHelper testOutput) : ToolingTes
             updater.AddDocument(hostProject2.Key, hostDocument, EmptyTextLoader.Instance);
         });
 
-        var solutionQueryOperations = projectManager.GetQueryOperations();
+        var componentAvailabilityService = new TestComponentAvailabilityService(projectManager);
 
-        var availability = await solutionQueryOperations.GetProjectAvailabilityTextAsync(hostDocument.FilePath, "MyTagHelper", DisposalToken);
+        var availability = await componentAvailabilityService.GetProjectAvailabilityTextAsync(hostDocument.FilePath, "MyTagHelper", DisposalToken);
 
         AssertEx.EqualOrDiff("""
 

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Tooltip/TestComponentAvailabilityService.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Tooltip/TestComponentAvailabilityService.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Microsoft.AspNetCore.Razor.PooledObjects;
+using Microsoft.AspNetCore.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+
+namespace Microsoft.CodeAnalysis.Razor.Tooltip;
+
+internal sealed class TestComponentAvailabilityService(ProjectSnapshotManager projectManager) : AbstractComponentAvailabilityService
+{
+    private readonly ProjectSnapshotManager _projectManager = projectManager;
+
+    protected override ImmutableArray<IProjectSnapshot> GetProjectsContainingDocument(string documentFilePath)
+    {
+        using var projects = new PooledArrayBuilder<IProjectSnapshot>();
+
+        foreach (var project in _projectManager.GetProjects())
+        {
+            if (project.ContainsDocument(documentFilePath))
+            {
+                projects.Add(project);
+            }
+        }
+
+        return projects.DrainToImmutable();
+    }
+}
+


### PR DESCRIPTION
When determining what projects a component or tag helper is available within, there is slightly different behavior in the Razor language server vs. co-hosting. In the language server, there is a special case to skip the misc-files project, but that case isn't bothered with in co-hosting. The special case is manifested via different implementations of `ISolutionQueryOperations.GetProjectsContainingDocument(...)` in the language server and co-hosting.

This change (which is largely mechanical) introduces a new service, `IComponentAvailabilityService`, that is used to determine what projects a component or tag helper is available within. The intention is that this service contains the behavior difference between the language server and co-hosting rather than relying on ISolutionQueryOperations, which will be going away with proper Razor solution snapshots.