### PR TITLE
Wire up the UseRoslynTokenizer feature properly

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/CSharp/ParseOptionsExtensions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/CSharp/ParseOptionsExtensions.cs
@@ -1,0 +1,13 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.Razor.Compiler.CSharp;
+
+internal static class ParseOptionsExtensions
+{
+    public static bool UseRoslynTokenizer(this ParseOptions parseOptions)
+        => parseOptions.Features.TryGetValue("use-roslyn-tokenizer", out var useRoslynTokenizerValue) &&
+           string.Equals(useRoslynTokenizerValue, "true", StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorConfiguration.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorConfiguration.cs
@@ -14,15 +14,25 @@ public sealed record class RazorConfiguration(
     ImmutableArray<RazorExtension> Extensions,
     LanguageVersion CSharpLanguageVersion = LanguageVersion.Default,
     bool UseConsolidatedMvcViews = true,
-    bool SuppressAddComponentParameter = false)
+    bool SuppressAddComponentParameter = false,
+    bool UseRoslynTokenizer = false,
+    ImmutableArray<string> PreprocessorSymbols = default)
 {
+    public ImmutableArray<string> PreprocessorSymbols
+    {
+        get => field.NullToEmpty();
+        init => field = value.NullToEmpty();
+    } = PreprocessorSymbols;
+
     public static readonly RazorConfiguration Default = new(
         RazorLanguageVersion.Latest,
         ConfigurationName: "unnamed",
         Extensions: [],
         CSharpLanguageVersion: CodeAnalysis.CSharp.LanguageVersion.Default,
         UseConsolidatedMvcViews: true,
-        SuppressAddComponentParameter: false);
+        SuppressAddComponentParameter: false,
+        UseRoslynTokenizer: false,
+        PreprocessorSymbols: []);
 
     public bool Equals(RazorConfiguration? other)
         => other is not null &&
@@ -31,6 +41,8 @@ public sealed record class RazorConfiguration(
            CSharpLanguageVersion == other.CSharpLanguageVersion &&
            SuppressAddComponentParameter == other.SuppressAddComponentParameter &&
            UseConsolidatedMvcViews == other.UseConsolidatedMvcViews &&
+           UseRoslynTokenizer == other.UseRoslynTokenizer &&
+           PreprocessorSymbols.SequenceEqual(other.PreprocessorSymbols) &&
            Extensions.SequenceEqual(other.Extensions);
 
     public override int GetHashCode()
@@ -42,6 +54,8 @@ public sealed record class RazorConfiguration(
         hash.Add(Extensions);
         hash.Add(SuppressAddComponentParameter);
         hash.Add(UseConsolidatedMvcViews);
+        hash.Add(UseRoslynTokenizer);
+        hash.Add(PreprocessorSymbols);
         return hash;
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorConfiguration.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorConfiguration.cs
@@ -20,9 +20,9 @@ public sealed record class RazorConfiguration(
 {
     public ImmutableArray<string> PreprocessorSymbols
     {
-        get => field.NullToEmpty();
+        get;
         init => field = value.NullToEmpty();
-    } = PreprocessorSymbols;
+    } = PreprocessorSymbols.NullToEmpty();
 
     public static readonly RazorConfiguration Default = new(
         RazorLanguageVersion.Latest,

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorConfiguration.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorConfiguration.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Immutable;
 using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.Language;
@@ -11,6 +12,7 @@ public sealed record class RazorConfiguration(
     RazorLanguageVersion LanguageVersion,
     string ConfigurationName,
     ImmutableArray<RazorExtension> Extensions,
+    LanguageVersion CSharpLanguageVersion = LanguageVersion.Default,
     bool UseConsolidatedMvcViews = true,
     bool SuppressAddComponentParameter = false)
 {
@@ -18,6 +20,7 @@ public sealed record class RazorConfiguration(
         RazorLanguageVersion.Latest,
         ConfigurationName: "unnamed",
         Extensions: [],
+        CSharpLanguageVersion: CodeAnalysis.CSharp.LanguageVersion.Default,
         UseConsolidatedMvcViews: true,
         SuppressAddComponentParameter: false);
 
@@ -25,6 +28,7 @@ public sealed record class RazorConfiguration(
         => other is not null &&
            LanguageVersion == other.LanguageVersion &&
            ConfigurationName == other.ConfigurationName &&
+           CSharpLanguageVersion == other.CSharpLanguageVersion &&
            SuppressAddComponentParameter == other.SuppressAddComponentParameter &&
            UseConsolidatedMvcViews == other.UseConsolidatedMvcViews &&
            Extensions.SequenceEqual(other.Extensions);
@@ -34,6 +38,7 @@ public sealed record class RazorConfiguration(
         var hash = HashCodeCombiner.Start();
         hash.Add(LanguageVersion);
         hash.Add(ConfigurationName);
+        hash.Add(CSharpLanguageVersion);
         hash.Add(Extensions);
         hash.Add(SuppressAddComponentParameter);
         hash.Add(UseConsolidatedMvcViews);

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/RazorSourceGenerator.RazorProviders.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/RazorSourceGenerator.RazorProviders.cs
@@ -53,11 +53,12 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                 ? false
                 : CSharpCompilation.Create("components", references: minimalReferences).HasAddComponentParameter();
 
-            var razorConfiguration = new RazorConfiguration(razorLanguageVersion, configurationName ?? "default", Extensions: [], UseConsolidatedMvcViews: true, SuppressAddComponentParameter: !isComponentParameterSupported);
 
             // We use the new tokenizer only when requested for now.
             var useRoslynTokenizer = parseOptions.Features.TryGetValue("use-roslyn-tokenizer", out var useRoslynTokenizerValue)
                                     && string.Equals(useRoslynTokenizerValue, "true", StringComparison.OrdinalIgnoreCase);
+
+            var razorConfiguration = new RazorConfiguration(razorLanguageVersion, configurationName ?? "default", Extensions: [], UseConsolidatedMvcViews: true, SuppressAddComponentParameter: !isComponentParameterSupported);
 
             var razorSourceGenerationOptions = new RazorSourceGenerationOptions()
             {

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/RazorSourceGenerator.RazorProviders.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/RazorSourceGenerator.RazorProviders.cs
@@ -53,12 +53,10 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
                 ? false
                 : CSharpCompilation.Create("components", references: minimalReferences).HasAddComponentParameter();
 
+            var razorConfiguration = new RazorConfiguration(razorLanguageVersion, configurationName ?? "default", Extensions: [], UseConsolidatedMvcViews: true, SuppressAddComponentParameter: !isComponentParameterSupported);
 
             // We use the new tokenizer only when requested for now.
-            var useRoslynTokenizer = parseOptions.Features.TryGetValue("use-roslyn-tokenizer", out var useRoslynTokenizerValue)
-                                    && string.Equals(useRoslynTokenizerValue, "true", StringComparison.OrdinalIgnoreCase);
-
-            var razorConfiguration = new RazorConfiguration(razorLanguageVersion, configurationName ?? "default", Extensions: [], UseConsolidatedMvcViews: true, SuppressAddComponentParameter: !isComponentParameterSupported);
+            var useRoslynTokenizer = parseOptions.UseRoslynTokenizer();
 
             var razorSourceGenerationOptions = new RazorSourceGenerationOptions()
             {

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
@@ -73,8 +73,7 @@ public class RazorLanguageServerBenchmarkBase : ProjectSnapshotManagerBenchmarkB
             updater =>
             {
                 updater.AddProject(hostProject);
-                var tagHelpers = CommonResources.LegacyTagHelpers;
-                var projectWorkspaceState = ProjectWorkspaceState.Create(tagHelpers, CodeAnalysis.CSharp.LanguageVersion.CSharp11);
+                var projectWorkspaceState = ProjectWorkspaceState.Create(CommonResources.LegacyTagHelpers);
                 updater.UpdateProjectWorkspaceState(hostProject.Key, projectWorkspaceState);
                 updater.AddDocument(hostProject.Key, hostDocument, text);
             },

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
@@ -39,7 +39,5 @@ internal class DefaultLanguageServerFeatureOptions : LanguageServerFeatureOption
 
     public override bool ForceRuntimeCodeGeneration => false;
 
-    public override bool UseRoslynTokenizer => false;
-
     public override bool UseNewFormattingEngine => false;
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hosting/ConfigurableLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hosting/ConfigurableLanguageServerFeatureOptions.cs
@@ -23,7 +23,6 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
     private readonly bool? _useRazorCohostServer;
     private readonly bool? _disableRazorLanguageServer;
     private readonly bool? _forceRuntimeCodeGeneration;
-    private readonly bool? _useRoslynTokenizer;
     private readonly bool? _useNewFormattingEngine;
 
     public override bool SupportsFileManipulation => _supportsFileManipulation ?? _defaults.SupportsFileManipulation;
@@ -39,7 +38,6 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
     public override bool UseRazorCohostServer => _useRazorCohostServer ?? _defaults.UseRazorCohostServer;
     public override bool DisableRazorLanguageServer => _disableRazorLanguageServer ?? _defaults.DisableRazorLanguageServer;
     public override bool ForceRuntimeCodeGeneration => _forceRuntimeCodeGeneration ?? _defaults.ForceRuntimeCodeGeneration;
-    public override bool UseRoslynTokenizer => _useRoslynTokenizer ?? _defaults.UseRoslynTokenizer;
     public override bool UseNewFormattingEngine => _useNewFormattingEngine ?? _defaults.UseNewFormattingEngine;
 
     public ConfigurableLanguageServerFeatureOptions(string[] args)
@@ -64,7 +62,6 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
             TryProcessBoolOption(nameof(UseRazorCohostServer), ref _useRazorCohostServer, option, args, i);
             TryProcessBoolOption(nameof(DisableRazorLanguageServer), ref _disableRazorLanguageServer, option, args, i);
             TryProcessBoolOption(nameof(ForceRuntimeCodeGeneration), ref _forceRuntimeCodeGeneration, option, args, i);
-            TryProcessBoolOption(nameof(UseRoslynTokenizer), ref _useRoslynTokenizer, option, args, i);
             TryProcessBoolOption(nameof(UseNewFormattingEngine), ref _useNewFormattingEngine, option, args, i);
         }
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
@@ -371,8 +371,7 @@ internal partial class RazorProjectService : IRazorProjectService, IRazorProject
 
                 var currentConfiguration = project.Configuration;
                 var currentRootNamespace = project.RootNamespace;
-                if (currentConfiguration.ConfigurationName == configuration?.ConfigurationName &&
-                    currentConfiguration.CSharpLanguageVersion == configuration?.CSharpLanguageVersion &&
+                if (currentConfiguration == configuration &&
                     currentRootNamespace == rootNamespace)
                 {
                     _logger.LogTrace($"Updating project '{project.Key}'. The project is already using configuration '{configuration.ConfigurationName}' and root namespace '{rootNamespace}' and C# lang version '{configuration.CSharpLanguageVersion}'.");
@@ -384,8 +383,7 @@ internal partial class RazorProjectService : IRazorProjectService, IRazorProject
                     configuration = FallbackRazorConfiguration.Latest;
                     _logger.LogInformation($"Updating project '{project.Key}' to use the latest configuration ('{configuration.ConfigurationName}')'.");
                 }
-                else if (currentConfiguration.ConfigurationName != configuration.ConfigurationName ||
-                    currentConfiguration.CSharpLanguageVersion != configuration.CSharpLanguageVersion)
+                else
                 {
                     _logger.LogInformation($"Updating project '{project.Key}' to Razor configuration '{configuration.ConfigurationName}' with language version '{configuration.LanguageVersion}' and C# lang version '{configuration.CSharpLanguageVersion}'.");
                 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/RazorProjectService.cs
@@ -364,7 +364,7 @@ internal partial class RazorProjectService : IRazorProjectService, IRazorProject
 
                 if (!projectWorkspaceState.Equals(ProjectWorkspaceState.Default))
                 {
-                    _logger.LogInformation($"Updating project '{project.Key}' TagHelpers ({projectWorkspaceState.TagHelpers.Length}) and C# Language Version ({projectWorkspaceState.CSharpLanguageVersion}).");
+                    _logger.LogInformation($"Updating project '{project.Key}' TagHelpers ({projectWorkspaceState.TagHelpers.Length}).");
                 }
 
                 updater.UpdateProjectWorkspaceState(project.Key, projectWorkspaceState);
@@ -372,9 +372,10 @@ internal partial class RazorProjectService : IRazorProjectService, IRazorProject
                 var currentConfiguration = project.Configuration;
                 var currentRootNamespace = project.RootNamespace;
                 if (currentConfiguration.ConfigurationName == configuration?.ConfigurationName &&
+                    currentConfiguration.CSharpLanguageVersion == configuration?.CSharpLanguageVersion &&
                     currentRootNamespace == rootNamespace)
                 {
-                    _logger.LogTrace($"Updating project '{project.Key}'. The project is already using configuration '{configuration.ConfigurationName}' and root namespace '{rootNamespace}'.");
+                    _logger.LogTrace($"Updating project '{project.Key}'. The project is already using configuration '{configuration.ConfigurationName}' and root namespace '{rootNamespace}' and C# lang version '{configuration.CSharpLanguageVersion}'.");
                     return;
                 }
 
@@ -383,9 +384,10 @@ internal partial class RazorProjectService : IRazorProjectService, IRazorProject
                     configuration = FallbackRazorConfiguration.Latest;
                     _logger.LogInformation($"Updating project '{project.Key}' to use the latest configuration ('{configuration.ConfigurationName}')'.");
                 }
-                else if (currentConfiguration.ConfigurationName != configuration.ConfigurationName)
+                else if (currentConfiguration.ConfigurationName != configuration.ConfigurationName ||
+                    currentConfiguration.CSharpLanguageVersion != configuration.CSharpLanguageVersion)
                 {
-                    _logger.LogInformation($"Updating project '{project.Key}' to Razor configuration '{configuration.ConfigurationName}' with language version '{configuration.LanguageVersion}'.");
+                    _logger.LogInformation($"Updating project '{project.Key}' to Razor configuration '{configuration.ConfigurationName}' with language version '{configuration.LanguageVersion}' and C# lang version '{configuration.CSharpLanguageVersion}'.");
                 }
 
                 if (currentRootNamespace != rootNamespace)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/ProjectSystem/ProjectWorkspaceState.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/ProjectSystem/ProjectWorkspaceState.cs
@@ -5,52 +5,40 @@ using System;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Extensions.Internal;
 
 namespace Microsoft.AspNetCore.Razor.ProjectSystem;
 
 internal sealed class ProjectWorkspaceState : IEquatable<ProjectWorkspaceState>
 {
-    public static readonly ProjectWorkspaceState Default = new(ImmutableArray<TagHelperDescriptor>.Empty, LanguageVersion.Default);
+    public static readonly ProjectWorkspaceState Default = new(ImmutableArray<TagHelperDescriptor>.Empty);
 
     public ImmutableArray<TagHelperDescriptor> TagHelpers { get; }
-    public LanguageVersion CSharpLanguageVersion { get; }
 
     private ProjectWorkspaceState(
-        ImmutableArray<TagHelperDescriptor> tagHelpers,
-        LanguageVersion csharpLanguageVersion)
+        ImmutableArray<TagHelperDescriptor> tagHelpers)
     {
         TagHelpers = tagHelpers;
-        CSharpLanguageVersion = csharpLanguageVersion;
     }
 
     public static ProjectWorkspaceState Create(
-        ImmutableArray<TagHelperDescriptor> tagHelpers,
-        LanguageVersion csharpLanguageVersion = LanguageVersion.Default)
-        => tagHelpers.IsEmpty && csharpLanguageVersion == LanguageVersion.Default
+        ImmutableArray<TagHelperDescriptor> tagHelpers)
+        => tagHelpers.IsEmpty
             ? Default
-            : new(tagHelpers, csharpLanguageVersion);
-
-    public static ProjectWorkspaceState Create(LanguageVersion csharpLanguageVersion)
-        => csharpLanguageVersion == LanguageVersion.Default
-            ? Default
-            : new(ImmutableArray<TagHelperDescriptor>.Empty, csharpLanguageVersion);
+            : new(tagHelpers);
 
     public override bool Equals(object? obj)
         => obj is ProjectWorkspaceState other && Equals(other);
 
     public bool Equals(ProjectWorkspaceState? other)
         => other is not null &&
-           TagHelpers.SequenceEqual(other.TagHelpers) &&
-           CSharpLanguageVersion == other.CSharpLanguageVersion;
+           TagHelpers.SequenceEqual(other.TagHelpers);
 
     public override int GetHashCode()
     {
         var hash = HashCodeCombiner.Start();
 
         hash.Add(TagHelpers);
-        hash.Add(CSharpLanguageVersion);
 
         return hash.CombinedHash;
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/ProjectWorkspaceStateFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/ProjectWorkspaceStateFormatter.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Serialization.MessagePack.Formatters.TagHelpers;
 using Microsoft.AspNetCore.Razor.Utilities;
-using Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.AspNetCore.Razor.Serialization.MessagePack.Formatters;
 
@@ -22,7 +21,7 @@ internal sealed class ProjectWorkspaceStateFormatter : ValueFormatter<ProjectWor
 
     public override ProjectWorkspaceState Deserialize(ref MessagePackReader reader, SerializerCachingOptions options)
     {
-        reader.ReadArrayHeaderAndVerify(3);
+        reader.ReadArrayHeaderAndVerify(2);
 
         var checksums = reader.Deserialize<ImmutableArray<Checksum>>(options);
 
@@ -47,19 +46,17 @@ internal sealed class ProjectWorkspaceStateFormatter : ValueFormatter<ProjectWor
         }
 
         var tagHelpers = builder.DrainToImmutable();
-        var csharpLanguageVersion = (LanguageVersion)reader.ReadInt32();
 
-        return ProjectWorkspaceState.Create(tagHelpers, csharpLanguageVersion);
+        return ProjectWorkspaceState.Create(tagHelpers);
     }
 
     public override void Serialize(ref MessagePackWriter writer, ProjectWorkspaceState value, SerializerCachingOptions options)
     {
-        writer.WriteArrayHeader(3);
+        writer.WriteArrayHeader(2);
 
         var checksums = value.TagHelpers.SelectAsArray(x => x.Checksum);
 
         writer.Serialize(checksums, options);
         writer.Serialize(value.TagHelpers, options);
-        writer.Write((int)value.CSharpLanguageVersion);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/RazorConfigurationFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/Formatters/RazorConfigurationFormatter.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Collections.Immutable;
 using MessagePack;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.PooledObjects;
@@ -10,7 +11,8 @@ namespace Microsoft.AspNetCore.Razor.Serialization.MessagePack.Formatters;
 
 internal sealed class RazorConfigurationFormatter : ValueFormatter<RazorConfiguration>
 {
-    private const int SerializerPropertyCount = 5;
+    private const int SerializerPropertyCount = 7;
+
     public static readonly ValueFormatter<RazorConfiguration> Instance = new RazorConfigurationFormatter();
 
     private RazorConfigurationFormatter()
@@ -27,6 +29,8 @@ internal sealed class RazorConfigurationFormatter : ValueFormatter<RazorConfigur
         var csharpLanguageVersion = (LanguageVersion)reader.ReadInt32();
         var suppressAddComponentParameter = reader.ReadBoolean();
         var useConsolidatedMvcViews = reader.ReadBoolean();
+        var useRoslynTokenizer = reader.ReadBoolean();
+        var preprocessorSymbols = reader.Deserialize<ImmutableArray<string>>(options);
 
         count -= SerializerPropertyCount;
 
@@ -50,7 +54,9 @@ internal sealed class RazorConfigurationFormatter : ValueFormatter<RazorConfigur
             extensions,
             csharpLanguageVersion,
             UseConsolidatedMvcViews: useConsolidatedMvcViews,
-            SuppressAddComponentParameter: suppressAddComponentParameter);
+            SuppressAddComponentParameter: suppressAddComponentParameter,
+            UseRoslynTokenizer: useRoslynTokenizer,
+            PreprocessorSymbols: preprocessorSymbols);
     }
 
     public override void Serialize(ref MessagePackWriter writer, RazorConfiguration value, SerializerCachingOptions options)
@@ -75,6 +81,8 @@ internal sealed class RazorConfigurationFormatter : ValueFormatter<RazorConfigur
         writer.Write((int)value.CSharpLanguageVersion);
         writer.Write(value.SuppressAddComponentParameter);
         writer.Write(value.UseConsolidatedMvcViews);
+        writer.Write(value.UseRoslynTokenizer);
+        writer.Serialize(value.PreprocessorSymbols, options);
 
         count -= SerializerPropertyCount;
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/SerializationFormat.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Serialization/MessagePack/SerializationFormat.cs
@@ -9,5 +9,5 @@ internal static class SerializationFormat
     // or any of the types that compose it changes. This includes: RazorConfiguration,
     // ProjectWorkspaceState, TagHelperDescriptor, and DocumentSnapshotHandle.
     // NOTE: If this version is changed, a coordinated insertion is required between Roslyn and Razor for the C# extension.
-    public const int Version = 6;
+    public const int Version = 7;
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/RazorProjectInfoFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/RazorProjectInfoFactory.cs
@@ -15,7 +15,6 @@ using Microsoft.AspNetCore.Razor.Serialization;
 using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Compiler.CSharp;
 
@@ -61,16 +60,14 @@ internal static class RazorProjectInfoFactory
             return new(null, "No razor documents in project");
         }
 
-        var csharpLanguageVersion = (project.ParseOptions as CSharpParseOptions)?.LanguageVersion ?? LanguageVersion.Default;
-
         var compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
         if (compilation is null)
         {
             return new(null, "Failed to get compilation for project");
         }
 
-        var options = project.AnalyzerOptions.AnalyzerConfigOptionsProvider;
-        var configuration = ComputeRazorConfigurationOptions(options, compilation, out var defaultNamespace);
+        var configuration = ComputeRazorConfigurationOptions(project, compilation, out var defaultNamespace);
+
         var fileSystem = RazorProjectFileSystem.Create(projectPath);
 
         var defaultConfigure = (RazorProjectEngineBuilder builder) =>
@@ -80,7 +77,7 @@ internal static class RazorProjectInfoFactory
                 builder.SetRootNamespace(defaultNamespace);
             }
 
-            builder.SetCSharpLanguageVersion(csharpLanguageVersion);
+            builder.SetCSharpLanguageVersion(configuration.CSharpLanguageVersion);
             builder.SetSupportLocalizedComponentNames(); // ProjectState in MS.CA.Razor.Workspaces does this, so I'm doing it too!
         };
 
@@ -93,7 +90,7 @@ internal static class RazorProjectInfoFactory
 
         var tagHelpers = await project.GetTagHelpersAsync(engine, NoOpTelemetryReporter.Instance, cancellationToken).ConfigureAwait(false);
 
-        var projectWorkspaceState = ProjectWorkspaceState.Create(tagHelpers, csharpLanguageVersion);
+        var projectWorkspaceState = ProjectWorkspaceState.Create(tagHelpers);
 
         var projectInfo = new RazorProjectInfo(
             projectKey: new ProjectKey(intermediateOutputPath),
@@ -107,11 +104,10 @@ internal static class RazorProjectInfoFactory
         return new(projectInfo, null);
     }
 
-    private static RazorConfiguration ComputeRazorConfigurationOptions(AnalyzerConfigOptionsProvider options, Compilation compilation, out string defaultNamespace)
+    public static RazorConfiguration ComputeRazorConfigurationOptions(Project project, Compilation? compilation, out string defaultNamespace)
     {
         // See RazorSourceGenerator.RazorProviders.cs
-
-        var globalOptions = options.GlobalOptions;
+        var globalOptions = project.AnalyzerOptions.AnalyzerConfigOptionsProvider.GlobalOptions;
 
         globalOptions.TryGetValue("build_property.RazorConfiguration", out var configurationName);
 
@@ -125,12 +121,15 @@ internal static class RazorProjectInfoFactory
             razorLanguageVersion = RazorLanguageVersion.Latest;
         }
 
-        var suppressAddComponentParameter = !compilation.HasAddComponentParameter();
+        var suppressAddComponentParameter = compilation is not null && !compilation.HasAddComponentParameter();
+
+        var csharpLanguageVersion = ((CSharpParseOptions)project.ParseOptions.AssumeNotNull()).LanguageVersion;
 
         var razorConfiguration = new RazorConfiguration(
             razorLanguageVersion,
             configurationName,
             Extensions: [],
+            CSharpLanguageVersion: csharpLanguageVersion,
             UseConsolidatedMvcViews: true,
             suppressAddComponentParameter);
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/RazorProjectInfoFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.ProjectEngineHost/Utilities/RazorProjectInfoFactory.cs
@@ -123,15 +123,17 @@ internal static class RazorProjectInfoFactory
 
         var suppressAddComponentParameter = compilation is not null && !compilation.HasAddComponentParameter();
 
-        var csharpLanguageVersion = ((CSharpParseOptions)project.ParseOptions.AssumeNotNull()).LanguageVersion;
+        var csharpParseOptions = project.ParseOptions as CSharpParseOptions ?? CSharpParseOptions.Default;
 
         var razorConfiguration = new RazorConfiguration(
             razorLanguageVersion,
             configurationName,
             Extensions: [],
-            CSharpLanguageVersion: csharpLanguageVersion,
+            CSharpLanguageVersion: csharpParseOptions.LanguageVersion,
             UseConsolidatedMvcViews: true,
-            suppressAddComponentParameter);
+            suppressAddComponentParameter,
+            UseRoslynTokenizer: csharpParseOptions.UseRoslynTokenizer(),
+            PreprocessorSymbols: csharpParseOptions.PreprocessorSymbolNames.ToImmutableArray());
 
         defaultNamespace = rootNamespace ?? "ASP"; // TODO: Source generator does this. Do we want it?
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
@@ -40,7 +40,5 @@ internal abstract class LanguageServerFeatureOptions
     /// </summary>
     public abstract bool ForceRuntimeCodeGeneration { get; }
 
-    public abstract bool UseRoslynTokenizer { get; }
-
     public abstract bool UseNewFormattingEngine { get; }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
@@ -89,7 +89,7 @@ internal sealed class ProjectState
 
     public ImmutableArray<TagHelperDescriptor> TagHelpers => ProjectWorkspaceState.TagHelpers;
 
-    public LanguageVersion CSharpLanguageVersion => ProjectWorkspaceState.CSharpLanguageVersion;
+    public LanguageVersion CSharpLanguageVersion => HostProject.Configuration.CSharpLanguageVersion;
 
     public RazorProjectEngine ProjectEngine
     {
@@ -274,10 +274,7 @@ internal sealed class ProjectState
 
         var documents = UpdateDocuments(static x => x.WithProjectWorkspaceStateChange());
 
-        // If the C# language version changed, we need a new project engine.
-        var retainProjectEngine = ProjectWorkspaceState.CSharpLanguageVersion == projectWorkspaceState.CSharpLanguageVersion;
-
-        return new(this, HostProject, projectWorkspaceState, documents, ImportsToRelatedDocuments, retainProjectEngine);
+        return new(this, HostProject, projectWorkspaceState, documents, ImportsToRelatedDocuments, retainProjectEngine: true);
     }
 
     private ImmutableDictionary<string, ImmutableHashSet<string>> AddToImportsToRelatedDocuments(HostDocument hostDocument)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
@@ -106,14 +106,15 @@ internal sealed class ProjectState
             {
                 var configuration = HostProject.Configuration;
                 var rootDirectoryPath = Path.GetDirectoryName(HostProject.FilePath).AssumeNotNull();
-                var useRoslynTokenizer = CompilerOptions.IsFlagSet(RazorCompilerOptions.UseRoslynTokenizer);
+                var useRoslynTokenizer = configuration.UseRoslynTokenizer;
+                var parseOptions = CSharpParseOptions.Default.WithPreprocessorSymbols(configuration.PreprocessorSymbols);
 
                 return _projectEngineFactoryProvider.Create(configuration, rootDirectoryPath, builder =>
                 {
                     builder.SetRootNamespace(HostProject.RootNamespace);
                     builder.SetCSharpLanguageVersion(CSharpLanguageVersion);
                     builder.SetSupportLocalizedComponentNames();
-                    builder.Features.Add(new ConfigureRazorParserOptions(useRoslynTokenizer, CSharpParseOptions.Default));
+                    builder.Features.Add(new ConfigureRazorParserOptions(useRoslynTokenizer, parseOptions));
                 });
             }
         }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
@@ -107,7 +107,7 @@ internal sealed class ProjectState
                 var configuration = HostProject.Configuration;
                 var rootDirectoryPath = Path.GetDirectoryName(HostProject.FilePath).AssumeNotNull();
                 var useRoslynTokenizer = configuration.UseRoslynTokenizer;
-                var parseOptions = CSharpParseOptions.Default.WithPreprocessorSymbols(configuration.PreprocessorSymbols);
+                var parseOptions = new CSharpParseOptions(languageVersion: CSharpLanguageVersion, preprocessorSymbols: configuration.PreprocessorSymbols);
 
                 return _projectEngineFactoryProvider.Create(configuration, rootDirectoryPath, builder =>
                 {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/RazorCompilerOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/RazorCompilerOptions.cs
@@ -9,6 +9,5 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 internal enum RazorCompilerOptions
 {
     None = 0,
-    ForceRuntimeCodeGeneration = 1 << 0,
-    UseRoslynTokenizer = 1 << 1
+    ForceRuntimeCodeGeneration = 1 << 0
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/RazorCompilerOptionsExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/RazorCompilerOptionsExtensions.cs
@@ -17,11 +17,6 @@ internal static class RazorCompilerOptionsExtensions
             options.SetFlag(RazorCompilerOptions.ForceRuntimeCodeGeneration);
         }
 
-        if (languageServerFeatureOptions.UseRoslynTokenizer)
-        {
-            options.SetFlag(RazorCompilerOptions.UseRoslynTokenizer);
-        }
-
         return options;
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RemoteClientInitializationOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RemoteClientInitializationOptions.cs
@@ -34,9 +34,6 @@ internal struct RemoteClientInitializationOptions
     [JsonPropertyName("showAllCSharpCodeActions")]
     public required bool ShowAllCSharpCodeActions { get; set; }
 
-    [JsonPropertyName("useRoslynTokenizer")]
-    public required bool UseRoslynTokenizer { get; set; }
-
     [JsonPropertyName("useNewFormattingEngine")]
     public required bool UseNewFormattingEngine { get; set; }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Initialization/RemoteLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Initialization/RemoteLanguageServerFeatureOptions.cs
@@ -43,7 +43,5 @@ internal class RemoteLanguageServerFeatureOptions : LanguageServerFeatureOptions
 
     public override bool ForceRuntimeCodeGeneration => _options.ForceRuntimeCodeGeneration;
 
-    public override bool UseRoslynTokenizer => _options.UseRoslynTokenizer;
-
     public override bool UseNewFormattingEngine => _options.UseNewFormattingEngine;
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteProjectSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteProjectSnapshot.cs
@@ -182,7 +182,7 @@ internal sealed class RemoteProjectSnapshot : IProjectSnapshot
         var configuration = await _lazyConfiguration.GetValueAsync(cancellationToken).ConfigureAwait(false);
 
         var useRoslynTokenizer = configuration.UseRoslynTokenizer;
-        var parseOptions = CSharpParseOptions.Default.WithPreprocessorSymbols(configuration.PreprocessorSymbols);
+        var parseOptions = new CSharpParseOptions(languageVersion: CSharpLanguageVersion, preprocessorSymbols: configuration.PreprocessorSymbols);
 
         return ProjectEngineFactories.DefaultProvider.Create(
             configuration,

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteProjectSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteProjectSnapshot.cs
@@ -182,7 +182,8 @@ internal sealed class RemoteProjectSnapshot : IProjectSnapshot
     {
         var configuration = await _lazyConfiguration.GetValueAsync(cancellationToken).ConfigureAwait(false);
 
-        var useRoslynTokenizer = SolutionSnapshot.SnapshotManager.CompilerOptions.IsFlagSet(RazorCompilerOptions.UseRoslynTokenizer);
+        var useRoslynTokenizer = configuration.UseRoslynTokenizer;
+        var parseOptions = CSharpParseOptions.Default.WithPreprocessorSymbols(configuration.PreprocessorSymbols);
 
         return ProjectEngineFactories.DefaultProvider.Create(
             configuration,
@@ -192,7 +193,7 @@ internal sealed class RemoteProjectSnapshot : IProjectSnapshot
                 builder.SetRootNamespace(RootNamespace);
                 builder.SetCSharpLanguageVersion(CSharpLanguageVersion);
                 builder.SetSupportLocalizedComponentNames();
-                builder.Features.Add(new ConfigureRazorParserOptions(useRoslynTokenizer, CSharpParseOptions.Default));
+                builder.Features.Add(new ConfigureRazorParserOptions(useRoslynTokenizer, parseOptions));
             });
     }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteProjectSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/ProjectSystem/RemoteProjectSnapshot.cs
@@ -172,7 +172,6 @@ internal sealed class RemoteProjectSnapshot : IProjectSnapshot
 
     private async Task<RazorConfiguration> ComputeConfigurationAsync(CancellationToken cancellationToken)
     {
-        // See RazorSourceGenerator.RazorProviders.cs
         var compilation = await _project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
 
         return RazorProjectInfoFactory.ComputeRazorConfigurationOptions(_project, compilation, out _);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectWorkspaceStateGenerator.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectWorkspaceStateGenerator.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,6 +13,7 @@ using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Razor.Compiler.CSharp;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
@@ -287,13 +289,13 @@ internal sealed partial class ProjectWorkspaceStateGenerator(
 
         try
         {
-            var csharpLanguageVersion = workspaceProject.ParseOptions is CSharpParseOptions csharpParseOptions
-                ? csharpParseOptions.LanguageVersion
-                : LanguageVersion.Default;
+            var csharpParseOptions = workspaceProject.ParseOptions as CSharpParseOptions ?? CSharpParseOptions.Default;
 
             configuration = configuration with
             {
-                CSharpLanguageVersion = csharpLanguageVersion
+                CSharpLanguageVersion = csharpParseOptions.LanguageVersion,
+                UseRoslynTokenizer = csharpParseOptions.UseRoslynTokenizer(),
+                PreprocessorSymbols = csharpParseOptions.PreprocessorSymbolNames.ToImmutableArray()
             };
 
             using var _ = StopwatchPool.GetPooledObject(out var watch);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectWorkspaceStateGenerator.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectWorkspaceStateGenerator.cs
@@ -291,6 +291,11 @@ internal sealed partial class ProjectWorkspaceStateGenerator(
                 ? csharpParseOptions.LanguageVersion
                 : LanguageVersion.Default;
 
+            configuration = configuration with
+            {
+                CSharpLanguageVersion = csharpLanguageVersion
+            };
+
             using var _ = StopwatchPool.GetPooledObject(out var watch);
 
             watch.Restart();
@@ -313,7 +318,7 @@ internal sealed partial class ProjectWorkspaceStateGenerator(
                 Project: {projectSnapshot.FilePath}
                 """);
 
-            return (ProjectWorkspaceState.Create(tagHelpers, csharpLanguageVersion), configuration);
+            return (ProjectWorkspaceState.Create(tagHelpers), configuration);
         }
         catch (OperationCanceledException)
         {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/RemoteServiceInvoker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/RemoteServiceInvoker.cs
@@ -141,7 +141,6 @@ internal sealed class RemoteServiceInvoker(
                     ForceRuntimeCodeGeneration = _languageServerFeatureOptions.ForceRuntimeCodeGeneration,
                     SupportsFileManipulation = _languageServerFeatureOptions.SupportsFileManipulation,
                     ShowAllCSharpCodeActions = _languageServerFeatureOptions.ShowAllCSharpCodeActions,
-                    UseRoslynTokenizer = _languageServerFeatureOptions.UseRoslynTokenizer,
                     UseNewFormattingEngine = _languageServerFeatureOptions.UseNewFormattingEngine,
                 };
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioLanguageServerFeatureOptions.cs
@@ -19,7 +19,6 @@ internal class VisualStudioLanguageServerFeatureOptions : LanguageServerFeatureO
     private readonly Lazy<bool> _useRazorCohostServer;
     private readonly Lazy<bool> _disableRazorLanguageServer;
     private readonly Lazy<bool> _forceRuntimeCodeGeneration;
-    private readonly Lazy<bool> _useRoslynTokenizer;
     private readonly Lazy<bool> _useNewFormattingEngine;
 
     [ImportingConstructor]
@@ -74,13 +73,6 @@ internal class VisualStudioLanguageServerFeatureOptions : LanguageServerFeatureO
             return forceRuntimeCodeGeneration;
         });
 
-        _useRoslynTokenizer = new Lazy<bool>(() =>
-        {
-            var featureFlags = (IVsFeatureFlags)Package.GetGlobalService(typeof(SVsFeatureFlags));
-            var useRoslynTokenizer = featureFlags.IsFeatureEnabled(WellKnownFeatureFlagNames.UseRoslynTokenizer, defaultValue: false);
-            return useRoslynTokenizer;
-        });
-
         _useNewFormattingEngine = new Lazy<bool>(() =>
         {
             var featureFlags = (IVsFeatureFlags)Package.GetGlobalService(typeof(SVsFeatureFlags));
@@ -118,8 +110,6 @@ internal class VisualStudioLanguageServerFeatureOptions : LanguageServerFeatureO
 
     /// <inheritdoc />
     public override bool ForceRuntimeCodeGeneration => _forceRuntimeCodeGeneration.Value;
-
-    public override bool UseRoslynTokenizer => _useRoslynTokenizer.Value;
 
     public override bool UseNewFormattingEngine => _useNewFormattingEngine.Value;
 }

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
@@ -75,12 +75,6 @@
 "Title"="Force use of runtime code generation for Razor (requires restart)"
 "PreviewPaneChannels"="*"
 
-[$RootKey$\FeatureFlags\Razor\LSP\UseRoslynTokenizer]
-"Description"="Enables some new C# features, like interpolated and raw strings, in Razor files opened in Visual Studio. This matches using '<features>use-roslyn-tokenizer</features>' in a project file for command line builds, and may result in inconsistencies if this option and your project files do not match."
-"Value"=dword:00000000
-"Title"="Use the C# tokenizer for Razor files in the IDE (requires restart)"
-"PreviewPaneChannels"="*"
-
 [$RootKey$\FeatureFlags\Razor\LSP\UseNewFormattingEngine]
 "Description"="Enables the new Razor formatting engine, which provides formatting results that more closely match C# formatting."
 "Value"=dword:00000000

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/OpenDocumentGeneratorTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/OpenDocumentGeneratorTest.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
 using Xunit;
@@ -141,8 +140,7 @@ public class OpenDocumentGeneratorTest(ITestOutputHelper testOutput) : LanguageS
             updater.AddDocument(_hostProject1.Key, _documents[0], EmptyTextLoader.Instance);
 
             // Act
-            updater.UpdateProjectWorkspaceState(_hostProject1.Key,
-                ProjectWorkspaceState.Create(LanguageVersion.CSharp8));
+            updater.UpdateProjectWorkspaceState(_hostProject1.Key, ProjectWorkspaceState.Default);
         });
 
         // Assert
@@ -165,8 +163,7 @@ public class OpenDocumentGeneratorTest(ITestOutputHelper testOutput) : LanguageS
             updater.OpenDocument(_hostProject1.Key, _documents[0].FilePath, SourceText.From(string.Empty));
 
             // Act
-            updater.UpdateProjectWorkspaceState(_hostProject1.Key,
-                ProjectWorkspaceState.Create(LanguageVersion.CSharp8));
+            updater.UpdateProjectWorkspaceState(_hostProject1.Key, ProjectWorkspaceState.Default);
         });
 
         // Assert

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorProjectServiceTest.cs
@@ -13,7 +13,6 @@ using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.AspNetCore.Razor.Test.Common.ProjectSystem;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
 using Moq;
@@ -66,7 +65,7 @@ public class RazorProjectServiceTest(ITestOutputHelper testOutput) : LanguageSer
             updater.AddProject(hostProject);
         });
 
-        var projectWorkspaceState = ProjectWorkspaceState.Create(LanguageVersion.LatestMajor);
+        var projectWorkspaceState = ProjectWorkspaceState.Default;
 
         // Act
         await _projectInfoListener.UpdatedAsync(new RazorProjectInfo(

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/Serialization/JsonSerializationTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/Serialization/JsonSerializationTest.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common;
-using Microsoft.CodeAnalysis.CSharp;
 using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
@@ -17,8 +16,7 @@ public class JsonSerializationTest(ITestOutputHelper testOutput) : ToolingTestBa
     private readonly RazorConfiguration _configuration = new(RazorLanguageVersion.Experimental, ConfigurationName: "Custom", [new("TestExtension")]);
 
     private readonly ProjectWorkspaceState _projectWorkspaceState = ProjectWorkspaceState.Create(
-        tagHelpers: [TagHelperDescriptorBuilder.Create("Test", "TestAssembly").Build()],
-        csharpLanguageVersion: LanguageVersion.LatestMajor);
+        tagHelpers: [TagHelperDescriptorBuilder.Create("Test", "TestAssembly").Build()]);
 
     [Fact]
     public void RazorProjectInfo_InvalidVersionThrows()

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/Serialization/ProjectSnapshotHandleSerializationTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/Serialization/ProjectSnapshotHandleSerializationTest.cs
@@ -30,7 +30,12 @@ public class ProjectSnapshotHandleSerializationTest(ITestOutputHelper testOutput
             projectId,
             new(RazorLanguageVersion.Version_1_1,
                 "Test",
-                [new("Test-Extension1"), new("Test-Extension2")]),
+                [new("Test-Extension1"), new("Test-Extension2")],
+                CodeAnalysis.CSharp.LanguageVersion.CSharp7,
+                UseConsolidatedMvcViews: false,
+                SuppressAddComponentParameter: true,
+                UseRoslynTokenizer: true,
+                PreprocessorSymbols: ["DEBUG", "TRACE", "DAVID"]),
             "Test");
 
         // Act
@@ -49,6 +54,14 @@ public class ProjectSnapshotHandleSerializationTest(ITestOutputHelper testOutput
             e => Assert.Equal("Test-Extension2", e.ExtensionName));
         Assert.Equal(expectedSnapshot.Configuration.LanguageVersion, actualSnapshot.Configuration.LanguageVersion);
         Assert.Equal(expectedSnapshot.RootNamespace, actualSnapshot.RootNamespace);
+        Assert.Equal(expectedSnapshot.Configuration.CSharpLanguageVersion, actualSnapshot.Configuration.CSharpLanguageVersion);
+        Assert.Equal(expectedSnapshot.Configuration.UseConsolidatedMvcViews, actualSnapshot.Configuration.UseConsolidatedMvcViews);
+        Assert.Equal(expectedSnapshot.Configuration.SuppressAddComponentParameter, actualSnapshot.Configuration.SuppressAddComponentParameter);
+        Assert.Equal(expectedSnapshot.Configuration.UseRoslynTokenizer, actualSnapshot.Configuration.UseRoslynTokenizer);
+        Assert.Collection(actualSnapshot.Configuration.PreprocessorSymbols,
+            s => Assert.Equal("DEBUG", s),
+            s => Assert.Equal("TRACE", s),
+            s => Assert.Equal("DAVID", s));
     }
 
     [Fact]

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/StreamExtensionTests.NetCore.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.ProjectEngineHost.Test/StreamExtensionTests.NetCore.cs
@@ -79,7 +79,7 @@ public class StreamExtensionTests(ITestOutputHelper testOutputHelper) : ToolingT
             .TagMatchingRuleDescriptor(rule => rule.RequireTagName("tag-name"))
             .Build();
 
-        var projectWorkspaceState = ProjectWorkspaceState.Create([tagHelper], CodeAnalysis.CSharp.LanguageVersion.Latest);
+        var projectWorkspaceState = ProjectWorkspaceState.Create([tagHelper]);
 
         var projectInfo = new RazorProjectInfo(
             new ProjectKey("TestProject"),

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/TestMocks.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/TestMocks.cs
@@ -106,8 +106,6 @@ internal static class TestMocks
 
         if (projectWorkspaceState is not null)
         {
-            mock.SetupGet(x => x.CSharpLanguageVersion)
-                .Returns(projectWorkspaceState.CSharpLanguageVersion);
             mock.Setup(x => x.GetTagHelpersAsync(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(projectWorkspaceState.TagHelpers);
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/TestLanguageServerFeatureOptions.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/TestLanguageServerFeatureOptions.cs
@@ -39,7 +39,5 @@ internal class TestLanguageServerFeatureOptions(
 
     public override bool ForceRuntimeCodeGeneration => forceRuntimeCodeGeneration;
 
-    public override bool UseRoslynTokenizer => false;
-
     public override bool UseNewFormattingEngine => useNewFormattingEngine;
 }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateGeneratedOutputTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateGeneratedOutputTest.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
-using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -160,33 +159,6 @@ public class ProjectStateGeneratedOutputTest : WorkspaceTestBase
 
         // Act
         var newState = state.WithProjectWorkspaceState(ProjectWorkspaceState.Create(_someTagHelpers));
-        var newOutput = await GetGeneratedOutputAsync(newState, _hostDocument);
-
-        // Assert
-        Assert.NotSame(output, newOutput);
-    }
-
-    [Fact]
-    public async Task WithProjectWorkspaceState_CSharpLanguageVersionChange_DoesNotCacheOutput()
-    {
-        // Arrange
-        var hostProject = TestProjectData.SomeProject with
-        {
-            Configuration = _hostProject.Configuration with { LanguageVersion = RazorLanguageVersion.Version_3_0 }
-        };
-
-        var projectWorkspaceState = ProjectWorkspaceState.Create(_someTagHelpers, LanguageVersion.CSharp7);
-
-        var state = ProjectState
-            .Create(hostProject, CompilerOptions, ProjectEngineFactoryProvider)
-            .WithProjectWorkspaceState(projectWorkspaceState)
-            .AddDocument(_hostDocument, TestMocks.CreateTextLoader("@DateTime.Now", VersionStamp.Default));
-
-        var output = await GetGeneratedOutputAsync(state, _hostDocument);
-
-        // Act
-        var newProjectWorkspaceState = ProjectWorkspaceState.Create(_someTagHelpers, LanguageVersion.CSharp8);
-        var newState = state.WithProjectWorkspaceState(newProjectWorkspaceState);
         var newOutput = await GetGeneratedOutputAsync(newState, _hostDocument);
 
         // Assert

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/ProjectSystem/ProjectStateTest.cs
@@ -10,7 +10,6 @@ using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.ProjectSystem;
 using Microsoft.AspNetCore.Razor.Utilities;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
 using Xunit;
 using Xunit.Abstractions;
@@ -571,7 +570,7 @@ public class ProjectStateTest(ITestOutputHelper testOutput) : ToolingTestBase(te
             .AddEmptyDocument(AnotherProjectNestedFile3)
             .AddEmptyDocument(SomeProjectFile2);
 
-        var newWorkspaceState = ProjectWorkspaceState.Create(s_projectWorkspaceState.TagHelpers, LanguageVersion.CSharp6);
+        var newWorkspaceState = ProjectWorkspaceState.Create([]);
 
         // Act
         var newState = state.WithProjectWorkspaceState(newWorkspaceState);
@@ -579,9 +578,8 @@ public class ProjectStateTest(ITestOutputHelper testOutput) : ToolingTestBase(te
         // Assert
         Assert.Same(newWorkspaceState, newState.ProjectWorkspaceState);
 
-        // The C# language version changed, and the tag helpers didn't change
-        Assert.NotSame(state.ProjectEngine, newState.ProjectEngine);
-        AssertSameTagHelpers(state.TagHelpers, newState.TagHelpers);
+        // The the tag helpers didn't change
+        Assert.Same(state.ProjectEngine, newState.ProjectEngine);
 
         Assert.NotSame(state.Documents[SomeProjectFile2.FilePath], newState.Documents[SomeProjectFile2.FilePath]);
         Assert.NotSame(state.Documents[AnotherProjectNestedFile3.FilePath], newState.Documents[AnotherProjectNestedFile3.FilePath]);
@@ -621,7 +619,7 @@ public class ProjectStateTest(ITestOutputHelper testOutput) : ToolingTestBase(te
             .AddEmptyDocument(SomeProjectFile2);
 
         // Act
-        var newState = state.WithProjectWorkspaceState(ProjectWorkspaceState.Create(state.TagHelpers, state.CSharpLanguageVersion));
+        var newState = state.WithProjectWorkspaceState(ProjectWorkspaceState.Create(state.TagHelpers));
 
         // Assert
         Assert.Same(state, newState);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Serialization/RazorConfigurationSerializationTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Serialization/RazorConfigurationSerializationTest.cs
@@ -17,7 +17,12 @@ public class RazorConfigurationSerializationTest(ITestOutputHelper testOutput) :
         var configuration = new RazorConfiguration(
             RazorLanguageVersion.Version_1_1,
             "Test",
-            [new("Test-Extension1"), new("Test-Extension2")]);
+            [new("Test-Extension1"), new("Test-Extension2")],
+            CodeAnalysis.CSharp.LanguageVersion.CSharp7,
+            UseConsolidatedMvcViews: false,
+            SuppressAddComponentParameter: true,
+            UseRoslynTokenizer: true,
+            PreprocessorSymbols: ["DEBUG", "TRACE", "DAVID"]);
 
         // Act
         var json = JsonDataConvert.Serialize(configuration);
@@ -33,6 +38,14 @@ public class RazorConfigurationSerializationTest(ITestOutputHelper testOutput) :
             e => Assert.Equal("Test-Extension1", e.ExtensionName),
             e => Assert.Equal("Test-Extension2", e.ExtensionName));
         Assert.Equal(configuration.LanguageVersion, obj.LanguageVersion);
+        Assert.Equal(configuration.CSharpLanguageVersion, obj.CSharpLanguageVersion);
+        Assert.Equal(configuration.UseConsolidatedMvcViews, obj.UseConsolidatedMvcViews);
+        Assert.Equal(configuration.SuppressAddComponentParameter, obj.SuppressAddComponentParameter);
+        Assert.Equal(configuration.UseRoslynTokenizer, obj.UseRoslynTokenizer);
+        Assert.Collection(obj.PreprocessorSymbols,
+            s => Assert.Equal("DEBUG", s),
+            s => Assert.Equal("TRACE", s),
+            s => Assert.Equal("DAVID", s));
     }
 
     [Fact]

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostEndpointTestBase.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostEndpointTestBase.cs
@@ -82,7 +82,6 @@ public abstract class CohostEndpointTestBase(ITestOutputHelper testOutputHelper)
             ForceRuntimeCodeGeneration = false,
             SupportsFileManipulation = true,
             ShowAllCSharpCodeActions = false,
-            UseRoslynTokenizer = false,
             UseNewFormattingEngine = false,
         };
         UpdateClientInitializationOptions(c => c);

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectReaders.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectReaders.cs
@@ -28,9 +28,11 @@ internal static partial class ObjectReaders
     {
         var configurationName = reader.ReadNonNullString(nameof(RazorConfiguration.ConfigurationName));
         var languageVersionText = reader.ReadNonNullString(nameof(RazorConfiguration.LanguageVersion));
-        var csharpLanguageVersion =  (LanguageVersion)reader.ReadInt32OrZero(nameof(RazorConfiguration.CSharpLanguageVersion));
+        var csharpLanguageVersion = (LanguageVersion)reader.ReadInt32OrZero(nameof(RazorConfiguration.CSharpLanguageVersion));
         var suppressAddComponentParameter = reader.ReadBooleanOrFalse(nameof(RazorConfiguration.SuppressAddComponentParameter));
         var useConsolidatedMvcViews = reader.ReadBooleanOrTrue(nameof(RazorConfiguration.UseConsolidatedMvcViews));
+        var useRoslynTokenizer = reader.ReadBooleanOrFalse(nameof(RazorConfiguration.UseRoslynTokenizer));
+        var preprocessorSymbols = reader.ReadImmutableArrayOrEmpty(nameof(RazorConfiguration.PreprocessorSymbols), r => r.ReadNonNullString());
         var extensions = reader.ReadImmutableArrayOrEmpty(nameof(RazorConfiguration.Extensions),
             static r =>
             {
@@ -42,7 +44,14 @@ internal static partial class ObjectReaders
             ? version
             : RazorLanguageVersion.Version_2_1;
 
-        return new(languageVersion, configurationName, extensions, csharpLanguageVersion, SuppressAddComponentParameter: suppressAddComponentParameter);
+        return new(
+            languageVersion,
+            configurationName,
+            extensions,
+            csharpLanguageVersion,
+            SuppressAddComponentParameter: suppressAddComponentParameter,
+            UseRoslynTokenizer: useRoslynTokenizer,
+            PreprocessorSymbols: preprocessorSymbols);
     }
 
     public static RazorDiagnostic ReadDiagnostic(JsonDataReader reader)

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectReaders.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectReaders.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Utilities;
+using Microsoft.CodeAnalysis.CSharp;
 
 namespace Microsoft.AspNetCore.Razor.Serialization.Json;
 
@@ -27,6 +28,7 @@ internal static partial class ObjectReaders
     {
         var configurationName = reader.ReadNonNullString(nameof(RazorConfiguration.ConfigurationName));
         var languageVersionText = reader.ReadNonNullString(nameof(RazorConfiguration.LanguageVersion));
+        var csharpLanguageVersion =  (LanguageVersion)reader.ReadInt32OrZero(nameof(RazorConfiguration.CSharpLanguageVersion));
         var suppressAddComponentParameter = reader.ReadBooleanOrFalse(nameof(RazorConfiguration.SuppressAddComponentParameter));
         var useConsolidatedMvcViews = reader.ReadBooleanOrTrue(nameof(RazorConfiguration.UseConsolidatedMvcViews));
         var extensions = reader.ReadImmutableArrayOrEmpty(nameof(RazorConfiguration.Extensions),
@@ -40,7 +42,7 @@ internal static partial class ObjectReaders
             ? version
             : RazorLanguageVersion.Version_2_1;
 
-        return new(languageVersion, configurationName, extensions, SuppressAddComponentParameter: suppressAddComponentParameter);
+        return new(languageVersion, configurationName, extensions, csharpLanguageVersion, SuppressAddComponentParameter: suppressAddComponentParameter);
     }
 
     public static RazorDiagnostic ReadDiagnostic(JsonDataReader reader)

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectReaders.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectReaders.cs
@@ -49,6 +49,7 @@ internal static partial class ObjectReaders
             configurationName,
             extensions,
             csharpLanguageVersion,
+            UseConsolidatedMvcViews: useConsolidatedMvcViews,
             SuppressAddComponentParameter: suppressAddComponentParameter,
             UseRoslynTokenizer: useRoslynTokenizer,
             PreprocessorSymbols: preprocessorSymbols);

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectReaders_ProjectSystem.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectReaders_ProjectSystem.cs
@@ -7,7 +7,6 @@ using System.IO;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using SR = Microsoft.AspNetCore.Razor.Serialization.Json.Internal.Strings;
 
 namespace Microsoft.AspNetCore.Razor.Serialization.Json;
@@ -43,9 +42,7 @@ internal static partial class ObjectReaders
 #endif
             ));
 
-        var csharpLanguageVersion = (LanguageVersion)reader.ReadInt32OrZero(nameof(ProjectWorkspaceState.CSharpLanguageVersion));
-
-        return ProjectWorkspaceState.Create(tagHelpers, csharpLanguageVersion);
+        return ProjectWorkspaceState.Create(tagHelpers);
     }
 
     public static RazorProjectInfo ReadProjectInfoFromProperties(JsonDataReader reader)

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectWriters.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectWriters.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Collections.Immutable;
 using System.Globalization;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Utilities;
@@ -38,6 +39,8 @@ internal static partial class ObjectWriters
         writer.WriteIfNotZero(nameof(value.CSharpLanguageVersion), (int)value.CSharpLanguageVersion);
         writer.WriteIfNotFalse(nameof(value.SuppressAddComponentParameter), value.SuppressAddComponentParameter);
         writer.WriteIfNotTrue(nameof(value.UseConsolidatedMvcViews), value.UseConsolidatedMvcViews);
+        writer.WriteIfNotFalse(nameof(value.UseRoslynTokenizer), value.UseRoslynTokenizer);
+        writer.WriteArrayIfNotDefaultOrEmpty(nameof(value.PreprocessorSymbols), value.PreprocessorSymbols, static (w, v) => w.Write(v));
 
         writer.WriteArrayIfNotNullOrEmpty(nameof(value.Extensions), value.Extensions, static (w, v) => w.Write(v.ExtensionName));
     }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectWriters.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectWriters.cs
@@ -35,6 +35,7 @@ internal static partial class ObjectWriters
 
         writer.Write(nameof(value.LanguageVersion), languageVersionText);
 
+        writer.WriteIfNotZero(nameof(value.CSharpLanguageVersion), (int)value.CSharpLanguageVersion);
         writer.WriteIfNotFalse(nameof(value.SuppressAddComponentParameter), value.SuppressAddComponentParameter);
         writer.WriteIfNotTrue(nameof(value.UseConsolidatedMvcViews), value.UseConsolidatedMvcViews);
 

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectWriters.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectWriters.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System.Collections.Immutable;
 using System.Globalization;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Utilities;

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectWriters_ProjectSystem.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/ObjectWriters_ProjectSystem.cs
@@ -34,7 +34,6 @@ internal static partial class ObjectWriters
     public static void WriteProperties(JsonDataWriter writer, ProjectWorkspaceState value)
     {
         writer.WriteArrayIfNotDefaultOrEmpty(nameof(value.TagHelpers), value.TagHelpers, Write);
-        writer.WriteIfNotZero(nameof(value.CSharpLanguageVersion), (int)value.CSharpLanguageVersion);
     }
 
     public static void Write(JsonDataWriter writer, RazorProjectInfo value)

--- a/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/SerializationFormat.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Serialization.Json/SerializationFormat.cs
@@ -9,5 +9,5 @@ internal static class SerializationFormat
     // or any of the types that compose it changes. This includes: RazorConfiguration,
     // ProjectWorkspaceState, TagHelperDescriptor, and DocumentSnapshotHandle.
     // NOTE: If this version is changed, a coordinated insertion is required between Roslyn and Razor for the C# extension.
-    public const int Version = 6;
+    public const int Version = 7;
 }

--- a/src/Shared/files/Tooling/project.razor.json
+++ b/src/Shared/files/Tooling/project.razor.json
@@ -1,10 +1,11 @@
 {
-  "__Version": 6,
+  "__Version": 7,
   "ProjectKey": "C:/Users/admin/location/blazorserver/obj/Debug/net7.0/",
   "FilePath": "C:\\Users\\admin\\location\\blazorserver\\blazorserver.csproj",
   "Configuration": {
     "ConfigurationName": "MVC-3.0",
     "LanguageVersion": "3.0",
+    "CSharpLanguageVersion": 800,
     "Extensions": [
       "MVC-3.0"
     ]
@@ -17805,8 +17806,7 @@
           "Runtime.Name": "Components.None"
         }
       }
-    ],
-    "CSharpLanguageVersion": 800
+    ]
   },
   "RootNamespace": "blazorserver",
   "Documents": [


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/11120

This wires up UseRoslynTokenizer properly, so we read from the project not from our feature flag, in time for it being on by default for .NET 10. It also serializes pre-processor symbols so they will work with it. It is not serializing the whole C# parse options because we need to do work in Roslyn to share that code properly.