### PR TITLE
TextMate bug: recognize codeblocks with curly braces in switch statements

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/EmbeddedGrammars/aspnetcorerazor.tmLanguage.json
@@ -1635,6 +1635,9 @@
           "include": "source.cs#switch-label"
         },
         {
+          "include": "#csharp-code-block"
+        },
+        {
           "include": "#razor-codeblock-body"
         }
       ],


### PR DESCRIPTION
This fixes https://github.com/dotnet/razor/issues/11249.

The problem here is that curly braces are not required within the `case` clause. I added one line in the TextMate syntax to account for this potential usage.

The code change and testing is done on the vscode-csharp repo where Razor TextMate source code is hosted. See original PR: https://github.com/dotnet/vscode-csharp/pull/7929.

Before:
<img width="704" alt="image" src="https://github.com/user-attachments/assets/74da2142-6bcf-41f3-9cdb-368810d7f964" />
After:
<img width="582" alt="image" src="https://github.com/user-attachments/assets/40e000b5-ecbf-4253-857e-85e8a4045eda" />
