### PR TITLE
Fix bad completion commit in vs code

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
@@ -41,5 +41,5 @@ internal class DefaultLanguageServerFeatureOptions : LanguageServerFeatureOption
 
     public override bool UseNewFormattingEngine => false;
 
-    public override bool AvoidExplicitCommitCharactersInTransitionCompletionItem => false;
+    public override bool SupportsSoftSelectionInCompletion => true;
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
@@ -40,4 +40,6 @@ internal class DefaultLanguageServerFeatureOptions : LanguageServerFeatureOption
     public override bool ForceRuntimeCodeGeneration => false;
 
     public override bool UseNewFormattingEngine => false;
+
+    public override bool AvoidExplicitCommitCharacters => false;
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
@@ -41,5 +41,5 @@ internal class DefaultLanguageServerFeatureOptions : LanguageServerFeatureOption
 
     public override bool UseNewFormattingEngine => false;
 
-    public override bool AvoidExplicitCommitCharacters => false;
+    public override bool AvoidExplicitCommitCharactersInTransitionCompletionItem => false;
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hosting/ConfigurableLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hosting/ConfigurableLanguageServerFeatureOptions.cs
@@ -24,7 +24,6 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
     private readonly bool? _disableRazorLanguageServer;
     private readonly bool? _forceRuntimeCodeGeneration;
     private readonly bool? _useNewFormattingEngine;
-    private readonly bool? _avoidExplicitCommitCharacters;
 
     public override bool SupportsFileManipulation => _supportsFileManipulation ?? _defaults.SupportsFileManipulation;
     public override string CSharpVirtualDocumentSuffix => _csharpVirtualDocumentSuffix ?? DefaultLanguageServerFeatureOptions.DefaultCSharpVirtualDocumentSuffix;
@@ -40,7 +39,7 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
     public override bool DisableRazorLanguageServer => _disableRazorLanguageServer ?? _defaults.DisableRazorLanguageServer;
     public override bool ForceRuntimeCodeGeneration => _forceRuntimeCodeGeneration ?? _defaults.ForceRuntimeCodeGeneration;
     public override bool UseNewFormattingEngine => _useNewFormattingEngine ?? _defaults.UseNewFormattingEngine;
-    public override bool AvoidExplicitCommitCharacters => _avoidExplicitCommitCharacters ?? _defaults.AvoidExplicitCommitCharacters;
+    public override bool AvoidExplicitCommitCharactersInTransitionCompletionItem => true;
 
     public ConfigurableLanguageServerFeatureOptions(string[] args)
     {
@@ -65,7 +64,6 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
             TryProcessBoolOption(nameof(DisableRazorLanguageServer), ref _disableRazorLanguageServer, option, args, i);
             TryProcessBoolOption(nameof(ForceRuntimeCodeGeneration), ref _forceRuntimeCodeGeneration, option, args, i);
             TryProcessBoolOption(nameof(UseNewFormattingEngine), ref _useNewFormattingEngine, option, args, i);
-            TryProcessBoolOption(nameof(AvoidExplicitCommitCharacters), ref _avoidExplicitCommitCharacters, option, args, i);
         }
     }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hosting/ConfigurableLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hosting/ConfigurableLanguageServerFeatureOptions.cs
@@ -24,6 +24,7 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
     private readonly bool? _disableRazorLanguageServer;
     private readonly bool? _forceRuntimeCodeGeneration;
     private readonly bool? _useNewFormattingEngine;
+    private readonly bool? _avoidExplicitCommitCharacters;
 
     public override bool SupportsFileManipulation => _supportsFileManipulation ?? _defaults.SupportsFileManipulation;
     public override string CSharpVirtualDocumentSuffix => _csharpVirtualDocumentSuffix ?? DefaultLanguageServerFeatureOptions.DefaultCSharpVirtualDocumentSuffix;
@@ -39,6 +40,7 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
     public override bool DisableRazorLanguageServer => _disableRazorLanguageServer ?? _defaults.DisableRazorLanguageServer;
     public override bool ForceRuntimeCodeGeneration => _forceRuntimeCodeGeneration ?? _defaults.ForceRuntimeCodeGeneration;
     public override bool UseNewFormattingEngine => _useNewFormattingEngine ?? _defaults.UseNewFormattingEngine;
+    public override bool AvoidExplicitCommitCharacters => _avoidExplicitCommitCharacters ?? _defaults.AvoidExplicitCommitCharacters;
 
     public ConfigurableLanguageServerFeatureOptions(string[] args)
     {
@@ -63,6 +65,7 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
             TryProcessBoolOption(nameof(DisableRazorLanguageServer), ref _disableRazorLanguageServer, option, args, i);
             TryProcessBoolOption(nameof(ForceRuntimeCodeGeneration), ref _forceRuntimeCodeGeneration, option, args, i);
             TryProcessBoolOption(nameof(UseNewFormattingEngine), ref _useNewFormattingEngine, option, args, i);
+            TryProcessBoolOption(nameof(AvoidExplicitCommitCharacters), ref _avoidExplicitCommitCharacters, option, args, i);
         }
     }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hosting/ConfigurableLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hosting/ConfigurableLanguageServerFeatureOptions.cs
@@ -39,7 +39,7 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
     public override bool DisableRazorLanguageServer => _disableRazorLanguageServer ?? _defaults.DisableRazorLanguageServer;
     public override bool ForceRuntimeCodeGeneration => _forceRuntimeCodeGeneration ?? _defaults.ForceRuntimeCodeGeneration;
     public override bool UseNewFormattingEngine => _useNewFormattingEngine ?? _defaults.UseNewFormattingEngine;
-    public override bool AvoidExplicitCommitCharactersInTransitionCompletionItem => true;
+    public override bool SupportsSoftSelectionInCompletion => false;
 
     public ConfigurableLanguageServerFeatureOptions(string[] args)
     {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeTransitionCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeTransitionCompletionItemProvider.cs
@@ -33,9 +33,9 @@ internal class DirectiveAttributeTransitionCompletionItemProvider(LanguageServer
             // where this directive attribute transition character ("@...") gets provided and then typing
             // `@` should re-trigger OR typing `/` should re-trigger.
             // However, in VS Code explicit commit characters like these cause issues, e.g. "@..." gets committed when trying to type "/" in a
-            // self-closing tag. So VS Code will pass AvoidExplicitCommitCharacters as a start-up parameter to the language server and we will
+            // self-closing tag. So in VS Code we have SupportSoftSelectionInCompletion set to false and we will
             // use empty commit character set in that case.
-            commitCharacters: _languageServerFeatureOptions.AvoidExplicitCommitCharactersInTransitionCompletionItem ? [] : RazorCommitCharacter.CreateArray(["@", "/", ">"]),
+            commitCharacters: _languageServerFeatureOptions.SupportsSoftSelectionInCompletion ? RazorCommitCharacter.CreateArray(["@", "/", ">"]) : [],
             isSnippet: false);
 
     public static bool IsTransitionCompletionItem(RazorCompletionItem completionItem)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeTransitionCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeTransitionCompletionItemProvider.cs
@@ -35,7 +35,7 @@ internal class DirectiveAttributeTransitionCompletionItemProvider(LanguageServer
             // However, in VS Code explicit commit characters like these cause issues, e.g. "@..." gets committed when trying to type "/" in a
             // self-closing tag. So VS Code will pass AvoidExplicitCommitCharacters as a start-up parameter to the language server and we will
             // use empty commit character set in that case.
-            commitCharacters: _languageServerFeatureOptions.AvoidExplicitCommitCharacters ? [] : RazorCommitCharacter.CreateArray(["@", "/", ">"]),
+            commitCharacters: _languageServerFeatureOptions.AvoidExplicitCommitCharactersInTransitionCompletionItem ? [] : RazorCommitCharacter.CreateArray(["@", "/", ">"]),
             isSnippet: false);
 
     public static bool IsTransitionCompletionItem(RazorCompletionItem completionItem)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionListProvider.cs
@@ -150,7 +150,7 @@ internal class RazorCompletionListProvider(
 
                     directiveCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
 
-                    if (razorCompletionItem == DirectiveAttributeTransitionCompletionItemProvider.TransitionCompletionItem)
+                    if (DirectiveAttributeTransitionCompletionItemProvider.IsTransitionCompletionItem(razorCompletionItem))
                     {
                         directiveCompletionItem.Command = s_retriggerCompletionCommand;
                         directiveCompletionItem.Kind = tagHelperCompletionItemKind;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
@@ -41,4 +41,10 @@ internal abstract class LanguageServerFeatureOptions
     public abstract bool ForceRuntimeCodeGeneration { get; }
 
     public abstract bool UseNewFormattingEngine { get; }
+
+    /// <summary>
+    /// When enabled, completion item providers should avoid specifying explicit commit characters in the return completion items
+    /// as doing so may cause undesirable commits in the current client.
+    /// </summary>
+    public abstract bool AvoidExplicitCommitCharacters { get; }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
@@ -43,8 +43,8 @@ internal abstract class LanguageServerFeatureOptions
     public abstract bool UseNewFormattingEngine { get; }
 
     /// <summary>
-    /// When enabled, DirectiveAttributeCompletionTransitionItemProvider should avoid specifying explicit commit characters 
-    /// in the return completion item as doing so may cause undesirable commits in the current client.
+    /// Indicates that client supports soft selection in completion list, meaning that typing a commit 
+    /// character with a soft-selected item will not commit that item.
     /// </summary>
-    public abstract bool AvoidExplicitCommitCharactersInTransitionCompletionItem { get; }
+    public abstract bool SupportsSoftSelectionInCompletion { get; }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
@@ -43,8 +43,8 @@ internal abstract class LanguageServerFeatureOptions
     public abstract bool UseNewFormattingEngine { get; }
 
     /// <summary>
-    /// When enabled, completion item providers should avoid specifying explicit commit characters in the return completion items
-    /// as doing so may cause undesirable commits in the current client.
+    /// When enabled, DirectiveAttributeCompletionTransitionItemProvider should avoid specifying explicit commit characters 
+    /// in the return completion item as doing so may cause undesirable commits in the current client.
     /// </summary>
-    public abstract bool AvoidExplicitCommitCharacters { get; }
+    public abstract bool AvoidExplicitCommitCharactersInTransitionCompletionItem { get; }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RemoteClientInitializationOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RemoteClientInitializationOptions.cs
@@ -38,5 +38,5 @@ internal struct RemoteClientInitializationOptions
     public required bool UseNewFormattingEngine { get; set; }
 
     [JsonPropertyName("avoidExplicitCommitCharacters")]
-    public required bool AvoidExplicitCommitCharacters { get; set; }
+    public required bool AvoidExplicitCommitCharactersInTransitionCompletionItem { get; set; }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RemoteClientInitializationOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RemoteClientInitializationOptions.cs
@@ -36,4 +36,7 @@ internal struct RemoteClientInitializationOptions
 
     [JsonPropertyName("useNewFormattingEngine")]
     public required bool UseNewFormattingEngine { get; set; }
+
+    [JsonPropertyName("avoidExplicitCommitCharacters")]
+    public required bool AvoidExplicitCommitCharacters { get; set; }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RemoteClientInitializationOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RemoteClientInitializationOptions.cs
@@ -38,5 +38,5 @@ internal struct RemoteClientInitializationOptions
     public required bool UseNewFormattingEngine { get; set; }
 
     [JsonPropertyName("avoidExplicitCommitCharacters")]
-    public required bool AvoidExplicitCommitCharactersInTransitionCompletionItem { get; set; }
+    public required bool SupportsSoftSelectionInCompletion { get; set; }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/OOPRazorCompletionItemProviders.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/OOPRazorCompletionItemProviders.cs
@@ -3,6 +3,7 @@
 
 using System.Composition;
 using Microsoft.CodeAnalysis.Razor.Completion;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor.Completion;
 
@@ -16,7 +17,9 @@ internal sealed class OOPDirectiveAttributeCompletionItemProvider : DirectiveAtt
 internal sealed class OOPDirectiveAttributeParameterCompletionItemProvider : DirectiveAttributeParameterCompletionItemProvider;
 
 [Export(typeof(IRazorCompletionItemProvider)), Shared]
-internal sealed class OOPDirectiveAttributeTransitionCompletionItemProvider : DirectiveAttributeTransitionCompletionItemProvider;
+[method: ImportingConstructor]
+internal sealed class OOPDirectiveAttributeTransitionCompletionItemProvider(LanguageServerFeatureOptions languageServerFeatureOptions)
+    : DirectiveAttributeTransitionCompletionItemProvider(languageServerFeatureOptions);
 
 [Export(typeof(IRazorCompletionItemProvider)), Shared]
 internal sealed class OOPMarkupTransitionCompletionItemProvider : MarkupTransitionCompletionItemProvider;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Initialization/RemoteLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Initialization/RemoteLanguageServerFeatureOptions.cs
@@ -45,5 +45,5 @@ internal class RemoteLanguageServerFeatureOptions : LanguageServerFeatureOptions
 
     public override bool UseNewFormattingEngine => _options.UseNewFormattingEngine;
 
-    public override bool AvoidExplicitCommitCharactersInTransitionCompletionItem => _options.AvoidExplicitCommitCharactersInTransitionCompletionItem;
+    public override bool SupportsSoftSelectionInCompletion => _options.SupportsSoftSelectionInCompletion;
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Initialization/RemoteLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Initialization/RemoteLanguageServerFeatureOptions.cs
@@ -44,4 +44,6 @@ internal class RemoteLanguageServerFeatureOptions : LanguageServerFeatureOptions
     public override bool ForceRuntimeCodeGeneration => _options.ForceRuntimeCodeGeneration;
 
     public override bool UseNewFormattingEngine => _options.UseNewFormattingEngine;
+
+    public override bool AvoidExplicitCommitCharacters => _options.AvoidExplicitCommitCharacters;
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Initialization/RemoteLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Initialization/RemoteLanguageServerFeatureOptions.cs
@@ -45,5 +45,5 @@ internal class RemoteLanguageServerFeatureOptions : LanguageServerFeatureOptions
 
     public override bool UseNewFormattingEngine => _options.UseNewFormattingEngine;
 
-    public override bool AvoidExplicitCommitCharacters => _options.AvoidExplicitCommitCharacters;
+    public override bool AvoidExplicitCommitCharactersInTransitionCompletionItem => _options.AvoidExplicitCommitCharactersInTransitionCompletionItem;
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/RemoteServiceInvoker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/RemoteServiceInvoker.cs
@@ -142,7 +142,7 @@ internal sealed class RemoteServiceInvoker(
                     SupportsFileManipulation = _languageServerFeatureOptions.SupportsFileManipulation,
                     ShowAllCSharpCodeActions = _languageServerFeatureOptions.ShowAllCSharpCodeActions,
                     UseNewFormattingEngine = _languageServerFeatureOptions.UseNewFormattingEngine,
-                    AvoidExplicitCommitCharacters = _languageServerFeatureOptions.AvoidExplicitCommitCharacters,
+                    AvoidExplicitCommitCharactersInTransitionCompletionItem = _languageServerFeatureOptions.AvoidExplicitCommitCharactersInTransitionCompletionItem,
                 };
 
                 _logger.LogDebug($"First OOP call, so initializing OOP service.");

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/RemoteServiceInvoker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/RemoteServiceInvoker.cs
@@ -142,7 +142,7 @@ internal sealed class RemoteServiceInvoker(
                     SupportsFileManipulation = _languageServerFeatureOptions.SupportsFileManipulation,
                     ShowAllCSharpCodeActions = _languageServerFeatureOptions.ShowAllCSharpCodeActions,
                     UseNewFormattingEngine = _languageServerFeatureOptions.UseNewFormattingEngine,
-                    AvoidExplicitCommitCharactersInTransitionCompletionItem = _languageServerFeatureOptions.AvoidExplicitCommitCharactersInTransitionCompletionItem,
+                    SupportsSoftSelectionInCompletion = _languageServerFeatureOptions.SupportsSoftSelectionInCompletion,
                 };
 
                 _logger.LogDebug($"First OOP call, so initializing OOP service.");

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/RemoteServiceInvoker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/RemoteServiceInvoker.cs
@@ -142,6 +142,7 @@ internal sealed class RemoteServiceInvoker(
                     SupportsFileManipulation = _languageServerFeatureOptions.SupportsFileManipulation,
                     ShowAllCSharpCodeActions = _languageServerFeatureOptions.ShowAllCSharpCodeActions,
                     UseNewFormattingEngine = _languageServerFeatureOptions.UseNewFormattingEngine,
+                    AvoidExplicitCommitCharacters = _languageServerFeatureOptions.AvoidExplicitCommitCharacters,
                 };
 
                 _logger.LogDebug($"First OOP call, so initializing OOP service.");

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioLanguageServerFeatureOptions.cs
@@ -114,5 +114,5 @@ internal class VisualStudioLanguageServerFeatureOptions : LanguageServerFeatureO
     public override bool UseNewFormattingEngine => _useNewFormattingEngine.Value;
 
     // VS actually needs explicit commit characters so don't avoid them.
-    public override bool AvoidExplicitCommitCharactersInTransitionCompletionItem => false;
+    public override bool SupportsSoftSelectionInCompletion => true;
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioLanguageServerFeatureOptions.cs
@@ -112,4 +112,7 @@ internal class VisualStudioLanguageServerFeatureOptions : LanguageServerFeatureO
     public override bool ForceRuntimeCodeGeneration => _forceRuntimeCodeGeneration.Value;
 
     public override bool UseNewFormattingEngine => _useNewFormattingEngine.Value;
+
+    // VS actually needs explicit commit characters so don't avoid them.
+    public override bool AvoidExplicitCommitCharacters => false;
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioLanguageServerFeatureOptions.cs
@@ -114,5 +114,5 @@ internal class VisualStudioLanguageServerFeatureOptions : LanguageServerFeatureO
     public override bool UseNewFormattingEngine => _useNewFormattingEngine.Value;
 
     // VS actually needs explicit commit characters so don't avoid them.
-    public override bool AvoidExplicitCommitCharacters => false;
+    public override bool AvoidExplicitCommitCharactersInTransitionCompletionItem => false;
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/TestLanguageServerFeatureOptions.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/TestLanguageServerFeatureOptions.cs
@@ -42,5 +42,5 @@ internal class TestLanguageServerFeatureOptions(
 
     public override bool UseNewFormattingEngine => useNewFormattingEngine;
 
-    public override bool AvoidExplicitCommitCharacters => avoidExplicitCommitCharacters;
+    public override bool AvoidExplicitCommitCharactersInTransitionCompletionItem => avoidExplicitCommitCharacters;
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/TestLanguageServerFeatureOptions.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/TestLanguageServerFeatureOptions.cs
@@ -9,7 +9,8 @@ internal class TestLanguageServerFeatureOptions(
     bool includeProjectKeyInGeneratedFilePath = false,
     bool forceRuntimeCodeGeneration = false,
     bool updateBuffersForClosedDocuments = false,
-    bool useNewFormattingEngine = false) : LanguageServerFeatureOptions
+    bool useNewFormattingEngine = false,
+    bool avoidExplicitCommitCharacters = false) : LanguageServerFeatureOptions
 {
     public static readonly LanguageServerFeatureOptions Instance = new TestLanguageServerFeatureOptions();
 
@@ -40,4 +41,6 @@ internal class TestLanguageServerFeatureOptions(
     public override bool ForceRuntimeCodeGeneration => forceRuntimeCodeGeneration;
 
     public override bool UseNewFormattingEngine => useNewFormattingEngine;
+
+    public override bool AvoidExplicitCommitCharacters => avoidExplicitCommitCharacters;
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/TestLanguageServerFeatureOptions.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/TestLanguageServerFeatureOptions.cs
@@ -10,7 +10,7 @@ internal class TestLanguageServerFeatureOptions(
     bool forceRuntimeCodeGeneration = false,
     bool updateBuffersForClosedDocuments = false,
     bool useNewFormattingEngine = false,
-    bool avoidExplicitCommitCharacters = false) : LanguageServerFeatureOptions
+    bool supportsSoftSelectionInCompletion = true) : LanguageServerFeatureOptions
 {
     public static readonly LanguageServerFeatureOptions Instance = new TestLanguageServerFeatureOptions();
 
@@ -42,5 +42,5 @@ internal class TestLanguageServerFeatureOptions(
 
     public override bool UseNewFormattingEngine => useNewFormattingEngine;
 
-    public override bool AvoidExplicitCommitCharactersInTransitionCompletionItem => avoidExplicitCommitCharacters;
+    public override bool SupportsSoftSelectionInCompletion => supportsSoftSelectionInCompletion;
 }

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeTransitionCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeTransitionCompletionItemProviderTest.cs
@@ -4,6 +4,7 @@
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.NET.Sdk.Razor.SourceGenerators;
@@ -14,8 +15,6 @@ namespace Microsoft.CodeAnalysis.Razor.Completion;
 
 public class DirectiveAttributeTransitionCompletionItemProviderTest : ToolingTestBase
 {
-    private static readonly RazorCompletionItem s_transitionCompletionItem = DirectiveAttributeTransitionCompletionItemProvider.TransitionCompletionItem;
-
     private readonly TagHelperDocumentContext _tagHelperDocumentContext;
     private readonly DirectiveAttributeTransitionCompletionItemProvider _provider;
 
@@ -23,7 +22,7 @@ public class DirectiveAttributeTransitionCompletionItemProviderTest : ToolingTes
         : base(testOutput)
     {
         _tagHelperDocumentContext = TagHelperDocumentContext.Create(prefix: string.Empty, tagHelpers: []);
-        _provider = new DirectiveAttributeTransitionCompletionItemProvider();
+        _provider = new DirectiveAttributeTransitionCompletionItemProvider(TestLanguageServerFeatureOptions.Instance);
     }
 
     [Fact]
@@ -194,7 +193,7 @@ public class DirectiveAttributeTransitionCompletionItemProviderTest : ToolingTes
 
         // Assert
         var item = Assert.Single(result);
-        Assert.Same(item, s_transitionCompletionItem);
+        Assert.True(DirectiveAttributeTransitionCompletionItemProvider.IsTransitionCompletionItem(item));
     }
 
     [Fact]
@@ -208,7 +207,7 @@ public class DirectiveAttributeTransitionCompletionItemProviderTest : ToolingTes
 
         // Assert
         var item = Assert.Single(result);
-        Assert.Same(item, s_transitionCompletionItem);
+        Assert.True(DirectiveAttributeTransitionCompletionItemProvider.IsTransitionCompletionItem(item));
     }
 
     [Fact]
@@ -222,7 +221,7 @@ public class DirectiveAttributeTransitionCompletionItemProviderTest : ToolingTes
 
         // Assert
         var item = Assert.Single(result);
-        Assert.Same(item, s_transitionCompletionItem);
+        Assert.True(DirectiveAttributeTransitionCompletionItemProvider.IsTransitionCompletionItem(item));
     }
 
     [Fact]
@@ -288,7 +287,7 @@ public class DirectiveAttributeTransitionCompletionItemProviderTest : ToolingTes
 
         // Assert
         var item = Assert.Single(result);
-        Assert.Same(item, s_transitionCompletionItem);
+        Assert.True(DirectiveAttributeTransitionCompletionItemProvider.IsTransitionCompletionItem(item));
     }
 
     [Fact]
@@ -302,7 +301,7 @@ public class DirectiveAttributeTransitionCompletionItemProviderTest : ToolingTes
 
         // Assert
         var item = Assert.Single(result);
-        Assert.Same(item, s_transitionCompletionItem);
+        Assert.True(DirectiveAttributeTransitionCompletionItemProvider.IsTransitionCompletionItem(item));
     }
 
     private static RazorSyntaxTree GetSyntaxTree(string text, string? fileKind = null)

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeTransitionCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeTransitionCompletionItemProviderTest.cs
@@ -307,11 +307,11 @@ public class DirectiveAttributeTransitionCompletionItemProviderTest : ToolingTes
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public void GetCompletionItems_WithAvoidExplicitCommitOption_ReturnsAppropriateCommitCharacters(bool avoidExplicitCommitOption)
+    public void GetCompletionItems_WithAvoidExplicitCommitOption_ReturnsAppropriateCommitCharacters(bool supportsSoftSelection)
     {
         // Arrange
         var context = CreateContext(absoluteIndex: 7, "<input  />");
-        var provider = new DirectiveAttributeTransitionCompletionItemProvider(new TestLanguageServerFeatureOptions(avoidExplicitCommitCharacters: avoidExplicitCommitOption));
+        var provider = new DirectiveAttributeTransitionCompletionItemProvider(new TestLanguageServerFeatureOptions(supportsSoftSelectionInCompletion: supportsSoftSelection));
 
         // Act
         var result = provider.GetCompletionItems(context);
@@ -319,13 +319,13 @@ public class DirectiveAttributeTransitionCompletionItemProviderTest : ToolingTes
         // Assert
         var item = Assert.Single(result);
         Assert.True(DirectiveAttributeTransitionCompletionItemProvider.IsTransitionCompletionItem(item));
-        if (avoidExplicitCommitOption)
+        if (supportsSoftSelection)
         {
-            Assert.Empty(item.CommitCharacters);
+            Assert.NotEmpty(item.CommitCharacters);
         }
         else
         {
-            Assert.NotEmpty(item.CommitCharacters);
+            Assert.Empty(item.CommitCharacters);
         }
     }
 

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeTransitionCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeTransitionCompletionItemProviderTest.cs
@@ -304,6 +304,31 @@ public class DirectiveAttributeTransitionCompletionItemProviderTest : ToolingTes
         Assert.True(DirectiveAttributeTransitionCompletionItemProvider.IsTransitionCompletionItem(item));
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void GetCompletionItems_WithAvoidExplicitCommitOption_ReturnsAppropriateCommitCharacters(bool avoidExplicitCommitOption)
+    {
+        // Arrange
+        var context = CreateContext(absoluteIndex: 7, "<input  />");
+        var provider = new DirectiveAttributeTransitionCompletionItemProvider(new TestLanguageServerFeatureOptions(avoidExplicitCommitCharacters: avoidExplicitCommitOption));
+
+        // Act
+        var result = provider.GetCompletionItems(context);
+
+        // Assert
+        var item = Assert.Single(result);
+        Assert.True(DirectiveAttributeTransitionCompletionItemProvider.IsTransitionCompletionItem(item));
+        if (avoidExplicitCommitOption)
+        {
+            Assert.Empty(item.CommitCharacters);
+        }
+        else
+        {
+            Assert.NotEmpty(item.CommitCharacters);
+        }
+    }
+
     private static RazorSyntaxTree GetSyntaxTree(string text, string? fileKind = null)
     {
         fileKind ??= FileKinds.Component;

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/RazorCompletionListProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/RazorCompletionListProviderTest.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
+using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 using Microsoft.CodeAnalysis.Razor.Tooltip;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -164,7 +165,8 @@ public class RazorCompletionListProviderTest : LanguageServerTestBase
     public void TryConvert_DirectiveAttributeTransition_SerializationDoesNotThrow()
     {
         // Arrange
-        var completionItem = DirectiveAttributeTransitionCompletionItemProvider.TransitionCompletionItem;
+        var directiveAttributeTransitionCompletionItemProvider = new DirectiveAttributeTransitionCompletionItemProvider(TestLanguageServerFeatureOptions.Instance);
+        var completionItem = directiveAttributeTransitionCompletionItemProvider.TransitionCompletionItem;
         RazorCompletionListProvider.TryConvert(completionItem, _clientCapabilities, out var converted);
 
         // Act & Assert
@@ -175,7 +177,8 @@ public class RazorCompletionListProviderTest : LanguageServerTestBase
     public void TryConvert_DirectiveAttributeTransition_ReturnsTrue()
     {
         // Arrange
-        var completionItem = DirectiveAttributeTransitionCompletionItemProvider.TransitionCompletionItem;
+        var directiveAttributeTransitionCompletionItemProvider = new DirectiveAttributeTransitionCompletionItemProvider(TestLanguageServerFeatureOptions.Instance);
+        var completionItem = directiveAttributeTransitionCompletionItemProvider.TransitionCompletionItem;
 
         // Act
         Assert.True(RazorCompletionListProvider.TryConvert(completionItem, _clientCapabilities, out var converted));

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostEndpointTestBase.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostEndpointTestBase.cs
@@ -83,7 +83,7 @@ public abstract class CohostEndpointTestBase(ITestOutputHelper testOutputHelper)
             SupportsFileManipulation = true,
             ShowAllCSharpCodeActions = false,
             UseNewFormattingEngine = false,
-            AvoidExplicitCommitCharacters = false,
+            AvoidExplicitCommitCharactersInTransitionCompletionItem = false,
         };
         UpdateClientInitializationOptions(c => c);
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostEndpointTestBase.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostEndpointTestBase.cs
@@ -83,6 +83,7 @@ public abstract class CohostEndpointTestBase(ITestOutputHelper testOutputHelper)
             SupportsFileManipulation = true,
             ShowAllCSharpCodeActions = false,
             UseNewFormattingEngine = false,
+            AvoidExplicitCommitCharacters = false,
         };
         UpdateClientInitializationOptions(c => c);
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostEndpointTestBase.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostEndpointTestBase.cs
@@ -83,7 +83,7 @@ public abstract class CohostEndpointTestBase(ITestOutputHelper testOutputHelper)
             SupportsFileManipulation = true,
             ShowAllCSharpCodeActions = false,
             UseNewFormattingEngine = false,
-            AvoidExplicitCommitCharactersInTransitionCompletionItem = false,
+            SupportsSoftSelectionInCompletion = true,
         };
         UpdateClientInitializationOptions(c => c);
 


### PR DESCRIPTION
﻿### Summary of the changes
We need to avoid specifying explicit commit characters in VS Code as there is no soft selection and typing when completion list is up is much more likely to commit wrong items. This is especially true when commit characters are specified explicitly in some Razor completion items to work around some of the VS completion quirks. We can do so by defining a new flag and passing it from VS Code to rzls to specify the desired commit character set.

There will be a corresponding PR in VS Code to actually pass the new flag.
-

Fixes:
https://github.com/dotnet/razor/issues/10601