### PR TITLE
Don't create overlapping changes when doing additional formatting

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/RazorFormattingPass.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/RazorFormattingPass.cs
@@ -461,7 +461,8 @@ internal sealed class RazorFormattingPass(LanguageServerFeatureOptions languageS
                 didFormat = true;
             }
 
-            // If there is no newline after the close brace, we add one.
+            // If there is code after the close brace, then we want to add a newline after it and push the code to the next
+            // line. In other words, we expect only whitespace characters after the close brace, on this line.
             var closeBraceLine = source.Text.Lines[closeBraceRange.End.Line];
             if (closeBraceLine.GetFirstNonWhitespaceOffset(closeBraceRange.End.Character).HasValue)
             {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/DocumentFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/DocumentFormattingTest.cs
@@ -5798,4 +5798,33 @@ public class DocumentFormattingTest(FormattingTestContext context, HtmlFormattin
                     
                     """);
     }
+
+    [FormattingTestFact]
+    [WorkItem("https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2347107")]
+    public async Task ImplicitExpressionAtEndOfCodeBlock()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                @page
+                @model IndexModel
+
+                <div>
+                </div>
+
+                @functions {void Foo() { }}@Foo()
+                """,
+            expected: """
+                @page
+                @model IndexModel
+                
+                <div>
+                </div>
+                
+                @functions {
+                    void Foo() { }
+                }
+                @Foo()
+                """,
+            fileKind: FileKinds.Legacy);
+    }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/DocumentFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/DocumentFormattingTest.cs
@@ -5827,4 +5827,31 @@ public class DocumentFormattingTest(FormattingTestContext context, HtmlFormattin
                 """,
             fileKind: FileKinds.Legacy);
     }
+
+    [FormattingTestFact]
+    public async Task LineBreakAtTheEndOfBlocks()
+    {
+        await RunFormattingTestAsync(
+            input: """
+                @page
+                @model IndexModel
+
+                <div>
+                </div>
+
+                @code {void Foo() { }}@Foo.ToString(   1  )
+                """,
+            expected: """
+                @page
+                @model IndexModel
+                
+                <div>
+                </div>
+                
+                @code {
+                    void Foo() { }
+                }
+                @Foo.ToString(1)
+                """);
+    }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/DocumentFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/DocumentFormattingTest.cs
@@ -5805,7 +5805,7 @@ public class DocumentFormattingTest(FormattingTestContext context, HtmlFormattin
     {
         await RunFormattingTestAsync(
             input: """
-                @page
+                @page "/"
                 @model IndexModel
 
                 <div>
@@ -5814,7 +5814,7 @@ public class DocumentFormattingTest(FormattingTestContext context, HtmlFormattin
                 @functions {void Foo() { }}@Foo()
                 """,
             expected: """
-                @page
+                @page "/"
                 @model IndexModel
                 
                 <div>
@@ -5833,7 +5833,7 @@ public class DocumentFormattingTest(FormattingTestContext context, HtmlFormattin
     {
         await RunFormattingTestAsync(
             input: """
-                @page
+                @page "/"
                 @model IndexModel
 
                 <div>
@@ -5842,7 +5842,7 @@ public class DocumentFormattingTest(FormattingTestContext context, HtmlFormattin
                 @code {void Foo() { }}@Foo.ToString(   1  )
                 """,
             expected: """
-                @page
+                @page "/"
                 @model IndexModel
                 
                 <div>


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2347107

First commit fixes the bug in the new formatting engine where we sometimes create overlapping edits, and instead now we drop those edits on the floor, so at least most of the file will format correctly.
Second commit then fixes the actual formatting issue with the code in hand, which means we no longer have overlapping edits in the first place.