### PR TITLE
Change recommended VS extension to ESLint

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,7 @@
 {
-	"recommendations": [
-		"ms-vscode.vscode-typescript-tslint-plugin",
-		"ms-dotnettools.csharp",
-		"EditorConfig.EditorConfig"
-	]
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "ms-dotnettools.csharp",
+    "EditorConfig.EditorConfig"
+  ]
 }


### PR DESCRIPTION
When I opened razor using VSCode for a quick change, I noticed that we recommending a depcricated extention (TSLink). So I am changing to the the recommended Microsoft Repalcement (ESLint). Both owned by Microsoft.


![Screenshot 2025-01-29 at 11 19 22 AM](https://github.com/user-attachments/assets/88dedd4c-182e-44d7-b1a8-92d61ad01e92)
![Screenshot 2025-01-29 at 11 19 29 AM](https://github.com/user-attachments/assets/81c09692-ae6b-4cec-971d-44fbb2bee347)
