### PR TITLE
[Dev17.14] fuse on by default

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
@@ -37,7 +37,7 @@ internal class DefaultLanguageServerFeatureOptions : LanguageServerFeatureOption
 
     public override bool DisableRazorLanguageServer => false;
 
-    public override bool ForceRuntimeCodeGeneration => false;
+    public override bool ForceRuntimeCodeGeneration => true;
 
     public override bool UseNewFormattingEngine => true;
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioLanguageServerFeatureOptions.cs
@@ -69,7 +69,7 @@ internal class VisualStudioLanguageServerFeatureOptions : LanguageServerFeatureO
         _forceRuntimeCodeGeneration = new Lazy<bool>(() =>
         {
             var featureFlags = (IVsFeatureFlags)Package.GetGlobalService(typeof(SVsFeatureFlags));
-            var forceRuntimeCodeGeneration = featureFlags.IsFeatureEnabled(WellKnownFeatureFlagNames.ForceRuntimeCodeGeneration, defaultValue: false);
+            var forceRuntimeCodeGeneration = featureFlags.IsFeatureEnabled(WellKnownFeatureFlagNames.ForceRuntimeCodeGeneration, defaultValue: true);
             return forceRuntimeCodeGeneration;
         });
 

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.Custom.pkgdef
@@ -71,7 +71,7 @@
 
 [$RootKey$\FeatureFlags\Razor\LSP\ForceRuntimeCodeGeneration]
 "Description"="Enable combined design time/runtime code generation for Razor files"
-"Value"=dword:00000000
+"Value"=dword:00000001
 "Title"="Force use of runtime code generation for Razor (requires restart)"
 "PreviewPaneChannels"="*"
 


### PR DESCRIPTION
targeting dev17.14 cherry picked from https://github.com/dotnet/razor/pull/11416
