### PR TITLE
Fix remote service invoker

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/CompilationHelpers.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/CompilationHelpers.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor;
@@ -78,10 +77,6 @@ internal static class CompilationHelpers
                 var importSource = RazorSourceDocument.Create(text, properties);
 
                 importSources.Add(importSource);
-            }
-            else if (importProjectItem.Exists)
-            {
-                Debug.Fail($"Encountered an import that was not a default import or tracked in the project system: {importProjectItem.PhysicalPath}.");
             }
         }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/RemoteServiceInvoker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/RemoteServiceInvoker.cs
@@ -26,8 +26,7 @@ internal sealed class RemoteServiceInvoker(
     IClientCapabilitiesService clientCapabilitiesService,
     ISemanticTokensLegendService semanticTokensLegendService,
     ITelemetryReporter telemetryReporter,
-    ILoggerFactory loggerFactory)
-    : IRemoteServiceInvoker
+    ILoggerFactory loggerFactory) : IRemoteServiceInvoker, IDisposable
 {
     private readonly IWorkspaceProvider _workspaceProvider = workspaceProvider;
     private readonly LanguageServerFeatureOptions _languageServerFeatureOptions = languageServerFeatureOptions;
@@ -36,10 +35,23 @@ internal sealed class RemoteServiceInvoker(
     private readonly ITelemetryReporter _telemetryReporter = telemetryReporter;
     private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<RemoteServiceInvoker>();
 
+    private readonly CancellationTokenSource _disposeTokenSource = new();
+
     private readonly object _gate = new();
     private ValueTask<bool>? _isInitializedTask;
     private ValueTask<bool>? _isLSPInitializedTask;
     private bool _fullyInitialized;
+
+    public void Dispose()
+    {
+        if (_disposeTokenSource.IsCancellationRequested)
+        {
+            return;
+        }
+
+        _disposeTokenSource.Cancel();
+        _disposeTokenSource.Dispose();
+    }
 
     public async ValueTask<TResult?> TryInvokeAsync<TService, TResult>(
         Solution solution,
@@ -114,12 +126,12 @@ internal sealed class RemoteServiceInvoker(
             return null;
         }
 
-        await InitializeRemoteClientAsync(remoteClient, cancellationToken).ConfigureAwait(false);
+        await InitializeRemoteClientAsync(remoteClient).ConfigureAwait(false);
 
         return remoteClient;
     }
 
-    private async Task InitializeRemoteClientAsync(RazorRemoteHostClient remoteClient, CancellationToken cancellationToken)
+    private async Task InitializeRemoteClientAsync(RazorRemoteHostClient remoteClient)
     {
         if (_fullyInitialized)
         {
@@ -149,7 +161,7 @@ internal sealed class RemoteServiceInvoker(
 
                 _isInitializedTask = remoteClient.TryInvokeAsync<IRemoteClientInitializationService>(
                     (s, ct) => s.InitializeAsync(initParams, ct),
-                    cancellationToken);
+                    _disposeTokenSource.Token);
             }
         }
 
@@ -172,7 +184,7 @@ internal sealed class RemoteServiceInvoker(
 
                     _isLSPInitializedTask = remoteClient.TryInvokeAsync<IRemoteClientInitializationService>(
                         (s, ct) => s.InitializeLSPAsync(initParams, ct),
-                        cancellationToken);
+                        _disposeTokenSource.Token);
                 }
             }
 


### PR DESCRIPTION
This fixes a bug in `RemoteServiceInvoker` that can cause its initialization step to be cancelled incorrectly, leaving it in a bad state. In this state, tag helpers/components never compute in Roslyn OOP for the lifetime of Visual Studio.

I recommend reviewing this change commit-by-commit. The description of the bug and the fix is in the first commit.

CI Build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2631845&view=results
Test Insertion: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/607258