### PR TITLE
Fix on type formatting line delta calculations

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpOnTypeFormattingPass.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Formatting/Passes/CSharpOnTypeFormattingPass.cs
@@ -267,7 +267,7 @@ internal sealed class CSharpOnTypeFormattingPass(
 
     private static int LineDelta(SourceText text, IEnumerable<TextChange> changes, out int firstLine, out int lastLine)
     {
-        firstLine = 0;
+        firstLine = int.MaxValue;
         lastLine = 0;
 
         // Let's compute the number of newlines added/removed by the incoming changes.

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/OnTypeFormattingTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/OnTypeFormattingTest.cs
@@ -1124,4 +1124,43 @@ public class OnTypeFormattingTest(FormattingTestContext context, HtmlFormattingF
             """,
             triggerCharacter: '}');
     }
+
+    [FormattingTestFact(SkipFlipLineEnding = true)]
+    [WorkItem("https://github.com/dotnet/razor/issues/11117")]
+    public async Task SemiColon_DoesntBreakHtmlAttributes()
+    {
+        await RunOnTypeFormattingTestAsync(
+            input: """
+                    <PageTitle>AI!</PageTitle>
+
+                    <div>
+                        <div class="asdf"
+                             style="text-color: black"
+                             accesskey="GF">
+                            Hello there
+                        </div>
+                    </div>
+
+                    @code {
+                     public class Foo{}$$
+                    }
+                    """,
+            expected: """
+                    <PageTitle>AI!</PageTitle>
+                    
+                    <div>
+                        <div class="asdf"
+                             style="text-color: black"
+                             accesskey="GF">
+                            Hello there
+                        </div>
+                    </div>
+
+                    @code {
+                        public class Foo { }
+                    }
+                    """,
+            triggerCharacter: '}',
+            expectedChangedLines: 1);
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/11117

Looks like I broke this in https://github.com/dotnet/razor/pull/10855
We were accidentally formatting everything from line 0 to the actual line we cared about, in on type formatting.