### PR TITLE
Make log levels match LogLevel.cs

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/UnifiedSettings/razor.registration.json
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/UnifiedSettings/razor.registration.json
@@ -168,31 +168,31 @@
           },
           "map": [
             {
-              "result": "trace",
+              "result": "none",
               "match": 0
             },
             {
-              "result": "debug",
+              "result": "trace",
               "match": 1
             },
             {
-              "result": "information",
+              "result": "debug",
               "match": 2
             },
             {
-              "result": "warning",
+              "result": "information",
               "match": 3
             },
             {
-              "result": "error",
+              "result": "warning",
               "match": 4
             },
             {
-              "result": "critical",
+              "result": "error",
               "match": 5
             },
             {
-              "result": "none",
+              "result": "critical",
               "match": 6
             }
           ]


### PR DESCRIPTION
Looks like https://github.com/dotnet/razor/pull/11228 changed log levels to match VS Code, but our unified settings json file wasn't updated. Noticed today while trying to repro a bug and switching between new and old options experiences.