### PR TITLE
Make sure we go through GetAbsolutePosition to handle LSP edge cases

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/SourceTextExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/SourceTextExtensions.cs
@@ -47,7 +47,7 @@ internal static class SourceTextExtensions
         => text.GetLinePositionSpan(TextSpan.FromBounds(start, end));
 
     public static int GetPosition(this SourceText text, LinePosition position)
-        => text.Lines.GetPosition(position);
+        => text.GetRequiredAbsoluteIndex(position);
 
     public static int GetPosition(this SourceText text, int line, int character)
         => text.GetPosition(new LinePosition(line, character));

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Mapping/RazorLanguageQueryEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Mapping/RazorLanguageQueryEndpointTest.cs
@@ -138,6 +138,36 @@ public class RazorLanguageQueryEndpointTest : LanguageServerTestBase
         Assert.Equal(1, response.Position.Character);
     }
 
+    [Fact]
+    public async Task Handle_AfterLastLineCharacterZero()
+    {
+        // Arrange
+        var documentPath = new Uri("C:/path/to/document.cshtml");
+        var codeDocument = CreateCodeDocumentWithCSharpProjection(
+            razorSource: "@",
+            projectedCSharpSource: "/* CSharp */",
+            sourceMappings: [new SourceMapping(new SourceSpan(0, 1), new SourceSpan(0, 12))]);
+        codeDocument.SetUnsupported();
+        var documentContext = CreateDocumentContext(documentPath, codeDocument);
+        var languageEndpoint = new RazorLanguageQueryEndpoint(_documentMappingService, LoggerFactory);
+        var request = new RazorLanguageQueryParams()
+        {
+            Uri = documentPath,
+            Position = VsLspFactory.CreatePosition(1, 0),
+        };
+
+        var requestContext = CreateRazorRequestContext(documentContext);
+
+        // Act
+        var response = await languageEndpoint.HandleRequestAsync(request, requestContext, DisposalToken);
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(RazorLanguageKind.Html, response.Kind);
+        Assert.Equal(1, response.Position.Line);
+        Assert.Equal(0, response.Position.Character);
+    }
+
     private static RazorCodeDocument CreateCodeDocumentWithCSharpProjection(string razorSource, string projectedCSharpSource, ImmutableArray<SourceMapping> sourceMappings)
     {
         var codeDocument = CreateCodeDocument(razorSource, tagHelpers: []);


### PR DESCRIPTION
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2347349

This is a bit speculative, but its legal in LSP to send a postion of `(LineCount, 0)` to represent the end of the document, but Roslyn will throw on that. Our `[Try]GetAbsoluteIndex` method handle this edge, so we just need to use it as much as possible.

Some of the errors on this bug fit this scenario, eg "The requested line number 23 must be less than the number of lines 23. (Parameter 'Line')"