### PR TITLE
Use different comletion trigger character set for VSCode

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCompletionBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCompletionBenchmark.cs
@@ -41,14 +41,14 @@ public class RazorCompletionBenchmark : RazorLanguageServerBenchmarkBase
         var documentMappingService = lspServices.GetRequiredService<IDocumentMappingService>();
         var clientConnection = lspServices.GetRequiredService<IClientConnection>();
         var completionListCache = lspServices.GetRequiredService<CompletionListCache>();
+        var completionTriggerAndCommitCharacters = lspServices.GetRequiredService<CompletionTriggerAndCommitCharacters>();
         var loggerFactory = lspServices.GetRequiredService<ILoggerFactory>();
 
-        var delegatedCompletionListProvider = new TestDelegatedCompletionListProvider(documentMappingService, clientConnection, completionListCache);
+        var delegatedCompletionListProvider = new TestDelegatedCompletionListProvider(documentMappingService, clientConnection, completionListCache, completionTriggerAndCommitCharacters);
         var completionListProvider = new CompletionListProvider(razorCompletionListProvider, delegatedCompletionListProvider);
         var configurationService = new DefaultRazorConfigurationService(clientConnection, loggerFactory);
         var optionsMonitor = new RazorLSPOptionsMonitor(configurationService, RazorLSPOptions.Default);
-
-        CompletionEndpoint = new RazorCompletionEndpoint(completionListProvider, telemetryReporter: null, optionsMonitor);
+        CompletionEndpoint = new RazorCompletionEndpoint(completionListProvider, completionTriggerAndCommitCharacters, telemetryReporter: null, optionsMonitor);
 
         var clientCapabilities = new VSInternalClientCapabilities
         {
@@ -141,8 +141,12 @@ public class RazorCompletionBenchmark : RazorLanguageServerBenchmarkBase
 
     private class TestDelegatedCompletionListProvider : DelegatedCompletionListProvider
     {
-        public TestDelegatedCompletionListProvider(IDocumentMappingService documentMappingService, IClientConnection clientConnection, CompletionListCache completionListCache)
-            : base(documentMappingService, clientConnection, completionListCache)
+        public TestDelegatedCompletionListProvider(
+            IDocumentMappingService documentMappingService,
+            IClientConnection clientConnection,
+            CompletionListCache completionListCache,
+            CompletionTriggerAndCommitCharacters completionTriggerAndCommitCharacters)
+            : base(documentMappingService, clientConnection, completionListCache, completionTriggerAndCommitCharacters)
         {
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionListProvider.cs
@@ -77,7 +77,12 @@ internal class DelegatedCompletionListProvider
             positionInfo = provisionalCompletionValue.DocumentPositionInfo;
         }
 
-        completionContext = DelegatedCompletionHelper.RewriteContext(completionContext, positionInfo.LanguageKind, _completionTriggerAndCommitCharacters);
+        if (DelegatedCompletionHelper.RewriteContext(completionContext, positionInfo.LanguageKind, _completionTriggerAndCommitCharacters) is not { } rewrittenContext)
+        {
+            return null;
+        }
+
+        completionContext = rewrittenContext;
 
         var razorCodeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
         // It's a bit confusing, but we have two different "add snippets" options - one is a part of

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionListProvider.cs
@@ -27,19 +27,22 @@ internal class DelegatedCompletionListProvider
     private readonly IDocumentMappingService _documentMappingService;
     private readonly IClientConnection _clientConnection;
     private readonly CompletionListCache _completionListCache;
+    private readonly CompletionTriggerAndCommitCharacters _completionTriggerAndCommitCharacters;
 
     public DelegatedCompletionListProvider(
         IDocumentMappingService documentMappingService,
         IClientConnection clientConnection,
-        CompletionListCache completionListCache)
+        CompletionListCache completionListCache,
+        CompletionTriggerAndCommitCharacters completionTriggerAndCommitCharacters)
     {
         _documentMappingService = documentMappingService;
         _clientConnection = clientConnection;
         _completionListCache = completionListCache;
+        _completionTriggerAndCommitCharacters = completionTriggerAndCommitCharacters;
     }
 
     // virtual for tests
-    public virtual FrozenSet<string> TriggerCharacters => CompletionTriggerAndCommitCharacters.AllDelegationTriggerCharacters;
+    public virtual FrozenSet<string> TriggerCharacters => _completionTriggerAndCommitCharacters.AllDelegationTriggerCharacters;
 
     // virtual for tests
     public virtual async Task<VSInternalCompletionList?> GetCompletionListAsync(
@@ -74,7 +77,7 @@ internal class DelegatedCompletionListProvider
             positionInfo = provisionalCompletionValue.DocumentPositionInfo;
         }
 
-        completionContext = DelegatedCompletionHelper.RewriteContext(completionContext, positionInfo.LanguageKind);
+        completionContext = DelegatedCompletionHelper.RewriteContext(completionContext, positionInfo.LanguageKind, _completionTriggerAndCommitCharacters);
 
         var razorCodeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
         // It's a bit confusing, but we have two different "add snippets" options - one is a part of

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.CodeAnalysis.Razor.Completion;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Telemetry;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -18,11 +19,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion;
 [RazorLanguageServerEndpoint(Methods.TextDocumentCompletionName)]
 internal class RazorCompletionEndpoint(
     CompletionListProvider completionListProvider,
+    CompletionTriggerAndCommitCharacters completionTriggerAndCommitCharacters,
     ITelemetryReporter? telemetryReporter,
     RazorLSPOptionsMonitor optionsMonitor)
     : IRazorRequestHandler<CompletionParams, VSInternalCompletionList?>, ICapabilitiesProvider
 {
     private readonly CompletionListProvider _completionListProvider = completionListProvider;
+    private readonly CompletionTriggerAndCommitCharacters _completionTriggerAndCommitCharacters = completionTriggerAndCommitCharacters;
     private readonly ITelemetryReporter? _telemetryReporter = telemetryReporter;
     private readonly RazorLSPOptionsMonitor _optionsMonitor = optionsMonitor;
 
@@ -37,7 +40,7 @@ internal class RazorCompletionEndpoint(
         serverCapabilities.CompletionProvider = new CompletionOptions()
         {
             ResolveProvider = true,
-            TriggerCharacters = CompletionTriggerAndCommitCharacters.AllTriggerCharacters,
+            TriggerCharacters = _completionTriggerAndCommitCharacters.AllTriggerCharacters,
             AllCommitCharacters = CompletionTriggerAndCommitCharacters.AllCommitCharacters
         };
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
@@ -43,5 +43,5 @@ internal class DefaultLanguageServerFeatureOptions : LanguageServerFeatureOption
 
     public override bool SupportsSoftSelectionInCompletion => true;
 
-    public override bool VsCodeCompletionTriggerCharacters => false;
+    public override bool UseVsCodeCompletionTriggerCharacters => false;
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/DefaultLanguageServerFeatureOptions.cs
@@ -42,4 +42,6 @@ internal class DefaultLanguageServerFeatureOptions : LanguageServerFeatureOption
     public override bool UseNewFormattingEngine => false;
 
     public override bool SupportsSoftSelectionInCompletion => true;
+
+    public override bool VsCodeCompletionTriggerCharacters => false;
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
@@ -83,6 +83,7 @@ internal static class IServiceCollectionExtensions
         services.AddSingleton<CompletionListProvider>();
         services.AddSingleton<DelegatedCompletionListProvider>();
         services.AddSingleton<RazorCompletionListProvider>();
+        services.AddSingleton<CompletionTriggerAndCommitCharacters>();
 
         services.AddSingleton<AggregateCompletionItemResolver>();
         services.AddSingleton<CompletionItemResolver, RazorCompletionItemResolver>();

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hosting/ConfigurableLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hosting/ConfigurableLanguageServerFeatureOptions.cs
@@ -40,7 +40,7 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
     public override bool ForceRuntimeCodeGeneration => _forceRuntimeCodeGeneration ?? _defaults.ForceRuntimeCodeGeneration;
     public override bool UseNewFormattingEngine => _useNewFormattingEngine ?? _defaults.UseNewFormattingEngine;
     public override bool SupportsSoftSelectionInCompletion => false;
-    public override bool VsCodeCompletionTriggerCharacters => true;
+    public override bool UseVsCodeCompletionTriggerCharacters => true;
 
     public ConfigurableLanguageServerFeatureOptions(string[] args)
     {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hosting/ConfigurableLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Hosting/ConfigurableLanguageServerFeatureOptions.cs
@@ -40,6 +40,7 @@ internal class ConfigurableLanguageServerFeatureOptions : LanguageServerFeatureO
     public override bool ForceRuntimeCodeGeneration => _forceRuntimeCodeGeneration ?? _defaults.ForceRuntimeCodeGeneration;
     public override bool UseNewFormattingEngine => _useNewFormattingEngine ?? _defaults.UseNewFormattingEngine;
     public override bool SupportsSoftSelectionInCompletion => false;
+    public override bool VsCodeCompletionTriggerCharacters => true;
 
     public ConfigurableLanguageServerFeatureOptions(string[] args)
     {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionTriggerCharacters.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/CompletionTriggerCharacters.cs
@@ -24,7 +24,7 @@ internal class CompletionTriggerAndCommitCharacters(LanguageServerFeatureOptions
     public static FrozenSet<string> RazorDelegationTriggerCharacters { get; } = new[] { "@" }.ToFrozenSet();
     public static FrozenSet<string> CSharpTriggerCharacters { get; } = new[] { " ", "(", "=", "#", ".", "<", "[", "{", "\"", "/", ":", "~" }.ToFrozenSet();
     public FrozenSet<string> HtmlTriggerCharacters =>
-        _languageServerFeatureOptions.VsCodeCompletionTriggerCharacters ? s_vsCodeHtmlTriggerCharacters : s_vsHtmlTriggerCharacters;
+        _languageServerFeatureOptions.UseVsCodeCompletionTriggerCharacters ? s_vsCodeHtmlTriggerCharacters : s_vsHtmlTriggerCharacters;
 
     public FrozenSet<string> AllDelegationTriggerCharacters => _allDelegationTriggerCharacters
         ??= RazorDelegationTriggerCharacters.Union(CSharpTriggerCharacters).Union(HtmlTriggerCharacters).ToFrozenSet();

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/DelegatedCompletionHelper.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/DelegatedCompletionHelper.cs
@@ -30,18 +30,22 @@ internal static class DelegatedCompletionHelper
         [new SnippetResponseRewriter(), new TextEditResponseRewriter(), new DesignTimeHelperResponseRewriter()];
 
     // Currently we only have one HTML response re-writer. Should we ever need more, we can create a common base and a collection
-    private static readonly HtmlCommitCharacterResponseRewriter s_delegatedHtmlCompletionResponseRewriter = new HtmlCommitCharacterResponseRewriter();
+    private static readonly HtmlCommitCharacterResponseRewriter s_delegatedHtmlCompletionResponseRewriter = new();
 
     /// <summary>
     /// Modifies completion context if needed so that it's acceptable to the delegated language.
     /// </summary>
     /// <param name="context">Original completion context passed to the completion handler</param>
     /// <param name="languageKind">Language of the completion position</param>
+    /// <param name="completionTriggerAndCommitCharacters">Per-client set of trigger and commit characters</param>
     /// <returns>Possibly modified completion context</returns>
     /// <remarks>For example, if we invoke C# completion in Razor via @ character, we will not
     /// want C# to see @ as the trigger character and instead will transform completion context
     /// into "invoked" and "explicit" rather than "typing", without a trigger character</remarks>
-    public static VSInternalCompletionContext RewriteContext(VSInternalCompletionContext context, RazorLanguageKind languageKind)
+    public static VSInternalCompletionContext RewriteContext(
+        VSInternalCompletionContext context,
+        RazorLanguageKind languageKind,
+        CompletionTriggerAndCommitCharacters completionTriggerAndCommitCharacters)
     {
         Debug.Assert(languageKind != RazorLanguageKind.Razor,
             $"{nameof(RewriteContext)} should be called for delegated completion only");
@@ -61,7 +65,7 @@ internal static class DelegatedCompletionHelper
         }
 
         if (languageKind == RazorLanguageKind.Html
-            && CompletionTriggerAndCommitCharacters.HtmlTriggerCharacters.Contains(triggerCharacter))
+            && completionTriggerAndCommitCharacters.HtmlTriggerCharacters.Contains(triggerCharacter))
         {
             // HTML trigger character for HTML content
             return context;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/DelegatedCompletionHelper.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/DelegatedCompletionHelper.cs
@@ -42,7 +42,7 @@ internal static class DelegatedCompletionHelper
     /// <remarks>For example, if we invoke C# completion in Razor via @ character, we will not
     /// want C# to see @ as the trigger character and instead will transform completion context
     /// into "invoked" and "explicit" rather than "typing", without a trigger character</remarks>
-    public static VSInternalCompletionContext RewriteContext(
+    public static VSInternalCompletionContext? RewriteContext(
         VSInternalCompletionContext context,
         RazorLanguageKind languageKind,
         CompletionTriggerAndCommitCharacters completionTriggerAndCommitCharacters)
@@ -64,11 +64,12 @@ internal static class DelegatedCompletionHelper
             return context;
         }
 
-        if (languageKind == RazorLanguageKind.Html
-            && completionTriggerAndCommitCharacters.HtmlTriggerCharacters.Contains(triggerCharacter))
+        if (languageKind == RazorLanguageKind.Html)
         {
-            // HTML trigger character for HTML content
-            return context;
+            // For HTML we don't want to delegate to HTML language server is completion is due to a trigger characters that is not
+            // HTML trigger character. Doing so causes bad side effects in VSCode HTML client as we will end up with non-matching
+            // completion entries
+            return completionTriggerAndCommitCharacters.HtmlTriggerCharacters.Contains(triggerCharacter) ? context : null;
         }
 
         // Trigger character not associated with the current language. Transform the context into an invoked context.

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionListProvider.cs
@@ -126,7 +126,7 @@ internal class RazorCompletionListProvider(
         }
 
         var tagHelperCompletionItemKind = CompletionItemKind.TypeParameter;
-        var supportedItemKinds = clientCapabilities.TextDocument?.Completion?.CompletionItemKind?.ValueSet ?? Array.Empty<CompletionItemKind>();
+        var supportedItemKinds = clientCapabilities.TextDocument?.Completion?.CompletionItemKind?.ValueSet ?? [];
         if (supportedItemKinds?.Contains(CompletionItemKind.TagHelper) == true)
         {
             tagHelperCompletionItemKind = CompletionItemKind.TagHelper;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
@@ -51,5 +51,5 @@ internal abstract class LanguageServerFeatureOptions
     /// <summary>
     /// Indicates that VSCode-compatible completion trigger character set should be used
     /// </summary>
-    public abstract bool VsCodeCompletionTriggerCharacters { get; }
+    public abstract bool UseVsCodeCompletionTriggerCharacters { get; }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/LanguageServerFeatureOptions.cs
@@ -47,4 +47,9 @@ internal abstract class LanguageServerFeatureOptions
     /// character with a soft-selected item will not commit that item.
     /// </summary>
     public abstract bool SupportsSoftSelectionInCompletion { get; }
+
+    /// <summary>
+    /// Indicates that VSCode-compatible completion trigger character set should be used
+    /// </summary>
+    public abstract bool VsCodeCompletionTriggerCharacters { get; }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RemoteClientInitializationOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RemoteClientInitializationOptions.cs
@@ -40,6 +40,6 @@ internal struct RemoteClientInitializationOptions
     [JsonPropertyName("supportsSoftSelectionInCompletion")]
     public required bool SupportsSoftSelectionInCompletion { get; set; }
 
-    [JsonPropertyName("vsCodeCompletionTriggerCharacters")]
+    [JsonPropertyName("useVSCodeCompletionTriggerCharacters")]
     public bool UseVsCodeCompletionTriggerCharacters { get; set; }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RemoteClientInitializationOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RemoteClientInitializationOptions.cs
@@ -37,6 +37,9 @@ internal struct RemoteClientInitializationOptions
     [JsonPropertyName("useNewFormattingEngine")]
     public required bool UseNewFormattingEngine { get; set; }
 
-    [JsonPropertyName("avoidExplicitCommitCharacters")]
+    [JsonPropertyName("supportsSoftSelectionInCompletion")]
     public required bool SupportsSoftSelectionInCompletion { get; set; }
+
+    [JsonPropertyName("vsCodeCompletionTriggerCharacters")]
+    public bool VsCodeCompletionTriggerCharacters { get; set; }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RemoteClientInitializationOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RemoteClientInitializationOptions.cs
@@ -41,5 +41,5 @@ internal struct RemoteClientInitializationOptions
     public required bool SupportsSoftSelectionInCompletion { get; set; }
 
     [JsonPropertyName("vsCodeCompletionTriggerCharacters")]
-    public bool VsCodeCompletionTriggerCharacters { get; set; }
+    public bool UseVsCodeCompletionTriggerCharacters { get; set; }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Initialization/RemoteLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Initialization/RemoteLanguageServerFeatureOptions.cs
@@ -47,5 +47,5 @@ internal class RemoteLanguageServerFeatureOptions : LanguageServerFeatureOptions
 
     public override bool SupportsSoftSelectionInCompletion => _options.SupportsSoftSelectionInCompletion;
 
-    public override bool VsCodeCompletionTriggerCharacters => _options.VsCodeCompletionTriggerCharacters;
+    public override bool UseVsCodeCompletionTriggerCharacters => _options.UseVsCodeCompletionTriggerCharacters;
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Initialization/RemoteLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Initialization/RemoteLanguageServerFeatureOptions.cs
@@ -46,4 +46,6 @@ internal class RemoteLanguageServerFeatureOptions : LanguageServerFeatureOptions
     public override bool UseNewFormattingEngine => _options.UseNewFormattingEngine;
 
     public override bool SupportsSoftSelectionInCompletion => _options.SupportsSoftSelectionInCompletion;
+
+    public override bool VsCodeCompletionTriggerCharacters => _options.VsCodeCompletionTriggerCharacters;
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostCompletionTriggerAndCommitCharacters.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostCompletionTriggerAndCommitCharacters.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.Razor.Completion;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+
+[Export(typeof(CompletionTriggerAndCommitCharacters))]
+[method: ImportingConstructor]
+class CohostCompletionTriggerAndCommitCharacters(LanguageServerFeatureOptions languageServerFeatureOptions) : CompletionTriggerAndCommitCharacters(languageServerFeatureOptions);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostCompletionTriggerAndCommitCharacters.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostCompletionTriggerAndCommitCharacters.cs
@@ -9,4 +9,4 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 
 [Export(typeof(CompletionTriggerAndCommitCharacters))]
 [method: ImportingConstructor]
-class CohostCompletionTriggerAndCommitCharacters(LanguageServerFeatureOptions languageServerFeatureOptions) : CompletionTriggerAndCommitCharacters(languageServerFeatureOptions);
+internal sealed class CohostCompletionTriggerAndCommitCharacters(LanguageServerFeatureOptions languageServerFeatureOptions) : CompletionTriggerAndCommitCharacters(languageServerFeatureOptions);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostDocumentCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostDocumentCompletionEndpoint.cs
@@ -118,7 +118,12 @@ internal sealed class CohostDocumentCompletionEndpoint(
         var documentPositionInfo = completionPositionInfo.DocumentPositionInfo;
         if (documentPositionInfo.LanguageKind != RazorLanguageKind.Razor)
         {
-            completionContext = DelegatedCompletionHelper.RewriteContext(completionContext, documentPositionInfo.LanguageKind, _completionTriggerAndCommitCharacters);
+            if (DelegatedCompletionHelper.RewriteContext(completionContext, documentPositionInfo.LanguageKind, _completionTriggerAndCommitCharacters) is not { } rewrittenContext)
+            {
+                return null;
+            }
+
+            completionContext = rewrittenContext;
         }
 
         // First of all, see if we in HTML and get HTML completions before calling OOP to get Razor completions.

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/RemoteServiceInvoker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/RemoteServiceInvoker.cs
@@ -143,7 +143,7 @@ internal sealed class RemoteServiceInvoker(
                     ShowAllCSharpCodeActions = _languageServerFeatureOptions.ShowAllCSharpCodeActions,
                     UseNewFormattingEngine = _languageServerFeatureOptions.UseNewFormattingEngine,
                     SupportsSoftSelectionInCompletion = _languageServerFeatureOptions.SupportsSoftSelectionInCompletion,
-                    VsCodeCompletionTriggerCharacters = _languageServerFeatureOptions.VsCodeCompletionTriggerCharacters,
+                    UseVsCodeCompletionTriggerCharacters = _languageServerFeatureOptions.UseVsCodeCompletionTriggerCharacters,
                 };
 
                 _logger.LogDebug($"First OOP call, so initializing OOP service.");

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/RemoteServiceInvoker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/RemoteServiceInvoker.cs
@@ -143,6 +143,7 @@ internal sealed class RemoteServiceInvoker(
                     ShowAllCSharpCodeActions = _languageServerFeatureOptions.ShowAllCSharpCodeActions,
                     UseNewFormattingEngine = _languageServerFeatureOptions.UseNewFormattingEngine,
                     SupportsSoftSelectionInCompletion = _languageServerFeatureOptions.SupportsSoftSelectionInCompletion,
+                    VsCodeCompletionTriggerCharacters = _languageServerFeatureOptions.VsCodeCompletionTriggerCharacters,
                 };
 
                 _logger.LogDebug($"First OOP call, so initializing OOP service.");

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioLanguageServerFeatureOptions.cs
@@ -115,4 +115,6 @@ internal class VisualStudioLanguageServerFeatureOptions : LanguageServerFeatureO
 
     // VS actually needs explicit commit characters so don't avoid them.
     public override bool SupportsSoftSelectionInCompletion => true;
+
+    public override bool VsCodeCompletionTriggerCharacters => false;
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/VisualStudioLanguageServerFeatureOptions.cs
@@ -116,5 +116,5 @@ internal class VisualStudioLanguageServerFeatureOptions : LanguageServerFeatureO
     // VS actually needs explicit commit characters so don't avoid them.
     public override bool SupportsSoftSelectionInCompletion => true;
 
-    public override bool VsCodeCompletionTriggerCharacters => false;
+    public override bool UseVsCodeCompletionTriggerCharacters => false;
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/CompletionListProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/CompletionListProviderTest.cs
@@ -81,7 +81,7 @@ public class CompletionListProviderTest : LanguageServerTestBase
         private readonly VSInternalCompletionList _completionList;
 
         public TestDelegatedCompletionListProvider(VSInternalCompletionList completionList, IEnumerable<string> triggerCharacters)
-            : base(null, null, null)
+            : base(null, null, null, null)
         {
             _completionList = completionList;
             TriggerCharacters = triggerCharacters.ToFrozenSet();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionListProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionListProviderTest.cs
@@ -103,7 +103,7 @@ public class DelegatedCompletionListProviderTest : LanguageServerTestBase
     }
 
     [Fact]
-    public async Task HtmlDelegation_UnsupportedTriggerCharacter_TranslatesToInvoked()
+    public async Task HtmlDelegation_UnsupportedTriggerCharacter_ReturnsNull()
     {
         // Arrange
         var completionContext = new VSInternalCompletionContext()
@@ -127,13 +127,7 @@ public class DelegatedCompletionListProviderTest : LanguageServerTestBase
 
         // Assert
         var delegatedParameters = _provider.DelegatedParams;
-        Assert.NotNull(delegatedParameters);
-        Assert.Equal(RazorLanguageKind.Html, delegatedParameters.ProjectedKind);
-        Assert.Equal(VsLspFactory.CreatePosition(0, 1), delegatedParameters.ProjectedPosition);
-        Assert.Equal(CompletionTriggerKind.Invoked, delegatedParameters.Context.TriggerKind);
-        Assert.Equal(VSInternalCompletionInvokeKind.Typing, delegatedParameters.Context.InvokeKind);
-        Assert.Equal(1, delegatedParameters.Identifier.Version);
-        Assert.Null(delegatedParameters.ProvisionalTextEdit);
+        Assert.Null(delegatedParameters);
     }
 
     [Fact]

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionListProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionListProviderTest.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
+using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 using Microsoft.CodeAnalysis.Razor.Completion;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.Protocol;
@@ -322,7 +323,8 @@ public class DelegatedCompletionListProviderTest : LanguageServerTestBase
         var completionProvider = new DelegatedCompletionListProvider(
             documentMappingServiceMock.Object,
             clientConnection,
-            new CompletionListCache());
+            new CompletionListCache(),
+            new CompletionTriggerAndCommitCharacters(TestLanguageServerFeatureOptions.Instance));
 
         var requestSent = false;
         clientConnection.RequestSent += (s, o) =>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/TestDelegatedCompletionListProvider.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/TestDelegatedCompletionListProvider.cs
@@ -30,7 +30,8 @@ internal class TestDelegatedCompletionListProvider : DelegatedCompletionListProv
             {
                 [LanguageServerConstants.RazorCompletionEndpointName] = completionFactory.OnDelegationAsync,
             }),
-            new CompletionListCache())
+            new CompletionListCache(),
+            new CompletionTriggerAndCommitCharacters(TestLanguageServerFeatureOptions.Instance))
     {
         _completionFactory = completionFactory;
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
@@ -21,7 +21,7 @@ public class RazorCompletionEndpointTest(ITestOutputHelper testOutput) : Languag
         // Arrange
         var documentPath = "C:/path/to/document.cshtml";
         var optionsMonitor = GetOptionsMonitor();
-        var completionEndpoint = new RazorCompletionEndpoint(completionListProvider: null, telemetryReporter: null, optionsMonitor);
+        var completionEndpoint = new RazorCompletionEndpoint(completionListProvider: null, completionTriggerAndCommitCharacters: null, telemetryReporter: null, optionsMonitor);
         var request = new CompletionParams()
         {
             TextDocument = new TextDocumentIdentifier()
@@ -49,7 +49,7 @@ public class RazorCompletionEndpointTest(ITestOutputHelper testOutput) : Languag
         var uri = new Uri(documentPath);
         var documentContext = CreateDocumentContext(uri, codeDocument);
         var optionsMonitor = GetOptionsMonitor(autoShowCompletion: false);
-        var completionEndpoint = new RazorCompletionEndpoint(completionListProvider: null, telemetryReporter: null, optionsMonitor);
+        var completionEndpoint = new RazorCompletionEndpoint(completionListProvider: null, completionTriggerAndCommitCharacters: null, telemetryReporter: null, optionsMonitor);
         var request = new CompletionParams()
         {
             TextDocument = new TextDocumentIdentifier()

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/TestLanguageServerFeatureOptions.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/TestLanguageServerFeatureOptions.cs
@@ -45,5 +45,5 @@ internal class TestLanguageServerFeatureOptions(
 
     public override bool SupportsSoftSelectionInCompletion => supportsSoftSelectionInCompletion;
 
-    public override bool VsCodeCompletionTriggerCharacters => vsCodeCompletionTriggerCharacters;
+    public override bool UseVsCodeCompletionTriggerCharacters => vsCodeCompletionTriggerCharacters;
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/TestLanguageServerFeatureOptions.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Workspaces/TestLanguageServerFeatureOptions.cs
@@ -10,7 +10,8 @@ internal class TestLanguageServerFeatureOptions(
     bool forceRuntimeCodeGeneration = false,
     bool updateBuffersForClosedDocuments = false,
     bool useNewFormattingEngine = false,
-    bool supportsSoftSelectionInCompletion = true) : LanguageServerFeatureOptions
+    bool supportsSoftSelectionInCompletion = true,
+    bool vsCodeCompletionTriggerCharacters = false) : LanguageServerFeatureOptions
 {
     public static readonly LanguageServerFeatureOptions Instance = new TestLanguageServerFeatureOptions();
 
@@ -43,4 +44,6 @@ internal class TestLanguageServerFeatureOptions(
     public override bool UseNewFormattingEngine => useNewFormattingEngine;
 
     public override bool SupportsSoftSelectionInCompletion => supportsSoftSelectionInCompletion;
+
+    public override bool VsCodeCompletionTriggerCharacters => vsCodeCompletionTriggerCharacters;
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentCompletionEndpointTest.cs
@@ -474,8 +474,8 @@ public class CohostDocumentCompletionEndpointTest(FuseTestContext context, ITest
             completionContext: new RoslynVSInternalCompletionContext()
             {
                 InvokeKind = RoslynVSInternalCompletionInvokeKind.Typing,
-                TriggerCharacter = "f",
-                TriggerKind = RoslynCompletionTriggerKind.TriggerCharacter
+                TriggerCharacter = null,
+                TriggerKind = RoslynCompletionTriggerKind.Invoked
             },
             expectedItemLabels: ["style", "dir", "culture", "event", "format", "get", "set", "after"],
             delegatedItemLabels: ["style", "dir"]);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentCompletionEndpointTest.cs
@@ -7,7 +7,9 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+using Microsoft.CodeAnalysis.Razor.Completion;
 using Microsoft.CodeAnalysis.Razor.Settings;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.ProjectSystem;
@@ -590,6 +592,7 @@ public class CohostDocumentCompletionEndpointTest(FuseTestContext context, ITest
             clientSettingsManager,
             TestHtmlDocumentSynchronizer.Instance,
             snippetCompletionItemProvider,
+            new CompletionTriggerAndCommitCharacters(TestLanguageServerFeatureOptions.Instance),
             requestInvoker,
             LoggerFactory);
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostEndpointTestBase.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostEndpointTestBase.cs
@@ -84,7 +84,7 @@ public abstract class CohostEndpointTestBase(ITestOutputHelper testOutputHelper)
             ShowAllCSharpCodeActions = false,
             UseNewFormattingEngine = false,
             SupportsSoftSelectionInCompletion = true,
-            VsCodeCompletionTriggerCharacters = false,
+            UseVsCodeCompletionTriggerCharacters = false,
         };
         UpdateClientInitializationOptions(c => c);
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostEndpointTestBase.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostEndpointTestBase.cs
@@ -84,6 +84,7 @@ public abstract class CohostEndpointTestBase(ITestOutputHelper testOutputHelper)
             ShowAllCSharpCodeActions = false,
             UseNewFormattingEngine = false,
             SupportsSoftSelectionInCompletion = true,
+            VsCodeCompletionTriggerCharacters = false,
         };
         UpdateClientInitializationOptions(c => c);
 


### PR DESCRIPTION
﻿### Summary of the changes
VS Code HTML language service is a lot more aggressive with showing low quality matches than VS HTML language service. We cannot use the same completion trigger characters in VS Code as in VS because it causes unwanted completion list with bad completion non-matches to pop up while user types in plain text.
-

Fixes:
https://github.com/dotnet/vscode-csharp/issues/7678
https://github.com/dotnet/vscode-csharp/issues/7871