### PR TITLE
Enforcing accessibility modifiers

### DIFF
--- a/src/Razor/.editorconfig
+++ b/src/Razor/.editorconfig
@@ -1,5 +1,8 @@
 ﻿[*.cs]
 
+# Enforce the use of accessibility modifiers for all types
+dotnet_diagnostic.IDE0040.severity = warning
+
 # Fix Formatting
 dotnet_diagnostic.IDE0055.severity = warning
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Snippets/SnippetInfo.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Snippets/SnippetInfo.cs
@@ -10,7 +10,7 @@ namespace Microsoft.VisualStudio.Razor.Snippets;
 
 internal record SnippetInfo
 {
-    Lazy<XmlSnippetParser.ParsedXmlSnippet?> _parsedXmlSnippet;
+    private readonly Lazy<XmlSnippetParser.ParsedXmlSnippet?> _parsedXmlSnippet;
 
     public SnippetInfo(
         string shortcut,


### PR DESCRIPTION
Adding IDE rule 0040 to Razor tooling .editorconfig to enforce the use of accessibility modifiers for all types.
