### PR TITLE
React to NuGet package pruning warnings

### DIFF
--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.csproj
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.ObjectPool" />
-    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="System.Collections.Immutable" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
   </ItemGroup>
 
   <ItemGroup Label="String Resources">


### PR DESCRIPTION
Contributes to https://github.com/dotnet/sdk/pull/46642

NuGet added a new feature that automatically prunes package and project references that are provided by the shared framework that is targeted.

Resolve the one warning that got emitted when source-building the repository.