### PR TITLE
Don't use Directory.Exists to check if a path is relative

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.TestAccessor.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.TestAccessor.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.ProjectSystem;
 using Microsoft.VisualStudio.ProjectSystem.Properties;
 
 namespace Microsoft.VisualStudio.Razor.ProjectSystem;
@@ -16,7 +18,17 @@ internal partial class WindowsRazorProjectHostBase
 
         internal bool GetIntermediateOutputPathFromProjectChange(IImmutableDictionary<string, IProjectRuleSnapshot> state, out string? result)
         {
+            _this._skipDirectoryExistCheck_TestOnly = true;
             return _this.TryGetIntermediateOutputPath(state, out result);
         }
+
+        internal Task InitializeAsync()
+            => _this.InitializeAsync();
+
+        internal Task OnProjectChangedAsync(string sliceDimensions, IProjectVersionedValue<IProjectSubscriptionUpdate> update)
+            => _this.OnProjectChangedAsync(sliceDimensions, update);
+
+        internal Task OnProjectRenamingAsync(string oldProjectFilePath, string newProjectFilePath)
+            => _this.OnProjectRenamingAsync(oldProjectFilePath, newProjectFilePath);
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.TestAccessor.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.TestAccessor.cs
@@ -16,7 +16,6 @@ internal partial class WindowsRazorProjectHostBase
 
         internal bool GetIntermediateOutputPathFromProjectChange(IImmutableDictionary<string, IProjectRuleSnapshot> state, out string? result)
         {
-            _this.SkipIntermediateOutputPathExistCheck_TestOnly = true;
             return _this.TryGetIntermediateOutputPath(state, out result);
         }
     }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
@@ -41,6 +41,7 @@ internal abstract partial class WindowsRazorProjectHostBase : OnceInitializedOnc
     // Internal settable for testing
     // 250ms between publishes to prevent bursts of changes yet still be responsive to changes.
     internal int EnqueueDelay { get; set; } = 250;
+    private bool _skipDirectoryExistCheck_TestOnly;
 
     protected WindowsRazorProjectHostBase(
         IUnconfiguredProjectCommonServices commonServices,
@@ -60,14 +61,6 @@ internal abstract partial class WindowsRazorProjectHostBase : OnceInitializedOnc
     protected abstract Task HandleProjectChangeAsync(string sliceDimensions, IProjectVersionedValue<IProjectSubscriptionUpdate> update);
 
     protected IUnconfiguredProjectCommonServices CommonServices { get; }
-
-    internal bool SkipIntermediateOutputPathExistCheck_TestOnly { get; set; }
-
-    // internal for tests. The product will call through the IProjectDynamicLoadComponent interface.
-    internal Task LoadAsync()
-    {
-        return InitializeAsync();
-    }
 
     protected sealed override Task InitializeCoreAsync(CancellationToken cancellationToken)
     {
@@ -155,8 +148,7 @@ internal abstract partial class WindowsRazorProjectHostBase : OnceInitializedOnc
         }
     }
 
-    // Internal for testing
-    internal Task OnProjectChangedAsync(string sliceDimensions, IProjectVersionedValue<IProjectSubscriptionUpdate> update)
+    private Task OnProjectChangedAsync(string sliceDimensions, IProjectVersionedValue<IProjectSubscriptionUpdate> update)
     {
         if (IsDisposing || IsDisposed)
         {
@@ -204,8 +196,7 @@ internal abstract partial class WindowsRazorProjectHostBase : OnceInitializedOnc
         }
     }
 
-    // Internal for tests
-    internal Task OnProjectRenamingAsync(string oldProjectFilePath, string newProjectFilePath)
+    private Task OnProjectRenamingAsync(string oldProjectFilePath, string newProjectFilePath)
     {
         // When a project gets renamed we expect any rules watched by the derived class to fire.
         //
@@ -385,7 +376,7 @@ internal abstract partial class WindowsRazorProjectHostBase : OnceInitializedOnc
         }
 
         var joinedPath = Path.Combine(projectDirectory, intermediateOutputPathValue);
-        if (!SkipIntermediateOutputPathExistCheck_TestOnly && !Directory.Exists(joinedPath))
+        if (!_skipDirectoryExistCheck_TestOnly && !Directory.Exists(joinedPath))
         {
             return null;
         }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
@@ -38,9 +38,6 @@ internal abstract partial class WindowsRazorProjectHostBase : OnceInitializedOnc
 
     internal const string ConfigurationGeneralSchemaName = "ConfigurationGeneral";
 
-    // Internal settable for testing
-    // 250ms between publishes to prevent bursts of changes yet still be responsive to changes.
-    internal int EnqueueDelay { get; set; } = 250;
     private bool _skipDirectoryExistCheck_TestOnly;
 
     protected WindowsRazorProjectHostBase(

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
@@ -320,7 +320,6 @@ internal abstract partial class WindowsRazorProjectHostBase : OnceInitializedOnc
         return TryGetIntermediateOutputPathFromProjectRuleSnapshot(beforeValues, out path);
     }
 
-    // virtual for testing
     protected virtual bool TryGetIntermediateOutputPath(
         IImmutableDictionary<string, IProjectRuleSnapshot> state,
         [NotNullWhen(returnValue: true)] out string? path)
@@ -357,15 +356,11 @@ internal abstract partial class WindowsRazorProjectHostBase : OnceInitializedOnc
         var basePath = new DirectoryInfo(baseIntermediateOutputPathValue).Parent;
         var joinedPath = Path.Combine(basePath.FullName, intermediateOutputPathValue);
 
-        if (!SkipIntermediateOutputPathExistCheck_TestOnly && !Directory.Exists(joinedPath))
+        if (!Path.IsPathRooted(baseIntermediateOutputPathValue))
         {
-            // The directory doesn't exist for the currently executing application.
-            // This can occur in Razor class library scenarios because:
-            //   1. Razor class libraries base intermediate path is not absolute. Meaning instead of C:/project/obj it returns /obj.
-            //   2. Our `new DirectoryInfo(...).Parent` call above is forgiving so if the path passed to it isn't absolute (Razor class library scenario) it utilizes Directory.GetCurrentDirectory where
-            //      in this case would be the C:/Windows/System path
-            // Because of the above two issues the joinedPath ends up looking like "C:\WINDOWS\system32\obj\Debug\netstandard2.0\" which doesn't actually exist and of course isn't writeable. The end-user effect of this
-            // quirk means that you don't get any component completions for Razor class libraries because we're unable to capture their project state information.
+            // For Razor class libraries, the base intermediate path is relative. Meaning instead of C:/project/obj it returns /obj.
+            // The `new DirectoryInfo(...).Parent` call above is forgiving so if the path passed to it isn't absolute (Razor class library scenario) it utilizes Directory.GetCurrentDirectory, which
+            // could be the C:/Windows/System path, or the solution path, or anything really.
             //
             // To workaround these inconsistencies with Razor class libraries we fall back to the MSBuildProjectDirectory and build what we think is the intermediate output path.
             joinedPath = ResolveFallbackIntermediateOutputPath(rule, intermediateOutputPathValue);
@@ -381,7 +376,7 @@ internal abstract partial class WindowsRazorProjectHostBase : OnceInitializedOnc
         return true;
     }
 
-    private static string? ResolveFallbackIntermediateOutputPath(IProjectRuleSnapshot rule, string intermediateOutputPathValue)
+    private string? ResolveFallbackIntermediateOutputPath(IProjectRuleSnapshot rule, string intermediateOutputPathValue)
     {
         if (!rule.Properties.TryGetValue(MSBuildProjectDirectoryPropertyName, out var projectDirectory))
         {
@@ -390,7 +385,7 @@ internal abstract partial class WindowsRazorProjectHostBase : OnceInitializedOnc
         }
 
         var joinedPath = Path.Combine(projectDirectory, intermediateOutputPathValue);
-        if (!Directory.Exists(joinedPath))
+        if (!SkipIntermediateOutputPathExistCheck_TestOnly && !Directory.Exists(joinedPath))
         {
             return null;
         }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
@@ -627,7 +627,7 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
         var host = new DefaultWindowsRazorProjectHost(services, _serviceProvider, _projectManager);
 
         // Act & Assert
-        await host.LoadAsync();
+        await host.GetTestAccessor().InitializeAsync();
         Assert.Empty(_projectManager.GetProjects());
 
         await host.DisposeAsync();
@@ -642,7 +642,7 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
         var host = new DefaultWindowsRazorProjectHost(services, _serviceProvider, _projectManager);
 
         // Act & Assert
-        await Task.Run(async () => await host.LoadAsync());
+        await Task.Run(async () => await host.GetTestAccessor().InitializeAsync());
         Assert.Empty(_projectManager.GetProjects());
 
         await Task.Run(async () => await host.DisposeAsync());
@@ -660,11 +660,13 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
         var host = new DefaultWindowsRazorProjectHost(services, _serviceProvider, _projectManager);
 
+        var testAccessor = host.GetTestAccessor();
+
         // Act & Assert
-        await Task.Run(async () => await host.LoadAsync());
+        await Task.Run(async () => await testAccessor.InitializeAsync());
         Assert.Empty(_projectManager.GetProjects());
 
-        await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
+        await Task.Run(async () => await testAccessor.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
         Assert.Empty(_projectManager.GetProjects());
     }
 
@@ -704,11 +706,13 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
 
         var host = new DefaultWindowsRazorProjectHost(services, _serviceProvider, _projectManager);
 
-        await Task.Run(async () => await host.LoadAsync());
+        var testAccessor = host.GetTestAccessor();
+
+        await Task.Run(async () => await testAccessor.InitializeAsync());
         Assert.Empty(_projectManager.GetProjects());
 
         // Act
-        await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
+        await Task.Run(async () => await testAccessor.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
 
         // Assert
         var project = Assert.Single(_projectManager.GetProjects());
@@ -783,7 +787,6 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
     {
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
         var host = new DefaultWindowsRazorProjectHost(services, _serviceProvider, _projectManager);
-        host.SkipIntermediateOutputPathExistCheck_TestOnly = true;
 
         var state = TestProjectRuleSnapshot.CreateProperties(
             WindowsRazorProjectHostBase.ConfigurationGeneralSchemaName,
@@ -829,11 +832,13 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
         var host = new DefaultWindowsRazorProjectHost(services, _serviceProvider, _projectManager);
 
-        await Task.Run(async () => await host.LoadAsync());
+        var testAccessor = host.GetTestAccessor();
+
+        await Task.Run(async () => await testAccessor.InitializeAsync());
         Assert.Empty(_projectManager.GetProjects());
 
         // Act
-        await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
+        await Task.Run(async () => await testAccessor.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
 
         // Assert
         Assert.Empty(_projectManager.GetProjects());
@@ -880,7 +885,9 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
         var host = new DefaultWindowsRazorProjectHost(services, _serviceProvider, _projectManager);
 
-        await Task.Run(async () => await host.LoadAsync());
+        var testAccessor = host.GetTestAccessor();
+
+        await Task.Run(async () => await testAccessor.InitializeAsync());
         Assert.Empty(_projectManager.GetProjects());
 
         // Act - 1
@@ -889,7 +896,7 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
             updater.SolutionClosed();
         });
 
-        await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
+        await Task.Run(async () => await testAccessor.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
 
         // Assert - 1
         Assert.False(_projectManager.IsSolutionClosing);
@@ -933,11 +940,13 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
         var host = new DefaultWindowsRazorProjectHost(services, _serviceProvider, _projectManager);
 
-        await Task.Run(async () => await host.LoadAsync());
+        var testAccessor = host.GetTestAccessor();
+
+        await Task.Run(async () => await testAccessor.InitializeAsync());
         Assert.Empty(_projectManager.GetProjects());
 
         // Act - 1
-        await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
+        await Task.Run(async () => await testAccessor.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
 
         // Assert - 1
         var project = Assert.Single(_projectManager.GetProjects());
@@ -998,7 +1007,7 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
             _configurationGeneral.ToChange(changes[5].After),
         };
 
-        await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
+        await Task.Run(async () => await host.GetTestAccessor().OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
 
         // Assert - 2
         project = Assert.Single(_projectManager.GetProjects());
@@ -1088,11 +1097,13 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
         var host = new DefaultWindowsRazorProjectHost(services, _serviceProvider, _projectManager);
 
-        await Task.Run(async () => await host.LoadAsync());
+        var testAccessor = host.GetTestAccessor();
+
+        await Task.Run(async () => await testAccessor.InitializeAsync());
         Assert.Empty(_projectManager.GetProjects());
 
         // Act - 1
-        await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
+        await Task.Run(async () => await testAccessor.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
 
         // Assert - 1
         var snapshot = Assert.Single(_projectManager.GetProjects());
@@ -1118,7 +1129,7 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
             _razorGenerateWithTargetPathItems.ToChange(changes[4].After),
         };
 
-        await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
+        await Task.Run(async () => await testAccessor.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
 
         // Assert - 2
         Assert.Empty(_projectManager.GetProjects());
@@ -1162,11 +1173,13 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
         var host = new DefaultWindowsRazorProjectHost(services, _serviceProvider, _projectManager);
 
-        await Task.Run(async () => await host.LoadAsync());
+        var testAccessor = host.GetTestAccessor();
+
+        await Task.Run(async () => await testAccessor.InitializeAsync());
         Assert.Empty(_projectManager.GetProjects());
 
         // Act - 1
-        await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
+        await Task.Run(async () => await testAccessor.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
 
         // Assert - 1
         var snapshot = Assert.Single(_projectManager.GetProjects());
@@ -1199,7 +1212,7 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
             _razorGenerateWithTargetPathItems.ToChange(changes[4].After),
         };
 
-        await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
+        await Task.Run(async () => await testAccessor.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
 
         // Assert - 3
         Assert.Empty(_projectManager.GetProjects());
@@ -1241,11 +1254,13 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
 
         var host = new DefaultWindowsRazorProjectHost(services, _serviceProvider, _projectManager);
 
-        await Task.Run(async () => await host.LoadAsync());
+        var testAccessor = host.GetTestAccessor();
+
+        await Task.Run(async () => await testAccessor.InitializeAsync());
         Assert.Empty(_projectManager.GetProjects());
 
         // Act - 1
-        await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
+        await Task.Run(async () => await testAccessor.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
 
         // Assert - 1
         var project = Assert.Single(_projectManager.GetProjects());
@@ -1271,7 +1286,7 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
 
         // Act - 2
         services.UnconfiguredProject.FullPath = TestProjectData.AnotherProject.FilePath;
-        await Task.Run(async () => await host.OnProjectRenamingAsync(TestProjectData.SomeProject.FilePath, TestProjectData.AnotherProject.FilePath));
+        await Task.Run(async () => await testAccessor.OnProjectRenamingAsync(TestProjectData.SomeProject.FilePath, TestProjectData.AnotherProject.FilePath));
 
         // Assert - 1
         project = Assert.Single(_projectManager.GetProjects());
@@ -1337,11 +1352,13 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
         var host = new DefaultWindowsRazorProjectHost(services, _serviceProvider, _projectManager);
 
-        await Task.Run(async () => await host.LoadAsync());
+        var testAccessor = host.GetTestAccessor();
+
+        await Task.Run(async () => await testAccessor.InitializeAsync());
         Assert.Empty(_projectManager.GetProjects());
 
         // Act - 1
-        await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
+        await Task.Run(async () => await testAccessor.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
 
         // Assert - 1
         var project = Assert.Single(_projectManager.GetProjects());
@@ -1390,7 +1407,7 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
             _configurationGeneral.ToChange(changes[5].After),
         };
 
-        await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
+        await Task.Run(async () => await testAccessor.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
 
         // Assert - 2
         // Changing intermediate output path is effectively removing the old project and adding a new one.

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
@@ -780,9 +780,9 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
 
     [UITheory]
     // This is what we see for Razor class libraries
-    [InlineData("obj/",    @"C:\my repo root\solution folder\projectFolder\", @"obj\Debug\net8.0", @"C:\my repo root\solution folder\projectFolder\obj\Debug\net8.0")]
+    [InlineData("obj/", @"C:\my repo root\solution folder\projectFolder\", @"obj\Debug\net8.0", @"C:\my repo root\solution folder\projectFolder\obj\Debug\net8.0")]
     [InlineData("../obj/", @"C:\my repo root\solution folder\projectFolder\", @"obj\Debug\net8.0", @"C:\my repo root\solution folder\projectFolder\obj\Debug\net8.0")]
-    [InlineData("../obj",  @"C:\my repo root\solution folder\projectFolder\", @"obj\Debug\net8.0", @"C:\my repo root\solution folder\projectFolder\obj\Debug\net8.0")]
+    [InlineData("../obj", @"C:\my repo root\solution folder\projectFolder\", @"obj\Debug\net8.0", @"C:\my repo root\solution folder\projectFolder\obj\Debug\net8.0")]
     public void IntermediateOutputPathCalculationHandlesRelativePaths_BaseIntermediateOutputPath(string baseIntermediateOutputPath, string msbuildProjectDirectoryPropertyName, string intermediateOutputPath, string expectedCombinedIOP)
     {
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
@@ -703,7 +703,6 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
 
         var host = new DefaultWindowsRazorProjectHost(services, _serviceProvider, _projectManager);
-        host.SkipIntermediateOutputPathExistCheck_TestOnly = true;
 
         await Task.Run(async () => await host.LoadAsync());
         Assert.Empty(_projectManager.GetProjects());
@@ -850,7 +849,6 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
 
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
         var host = new DefaultWindowsRazorProjectHost(services, _serviceProvider, _projectManager);
-        host.SkipIntermediateOutputPathExistCheck_TestOnly = true;
 
         await Task.Run(async () => await host.LoadAsync());
         Assert.Empty(_projectManager.GetProjects());
@@ -904,7 +902,6 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
 
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
         var host = new DefaultWindowsRazorProjectHost(services, _serviceProvider, _projectManager);
-        host.SkipIntermediateOutputPathExistCheck_TestOnly = true;
 
         await Task.Run(async () => await host.LoadAsync());
         Assert.Empty(_projectManager.GetProjects());
@@ -1060,7 +1057,6 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
 
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
         var host = new DefaultWindowsRazorProjectHost(services, _serviceProvider, _projectManager);
-        host.SkipIntermediateOutputPathExistCheck_TestOnly = true;
 
         await Task.Run(async () => await host.LoadAsync());
         Assert.Empty(_projectManager.GetProjects());
@@ -1135,7 +1131,6 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
 
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
         var host = new DefaultWindowsRazorProjectHost(services, _serviceProvider, _projectManager);
-        host.SkipIntermediateOutputPathExistCheck_TestOnly = true;
 
         await Task.Run(async () => await host.LoadAsync());
         Assert.Empty(_projectManager.GetProjects());
@@ -1215,7 +1210,6 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
 
         var host = new DefaultWindowsRazorProjectHost(services, _serviceProvider, _projectManager);
-        host.SkipIntermediateOutputPathExistCheck_TestOnly = true;
 
         await Task.Run(async () => await host.LoadAsync());
         Assert.Empty(_projectManager.GetProjects());
@@ -1312,7 +1306,6 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
 
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
         var host = new DefaultWindowsRazorProjectHost(services, _serviceProvider, _projectManager);
-        host.SkipIntermediateOutputPathExistCheck_TestOnly = true;
 
         await Task.Run(async () => await host.LoadAsync());
         Assert.Empty(_projectManager.GetProjects());

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
@@ -692,12 +692,12 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
 
         var changes = new TestProjectChangeDescription[]
         {
-             _razorGeneralProperties.ToChange(),
-             _configurationItems.ToChange(),
-             _extensionItems.ToChange(),
-             _razorComponentWithTargetPathItems.ToChange(),
-             _razorGenerateWithTargetPathItems.ToChange(),
-             _configurationGeneral.ToChange(),
+            _razorGeneralProperties.ToChange(),
+            _configurationItems.ToChange(),
+            _extensionItems.ToChange(),
+            _razorComponentWithTargetPathItems.ToChange(),
+            _razorGenerateWithTargetPathItems.ToChange(),
+            _configurationGeneral.ToChange(),
         };
 
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
@@ -758,12 +758,12 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
         var host = new DefaultWindowsRazorProjectHost(services, _serviceProvider, _projectManager);
 
         var state = TestProjectRuleSnapshot.CreateProperties(
-             WindowsRazorProjectHostBase.ConfigurationGeneralSchemaName,
-             new Dictionary<string, string>()
-             {
-                 [WindowsRazorProjectHostBase.IntermediateOutputPathPropertyName] = intermediateOutputPath,
-                 [WindowsRazorProjectHostBase.BaseIntermediateOutputPathPropertyName] = baseIntermediateOutputPath,
-             });
+            WindowsRazorProjectHostBase.ConfigurationGeneralSchemaName,
+            new Dictionary<string, string>()
+            {
+                [WindowsRazorProjectHostBase.IntermediateOutputPathPropertyName] = intermediateOutputPath,
+                [WindowsRazorProjectHostBase.BaseIntermediateOutputPathPropertyName] = baseIntermediateOutputPath,
+            });
 
         var dict = ImmutableDictionary<string, IProjectRuleSnapshot>.Empty;
         dict = dict.Add(WindowsRazorProjectHostBase.ConfigurationGeneralSchemaName, state);
@@ -790,11 +790,11 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
 
         var changes = new TestProjectChangeDescription[]
         {
-             _razorGeneralProperties.ToChange(),
-             _configurationItems.ToChange(),
-             _extensionItems.ToChange(),
-             _razorComponentWithTargetPathItems.ToChange(),
-             _razorGenerateWithTargetPathItems.ToChange(),
+            _razorGeneralProperties.ToChange(),
+            _configurationItems.ToChange(),
+            _extensionItems.ToChange(),
+            _razorComponentWithTargetPathItems.ToChange(),
+            _razorGenerateWithTargetPathItems.ToChange(),
         };
 
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
@@ -840,12 +840,12 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
 
         var changes = new TestProjectChangeDescription[]
         {
-             _razorGeneralProperties.ToChange(),
-             _configurationItems.ToChange(),
-             _extensionItems.ToChange(),
-             _razorComponentWithTargetPathItems.ToChange(),
-             _razorGenerateWithTargetPathItems.ToChange(),
-             _configurationGeneral.ToChange(),
+            _razorGeneralProperties.ToChange(),
+            _configurationItems.ToChange(),
+            _extensionItems.ToChange(),
+            _razorComponentWithTargetPathItems.ToChange(),
+            _razorGenerateWithTargetPathItems.ToChange(),
+            _configurationGeneral.ToChange(),
         };
 
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
@@ -894,12 +894,12 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
 
         var changes = new TestProjectChangeDescription[]
         {
-             _razorGeneralProperties.ToChange(),
-             _configurationItems.ToChange(),
-             _extensionItems.ToChange(),
-             _razorComponentWithTargetPathItems.ToChange(),
-             _razorGenerateWithTargetPathItems.ToChange(),
-             _configurationGeneral.ToChange(),
+            _razorGeneralProperties.ToChange(),
+            _configurationItems.ToChange(),
+            _extensionItems.ToChange(),
+            _razorComponentWithTargetPathItems.ToChange(),
+            _razorGenerateWithTargetPathItems.ToChange(),
+            _configurationGeneral.ToChange(),
         };
 
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
@@ -953,22 +953,22 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
         _configurationItems.Item("MVC-2.0", new Dictionary<string, string>() { { "Extensions", "MVC-2.0;Another-Thing" }, });
         _extensionItems.Item("MVC-2.0");
         _razorComponentWithTargetPathItems.Item(TestProjectData.AnotherProjectNestedComponentFile3.FilePath, new Dictionary<string, string>()
-         {
-             { Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.AnotherProjectNestedComponentFile3.TargetPath },
-         });
+        {
+            { Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.AnotherProjectNestedComponentFile3.TargetPath },
+        });
         _razorGenerateWithTargetPathItems.Item(TestProjectData.AnotherProjectNestedFile3.FilePath, new Dictionary<string, string>()
-         {
-             { Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.AnotherProjectNestedFile3.TargetPath },
-         });
+        {
+            { Rules.RazorGenerateWithTargetPath.TargetPathProperty, TestProjectData.AnotherProjectNestedFile3.TargetPath },
+        });
 
         changes = new TestProjectChangeDescription[]
         {
-             _razorGeneralProperties.ToChange(changes[0].After),
-             _configurationItems.ToChange(changes[1].After),
-             _extensionItems.ToChange(changes[2].After),
-             _razorComponentWithTargetPathItems.ToChange(changes[3].After),
-             _razorGenerateWithTargetPathItems.ToChange(changes[4].After),
-             _configurationGeneral.ToChange(changes[5].After),
+            _razorGeneralProperties.ToChange(changes[0].After),
+            _configurationItems.ToChange(changes[1].After),
+            _extensionItems.ToChange(changes[2].After),
+            _razorComponentWithTargetPathItems.ToChange(changes[3].After),
+            _razorGenerateWithTargetPathItems.ToChange(changes[4].After),
+            _configurationGeneral.ToChange(changes[5].After),
         };
 
         await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
@@ -1050,12 +1050,12 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
 
         var changes = new TestProjectChangeDescription[]
         {
-             _razorGeneralProperties.ToChange(),
-             _configurationItems.ToChange(),
-             _extensionItems.ToChange(),
-             _razorComponentWithTargetPathItems.ToChange(),
-             _razorGenerateWithTargetPathItems.ToChange(),
-             _configurationGeneral.ToChange(),
+            _razorGeneralProperties.ToChange(),
+            _configurationItems.ToChange(),
+            _extensionItems.ToChange(),
+            _razorComponentWithTargetPathItems.ToChange(),
+            _razorGenerateWithTargetPathItems.ToChange(),
+            _configurationGeneral.ToChange(),
         };
 
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
@@ -1085,11 +1085,11 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
 
         changes = new TestProjectChangeDescription[]
         {
-             _razorGeneralProperties.ToChange(changes[0].After),
-             _configurationItems.ToChange(changes[1].After),
-             _extensionItems.ToChange(changes[2].After),
-             _razorComponentWithTargetPathItems.ToChange(changes[3].After),
-             _razorGenerateWithTargetPathItems.ToChange(changes[4].After),
+            _razorGeneralProperties.ToChange(changes[0].After),
+            _configurationItems.ToChange(changes[1].After),
+            _extensionItems.ToChange(changes[2].After),
+            _razorComponentWithTargetPathItems.ToChange(changes[3].After),
+            _razorGenerateWithTargetPathItems.ToChange(changes[4].After),
         };
 
         await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
@@ -1125,12 +1125,12 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
 
         var changes = new TestProjectChangeDescription[]
         {
-             _razorGeneralProperties.ToChange(),
-             _configurationItems.ToChange(),
-             _extensionItems.ToChange(),
-             _razorComponentWithTargetPathItems.ToChange(),
-             _razorGenerateWithTargetPathItems.ToChange(),
-             _configurationGeneral.ToChange(),
+            _razorGeneralProperties.ToChange(),
+            _configurationItems.ToChange(),
+            _extensionItems.ToChange(),
+            _razorComponentWithTargetPathItems.ToChange(),
+            _razorGenerateWithTargetPathItems.ToChange(),
+            _configurationGeneral.ToChange(),
         };
 
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
@@ -1167,11 +1167,11 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
 
         changes = new TestProjectChangeDescription[]
         {
-             _razorGeneralProperties.ToChange(changes[0].After),
-             _configurationItems.ToChange(changes[1].After),
-             _extensionItems.ToChange(changes[2].After),
-             _razorComponentWithTargetPathItems.ToChange(changes[3].After),
-             _razorGenerateWithTargetPathItems.ToChange(changes[4].After),
+            _razorGeneralProperties.ToChange(changes[0].After),
+            _configurationItems.ToChange(changes[1].After),
+            _extensionItems.ToChange(changes[2].After),
+            _razorComponentWithTargetPathItems.ToChange(changes[3].After),
+            _razorGenerateWithTargetPathItems.ToChange(changes[4].After),
         };
 
         await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
@@ -1204,12 +1204,12 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
 
         var changes = new TestProjectChangeDescription[]
         {
-             _razorGeneralProperties.ToChange(),
-             _configurationItems.ToChange(),
-             _extensionItems.ToChange(),
-             _razorComponentWithTargetPathItems.ToChange(),
-             _razorGenerateWithTargetPathItems.ToChange(),
-             _configurationGeneral.ToChange(),
+            _razorGeneralProperties.ToChange(),
+            _configurationItems.ToChange(),
+            _extensionItems.ToChange(),
+            _razorComponentWithTargetPathItems.ToChange(),
+            _razorGenerateWithTargetPathItems.ToChange(),
+            _configurationGeneral.ToChange(),
         };
 
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
@@ -1229,21 +1229,21 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
         Assert.Same("MVC-2.1", project.Configuration.ConfigurationName);
 
         Assert.Collection(
-           project.DocumentFilePaths.OrderBy(d => d),
-           d =>
-           {
-               var document = project.GetRequiredDocument(d);
-               Assert.Equal(TestProjectData.SomeProjectFile1.FilePath, document.FilePath);
-               Assert.Equal(TestProjectData.SomeProjectFile1.TargetPath, document.TargetPath);
-               Assert.Equal(FileKinds.Legacy, document.FileKind);
-           },
-           d =>
-           {
-               var document = project.GetRequiredDocument(d);
-               Assert.Equal(TestProjectData.SomeProjectComponentFile1.FilePath, document.FilePath);
-               Assert.Equal(TestProjectData.SomeProjectComponentFile1.TargetPath, document.TargetPath);
-               Assert.Equal(FileKinds.Component, document.FileKind);
-           });
+            project.DocumentFilePaths.OrderBy(d => d),
+            d =>
+            {
+                var document = project.GetRequiredDocument(d);
+                Assert.Equal(TestProjectData.SomeProjectFile1.FilePath, document.FilePath);
+                Assert.Equal(TestProjectData.SomeProjectFile1.TargetPath, document.TargetPath);
+                Assert.Equal(FileKinds.Legacy, document.FileKind);
+            },
+            d =>
+            {
+                var document = project.GetRequiredDocument(d);
+                Assert.Equal(TestProjectData.SomeProjectComponentFile1.FilePath, document.FilePath);
+                Assert.Equal(TestProjectData.SomeProjectComponentFile1.TargetPath, document.TargetPath);
+                Assert.Equal(FileKinds.Component, document.FileKind);
+            });
 
         // Act - 2
         services.UnconfiguredProject.FullPath = TestProjectData.AnotherProject.FilePath;
@@ -1255,21 +1255,21 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
         Assert.Same("MVC-2.1", project.Configuration.ConfigurationName);
 
         Assert.Collection(
-           project.DocumentFilePaths.OrderBy(d => d),
-           d =>
-           {
-               var document = project.GetRequiredDocument(d);
-               Assert.Equal(TestProjectData.SomeProjectFile1.FilePath, document.FilePath);
-               Assert.Equal(TestProjectData.SomeProjectFile1.TargetPath, document.TargetPath);
-               Assert.Equal(FileKinds.Legacy, document.FileKind);
-           },
-           d =>
-           {
-               var document = project.GetRequiredDocument(d);
-               Assert.Equal(TestProjectData.SomeProjectComponentFile1.FilePath, document.FilePath);
-               Assert.Equal(TestProjectData.SomeProjectComponentFile1.TargetPath, document.TargetPath);
-               Assert.Equal(FileKinds.Component, document.FileKind);
-           });
+            project.DocumentFilePaths.OrderBy(d => d),
+            d =>
+            {
+                var document = project.GetRequiredDocument(d);
+                Assert.Equal(TestProjectData.SomeProjectFile1.FilePath, document.FilePath);
+                Assert.Equal(TestProjectData.SomeProjectFile1.TargetPath, document.TargetPath);
+                Assert.Equal(FileKinds.Legacy, document.FileKind);
+            },
+            d =>
+            {
+                var document = project.GetRequiredDocument(d);
+                Assert.Equal(TestProjectData.SomeProjectComponentFile1.FilePath, document.FilePath);
+                Assert.Equal(TestProjectData.SomeProjectComponentFile1.TargetPath, document.TargetPath);
+                Assert.Equal(FileKinds.Component, document.FileKind);
+            });
 
         await Task.Run(async () => await host.DisposeAsync());
         Assert.Empty(_projectManager.GetProjects());
@@ -1302,12 +1302,12 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
 
         var changes = new TestProjectChangeDescription[]
         {
-             _razorGeneralProperties.ToChange(),
-             _configurationItems.ToChange(),
-             _extensionItems.ToChange(),
-             _razorComponentWithTargetPathItems.ToChange(),
-             _razorGenerateWithTargetPathItems.ToChange(),
-             _configurationGeneral.ToChange(),
+            _razorGeneralProperties.ToChange(),
+            _configurationItems.ToChange(),
+            _extensionItems.ToChange(),
+            _razorComponentWithTargetPathItems.ToChange(),
+            _razorGenerateWithTargetPathItems.ToChange(),
+            _configurationGeneral.ToChange(),
         };
 
         var services = new TestProjectSystemServices(TestProjectData.SomeProject.FilePath);
@@ -1359,12 +1359,12 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
 
         changes = new TestProjectChangeDescription[]
         {
-             _razorGeneralProperties.ToChange(changes[0].After),
-             _configurationItems.ToChange(changes[1].After),
-             _extensionItems.ToChange(changes[2].After),
-             _razorComponentWithTargetPathItems.ToChange(changes[3].After),
-             _razorGenerateWithTargetPathItems.ToChange(changes[4].After),
-             _configurationGeneral.ToChange(changes[5].After),
+            _razorGeneralProperties.ToChange(changes[0].After),
+            _configurationItems.ToChange(changes[1].After),
+            _extensionItems.ToChange(changes[2].After),
+            _razorComponentWithTargetPathItems.ToChange(changes[3].After),
+            _razorGenerateWithTargetPathItems.ToChange(changes[4].After),
+            _configurationGeneral.ToChange(changes[5].After),
         };
 
         await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/FallbackWindowsRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/FallbackWindowsRazorProjectHostTest.cs
@@ -304,7 +304,7 @@ public class FallbackWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
         var host = new TestFallbackRazorProjectHost(services, _serviceProvider, _projectManager);
 
         // Act & Assert
-        await host.LoadAsync();
+        await host.GetTestAccessor().InitializeAsync();
         Assert.Empty(_projectManager.GetProjects());
 
         await host.DisposeAsync();
@@ -320,7 +320,7 @@ public class FallbackWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
         var host = new TestFallbackRazorProjectHost(services, _serviceProvider, _projectManager);
 
         // Act & Assert
-        await Task.Run(async () => await host.LoadAsync());
+        await Task.Run(async () => await host.GetTestAccessor().InitializeAsync());
         Assert.Empty(_projectManager.GetProjects());
 
         await Task.Run(async () => await host.DisposeAsync());
@@ -342,11 +342,13 @@ public class FallbackWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
             AssemblyVersion = new Version(2, 0),
         };
 
+        var testAccessor = host.GetTestAccessor();
+
         // Act & Assert
-        await Task.Run(async () => await host.LoadAsync());
+        await Task.Run(async () => await testAccessor.InitializeAsync());
         Assert.Empty(_projectManager.GetProjects());
 
-        await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
+        await Task.Run(async () => await testAccessor.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
         Assert.Empty(_projectManager.GetProjects());
     }
 
@@ -378,11 +380,13 @@ public class FallbackWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
             AssemblyVersion = new Version(2, 0), // Mock for reading the assembly's version
         };
 
-        await Task.Run(async () => await host.LoadAsync());
+        var testAccessor = host.GetTestAccessor();
+
+        await Task.Run(async () => await testAccessor.InitializeAsync());
         Assert.Empty(_projectManager.GetProjects());
 
         // Act
-        await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
+        await Task.Run(async () => await testAccessor.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
 
         // Assert
         var snapshot = Assert.Single(_projectManager.GetProjects());
@@ -410,11 +414,13 @@ public class FallbackWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
 
         var host = new TestFallbackRazorProjectHost(services, _serviceProvider, _projectManager);
 
-        await Task.Run(async () => await host.LoadAsync());
+        var testAccessor = host.GetTestAccessor();
+
+        await Task.Run(async () => await testAccessor.InitializeAsync());
         Assert.Empty(_projectManager.GetProjects());
 
         // Act
-        await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
+        await Task.Run(async () => await testAccessor.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
 
         // Assert
         Assert.Empty(_projectManager.GetProjects());
@@ -438,11 +444,13 @@ public class FallbackWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
 
         var host = new TestFallbackRazorProjectHost(services, _serviceProvider, _projectManager);
 
-        await Task.Run(async () => await host.LoadAsync());
+        var testAccessor = host.GetTestAccessor();
+
+        await Task.Run(async () => await testAccessor.InitializeAsync());
         Assert.Empty(_projectManager.GetProjects());
 
         // Act
-        await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
+        await Task.Run(async () => await testAccessor.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
 
         // Assert
         Assert.Empty(_projectManager.GetProjects());
@@ -480,11 +488,13 @@ public class FallbackWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
             AssemblyVersion = new Version(2, 0),
         };
 
-        await Task.Run(async () => await host.LoadAsync());
+        var testAccessor = host.GetTestAccessor();
+
+        await Task.Run(async () => await testAccessor.InitializeAsync());
         Assert.Empty(_projectManager.GetProjects());
 
         // Act - 1
-        await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(initialChanges)));
+        await Task.Run(async () => await testAccessor.OnProjectChangedAsync(string.Empty, services.CreateUpdate(initialChanges)));
 
         // Assert - 1
         var snapshot = Assert.Single(_projectManager.GetProjects());
@@ -495,7 +505,7 @@ public class FallbackWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
 
         // Act - 2
         host.AssemblyVersion = new Version(1, 0);
-        await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
+        await Task.Run(async () => await testAccessor.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
 
         // Assert - 2
         snapshot = Assert.Single(_projectManager.GetProjects());
@@ -525,11 +535,13 @@ public class FallbackWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
             AssemblyVersion = new Version(2, 0),
         };
 
-        await Task.Run(async () => await host.LoadAsync());
+        var testAccessor = host.GetTestAccessor();
+
+        await Task.Run(async () => await testAccessor.InitializeAsync());
         Assert.Empty(_projectManager.GetProjects());
 
         // Act - 1
-        await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
+        await Task.Run(async () => await testAccessor.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
 
         // Assert - 1
         var snapshot = Assert.Single(_projectManager.GetProjects());
@@ -538,7 +550,7 @@ public class FallbackWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
 
         // Act - 2
         host.AssemblyVersion = null;
-        await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
+        await Task.Run(async () => await testAccessor.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
 
         // Assert - 2
         Assert.Empty(_projectManager.GetProjects());
@@ -570,11 +582,13 @@ public class FallbackWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
             AssemblyVersion = new Version(2, 0),
         };
 
-        await Task.Run(async () => await host.LoadAsync());
+        var testAccessor = host.GetTestAccessor();
+
+        await Task.Run(async () => await testAccessor.InitializeAsync());
         Assert.Empty(_projectManager.GetProjects());
 
         // Act - 1
-        await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
+        await Task.Run(async () => await testAccessor.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
 
         // Assert - 1
         var snapshot = Assert.Single(_projectManager.GetProjects());
@@ -591,7 +605,7 @@ public class FallbackWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
 
         // Act - 3
         host.AssemblyVersion = new Version(1, 1);
-        await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
+        await Task.Run(async () => await testAccessor.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
 
         // Assert - 3
         Assert.Empty(_projectManager.GetProjects());
@@ -615,11 +629,13 @@ public class FallbackWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
             AssemblyVersion = new Version(2, 0), // Mock for reading the assembly's version
         };
 
-        await Task.Run(async () => await host.LoadAsync());
+        var testAccessor = host.GetTestAccessor();
+
+        await Task.Run(async () => await testAccessor.InitializeAsync());
         Assert.Empty(_projectManager.GetProjects());
 
         // Act - 1
-        await Task.Run(async () => await host.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
+        await Task.Run(async () => await testAccessor.OnProjectChangedAsync(string.Empty, services.CreateUpdate(changes)));
 
         // Assert - 1
         var snapshot = Assert.Single(_projectManager.GetProjects());
@@ -628,7 +644,7 @@ public class FallbackWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
 
         // Act - 2
         services.UnconfiguredProject.FullPath = "Test2.csproj";
-        await Task.Run(async () => await host.OnProjectRenamingAsync("Test.csproj", "Test2.csproj"));
+        await Task.Run(async () => await testAccessor.OnProjectRenamingAsync("Test.csproj", "Test2.csproj"));
 
         // Assert - 1
         snapshot = Assert.Single(_projectManager.GetProjects());
@@ -647,7 +663,6 @@ public class FallbackWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
             ProjectSnapshotManager projectManager)
             : base(commonServices, serviceProvider, projectManager)
         {
-            SkipIntermediateOutputPathExistCheck_TestOnly = true;
         }
 
         public Version AssemblyVersion { get; set; }


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/11482

Explanation, copied from the issue: RCLs don't have an absolute `BaseIntermediateOutputPath`, so we end up seeing `<current directory>\obj` as the obj path, and we have a `Directory.Exists` check that catches if that happens, and falls back to different logic for an RCL. Turns out current directory is the solution folder, and so sometimes that obj path does exist, but it exists for a different project, and then all sorts of fun shenanigans ensue.