### PR TITLE
Fix a couple of options in the old options screen

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Options/AdvancedOptionPage.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Options/AdvancedOptionPage.cs
@@ -97,7 +97,7 @@ internal class AdvancedOptionPage : DialogPage
     [LocDisplayName(nameof(VSPackage.Setting_FormattingOnPasteDisplayName))]
     public bool FormatOnPaste
     {
-        get => _formatOnPaste ?? true;
+        get => _formatOnPaste ?? _optionsStorage.Value.FormatOnPaste;
         set => _formatOnPaste = value;
     }
 
@@ -106,7 +106,7 @@ internal class AdvancedOptionPage : DialogPage
     [LocDisplayName(nameof(VSPackage.Setting_SnippetsDisplayName))]
     public SnippetSetting Snippets
     {
-        get => _snippets ?? (SnippetSetting)_optionsStorage.Value.Snippets;
+        get => _snippets ?? _optionsStorage.Value.Snippets;
         set => _snippets = value;
     }
 
@@ -115,7 +115,7 @@ internal class AdvancedOptionPage : DialogPage
     [LocDisplayName(nameof(VSPackage.Setting_LogLevelDisplayName))]
     public LogLevel LogLevel
     {
-        get => _logLevel ?? (LogLevel)_optionsStorage.Value.LogLevel;
+        get => _logLevel ?? _optionsStorage.Value.LogLevel;
         set => _logLevel = value;
     }
 
@@ -136,14 +136,24 @@ internal class AdvancedOptionPage : DialogPage
             _optionsStorage.Value.AutoInsertAttributeQuotes = _autoInsertAttributeQuotes.Value;
         }
 
+        if (_commitElementsWithSpace is not null)
+        {
+            _optionsStorage.Value.CommitElementsWithSpace = _commitElementsWithSpace.Value;
+        }
+
         if (_colorBackground is not null)
         {
             _optionsStorage.Value.ColorBackground = _colorBackground.Value;
         }
 
-        if (_commitElementsWithSpace is not null)
+        if (_codeBlockBraceOnNextLine is not null)
         {
-            _optionsStorage.Value.CommitElementsWithSpace = _commitElementsWithSpace.Value;
+            _optionsStorage.Value.CodeBlockBraceOnNextLine = _codeBlockBraceOnNextLine.Value;
+        }
+
+        if (_formatOnPaste is not null)
+        {
+            _optionsStorage.Value.FormatOnPaste = _formatOnPaste.Value;
         }
 
         if (_snippets is SnippetSetting snippets)
@@ -162,8 +172,10 @@ internal class AdvancedOptionPage : DialogPage
         _formatOnType = null;
         _autoClosingTags = null;
         _autoInsertAttributeQuotes = null;
-        _colorBackground = null;
         _commitElementsWithSpace = null;
+        _colorBackground = null;
+        _codeBlockBraceOnNextLine = null;
+        _formatOnPaste = null;
         _snippets = null;
         _logLevel = null;
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/7025

Turns out in the old options screen we weren't setting two of the options to honour user choices, and we were also clobbering their choice for one of them every time the screen opened.