### PR TITLE
Prevent warnings from new IVTs from Roslyn

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -55,6 +55,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="$(MicrosoftCodeAnalysisWorkspacesCommonPackageVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="$(MicrosoftCodeAnalysisWorkspacesMSBuildPackageVersion)" />
     <PackageVersion Include="Microsoft.CommonLanguageServerProtocol.Framework" Version="$(MicrosoftCommonLanguageServerProtocolFrameworkPackageVersion)" PrivateAssets="all" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.LanguageServer.Protocol" Version="$(MicrosoftCodeAnalysisExternalAccessRazorPackageVersion)" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Css.Parser" Version="1.0.0-20230414.1" />
     <PackageVersion Include="Microsoft.DiaSymReader" Version="2.0.0" />

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks.csproj
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks.csproj
@@ -37,6 +37,8 @@
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.DiaSymReader" />
+
+    <PackageReference Include="Microsoft.CodeAnalysis.LanguageServer.Protocol" Aliases="RLSP" />
   </ItemGroup>
 
   <Import Project="..\..\..\Shared\Microsoft.AspNetCore.Razor.Serialization.Json\Microsoft.AspNetCore.Razor.Serialization.Json.projitems" Label="Shared" />

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Microsoft.AspNetCore.Razor.LanguageServer.csproj
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Microsoft.AspNetCore.Razor.LanguageServer.csproj
@@ -33,6 +33,14 @@
       Now we aren't sure why this exposes a "flaky" issue; however, to workaround the break we pin the following packages to workaround the issue.
     -->
     <PackageReference Include="Microsoft.VisualStudio.RpcContracts" />
+
+    <!--
+      Razor and Roslyn both use CLaSP as the basis for their language servers, but CLaSP is a source package
+      which means when we reference Roslyn's server to get the LSP protocol types (which we have a restricted
+      IVT to) we get ambiguous type errors for everything in CLaSP. To fix this we reference Roslyn with an
+      alias, and then have a global using for the LSP protocol types only.
+    -->
+    <PackageReference Include="Microsoft.CodeAnalysis.LanguageServer.Protocol" Aliases="RLSP" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Microsoft.AspNetCore.Razor.LanguageServer.Test.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Microsoft.AspNetCore.Razor.LanguageServer.Test.csproj
@@ -20,4 +20,14 @@
     <EmbeddedResource Include="Semantic\TestFiles\**\*" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!--
+      Razor and Roslyn both use CLaSP as the basis for their language servers, but CLaSP is a source package
+      which means when we reference Roslyn's server to get the LSP protocol types (which we have a restricted
+      IVT to) we get ambiguous type errors for everything in CLaSP. To fix this we reference Roslyn with an
+      alias, and then have a global using for the LSP protocol types only.
+    -->
+    <PackageReference Include="Microsoft.CodeAnalysis.LanguageServer.Protocol" Aliases="RLSP" />
+  </ItemGroup>
+  
 </Project>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Microsoft.AspNetCore.Razor.Test.Common.Tooling.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Microsoft.AspNetCore.Razor.Test.Common.Tooling.csproj
@@ -61,6 +61,8 @@
     <PackageReference Include="xunit.extensibility.execution" />
     <PackageReference Include="Xunit.Combinatorial" />
     <PackageReference Include="Xunit.StaFact" />
+
+    <PackageReference Include="Microsoft.CodeAnalysis.LanguageServer.Protocol" Aliases="RLSP" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == '$(DefaultNetFxTargetFramework)'">


### PR DESCRIPTION
Response to https://github.com/dotnet/roslyn/pull/74597 to pave the way for https://github.com/dotnet/razor/pull/10682 once Web Tools inserts.

The break from the Roslyn change is not binary breaking, so no need for dual insertion, and since this change doesn't break anything, we can get this in now, and whenever we happen to bump Roslyn next, there should be no build issues.