### PR TITLE
Fix code actions appearing for the wrong context when invoked from light bulb

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CodeActions/CodeActionEndpoint.cs
@@ -55,19 +55,7 @@ internal sealed class CodeActionEndpoint(
             return null;
         }
 
-        // VS Provides `CodeActionParams.Context.SelectionRange` in addition to
-        // `CodeActionParams.Range`. The `SelectionRange` is relative to where the
-        // code action was invoked (ex. line 14, char 3) whereas the `Range` is
-        // always at the start of the line (ex. line 14, char 0). We want to utilize
-        // the relative positioning to ensure we provide code actions for the appropriate
-        // context.
-        //
-        // Note: VS Code doesn't provide a `SelectionRange`.
-        var vsCodeActionContext = request.Context;
-        if (vsCodeActionContext.SelectionRange != null)
-        {
-            request.Range = vsCodeActionContext.SelectionRange;
-        }
+        CodeActionsService.AdjustRequestRangeIfNecessary(request);
 
         var correlationId = Guid.NewGuid();
         using var __ = _telemetryReporter.TrackLspRequest(LspEndpointName, LanguageServerConstants.RazorLanguageServerName, TelemetryThresholds.CodeActionRazorTelemetryThreshold, correlationId);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/CodeActionsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/CodeActionsService.cs
@@ -279,4 +279,27 @@ internal class CodeActionsService(
 
         return availableCodeActionNames.ToImmutableHashSet();
     }
+
+    public static void AdjustRequestRangeIfNecessary(VSCodeActionParams request)
+    {
+        // VS Provides `CodeActionParams.Context.SelectionRange` in addition to
+        // `CodeActionParams.Range`. The `SelectionRange` is relative to where the
+        // code action was invoked (ex. line 14, char 3) whereas the `Range` is
+        // always at the start of the line (ex. line 14, char 0). We want to utilize
+        // the relative positioning to ensure we provide code actions for the appropriate
+        // context.
+        //
+        // We only do this if the Range contains the SelectionRange, or in other words if
+        // the SelectionRange serves to better focus the Range. It is possible for the selection
+        // to be on one line, and the code action request to be for an entirely different line
+        // if the user is invoking from the lightbulb button directly, for example on hovering
+        // over a diagnostic. In those cases, using SelectionRange would be wrong.
+        //
+        // Note: VS Code doesn't provide a `SelectionRange`.
+        if (request.Context.SelectionRange is { } selectionRange &&
+            request.Range.Contains(selectionRange))
+        {
+            request.Range = selectionRange;
+        }
+    }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostCodeActionsEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostCodeActionsEndpoint.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost.Handlers;
+using Microsoft.CodeAnalysis.Razor.CodeActions;
 using Microsoft.CodeAnalysis.Razor.CodeActions.Models;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Protocol.CodeActions;
@@ -72,19 +73,7 @@ internal sealed class CohostCodeActionsEndpoint(
         var correlationId = Guid.NewGuid();
         using var _ = _telemetryReporter.TrackLspRequest(Methods.TextDocumentCodeActionName, LanguageServerConstants.RazorLanguageServerName, TelemetryThresholds.CodeActionRazorTelemetryThreshold, correlationId);
 
-        // VS Provides `CodeActionParams.Context.SelectionRange` in addition to
-        // `CodeActionParams.Range`. The `SelectionRange` is relative to where the
-        // code action was invoked (ex. line 14, char 3) whereas the `Range` is
-        // always at the start of the line (ex. line 14, char 0). We want to utilize
-        // the relative positioning to ensure we provide code actions for the appropriate
-        // context.
-        //
-        // Note: VS Code doesn't provide a `SelectionRange`.
-        var vsCodeActionContext = request.Context;
-        if (vsCodeActionContext.SelectionRange != null)
-        {
-            request.Range = vsCodeActionContext.SelectionRange;
-        }
+        CodeActionsService.AdjustRequestRangeIfNecessary(request);
 
         var requestInfo = await _remoteServiceInvoker.TryInvokeAsync<IRemoteCodeActionsService, CodeActionRequestInfo>(
             razorDocument.Project.Solution,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndToEndTest.NetFx.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndToEndTest.NetFx.cs
@@ -26,6 +26,30 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEn
     #region CSharp CodeAction Tests
 
     [Fact]
+    public async Task Handle_GenerateConstructor_SelectionOutsideRange()
+    {
+        var input = """
+
+            <div></div>
+
+            @functions
+            {
+                public Goo [|M()|]
+                {
+                    return new Goo();
+                }
+
+                public class {|selection:Goo|}
+                {
+                }
+            }
+
+            """;
+
+        await ValidateCodeActionAsync(input, expected: null, RazorPredefinedCodeRefactoringProviderNames.GenerateConstructorFromMembers);
+    }
+
+    [Fact]
     public async Task Handle_GenerateConstructor()
     {
         var input = """

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndToEndTestBase.NetFx.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndToEndTestBase.NetFx.cs
@@ -160,7 +160,6 @@ public abstract class CodeActionEndToEndTestBase(ITestOutputHelper testOutput) :
             diagnostics,
             selectionRange: selectionRange);
 
-        Assert.NotEmpty(result);
         var codeActionToRun = GetCodeActionToRun(codeAction, childActionIndex, result);
 
         if (expected is null)


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/11536