### PR TITLE
Unskip cohosting diagnostics tests

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/AbstractFilePathService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/AbstractFilePathService.cs
@@ -38,21 +38,22 @@ internal abstract class AbstractFilePathService(LanguageServerFeatureOptions lan
     private string GetRazorFilePath(string filePath)
     {
         var trimIndex = filePath.LastIndexOf(_languageServerFeatureOptions.HtmlVirtualDocumentSuffix);
+
         // We don't check for C# in cohosting, as it will throw, and people might call this method on any
         // random path.
         if (trimIndex == -1 && !_languageServerFeatureOptions.UseRazorCohostServer)
         {
             trimIndex = filePath.LastIndexOf(_languageServerFeatureOptions.CSharpVirtualDocumentSuffix);
-        }
-        else if (_languageServerFeatureOptions.IncludeProjectKeyInGeneratedFilePath)
-        {
+
             // If this is a C# generated file, and we're including the project suffix, then filename will be
             // <Page>.razor.<project slug><c# suffix>
-            // This means we can remove the project key easily, by just looking for the last '.'. The project
-            // slug itself cannot a '.', enforced by the assert below in GetProjectSuffix
-
-            trimIndex = filePath.LastIndexOf('.', trimIndex - 1);
-            Debug.Assert(trimIndex != -1, "There was no project element to the generated file name?");
+            if (_languageServerFeatureOptions.IncludeProjectKeyInGeneratedFilePath)
+            {
+                // We can remove the project key easily, by just looking for the last '.'. The project
+                // slug itself cannot a '.', enforced by the assert below in GetProjectSuffix
+                trimIndex = filePath.LastIndexOf('.', trimIndex - 1);
+                Debug.Assert(trimIndex != -1, "There was no project element to the generated file name?");
+            }
         }
 
         if (trimIndex != -1)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/AbstractFilePathService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/AbstractFilePathService.cs
@@ -15,7 +15,7 @@ internal abstract class AbstractFilePathService(LanguageServerFeatureOptions lan
     public string GetRazorCSharpFilePath(ProjectKey projectKey, string razorFilePath)
         => GetGeneratedFilePath(projectKey, razorFilePath, _languageServerFeatureOptions.CSharpVirtualDocumentSuffix);
 
-    public Uri GetRazorDocumentUri(Uri virtualDocumentUri)
+    public virtual Uri GetRazorDocumentUri(Uri virtualDocumentUri)
     {
         var uriPath = virtualDocumentUri.AbsoluteUri;
         var razorFilePath = GetRazorFilePath(uriPath);
@@ -23,7 +23,7 @@ internal abstract class AbstractFilePathService(LanguageServerFeatureOptions lan
         return uri;
     }
 
-    public bool IsVirtualCSharpFile(Uri uri)
+    public virtual bool IsVirtualCSharpFile(Uri uri)
         => CheckIfFileUriAndExtensionMatch(uri, _languageServerFeatureOptions.CSharpVirtualDocumentSuffix);
 
     public bool IsVirtualHtmlFile(Uri uri)
@@ -37,10 +37,12 @@ internal abstract class AbstractFilePathService(LanguageServerFeatureOptions lan
 
     private string GetRazorFilePath(string filePath)
     {
-        var trimIndex = filePath.LastIndexOf(_languageServerFeatureOptions.CSharpVirtualDocumentSuffix);
-        if (trimIndex == -1)
+        var trimIndex = filePath.LastIndexOf(_languageServerFeatureOptions.HtmlVirtualDocumentSuffix);
+        // We don't check for C# in cohosting, as it will throw, and people might call this method on any
+        // random path.
+        if (trimIndex == -1 && !_languageServerFeatureOptions.UseRazorCohostServer)
         {
-            trimIndex = filePath.LastIndexOf(_languageServerFeatureOptions.HtmlVirtualDocumentSuffix);
+            trimIndex = filePath.LastIndexOf(_languageServerFeatureOptions.CSharpVirtualDocumentSuffix);
         }
         else if (_languageServerFeatureOptions.IncludeProjectKeyInGeneratedFilePath)
         {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/ProjectExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/ProjectExtensions.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor;
 
 namespace Microsoft.CodeAnalysis;
@@ -33,5 +35,20 @@ internal static class ProjectExtensions
         }
 
         return document is not null;
+    }
+
+    /// <summary>
+    /// Finds source generated documents by iterating through all of them. In OOP there are better options!
+    /// </summary>
+    public static async Task<Document?> TryGetSourceGeneratedDocumentFromHintNameAsync(this Project project, string? hintName, CancellationToken cancellationToken)
+    {
+        // TODO: use this when the location is case-insensitive on windows (https://github.com/dotnet/roslyn/issues/76869)
+        //var generator = typeof(RazorSourceGenerator);
+        //var generatorAssembly = generator.Assembly;
+        //var generatorName = generatorAssembly.GetName();
+        //var generatedDocuments = await _project.GetSourceGeneratedDocumentsForGeneratorAsync(generatorName.Name!, generatorAssembly.Location, generatorName.Version!, generator.Name, cancellationToken).ConfigureAwait(false);
+
+        var generatedDocuments = await project.GetSourceGeneratedDocumentsAsync(cancellationToken).ConfigureAwait(false);
+        return generatedDocuments.SingleOrDefault(d => d.HintName == hintName);
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RemoteClientInitializationOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Remote/RemoteClientInitializationOptions.cs
@@ -13,9 +13,6 @@ internal struct RemoteClientInitializationOptions
     [JsonPropertyName("usePreciseSemanticTokenRanges")]
     public required bool UsePreciseSemanticTokenRanges { get; set; }
 
-    [JsonPropertyName("csharpVirtualDocumentSuffix")]
-    public required string CSharpVirtualDocumentSuffix { get; set; }
-
     [JsonPropertyName("htmlVirtualDocumentSuffix")]
     public required string HtmlVirtualDocumentSuffix { get; set; }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Initialization/RemoteLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Initialization/RemoteLanguageServerFeatureOptions.cs
@@ -26,7 +26,7 @@ internal class RemoteLanguageServerFeatureOptions : LanguageServerFeatureOptions
 
     public override bool SupportsFileManipulation => _options.SupportsFileManipulation;
 
-    public override string CSharpVirtualDocumentSuffix => _options.CSharpVirtualDocumentSuffix;
+    public override string CSharpVirtualDocumentSuffix => throw new InvalidOperationException("This property is not valid in OOP");
 
     public override string HtmlVirtualDocumentSuffix => _options.HtmlVirtualDocumentSuffix;
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RemoteFilePathService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/RemoteFilePathService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System;
 using System.Composition;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 
@@ -10,4 +11,18 @@ namespace Microsoft.CodeAnalysis.Remote.Razor;
 [method: ImportingConstructor]
 internal sealed class RemoteFilePathService(LanguageServerFeatureOptions options) : AbstractFilePathService(options)
 {
+    public override Uri GetRazorDocumentUri(Uri virtualDocumentUri)
+    {
+        if (IsVirtualCSharpFile(virtualDocumentUri))
+        {
+            throw new InvalidOperationException("Can not get a Razor document from a generated document Uri in cohosting");
+        }
+
+        return base.GetRazorDocumentUri(virtualDocumentUri);
+    }
+
+    public override bool IsVirtualCSharpFile(Uri uri)
+    {
+        return uri.Scheme == "source-generated";
+    }
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Extensions/TextDocumentExtensions.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Extensions/TextDocumentExtensions.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using Microsoft.CodeAnalysis;
+using Microsoft.NET.Sdk.Razor.SourceGenerators;
+
+namespace Microsoft.VisualStudio.Razor.Extensions;
+
+internal static class TextDocumentExtensions
+{
+    /// <summary>
+    /// This method tries to compute the source generated hint name for a Razor document using only string manipulation
+    /// </summary>
+    /// <remarks>
+    /// This should only be used in the devenv process. In OOP we can look at the actual generated run result to find this
+    /// information.
+    /// </remarks>
+    public static bool TryComputeHintNameFromRazorDocument(this TextDocument razorDocument, [NotNullWhen(true)] out string? hintName)
+    {
+        if (razorDocument.FilePath is null)
+        {
+            hintName = null;
+            return false;
+        }
+
+        var projectBasePath = Path.GetDirectoryName(razorDocument.Project.FilePath);
+        var relativeDocumentPath = razorDocument.FilePath[projectBasePath.Length..].TrimStart('/', '\\');
+        hintName = RazorSourceGenerator.GetIdentifierFromPath(relativeDocumentPath);
+
+        return hintName is not null;
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostDocumentPullDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostDocumentPullDiagnosticsEndpoint.cs
@@ -13,12 +13,12 @@ using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
 using Microsoft.CodeAnalysis.Razor.Logging;
-using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Microsoft.VisualStudio.Razor.Extensions;
 using ExternalHandlers = Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost.Handlers;
 using LspDiagnostic = Microsoft.VisualStudio.LanguageServer.Protocol.Diagnostic;
 using RoslynDiagnostic = Roslyn.LanguageServer.Protocol.Diagnostic;
@@ -124,13 +124,13 @@ internal class CohostDocumentPullDiagnosticsEndpoint(
 
     private async Task<LspDiagnostic[]> GetCSharpDiagnosticsAsync(TextDocument razorDocument, CancellationToken cancellationToken)
     {
-        // TODO: This code will not work when the source generator is hooked up.
-        //       How do we get the source generated C# document without OOP? Can we reverse engineer a file path?
-        var projectKey = razorDocument.Project.ToProjectKey();
-        var csharpFilePath = _filePathService.GetRazorCSharpFilePath(projectKey, razorDocument.FilePath.AssumeNotNull());
-        // We put the project Id in the generated document path, so there can only be one document
-        if (razorDocument.Project.Solution.GetDocumentIdsWithFilePath(csharpFilePath) is not [{ } generatedDocumentId] ||
-            razorDocument.Project.GetDocument(generatedDocumentId) is not { } generatedDocument)
+        if (!razorDocument.TryComputeHintNameFromRazorDocument(out var hintName))
+        {
+            return [];
+        }
+
+        var generatedDocuments = await razorDocument.Project.GetSourceGeneratedDocumentsAsync(cancellationToken);
+        if (generatedDocuments.FirstOrDefault(d => d.HintName == hintName) is not { } generatedDocument)
         {
             return [];
         }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostDocumentPullDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostDocumentPullDiagnosticsEndpoint.cs
@@ -15,7 +15,6 @@ using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Remote;
-using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.Razor.Extensions;
@@ -36,14 +35,12 @@ internal class CohostDocumentPullDiagnosticsEndpoint(
     IRemoteServiceInvoker remoteServiceInvoker,
     IHtmlDocumentSynchronizer htmlDocumentSynchronizer,
     LSPRequestInvoker requestInvoker,
-    IFilePathService filePathService,
     ILoggerFactory loggerFactory)
     : AbstractRazorCohostDocumentRequestHandler<VSInternalDocumentDiagnosticsParams, VSInternalDiagnosticReport[]?>, IDynamicRegistrationProvider
 {
     private readonly IRemoteServiceInvoker _remoteServiceInvoker = remoteServiceInvoker;
     private readonly IHtmlDocumentSynchronizer _htmlDocumentSynchronizer = htmlDocumentSynchronizer;
     private readonly LSPRequestInvoker _requestInvoker = requestInvoker;
-    private readonly IFilePathService _filePathService = filePathService;
     private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<CohostDocumentPullDiagnosticsEndpoint>();
 
     protected override bool MutatesSolutionState => false;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostDocumentPullDiagnosticsEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/CohostDocumentPullDiagnosticsEndpoint.cs
@@ -121,13 +121,8 @@ internal class CohostDocumentPullDiagnosticsEndpoint(
 
     private async Task<LspDiagnostic[]> GetCSharpDiagnosticsAsync(TextDocument razorDocument, CancellationToken cancellationToken)
     {
-        if (!razorDocument.TryComputeHintNameFromRazorDocument(out var hintName))
-        {
-            return [];
-        }
-
-        var generatedDocuments = await razorDocument.Project.GetSourceGeneratedDocumentsAsync(cancellationToken);
-        if (generatedDocuments.FirstOrDefault(d => d.HintName == hintName) is not { } generatedDocument)
+        if (!razorDocument.TryComputeHintNameFromRazorDocument(out var hintName) ||
+            await razorDocument.Project.TryGetSourceGeneratedDocumentFromHintNameAsync(hintName, cancellationToken).ConfigureAwait(false) is not { } generatedDocument)
         {
             return [];
         }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/RemoteServiceInvoker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Remote/RemoteServiceInvoker.cs
@@ -169,7 +169,6 @@ internal sealed class RemoteServiceInvoker(
                 {
                     UseRazorCohostServer = _languageServerFeatureOptions.UseRazorCohostServer,
                     UsePreciseSemanticTokenRanges = _languageServerFeatureOptions.UsePreciseSemanticTokenRanges,
-                    CSharpVirtualDocumentSuffix = _languageServerFeatureOptions.CSharpVirtualDocumentSuffix,
                     HtmlVirtualDocumentSuffix = _languageServerFeatureOptions.HtmlVirtualDocumentSuffix,
                     IncludeProjectKeyInGeneratedFilePath = _languageServerFeatureOptions.IncludeProjectKeyInGeneratedFilePath,
                     ReturnCodeActionAndRenamePathsWithPrefixedSlash = _languageServerFeatureOptions.ReturnCodeActionAndRenamePathsWithPrefixedSlash,

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentPullDiagnosticsTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentPullDiagnosticsTest.cs
@@ -144,7 +144,7 @@ public class CohostDocumentPullDiagnosticsTest(FuseTestContext context, ITestOut
 
         var requestInvoker = new TestLSPRequestInvoker([(VSInternalMethods.DocumentPullDiagnosticName, htmlResponse)]);
 
-        var endpoint = new CohostDocumentPullDiagnosticsEndpoint(RemoteServiceInvoker, TestHtmlDocumentSynchronizer.Instance, requestInvoker, FilePathService, LoggerFactory);
+        var endpoint = new CohostDocumentPullDiagnosticsEndpoint(RemoteServiceInvoker, TestHtmlDocumentSynchronizer.Instance, requestInvoker, LoggerFactory);
 
         var result = await endpoint.GetTestAccessor().HandleRequestAsync(document, DisposalToken);
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentPullDiagnosticsTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentPullDiagnosticsTest.cs
@@ -17,7 +17,7 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 
 public class CohostDocumentPullDiagnosticsTest(FuseTestContext context, ITestOutputHelper testOutputHelper) : CohostEndpointTestBase(testOutputHelper), IClassFixture<FuseTestContext>
 {
-    [FuseFact(Skip = "Need to get generated C# doc without OOP")]
+    [FuseFact]
     public Task CSharp()
         => VerifyDiagnosticsAsync("""
             <div></div>
@@ -107,7 +107,7 @@ public class CohostDocumentPullDiagnosticsTest(FuseTestContext context, ITestOut
             }]);
     }
 
-    [FuseFact(Skip = "Need to get generated C# doc without OOP")]
+    [FuseFact]
     public Task CombinedAndNestedDiagnostics()
         => VerifyDiagnosticsAsync("""
             @using System.Threading.Tasks;

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostEndpointTestBase.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostEndpointTestBase.cs
@@ -32,7 +32,6 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 
 public abstract class CohostEndpointTestBase(ITestOutputHelper testOutputHelper) : ToolingTestBase(testOutputHelper)
 {
-    private const string CSharpVirtualDocumentSuffix = ".g.cs";
     private ExportProvider? _exportProvider;
     private TestRemoteServiceInvoker? _remoteServiceInvoker;
     private RemoteClientInitializationOptions _clientInitializationOptions;
@@ -76,7 +75,6 @@ public abstract class CohostEndpointTestBase(ITestOutputHelper testOutputHelper)
 
         _clientInitializationOptions = new()
         {
-            CSharpVirtualDocumentSuffix = CSharpVirtualDocumentSuffix,
             HtmlVirtualDocumentSuffix = ".g.html",
             IncludeProjectKeyInGeneratedFilePath = false,
             UsePreciseSemanticTokenRanges = false,


### PR DESCRIPTION
Step one of The Great Unskippening!™

Part of https://github.com/dotnet/razor/issues/10693

It is no longer simply possible to use string manipulation to get a generated C# document path from a Razor document path. The alternative options for what is available differ depending on which process code is running in. Yay! :)