### PR TITLE
Fix extra JITing

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Initialization/RemoteLanguageServerFeatureOptions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Initialization/RemoteLanguageServerFeatureOptions.cs
@@ -20,9 +20,20 @@ internal class RemoteLanguageServerFeatureOptions : LanguageServerFeatureOptions
     {
         _options = options;
 
-        // ensure the source generator is in the correct mode
-        RazorSourceGenerator.UseRazorCohostServer = options.UseRazorCohostServer;
+        if (options.UseRazorCohostServer)
+        {
+            // ensure the source generator is in the correct mode
+            SetGeneratorToCohostMode();
+        }
     }
+
+    /// <summary>
+    /// Sets the generator into cohosting mode.
+    /// </summary>
+    /// <remarks>
+    /// This is explicitly a separate method so that if not used we don't unnecessarily JIT any of the generator code.
+    /// </remarks>
+    private static void SetGeneratorToCohostMode() => RazorSourceGenerator.UseRazorCohostServer = true;
 
     public override bool SupportsFileManipulation => _options.SupportsFileManipulation;
 


### PR DESCRIPTION
Move static accessor into separate method so we don't JIT it unless we're turning it on
