### PR TITLE
Don't send invalid ranges for diagnostics if they do not map

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Diagnostics/RazorTranslateDiagnosticsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Diagnostics/RazorTranslateDiagnosticsService.cs
@@ -501,7 +501,7 @@ internal class RazorTranslateDiagnosticsService(IDocumentMappingService document
             // for mapping when a user reports not seeing an error they thought they should
             if (diagnostic.Severity == LspDiagnosticSeverity.Error)
             {
-                this._logger.LogDebug($"Dropping diagnostic {diagnostic.Code}:{diagnostic.Message} at csharp range {diagnostic.Range}");
+                this._logger.LogWarning($"Dropping diagnostic {diagnostic.Code}:{diagnostic.Message} at csharp range {diagnostic.Range}");
             }
 
             return false;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Diagnostics/RazorTranslateDiagnosticsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Diagnostics/RazorTranslateDiagnosticsService.cs
@@ -497,16 +497,14 @@ internal class RazorTranslateDiagnosticsService(IDocumentMappingService document
             out originalRange))
         {
             // Couldn't remap the range correctly.
-            // If this isn't an `Error` Severity Diagnostic we can discard it.
-            if (diagnostic.Severity != LspDiagnosticSeverity.Error)
+            // If this is error it's worth at least logging so we know if there's an issue
+            // for mapping when a user reports not seeing an error they thought they should
+            if (diagnostic.Severity == LspDiagnosticSeverity.Error)
             {
-                return false;
+                this._logger.LogDebug($"Dropping diagnostic {diagnostic.Code}:{diagnostic.Message} at csharp range {diagnostic.Range}");
             }
 
-            // For `Error` Severity diagnostics we still show the diagnostics to
-            // the user, however we set the range to an undefined range to ensure
-            // clicking on the diagnostic doesn't cause errors.
-            originalRange = VsLspFactory.UndefinedRange;
+            return false;
         }
 
         return true;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsPublisherTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsPublisherTest.cs
@@ -193,6 +193,12 @@ public class RazorDiagnosticsPublisherTest : LanguageServerTestBase
             await UpdateWithErrorTextAsync();
         }
 
+        var openDocument = _projectManager.GetRequiredDocument(s_hostProject.Key, s_openHostDocument.FilePath);
+
+        var generatedDocument = await openDocument.GetGeneratedOutputAsync(DisposalToken).ConfigureAwait(false);
+        var csharpDocument = generatedDocument.GetCSharpDocument();
+        var diagnosticRange = csharpDocument.Text.GetRange(csharpDocument.SourceMappings[0].GeneratedSpan);
+
         var singleCSharpDiagnostic = new[]
         {
             new Diagnostic()
@@ -200,11 +206,9 @@ public class RazorDiagnosticsPublisherTest : LanguageServerTestBase
                 Code = "TestCode",
                 Severity = DiagnosticSeverity.Error,
                 Message = "TestMessage",
-                Range = VsLspFactory.CreateSingleLineRange(line: 0, character: 0, length: 1)
+                Range = diagnosticRange
             }
         };
-
-        var openDocument = _projectManager.GetRequiredDocument(s_hostProject.Key, s_openHostDocument.FilePath);
 
         var clientConnectionMock = new StrictMock<IClientConnection>();
         var requestResult = new FullDocumentDiagnosticReport();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsPublisherTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Diagnostics/RazorDiagnosticsPublisherTest.cs
@@ -195,7 +195,7 @@ public class RazorDiagnosticsPublisherTest : LanguageServerTestBase
 
         var openDocument = _projectManager.GetRequiredDocument(s_hostProject.Key, s_openHostDocument.FilePath);
 
-        var generatedDocument = await openDocument.GetGeneratedOutputAsync(DisposalToken).ConfigureAwait(false);
+        var generatedDocument = await openDocument.GetGeneratedOutputAsync(DisposalToken);
         var csharpDocument = generatedDocument.GetCSharpDocument();
         var diagnosticRange = csharpDocument.Text.GetRange(csharpDocument.SourceMappings[0].GeneratedSpan);
 


### PR DESCRIPTION
TLDR: This was always wrong. The spec doesn't say anything, but VS Code always threw in converting these diagnostics (silently) and VS seems to do the same. 

VS Code had a lot of version bumps in this change https://github.com/dotnet/vscode-csharp/pull/7984

Unfortunately, that changed `vscode-languageclient` from `8.2.0-next.1` to `10.0.0-next.14`. Functionally this wasn't a problem, but it did add a sneaky line here to helpfully let extension developers know they are doing something wrong very loudly [microsoft/vscode-languageserver-node@`release/client/8.2.0-next.1...release/client/10.0.0-next.14`#diff-1442f78812](https://github.com/microsoft/vscode-languageserver-node/compare/release/client/8.2.0-next.1...release/client/10.0.0-next.14#diff-1442f78812d67be25f18d3b5d82e8b4191ae2f939a900eac32d4360222c5d845R1734) 

This change meant that diagnostics we sent prior that could not be converted correctly (such as a negative line number) would silently bubble up and be dropped. Now there is an error reported that matches exactly what https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2397532/?view=edit reports. 

From testing VS also drops these diagnostics so there's no real point in keeping them. I'd rather find bugs where a user expects diagnostics that aren't there than yell at a user for our code doing bad things. 


