### PR TITLE
Make logging fall into the pit of success

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Logging/Handlers/LogMessageInterpolatedStringHandler.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Logging/Handlers/LogMessageInterpolatedStringHandler.cs
@@ -4,6 +4,8 @@
 using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.AspNetCore.Razor.PooledObjects;
+using Microsoft.VisualStudio.LanguageServer.Protocol;
+using Roslyn.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.Razor.Logging;
 
@@ -32,7 +34,7 @@ internal ref struct LogMessageInterpolatedStringHandler
 
     public void AppendFormatted<T>(T t)
     {
-        _builder.Object.Append(t?.ToString() ?? "[null]");
+        _builder.Object.Append(GetMessage(t));
     }
 
     public void AppendFormatted<T>(T t, string format)
@@ -46,4 +48,19 @@ internal ref struct LogMessageInterpolatedStringHandler
         _builder.Dispose();
         return result;
     }
+
+    private static string GetMessage(object? value)
+        => value switch
+        {
+            VisualStudio.LanguageServer.Protocol.Range range => range.ToDisplayString(),
+            VisualStudio.LanguageServer.Protocol.Position position => position.ToDisplayString(),
+            VisualStudio.LanguageServer.Protocol.ISumType sumType => GetMessage(sumType.Value),
+
+            Roslyn.LanguageServer.Protocol.Range range => range.ToDisplayString(),
+            Roslyn.LanguageServer.Protocol.Position position => position.ToDisplayString(),
+            Roslyn.LanguageServer.Protocol.ISumType sumType => GetMessage(sumType.Value),
+
+            null => "[null]",
+            _ => value.ToString() ?? "[null]"
+        };
 }


### PR DESCRIPTION
A bright eyed young developer recently added a log message to our code, because they wanted to be kind, helpful, and allow Razor tooling developers to help customers track down issues in future. Little did they know that our logging infrastructure was actually the PIT OF DESPAIR in disguise! To save this kind soul, and hopefully avoid their drive for success from being beaten down further that our regular baseline level of despair these days, I have decided to renovate the pit into a pit of success!

Before:

``[LSP][Diagnostics.RazorTranslateDiagnosticsService] [08:20:43.7052932] Dropping diagnostic Microsoft.VisualStudio.LanguageServer.Protocol.SumType`2[System.Int32,System.String]:; expected at csharp range Microsoft.VisualStudio.LanguageServer.Protocol.Range``

After:

`[LSP][Diagnostics.RazorTranslateDiagnosticsService] [08:20:43.7052932] Dropping diagnostic CS1002:; expected at csharp range (134, 22)-(134, 22)`