### PR TITLE
Change symbol publishing for more reliable builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,6 +28,9 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
 
+    <!-- VS does not require Windows PDBs to be published anymore. -->
+    <PublishWindowsPdb>false</PublishWindowsPdb>
+
     <SharedSourceRoot>$(MSBuildThisFileDirectory)src\Shared\</SharedSourceRoot>
     <SharedFilesRoot>$(SharedSourceRoot)files\</SharedFilesRoot>
 

--- a/src/Analyzers/Directory.Build.props
+++ b/src/Analyzers/Directory.Build.props
@@ -8,9 +8,6 @@
     <IncludeSymbols>true</IncludeSymbols>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 
-    <!-- In theory we want to have this property set, but our pipeline doesn't set the access tokens yet -->
-    <PublishWindowsPdb Condition="'$(DotNetSymbolServerTokenMsdl)'!='' and '$(DotNetSymbolServerTokenSymWeb)'!=''">true</PublishWindowsPdb>
-
     <RollForward Condition="'$(IsTestProject)' == 'true'">LatestMajor</RollForward>
   </PropertyGroup>
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Microsoft.CodeAnalysis.Razor.Compiler.csproj
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Microsoft.CodeAnalysis.Razor.Compiler.csproj
@@ -4,6 +4,9 @@
     <Description>Razor is a markup syntax for adding server-side logic to web pages. This package contains the Razor compiler.</Description>
     <TargetFrameworks>$(DefaultNetCoreTargetFramework);netstandard2.0</TargetFrameworks>
     <ExcludeFromSourceOnlyBuild>false</ExcludeFromSourceOnlyBuild>
+    <IsPackable>true</IsPackable>
+    <IsShippingAssembly>true</IsShippingAssembly>
+    <IncludeSymbols>true</IncludeSymbols>
 
     <!--
       RS2008: Enable analyzer release tracking

--- a/src/Razor/src/Directory.Build.props
+++ b/src/Razor/src/Directory.Build.props
@@ -7,9 +7,6 @@
     <IsShipping>true</IsShipping>
     <IncludeSymbols>true</IncludeSymbols>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-
-    <!-- In theory we want to have this property set, but our pipeline doesn't set the access tokens yet -->
-    <PublishWindowsPdb Condition="'$(DotNetSymbolServerTokenMsdl)'!='' and '$(DotNetSymbolServerTokenSymWeb)'!=''">true</PublishWindowsPdb>
   </PropertyGroup>
 
 </Project>

--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
@@ -19,7 +19,8 @@
     <!-- Update the VSToolsPath to ensure VSIX builds -->
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
-    <IsPackable>false</IsPackable>
+    <IsPackable>true</IsPackable>
+    <IsShippingAssembly>true</IsShippingAssembly>
 
     <GenerateResourceUsePreserializedResources Condition="'$(MSBuildRuntimeType)' == 'Core'">true</GenerateResourceUsePreserializedResources>
 

--- a/src/Shared/Directory.Build.props
+++ b/src/Shared/Directory.Build.props
@@ -8,9 +8,6 @@
     <IncludeSymbols>true</IncludeSymbols>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 
-    <!-- In theory we want to have this property set, but our pipeline doesn't set the access tokens yet -->
-    <PublishWindowsPdb Condition="'$(DotNetSymbolServerTokenMsdl)'!='' and '$(DotNetSymbolServerTokenSymWeb)'!=''">true</PublishWindowsPdb>
-
     <RollForward Condition="'$(IsTestProject)' == 'true'">LatestMajor</RollForward>
   </PropertyGroup>
 


### PR DESCRIPTION
Change symbol publishing for more reliable builds

Undoes #11568 
Set "IsPackable"
Set "IncludeSymbols"
Set "IsShippingAssembly"
