### PR TITLE
Stop allowing FileKind to be set on a RazorCodeDocument independently from the RazorParserOptions

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/DefaultRazorProjectEngineIntegrationTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/DefaultRazorProjectEngineIntegrationTest.cs
@@ -153,7 +153,7 @@ public class DefaultRazorProjectEngineIntegrationTest
         var codeDocument = projectEngine.Process(RazorSourceDocument.ReadFrom(projectItem), "test", importSources: default, tagHelpers: null);
 
         // Assert
-        var actual = codeDocument.GetFileKind();
+        var actual = codeDocument.FileKind;
         Assert.Equal("test", actual);
     }
 
@@ -201,7 +201,7 @@ public class DefaultRazorProjectEngineIntegrationTest
         var codeDocument = projectEngine.Process(projectItem);
 
         // Assert
-        var actual = codeDocument.GetFileKind();
+        var actual = codeDocument.FileKind;
         Assert.Same(FileKinds.Legacy, actual);
     }
 
@@ -217,7 +217,7 @@ public class DefaultRazorProjectEngineIntegrationTest
         var codeDocument = projectEngine.Process(projectItem);
 
         // Assert
-        var actual = codeDocument.GetFileKind();
+        var actual = codeDocument.FileKind;
         Assert.Same(FileKinds.Component, actual);
     }
 
@@ -288,7 +288,7 @@ public class DefaultRazorProjectEngineIntegrationTest
         var codeDocument = projectEngine.ProcessDesignTime(projectItem);
 
         // Assert
-        var actual = codeDocument.GetFileKind();
+        var actual = codeDocument.FileKind;
         Assert.Same(FileKinds.Legacy, actual);
     }
 
@@ -304,7 +304,7 @@ public class DefaultRazorProjectEngineIntegrationTest
         var codeDocument = projectEngine.ProcessDesignTime(projectItem);
 
         // Assert
-        var actual = codeDocument.GetFileKind();
+        var actual = codeDocument.FileKind;
         Assert.Same(FileKinds.Component, actual);
     }
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/RazorCodeDocumentExtensionsTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/RazorCodeDocumentExtensionsTest.cs
@@ -300,7 +300,6 @@ public class RazorCodeDocumentExtensionsTest
             filePath: "C:\\Hello\\Components\\Test.cshtml",
             relativePath: "\\Components\\Test.cshtml");
 
-
         var codeDocument = RazorCodeDocument.Create(
             source,
             parserOptions: RazorParserOptions.Create(RazorLanguageVersion.Latest, FileKinds.Component, builder =>

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/RazorCodeDocumentExtensionsTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/RazorCodeDocumentExtensionsTest.cs
@@ -300,12 +300,15 @@ public class RazorCodeDocumentExtensionsTest
             filePath: "C:\\Hello\\Components\\Test.cshtml",
             relativePath: "\\Components\\Test.cshtml");
 
+
         var codeDocument = RazorCodeDocument.Create(
             source,
-            parserOptions: RazorParserOptions.Default.WithDirectives(NamespaceDirective.Directive),
+            parserOptions: RazorParserOptions.Create(RazorLanguageVersion.Latest, FileKinds.Component, builder =>
+            {
+                builder.Directives = [NamespaceDirective.Directive];
+            }),
             codeGenerationOptions: RazorCodeGenerationOptions.Default.WithRootNamespace("Hello.World"));
 
-        codeDocument.SetFileKind(FileKinds.Component);
         codeDocument.SetSyntaxTree(RazorSyntaxTree.Parse(source, codeDocument.ParserOptions));
 
         // Act
@@ -325,10 +328,12 @@ public class RazorCodeDocumentExtensionsTest
 
         var codeDocument = RazorCodeDocument.Create(
             source,
-            parserOptions: RazorParserOptions.Default.WithDirectives(NamespaceDirective.Directive),
+            parserOptions: RazorParserOptions.Create(RazorLanguageVersion.Latest, FileKinds.Component, builder =>
+            {
+                builder.Directives = [NamespaceDirective.Directive];
+            }),
             codeGenerationOptions: RazorCodeGenerationOptions.Default.WithRootNamespace("Hello.World"));
 
-        codeDocument.SetFileKind(FileKinds.Component);
         codeDocument.SetSyntaxTree(RazorSyntaxTree.Parse(source, codeDocument.ParserOptions));
 
         var importSource = TestRazorSourceDocument.Create(
@@ -356,10 +361,12 @@ public class RazorCodeDocumentExtensionsTest
 
         var codeDocument = RazorCodeDocument.Create(
             source,
-            parserOptions: RazorParserOptions.Default.WithDirectives(NamespaceDirective.Directive),
+            parserOptions: RazorParserOptions.Create(RazorLanguageVersion.Latest, FileKinds.Component, builder =>
+            {
+                builder.Directives = [NamespaceDirective.Directive];
+            }),
             codeGenerationOptions: RazorCodeGenerationOptions.Default.WithRootNamespace("Hello.World"));
 
-        codeDocument.SetFileKind(FileKinds.Component);
         codeDocument.SetSyntaxTree(RazorSyntaxTree.Parse(source, codeDocument.ParserOptions));
 
         var importSource = TestRazorSourceDocument.Create(
@@ -388,9 +395,11 @@ public class RazorCodeDocumentExtensionsTest
 
         var codeDocument = RazorCodeDocument.Create(
             source,
-            parserOptions: RazorParserOptions.Default.WithDirectives(NamespaceDirective.Directive));
+            parserOptions: RazorParserOptions.Create(RazorLanguageVersion.Latest, FileKinds.Component, builder =>
+            {
+                builder.Directives = [NamespaceDirective.Directive];
+            }));
 
-        codeDocument.SetFileKind(FileKinds.Component);
         codeDocument.SetSyntaxTree(RazorSyntaxTree.Parse(source, codeDocument.ParserOptions));
 
         var importSource = TestRazorSourceDocument.Create(

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/RazorProjectEngineBuilderExtensionsTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/RazorProjectEngineBuilderExtensionsTest.cs
@@ -121,7 +121,7 @@ public class RazorProjectEngineBuilderExtensionsTest
         });
 
         var features = projectEngine.Engine.GetFeatures<IConfigureRazorCodeGenerationOptionsFeature>().OrderByAsArray(static x => x.Order);
-        var builder = new RazorCodeGenerationOptions.Builder(RazorLanguageVersion.Latest, FileKinds.Legacy);
+        var builder = new RazorCodeGenerationOptions.Builder(RazorLanguageVersion.Latest);
 
         foreach (var feature in features)
         {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/RazorProjectEngineBuilderExtensionsTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/RazorProjectEngineBuilderExtensionsTest.cs
@@ -121,7 +121,7 @@ public class RazorProjectEngineBuilderExtensionsTest
         });
 
         var features = projectEngine.Engine.GetFeatures<IConfigureRazorCodeGenerationOptionsFeature>().OrderByAsArray(static x => x.Order);
-        var builder = new RazorCodeGenerationOptions.Builder(RazorLanguageVersion.Latest);
+        var builder = new RazorCodeGenerationOptions.Builder();
 
         foreach (var feature in features)
         {

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentDocumentClassifierPass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentDocumentClassifierPass.cs
@@ -47,7 +47,7 @@ internal class ComponentDocumentClassifierPass : DocumentClassifierPassBase
 
     protected override bool IsMatch(RazorCodeDocument codeDocument, DocumentIntermediateNode documentNode)
     {
-        return FileKinds.IsComponent(codeDocument.GetFileKind());
+        return FileKinds.IsComponent(codeDocument.FileKind);
     }
 
     protected override CodeTarget CreateTarget(RazorCodeDocument codeDocument, RazorCodeGenerationOptions options)
@@ -95,7 +95,7 @@ internal class ComponentDocumentClassifierPass : DocumentClassifierPassBase
         @class.Modifiers.Add("public");
         @class.Modifiers.Add("partial");
 
-        if (FileKinds.IsComponentImport(codeDocument.GetFileKind()))
+        if (FileKinds.IsComponentImport(codeDocument.FileKind))
         {
             // We don't want component imports to be considered as real component.
             // But we still want to generate code for it so we can get diagnostics.

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentPageDirectivePass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentPageDirectivePass.cs
@@ -38,7 +38,7 @@ internal class ComponentPageDirectivePass : IntermediateNodePassBase, IRazorDire
         for (var i = 0; i < directives.Count; i++)
         {
             var directive = directives[i];
-            if (FileKinds.IsComponentImport(codeDocument.GetFileKind()) || directive.Node.IsImported())
+            if (FileKinds.IsComponentImport(codeDocument.FileKind) || directive.Node.IsImported())
             {
                 directive.Node.Diagnostics.Add(ComponentDiagnosticFactory.CreatePageDirective_CannotBeImported(directive.Node.Source.GetValueOrDefault()));
             }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultDirectiveSyntaxTreePass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultDirectiveSyntaxTreePass.cs
@@ -14,7 +14,7 @@ internal class DefaultDirectiveSyntaxTreePass : RazorEngineFeatureBase, IRazorSy
 
     public RazorSyntaxTree Execute(RazorCodeDocument codeDocument, RazorSyntaxTree syntaxTree)
     {
-        if (FileKinds.IsComponent(codeDocument.GetFileKind()))
+        if (FileKinds.IsComponent(codeDocument.FileKind))
         {
             // Nothing to do here.
             return syntaxTree;

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultRazorIntermediateNodeLoweringPhase.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultRazorIntermediateNodeLoweringPhase.cs
@@ -43,7 +43,7 @@ internal class DefaultRazorIntermediateNodeLoweringPhase : RazorEnginePhaseBase,
         // We need to decide up front if this document is a "component" file. This will affect how
         // lowering behaves.
         LoweringVisitor visitor;
-        if (FileKinds.IsComponentImport(codeDocument.GetFileKind()) &&
+        if (FileKinds.IsComponentImport(codeDocument.FileKind) &&
             syntaxTree.Options.AllowComponentFileKind)
         {
             visitor = new ComponentImportFileKindVisitor(documentNode, builder, syntaxTree.Options)
@@ -53,7 +53,7 @@ internal class DefaultRazorIntermediateNodeLoweringPhase : RazorEnginePhaseBase,
 
             visitor.Visit(syntaxTree.Root);
         }
-        else if (FileKinds.IsComponent(codeDocument.GetFileKind()) &&
+        else if (FileKinds.IsComponent(codeDocument.FileKind) &&
             syntaxTree.Options.AllowComponentFileKind)
         {
             visitor = new ComponentFileKindVisitor(documentNode, builder, syntaxTree.Options)

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultRazorTagHelperContextDiscoveryPhase_Pooling.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultRazorTagHelperContextDiscoveryPhase_Pooling.cs
@@ -52,7 +52,7 @@ internal partial class DefaultRazorTagHelperContextDiscoveryPhase
         out DirectiveVisitor visitor)
     {
         var useComponentDirectiveVisitor = codeDocument.ParserOptions.AllowComponentFileKind &&
-                                           FileKinds.IsComponent(codeDocument.GetFileKind());
+                                           FileKinds.IsComponent(codeDocument.FileKind);
 
         if (useComponentDirectiveVisitor)
         {

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Extensions/FunctionsDirectivePass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Extensions/FunctionsDirectivePass.cs
@@ -23,7 +23,7 @@ public sealed class FunctionsDirectivePass : IntermediateNodePassBase, IRazorDir
         var directiveNodes = new List<IntermediateNodeReference>();
         directiveNodes.AddRange(documentNode.FindDirectiveReferences(FunctionsDirective.Directive));
 
-        if (FileKinds.IsComponent(codeDocument.GetFileKind()))
+        if (FileKinds.IsComponent(codeDocument.FileKind))
         {
             directiveNodes.AddRange(documentNode.FindDirectiveReferences(ComponentCodeDirective.Directive));
         }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeDocument.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeDocument.cs
@@ -15,8 +15,6 @@ public sealed class RazorCodeDocument
     public RazorParserOptions ParserOptions { get; }
     public RazorCodeGenerationOptions CodeGenerationOptions { get; }
 
-    private string? _fileKind;
-
     private RazorCodeDocument(
         RazorSourceDocument source,
         ImmutableArray<RazorSourceDocument> imports,
@@ -54,10 +52,5 @@ public sealed class RazorCodeDocument
     }
 
     public string? GetFileKind()
-        => _fileKind;
-
-    public void SetFileKind(string fileKind)
-    {
-        _fileKind = fileKind;
-    }
+        => ParserOptions.FileKind;
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeDocument.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeDocument.cs
@@ -15,6 +15,8 @@ public sealed class RazorCodeDocument
     public RazorParserOptions ParserOptions { get; }
     public RazorCodeGenerationOptions CodeGenerationOptions { get; }
 
+    public string FileKind => ParserOptions.FileKind;
+
     private RazorCodeDocument(
         RazorSourceDocument source,
         ImmutableArray<RazorSourceDocument> imports,
@@ -50,7 +52,4 @@ public sealed class RazorCodeDocument
 
         return new RazorCodeDocument(source, imports, parserOptions, codeGenerationOptions);
     }
-
-    public string? GetFileKind()
-        => ParserOptions.FileKind;
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeDocument.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeDocument.cs
@@ -15,6 +15,8 @@ public sealed class RazorCodeDocument
     public RazorParserOptions ParserOptions { get; }
     public RazorCodeGenerationOptions CodeGenerationOptions { get; }
 
+    private string? _fileKind;
+
     private RazorCodeDocument(
         RazorSourceDocument source,
         ImmutableArray<RazorSourceDocument> imports,
@@ -49,5 +51,13 @@ public sealed class RazorCodeDocument
         ArgHelper.ThrowIfNull(source);
 
         return new RazorCodeDocument(source, imports, parserOptions, codeGenerationOptions);
+    }
+
+    public string? GetFileKind()
+        => _fileKind;
+
+    public void SetFileKind(string fileKind)
+    {
+        _fileKind = fileKind;
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeDocumentExtensions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeDocumentExtensions.cs
@@ -202,26 +202,6 @@ public static class RazorCodeDocumentExtensions
         document.Items[typeof(RazorCSharpDocument)] = csharp;
     }
 
-    public static string GetFileKind(this RazorCodeDocument document)
-    {
-        if (document == null)
-        {
-            throw new ArgumentNullException(nameof(document));
-        }
-
-        return (string)document.Items[typeof(FileKinds)];
-    }
-
-    public static void SetFileKind(this RazorCodeDocument document, string fileKind)
-    {
-        if (document == null)
-        {
-            throw new ArgumentNullException(nameof(document));
-        }
-
-        document.Items[typeof(FileKinds)] = fileKind;
-    }
-
     public static string GetCssScope(this RazorCodeDocument document)
     {
         if (document == null)

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeDocumentExtensions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeDocumentExtensions.cs
@@ -340,7 +340,7 @@ public static class RazorCodeDocumentExtensions
                 appendSuffix = true;
 
                 // Empty RootNamespace is allowed only in components.
-                if (!FileKinds.IsComponent(codeDocument.GetFileKind()) && string.IsNullOrEmpty(baseNamespace))
+                if (!FileKinds.IsComponent(codeDocument.FileKind) && string.IsNullOrEmpty(baseNamespace))
                 {
                     @namespace = null;
                     return false;

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeGenerationOptions.Builder.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeGenerationOptions.Builder.cs
@@ -7,8 +7,6 @@ public sealed partial class RazorCodeGenerationOptions
 {
     public sealed class Builder
     {
-        public RazorLanguageVersion LanguageVersion { get; }
-
         private Flags _flags;
 
         public int IndentSize { get; set; }
@@ -24,9 +22,8 @@ public sealed partial class RazorCodeGenerationOptions
         /// </summary>
         public string? SuppressUniqueIds { get; set; }
 
-        internal Builder(RazorLanguageVersion languageVersion)
+        internal Builder()
         {
-            LanguageVersion = languageVersion ?? DefaultLanguageVersion;
             IndentSize = DefaultIndentSize;
             NewLine = DefaultNewLine;
         }
@@ -157,6 +154,6 @@ public sealed partial class RazorCodeGenerationOptions
         }
 
         public RazorCodeGenerationOptions ToOptions()
-            => new(LanguageVersion, IndentSize, NewLine, RootNamespace, SuppressUniqueIds, _flags);
+            => new(IndentSize, NewLine, RootNamespace, SuppressUniqueIds, _flags);
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeGenerationOptions.Builder.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeGenerationOptions.Builder.cs
@@ -8,7 +8,6 @@ public sealed partial class RazorCodeGenerationOptions
     public sealed class Builder
     {
         public RazorLanguageVersion LanguageVersion { get; }
-        public string FileKind { get; }
 
         private Flags _flags;
 
@@ -25,10 +24,9 @@ public sealed partial class RazorCodeGenerationOptions
         /// </summary>
         public string? SuppressUniqueIds { get; set; }
 
-        internal Builder(RazorLanguageVersion languageVersion, string fileKind)
+        internal Builder(RazorLanguageVersion languageVersion)
         {
             LanguageVersion = languageVersion ?? DefaultLanguageVersion;
-            FileKind = fileKind ?? DefaultFileKind;
             IndentSize = DefaultIndentSize;
             NewLine = DefaultNewLine;
         }
@@ -159,6 +157,6 @@ public sealed partial class RazorCodeGenerationOptions
         }
 
         public RazorCodeGenerationOptions ToOptions()
-            => new(LanguageVersion, FileKind, IndentSize, NewLine, RootNamespace, SuppressUniqueIds, _flags);
+            => new(LanguageVersion, IndentSize, NewLine, RootNamespace, SuppressUniqueIds, _flags);
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeGenerationOptions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeGenerationOptions.cs
@@ -8,12 +8,10 @@ namespace Microsoft.AspNetCore.Razor.Language;
 
 public sealed partial class RazorCodeGenerationOptions
 {
-    private static RazorLanguageVersion DefaultLanguageVersion => RazorLanguageVersion.Latest;
     private static int DefaultIndentSize => 4;
     private static string DefaultNewLine => Environment.NewLine;
 
     public static RazorCodeGenerationOptions Default { get; } = new(
-        languageVersion: DefaultLanguageVersion,
         indentSize: DefaultIndentSize,
         newLine: DefaultNewLine,
         rootNamespace: null,
@@ -21,14 +19,11 @@ public sealed partial class RazorCodeGenerationOptions
         flags: Flags.DefaultFlags);
 
     public static RazorCodeGenerationOptions DesignTimeDefault { get; } = new(
-        languageVersion: DefaultLanguageVersion,
         indentSize: DefaultIndentSize,
         newLine: DefaultNewLine,
         rootNamespace: null,
         suppressUniqueIds: null,
         flags: Flags.DefaultDesignTimeFlags);
-
-    public RazorLanguageVersion LanguageVersion { get; }
 
     public int IndentSize { get; }
     public string NewLine { get; }
@@ -46,14 +41,12 @@ public sealed partial class RazorCodeGenerationOptions
     private readonly Flags _flags;
 
     private RazorCodeGenerationOptions(
-        RazorLanguageVersion languageVersion,
         int indentSize,
         string newLine,
         string? rootNamespace,
         string? suppressUniqueIds,
         Flags flags)
     {
-        LanguageVersion = languageVersion ?? DefaultLanguageVersion;
         IndentSize = indentSize;
         NewLine = newLine;
         RootNamespace = rootNamespace;
@@ -153,22 +146,22 @@ public sealed partial class RazorCodeGenerationOptions
     public RazorCodeGenerationOptions WithIndentSize(int value)
         => IndentSize == value
             ? this
-            : new(LanguageVersion, value, NewLine, RootNamespace, SuppressUniqueIds, _flags);
+            : new(value, NewLine, RootNamespace, SuppressUniqueIds, _flags);
 
     public RazorCodeGenerationOptions WithNewLine(string value)
         => NewLine == value
             ? this
-            : new(LanguageVersion, IndentSize, value, RootNamespace, SuppressUniqueIds, _flags);
+            : new(IndentSize, value, RootNamespace, SuppressUniqueIds, _flags);
 
     public RazorCodeGenerationOptions WithRootNamespace(string? value)
         => RootNamespace == value
             ? this
-            : new(LanguageVersion, IndentSize, NewLine, value, SuppressUniqueIds, _flags);
+            : new(IndentSize, NewLine, value, SuppressUniqueIds, _flags);
 
     public RazorCodeGenerationOptions WithSuppressUniqueIds(string? value)
         => RootNamespace == value
             ? this
-            : new(LanguageVersion, IndentSize, NewLine, RootNamespace, value, _flags);
+            : new(IndentSize, NewLine, RootNamespace, value, _flags);
 
     public RazorCodeGenerationOptions WithFlags(
         Optional<bool> designTime = default,
@@ -248,6 +241,6 @@ public sealed partial class RazorCodeGenerationOptions
 
         return flags == _flags
             ? this
-            : new(LanguageVersion, IndentSize, NewLine, RootNamespace, SuppressUniqueIds, flags);
+            : new(IndentSize, NewLine, RootNamespace, SuppressUniqueIds, flags);
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeGenerationOptions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeGenerationOptions.cs
@@ -9,13 +9,11 @@ namespace Microsoft.AspNetCore.Razor.Language;
 public sealed partial class RazorCodeGenerationOptions
 {
     private static RazorLanguageVersion DefaultLanguageVersion => RazorLanguageVersion.Latest;
-    private static string DefaultFileKind => FileKinds.Legacy;
     private static int DefaultIndentSize => 4;
     private static string DefaultNewLine => Environment.NewLine;
 
     public static RazorCodeGenerationOptions Default { get; } = new(
         languageVersion: DefaultLanguageVersion,
-        fileKind: DefaultFileKind,
         indentSize: DefaultIndentSize,
         newLine: DefaultNewLine,
         rootNamespace: null,
@@ -24,7 +22,6 @@ public sealed partial class RazorCodeGenerationOptions
 
     public static RazorCodeGenerationOptions DesignTimeDefault { get; } = new(
         languageVersion: DefaultLanguageVersion,
-        fileKind: DefaultFileKind,
         indentSize: DefaultIndentSize,
         newLine: DefaultNewLine,
         rootNamespace: null,
@@ -32,7 +29,6 @@ public sealed partial class RazorCodeGenerationOptions
         flags: Flags.DefaultDesignTimeFlags);
 
     public RazorLanguageVersion LanguageVersion { get; }
-    internal string FileKind { get; }
 
     public int IndentSize { get; }
     public string NewLine { get; }
@@ -51,7 +47,6 @@ public sealed partial class RazorCodeGenerationOptions
 
     private RazorCodeGenerationOptions(
         RazorLanguageVersion languageVersion,
-        string fileKind,
         int indentSize,
         string newLine,
         string? rootNamespace,
@@ -59,7 +54,6 @@ public sealed partial class RazorCodeGenerationOptions
         Flags flags)
     {
         LanguageVersion = languageVersion ?? DefaultLanguageVersion;
-        FileKind = fileKind ?? DefaultFileKind;
         IndentSize = indentSize;
         NewLine = newLine;
         RootNamespace = rootNamespace;
@@ -159,22 +153,22 @@ public sealed partial class RazorCodeGenerationOptions
     public RazorCodeGenerationOptions WithIndentSize(int value)
         => IndentSize == value
             ? this
-            : new(LanguageVersion, FileKind, value, NewLine, RootNamespace, SuppressUniqueIds, _flags);
+            : new(LanguageVersion, value, NewLine, RootNamespace, SuppressUniqueIds, _flags);
 
     public RazorCodeGenerationOptions WithNewLine(string value)
         => NewLine == value
             ? this
-            : new(LanguageVersion, FileKind, IndentSize, value, RootNamespace, SuppressUniqueIds, _flags);
+            : new(LanguageVersion, IndentSize, value, RootNamespace, SuppressUniqueIds, _flags);
 
     public RazorCodeGenerationOptions WithRootNamespace(string? value)
         => RootNamespace == value
             ? this
-            : new(LanguageVersion, FileKind, IndentSize, NewLine, value, SuppressUniqueIds, _flags);
+            : new(LanguageVersion, IndentSize, NewLine, value, SuppressUniqueIds, _flags);
 
     public RazorCodeGenerationOptions WithSuppressUniqueIds(string? value)
         => RootNamespace == value
             ? this
-            : new(LanguageVersion, FileKind, IndentSize, NewLine, RootNamespace, value, _flags);
+            : new(LanguageVersion, IndentSize, NewLine, RootNamespace, value, _flags);
 
     public RazorCodeGenerationOptions WithFlags(
         Optional<bool> designTime = default,
@@ -254,6 +248,6 @@ public sealed partial class RazorCodeGenerationOptions
 
         return flags == _flags
             ? this
-            : new(LanguageVersion, FileKind, IndentSize, NewLine, RootNamespace, SuppressUniqueIds, flags);
+            : new(LanguageVersion, IndentSize, NewLine, RootNamespace, SuppressUniqueIds, flags);
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeGenerationOptions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorCodeGenerationOptions.cs
@@ -54,6 +54,14 @@ public sealed partial class RazorCodeGenerationOptions
         _flags = flags;
     }
 
+    public static RazorCodeGenerationOptions Create(Action<Builder> configure)
+    {
+        var builder = new Builder();
+        configure?.Invoke(builder);
+
+        return builder.ToOptions();
+    }
+
     public bool DesignTime
         => _flags.HasFlag(Flags.DesignTime);
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorParserOptions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorParserOptions.cs
@@ -49,6 +49,14 @@ public sealed partial class RazorParserOptions
         _flags = flags;
     }
 
+    public static RazorParserOptions Create(RazorLanguageVersion languageVersion, string fileKind, Action<Builder>? configure = null)
+    {
+        var builder = new Builder(languageVersion, fileKind);
+        configure?.Invoke(builder);
+
+        return builder.ToOptions();
+    }
+
     public bool DesignTime
         => _flags.IsFlagSet(Flags.DesignTime);
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorProjectEngine.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorProjectEngine.cs
@@ -266,7 +266,7 @@ public sealed class RazorProjectEngine
     private RazorCodeGenerationOptions ComputeCodeGenerationOptions(Action<RazorCodeGenerationOptions.Builder>? configure)
     {
         var configuration = Configuration;
-        var builder = new RazorCodeGenerationOptions.Builder(configuration.LanguageVersion)
+        var builder = new RazorCodeGenerationOptions.Builder()
         {
             SuppressAddComponentParameter = configuration.SuppressAddComponentParameter
         };

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorProjectEngine.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorProjectEngine.cs
@@ -191,7 +191,7 @@ public sealed class RazorProjectEngine
         Action<RazorCodeGenerationOptions.Builder>? configureCodeGeneration)
     {
         var parserOptions = ComputeParserOptions(fileKind, configureParser);
-        var codeGenerationOptions = ComputeCodeGenerationOptions(fileKind, configureCodeGeneration);
+        var codeGenerationOptions = ComputeCodeGenerationOptions(configureCodeGeneration);
 
         var codeDocument = RazorCodeDocument.Create(source, importSources, parserOptions, codeGenerationOptions);
 
@@ -233,7 +233,7 @@ public sealed class RazorProjectEngine
             configureParser?.Invoke(builder);
         });
 
-        var codeGenerationOptions = ComputeCodeGenerationOptions(fileKind, builder =>
+        var codeGenerationOptions = ComputeCodeGenerationOptions(builder =>
         {
             builder.DesignTime = true;
             builder.SuppressChecksum = true;
@@ -263,10 +263,10 @@ public sealed class RazorProjectEngine
         return builder.ToOptions();
     }
 
-    private RazorCodeGenerationOptions ComputeCodeGenerationOptions(string fileKind, Action<RazorCodeGenerationOptions.Builder>? configure)
+    private RazorCodeGenerationOptions ComputeCodeGenerationOptions(Action<RazorCodeGenerationOptions.Builder>? configure)
     {
         var configuration = Configuration;
-        var builder = new RazorCodeGenerationOptions.Builder(configuration.LanguageVersion, fileKind)
+        var builder = new RazorCodeGenerationOptions.Builder(configuration.LanguageVersion)
         {
             SuppressAddComponentParameter = configuration.SuppressAddComponentParameter
         };

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorProjectEngine.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorProjectEngine.cs
@@ -196,7 +196,6 @@ public sealed class RazorProjectEngine
         var codeDocument = RazorCodeDocument.Create(source, importSources, parserOptions, codeGenerationOptions);
 
         codeDocument.SetTagHelpers(tagHelpers);
-        codeDocument.SetFileKind(fileKind);
 
         if (cssScope != null)
         {
@@ -246,7 +245,6 @@ public sealed class RazorProjectEngine
         var codeDocument = RazorCodeDocument.Create(sourceDocument, importSources, parserOptions, codeGenerationOptions);
 
         codeDocument.SetTagHelpers(tagHelpers);
-        codeDocument.SetFileKind(fileKind);
 
         return codeDocument;
     }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LinkedEditingRange/LinkedEditingRangeEndpoint.cs
@@ -45,7 +45,7 @@ internal class LinkedEditingRangeEndpoint(ILoggerFactory loggerFactory)
         var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
         if (codeDocument.IsUnsupported())
         {
-            _logger.LogWarning($"FileKind {codeDocument.GetFileKind()} is unsupported");
+            _logger.LogWarning($"FileKind {codeDocument.FileKind} is unsupported");
             return null;
         }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/Razor/CreateComponentCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/Razor/CreateComponentCodeActionResolver.cs
@@ -40,7 +40,7 @@ internal class CreateComponentCodeActionResolver(LanguageServerFeatureOptions la
             return null;
         }
 
-        if (!FileKinds.IsComponent(codeDocument.GetFileKind()))
+        if (!FileKinds.IsComponent(codeDocument.FileKind))
         {
             return null;
         }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/Razor/ExtractToCodeBehindCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/Razor/ExtractToCodeBehindCodeActionProvider.cs
@@ -31,7 +31,7 @@ internal class ExtractToCodeBehindCodeActionProvider(ILoggerFactory loggerFactor
             return SpecializedTasks.EmptyImmutableArray<RazorVSInternalCodeAction>();
         }
 
-        if (!FileKinds.IsComponent(context.CodeDocument.GetFileKind()))
+        if (!FileKinds.IsComponent(context.CodeDocument.FileKind))
         {
             return SpecializedTasks.EmptyImmutableArray<RazorVSInternalCodeAction>();
         }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/Razor/ExtractToCodeBehindCodeActionResolver.cs
@@ -45,7 +45,7 @@ internal class ExtractToCodeBehindCodeActionResolver(
             return null;
         }
 
-        if (!FileKinds.IsComponent(codeDocument.GetFileKind()))
+        if (!FileKinds.IsComponent(codeDocument.FileKind))
         {
             return null;
         }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/Razor/ExtractToComponentCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/Razor/ExtractToComponentCodeActionProvider.cs
@@ -26,7 +26,7 @@ internal class ExtractToComponentCodeActionProvider() : IRazorCodeActionProvider
             return SpecializedTasks.EmptyImmutableArray<RazorVSInternalCodeAction>();
         }
 
-        if (!FileKinds.IsComponent(context.CodeDocument.GetFileKind()))
+        if (!FileKinds.IsComponent(context.CodeDocument.FileKind))
         {
             return SpecializedTasks.EmptyImmutableArray<RazorVSInternalCodeAction>();
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/AddUsingsCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/AddUsingsCodeActionResolverTest.cs
@@ -166,14 +166,22 @@ public class AddUsingsCodeActionResolverTest(ITestOutputHelper testOutput) : Lan
             @model IndexModel
             """;
 
-        var projectItem = new TestRazorProjectItem("c:/Test.cshtml", "c:/Test.cshtml", "Test.cshtml") { Content = contents };
-        var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty, (builder) =>
+        var projectItem = new TestRazorProjectItem(
+            filePath: "c:/Test.cshtml",
+            physicalPath: "c:/Test.cshtml",
+            relativePhysicalPath: "Test.cshtml",
+            fileKind: FileKinds.Legacy)
+        {
+            Content = contents
+        };
+
+        var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty, builder =>
         {
             PageDirective.Register(builder);
             ModelDirective.Register(builder);
         });
+
         var codeDocument = projectEngine.Process(projectItem);
-        codeDocument.SetFileKind(FileKinds.Legacy);
 
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
         var resolver = new AddUsingsCodeActionResolver();
@@ -390,11 +398,21 @@ public class AddUsingsCodeActionResolverTest(ITestOutputHelper testOutput) : Lan
     private static RazorCodeDocument CreateCodeDocument(string text)
     {
         var fileName = "Test.razor";
-        var filePath = "c:/{fileName}";
-        var projectItem = new TestRazorProjectItem(filePath, filePath, fileName) { Content = text };
-        var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty, (builder) => PageDirective.Register(builder));
-        var codeDocument = projectEngine.Process(projectItem);
-        codeDocument.SetFileKind(FileKinds.Component);
-        return codeDocument;
+        var filePath = $"c:/{fileName}";
+        var projectItem = new TestRazorProjectItem(
+            filePath,
+            physicalPath: filePath,
+            relativePhysicalPath: fileName,
+            fileKind: FileKinds.Component)
+        {
+            Content = text
+        };
+
+        var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty, builder =>
+        {
+            PageDirective.Register(builder);
+        });
+
+        return projectEngine.Process(projectItem);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/CSharpCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/CSharpCodeActionProviderTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -59,7 +60,6 @@ public class CSharpCodeActionProviderTest : LanguageServerTestBase
         };
 
         var context = CreateRazorCodeActionContext(request, cursorPosition, documentPath, contents, new SourceSpan(8, 4));
-        context.CodeDocument.SetFileKind(FileKinds.Legacy);
 
         var provider = new CSharpCodeActionProvider(TestLanguageServerFeatureOptions.Instance);
 
@@ -89,7 +89,6 @@ public class CSharpCodeActionProviderTest : LanguageServerTestBase
         };
 
         var context = CreateRazorCodeActionContext(request, cursorPosition, documentPath, contents, new SourceSpan(8, 4), supportsCodeActionResolve: false);
-        context.CodeDocument.SetFileKind(FileKinds.Legacy);
 
         var provider = new CSharpCodeActionProvider(TestLanguageServerFeatureOptions.Instance);
 
@@ -116,7 +115,6 @@ public class CSharpCodeActionProviderTest : LanguageServerTestBase
         };
 
         var context = CreateRazorCodeActionContext(request, cursorPosition, documentPath, contents, new SourceSpan(13, 4));
-        context.CodeDocument.SetFileKind(FileKinds.Legacy);
 
         var provider = new CSharpCodeActionProvider(TestLanguageServerFeatureOptions.Instance);
 
@@ -148,7 +146,6 @@ $$Path;
         };
 
         var context = CreateRazorCodeActionContext(request, cursorPosition, documentPath, contents, new SourceSpan(13, 4));
-        context.CodeDocument.SetFileKind(FileKinds.Legacy);
 
         var provider = new CSharpCodeActionProvider(TestLanguageServerFeatureOptions.Instance);
 
@@ -181,7 +178,6 @@ $$Path;
         };
 
         var context = CreateRazorCodeActionContext(request, cursorPosition, documentPath, contents, new SourceSpan(13, 4));
-        context.CodeDocument.SetFileKind(FileKinds.Legacy);
 
         var provider = new CSharpCodeActionProvider(TestLanguageServerFeatureOptions.Instance);
 
@@ -211,7 +207,6 @@ $$Path;
         };
 
         var context = CreateRazorCodeActionContext(request, cursorPosition, documentPath, contents, new SourceSpan(8, 4));
-        context.CodeDocument.SetFileKind(FileKinds.Legacy);
 
         var provider = new CSharpCodeActionProvider(TestLanguageServerFeatureOptions.Instance);
 
@@ -247,7 +242,6 @@ $$Path;
         };
 
         var context = CreateRazorCodeActionContext(request, cursorPosition, documentPath, contents, new SourceSpan(8, 4));
-        context.CodeDocument.SetFileKind(FileKinds.Legacy);
 
         var options = new ConfigurableLanguageServerFeatureOptions(new[] { $"--{nameof(ConfigurableLanguageServerFeatureOptions.ShowAllCSharpCodeActions)}" });
         var provider = new CSharpCodeActionProvider(options);
@@ -292,7 +286,6 @@ $$Path;
         };
 
         var context = CreateRazorCodeActionContext(request, cursorPosition, documentPath, contents, new SourceSpan(8, 4));
-        context.CodeDocument.SetFileKind(FileKinds.Legacy);
 
         var provider = new CSharpCodeActionProvider(TestLanguageServerFeatureOptions.Instance);
 
@@ -326,7 +319,8 @@ $$Path;
                 builder.UseRoslynTokenizer = true;
             });
         });
-        var codeDocument = projectEngine.ProcessDesignTime(sourceDocument, FileKinds.Component, importSources: default, tagHelpers);
+
+        var codeDocument = projectEngine.ProcessDesignTime(sourceDocument, FileKinds.Legacy, importSources: default, tagHelpers);
 
         var csharpDocument = codeDocument.GetCSharpDocument();
         var diagnosticDescriptor = new RazorDiagnosticDescriptor("RZ10012", "diagnostic", RazorDiagnosticSeverity.Error);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/CSharpCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/CSharpCodeActionResolverTest.cs
@@ -177,10 +177,18 @@ public class CSharpCodeActionResolverTest(ITestOutputHelper testOutput) : Langua
 
     private static RazorCodeDocument CreateCodeDocument(string text, string documentPath)
     {
-        var projectItem = new TestRazorProjectItem(documentPath) { Content = text };
-        var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty, (builder) => PageDirective.Register(builder));
-        var codeDocument = projectEngine.Process(projectItem);
-        codeDocument.SetFileKind(FileKinds.Component);
-        return codeDocument;
+        var projectItem = new TestRazorProjectItem(
+            filePath: documentPath,
+            fileKind: FileKinds.Component)
+        {
+            Content = text
+        };
+
+        var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty, builder =>
+        {
+            PageDirective.Register(builder);
+        });
+
+        return projectEngine.Process(projectItem);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/TypeAccessibilityCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CSharp/TypeAccessibilityCodeActionProviderTest.cs
@@ -43,7 +43,6 @@ public class TypeAccessibilityCodeActionProviderTest(ITestOutputHelper testOutpu
         };
 
         var context = CreateRazorCodeActionContext(request, absoluteIndex: 0, documentPath, contents, new SourceSpan(0, 0));
-        context.CodeDocument.SetFileKind(FileKinds.Legacy);
 
         var provider = new TypeAccessibilityCodeActionProvider();
         ImmutableArray<RazorVSInternalCodeAction> csharpCodeActions =
@@ -97,7 +96,6 @@ public class TypeAccessibilityCodeActionProviderTest(ITestOutputHelper testOutpu
         };
 
         var context = CreateRazorCodeActionContext(request, absoluteIndex: 0, documentPath, contents, new SourceSpan(0, 0), supportsCodeActionResolve: false);
-        context.CodeDocument.SetFileKind(FileKinds.Legacy);
 
         var provider = new TypeAccessibilityCodeActionProvider();
         ImmutableArray<RazorVSInternalCodeAction> csharpCodeActions =
@@ -138,7 +136,6 @@ public class TypeAccessibilityCodeActionProviderTest(ITestOutputHelper testOutpu
         };
 
         var context = CreateRazorCodeActionContext(request, absoluteIndex: 0, documentPath, contents, new SourceSpan(0, 0));
-        context.CodeDocument.SetFileKind(FileKinds.Legacy);
 
         var provider = new TypeAccessibilityCodeActionProvider();
         var csharpCodeActions = ImmutableArray<RazorVSInternalCodeAction>.Empty;
@@ -188,7 +185,6 @@ public class TypeAccessibilityCodeActionProviderTest(ITestOutputHelper testOutpu
         };
 
         var context = CreateRazorCodeActionContext(request, absoluteIndex: 0, documentPath, contents, new SourceSpan(8, 4), supportsCodeActionResolve: false);
-        context.CodeDocument.SetFileKind(FileKinds.Legacy);
 
         var provider = new TypeAccessibilityCodeActionProvider();
         ImmutableArray<RazorVSInternalCodeAction> csharpCodeActions =
@@ -246,7 +242,6 @@ public class TypeAccessibilityCodeActionProviderTest(ITestOutputHelper testOutpu
         };
 
         var context = CreateRazorCodeActionContext(request, absoluteIndex: 8, documentPath, contents, new SourceSpan(8, 4), supportsCodeActionResolve: true);
-        context.CodeDocument.SetFileKind(FileKinds.Legacy);
 
         var provider = new TypeAccessibilityCodeActionProvider();
         ImmutableArray<RazorVSInternalCodeAction> csharpCodeActions =
@@ -297,7 +292,6 @@ public class TypeAccessibilityCodeActionProviderTest(ITestOutputHelper testOutpu
         };
 
         var context = CreateRazorCodeActionContext(request, absoluteIndex: 0, documentPath, contents, new SourceSpan(8, 4), supportsCodeActionResolve: true);
-        context.CodeDocument.SetFileKind(FileKinds.Legacy);
 
         var provider = new TypeAccessibilityCodeActionProvider();
         ImmutableArray<RazorVSInternalCodeAction> csharpCodeActions =
@@ -371,7 +365,6 @@ public class TypeAccessibilityCodeActionProviderTest(ITestOutputHelper testOutpu
         };
 
         var context = CreateRazorCodeActionContext(request, absoluteIndex: 0, documentPath, contents, new SourceSpan(8, 4), supportsCodeActionResolve: false);
-        context.CodeDocument.SetFileKind(FileKinds.Legacy);
 
         var provider = new TypeAccessibilityCodeActionProvider();
         ImmutableArray<RazorVSInternalCodeAction> csharpCodeActions =
@@ -453,7 +446,8 @@ public class TypeAccessibilityCodeActionProviderTest(ITestOutputHelper testOutpu
                 builder.UseRoslynTokenizer = true;
             });
         });
-        var codeDocument = projectEngine.ProcessDesignTime(sourceDocument, FileKinds.Component, importSources: default, tagHelpers);
+
+        var codeDocument = projectEngine.ProcessDesignTime(sourceDocument, FileKinds.Legacy, importSources: default, tagHelpers);
 
         var csharpDocument = codeDocument.GetCSharpDocument();
         var diagnosticDescriptor = new RazorDiagnosticDescriptor("RZ10012", "diagnostic", RazorDiagnosticSeverity.Error);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Html/HtmlCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Html/HtmlCodeActionProviderTest.cs
@@ -41,7 +41,6 @@ public class HtmlCodeActionProviderTest(ITestOutputHelper testOutput) : Language
         };
 
         var context = CreateRazorCodeActionContext(request, cursorPosition, documentPath, contents);
-        context.CodeDocument.SetFileKind(FileKinds.Legacy);
 
         var documentMappingService = StrictMock.Of<IEditMappingService>();
         var provider = new HtmlCodeActionProvider(documentMappingService);
@@ -73,7 +72,6 @@ public class HtmlCodeActionProviderTest(ITestOutputHelper testOutput) : Language
         };
 
         var context = CreateRazorCodeActionContext(request, cursorPosition, documentPath, contents);
-        context.CodeDocument.SetFileKind(FileKinds.Legacy);
 
         var remappedEdit = new WorkspaceEdit
         {
@@ -156,7 +154,7 @@ public class HtmlCodeActionProviderTest(ITestOutputHelper testOutput) : Language
                 builder.UseRoslynTokenizer = true;
             });
         });
-        var codeDocument = projectEngine.ProcessDesignTime(sourceDocument, FileKinds.Component, importSources: default, tagHelpers);
+        var codeDocument = projectEngine.ProcessDesignTime(sourceDocument, FileKinds.Legacy, importSources: default, tagHelpers);
 
         var documentSnapshotMock = new StrictMock<IDocumentSnapshot>();
         documentSnapshotMock

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ComponentAccessibilityCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ComponentAccessibilityCodeActionProviderTest.cs
@@ -70,8 +70,13 @@ public class ComponentAccessibilityCodeActionProviderTest(ITestOutputHelper test
             Context = new VSInternalCodeActionContext()
         };
 
-        var context = CreateRazorCodeActionContext(request, cursorPosition, documentPath, contents, new SourceSpan(0, 0));
-        context.CodeDocument.SetFileKind(FileKinds.Legacy);
+        var context = CreateRazorCodeActionContext(
+            request,
+            cursorPosition,
+            documentPath,
+            contents,
+            new SourceSpan(0, 0),
+            fileKind: FileKinds.Legacy);
 
         var provider = new ComponentAccessibilityCodeActionProvider(new FileSystem());
 
@@ -423,7 +428,14 @@ public class ComponentAccessibilityCodeActionProviderTest(ITestOutputHelper test
             });
     }
 
-    private static RazorCodeActionContext CreateRazorCodeActionContext(VSCodeActionParams request, int absoluteIndex, string filePath, string text, SourceSpan componentSourceSpan, bool supportsFileCreation = true)
+    private static RazorCodeActionContext CreateRazorCodeActionContext(
+        VSCodeActionParams request,
+        int absoluteIndex,
+        string filePath,
+        string text,
+        SourceSpan componentSourceSpan,
+        string? fileKind = null,
+        bool supportsFileCreation = true)
     {
         var shortComponent = TagHelperDescriptorBuilder.Create(ComponentMetadata.Component.TagHelperKind, "Fully.Qualified.Component", "TestAssembly");
         shortComponent.CaseSensitive = true;
@@ -455,7 +467,10 @@ public class ComponentAccessibilityCodeActionProviderTest(ITestOutputHelper test
                 builder.UseRoslynTokenizer = true;
             });
         });
-        var codeDocument = projectEngine.ProcessDesignTime(sourceDocument, FileKinds.Component, importSources: default, tagHelpers);
+
+        fileKind ??= FileKinds.Component;
+
+        var codeDocument = projectEngine.ProcessDesignTime(sourceDocument, fileKind, importSources: default, tagHelpers);
 
         var csharpDocument = codeDocument.GetCSharpDocument();
         var diagnosticDescriptor = new RazorDiagnosticDescriptor("RZ10012", "diagnostic", RazorDiagnosticSeverity.Error);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/CreateComponentCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/CreateComponentCodeActionResolverTest.cs
@@ -49,8 +49,7 @@ public class CreateComponentCodeActionResolverTest(ITestOutputHelper testOutput)
         // Arrange
         var documentPath = new Uri("c:/Test.razor");
         var contents = $"@page \"/test\"";
-        var codeDocument = CreateCodeDocument(contents);
-        codeDocument.SetFileKind(FileKinds.Legacy);
+        var codeDocument = CreateCodeDocument(contents, fileKind: FileKinds.Legacy);
 
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
         var resolver = new CreateComponentCodeActionResolver(TestLanguageServerFeatureOptions.Instance);
@@ -129,14 +128,24 @@ public class CreateComponentCodeActionResolverTest(ITestOutputHelper testOutput)
         Assert.Contains("@namespace Another.Namespace", editNewComponentEdit.NewText, StringComparison.Ordinal);
     }
 
-    private static RazorCodeDocument CreateCodeDocument(string text)
+    private static RazorCodeDocument CreateCodeDocument(string text, string? fileKind = null)
     {
-        var projectItem = new TestRazorProjectItem("c:/Test.razor", "c:/Test.razor", "Test.razor") { Content = text };
-        var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty, (builder) => builder.SetRootNamespace("test.Pages"));
+        fileKind ??= FileKinds.Component;
 
-        var codeDocument = projectEngine.Process(projectItem);
-        codeDocument.SetFileKind(FileKinds.Component);
+        var projectItem = new TestRazorProjectItem(
+            filePath: "c:/Test.razor",
+            physicalPath: "c:/Test.razor",
+            relativePhysicalPath: "Test.razor",
+            fileKind: fileKind)
+        {
+            Content = text
+        };
 
-        return codeDocument;
+        var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty, builder =>
+        {
+            builder.SetRootNamespace("test.Pages");
+        });
+
+        return projectEngine.Process(projectItem);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionProviderTest.cs
@@ -46,8 +46,7 @@ public class ExtractToCodeBehindCodeActionProviderTest(ITestOutputHelper testOut
             Context = new VSInternalCodeActionContext()
         };
 
-        var context = CreateRazorCodeActionContext(request, cursorPosition, documentPath, contents);
-        context.CodeDocument.SetFileKind(FileKinds.Legacy);
+        var context = CreateRazorCodeActionContext(request, cursorPosition, documentPath, contents, fileKind: FileKinds.Legacy);
 
         var provider = new ExtractToCodeBehindCodeActionProvider(LoggerFactory);
 
@@ -368,20 +367,39 @@ public class ExtractToCodeBehindCodeActionProviderTest(ITestOutputHelper testOut
         Assert.Empty(commandOrCodeActionContainer);
     }
 
-    private static RazorCodeActionContext CreateRazorCodeActionContext(VSCodeActionParams request, int absoluteIndex, string filePath, string text, bool supportsFileCreation = true)
-        => CreateRazorCodeActionContext(request, absoluteIndex, filePath, text, relativePath: filePath, supportsFileCreation: supportsFileCreation);
+    private static RazorCodeActionContext CreateRazorCodeActionContext(
+        VSCodeActionParams request,
+        int absoluteIndex,
+        string filePath,
+        string text,
+        string? fileKind = null,
+        bool supportsFileCreation = true)
+        => CreateRazorCodeActionContext(
+            request, absoluteIndex, filePath, text, relativePath: filePath, fileKind, supportsFileCreation: supportsFileCreation);
 
-    private static RazorCodeActionContext CreateRazorCodeActionContext(VSCodeActionParams request, int absoluteIndex, string filePath, string text, string? relativePath, bool supportsFileCreation = true)
+    private static RazorCodeActionContext CreateRazorCodeActionContext(
+        VSCodeActionParams request,
+        int absoluteIndex,
+        string filePath,
+        string text,
+        string? relativePath,
+        string? fileKind = null,
+        bool supportsFileCreation = true)
     {
         var source = RazorSourceDocument.Create(text, RazorSourceDocumentProperties.Create(filePath, relativePath));
+
+        fileKind ??= FileKinds.Component;
+
         var codeDocument = RazorCodeDocument.Create(
             source,
-            parserOptions: RazorParserOptions.Default.WithDirectives(ComponentCodeDirective.Directive, FunctionsDirective.Directive),
+            parserOptions: RazorParserOptions.Create(RazorLanguageVersion.Latest, fileKind, builder =>
+            {
+                builder.Directives = [ComponentCodeDirective.Directive, FunctionsDirective.Directive];
+            }),
             codeGenerationOptions: RazorCodeGenerationOptions.Default.WithRootNamespace("ExtractToCodeBehindTest"));
 
         var syntaxTree = RazorSyntaxTree.Parse(source, codeDocument.ParserOptions);
 
-        codeDocument.SetFileKind(FileKinds.Component);
         codeDocument.SetSyntaxTree(syntaxTree);
 
         var documentSnapshotMock = new StrictMock<IDocumentSnapshot>();

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToCodeBehindCodeActionResolverTest.cs
@@ -63,8 +63,7 @@ public class ExtractToCodeBehindCodeActionResolverTest(ITestOutputHelper testOut
             @page "/test"
             @code { private int x = 1; }
             """;
-        var codeDocument = CreateCodeDocument(contents);
-        codeDocument.SetFileKind(FileKinds.Legacy);
+        var codeDocument = CreateCodeDocument(contents, fileKind: FileKinds.Legacy);
 
         var documentContext = CreateDocumentContext(documentPath, codeDocument);
         var roslynCodeActionHelpers = new RoslynCodeActionHelpers(_languageServer);
@@ -712,15 +711,25 @@ public class ExtractToCodeBehindCodeActionResolverTest(ITestOutputHelper testOut
             editCodeBehindEdit.NewText);
     }
 
-    private static RazorCodeDocument CreateCodeDocument(string text)
+    private static RazorCodeDocument CreateCodeDocument(string text, string? fileKind = null)
     {
-        var projectItem = new TestRazorProjectItem("c:/Test.razor", "c:/Test.razor", "Test.razor") { Content = text };
-        var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty, (builder) => builder.SetRootNamespace("test.Pages"));
+        fileKind ??= FileKinds.Component;
 
-        var codeDocument = projectEngine.Process(projectItem);
-        codeDocument.SetFileKind(FileKinds.Component);
+        var projectItem = new TestRazorProjectItem(
+            filePath: "c:/Test.razor",
+            physicalPath: "c:/Test.razor",
+            relativePhysicalPath: "Test.razor",
+            fileKind: fileKind)
+        {
+            Content = text
+        };
 
-        return codeDocument;
+        var projectEngine = RazorProjectEngine.Create(RazorConfiguration.Default, TestRazorProjectFileSystem.Empty, builder =>
+        {
+            builder.SetRootNamespace("test.Pages");
+        });
+
+        return projectEngine.Process(projectItem);
     }
 
     private static ExtractToCodeBehindCodeActionParams CreateExtractToCodeBehindCodeActionParams(string contents, string removeStart, string @namespace)

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToComponentCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToComponentCodeActionProviderTest.cs
@@ -65,8 +65,7 @@ public class ExtractToComponentCodeActionProviderTest(ITestOutputHelper testOutp
             Context = new VSInternalCodeActionContext()
         };
 
-        var context = CreateRazorCodeActionContext(request, selectionSpan, documentPath, contents);
-        context.CodeDocument.SetFileKind(FileKinds.Legacy);
+        var context = CreateRazorCodeActionContext(request, selectionSpan, documentPath, contents, fileKind: FileKinds.Legacy);
 
         var provider = new ExtractToComponentCodeActionProvider();
 
@@ -611,19 +610,23 @@ public class ExtractToComponentCodeActionProviderTest(ITestOutputHelper testOutp
         string filePath,
         string text,
         string? relativePath = null,
+        string? fileKind = null,
         bool supportsFileCreation = true)
     {
         relativePath ??= filePath;
+        fileKind ??= FileKinds.Component;
 
         var source = RazorSourceDocument.Create(text, RazorSourceDocumentProperties.Create(filePath, relativePath));
         var codeDocument = RazorCodeDocument.Create(
             source,
-            parserOptions: RazorParserOptions.Default.WithDirectives(ComponentCodeDirective.Directive, FunctionsDirective.Directive),
+            parserOptions: RazorParserOptions.Create(RazorLanguageVersion.Latest, fileKind, builder =>
+            {
+                builder.Directives = [ComponentCodeDirective.Directive, FunctionsDirective.Directive];
+            }),
             codeGenerationOptions: RazorCodeGenerationOptions.Default.WithRootNamespace("ExtractToComponentTest"));
 
         var syntaxTree = RazorSyntaxTree.Parse(source, codeDocument.ParserOptions);
 
-        codeDocument.SetFileKind(FileKinds.Component);
         codeDocument.SetSyntaxTree(syntaxTree);
 
         var documentSnapshot = new StrictMock<IDocumentSnapshot>();

--- a/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/Parsing/VisualStudioRazorParserIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/Parsing/VisualStudioRazorParserIntegrationTest.cs
@@ -61,7 +61,7 @@ public class VisualStudioRazorParserIntegrationTest : VisualStudioTestBase
 
             var codeDocument = await manager.InnerParser.GetLatestCodeDocumentAsync(snapshot);
             Assert.NotNull(codeDocument);
-            Assert.Equal(FileKinds.Component, codeDocument.GetFileKind());
+            Assert.Equal(FileKinds.Component, codeDocument.FileKind);
 
             // @code is only applicable in component files so we're verifying that `@code` was treated as a directive.
             var directiveNodes = manager.CurrentSyntaxTree!.Root.DescendantNodes().Where(child => child.Kind == SyntaxKind.RazorDirective);

--- a/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/Parsing/VisualStudioRazorParserIntegrationTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/Parsing/VisualStudioRazorParserIntegrationTest.cs
@@ -60,6 +60,7 @@ public class VisualStudioRazorParserIntegrationTest : VisualStudioTestBase
             Assert.Equal(1, manager._parseCount);
 
             var codeDocument = await manager.InnerParser.GetLatestCodeDocumentAsync(snapshot);
+            Assert.NotNull(codeDocument);
             Assert.Equal(FileKinds.Component, codeDocument.GetFileKind());
 
             // @code is only applicable in component files so we're verifying that `@code` was treated as a directive.


### PR DESCRIPTION
There are two extension methods targeting `RazorCodeDocument` that allow consumers to set or get the file kind for the document. However, this can result in inconsistencies because that file kind value (stored in `RazorCodeDocument.Items`) is independent from `RazorCodeDocument.ParserOptions.FileKind`. This PR removes both methods in favor `RazorParserOptions.FileKind`.

Summary of changes:
- Remove the `GetFileKind()` and `SetFileKind(...)` extension methods and expose a convenience `RazorCodeDocument.FileKind` property that delegates to `ParserOptions.FileKind`.
- Add `RazorParserOptions.Create(...)` and `RazorCodeGenerationOptions.Create(...)` convenience factory methods.
- Remove `LanguageVersion` and `FileKind` from `RazorCodeGenerationOptions` to avoid the possibility of a `RazorCodeDocument` containing parser options and code generation options that disagree about these values.
- Update tests (mostly in tooling) to stop calling `SetFileKind(...)` and pass the value as part of `RazorCodeDocument` creation.

> [!NOTE]
> `GetFileKind()` and `SetFileKind(...)` are public extension methods but are not used by the RazorSdk, so they should be safe to remove.