### PR TITLE
Remove excess async state machines in completion

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/CompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/CompletionListProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,7 +23,7 @@ internal class CompletionListProvider(
     private readonly DelegatedCompletionListProvider _delegatedCompletionListProvider = delegatedCompletionListProvider;
     private readonly CompletionTriggerAndCommitCharacters _triggerAndCommitCharacters = triggerAndCommitCharacters;
 
-    public async Task<VSInternalCompletionList?> GetCompletionListAsync(
+    public ValueTask<VSInternalCompletionList?> GetCompletionListAsync(
         int absoluteIndex,
         VSInternalCompletionContext completionContext,
         DocumentContext documentContext,
@@ -31,37 +32,78 @@ internal class CompletionListProvider(
         Guid correlationId,
         CancellationToken cancellationToken)
     {
-        // First we delegate to get completion items from the individual language server
-        var delegatedCompletionList = _triggerAndCommitCharacters.IsValidDelegationTrigger(completionContext)
-            ? await _delegatedCompletionListProvider.GetCompletionListAsync(
+        var isDelegationTrigger = _triggerAndCommitCharacters.IsValidDelegationTrigger(completionContext);
+        var isRazorTrigger = _triggerAndCommitCharacters.IsValidRazorTrigger(completionContext);
+
+        // We don't have a valid trigger, so we can't provide completions
+        return isDelegationTrigger || isRazorTrigger
+            ? new(GetCompletionListCoreAsync(
                 absoluteIndex,
                 completionContext,
                 documentContext,
                 clientCapabilities,
                 razorCompletionOptions,
                 correlationId,
-                cancellationToken).ConfigureAwait(false)
-            : null;
+                isDelegationTrigger,
+                isRazorTrigger,
+                cancellationToken))
+            : default;
+    }
 
-        // Extract the items we got back from the delegated server, to inform tag helper completion
-        var existingItems = delegatedCompletionList?.Items != null
-            ? new HashSet<string>(delegatedCompletionList.Items.Select(i => i.Label))
-            : null;
+    private async Task<VSInternalCompletionList?> GetCompletionListCoreAsync(
+        int absoluteIndex,
+        VSInternalCompletionContext completionContext,
+        DocumentContext documentContext,
+        VSInternalClientCapabilities clientCapabilities,
+        RazorCompletionOptions razorCompletionOptions,
+        Guid correlationId,
+        bool isDelegationTrigger,
+        bool isRazorTrigger,
+        CancellationToken cancellationToken)
+    {
+        Debug.Assert(isDelegationTrigger || isRazorTrigger);
+
+        var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+
+        // First we delegate to get completion items from the individual language server
+        VSInternalCompletionList? delegatedCompletionList = null;
+        HashSet<string>? existingItems = null;
+
+        if (isDelegationTrigger)
+        {
+            delegatedCompletionList = await _delegatedCompletionListProvider
+                .GetCompletionListAsync(
+                    codeDocument,
+                    absoluteIndex,
+                    completionContext,
+                    documentContext,
+                    clientCapabilities,
+                    razorCompletionOptions,
+                    correlationId,
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            // Extract the items we got back from the delegated server, to inform tag helper completion
+            if (delegatedCompletionList?.Items is { } delegatedItems)
+            {
+                existingItems = [.. delegatedItems.Select(static i => i.Label)];
+            }
+        }
 
         // Now we get the Razor completion list, using information from the actual language server if necessary
-        var razorCompletionList = _triggerAndCommitCharacters.IsValidRazorTrigger(completionContext)
-            ? await _razorCompletionListProvider.GetCompletionListAsync(
+        VSInternalCompletionList? razorCompletionList = null;
+
+        if (isRazorTrigger)
+        {
+            razorCompletionList = _razorCompletionListProvider.GetCompletionList(
+                codeDocument,
                 absoluteIndex,
                 completionContext,
-                documentContext,
                 clientCapabilities,
                 existingItems,
-                razorCompletionOptions,
-                cancellationToken).ConfigureAwait(false)
-            : null;
+                razorCompletionOptions);
+        }
 
-        var finalCompletionList = CompletionListMerger.Merge(razorCompletionList, delegatedCompletionList);
-
-        return finalCompletionList;
+        return CompletionListMerger.Merge(razorCompletionList, delegatedCompletionList);
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionListProvider.cs
@@ -81,12 +81,13 @@ internal class DelegatedCompletionListProvider
 
         completionContext = rewrittenContext;
 
-        var razorCodeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+
         // It's a bit confusing, but we have two different "add snippets" options - one is a part of
         // RazorCompletionOptions and becomes a part of RazorCompletionContext and is used by
         // RazorCompletionFactsService, and the second one below that's used for delegated completion
         // Their values are not related in any way.
-        var shouldIncludeDelegationSnippets = DelegatedCompletionHelper.ShouldIncludeSnippets(razorCodeDocument, absoluteIndex);
+        var shouldIncludeDelegationSnippets = DelegatedCompletionHelper.ShouldIncludeSnippets(codeDocument, absoluteIndex);
 
         var delegatedParams = new DelegatedCompletionParams(
             documentContext.GetTextDocumentIdentifierAndVersion(),
@@ -103,14 +104,7 @@ internal class DelegatedCompletionListProvider
             cancellationToken).ConfigureAwait(false);
 
         var rewrittenResponse = delegatedParams.ProjectedKind == RazorLanguageKind.CSharp
-             ? await DelegatedCompletionHelper.RewriteCSharpResponseAsync(
-                delegatedResponse,
-                absoluteIndex,
-                documentContext,
-                delegatedParams.ProjectedPosition,
-                razorCompletionOptions,
-                cancellationToken)
-                .ConfigureAwait(false)
+             ? DelegatedCompletionHelper.RewriteCSharpResponse(delegatedResponse, absoluteIndex, codeDocument, delegatedParams.ProjectedPosition, razorCompletionOptions)
             : DelegatedCompletionHelper.RewriteHtmlResponse(delegatedResponse, razorCompletionOptions);
 
         var completionCapability = clientCapabilities?.TextDocument?.Completion as VSInternalCompletionSetting;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/Delegation/DelegatedCompletionListProvider.cs
@@ -51,17 +51,14 @@ internal class DelegatedCompletionListProvider
         Guid correlationId,
         CancellationToken cancellationToken)
     {
-        var positionInfo = await _documentMappingService
-            .GetPositionInfoAsync(documentContext, absoluteIndex, cancellationToken)
-            .ConfigureAwait(false);
+        var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
 
+        var positionInfo = _documentMappingService.GetPositionInfo(codeDocument, absoluteIndex);
         if (positionInfo.LanguageKind == RazorLanguageKind.Razor)
         {
             // Nothing to delegate to.
             return null;
         }
-
-        var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
 
         TextEdit? provisionalTextEdit = null;
         if (DelegatedCompletionHelper.TryGetProvisionalCompletionInfo(codeDocument, completionContext, positionInfo, _documentMappingService, out var provisionalCompletion))

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Completion/RazorCompletionEndpoint.cs
@@ -19,14 +19,14 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Completion;
 [RazorLanguageServerEndpoint(Methods.TextDocumentCompletionName)]
 internal class RazorCompletionEndpoint(
     CompletionListProvider completionListProvider,
-    CompletionTriggerAndCommitCharacters completionTriggerAndCommitCharacters,
-    ITelemetryReporter? telemetryReporter,
+    CompletionTriggerAndCommitCharacters triggerAndCommitCharacters,
+    ITelemetryReporter telemetryReporter,
     RazorLSPOptionsMonitor optionsMonitor)
     : IRazorRequestHandler<CompletionParams, VSInternalCompletionList?>, ICapabilitiesProvider
 {
     private readonly CompletionListProvider _completionListProvider = completionListProvider;
-    private readonly CompletionTriggerAndCommitCharacters _triggerAndCommitCharacters = completionTriggerAndCommitCharacters;
-    private readonly ITelemetryReporter? _telemetryReporter = telemetryReporter;
+    private readonly CompletionTriggerAndCommitCharacters _triggerAndCommitCharacters = triggerAndCommitCharacters;
+    private readonly ITelemetryReporter _telemetryReporter = telemetryReporter;
     private readonly RazorLSPOptionsMonitor _optionsMonitor = optionsMonitor;
 
     private VSInternalClientCapabilities? _clientCapabilities;
@@ -52,9 +52,15 @@ internal class RazorCompletionEndpoint(
 
     public async Task<VSInternalCompletionList?> HandleRequestAsync(CompletionParams request, RazorRequestContext requestContext, CancellationToken cancellationToken)
     {
-        var documentContext = requestContext.DocumentContext;
+        if (request.Context is not VSInternalCompletionContext completionContext ||
+            requestContext.DocumentContext is not { } documentContext)
+        {
+            return null;
+        }
 
-        if (request.Context is null || documentContext is null)
+        var autoShownCompletion = completionContext.InvokeKind != VSInternalCompletionInvokeKind.Explicit;
+        var options = _optionsMonitor.CurrentValue;
+        if (autoShownCompletion && !options.AutoShowCompletion)
         {
             return null;
         }
@@ -65,33 +71,24 @@ internal class RazorCompletionEndpoint(
             return null;
         }
 
-        if (request.Context is not VSInternalCompletionContext completionContext)
-        {
-            Debug.Fail("Completion context should never be null in practice");
-            return null;
-        }
-
-        var autoShownCompletion = completionContext.InvokeKind != VSInternalCompletionInvokeKind.Explicit;
-        if (autoShownCompletion && !_optionsMonitor.CurrentValue.AutoShowCompletion)
-        {
-            return null;
-        }
-
         var correlationId = Guid.NewGuid();
-        using var _ = _telemetryReporter?.TrackLspRequest(Methods.TextDocumentCompletionName, LanguageServerConstants.RazorLanguageServerName, TelemetryThresholds.CompletionRazorTelemetryThreshold, correlationId);
+        using (_telemetryReporter.TrackLspRequest(Methods.TextDocumentCompletionName, LanguageServerConstants.RazorLanguageServerName, TelemetryThresholds.CompletionRazorTelemetryThreshold, correlationId))
+        {
+            var razorCompletionOptions = new RazorCompletionOptions(
+                SnippetsSupported: true,
+                AutoInsertAttributeQuotes: options.AutoInsertAttributeQuotes,
+                CommitElementsWithSpace: options.CommitElementsWithSpace);
 
-        var razorCompletionOptions = new RazorCompletionOptions(
-            SnippetsSupported: true,
-            AutoInsertAttributeQuotes: _optionsMonitor.CurrentValue.AutoInsertAttributeQuotes,
-            CommitElementsWithSpace: _optionsMonitor.CurrentValue.CommitElementsWithSpace);
-        var completionList = await _completionListProvider.GetCompletionListAsync(
-            hostDocumentIndex,
-            completionContext,
-            documentContext,
-            _clientCapabilities!,
-            razorCompletionOptions,
-            correlationId,
-            cancellationToken).ConfigureAwait(false);
-        return completionList;
+            return await _completionListProvider
+                .GetCompletionListAsync(
+                    hostDocumentIndex,
+                    completionContext,
+                    documentContext,
+                    _clientCapabilities.AssumeNotNull(),
+                    razorCompletionOptions,
+                    correlationId,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/DelegatedCompletionHelper.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/DelegatedCompletionHelper.cs
@@ -113,17 +113,18 @@ internal static class DelegatedCompletionHelper
             return new VSInternalCompletionList() { IsIncomplete = true, Items = [] };
         }
 
+        var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+
         var rewrittenResponse = delegatedResponse;
 
         foreach (var rewriter in s_delegatedCSharpCompletionResponseRewriters)
         {
-            rewrittenResponse = await rewriter.RewriteAsync(
+            rewrittenResponse = rewriter.Rewrite(
                 rewrittenResponse,
+                codeDocument,
                 absoluteIndex,
-                documentContext,
                 projectedPosition,
-                completionOptions,
-                cancellationToken).ConfigureAwait(false);
+                completionOptions);
         }
 
         return rewrittenResponse;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/DelegatedCompletionHelper.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/DelegatedCompletionHelper.cs
@@ -96,13 +96,12 @@ internal static class DelegatedCompletionHelper
     /// <returns>
     /// Possibly modified completion response.
     /// </returns>
-    public static async ValueTask<VSInternalCompletionList> RewriteCSharpResponseAsync(
+    public static VSInternalCompletionList RewriteCSharpResponse(
         VSInternalCompletionList? delegatedResponse,
         int absoluteIndex,
-        DocumentContext documentContext,
+        RazorCodeDocument codeDocument,
         Position projectedPosition,
-        RazorCompletionOptions completionOptions,
-        CancellationToken cancellationToken)
+        RazorCompletionOptions completionOptions)
     {
         if (delegatedResponse?.Items is null)
         {
@@ -112,8 +111,6 @@ internal static class DelegatedCompletionHelper
             // so we'd only ever return Razor completion items.
             return new VSInternalCompletionList() { IsIncomplete = true, Items = [] };
         }
-
-        var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
 
         var rewrittenResponse = delegatedResponse;
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/DelegatedCompletionHelper.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/DelegatedCompletionHelper.cs
@@ -3,11 +3,8 @@
 
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.CodeAnalysis.Razor.DocumentMapping;
-using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Protocol.Completion;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -159,34 +156,34 @@ internal static class DelegatedCompletionHelper
     /// to C# and will return a temporary edit that should be made to the generated document
     /// in order to add the '.' to the generated C# contents.
     /// </remarks>
-    public static async Task<CompletionPositionInfo?> TryGetProvisionalCompletionInfoAsync(
-        DocumentContext documentContext,
+    public static bool TryGetProvisionalCompletionInfo(
+        RazorCodeDocument codeDocument,
         VSInternalCompletionContext completionContext,
         DocumentPositionInfo originalPositionInfo,
         IDocumentMappingService documentMappingService,
-        CancellationToken cancellationToken)
+        out CompletionPositionInfo result)
     {
+        result = default;
+
         if (originalPositionInfo.LanguageKind != RazorLanguageKind.Html ||
             completionContext.TriggerKind != CompletionTriggerKind.TriggerCharacter ||
             completionContext.TriggerCharacter != ".")
         {
             // Invalid provisional completion context
-            return null;
+            return false;
         }
 
         if (originalPositionInfo.Position.Character == 0)
         {
             // We're at the start of line. Can't have provisional completions here.
-            return null;
+            return false;
         }
 
-        var previousCharacterPositionInfo = await documentMappingService
-            .GetPositionInfoAsync(documentContext, originalPositionInfo.HostDocumentIndex - 1, cancellationToken)
-            .ConfigureAwait(false);
+        var previousCharacterPositionInfo = documentMappingService.GetPositionInfo(codeDocument, originalPositionInfo.HostDocumentIndex - 1);
 
         if (previousCharacterPositionInfo.LanguageKind != RazorLanguageKind.CSharp)
         {
-            return null;
+            return false;
         }
 
         var previousPosition = previousCharacterPositionInfo.Position;
@@ -202,7 +199,8 @@ internal static class DelegatedCompletionHelper
                 previousPosition.Character + 1),
             previousCharacterPositionInfo.HostDocumentIndex + 1);
 
-        return new CompletionPositionInfo(addProvisionalDot, provisionalPositionInfo, ShouldIncludeDelegationSnippets: false);
+        result = new CompletionPositionInfo(addProvisionalDot, provisionalPositionInfo, ShouldIncludeDelegationSnippets: false);
+        return true;
     }
 
     public static bool ShouldIncludeSnippets(RazorCodeDocument razorCodeDocument, int absoluteIndex)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/IDelegatedCSharpCompletionResponseRewriter.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/IDelegatedCSharpCompletionResponseRewriter.cs
@@ -1,20 +1,17 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.Razor.Completion.Delegation;
 
 internal interface IDelegatedCSharpCompletionResponseRewriter
 {
-    Task<VSInternalCompletionList> RewriteAsync(
+    VSInternalCompletionList Rewrite(
         VSInternalCompletionList completionList,
+        RazorCodeDocument codeDocument,
         int hostDocumentIndex,
-        DocumentContext hostDocumentContext,
         Position projectedPosition,
-        RazorCompletionOptions completionOptions,
-        CancellationToken cancellationToken);
+        RazorCompletionOptions completionOptions);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/SnippetResponseRewriter.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/SnippetResponseRewriter.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System.Threading;
-using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.PooledObjects;
-using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.Razor.Completion.Delegation;
@@ -17,13 +15,12 @@ namespace Microsoft.CodeAnalysis.Razor.Completion.Delegation;
 /// </remarks>
 internal class SnippetResponseRewriter : IDelegatedCSharpCompletionResponseRewriter
 {
-    public Task<VSInternalCompletionList> RewriteAsync(
+    public VSInternalCompletionList Rewrite(
         VSInternalCompletionList completionList,
+        RazorCodeDocument codeDocument,
         int hostDocumentIndex,
-        DocumentContext hostDocumentContext,
         Position projectedPosition,
-        RazorCompletionOptions completionOptions,
-        CancellationToken cancellationToken)
+        RazorCompletionOptions completionOptionsn)
     {
         using var items = new PooledArrayBuilder<CompletionItem>(completionList.Items.Length);
 
@@ -43,6 +40,6 @@ internal class SnippetResponseRewriter : IDelegatedCSharpCompletionResponseRewri
             completionList.Items = items.ToArray();
         }
 
-        return Task.FromResult(completionList);
+        return completionList;
     }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/TextEditResponseRewriter.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/Delegation/TextEditResponseRewriter.cs
@@ -1,24 +1,21 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.Razor.Completion.Delegation;
 
 internal class TextEditResponseRewriter : IDelegatedCSharpCompletionResponseRewriter
 {
-    public async Task<VSInternalCompletionList> RewriteAsync(
+    public VSInternalCompletionList Rewrite(
         VSInternalCompletionList completionList,
+        RazorCodeDocument codeDocument,
         int hostDocumentIndex,
-        DocumentContext hostDocumentContext,
         Position projectedPosition,
-        RazorCompletionOptions completionOptions,
-        CancellationToken cancellationToken)
+        RazorCompletionOptions completionOptions)
     {
-        var sourceText = await hostDocumentContext.GetSourceTextAsync(cancellationToken).ConfigureAwait(false);
+        var sourceText = codeDocument.Source.Text;
 
         var hostDocumentPosition = sourceText.GetPosition(hostDocumentIndex);
         completionList = TranslateTextEdits(hostDocumentPosition, projectedPosition, completionList);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionListProvider.cs
@@ -7,12 +7,11 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor;
+using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.Razor.Logging;
-using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
 namespace Microsoft.CodeAnalysis.Razor.Completion;
@@ -32,14 +31,13 @@ internal class RazorCompletionListProvider(
     };
 
     // virtual for tests
-    public virtual async Task<VSInternalCompletionList?> GetCompletionListAsync(
+    public virtual VSInternalCompletionList? GetCompletionList(
+        RazorCodeDocument codeDocument,
         int absoluteIndex,
         VSInternalCompletionContext completionContext,
-        DocumentContext documentContext,
         VSInternalClientCapabilities clientCapabilities,
         HashSet<string>? existingCompletions,
-        RazorCompletionOptions completionOptions,
-        CancellationToken cancellationToken)
+        RazorCompletionOptions completionOptions)
     {
         if (!IsApplicableTriggerContext(completionContext))
         {
@@ -54,8 +52,9 @@ internal class RazorCompletionListProvider(
             _ => CompletionReason.Typing,
         };
 
-        var syntaxTree = await documentContext.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-        var tagHelperContext = await documentContext.GetTagHelperContextAsync(cancellationToken).ConfigureAwait(false);
+        var syntaxTree = codeDocument.GetRequiredSyntaxTree();
+        var tagHelperContext = codeDocument.GetRequiredTagHelperContext();
+
         var owner = syntaxTree.Root.FindInnermostNode(absoluteIndex, includeWhitespace: true, walkMarkersBack: true);
         owner = AbstractRazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, absoluteIndex);
 
@@ -77,7 +76,8 @@ internal class RazorCompletionListProvider(
         var completionCapability = clientCapabilities?.TextDocument?.Completion as VSInternalCompletionSetting;
 
         // The completion list is cached and can be retrieved via this result id to enable the resolve completion functionality.
-        var razorResolveContext = new RazorCompletionResolveContext(documentContext.FilePath, razorCompletionItems);
+        var filePath = codeDocument.Source.FilePath.AssumeNotNull();
+        var razorResolveContext = new RazorCompletionResolveContext(filePath, razorCompletionItems);
         var resultId = _completionListCache.Add(completionList, razorResolveContext);
         completionList.SetResultId(resultId, completionCapability);
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/IDocumentMappingServiceExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/DocumentMapping/IDocumentMappingServiceExtensions.cs
@@ -5,11 +5,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.Language;
-using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
@@ -34,13 +31,6 @@ internal static class IDocumentMappingServiceExtensions
 
     public static bool TryMapToHostDocumentRange(this IDocumentMappingService service, IRazorGeneratedDocument generatedDocument, Range projectedRange, [NotNullWhen(true)] out Range? originalRange)
         => service.TryMapToHostDocumentRange(generatedDocument, projectedRange, MappingBehavior.Strict, out originalRange);
-
-    public static async Task<DocumentPositionInfo> GetPositionInfoAsync(this IDocumentMappingService service, DocumentContext documentContext, int hostDocumentIndex, CancellationToken cancellationToken)
-    {
-        var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
-
-        return service.GetPositionInfo(codeDocument, hostDocumentIndex);
-    }
 
     public static DocumentPositionInfo GetPositionInfo(
         this IDocumentMappingService service,

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/RazorCodeDocumentExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/RazorCodeDocumentExtensions.cs
@@ -28,6 +28,9 @@ internal static class RazorCodeDocumentExtensions
     public static Syntax.SyntaxNode GetRequiredSyntaxRoot(this RazorCodeDocument codeDocument)
         => codeDocument.GetRequiredSyntaxTree().Root;
 
+    public static TagHelperDocumentContext GetRequiredTagHelperContext(this RazorCodeDocument codeDocument)
+        => codeDocument.GetTagHelperContext().AssumeNotNull();
+
     public static SourceText GetCSharpSourceText(this RazorCodeDocument document)
         => document.GetCSharpDocument().Text;
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/RazorCodeDocumentExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Extensions/RazorCodeDocumentExtensions.cs
@@ -22,6 +22,12 @@ internal static class RazorCodeDocumentExtensions
 {
     private static readonly object s_csharpSyntaxTreeKey = new();
 
+    public static RazorSyntaxTree GetRequiredSyntaxTree(this RazorCodeDocument codeDocument)
+        => codeDocument.GetSyntaxTree().AssumeNotNull();
+
+    public static Syntax.SyntaxNode GetRequiredSyntaxRoot(this RazorCodeDocument codeDocument)
+        => codeDocument.GetRequiredSyntaxTree().Root;
+
     public static SourceText GetCSharpSourceText(this RazorCodeDocument document)
         => document.GetCSharpDocument().Text;
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
@@ -63,18 +63,10 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
         var positionInfo = GetPositionInfo(codeDocument, index);
 
         if (positionInfo.LanguageKind != RazorLanguageKind.Razor
-           && await DelegatedCompletionHelper.TryGetProvisionalCompletionInfoAsync(
-                remoteDocumentContext,
-                completionContext,
-                positionInfo,
-                DocumentMappingService,
-                cancellationToken)
-                .ConfigureAwait(false) is { } provisionalCompletionInfo)
+            && DelegatedCompletionHelper.TryGetProvisionalCompletionInfo(
+                codeDocument, completionContext, positionInfo, DocumentMappingService, out var provisionalCompletionInfo))
         {
-            return new CompletionPositionInfo(
-                provisionalCompletionInfo.ProvisionalTextEdit,
-                provisionalCompletionInfo.DocumentPositionInfo,
-                ShouldIncludeDelegationSnippets: false);
+            return provisionalCompletionInfo with { ShouldIncludeDelegationSnippets = false };
         }
 
         var shouldIncludeSnippets = positionInfo.LanguageKind == RazorLanguageKind.Html

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Completion/RemoteCompletionService.cs
@@ -212,16 +212,16 @@ internal sealed class RemoteCompletionService(in ServiceArgs args) : RazorDocume
             };
         }
 
+        var codeDocument = await remoteDocumentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+
         var vsPlatformCompletionList = JsonHelpers.ToVsLSP<VSInternalCompletionList, RoslynCompletionList>(roslynCompletionList);
 
-        var rewrittenResponse = await DelegatedCompletionHelper.RewriteCSharpResponseAsync(
+        var rewrittenResponse = DelegatedCompletionHelper.RewriteCSharpResponse(
             vsPlatformCompletionList,
             documentIndex,
-            remoteDocumentContext,
+            codeDocument,
             mappedPosition,
-            razorCompletionOptions,
-            cancellationToken)
-            .ConfigureAwait(false);
+            razorCompletionOptions);
 
         return rewrittenResponse;
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/CompletionListProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/CompletionListProviderTest.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Completion.Delegation;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
@@ -88,7 +89,8 @@ public class CompletionListProviderTest : LanguageServerTestBase
             _completionList = completionList;
         }
 
-        public override Task<VSInternalCompletionList> GetCompletionListAsync(
+        public override ValueTask<VSInternalCompletionList> GetCompletionListAsync(
+            RazorCodeDocument codeDocument,
             int absoluteIndex,
             VSInternalCompletionContext completionContext,
             DocumentContext documentContext,
@@ -97,7 +99,7 @@ public class CompletionListProviderTest : LanguageServerTestBase
             Guid correlationId,
             CancellationToken cancellationToken)
         {
-            return Task.FromResult(_completionList);
+            return new(_completionList);
         }
     }
 
@@ -113,16 +115,13 @@ public class CompletionListProviderTest : LanguageServerTestBase
             _completionList = completionList;
         }
 
-        public override Task<VSInternalCompletionList> GetCompletionListAsync(
+        public override VSInternalCompletionList GetCompletionList(
+            RazorCodeDocument codeDocument,
             int absoluteIndex,
             VSInternalCompletionContext completionContext,
-            DocumentContext documentContext,
             VSInternalClientCapabilities clientCapabilities,
             HashSet<string> existingCompletions,
-            RazorCompletionOptions razorCompletionOptions,
-            CancellationToken cancellationToken)
-        {
-            return Task.FromResult(_completionList);
-        }
+            RazorCompletionOptions razorCompletionOptions)
+            => _completionList;
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionItemResolverTest.NetFx.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionItemResolverTest.NetFx.cs
@@ -234,7 +234,7 @@ public class DelegatedCompletionItemResolverTest : LanguageServerTestBase
     private async Task<VSInternalCompletionItem> ResolveCompletionItemAsync(string content, string itemToResolve, CancellationToken cancellationToken)
     {
         TestFileMarkupParser.GetPosition(content, out var documentContent, out var cursorPosition);
-        var codeDocument = CreateCodeDocument(documentContent);
+        var codeDocument = CreateCodeDocument(documentContent, filePath: "C:/path/to/file.razor");
         await using var csharpServer = await CreateCSharpServerAsync(codeDocument);
 
         var server = TestDelegatedCompletionItemResolverServer.Create(csharpServer, DisposalToken);
@@ -289,6 +289,7 @@ public class DelegatedCompletionItemResolverTest : LanguageServerTestBase
         var provider = TestDelegatedCompletionListProvider.Create(csharpServer, LoggerFactory, DisposalToken);
 
         var completionList = await provider.GetCompletionListAsync(
+            codeDocument,
             cursorPosition,
             completionContext,
             documentContext,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionListProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/DelegatedCompletionListProviderTest.cs
@@ -50,6 +50,7 @@ public class DelegatedCompletionListProviderTest : LanguageServerTestBase
 
         // Act
         await _provider.GetCompletionListAsync(
+            codeDocument,
             absoluteIndex: 1,
             completionContext,
             documentContext,
@@ -83,6 +84,7 @@ public class DelegatedCompletionListProviderTest : LanguageServerTestBase
 
         // Act
         await _provider.GetCompletionListAsync(
+            codeDocument,
             absoluteIndex: 1,
             completionContext,
             documentContext,
@@ -117,6 +119,7 @@ public class DelegatedCompletionListProviderTest : LanguageServerTestBase
 
         // Act
         await _provider.GetCompletionListAsync(
+            codeDocument,
             absoluteIndex: 1,
             completionContext,
             documentContext,
@@ -146,6 +149,7 @@ public class DelegatedCompletionListProviderTest : LanguageServerTestBase
 
         // Act
         var delegatedCompletionList = await provider.GetCompletionListAsync(
+            codeDocument,
             absoluteIndex: 1,
             completionContext,
             documentContext,
@@ -199,6 +203,7 @@ public class DelegatedCompletionListProviderTest : LanguageServerTestBase
 
         // Act
         var completionList = await _provider.GetCompletionListAsync(
+            codeDocument,
             absoluteIndex: 11,
             completionContext,
             documentContext,
@@ -228,6 +233,7 @@ public class DelegatedCompletionListProviderTest : LanguageServerTestBase
 
         // Act
         await _provider.GetCompletionListAsync(
+            codeDocument,
             absoluteIndex: 10,
             completionContext,
             documentContext,
@@ -264,6 +270,7 @@ public class DelegatedCompletionListProviderTest : LanguageServerTestBase
 
         // Act
         await _provider.GetCompletionListAsync(
+            codeDocument,
             absoluteIndex: 10,
             completionContext,
             documentContext,
@@ -337,6 +344,7 @@ public class DelegatedCompletionListProviderTest : LanguageServerTestBase
         };
 
         await completionProvider.GetCompletionListAsync(
+            codeDocument,
             cursorPosition,
             completionContext,
             documentContext,
@@ -380,6 +388,7 @@ public class DelegatedCompletionListProviderTest : LanguageServerTestBase
         var provider = TestDelegatedCompletionListProvider.Create(csharpServer, LoggerFactory, DisposalToken);
 
         var completionList = await provider.GetCompletionListAsync(
+            codeDocument,
             absoluteIndex: cursorPosition,
             completionContext,
             documentContext,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/ResponseRewriterTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/Delegation/ResponseRewriterTestBase.cs
@@ -39,12 +39,15 @@ public abstract class ResponseRewriterTestBase : LanguageServerTestBase
         VSInternalCompletionList initialCompletionList,
         RazorCompletionOptions razorCompletionOptions)
     {
+        const string FilePath = "C:/path/to/file.cshtml";
+
         var completionContext = new VSInternalCompletionContext();
-        var codeDocument = CreateCodeDocument(documentContent);
-        var documentContext = TestDocumentContext.Create("C:/path/to/file.cshtml", codeDocument);
+        var codeDocument = CreateCodeDocument(documentContent, filePath: FilePath);
+        var documentContext = TestDocumentContext.Create(FilePath, codeDocument);
         var provider = TestDelegatedCompletionListProvider.Create(initialCompletionList, LoggerFactory);
         var clientCapabilities = new VSInternalClientCapabilities();
         var completionList = await provider.GetCompletionListAsync(
+            codeDocument,
             absoluteIndex,
             completionContext,
             documentContext,

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Completion/RazorCompletionEndpointTest.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Telemetry;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Xunit;
@@ -21,7 +22,7 @@ public class RazorCompletionEndpointTest(ITestOutputHelper testOutput) : Languag
         // Arrange
         var documentPath = "C:/path/to/document.cshtml";
         var optionsMonitor = GetOptionsMonitor();
-        var completionEndpoint = new RazorCompletionEndpoint(completionListProvider: null, completionTriggerAndCommitCharacters: null, telemetryReporter: null, optionsMonitor);
+        var completionEndpoint = new RazorCompletionEndpoint(completionListProvider: null, triggerAndCommitCharacters: null, NoOpTelemetryReporter.Instance, optionsMonitor);
         var request = new CompletionParams()
         {
             TextDocument = new TextDocumentIdentifier()
@@ -49,7 +50,7 @@ public class RazorCompletionEndpointTest(ITestOutputHelper testOutput) : Languag
         var uri = new Uri(documentPath);
         var documentContext = CreateDocumentContext(uri, codeDocument);
         var optionsMonitor = GetOptionsMonitor(autoShowCompletion: false);
-        var completionEndpoint = new RazorCompletionEndpoint(completionListProvider: null, completionTriggerAndCommitCharacters: null, telemetryReporter: null, optionsMonitor);
+        var completionEndpoint = new RazorCompletionEndpoint(completionListProvider: null, triggerAndCommitCharacters: null, NoOpTelemetryReporter.Instance, optionsMonitor);
         var request = new CompletionParams()
         {
             TextDocument = new TextDocumentIdentifier()

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/RazorCompletionListProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/RazorCompletionListProviderTest.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.Test.Common;
@@ -378,18 +377,17 @@ public class RazorCompletionListProviderTest : LanguageServerTestBase
     [InlineData("@page\r\n<div></div>\r\n@f$$\r\n")]
     [WorkItem("https://github.com/dotnet/razor-tooling/issues/4547")]
     [WorkItem("https://github.com/dotnet/razor/issues/9955")]
-    public async Task GetCompletionListAsync_ProvidesDirectiveCompletionItems(string documentText)
+    public void GetCompletionList_ProvidesDirectiveCompletionItems(string documentText)
     {
         // Arrange
         var documentPath = "C:/path/to/document.cshtml";
         TestFileMarkupParser.GetPosition(documentText, out documentText, out var cursorPosition);
-        var codeDocument = CreateCodeDocument(documentText);
-        var documentContext = TestDocumentContext.Create(documentPath, codeDocument);
+        var codeDocument = CreateCodeDocument(documentText, documentPath);
         var provider = new RazorCompletionListProvider(_completionFactsService, _completionListCache, LoggerFactory);
 
         // Act
-        var completionList = await provider.GetCompletionListAsync(
-            absoluteIndex: cursorPosition, _defaultCompletionContext, documentContext, _clientCapabilities, existingCompletions: null, _razorCompletionOptions, DisposalToken);
+        var completionList = provider.GetCompletionList(
+            codeDocument, absoluteIndex: cursorPosition, _defaultCompletionContext, _clientCapabilities, existingCompletions: null, _razorCompletionOptions);
 
         // Assert
 
@@ -402,22 +400,22 @@ public class RazorCompletionListProviderTest : LanguageServerTestBase
     }
 
     [Fact]
-    public async Task GetCompletionListAsync_ProvidesDirectiveCompletions_IncompleteTriggerOnDeletion()
+    public void GetCompletionListAsync_ProvidesDirectiveCompletions_IncompleteTriggerOnDeletion()
     {
         // Arrange
         var documentPath = "C:/path/to/document.cshtml";
-        var codeDocument = CreateCodeDocument("@");
-        var documentContext = TestDocumentContext.Create(documentPath, codeDocument);
+        var codeDocument = CreateCodeDocument("@", documentPath);
         var completionContext = new VSInternalCompletionContext()
         {
             TriggerKind = CompletionTriggerKind.TriggerForIncompleteCompletions,
             InvokeKind = VSInternalCompletionInvokeKind.Deletion,
         };
+
         var provider = new RazorCompletionListProvider(_completionFactsService, _completionListCache, LoggerFactory);
 
         // Act
-        var completionList = await provider.GetCompletionListAsync(
-            absoluteIndex: 1, completionContext, documentContext, _clientCapabilities, existingCompletions: null, _razorCompletionOptions, DisposalToken);
+        var completionList = provider.GetCompletionList(
+            codeDocument, absoluteIndex: 1, completionContext, _clientCapabilities, existingCompletions: null, _razorCompletionOptions);
 
         // Assert
         Assert.NotNull(completionList);
@@ -430,7 +428,7 @@ public class RazorCompletionListProviderTest : LanguageServerTestBase
 
     [Fact]
     [WorkItem("https://github.com/dotnet/razor-tooling/issues/4547")]
-    public async Task GetCompletionListAsync_ProvidesInjectOnIncomplete_KeywordIn()
+    public void GetCompletionList_ProvidesInjectOnIncomplete_KeywordIn()
     {
         // Arrange
         var documentPath = "C:/path/to/document.razor";
@@ -439,9 +437,8 @@ public class RazorCompletionListProviderTest : LanguageServerTestBase
         builder.Metadata(TypeName("TestNamespace.TestTagHelper"));
         var tagHelper = builder.Build();
         var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, [tagHelper]);
-        var codeDocument = CreateCodeDocument("@in");
+        var codeDocument = CreateCodeDocument("@in", documentPath);
         codeDocument.SetTagHelperContext(tagHelperContext);
-        var documentContext = TestDocumentContext.Create(documentPath, codeDocument);
         var provider = new RazorCompletionListProvider(_completionFactsService, _completionListCache, LoggerFactory);
         var completionContext = new VSInternalCompletionContext()
         {
@@ -449,8 +446,8 @@ public class RazorCompletionListProviderTest : LanguageServerTestBase
         };
 
         // Act
-        var completionList = await provider.GetCompletionListAsync(
-            absoluteIndex: 1, completionContext, documentContext, _clientCapabilities, existingCompletions: null, _razorCompletionOptions, DisposalToken);
+        var completionList = provider.GetCompletionList(
+            codeDocument, absoluteIndex: 1, completionContext, _clientCapabilities, existingCompletions: null, _razorCompletionOptions);
 
         // Assert
         Assert.NotNull(completionList);
@@ -461,7 +458,7 @@ public class RazorCompletionListProviderTest : LanguageServerTestBase
     }
 
     [Fact]
-    public async Task GetCompletionListAsync_DoesNotProvideInjectOnInvoked()
+    public void GetCompletionList_DoesNotProvideInjectOnInvoked()
     {
         // Arrange
         var documentPath = "C:/path/to/document.razor";
@@ -470,9 +467,8 @@ public class RazorCompletionListProviderTest : LanguageServerTestBase
         builder.Metadata(TypeName("TestNamespace.TestTagHelper"));
         var tagHelper = builder.Build();
         var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, [tagHelper]);
-        var codeDocument = CreateCodeDocument("@inje");
+        var codeDocument = CreateCodeDocument("@inje", documentPath);
         codeDocument.SetTagHelperContext(tagHelperContext);
-        var documentContext = TestDocumentContext.Create(documentPath, codeDocument);
         var provider = new RazorCompletionListProvider(_completionFactsService, _completionListCache, LoggerFactory);
         var completionContext = new VSInternalCompletionContext()
         {
@@ -480,8 +476,8 @@ public class RazorCompletionListProviderTest : LanguageServerTestBase
         };
 
         // Act
-        var completionList = await provider.GetCompletionListAsync(
-            absoluteIndex: 1, completionContext, documentContext, _clientCapabilities, existingCompletions: null, _razorCompletionOptions, DisposalToken);
+        var completionList = provider.GetCompletionList(
+            codeDocument, absoluteIndex: 1, completionContext, _clientCapabilities, existingCompletions: null, _razorCompletionOptions);
 
         // Assert
         Assert.NotNull(completionList);
@@ -490,7 +486,7 @@ public class RazorCompletionListProviderTest : LanguageServerTestBase
 
     [Fact]
     [WorkItem("https://github.com/dotnet/razor-tooling/issues/4547")]
-    public async Task GetCompletionListAsync_ProvidesInjectOnIncomplete()
+    public void GetCompletionList_ProvidesInjectOnIncomplete()
     {
         // Arrange
         var documentPath = "C:/path/to/document.razor";
@@ -499,9 +495,8 @@ public class RazorCompletionListProviderTest : LanguageServerTestBase
         builder.Metadata(TypeName("TestNamespace.TestTagHelper"));
         var tagHelper = builder.Build();
         var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, [tagHelper]);
-        var codeDocument = CreateCodeDocument("@inje");
+        var codeDocument = CreateCodeDocument("@inje", documentPath);
         codeDocument.SetTagHelperContext(tagHelperContext);
-        var documentContext = TestDocumentContext.Create(documentPath, codeDocument);
         var provider = new RazorCompletionListProvider(_completionFactsService, _completionListCache, LoggerFactory);
         var completionContext = new VSInternalCompletionContext()
         {
@@ -509,8 +504,8 @@ public class RazorCompletionListProviderTest : LanguageServerTestBase
         };
 
         // Act
-        var completionList = await provider.GetCompletionListAsync(
-            absoluteIndex: 1, completionContext, documentContext, _clientCapabilities, existingCompletions: null, _razorCompletionOptions, DisposalToken);
+        var completionList = provider.GetCompletionList(
+            codeDocument, absoluteIndex: 1, completionContext, _clientCapabilities, existingCompletions: null, _razorCompletionOptions);
 
         // Assert
         Assert.NotNull(completionList);
@@ -522,7 +517,7 @@ public class RazorCompletionListProviderTest : LanguageServerTestBase
 
     // This is more of an integration test to validate that all the pieces work together
     [Fact]
-    public async Task GetCompletionListAsync_ProvidesTagHelperElementCompletionItems()
+    public void GetCompletionList_ProvidesTagHelperElementCompletionItems()
     {
         // Arrange
         var documentPath = "C:/path/to/document.cshtml";
@@ -531,14 +526,13 @@ public class RazorCompletionListProviderTest : LanguageServerTestBase
         builder.Metadata(TypeName("TestNamespace.TestTagHelper"));
         var tagHelper = builder.Build();
         var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, [tagHelper]);
-        var codeDocument = CreateCodeDocument("<");
+        var codeDocument = CreateCodeDocument("<", documentPath);
         codeDocument.SetTagHelperContext(tagHelperContext);
-        var documentContext = TestDocumentContext.Create(documentPath, codeDocument);
         var provider = new RazorCompletionListProvider(_completionFactsService, _completionListCache, LoggerFactory);
 
         // Act
-        var completionList = await provider.GetCompletionListAsync(
-            absoluteIndex: 1, _defaultCompletionContext, documentContext, _clientCapabilities, existingCompletions: null, _razorCompletionOptions, DisposalToken);
+        var completionList = provider.GetCompletionList(
+            codeDocument, absoluteIndex: 1, _defaultCompletionContext, _clientCapabilities, existingCompletions: null, _razorCompletionOptions);
 
         // Assert
         Assert.NotNull(completionList);
@@ -547,7 +541,7 @@ public class RazorCompletionListProviderTest : LanguageServerTestBase
 
     // This is more of an integration test to validate that all the pieces work together
     [Fact]
-    public async Task GetCompletionListAsync_ProvidesTagHelperAttributeItems()
+    public void GetCompletionList_ProvidesTagHelperAttributeItems()
     {
         // Arrange
         var documentPath = "C:/path/to/document.cshtml";
@@ -562,14 +556,13 @@ public class RazorCompletionListProviderTest : LanguageServerTestBase
         builder.Metadata(TypeName("TestNamespace.TestTagHelper"));
         var tagHelper = builder.Build();
         var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, [tagHelper]);
-        var codeDocument = CreateCodeDocument("<test  ");
+        var codeDocument = CreateCodeDocument("<test  ", documentPath);
         codeDocument.SetTagHelperContext(tagHelperContext);
-        var documentContext = TestDocumentContext.Create(documentPath, codeDocument);
         var provider = new RazorCompletionListProvider(_completionFactsService, _completionListCache, LoggerFactory);
 
         // Act
-        var completionList = await provider.GetCompletionListAsync(
-            absoluteIndex: 6, _defaultCompletionContext, documentContext, _clientCapabilities, existingCompletions: null, _razorCompletionOptions, DisposalToken);
+        var completionList = provider.GetCompletionList(
+            codeDocument, absoluteIndex: 6, _defaultCompletionContext, _clientCapabilities, existingCompletions: null, _razorCompletionOptions);
 
         // Assert
         Assert.NotNull(completionList);
@@ -577,7 +570,7 @@ public class RazorCompletionListProviderTest : LanguageServerTestBase
     }
 
     [Fact]
-    public async Task GetCompletionListAsync_ProvidesTagHelperAttributeItems_AttributeQuotesOff()
+    public void GetCompletionList_ProvidesTagHelperAttributeItems_AttributeQuotesOff()
     {
         // Arrange
         var documentPath = "C:/path/to/document.cshtml";
@@ -592,9 +585,8 @@ public class RazorCompletionListProviderTest : LanguageServerTestBase
         builder.SetMetadata(TypeName("TestNamespace.TestTagHelper"));
         var tagHelper = builder.Build();
         var tagHelperContext = TagHelperDocumentContext.Create(prefix: string.Empty, [tagHelper]);
-        var codeDocument = CreateCodeDocument("<test  ");
+        var codeDocument = CreateCodeDocument("<test  ", documentPath);
         codeDocument.SetTagHelperContext(tagHelperContext);
-        var documentContext = TestDocumentContext.Create(documentPath, codeDocument);
 
         // Set up desired options
         var razorCompletionOptions = new RazorCompletionOptions(SnippetsSupported: true, AutoInsertAttributeQuotes: false, CommitElementsWithSpace: true);
@@ -603,18 +595,18 @@ public class RazorCompletionListProviderTest : LanguageServerTestBase
         var provider = new RazorCompletionListProvider(completionFactsService, _completionListCache, LoggerFactory);
 
         // Act
-        var completionList = await provider.GetCompletionListAsync(
-            absoluteIndex: 6, _defaultCompletionContext, documentContext, _clientCapabilities, existingCompletions: null, razorCompletionOptions, DisposalToken);
+        var completionList = provider.GetCompletionList(
+            codeDocument, absoluteIndex: 6, _defaultCompletionContext, _clientCapabilities, existingCompletions: null, razorCompletionOptions);
 
         // Assert
         Assert.NotNull(completionList);
         Assert.Contains(completionList.Items, item => item.InsertText == "testAttribute=$0");
     }
 
-    private static RazorCodeDocument CreateCodeDocument(string text)
+    private static RazorCodeDocument CreateCodeDocument(string text, string documentFilePath)
     {
         var codeDocument = TestRazorCodeDocument.CreateEmpty();
-        var sourceDocument = TestRazorSourceDocument.Create(text);
+        var sourceDocument = TestRazorSourceDocument.Create(text, filePath: documentFilePath);
         var syntaxTree = RazorSyntaxTree.Parse(sourceDocument);
         codeDocument.SetSyntaxTree(syntaxTree);
         var tagHelperDocumentContext = TagHelperDocumentContext.Create(prefix: string.Empty, tagHelpers: []);


### PR DESCRIPTION
A lot of the code to compute completion lists is asynchronous in order to call `DocumentContext.GetCodeDocumentAsync(...)`. However, many of these calls can be made synchronous if the `RazorCodeDocument` is computed up front and passed in. In addition, I've updated some methods that have both synchronous and asynchronous paths to return `ValueTask`.

I hope that I don't conflict too badly with @davidwengier's completion work.

CI Build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2662887&view=results
Test Insertion: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/619102