### PR TITLE
Couple of small code actions tweaks

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/Razor/ExtractToComponentCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/Razor/ExtractToComponentCodeActionProvider.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.Threading;
 using Microsoft.CodeAnalysis.Razor.CodeActions.Models;
@@ -23,6 +24,14 @@ internal class ExtractToComponentCodeActionProvider() : IRazorCodeActionProvider
     {
         if (!context.SupportsFileCreation)
         {
+            return SpecializedTasks.EmptyImmutableArray<RazorVSInternalCodeAction>();
+        }
+
+        if (context.ContainsDiagnostic(ComponentDiagnosticFactory.UnexpectedMarkupElement.Id) &&
+            !context.HasSelection)
+        {
+            // If we are telling the user that a component doesn't exist, and they just have their cursor in the tag, they
+            // won't get any benefit from extracting a non-existing component to a new component.
             return SpecializedTasks.EmptyImmutableArray<RazorVSInternalCodeAction>();
         }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/Razor/GenerateMethodCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/Razor/GenerateMethodCodeActionProvider.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor;
@@ -14,7 +12,6 @@ using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.AspNetCore.Razor.Threading;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor.CodeActions.Models;
 using SyntaxFacts = Microsoft.CodeAnalysis.CSharp.SyntaxFacts;
 
@@ -26,8 +23,7 @@ internal class GenerateMethodCodeActionProvider : IRazorCodeActionProvider
 {
     public Task<ImmutableArray<RazorVSInternalCodeAction>> ProvideAsync(RazorCodeActionContext context, CancellationToken cancellationToken)
     {
-        var nameNotExistDiagnostics = context.Request.Context.Diagnostics.Any(d => d.Code == "CS0103");
-        if (!nameNotExistDiagnostics)
+        if (!context.ContainsDiagnostic("CS0103"))
         {
             return SpecializedTasks.EmptyImmutableArray<RazorVSInternalCodeAction>();
         }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/RazorCodeActionContext.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/RazorCodeActionContext.cs
@@ -22,4 +22,24 @@ internal sealed record class RazorCodeActionContext(
     bool SupportsCodeActionResolve)
 {
     public bool HasSelection => StartAbsoluteIndex != EndAbsoluteIndex;
+
+    public bool ContainsDiagnostic(string code)
+    {
+        if (Request.Context.Diagnostics is null)
+        {
+            return false;
+        }
+
+        foreach (var diagnostic in Request.Context.Diagnostics)
+        {
+            if (diagnostic.Code is { } codeSumType &&
+                codeSumType.TryGetSecond(out var codeString) &&
+                codeString == code)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CodeActions/CohostCodeActionsEndpointTestBase.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CodeActions/CohostCodeActionsEndpointTestBase.cs
@@ -89,10 +89,14 @@ public abstract class CohostCodeActionsEndpointTestBase(ITestOutputHelper testOu
             }
         }
 
+        var range = input.HasSpans
+            ? inputText.GetRange(input.Span)
+            : inputText.GetRange(input.Position, input.Position);
+
         var request = new VSCodeActionParams
         {
             TextDocument = new VSTextDocumentIdentifier { Uri = document.CreateUri() },
-            Range = inputText.GetRange(input.Span),
+            Range = range,
             Context = new VSInternalCodeActionContext() { Diagnostics = diagnostics.ToArray() }
         };
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CodeActions/ExtractToComponentTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CodeActions/ExtractToComponentTests.cs
@@ -38,4 +38,23 @@ public class ExtractToComponentTests(ITestOutputHelper testOutputHelper) : Cohos
                     </div>
                     """)]);
     }
+
+    [Fact]
+    public async Task DontOfferOnNonExistentComponent()
+    {
+        await VerifyCodeActionAsync(
+            input: """
+                <div></div>
+
+                <div>
+                    Hello World
+                </div>
+
+                <{|RZ10012:Not$$AComponent|} />
+
+                <div></div>
+                """,
+            expected: null,
+            codeActionName: WorkspacesSR.ExtractTo_Component_Title);
+    }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CodeActions/WrapAttributeTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CodeActions/WrapAttributeTests.cs
@@ -101,4 +101,31 @@ public class WrapAttributeTests(ITestOutputHelper testOutputHelper) : CohostCode
             expected: null,
             codeActionName: LanguageServerConstants.CodeActions.WrapAttributes);
     }
+
+    [Fact]
+    public async Task SelfClosing()
+    {
+        await VerifyCodeActionAsync(
+            input: """
+                @if (true)
+                {
+                    <div>
+                        <in[||]put bar="Baz" Zip="Zap" checked @onclick="foo" Pop="Pap" />
+                    </div>
+                }
+                """,
+            expected: """
+                @if (true)
+                {
+                    <div>
+                        <input bar="Baz"
+                               Zip="Zap"
+                               checked
+                               @onclick="foo"
+                               Pop="Pap" />
+                    </div>
+                }
+                """,
+            codeActionName: LanguageServerConstants.CodeActions.WrapAttributes);
+    }
 }


### PR DESCRIPTION
A two-for-one PR!

I noticed Wrap Attributes wasn't working for self-closing input tags when I was recording a video yesterday, and overnight @AdmiralSnyder reported an annoyance with Extract to Component, and they were both small fixes, so here they are.