### PR TITLE
Fix a couple of Razor project issues

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshotManager.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshotManager.cs
@@ -301,30 +301,22 @@ internal partial class ProjectSnapshotManager : IDisposable
 
     private void OpenDocument(ProjectKey projectKey, string documentFilePath, SourceText text)
     {
-        if (TryUpdateProject(
-            projectKey,
-            transformer: state => state.WithDocumentText(documentFilePath, text),
-            onAfterUpdate: () => _openDocumentSet.Add(documentFilePath),
-            out var oldProject,
-            out var newProject,
-            out var isSolutionClosing))
+        using (_readerWriterLock.DisposableWrite())
         {
-            NotifyListeners(ProjectChangeEventArgs.DocumentChanged(oldProject, newProject, documentFilePath, isSolutionClosing));
+            _openDocumentSet.Add(documentFilePath);
         }
+
+        UpdateDocumentText(projectKey, documentFilePath, text);
     }
 
     private void CloseDocument(ProjectKey projectKey, string documentFilePath, TextLoader textLoader)
     {
-        if (TryUpdateProject(
-            projectKey,
-            transformer: state => state.WithDocumentText(documentFilePath, textLoader),
-            onAfterUpdate: () => _openDocumentSet.Remove(documentFilePath),
-            out var oldProject,
-            out var newProject,
-            out var isSolutionClosing))
+        using (_readerWriterLock.DisposableWrite())
         {
-            NotifyListeners(ProjectChangeEventArgs.DocumentChanged(oldProject, newProject, documentFilePath, isSolutionClosing));
+            _openDocumentSet.Remove(documentFilePath);
         }
+
+        UpdateDocumentText(projectKey, documentFilePath, textLoader);
     }
 
     private void UpdateDocumentText(ProjectKey projectKey, string documentFilePath, SourceText text)
@@ -413,15 +405,6 @@ internal partial class ProjectSnapshotManager : IDisposable
         [NotNullWhen(true)] out ProjectSnapshot? oldProject,
         [NotNullWhen(true)] out ProjectSnapshot? newProject,
         out bool isSolutionClosing)
-        => TryUpdateProject(projectKey, transformer, onAfterUpdate: null, out oldProject, out newProject, out isSolutionClosing);
-
-    private bool TryUpdateProject(
-        ProjectKey projectKey,
-        Func<ProjectState, ProjectState> transformer,
-        Action? onAfterUpdate,
-        [NotNullWhen(true)] out ProjectSnapshot? oldProject,
-        [NotNullWhen(true)] out ProjectSnapshot? newProject,
-        out bool isSolutionClosing)
     {
         if (_initialized)
         {
@@ -458,8 +441,6 @@ internal partial class ProjectSnapshotManager : IDisposable
 
         var newEntry = new Entry(newState);
         _projectMap[projectKey] = newEntry;
-
-        onAfterUpdate?.Invoke();
 
         oldProject = oldEntry.GetSnapshot();
         newProject = newEntry.GetSnapshot();

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Discovery/OutOfProcTagHelperResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Discovery/OutOfProcTagHelperResolver.cs
@@ -4,6 +4,9 @@
 using System;
 using System.Collections.Immutable;
 using System.ComponentModel.Composition;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
@@ -87,39 +90,52 @@ internal class OutOfProcTagHelperResolver(
 
         if (deltaResult is null)
         {
+            // For some reason, TryInvokeAsync can return null if it is cancelled while fetching the client.
             return default;
         }
 
         // Apply the delta we received to any cached checksums for the current project.
         var checksums = ProduceChecksumsFromDelta(project.Id, lastResultId, deltaResult);
 
-        using var tagHelpers = new PooledArrayBuilder<TagHelperDescriptor>(capacity: checksums.Length);
-        using var checksumsToFetch = new PooledArrayBuilder<Checksum>(capacity: checksums.Length);
+        // Create an array to hold the result. We'll wrap it in an ImmutableArray at the end.
+        var result = new TagHelperDescriptor[checksums.Length];
 
-        foreach (var checksum in checksums)
+        // We need to keep track of which checksums we still need to fetch tag helpers for from OOP.
+        // In addition, we'll track the indices in tagHelpers that we'll need to replace with those we
+        // fetch to ensure that the results stay in the same order.
+        using var checksumsToFetchBuilder = new PooledArrayBuilder<Checksum>(capacity: checksums.Length);
+        using var checksumIndicesBuilder = new PooledArrayBuilder<int>(capacity: checksums.Length);
+
+        for (var i = 0; i < checksums.Length; i++)
         {
+            var checksum = checksums[i];
+
             // See if we have a cached version of this tag helper. If not, we'll need to fetch it from OOP.
             if (TagHelperCache.Default.TryGet(checksum, out var tagHelper))
             {
-                tagHelpers.Add(tagHelper);
+                result[i] = tagHelper;
             }
             else
             {
-                checksumsToFetch.Add(checksum);
+                checksumsToFetchBuilder.Add(checksum);
+                checksumIndicesBuilder.Add(i);
             }
         }
 
-        if (checksumsToFetch.Count > 0)
+        if (checksumsToFetchBuilder.Count > 0)
         {
+            var checksumsToFetch = checksumsToFetchBuilder.DrainToImmutable();
+
             // There are checksums that we don't have cached tag helpers for, so we need to fetch them from OOP.
             var fetchResult = await _remoteServiceInvoker.TryInvokeAsync<IRemoteTagHelperProviderService, FetchTagHelpersResult>(
                 project.Solution,
                 (service, solutionInfo, innerCancellationToken) =>
-                    service.FetchTagHelpersAsync(solutionInfo, projectHandle, checksumsToFetch.DrainToImmutable(), innerCancellationToken),
+                    service.FetchTagHelpersAsync(solutionInfo, projectHandle, checksumsToFetch, innerCancellationToken),
                 cancellationToken);
 
             if (fetchResult is null)
             {
+                // For some reason, TryInvokeAsync can return null if it is cancelled while fetching the client.
                 return default;
             }
 
@@ -131,16 +147,46 @@ internal class OutOfProcTagHelperResolver(
                 throw new InvalidOperationException("Tag helpers could not be fetched from the Roslyn OOP.");
             }
 
+            Debug.Assert(
+                checksumsToFetch.Length == fetchedTagHelpers.Length,
+                $"{nameof(FetchTagHelpersResult)} should return the same number of tag helpers as checksums requested.");
+
+            Debug.Assert(
+                checksumsToFetch.SequenceEqual(fetchedTagHelpers.Select(static t => t.Checksum)),
+                $"{nameof(FetchTagHelpersResult)} should return tag helpers that match the checksums requested.");
+
             // Be sure to add the tag helpers we just fetched to the cache.
             var cache = TagHelperCache.Default;
-            foreach (var tagHelper in fetchedTagHelpers)
+
+            for (var i = 0; i < fetchedTagHelpers.Length; i++)
             {
-                tagHelpers.Add(tagHelper);
-                cache.TryAdd(tagHelper.Checksum, tagHelper);
+                var index = checksumIndicesBuilder[i];
+                Debug.Assert(result[index] is null);
+
+                var fetchedTagHelper = fetchedTagHelpers[i];
+                result[index] = fetchedTagHelper;
+                cache.TryAdd(fetchedTagHelper.Checksum, fetchedTagHelper);
+            }
+
+            if (checksumsToFetch.Length != fetchedTagHelpers.Length)
+            {
+                // We didn't receive all the tag helpers we requested. This is bad. However, instead of failing,
+                // we'll just return the tag helpers we were able to retrieve.
+                using var resultBuilder = new PooledArrayBuilder<TagHelperDescriptor>(capacity: result.Length);
+
+                foreach (var tagHelper in result)
+                {
+                    if (tagHelper is not null)
+                    {
+                        resultBuilder.Add(tagHelper);
+                    }
+                }
+
+                return resultBuilder.DrainToImmutable();
             }
         }
 
-        return tagHelpers.DrainToImmutable();
+        return ImmutableCollectionsMarshal.AsImmutableArray(result);
     }
 
     // Protected virtual for testing

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Discovery/OutOfProcTagHelperResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Discovery/OutOfProcTagHelperResolver.cs
@@ -170,6 +170,9 @@ internal class OutOfProcTagHelperResolver(
 
             if (checksumsToFetch.Length != fetchedTagHelpers.Length)
             {
+                _logger.LogWarning($"Expected to receive {checksumsToFetch.Length} tag helpers from Roslyn OOP, " +
+                    $"but received {fetchedTagHelpers.Length} instead. Returning a partial set of tag helpers.");
+
                 // We didn't receive all the tag helpers we requested. This is bad. However, instead of failing,
                 // we'll just return the tag helpers we were able to retrieve.
                 using var resultBuilder = new PooledArrayBuilder<TagHelperDescriptor>(capacity: result.Length);

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/ProjectSnapshotManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/ProjectSnapshotManagerTest.cs
@@ -892,4 +892,31 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
 
         textLoader.Verify(d => d.LoadTextAndVersionAsync(It.IsAny<LoadTextOptions>(), It.IsAny<CancellationToken>()), Times.Never());
     }
+
+    [Fact]
+    public async Task SolutionClosing_RemovesProjectAndClosesDocument()
+    {
+        // Arrange
+
+        // Add project and open document.
+        await _projectManager.UpdateAsync(updater =>
+        {
+            updater.AddProject(s_hostProject);
+            updater.AddDocument(s_hostProject.Key, s_documents[0], EmptyTextLoader.Instance);
+            updater.OpenDocument(s_hostProject.Key, s_documents[0].FilePath, _sourceText);
+        });
+
+        // Act
+        await _projectManager.UpdateAsync(updater =>
+        {
+            updater.SolutionClosed();
+            updater.RemoveProject(s_hostProject.Key);
+            updater.CloseDocument(s_hostProject.Key, s_documents[0].FilePath, EmptyTextLoader.Instance);
+        });
+
+        // Assert
+        Assert.False(_projectManager.ContainsDocument(s_hostProject.Key, s_documents[0].FilePath));
+        Assert.False(_projectManager.ContainsProject(s_hostProject.Key));
+        Assert.False(_projectManager.IsDocumentOpen(s_documents[0].FilePath));
+    }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/ProjectSnapshotManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/ProjectSnapshotManagerTest.cs
@@ -63,7 +63,7 @@ public class ProjectSnapshotManagerTest : VisualStudioWorkspaceTestBase
     }
 
     [UIFact]
-    public async Task Initialize_DoneInCorrectOrderBasedOnInitializePriorityPriority()
+    public async Task Initialize_DoneInCorrectOrderBasedOnInitializePriority()
     {
         // Arrange
         var initializedOrder = new List<string>();


### PR DESCRIPTION
I was debugging through `ProjectSnapshotManager` and noticed a couple of issues:

1. Documents won't be cleared from `ProjectSnapshotManager`'s open documents on solution close.
2. The algorithm to request tag helpers from OOP has some undesirable behavior. Essentially, any tag helpers that it had to fetch from OOP using checksums will be added to the end of the result. That can result in cases when the `ProjectWorkspaceState` is updated for a project with exactly the same tag helpers in a different order. This results in `SequenceEquals(...)` returning false when comparing old and new `ProjectWorkspaceState` and all of the documents being invalidated.

CI Build: https://dev.azure.com/dnceng/internal/_build/results?buildId=2668868&view=results
Test Insertion: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/621272

