### PR TITLE
Don't format if we didn't get a response from the Html formatter

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DocumentFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DocumentFormattingEndpoint.cs
@@ -56,7 +56,15 @@ internal class DocumentFormattingEndpoint(
 
         var options = RazorFormattingOptions.From(request.Options, _optionsMonitor.CurrentValue.CodeBlockBraceOnNextLine);
 
-        var htmlChanges = await _htmlFormatter.GetDocumentFormattingEditsAsync(documentContext.Snapshot, documentContext.Uri, request.Options, cancellationToken).ConfigureAwait(false);
+        if (await _htmlFormatter.GetDocumentFormattingEditsAsync(
+            documentContext.Snapshot,
+            documentContext.Uri,
+            request.Options,
+            cancellationToken).ConfigureAwait(false) is not { } htmlChanges)
+        {
+            return null;
+        }
+
         var changes = await _razorFormattingService.GetDocumentFormattingChangesAsync(documentContext, htmlChanges, span: null, options, cancellationToken).ConfigureAwait(false);
 
         return [.. changes.Select(codeDocument.Source.Text.GetTextEdit)];

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DocumentOnTypeFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DocumentOnTypeFormattingEndpoint.cs
@@ -106,7 +106,17 @@ internal class DocumentOnTypeFormattingEndpoint(
         }
         else if (triggerCharacterKind == RazorLanguageKind.Html)
         {
-            var htmlChanges = await _htmlFormatter.GetOnTypeFormattingEditsAsync(documentContext.Snapshot, documentContext.Uri, request.Position, request.Character, request.Options, cancellationToken).ConfigureAwait(false);
+            if (await _htmlFormatter.GetOnTypeFormattingEditsAsync(
+                documentContext.Snapshot,
+                documentContext.Uri,
+                request.Position,
+                request.Character,
+                request.Options,
+                cancellationToken).ConfigureAwait(false) is not { } htmlChanges)
+            {
+                return null;
+            }
+
             formattedChanges = await _razorFormattingService.GetHtmlOnTypeFormattingChangesAsync(documentContext, htmlChanges, options, hostDocumentIndex, request.Character[0], cancellationToken).ConfigureAwait(false);
         }
         else

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DocumentRangeFormattingEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/DocumentRangeFormattingEndpoint.cs
@@ -69,7 +69,15 @@ internal class DocumentRangeFormattingEndpoint(
 
         var options = RazorFormattingOptions.From(request.Options, _optionsMonitor.CurrentValue.CodeBlockBraceOnNextLine);
 
-        var htmlChanges = await _htmlFormatter.GetDocumentFormattingEditsAsync(documentContext.Snapshot, documentContext.Uri, request.Options, cancellationToken).ConfigureAwait(false);
+        if (await _htmlFormatter.GetDocumentFormattingEditsAsync(
+            documentContext.Snapshot,
+            documentContext.Uri,
+            request.Options,
+            cancellationToken).ConfigureAwait(false) is not { } htmlChanges)
+        {
+            return null;
+        }
+
         var changes = await _razorFormattingService.GetDocumentFormattingChangesAsync(documentContext, htmlChanges, request.Range.ToLinePositionSpan(), options, cancellationToken).ConfigureAwait(false);
 
         return [.. changes.Select(codeDocument.Source.Text.GetTextEdit)];

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/HtmlFormatter.cs
@@ -21,7 +21,7 @@ internal sealed class HtmlFormatter(
 {
     private readonly IClientConnection _clientConnection = clientConnection;
 
-    public async Task<ImmutableArray<TextChange>> GetDocumentFormattingEditsAsync(
+    public async Task<ImmutableArray<TextChange>?> GetDocumentFormattingEditsAsync(
         IDocumentSnapshot documentSnapshot,
         Uri uri,
         FormattingOptions options,
@@ -44,14 +44,14 @@ internal sealed class HtmlFormatter(
 
         if (result?.Edits is null)
         {
-            return [];
+            return null;
         }
 
         var sourceText = await documentSnapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);
         return result.Edits.SelectAsArray(sourceText.GetTextChange);
     }
 
-    public async Task<ImmutableArray<TextChange>> GetOnTypeFormattingEditsAsync(
+    public async Task<ImmutableArray<TextChange>?> GetOnTypeFormattingEditsAsync(
         IDocumentSnapshot documentSnapshot,
         Uri uri,
         Position position,
@@ -75,7 +75,7 @@ internal sealed class HtmlFormatter(
 
         if (result?.Edits is null)
         {
-            return [];
+            return null;
         }
 
         var sourceText = await documentSnapshot.GetTextAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/IHtmlFormatter.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Formatting/IHtmlFormatter.cs
@@ -13,6 +13,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 
 internal interface IHtmlFormatter
 {
-    Task<ImmutableArray<TextChange>> GetDocumentFormattingEditsAsync(IDocumentSnapshot documentSnapshot, Uri uri, FormattingOptions options, CancellationToken cancellationToken);
-    Task<ImmutableArray<TextChange>> GetOnTypeFormattingEditsAsync(IDocumentSnapshot documentSnapshot, Uri uri, Position position, string triggerCharacter, FormattingOptions options, CancellationToken cancellationToken);
+    Task<ImmutableArray<TextChange>?> GetDocumentFormattingEditsAsync(IDocumentSnapshot documentSnapshot, Uri uri, FormattingOptions options, CancellationToken cancellationToken);
+    Task<ImmutableArray<TextChange>?> GetOnTypeFormattingEditsAsync(IDocumentSnapshot documentSnapshot, Uri uri, Position position, string triggerCharacter, FormattingOptions options, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_HtmlFormatting.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_HtmlFormatting.cs
@@ -16,7 +16,7 @@ internal partial class RazorCustomMessageTarget
 {
     // Called by the Razor Language Server to invoke a razor/htmlFormatting request on the virtual Html buffer.
     [JsonRpcMethod(CustomMessageNames.RazorHtmlFormattingEndpoint, UseSingleObjectParameterDeserialization = true)]
-    public async Task<RazorDocumentFormattingResponse> HtmlFormattingAsync(RazorDocumentFormattingParams request, CancellationToken cancellationToken)
+    public async Task<RazorDocumentFormattingResponse?> HtmlFormattingAsync(RazorDocumentFormattingParams request, CancellationToken cancellationToken)
     {
         var response = new RazorDocumentFormattingResponse() { Edits = Array.Empty<TextEdit>() };
 
@@ -32,7 +32,7 @@ internal partial class RazorCustomMessageTarget
         if (!synchronized || htmlDocument is null)
         {
             Debug.Fail("RangeFormatting not synchronized.");
-            return response;
+            return null;
         }
 
         var projectedUri = htmlDocument.Uri;
@@ -51,14 +51,19 @@ internal partial class RazorCustomMessageTarget
             formattingParams,
             cancellationToken).ConfigureAwait(false);
 
-        response.Edits = edits?.Response ?? Array.Empty<TextEdit>();
+        if (edits?.Response is null)
+        {
+            return null;
+        }
+
+        response.Edits = edits.Response;
 
         return response;
     }
 
     // Called by the Razor Language Server to invoke a razor/htmlOnTypeFormatting request on the virtual Html buffer.
     [JsonRpcMethod(CustomMessageNames.RazorHtmlOnTypeFormattingEndpoint, UseSingleObjectParameterDeserialization = true)]
-    public async Task<RazorDocumentFormattingResponse> HtmlOnTypeFormattingAsync(RazorDocumentOnTypeFormattingParams request, CancellationToken cancellationToken)
+    public async Task<RazorDocumentFormattingResponse?> HtmlOnTypeFormattingAsync(RazorDocumentOnTypeFormattingParams request, CancellationToken cancellationToken)
     {
         var response = new RazorDocumentFormattingResponse() { Edits = Array.Empty<TextEdit>() };
 
@@ -69,7 +74,7 @@ internal partial class RazorCustomMessageTarget
 
         if (!synchronized || htmlDocument is null)
         {
-            return response;
+            return null;
         }
 
         var formattingParams = new DocumentOnTypeFormattingParams()
@@ -88,7 +93,12 @@ internal partial class RazorCustomMessageTarget
             formattingParams,
             cancellationToken).ConfigureAwait(false);
 
-        response.Edits = edits?.Response ?? Array.Empty<TextEdit>();
+        if (edits?.Response is null)
+        {
+            return null;
+        }
+
+        response.Edits = edits.Response;
 
         return response;
     }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/FormattingTestBase.cs
@@ -113,7 +113,7 @@ public abstract class FormattingTestBase : RazorToolingIntegrationTestBase
         var htmlChanges = await htmlFormatter.GetDocumentFormattingEditsAsync(documentSnapshot, uri, options, DisposalToken);
 
         // Act
-        var changes = await formattingService.GetDocumentFormattingChangesAsync(documentContext, htmlChanges, range, razorOptions, DisposalToken);
+        var changes = await formattingService.GetDocumentFormattingChangesAsync(documentContext, htmlChanges.AssumeNotNull(), range, razorOptions, DisposalToken);
 
         // Assert
         var edited = source.WithChanges(changes);
@@ -182,7 +182,7 @@ public abstract class FormattingTestBase : RazorToolingIntegrationTestBase
 
             var htmlFormatter = new HtmlFormatter(client);
             var htmlChanges = await htmlFormatter.GetDocumentFormattingEditsAsync(documentSnapshot, uri, options, DisposalToken);
-            changes = await formattingService.GetHtmlOnTypeFormattingChangesAsync(documentContext, htmlChanges, razorOptions, hostDocumentIndex: positionAfterTrigger, triggerCharacter: triggerCharacter, DisposalToken);
+            changes = await formattingService.GetHtmlOnTypeFormattingChangesAsync(documentContext, htmlChanges.AssumeNotNull(), razorOptions, hostDocumentIndex: positionAfterTrigger, triggerCharacter: triggerCharacter, DisposalToken);
         }
 
         // Assert

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/TestHtmlFormatter.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Formatting_NetFx/TestHtmlFormatter.cs
@@ -6,7 +6,6 @@ using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.ProjectSystem;
-using Microsoft.AspNetCore.Razor.Threading;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -14,13 +13,13 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 
 internal class TestHtmlFormatter : IHtmlFormatter
 {
-    public Task<ImmutableArray<TextChange>> GetDocumentFormattingEditsAsync(IDocumentSnapshot documentSnapshot, Uri uri, FormattingOptions options, CancellationToken cancellationToken)
+    public Task<ImmutableArray<TextChange>?> GetDocumentFormattingEditsAsync(IDocumentSnapshot documentSnapshot, Uri uri, FormattingOptions options, CancellationToken cancellationToken)
     {
-        return SpecializedTasks.EmptyImmutableArray<TextChange>();
+        return Task.FromResult<ImmutableArray<TextChange>?>([]);
     }
 
-    public Task<ImmutableArray<TextChange>> GetOnTypeFormattingEditsAsync(IDocumentSnapshot documentSnapshot, Uri uri, Position position, string triggerCharacter, FormattingOptions options, CancellationToken cancellationToken)
+    public Task<ImmutableArray<TextChange>?> GetOnTypeFormattingEditsAsync(IDocumentSnapshot documentSnapshot, Uri uri, Position position, string triggerCharacter, FormattingOptions options, CancellationToken cancellationToken)
     {
-        return SpecializedTasks.EmptyImmutableArray<TextChange>();
+        return Task.FromResult<ImmutableArray<TextChange>?>([]);
     }
 }


### PR DESCRIPTION
Partial fix for the symptoms of https://github.com/dotnet/razor/issues/11643

Turns out there is a bug in our handling of Html documents in multi-target projects, and most likely everything has been quietly failing sometimes. Additionally it turns out that the new formatting engine doesn't format things nicely if we don't get a response from Html, so this PR fixes that, and stops things breaking users documents.

I'll follow up with a proper fix soon.