### PR TITLE
Fix Html issues in multi-targeted projects

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget.cs
@@ -141,7 +141,7 @@ internal partial class RazorCustomMessageTarget
         where TVirtualDocumentSnapshot : VirtualDocumentSnapshot
     {
         if (_languageServerFeatureOptions.UseRazorCohostServer &&
-    typeof(TVirtualDocumentSnapshot) == typeof(HtmlVirtualDocumentSnapshot))
+            typeof(TVirtualDocumentSnapshot) == typeof(HtmlVirtualDocumentSnapshot))
         {
             return await TempForCohost_TrySynchronizeVirtualDocumentAsync<TVirtualDocumentSnapshot>(hostDocument, cancellationToken);
         }

--- a/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/MultiTargetProjectTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.Razor.IntegrationTests/MultiTargetProjectTests.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using System.Threading.Tasks;
+using Roslyn.Test.Utilities;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -82,5 +83,24 @@ public class MultiTargetProjectTests(ITestOutputHelper testOutputHelper) : Abstr
         Assert.Equal(expectedProjectFileName, actualProjectFileName);
 
         await TestServices.Editor.CloseCodeFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.ErrorCshtmlFile, saveFile: false, ControlledHangMitigatingCancellationToken);
+    }
+
+    [IdeFact]
+    public async Task HtmlHover()
+    {
+        await TestServices.SolutionExplorer.OpenFileAsync(RazorProjectConstants.BlazorProjectName, RazorProjectConstants.CounterRazorFile, ControlledHangMitigatingCancellationToken);
+
+        await TestServices.Editor.WaitForComponentClassificationAsync(ControlledHangMitigatingCancellationToken);
+
+        await TestServices.Workspace.WaitForProjectSystemAsync(ControlledHangMitigatingCancellationToken);
+
+        await TestServices.Editor.PlaceCaretAsync("h1", charsOffset: -1, ControlledHangMitigatingCancellationToken);
+
+        var position = await TestServices.Editor.GetCaretPositionAsync(ControlledHangMitigatingCancellationToken);
+
+        var hoverString = await TestServices.Editor.WaitForHoverStringAsync(position, ControlledHangMitigatingCancellationToken);
+
+        const string ExpectedResult = "These elements represent headings for their sections.";
+        AssertEx.EqualOrDiff(ExpectedResult, hoverString);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/11643

Simple fix in the end. In an ideal world we'd probably move to checksums as well as version numbers but cohosting already uses checksums so seemed not worth the effort.

You'll just have to trust me that the integration test fails without this fix, but it totally does!