### PR TITLE
Set PackageProjectUrl

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,6 +28,9 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
 
+    <!-- When building in the VMR, we still want the package project url to point to this repo -->
+    <PackageProjectUrl>https://github.com/dotnet/razor</PackageProjectUrl>
+
     <!-- VS does not require Windows PDBs to be published anymore. -->
     <PublishWindowsPdb>false</PublishWindowsPdb>
 


### PR DESCRIPTION
Avoids the SDK setting this to dotnet/dotnet automatically, which is generally not useful for customers.

﻿### Summary of the changes

-

Fixes:
