### PR TITLE
Fuse/fix debugging info

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentCodeGenerationTestBase.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/IntegrationTests/ComponentCodeGenerationTestBase.cs
@@ -2325,7 +2325,7 @@ namespace Test
             ] : [
             // (24,36): error CS1525: Invalid expression term ')'
             //             __builder.AddContent(3, 
-            Diagnostic(ErrorCode.ERR_InvalidExprTerm, "").WithArguments(")").WithLocation(24, 36)
+            Diagnostic(ErrorCode.ERR_InvalidExprTerm, "").WithArguments(")").WithLocation(3, 2)
             ]);
     }
 
@@ -10607,7 +10607,7 @@ namespace Test
                Diagnostic(ErrorCode.ERR_NameNotInContext, "Foo").WithArguments("Foo").WithLocation(5, 2),
                // (33,13): error CS0103: The name '__builder' does not exist in the current context
                //             __builder.AddContent(0,
-               Diagnostic(ErrorCode.ERR_NameNotInContext, "__builder").WithArguments("__builder").WithLocation(41, 13)]);
+               Diagnostic(ErrorCode.ERR_NameNotInContext, "__builder").WithArguments("__builder").WithLocation(5, 2)]);
     }
 
     [IntegrationTestFact]

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AtTransitions/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AtTransitions/TestComponent.codegen.cs
@@ -27,10 +27,9 @@ namespace Test
 #line hidden
 #nullable disable
 
-            __builder.AddContent(0, 
 #nullable restore
-#line (3,6)-(3,7) "x:\dir\subdir\Test\TestComponent.cshtml"
-x
+#line (3,6)-(3,7) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(0, x
 
 #line default
 #line hidden
@@ -44,10 +43,9 @@ x
 #line hidden
 #nullable disable
 
-            __builder.AddContent(1, 
 #nullable restore
-#line (3,22)-(3,23) "x:\dir\subdir\Test\TestComponent.cshtml"
-x
+#line (3,22)-(3,23) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(1, x
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AtTransitions/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/AtTransitions/TestComponent.mappings.txt
@@ -9,23 +9,23 @@ Generated Location: (734:21,0 [32] )
 
 Source Location: (35:2,5 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |x|
-Generated Location: (938:32,0 [1] )
+Generated Location: (927:31,24 [1] )
 |x|
 
 Source Location: (36:2,6 [14] x:\dir\subdir\Test\TestComponent.cshtml)
 | x = "world"; |
-Generated Location: (1088:40,0 [14] )
+Generated Location: (1077:39,0 [14] )
 | x = "world"; |
 
 Source Location: (51:2,21 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |x|
-Generated Location: (1276:49,0 [1] )
+Generated Location: (1254:47,24 [1] )
 |x|
 
 Source Location: (52:2,22 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |  
 |
-Generated Location: (1426:57,0 [4] )
+Generated Location: (1404:55,0 [4] )
 |  
 |
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingBindValueWithGetSet/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingBindValueWithGetSet/TestComponent.codegen.cs
@@ -37,10 +37,9 @@ UpdateValue
 #nullable disable
             , value: ParentValue), ParentValue));
             __builder.SetUpdatesAttributeName("myvalue");
-            __builder.AddContent(3, 
 #nullable restore
-#line (1,39)-(1,50) "x:\dir\subdir\Test\TestComponent.cshtml"
-ParentValue
+#line (1,39)-(1,50) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(3, ParentValue
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingBindValueWithGetSet/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BindToElement_MixingBindValueWithGetSet/TestComponent.mappings.txt
@@ -10,7 +10,7 @@ Generated Location: (1300:32,0 [11] )
 
 Source Location: (38:0,38 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |ParentValue|
-Generated Location: (1593:42,0 [11] )
+Generated Location: (1582:41,24 [11] )
 |ParentValue|
 
 Source Location: (86:1,7 [124] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -19,7 +19,7 @@ Source Location: (86:1,7 [124] x:\dir\subdir\Test\TestComponent.cshtml)
 
     public void UpdateValue(string value) => ParentValue = value;
 |
-Generated Location: (1840:53,0 [124] )
+Generated Location: (1829:52,0 [124] )
 |
     public string ParentValue { get; set; } = "hi";
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndAttributeChildContent/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndAttributeChildContent/TestComponent.codegen.cs
@@ -27,10 +27,9 @@ namespace Test
 
             (__builder2) => {
                 __builder2.OpenElement(0, "div");
-                __builder2.AddContent(1, 
 #nullable restore
-#line (1,56)-(1,82) "x:\dir\subdir\Test\TestComponent.cshtml"
-context.ToLowerInvariant()
+#line (1,56)-(1,82) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(1, context.ToLowerInvariant()
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndAttributeChildContent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndAttributeChildContent/TestComponent.mappings.txt
@@ -5,21 +5,21 @@ Generated Location: (735:21,0 [46] )
 
 Source Location: (55:0,55 [26] x:\dir\subdir\Test\TestComponent.cshtml)
 |context.ToLowerInvariant()|
-Generated Location: (1042:32,0 [26] )
+Generated Location: (1027:31,25 [26] )
 |context.ToLowerInvariant()|
 
 Source Location: (87:0,87 [2] x:\dir\subdir\Test\TestComponent.cshtml)
 |; |
-Generated Location: (1281:42,0 [2] )
+Generated Location: (1266:41,0 [2] )
 |; |
 
 Source Location: (105:1,13 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |Header|
-Generated Location: (1567:52,0 [6] )
+Generated Location: (1552:51,0 [6] )
 |Header|
 
 Source Location: (113:1,21 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |header|
-Generated Location: (1804:60,0 [6] )
+Generated Location: (1789:59,0 [6] )
 |header|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndExplicitChildContent/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndExplicitChildContent/TestComponent.codegen.cs
@@ -27,10 +27,9 @@ namespace Test
 
             (__builder2) => {
                 __builder2.OpenElement(0, "div");
-                __builder2.AddContent(1, 
 #nullable restore
-#line (1,56)-(1,82) "x:\dir\subdir\Test\TestComponent.cshtml"
-context.ToLowerInvariant()
+#line (1,56)-(1,82) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(1, context.ToLowerInvariant()
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndExplicitChildContent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/BodyAndExplicitChildContent/TestComponent.mappings.txt
@@ -5,21 +5,21 @@ Generated Location: (735:21,0 [46] )
 
 Source Location: (55:0,55 [26] x:\dir\subdir\Test\TestComponent.cshtml)
 |context.ToLowerInvariant()|
-Generated Location: (1042:32,0 [26] )
+Generated Location: (1027:31,25 [26] )
 |context.ToLowerInvariant()|
 
 Source Location: (87:0,87 [2] x:\dir\subdir\Test\TestComponent.cshtml)
 |; |
-Generated Location: (1281:42,0 [2] )
+Generated Location: (1266:41,0 [2] )
 |; |
 
 Source Location: (105:1,13 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |Header|
-Generated Location: (1567:52,0 [6] )
+Generated Location: (1552:51,0 [6] )
 |Header|
 
 Source Location: (113:1,21 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |header|
-Generated Location: (1804:60,0 [6] )
+Generated Location: (1789:59,0 [6] )
 |header|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CanProduceLinePragmasForComponentWithRenderFragment_01/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CanProduceLinePragmasForComponentWithRenderFragment_01/TestComponent.codegen.cs
@@ -23,10 +23,9 @@ namespace Test
             __builder.AddAttribute(3, "href", "#");
             __builder.AddAttribute(4, "@onclick", "Toggle");
             __builder.AddAttribute(5, "class", "col-12");
-            __builder.AddContent(6, 
 #nullable restore
-#line (2,47)-(2,57) "x:\dir\subdir\Test\TestComponent.cshtml"
-ActionText
+#line (2,47)-(2,57) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(6, ActionText
 
 #line default
 #line hidden
@@ -52,10 +51,9 @@ if (!Collapsed)
 
             __builder.OpenElement(7, "div");
             __builder.AddAttribute(8, "class", "col-12 card card-body");
-            __builder.AddContent(9, 
 #nullable restore
-#line (6,8)-(6,20) "x:\dir\subdir\Test\TestComponent.cshtml"
-ChildContent
+#line (6,8)-(6,20) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(9, ChildContent
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CanProduceLinePragmasForComponentWithRenderFragment_01/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CanProduceLinePragmasForComponentWithRenderFragment_01/TestComponent.mappings.txt
@@ -1,31 +1,31 @@
 ﻿Source Location: (65:1,46 [10] x:\dir\subdir\Test\TestComponent.cshtml)
 |ActionText|
-Generated Location: (1094:28,0 [10] )
+Generated Location: (1083:27,24 [10] )
 |ActionText|
 
 Source Location: (81:2,0 [2] x:\dir\subdir\Test\TestComponent.cshtml)
 |  |
-Generated Location: (1291:37,0 [2] )
+Generated Location: (1280:36,0 [2] )
 |  |
 
 Source Location: (84:2,3 [22] x:\dir\subdir\Test\TestComponent.cshtml)
 |if (!Collapsed)
   {
 |
-Generated Location: (1427:45,0 [22] )
+Generated Location: (1416:44,0 [22] )
 |if (!Collapsed)
   {
 |
 
 Source Location: (154:5,7 [12] x:\dir\subdir\Test\TestComponent.cshtml)
 |ChildContent|
-Generated Location: (1740:57,0 [12] )
+Generated Location: (1718:55,24 [12] )
 |ChildContent|
 
 Source Location: (180:7,0 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |  }
 |
-Generated Location: (1939:66,0 [5] )
+Generated Location: (1917:64,0 [5] )
 |  }
 |
 
@@ -41,7 +41,7 @@ Source Location: (201:10,1 [277] x:\dir\subdir\Test\TestComponent.cshtml)
     Collapsed = !Collapsed;
   }
 |
-Generated Location: (2166:77,0 [277] )
+Generated Location: (2144:75,0 [277] )
 |
   [Parameter]
   public RenderFragment ChildContent { get; set; } = (context) => <p>@context</p>

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CanProduceLinePragmasForComponentWithRenderFragment_02/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CanProduceLinePragmasForComponentWithRenderFragment_02/TestComponent.codegen.cs
@@ -23,10 +23,9 @@ namespace Test
             __builder.AddAttribute(3, "href", "#");
             __builder.AddAttribute(4, "@onclick", "Toggle");
             __builder.AddAttribute(5, "class", "col-12");
-            __builder.AddContent(6, 
 #nullable restore
-#line (2,47)-(2,57) "x:\dir\subdir\Test\TestComponent.cshtml"
-ActionText
+#line (2,47)-(2,57) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(6, ActionText
 
 #line default
 #line hidden
@@ -52,10 +51,9 @@ if (!Collapsed)
 
             __builder.OpenElement(7, "div");
             __builder.AddAttribute(8, "class", "col-12 card card-body");
-            __builder.AddContent(9, 
 #nullable restore
-#line (6,8)-(6,20) "x:\dir\subdir\Test\TestComponent.cshtml"
-ChildContent
+#line (6,8)-(6,20) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(9, ChildContent
 
 #line default
 #line hidden
@@ -85,10 +83,9 @@ ChildContent
 
         (__builder2) => {
             __builder2.OpenElement(10, "p");
-            __builder2.AddContent(11, 
 #nullable restore
-#line (13,80)-(13,87) "x:\dir\subdir\Test\TestComponent.cshtml"
-context
+#line (13,80)-(13,87) 26 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(11, context
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CanProduceLinePragmasForComponentWithRenderFragment_02/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CanProduceLinePragmasForComponentWithRenderFragment_02/TestComponent.mappings.txt
@@ -1,31 +1,31 @@
 ﻿Source Location: (65:1,46 [10] x:\dir\subdir\Test\TestComponent.cshtml)
 |ActionText|
-Generated Location: (1094:28,0 [10] )
+Generated Location: (1083:27,24 [10] )
 |ActionText|
 
 Source Location: (81:2,0 [2] x:\dir\subdir\Test\TestComponent.cshtml)
 |  |
-Generated Location: (1291:37,0 [2] )
+Generated Location: (1280:36,0 [2] )
 |  |
 
 Source Location: (84:2,3 [22] x:\dir\subdir\Test\TestComponent.cshtml)
 |if (!Collapsed)
   {
 |
-Generated Location: (1427:45,0 [22] )
+Generated Location: (1416:44,0 [22] )
 |if (!Collapsed)
   {
 |
 
 Source Location: (154:5,7 [12] x:\dir\subdir\Test\TestComponent.cshtml)
 |ChildContent|
-Generated Location: (1740:57,0 [12] )
+Generated Location: (1718:55,24 [12] )
 |ChildContent|
 
 Source Location: (180:7,0 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |  }
 |
-Generated Location: (1939:66,0 [5] )
+Generated Location: (1917:64,0 [5] )
 |  }
 |
 
@@ -33,14 +33,14 @@ Source Location: (201:10,1 [91] x:\dir\subdir\Test\TestComponent.cshtml)
 |
   [Parameter]
   public RenderFragment<string> ChildContent { get; set; } = (context) => |
-Generated Location: (2167:77,0 [91] )
+Generated Location: (2145:75,0 [91] )
 |
   [Parameter]
   public RenderFragment<string> ChildContent { get; set; } = (context) => |
 
 Source Location: (297:12,79 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |context|
-Generated Location: (2509:90,0 [7] )
+Generated Location: (2476:87,26 [7] )
 |context|
 
 Source Location: (308:12,90 [180] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -53,7 +53,7 @@ Source Location: (308:12,90 [180] x:\dir\subdir\Test\TestComponent.cshtml)
     Collapsed = !Collapsed;
   }
 |
-Generated Location: (2718:100,0 [180] )
+Generated Location: (2685:97,0 [180] )
 |;
   [Parameter]
   public bool Collapsed { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_GenericChildContent/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_GenericChildContent/TestComponent.codegen.cs
@@ -29,10 +29,9 @@ Array.Empty<DateTime>()
                 , out var __typeInferenceArg_0___arg0);
                 global::__Blazor.Test.TestComponent.TypeInference.CreateGrid_0(__builder, 0, 1, __typeInferenceArg_0___arg0, 2, (__builder2) => {
                     global::__Blazor.Test.TestComponent.TypeInference.CreateColumn_1(__builder2, 3, __typeInferenceArg_0___arg0, 4, (context) => (__builder3) => {
-                        __builder3.AddContent(5, 
 #nullable restore
-#line (1,51)-(1,63) "x:\dir\subdir\Test\TestComponent.cshtml"
-context.Year
+#line (1,51)-(1,63) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder3.AddContent(5, context.Year
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_GenericChildContent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/CascadingGenericInference_GenericChildContent/TestComponent.mappings.txt
@@ -5,11 +5,11 @@ Generated Location: (850:23,0 [23] )
 
 Source Location: (50:0,50 [12] x:\dir\subdir\Test\TestComponent.cshtml)
 |context.Year|
-Generated Location: (1426:34,0 [12] )
+Generated Location: (1403:33,25 [12] )
 |context.Year|
 
 Source Location: (6:0,6 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Items|
-Generated Location: (2366:61,0 [5] )
+Generated Location: (2343:60,0 [5] )
 |Items|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericChildContent/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericChildContent/TestComponent.codegen.cs
@@ -37,10 +37,9 @@ Item
             ));
             __builder.AddAttribute(2, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment<string>)((context) => (__builder2) => {
                 __builder2.OpenElement(3, "div");
-                __builder2.AddContent(4, 
 #nullable restore
-#line (2,9)-(2,26) "x:\dir\subdir\Test\TestComponent.cshtml"
-context.ToLower()
+#line (2,9)-(2,26) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(4, context.ToLower()
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericChildContent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericChildContent/TestComponent.mappings.txt
@@ -10,6 +10,6 @@ Generated Location: (1145:31,0 [4] )
 
 Source Location: (51:1,8 [17] x:\dir\subdir\Test\TestComponent.cshtml)
 |context.ToLower()|
-Generated Location: (1544:42,0 [17] )
+Generated Location: (1529:41,25 [17] )
 |context.ToLower()|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericChildContent_TypeInference/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericChildContent_TypeInference/TestComponent.codegen.cs
@@ -27,10 +27,9 @@ namespace Test
 #nullable disable
             , 2, (context) => (__builder2) => {
                 __builder2.OpenElement(3, "div");
-                __builder2.AddContent(4, 
 #nullable restore
-#line (2,9)-(2,26) "x:\dir\subdir\Test\TestComponent.cshtml"
-context.ToLower()
+#line (2,9)-(2,26) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(4, context.ToLower()
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericChildContent_TypeInference/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_GenericChildContent_TypeInference/TestComponent.mappings.txt
@@ -5,11 +5,11 @@ Generated Location: (837:22,0 [4] )
 
 Source Location: (38:1,8 [17] x:\dir\subdir\Test\TestComponent.cshtml)
 |context.ToLower()|
-Generated Location: (1117:32,0 [17] )
+Generated Location: (1102:31,25 [17] )
 |context.ToLower()|
 
 Source Location: (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |Item|
-Generated Location: (1953:56,0 [4] )
+Generated Location: (1938:55,0 [4] )
 |Item|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_MultipleGenerics/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_MultipleGenerics/TestComponent.codegen.cs
@@ -37,10 +37,9 @@ Item
             ));
             __builder.AddAttribute(2, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment<string>)((context) => (__builder2) => {
                 __builder2.OpenElement(3, "div");
-                __builder2.AddContent(4, 
 #nullable restore
-#line (2,23)-(2,40) "x:\dir\subdir\Test\TestComponent.cshtml"
-context.ToLower()
+#line (2,23)-(2,40) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(4, context.ToLower()
 
 #line default
 #line hidden
@@ -50,10 +49,9 @@ context.ToLower()
             }
             ));
             __builder.AddAttribute(5, "AnotherChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment<Test.MyComponent<string, int>.Context>)((item) => (__builder2) => {
-                __builder2.AddContent(6, 
 #nullable restore
-#line (4,4)-(4,33) "x:\dir\subdir\Test\TestComponent.cshtml"
-System.Math.Max(0, item.Item)
+#line (4,4)-(4,33) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(6, System.Math.Max(0, item.Item)
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_MultipleGenerics/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_MultipleGenerics/TestComponent.mappings.txt
@@ -10,11 +10,11 @@ Generated Location: (1155:31,0 [4] )
 
 Source Location: (77:1,22 [17] x:\dir\subdir\Test\TestComponent.cshtml)
 |context.ToLower()|
-Generated Location: (1555:42,0 [17] )
+Generated Location: (1540:41,25 [17] )
 |context.ToLower()|
 
 Source Location: (158:3,3 [29] x:\dir\subdir\Test\TestComponent.cshtml)
 |System.Math.Max(0, item.Item)|
-Generated Location: (2030:55,0 [29] )
+Generated Location: (2000:53,25 [29] )
 |System.Math.Max(0, item.Item)|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_MultipleGenerics_TypeInference/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_MultipleGenerics_TypeInference/TestComponent.codegen.cs
@@ -35,10 +35,9 @@ new List<long>()
 #nullable disable
             , 3, (context) => (__builder2) => {
                 __builder2.OpenElement(4, "div");
-                __builder2.AddContent(5, 
 #nullable restore
-#line (2,23)-(2,40) "x:\dir\subdir\Test\TestComponent.cshtml"
-context.ToLower()
+#line (2,23)-(2,40) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(5, context.ToLower()
 
 #line default
 #line hidden
@@ -47,10 +46,9 @@ context.ToLower()
                 __builder2.CloseElement();
             }
             , 6, (item) => (__builder2) => {
-                __builder2.AddContent(7, 
 #nullable restore
-#line (4,4)-(4,33) "x:\dir\subdir\Test\TestComponent.cshtml"
-System.Math.Max(0, item.Item)
+#line (4,4)-(4,33) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(7, System.Math.Max(0, item.Item)
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_MultipleGenerics_TypeInference/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_MultipleGenerics_TypeInference/TestComponent.mappings.txt
@@ -10,21 +10,21 @@ Generated Location: (994:30,0 [16] )
 
 Source Location: (78:1,22 [17] x:\dir\subdir\Test\TestComponent.cshtml)
 |context.ToLower()|
-Generated Location: (1287:40,0 [17] )
+Generated Location: (1272:39,25 [17] )
 |context.ToLower()|
 
 Source Location: (159:3,3 [29] x:\dir\subdir\Test\TestComponent.cshtml)
 |System.Math.Max(0, item.Item)|
-Generated Location: (1605:52,0 [29] )
+Generated Location: (1575:50,25 [29] )
 |System.Math.Max(0, item.Item)|
 
 Source Location: (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |Item|
-Generated Location: (2689:76,0 [4] )
+Generated Location: (2659:74,0 [4] )
 |Item|
 
 Source Location: (28:0,28 [5] x:\dir\subdir\Test\TestComponent.cshtml)
 |Items|
-Generated Location: (2946:85,0 [5] )
+Generated Location: (2916:83,0 [5] )
 |Items|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_NonGenericParameterizedChildContent_TypeInference/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_NonGenericParameterizedChildContent_TypeInference/TestComponent.codegen.cs
@@ -26,10 +26,9 @@ namespace Test
 #line hidden
 #nullable disable
             , 2, (context) => (__builder2) => {
-                __builder2.AddContent(3, 
 #nullable restore
-#line (2,21)-(2,38) "x:\dir\subdir\Test\TestComponent.cshtml"
-context.ToLower()
+#line (2,21)-(2,38) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(3, context.ToLower()
 
 #line default
 #line hidden
@@ -37,10 +36,9 @@ context.ToLower()
                 );
             }
             , 4, (context) => (__builder2) => {
-                __builder2.AddContent(5, 
 #nullable restore
-#line (3,17)-(3,24) "x:\dir\subdir\Test\TestComponent.cshtml"
-context
+#line (3,17)-(3,24) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(5, context
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_NonGenericParameterizedChildContent_TypeInference/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_NonGenericParameterizedChildContent_TypeInference/TestComponent.mappings.txt
@@ -5,16 +5,16 @@ Generated Location: (837:22,0 [4] )
 
 Source Location: (50:1,20 [17] x:\dir\subdir\Test\TestComponent.cshtml)
 |context.ToLower()|
-Generated Location: (1067:31,0 [17] )
+Generated Location: (1052:30,25 [17] )
 |context.ToLower()|
 
 Source Location: (103:2,16 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |context|
-Generated Location: (1345:42,0 [7] )
+Generated Location: (1315:40,25 [7] )
 |context|
 
 Source Location: (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |Item|
-Generated Location: (2224:65,0 [4] )
+Generated Location: (2194:63,0 [4] )
 |Item|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitGenericChildContent/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitGenericChildContent/TestComponent.codegen.cs
@@ -19,10 +19,9 @@ namespace Test
         {
             __builder.OpenComponent<global::Test.MyComponent>(0);
             __builder.AddAttribute(1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment<global::System.String>)((context) => (__builder2) => {
-                __builder2.AddContent(2, 
 #nullable restore
-#line (1,29)-(1,36) "x:\dir\subdir\Test\TestComponent.cshtml"
-context
+#line (1,29)-(1,36) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(2, context
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitGenericChildContent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithExplicitGenericChildContent/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 ﻿Source Location: (28:0,28 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |context|
-Generated Location: (1012:24,0 [7] )
+Generated Location: (997:23,25 [7] )
 |context|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithGenericChildContent/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithGenericChildContent/TestComponent.codegen.cs
@@ -31,10 +31,9 @@ MyAttr
                 __builder2.AddContent(3, "Some text");
                 __builder2.OpenElement(4, "some-child");
                 __builder2.AddAttribute(5, "a", "1");
-                __builder2.AddContent(6, 
 #nullable restore
-#line (1,55)-(1,81) "x:\dir\subdir\Test\TestComponent.cshtml"
-context.ToLowerInvariant()
+#line (1,55)-(1,81) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(6, context.ToLowerInvariant()
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithGenericChildContent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithGenericChildContent/TestComponent.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (884:23,0 [6] )
 
 Source Location: (54:0,54 [26] x:\dir\subdir\Test\TestComponent.cshtml)
 |context.ToLowerInvariant()|
-Generated Location: (1426:36,0 [26] )
+Generated Location: (1411:35,25 [26] )
 |context.ToLowerInvariant()|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterName/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterName/TestComponent.codegen.cs
@@ -31,10 +31,9 @@ MyAttr
                 __builder2.AddMarkupContent(3, "\r\n    Some text");
                 __builder2.OpenElement(4, "some-child");
                 __builder2.AddAttribute(5, "a", "1");
-                __builder2.AddContent(6, 
 #nullable restore
-#line (3,33)-(3,56) "x:\dir\subdir\Test\TestComponent.cshtml"
-item.ToLowerInvariant()
+#line (3,33)-(3,56) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(6, item.ToLowerInvariant()
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterName/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterName/TestComponent.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (884:23,0 [6] )
 
 Source Location: (93:2,32 [23] x:\dir\subdir\Test\TestComponent.cshtml)
 |item.ToLowerInvariant()|
-Generated Location: (1437:36,0 [23] )
+Generated Location: (1422:35,25 [23] )
 |item.ToLowerInvariant()|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterNameOnComponent/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterNameOnComponent/TestComponent.codegen.cs
@@ -31,10 +31,9 @@ MyAttr
                 __builder2.AddMarkupContent(3, "\r\n    Some text");
                 __builder2.OpenElement(4, "some-child");
                 __builder2.AddAttribute(5, "a", "1");
-                __builder2.AddContent(6, 
 #nullable restore
-#line (3,33)-(3,56) "x:\dir\subdir\Test\TestComponent.cshtml"
-item.ToLowerInvariant()
+#line (3,33)-(3,56) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(6, item.ToLowerInvariant()
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterNameOnComponent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildComponent_WithGenericChildContent_SetsParameterNameOnComponent/TestComponent.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (884:23,0 [6] )
 
 Source Location: (93:2,32 [23] x:\dir\subdir\Test\TestComponent.cshtml)
 |item.ToLowerInvariant()|
-Generated Location: (1437:36,0 [23] )
+Generated Location: (1422:35,25 [23] )
 |item.ToLowerInvariant()|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildContent_FromAnotherNamespace/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildContent_FromAnotherNamespace/TestComponent.codegen.cs
@@ -32,10 +32,9 @@ using AnotherTest
             __builder.AddMarkupContent(3, "\r\n");
             __builder.OpenComponent<global::AnotherTest.FooterComponent>(4);
             __builder.AddAttribute(5, "Footer", (global::Microsoft.AspNetCore.Components.RenderFragment<global::System.DateTime>)((context) => (__builder2) => {
-                __builder2.AddContent(6, 
 #nullable restore
-#line (7,14)-(7,21) "x:\dir\subdir\Test\TestComponent.cshtml"
-context
+#line (7,14)-(7,21) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(6, context
 
 #line default
 #line hidden
@@ -54,10 +53,9 @@ context
             __builder.AddMarkupContent(11, "\r\n");
             __builder.OpenComponent<global::AnotherTest.FooterComponent>(12);
             __builder.AddAttribute(13, "Footer", (global::Microsoft.AspNetCore.Components.RenderFragment<global::System.DateTime>)((context) => (__builder2) => {
-                __builder2.AddContent(14, 
 #nullable restore
-#line (13,14)-(13,21) "x:\dir\subdir\Test\TestComponent.cshtml"
-context
+#line (13,14)-(13,21) 26 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(14, context
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildContent_FromAnotherNamespace/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ChildContent_FromAnotherNamespace/TestComponent.mappings.txt
@@ -5,11 +5,11 @@ Generated Location: (372:12,0 [17] )
 
 Source Location: (119:6,13 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |context|
-Generated Location: (1517:37,0 [7] )
+Generated Location: (1502:36,25 [7] )
 |context|
 
 Source Location: (276:12,13 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |context|
-Generated Location: (2463:59,0 [7] )
+Generated Location: (2433:57,26 [7] )
 |context|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentImports/_Imports.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentImports/_Imports.codegen.cs
@@ -38,10 +38,9 @@ MainLayout
         #pragma warning disable 1998
         protected void Execute()
         {
-            __builder.AddContent(0, 
 #nullable restore
-#line (5,2)-(5,5) "x:\dir\subdir\Test\_Imports.razor"
-Foo
+#line (5,2)-(5,5) 24 "x:\dir\subdir\Test\_Imports.razor"
+__builder.AddContent(0, Foo
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentImports/_Imports.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentImports/_Imports.mappings.txt
@@ -15,6 +15,6 @@ Generated Location: (723:27,0 [10] )
 
 Source Location: (69:4,1 [3] x:\dir\subdir\Test\_Imports.razor)
 |Foo|
-Generated Location: (1086:43,0 [3] )
+Generated Location: (1075:42,24 [3] )
 |Foo|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithBooleanParameter/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithBooleanParameter/TestComponent.codegen.cs
@@ -18,10 +18,9 @@ namespace Test
         protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
             __builder.OpenElement(0, "strong");
-            __builder.AddContent(1, 
 #nullable restore
-#line (1,10)-(1,18) "x:\dir\subdir\Test\TestComponent.cshtml"
-TestBool
+#line (1,10)-(1,18) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(1, TestBool
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithBooleanParameter/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithBooleanParameter/TestComponent.mappings.txt
@@ -1,16 +1,16 @@
 ﻿Source Location: (9:0,9 [8] x:\dir\subdir\Test\TestComponent.cshtml)
 |TestBool|
-Generated Location: (823:23,0 [8] )
+Generated Location: (812:22,24 [8] )
 |TestBool|
 
 Source Location: (45:2,15 [8] x:\dir\subdir\Test\TestComponent.cshtml)
 |TestBool|
-Generated Location: (1228:35,0 [8] )
+Generated Location: (1217:34,0 [8] )
 |TestBool|
 
 Source Location: (55:2,25 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |true|
-Generated Location: (1493:43,0 [4] )
+Generated Location: (1482:42,0 [4] )
 |true|
 
 Source Location: (74:4,7 [59] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -18,7 +18,7 @@ Source Location: (74:4,7 [59] x:\dir\subdir\Test\TestComponent.cshtml)
     [Parameter]
     public bool TestBool { get; set; }
 |
-Generated Location: (1736:54,0 [59] )
+Generated Location: (1725:53,0 [59] )
 |
     [Parameter]
     public bool TestBool { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithBooleanParameter_Minimized/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithBooleanParameter_Minimized/TestComponent.codegen.cs
@@ -18,10 +18,9 @@ namespace Test
         protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
             __builder.OpenElement(0, "strong");
-            __builder.AddContent(1, 
 #nullable restore
-#line (1,10)-(1,18) "x:\dir\subdir\Test\TestComponent.cshtml"
-TestBool
+#line (1,10)-(1,18) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(1, TestBool
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithBooleanParameter_Minimized/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithBooleanParameter_Minimized/TestComponent.mappings.txt
@@ -1,11 +1,11 @@
 ﻿Source Location: (9:0,9 [8] x:\dir\subdir\Test\TestComponent.cshtml)
 |TestBool|
-Generated Location: (823:23,0 [8] )
+Generated Location: (812:22,24 [8] )
 |TestBool|
 
 Source Location: (45:2,15 [8] x:\dir\subdir\Test\TestComponent.cshtml)
 |TestBool|
-Generated Location: (1228:35,0 [8] )
+Generated Location: (1217:34,0 [8] )
 |TestBool|
 
 Source Location: (67:4,7 [59] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -13,7 +13,7 @@ Source Location: (67:4,7 [59] x:\dir\subdir\Test\TestComponent.cshtml)
     [Parameter]
     public bool TestBool { get; set; }
 |
-Generated Location: (1481:46,0 [59] )
+Generated Location: (1470:45,0 [59] )
 |
     [Parameter]
     public bool TestBool { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters/TestComponent.codegen.cs
@@ -77,10 +77,9 @@ foreach (var item2 in Items2)
 #nullable disable
 
             __builder.OpenElement(1, "p");
-            __builder.AddContent(2, 
 #nullable restore
-#line (10,6)-(10,25) "x:\dir\subdir\Test\TestComponent.cshtml"
-ChildContent(item2)
+#line (10,6)-(10,25) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(2, ChildContent(item2)
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters/TestComponent.mappings.txt
@@ -44,13 +44,13 @@ Generated Location: (1796:71,0 [34] )
 
 Source Location: (234:9,5 [19] x:\dir\subdir\Test\TestComponent.cshtml)
 |ChildContent(item2)|
-Generated Location: (2047:82,0 [19] )
+Generated Location: (2036:81,24 [19] )
 |ChildContent(item2)|
 
 Source Location: (266:11,0 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |}
 |
-Generated Location: (2312:92,0 [3] )
+Generated Location: (2301:91,0 [3] )
 |}
 |
 
@@ -61,7 +61,7 @@ Source Location: (294:15,7 [236] x:\dir\subdir\Test\TestComponent.cshtml)
     [Parameter] public TItem3 Item3 { get; set; }
     [Parameter] public RenderFragment<TItem2> ChildContent { get; set; }
 |
-Generated Location: (2558:103,0 [236] )
+Generated Location: (2547:102,0 [236] )
 |
     [Parameter] public TItem1 Item1 { get; set; }
     [Parameter] public List<TItem2> Items2 { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters/UseTestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters/UseTestComponent.codegen.cs
@@ -49,10 +49,9 @@ item1
 #nullable disable
             , 4, (context) => (__builder2) => {
                 __builder2.OpenElement(5, "p");
-                __builder2.AddContent(6, 
 #nullable restore
-#line (3,9)-(3,16) "x:\dir\subdir\Test\UseTestComponent.cshtml"
-context
+#line (3,9)-(3,16) 25 "x:\dir\subdir\Test\UseTestComponent.cshtml"
+__builder2.AddContent(6, context
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters/UseTestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters/UseTestComponent.mappings.txt
@@ -20,7 +20,7 @@ Generated Location: (1294:44,0 [5] )
 
 Source Location: (78:2,8 [7] x:\dir\subdir\Test\UseTestComponent.cshtml)
 |context|
-Generated Location: (1576:54,0 [7] )
+Generated Location: (1561:53,25 [7] )
 |context|
 
 Source Location: (118:5,7 [268] x:\dir\subdir\Test\UseTestComponent.cshtml)
@@ -30,7 +30,7 @@ Source Location: (118:5,7 [268] x:\dir\subdir\Test\UseTestComponent.cshtml)
     static Tag tag2 = new Tag() { description = "Another description."};
     List<Tag> items = new List<Tag>() { tag1, tag2 };
 |
-Generated Location: (1863:67,0 [268] )
+Generated Location: (1848:66,0 [268] )
 |
     Image item1 = new Image() { id = 1, url="https://example.com"};
     static Tag tag1 = new Tag() { description = "A description."};
@@ -40,16 +40,16 @@ Generated Location: (1863:67,0 [268] )
 
 Source Location: (28:1,15 [5] x:\dir\subdir\Test\UseTestComponent.cshtml)
 |Item1|
-Generated Location: (3098:93,0 [5] )
+Generated Location: (3083:92,0 [5] )
 |Item1|
 
 Source Location: (41:1,28 [6] x:\dir\subdir\Test\UseTestComponent.cshtml)
 |Items2|
-Generated Location: (3369:102,0 [6] )
+Generated Location: (3354:101,0 [6] )
 |Items2|
 
 Source Location: (55:1,42 [5] x:\dir\subdir\Test\UseTestComponent.cshtml)
 |Item3|
-Generated Location: (3641:111,0 [5] )
+Generated Location: (3626:110,0 [5] )
 |Item3|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters_WithSemicolon/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters_WithSemicolon/TestComponent.codegen.cs
@@ -77,10 +77,9 @@ foreach (var item2 in Items2)
 #nullable disable
 
             __builder.OpenElement(1, "p");
-            __builder.AddContent(2, 
 #nullable restore
-#line (10,6)-(10,25) "x:\dir\subdir\Test\TestComponent.cshtml"
-ChildContent(item2)
+#line (10,6)-(10,25) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(2, ChildContent(item2)
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters_WithSemicolon/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters_WithSemicolon/TestComponent.mappings.txt
@@ -44,13 +44,13 @@ Generated Location: (1796:71,0 [34] )
 
 Source Location: (237:9,5 [19] x:\dir\subdir\Test\TestComponent.cshtml)
 |ChildContent(item2)|
-Generated Location: (2047:82,0 [19] )
+Generated Location: (2036:81,24 [19] )
 |ChildContent(item2)|
 
 Source Location: (269:11,0 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |}
 |
-Generated Location: (2312:92,0 [3] )
+Generated Location: (2301:91,0 [3] )
 |}
 |
 
@@ -61,7 +61,7 @@ Source Location: (297:15,7 [236] x:\dir\subdir\Test\TestComponent.cshtml)
     [Parameter] public TItem3 Item3 { get; set; }
     [Parameter] public RenderFragment<TItem2> ChildContent { get; set; }
 |
-Generated Location: (2558:103,0 [236] )
+Generated Location: (2547:102,0 [236] )
 |
     [Parameter] public TItem1 Item1 { get; set; }
     [Parameter] public List<TItem2> Items2 { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters_WithSemicolon/UseTestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters_WithSemicolon/UseTestComponent.codegen.cs
@@ -49,10 +49,9 @@ item1
 #nullable disable
             , 4, (context) => (__builder2) => {
                 __builder2.OpenElement(5, "p");
-                __builder2.AddContent(6, 
 #nullable restore
-#line (3,9)-(3,16) "x:\dir\subdir\Test\UseTestComponent.cshtml"
-context
+#line (3,9)-(3,16) 25 "x:\dir\subdir\Test\UseTestComponent.cshtml"
+__builder2.AddContent(6, context
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters_WithSemicolon/UseTestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithConstrainedTypeParameters_WithSemicolon/UseTestComponent.mappings.txt
@@ -20,7 +20,7 @@ Generated Location: (1294:44,0 [5] )
 
 Source Location: (78:2,8 [7] x:\dir\subdir\Test\UseTestComponent.cshtml)
 |context|
-Generated Location: (1576:54,0 [7] )
+Generated Location: (1561:53,25 [7] )
 |context|
 
 Source Location: (118:5,7 [268] x:\dir\subdir\Test\UseTestComponent.cshtml)
@@ -30,7 +30,7 @@ Source Location: (118:5,7 [268] x:\dir\subdir\Test\UseTestComponent.cshtml)
     static Tag tag2 = new Tag() { description = "Another description."};
     List<Tag> items = new List<Tag>() { tag1, tag2 };
 |
-Generated Location: (1863:67,0 [268] )
+Generated Location: (1848:66,0 [268] )
 |
     Image item1 = new Image() { id = 1, url="https://example.com"};
     static Tag tag1 = new Tag() { description = "A description."};
@@ -40,16 +40,16 @@ Generated Location: (1863:67,0 [268] )
 
 Source Location: (28:1,15 [5] x:\dir\subdir\Test\UseTestComponent.cshtml)
 |Item1|
-Generated Location: (3098:93,0 [5] )
+Generated Location: (3083:92,0 [5] )
 |Item1|
 
 Source Location: (41:1,28 [6] x:\dir\subdir\Test\UseTestComponent.cshtml)
 |Items2|
-Generated Location: (3369:102,0 [6] )
+Generated Location: (3354:101,0 [6] )
 |Items2|
 
 Source Location: (55:1,42 [5] x:\dir\subdir\Test\UseTestComponent.cshtml)
 |Item3|
-Generated Location: (3641:111,0 [5] )
+Generated Location: (3626:110,0 [5] )
 |Item3|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithDecimalParameter/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithDecimalParameter/TestComponent.codegen.cs
@@ -18,10 +18,9 @@ namespace Test
         protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
             __builder.OpenElement(0, "strong");
-            __builder.AddContent(1, 
 #nullable restore
-#line (1,10)-(1,21) "x:\dir\subdir\Test\TestComponent.cshtml"
-TestDecimal
+#line (1,10)-(1,21) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(1, TestDecimal
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithDecimalParameter/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithDecimalParameter/TestComponent.mappings.txt
@@ -1,16 +1,16 @@
 ﻿Source Location: (9:0,9 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |TestDecimal|
-Generated Location: (823:23,0 [11] )
+Generated Location: (812:22,24 [11] )
 |TestDecimal|
 
 Source Location: (48:2,15 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |TestDecimal|
-Generated Location: (1231:35,0 [11] )
+Generated Location: (1220:34,0 [11] )
 |TestDecimal|
 
 Source Location: (61:2,28 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |4|
-Generated Location: (1499:43,0 [1] )
+Generated Location: (1488:42,0 [1] )
 |4|
 
 Source Location: (77:4,7 [65] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -18,7 +18,7 @@ Source Location: (77:4,7 [65] x:\dir\subdir\Test\TestComponent.cshtml)
     [Parameter]
     public decimal TestDecimal { get; set; }
 |
-Generated Location: (1739:54,0 [65] )
+Generated Location: (1728:53,0 [65] )
 |
     [Parameter]
     public decimal TestDecimal { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithDynamicParameter/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithDynamicParameter/TestComponent.codegen.cs
@@ -18,10 +18,9 @@ namespace Test
         protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
             __builder.OpenElement(0, "strong");
-            __builder.AddContent(1, 
 #nullable restore
-#line (1,10)-(1,21) "x:\dir\subdir\Test\TestComponent.cshtml"
-TestDynamic
+#line (1,10)-(1,21) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(1, TestDynamic
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithDynamicParameter/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithDynamicParameter/TestComponent.mappings.txt
@@ -1,16 +1,16 @@
 ﻿Source Location: (9:0,9 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |TestDynamic|
-Generated Location: (823:23,0 [11] )
+Generated Location: (812:22,24 [11] )
 |TestDynamic|
 
 Source Location: (48:2,15 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |TestDynamic|
-Generated Location: (1231:35,0 [11] )
+Generated Location: (1220:34,0 [11] )
 |TestDynamic|
 
 Source Location: (61:2,28 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |4|
-Generated Location: (1484:43,0 [1] )
+Generated Location: (1473:42,0 [1] )
 |4|
 
 Source Location: (77:4,7 [65] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -18,7 +18,7 @@ Source Location: (77:4,7 [65] x:\dir\subdir\Test\TestComponent.cshtml)
     [Parameter]
     public dynamic TestDynamic { get; set; }
 |
-Generated Location: (1724:54,0 [65] )
+Generated Location: (1713:53,0 [65] )
 |
     [Parameter]
     public dynamic TestDynamic { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterArray/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterArray/TestComponent.codegen.cs
@@ -31,10 +31,9 @@ TItem
         {
             __builder.AddMarkupContent(0, "<h1>Item</h1>\r\n\r\n");
             __builder.OpenElement(1, "p");
-            __builder.AddContent(2, 
 #nullable restore
-#line (6,5)-(6,25) "x:\dir\subdir\Test\TestComponent.cshtml"
-ChildContent(Items1)
+#line (6,5)-(6,25) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(2, ChildContent(Items1)
 
 #line default
 #line hidden
@@ -51,10 +50,9 @@ foreach (var item in Items2)
 #nullable disable
 
             __builder.OpenElement(3, "p");
-            __builder.AddContent(4, 
 #nullable restore
-#line (10,9)-(10,27) "x:\dir\subdir\Test\TestComponent.cshtml"
-ChildContent(item)
+#line (10,9)-(10,27) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(4, ChildContent(item)
 
 #line default
 #line hidden
@@ -70,10 +68,9 @@ ChildContent(item)
 #nullable disable
 
             __builder.OpenElement(5, "p");
-            __builder.AddContent(6, 
 #nullable restore
-#line (13,5)-(13,27) "x:\dir\subdir\Test\TestComponent.cshtml"
-ChildContent(Items3())
+#line (13,5)-(13,27) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(6, ChildContent(Items3())
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterArray/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterArray/TestComponent.mappings.txt
@@ -10,33 +10,33 @@ Generated Location: (564:20,0 [5] )
 
 Source Location: (82:5,4 [20] x:\dir\subdir\Test\TestComponent.cshtml)
 |ChildContent(Items1)|
-Generated Location: (1123:36,0 [20] )
+Generated Location: (1112:35,24 [20] )
 |ChildContent(Items1)|
 
 Source Location: (111:7,1 [33] x:\dir\subdir\Test\TestComponent.cshtml)
 |foreach (var item in Items2)
 {
 |
-Generated Location: (1331:45,0 [33] )
+Generated Location: (1320:44,0 [33] )
 |foreach (var item in Items2)
 {
 |
 
 Source Location: (152:9,8 [18] x:\dir\subdir\Test\TestComponent.cshtml)
 |ChildContent(item)|
-Generated Location: (1581:56,0 [18] )
+Generated Location: (1559:54,24 [18] )
 |ChildContent(item)|
 
 Source Location: (176:10,0 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |}
 |
-Generated Location: (1788:65,0 [3] )
+Generated Location: (1766:63,0 [3] )
 |}
 |
 
 Source Location: (185:12,4 [22] x:\dir\subdir\Test\TestComponent.cshtml)
 |ChildContent(Items3())|
-Generated Location: (2008:75,0 [22] )
+Generated Location: (1975:72,24 [22] )
 |ChildContent(Items3())|
 
 Source Location: (222:14,7 [248] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -46,7 +46,7 @@ Source Location: (222:14,7 [248] x:\dir\subdir\Test\TestComponent.cshtml)
     [Parameter] public Func<TItem[]> Items3 { get; set; }
     [Parameter] public RenderFragment<TItem[]> ChildContent { get; set; }
 |
-Generated Location: (2268:86,0 [248] )
+Generated Location: (2235:83,0 [248] )
 |
     [Parameter] public TItem[] Items1 { get; set; }
     [Parameter] public List<TItem[]> Items2 { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterArray/UseTestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterArray/UseTestComponent.codegen.cs
@@ -49,10 +49,9 @@ items3
 #nullable disable
             , 4, (context) => (__builder2) => {
                 __builder2.OpenElement(5, "p");
-                __builder2.AddContent(6, 
 #nullable restore
-#line (3,9)-(3,31) "x:\dir\subdir\Test\UseTestComponent.cshtml"
-context[0].description
+#line (3,9)-(3,31) 25 "x:\dir\subdir\Test\UseTestComponent.cshtml"
+__builder2.AddContent(6, context[0].description
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterArray/UseTestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterArray/UseTestComponent.mappings.txt
@@ -20,7 +20,7 @@ Generated Location: (1296:44,0 [6] )
 
 Source Location: (80:2,8 [22] x:\dir\subdir\Test\UseTestComponent.cshtml)
 |context[0].description|
-Generated Location: (1579:54,0 [22] )
+Generated Location: (1564:53,25 [22] )
 |context[0].description|
 
 Source Location: (135:5,7 [208] x:\dir\subdir\Test\UseTestComponent.cshtml)
@@ -30,7 +30,7 @@ Source Location: (135:5,7 [208] x:\dir\subdir\Test\UseTestComponent.cshtml)
     List<Tag[]> items2 = new List<Tag[]>() { new [] { tag } };
     Tag[] items3() => new [] { tag };
 |
-Generated Location: (1881:67,0 [208] )
+Generated Location: (1866:66,0 [208] )
 |
     static Tag tag = new Tag() { description = "A description."};
     Tag[] items1 = new [] { tag };
@@ -40,16 +40,16 @@ Generated Location: (1881:67,0 [208] )
 
 Source Location: (28:1,15 [6] x:\dir\subdir\Test\UseTestComponent.cshtml)
 |Items1|
-Generated Location: (2898:90,0 [6] )
+Generated Location: (2883:89,0 [6] )
 |Items1|
 
 Source Location: (42:1,29 [6] x:\dir\subdir\Test\UseTestComponent.cshtml)
 |Items2|
-Generated Location: (3153:99,0 [6] )
+Generated Location: (3138:98,0 [6] )
 |Items2|
 
 Source Location: (56:1,43 [6] x:\dir\subdir\Test\UseTestComponent.cshtml)
 |Items3|
-Generated Location: (3408:108,0 [6] )
+Generated Location: (3393:107,0 [6] )
 |Items3|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterValueTuple/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterValueTuple/TestComponent.codegen.cs
@@ -39,10 +39,9 @@ TItem2
         {
             __builder.AddMarkupContent(0, "<h1>Item</h1>\r\n\r\n");
             __builder.OpenElement(1, "p");
-            __builder.AddContent(2, 
 #nullable restore
-#line (7,5)-(7,24) "x:\dir\subdir\Test\TestComponent.cshtml"
-ChildContent(Item1)
+#line (7,5)-(7,24) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(2, ChildContent(Item1)
 
 #line default
 #line hidden
@@ -59,10 +58,9 @@ foreach (var item in Items2)
 #nullable disable
 
             __builder.OpenElement(3, "p");
-            __builder.AddContent(4, 
 #nullable restore
-#line (11,9)-(11,27) "x:\dir\subdir\Test\TestComponent.cshtml"
-ChildContent(item)
+#line (11,9)-(11,27) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(4, ChildContent(item)
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterValueTuple/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterValueTuple/TestComponent.mappings.txt
@@ -15,27 +15,27 @@ Generated Location: (711:28,0 [6] )
 
 Source Location: (102:6,4 [19] x:\dir\subdir\Test\TestComponent.cshtml)
 |ChildContent(Item1)|
-Generated Location: (1271:44,0 [19] )
+Generated Location: (1260:43,24 [19] )
 |ChildContent(Item1)|
 
 Source Location: (130:8,1 [33] x:\dir\subdir\Test\TestComponent.cshtml)
 |foreach (var item in Items2)
 {
 |
-Generated Location: (1478:53,0 [33] )
+Generated Location: (1467:52,0 [33] )
 |foreach (var item in Items2)
 {
 |
 
 Source Location: (171:10,8 [18] x:\dir\subdir\Test\TestComponent.cshtml)
 |ChildContent(item)|
-Generated Location: (1728:64,0 [18] )
+Generated Location: (1706:62,24 [18] )
 |ChildContent(item)|
 
 Source Location: (195:11,0 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |}
 |
-Generated Location: (1935:73,0 [3] )
+Generated Location: (1913:71,0 [3] )
 |}
 |
 
@@ -45,7 +45,7 @@ Source Location: (207:13,7 [215] x:\dir\subdir\Test\TestComponent.cshtml)
     [Parameter] public List<(TItem1, TItem2)> Items2 { get; set; }
     [Parameter] public RenderFragment<(TItem1, TItem2)> ChildContent { get; set; }
 |
-Generated Location: (2121:83,0 [215] )
+Generated Location: (2099:81,0 [215] )
 |
     [Parameter] public (TItem1, TItem2) Item1 { get; set; }
     [Parameter] public List<(TItem1, TItem2)> Items2 { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterValueTuple/UseTestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterValueTuple/UseTestComponent.codegen.cs
@@ -41,10 +41,9 @@ items2
 #nullable disable
             , 3, (context) => (__builder2) => {
                 __builder2.OpenElement(4, "p");
-                __builder2.AddContent(5, 
 #nullable restore
-#line (3,9)-(3,16) "x:\dir\subdir\Test\UseTestComponent.cshtml"
-context
+#line (3,9)-(3,16) 25 "x:\dir\subdir\Test\UseTestComponent.cshtml"
+__builder2.AddContent(5, context
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterValueTuple/UseTestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterValueTuple/UseTestComponent.mappings.txt
@@ -15,7 +15,7 @@ Generated Location: (1133:36,0 [6] )
 
 Source Location: (64:2,8 [7] x:\dir\subdir\Test\UseTestComponent.cshtml)
 |context|
-Generated Location: (1416:46,0 [7] )
+Generated Location: (1401:45,25 [7] )
 |context|
 
 Source Location: (104:5,7 [176] x:\dir\subdir\Test\UseTestComponent.cshtml)
@@ -24,7 +24,7 @@ Source Location: (104:5,7 [176] x:\dir\subdir\Test\UseTestComponent.cshtml)
     static (string, int) item2 = ("Another string", 42);
     List<(string, int)> items2 = new List<(string, int)>() { item2 };
 |
-Generated Location: (1703:59,0 [176] )
+Generated Location: (1688:58,0 [176] )
 |
     (string, int) item1 = ("A string", 42);
     static (string, int) item2 = ("Another string", 42);
@@ -33,11 +33,11 @@ Generated Location: (1703:59,0 [176] )
 
 Source Location: (28:1,15 [5] x:\dir\subdir\Test\UseTestComponent.cshtml)
 |Item1|
-Generated Location: (2693:81,0 [5] )
+Generated Location: (2678:80,0 [5] )
 |Item1|
 
 Source Location: (40:1,27 [6] x:\dir\subdir\Test\UseTestComponent.cshtml)
 |Items2|
-Generated Location: (2956:90,0 [6] )
+Generated Location: (2941:89,0 [6] )
 |Items2|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterValueTupleGloballyQualifiedTypes/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterValueTupleGloballyQualifiedTypes/TestComponent.codegen.cs
@@ -40,20 +40,18 @@ TParam
 #line hidden
 #nullable disable
             , 2, (context) => (__builder2) => {
-                __builder2.AddContent(3, 
 #nullable restore
-#line (14,10)-(14,30) "x:\dir\subdir\Test\TestComponent.cshtml"
-context.I1.MyClassId
+#line (14,10)-(14,30) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(3, context.I1.MyClassId
 
 #line default
 #line hidden
 #nullable disable
                 );
                 __builder2.AddContent(4, " - ");
-                __builder2.AddContent(5, 
 #nullable restore
-#line (14,34)-(14,55) "x:\dir\subdir\Test\TestComponent.cshtml"
-context.I2.MyStructId
+#line (14,34)-(14,55) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(5, context.I2.MyStructId
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterValueTupleGloballyQualifiedTypes/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameterValueTupleGloballyQualifiedTypes/TestComponent.mappings.txt
@@ -15,12 +15,12 @@ Generated Location: (1106:36,0 [1] )
 
 Source Location: (269:13,9 [20] x:\dir\subdir\Test\TestComponent.cshtml)
 |context.I1.MyClassId|
-Generated Location: (1335:45,0 [20] )
+Generated Location: (1320:44,25 [20] )
 |context.I1.MyClassId|
 
 Source Location: (293:13,33 [21] x:\dir\subdir\Test\TestComponent.cshtml)
 |context.I2.MyStructId|
-Generated Location: (1604:55,0 [21] )
+Generated Location: (1574:53,25 [21] )
 |context.I2.MyStructId|
 
 Source Location: (38:3,7 [169] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -31,7 +31,7 @@ Source Location: (38:3,7 [169] x:\dir\subdir\Test\TestComponent.cshtml)
     [Parameter]
     public RenderFragment<(MyClass I1, MyStruct I2, TParam P)> Template { get; set; }
 |
-Generated Location: (1858:67,0 [169] )
+Generated Location: (1828:65,0 [169] )
 |
     [Parameter]
     public TParam InferParam { get; set; }
@@ -42,6 +42,6 @@ Generated Location: (1858:67,0 [169] )
 
 Source Location: (227:11,15 [10] x:\dir\subdir\Test\TestComponent.cshtml)
 |InferParam|
-Generated Location: (2764:91,0 [10] )
+Generated Location: (2734:89,0 [10] )
 |InferParam|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.codegen.cs
@@ -48,10 +48,9 @@ foreach (var item2 in Items2)
 #nullable disable
 
             __builder.OpenElement(1, "p");
-            __builder.AddContent(2, 
 #nullable restore
-#line (9,6)-(9,25) "x:\dir\subdir\Test\TestComponent.cshtml"
-ChildContent(item2)
+#line (9,6)-(9,25) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(2, ChildContent(item2)
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameters/TestComponent.mappings.txt
@@ -24,13 +24,13 @@ Generated Location: (1181:42,0 [34] )
 
 Source Location: (146:8,5 [19] x:\dir\subdir\Test\TestComponent.cshtml)
 |ChildContent(item2)|
-Generated Location: (1430:53,0 [19] )
+Generated Location: (1419:52,24 [19] )
 |ChildContent(item2)|
 
 Source Location: (178:10,0 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |}
 |
-Generated Location: (1695:63,0 [3] )
+Generated Location: (1684:62,0 [3] )
 |}
 |
 
@@ -40,7 +40,7 @@ Source Location: (188:11,7 [185] x:\dir\subdir\Test\TestComponent.cshtml)
     [Parameter] public List<TItem2> Items2 { get; set; }
     [Parameter] public RenderFragment<TItem2> ChildContent { get; set; }
 |
-Generated Location: (1881:73,0 [185] )
+Generated Location: (1870:72,0 [185] )
 |
     [Parameter] public TItem1 Item1 { get; set; }
     [Parameter] public List<TItem2> Items2 { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameters_WithSemicolon/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameters_WithSemicolon/TestComponent.codegen.cs
@@ -48,10 +48,9 @@ foreach (var item2 in Items2)
 #nullable disable
 
             __builder.OpenElement(1, "p");
-            __builder.AddContent(2, 
 #nullable restore
-#line (9,6)-(9,25) "x:\dir\subdir\Test\TestComponent.cshtml"
-ChildContent(item2)
+#line (9,6)-(9,25) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(2, ChildContent(item2)
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameters_WithSemicolon/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ComponentWithTypeParameters_WithSemicolon/TestComponent.mappings.txt
@@ -24,13 +24,13 @@ Generated Location: (1181:42,0 [34] )
 
 Source Location: (148:8,5 [19] x:\dir\subdir\Test\TestComponent.cshtml)
 |ChildContent(item2)|
-Generated Location: (1430:53,0 [19] )
+Generated Location: (1419:52,24 [19] )
 |ChildContent(item2)|
 
 Source Location: (180:10,0 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |}
 |
-Generated Location: (1695:63,0 [3] )
+Generated Location: (1684:62,0 [3] )
 |}
 |
 
@@ -40,7 +40,7 @@ Source Location: (190:11,7 [185] x:\dir\subdir\Test\TestComponent.cshtml)
     [Parameter] public List<TItem2> Items2 { get; set; }
     [Parameter] public RenderFragment<TItem2> ChildContent { get; set; }
 |
-Generated Location: (1881:73,0 [185] )
+Generated Location: (1870:72,0 [185] )
 |
     [Parameter] public TItem1 Item1 { get; set; }
     [Parameter] public List<TItem2> Items2 { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_PreserveWhitespaceDirective_InImports/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_PreserveWhitespaceDirective_InImports/TestComponent.codegen.cs
@@ -21,10 +21,9 @@ namespace Test
             __builder.AddMarkupContent(1, "\r\n    ");
             __builder.OpenElement(2, "child");
             __builder.AddContent(3, " ");
-            __builder.AddContent(4, 
 #nullable restore
-#line (2,14)-(2,26) "x:\dir\subdir\Test\TestComponent.cshtml"
-DateTime.Now
+#line (2,14)-(2,26) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(4, DateTime.Now
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_PreserveWhitespaceDirective_InImports/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_PreserveWhitespaceDirective_InImports/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 ﻿Source Location: (23:1,13 [12] x:\dir\subdir\Test\TestComponent.cshtml)
 |DateTime.Now|
-Generated Location: (970:26,0 [12] )
+Generated Location: (959:25,24 [12] )
 |DateTime.Now|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_PreserveWhitespaceDirective_OverrideImports/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_PreserveWhitespaceDirective_OverrideImports/TestComponent.codegen.cs
@@ -19,10 +19,9 @@ namespace Test
         {
             __builder.OpenElement(0, "parent");
             __builder.OpenElement(1, "child");
-            __builder.AddContent(2, 
 #nullable restore
-#line (4,14)-(4,26) "x:\dir\subdir\Test\TestComponent.cshtml"
-DateTime.Now
+#line (4,14)-(4,26) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(2, DateTime.Now
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_PreserveWhitespaceDirective_OverrideImports/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_PreserveWhitespaceDirective_OverrideImports/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 ﻿Source Location: (52:3,13 [12] x:\dir\subdir\Test\TestComponent.cshtml)
 |DateTime.Now|
-Generated Location: (871:24,0 [12] )
+Generated Location: (860:23,24 [12] )
 |DateTime.Now|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithCssScope/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithCssScope/TestComponent.codegen.cs
@@ -142,10 +142,9 @@ i
         );
         __builder.AddAttribute(25, "TestCssScope");
         __builder.AddContent(26, "Something ");
-        __builder.AddContent(27, 
 #nullable restore
-#line (26,42)-(26,43) "x:\dir\subdir\Test\TestComponent.cshtml"
-i
+#line (26,42)-(26,43) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(27, i
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithCssScope/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithCssScope/TestComponent.mappings.txt
@@ -74,7 +74,7 @@ Generated Location: (4718:136,0 [1] )
 
 Source Location: (925:25,41 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |i|
-Generated Location: (5004:147,0 [1] )
+Generated Location: (4997:146,25 [1] )
 |i|
 
 Source Location: (933:26,0 [164] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -85,7 +85,7 @@ Source Location: (933:26,0 [164] x:\dir\subdir\Test\TestComponent.cshtml)
         System.GC.KeepAlive(myVariable);
     }
 |
-Generated Location: (5186:156,0 [164] )
+Generated Location: (5179:155,0 [164] )
 |        }
 
         System.GC.KeepAlive(myElementReference);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithPreserveWhitespaceDirective_False/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithPreserveWhitespaceDirective_False/TestComponent.codegen.cs
@@ -36,10 +36,9 @@ foreach (var item in Enumerable.Range(1, 100))
 #nullable disable
 
             __builder.OpenElement(1, "li");
-            __builder.AddContent(2, 
 #nullable restore
-#line (7,14)-(7,18) "x:\dir\subdir\Test\TestComponent.cshtml"
-item
+#line (7,14)-(7,18) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(2, item
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithPreserveWhitespaceDirective_False/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithPreserveWhitespaceDirective_False/TestComponent.mappings.txt
@@ -14,13 +14,13 @@ Generated Location: (917:30,0 [55] )
 
 Source Location: (122:6,13 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |item|
-Generated Location: (1189:41,0 [4] )
+Generated Location: (1178:40,24 [4] )
 |item|
 
 Source Location: (143:8,0 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |    }
 |
-Generated Location: (1381:50,0 [7] )
+Generated Location: (1370:49,0 [7] )
 |    }
 |
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithPreserveWhitespaceDirective_True/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithPreserveWhitespaceDirective_True/TestComponent.codegen.cs
@@ -40,10 +40,9 @@ foreach (var item in Enumerable.Range(1, 100))
             __builder.AddContent(3, "        ");
             __builder.OpenElement(4, "li");
             __builder.AddMarkupContent(5, "\r\n            ");
-            __builder.AddContent(6, 
 #nullable restore
-#line (7,14)-(7,18) "x:\dir\subdir\Test\TestComponent.cshtml"
-item
+#line (7,14)-(7,18) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(6, item
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithPreserveWhitespaceDirective_True/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Component_WithPreserveWhitespaceDirective_True/TestComponent.mappings.txt
@@ -14,13 +14,13 @@ Generated Location: (1021:32,0 [55] )
 
 Source Location: (121:6,13 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |item|
-Generated Location: (1407:45,0 [4] )
+Generated Location: (1396:44,24 [4] )
 |item|
 
 Source Location: (142:8,0 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |    }
 |
-Generated Location: (1711:56,0 [7] )
+Generated Location: (1700:55,0 [7] )
 |    }
 |
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_ChildContent/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_ChildContent/TestComponent.codegen.cs
@@ -28,10 +28,9 @@ using Microsoft.AspNetCore.Components.Web
             __builder.AddAttribute(1, "class", "nice");
             __builder.AddNamedEvent("onsubmit", __formName);
             __builder.OpenElement(2, "p");
-            __builder.AddContent(3, 
 #nullable restore
-#line (3,9)-(3,21) "x:\dir\subdir\Test\TestComponent.cshtml"
-DateTime.Now
+#line (3,9)-(3,21) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(3, DateTime.Now
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_ChildContent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_ChildContent/TestComponent.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (372:12,0 [41] )
 
 Source Location: (92:2,8 [12] x:\dir\subdir\Test\TestComponent.cshtml)
 |DateTime.Now|
-Generated Location: (1269:33,0 [12] )
+Generated Location: (1258:32,24 [12] )
 |DateTime.Now|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Duplicate_CSharpValue/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Duplicate_CSharpValue/TestComponent.codegen.cs
@@ -43,10 +43,9 @@ x
 #line hidden
 #nullable disable
             );
-            __builder.AddContent(3, 
 #nullable restore
-#line (2,70)-(2,71) "x:\dir\subdir\Test\TestComponent.cshtml"
-y
+#line (2,70)-(2,71) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(3, y
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Duplicate_CSharpValue/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/FormName_Duplicate_CSharpValue/TestComponent.mappings.txt
@@ -15,7 +15,7 @@ Generated Location: (1430:39,0 [1] )
 
 Source Location: (113:1,69 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |y|
-Generated Location: (1619:48,0 [1] )
+Generated Location: (1608:47,24 [1] )
 |y|
 
 Source Location: (132:2,7 [44] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -23,7 +23,7 @@ Source Location: (132:2,7 [44] x:\dir\subdir\Test\TestComponent.cshtml)
     string x = "a";
     string y = "b";
 |
-Generated Location: (1971:61,0 [44] )
+Generated Location: (1960:60,0 [44] )
 |
     string x = "a";
     string y = "b";

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_NonPrimitiveTypeRenderFragment/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_NonPrimitiveTypeRenderFragment/TestComponent.codegen.cs
@@ -26,10 +26,9 @@ new CustomType()
 #line hidden
 #nullable disable
             , 2, (context) => (__builder2) => {
-                __builder2.AddContent(3, 
 #nullable restore
-#line (1,39)-(1,57) "x:\dir\subdir\Test\TestComponent.cshtml"
-context.ToString()
+#line (1,39)-(1,57) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(3, context.ToString()
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_NonPrimitiveTypeRenderFragment/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_NonPrimitiveTypeRenderFragment/TestComponent.mappings.txt
@@ -5,11 +5,11 @@ Generated Location: (837:22,0 [16] )
 
 Source Location: (38:0,38 [18] x:\dir\subdir\Test\TestComponent.cshtml)
 |context.ToString()|
-Generated Location: (1079:31,0 [18] )
+Generated Location: (1064:30,25 [18] )
 |context.ToString()|
 
 Source Location: (13:0,13 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |Item|
-Generated Location: (1890:54,0 [4] )
+Generated Location: (1875:53,0 [4] )
 |Item|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithFullyQualifiedTagName/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithFullyQualifiedTagName/TestComponent.codegen.cs
@@ -27,10 +27,9 @@ namespace Test
 #nullable disable
             , 2, (context) => (__builder2) => {
                 __builder2.OpenElement(3, "div");
-                __builder2.AddContent(4, 
 #nullable restore
-#line (2,9)-(2,26) "x:\dir\subdir\Test\TestComponent.cshtml"
-context.ToLower()
+#line (2,9)-(2,26) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(4, context.ToLower()
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithFullyQualifiedTagName/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/GenericComponent_WithFullyQualifiedTagName/TestComponent.mappings.txt
@@ -5,11 +5,11 @@ Generated Location: (842:22,0 [4] )
 
 Source Location: (43:1,8 [17] x:\dir\subdir\Test\TestComponent.cshtml)
 |context.ToLower()|
-Generated Location: (1122:32,0 [17] )
+Generated Location: (1107:31,25 [17] )
 |context.ToLower()|
 
 Source Location: (18:0,18 [4] x:\dir\subdir\Test\TestComponent.cshtml)
 |Item|
-Generated Location: (1963:56,0 [4] )
+Generated Location: (1948:55,0 [4] )
 |Item|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/InheritsDirective_NullableReferenceType/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/InheritsDirective_NullableReferenceType/TestComponent.codegen.cs
@@ -26,10 +26,9 @@ BaseComponent<string?>
         protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
             __builder.AddMarkupContent(0, "<h1>My component</h1>\r\n");
-            __builder.AddContent(1, 
 #nullable restore
-#line (4,3)-(4,20) "x:\dir\subdir\Test\TestComponent.cshtml"
-_field.ToString()
+#line (4,3)-(4,20) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(1, _field.ToString()
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/InheritsDirective_NullableReferenceType/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/InheritsDirective_NullableReferenceType/TestComponent.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (476:16,0 [22] )
 
 Source Location: (61:3,2 [17] x:\dir\subdir\Test\TestComponent.cshtml)
 |_field.ToString()|
-Generated Location: (951:31,0 [17] )
+Generated Location: (940:30,24 [17] )
 |_field.ToString()|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/InheritsDirective_NullableReferenceType_NullableDisabled/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/InheritsDirective_NullableReferenceType_NullableDisabled/TestComponent.codegen.cs
@@ -26,10 +26,9 @@ BaseComponent<string?>
         protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
             __builder.AddMarkupContent(0, "<h1>My component</h1>\r\n");
-            __builder.AddContent(1, 
 #nullable restore
-#line (4,3)-(4,20) "x:\dir\subdir\Test\TestComponent.cshtml"
-_field.ToString()
+#line (4,3)-(4,20) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(1, _field.ToString()
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/InheritsDirective_NullableReferenceType_NullableDisabled/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/InheritsDirective_NullableReferenceType_NullableDisabled/TestComponent.mappings.txt
@@ -5,6 +5,6 @@ Generated Location: (476:16,0 [22] )
 
 Source Location: (61:3,2 [17] x:\dir\subdir\Test\TestComponent.cshtml)
 |_field.ToString()|
-Generated Location: (951:31,0 [17] )
+Generated Location: (940:30,24 [17] )
 |_field.ToString()|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/InvalidCode_EmptyTransition/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/InvalidCode_EmptyTransition/TestComponent.codegen.cs
@@ -21,9 +21,9 @@ namespace Test
             __builder.AddComponentParameter(1, "Value", "Hello");
             __builder.CloseComponent();
             __builder.AddMarkupContent(2, "\r\n\r\n");
-            __builder.AddContent(3, 
 #nullable restore
-#line (3,2)-(3,2) "x:\dir\subdir\Test\TestComponent.cshtml"
+#line (3,2)-(3,2) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(3, 
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/InvalidCode_EmptyTransition/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/InvalidCode_EmptyTransition/TestComponent.mappings.txt
@@ -1,13 +1,13 @@
 ﻿Source Location: (36:2,1 [0] x:\dir\subdir\Test\TestComponent.cshtml)
 ||
-Generated Location: (1005:26,0 [0] )
+Generated Location: (994:25,24 [0] )
 ||
 
 Source Location: (47:4,7 [50] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     [Parameter] public int Param { get; set; }
 |
-Generated Location: (1200:35,0 [50] )
+Generated Location: (1191:35,0 [50] )
 |
     [Parameter] public int Param { get; set; }
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LeadingWhiteSpace_WithCSharpExpression/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LeadingWhiteSpace_WithCSharpExpression/TestComponent.codegen.cs
@@ -17,10 +17,9 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
-            __builder.AddContent(0, 
 #nullable restore
-#line (1,3)-(1,13) "x:\dir\subdir\Test\TestComponent.cshtml"
-"My value"
+#line (1,3)-(1,13) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(0, "My value"
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LeadingWhiteSpace_WithCSharpExpression/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LeadingWhiteSpace_WithCSharpExpression/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 ﻿Source Location: (2:0,2 [10] x:\dir\subdir\Test\TestComponent.cshtml)
 |"My value"|
-Generated Location: (773:22,0 [10] )
+Generated Location: (762:21,24 [10] )
 |"My value"|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LeadingWhiteSpace_WithComponent/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LeadingWhiteSpace_WithComponent/TestComponent.codegen.cs
@@ -21,10 +21,9 @@ namespace Test
             __builder.AddAttribute(1, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
                 __builder2.OpenElement(2, "h1");
                 __builder2.AddContent(3, "Child content at ");
-                __builder2.AddContent(4, 
 #nullable restore
-#line (2,27)-(2,39) "x:\dir\subdir\Test\TestComponent.cshtml"
-DateTime.Now
+#line (2,27)-(2,39) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(4, DateTime.Now
 
 #line default
 #line hidden
@@ -34,10 +33,9 @@ DateTime.Now
                 __builder2.AddMarkupContent(5, "\r\n    ");
                 __builder2.OpenElement(6, "p");
                 __builder2.AddContent(7, "Very ");
-                __builder2.AddContent(8, 
 #nullable restore
-#line (3,15)-(3,21) "x:\dir\subdir\Test\TestComponent.cshtml"
-"good"
+#line (3,15)-(3,21) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(8, "good"
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LeadingWhiteSpace_WithComponent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LeadingWhiteSpace_WithComponent/TestComponent.mappings.txt
@@ -1,10 +1,10 @@
 ﻿Source Location: (48:1,26 [12] x:\dir\subdir\Test\TestComponent.cshtml)
 |DateTime.Now|
-Generated Location: (1097:26,0 [12] )
+Generated Location: (1082:25,25 [12] )
 |DateTime.Now|
 
 Source Location: (81:2,14 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |"good"|
-Generated Location: (1512:39,0 [6] )
+Generated Location: (1482:37,25 [6] )
 |"good"|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_LeadingWhiteSpace_WithCSharpExpression/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_LeadingWhiteSpace_WithCSharpExpression/TestComponent.codegen.cs
@@ -17,10 +17,9 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
-            __builder.AddContent(0, 
 #nullable restore
-#line (1,3)-(1,13) "x:\dir\subdir\Test\TestComponent.cshtml"
-"My value"
+#line (1,3)-(1,13) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(0, "My value"
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_LeadingWhiteSpace_WithCSharpExpression/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_LeadingWhiteSpace_WithCSharpExpression/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 ﻿Source Location: (2:0,2 [10] x:\dir\subdir\Test\TestComponent.cshtml)
 |"My value"|
-Generated Location: (773:22,0 [10] )
+Generated Location: (762:21,24 [10] )
 |"My value"|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_LeadingWhiteSpace_WithComponent/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_LeadingWhiteSpace_WithComponent/TestComponent.codegen.cs
@@ -22,10 +22,9 @@ namespace Test
                 __builder2.AddMarkupContent(2, "\r\n    ");
                 __builder2.OpenElement(3, "h1");
                 __builder2.AddContent(4, "Child content at ");
-                __builder2.AddContent(5, 
 #nullable restore
-#line (2,27)-(2,39) "x:\dir\subdir\Test\TestComponent.cshtml"
-DateTime.Now
+#line (2,27)-(2,39) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(5, DateTime.Now
 
 #line default
 #line hidden
@@ -35,10 +34,9 @@ DateTime.Now
                 __builder2.AddMarkupContent(6, "\r\n    ");
                 __builder2.OpenElement(7, "p");
                 __builder2.AddContent(8, "Very ");
-                __builder2.AddContent(9, 
 #nullable restore
-#line (3,15)-(3,21) "x:\dir\subdir\Test\TestComponent.cshtml"
-"good"
+#line (3,15)-(3,21) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(9, "good"
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_LeadingWhiteSpace_WithComponent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_LeadingWhiteSpace_WithComponent/TestComponent.mappings.txt
@@ -1,10 +1,10 @@
 ﻿Source Location: (48:1,26 [12] x:\dir\subdir\Test\TestComponent.cshtml)
 |DateTime.Now|
-Generated Location: (1158:27,0 [12] )
+Generated Location: (1143:26,25 [12] )
 |DateTime.Now|
 
 Source Location: (81:2,14 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |"good"|
-Generated Location: (1573:40,0 [6] )
+Generated Location: (1543:38,25 [6] )
 |"good"|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_TrailingWhiteSpace_WithCSharpExpression/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_TrailingWhiteSpace_WithCSharpExpression/TestComponent.codegen.cs
@@ -18,10 +18,9 @@ namespace Test
         protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
             __builder.AddMarkupContent(0, "<h1>Hello</h1>\r\n\r\n");
-            __builder.AddContent(1, 
 #nullable restore
-#line (3,3)-(3,13) "x:\dir\subdir\Test\TestComponent.cshtml"
-"My value"
+#line (3,3)-(3,13) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(1, "My value"
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_TrailingWhiteSpace_WithCSharpExpression/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_TrailingWhiteSpace_WithCSharpExpression/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 ﻿Source Location: (20:2,2 [10] x:\dir\subdir\Test\TestComponent.cshtml)
 |"My value"|
-Generated Location: (843:23,0 [10] )
+Generated Location: (832:22,24 [10] )
 |"My value"|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_WhiteSpace_InMarkupInFunctionsBlock/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_WhiteSpace_InMarkupInFunctionsBlock/TestComponent.codegen.cs
@@ -58,10 +58,9 @@ for (var i = 0; i < 100; i++)
         __builder.AddContent(3, "                ");
         __builder.OpenElement(4, "li");
         __builder.AddMarkupContent(5, "\r\n                    ");
-        __builder.AddContent(6, 
 #nullable restore
-#line (9,22)-(9,23) "x:\dir\subdir\Test\TestComponent.cshtml"
-i
+#line (9,22)-(9,23) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(6, i
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_WhiteSpace_InMarkupInFunctionsBlock/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/Legacy_3_1_WhiteSpace_InMarkupInFunctionsBlock/TestComponent.mappings.txt
@@ -30,20 +30,20 @@ Generated Location: (1413:50,0 [46] )
 
 Source Location: (230:8,21 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |i|
-Generated Location: (1790:63,0 [1] )
+Generated Location: (1783:62,24 [1] )
 |i|
 
 Source Location: (256:10,0 [15] x:\dir\subdir\Test\TestComponent.cshtml)
 |            }
 |
-Generated Location: (2084:74,0 [15] )
+Generated Location: (2077:73,0 [15] )
 |            }
 |
 
 Source Location: (286:12,0 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |    }
 |
-Generated Location: (2363:85,0 [7] )
+Generated Location: (2356:84,0 [7] )
 |    }
 |
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LinePragma_Multiline/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LinePragma_Multiline/TestComponent.codegen.cs
@@ -17,10 +17,9 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
-            __builder.AddContent(0, 
 #nullable restore
-#line (1,3)-(2,1) "x:\dir\subdir\Test\TestComponent.cshtml"
-"text"
+#line (1,3)-(2,1) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(0, "text"
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LinePragma_Multiline/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/LinePragma_Multiline/TestComponent.mappings.txt
@@ -1,7 +1,7 @@
 ﻿Source Location: (2:0,2 [8] x:\dir\subdir\Test\TestComponent.cshtml)
 |"text"
 |
-Generated Location: (772:22,0 [8] )
+Generated Location: (761:21,24 [8] )
 |"text"
 |
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/MarkupComment_IsNotIncluded/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/MarkupComment_IsNotIncluded/TestComponent.codegen.cs
@@ -27,10 +27,9 @@ namespace Test
 #nullable disable
 
             __builder.OpenElement(0, "div");
-            __builder.AddContent(1, 
 #nullable restore
-#line (4,7)-(4,14) "x:\dir\subdir\Test\TestComponent.cshtml"
-myValue
+#line (4,7)-(4,14) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(1, myValue
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/MarkupComment_IsNotIncluded/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/MarkupComment_IsNotIncluded/TestComponent.mappings.txt
@@ -9,6 +9,6 @@ Generated Location: (734:21,0 [39] )
 
 Source Location: (50:3,6 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |myValue|
-Generated Location: (990:32,0 [7] )
+Generated Location: (979:31,24 [7] )
 |myValue|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/MultipleExplictChildContent/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/MultipleExplictChildContent/TestComponent.codegen.cs
@@ -23,10 +23,9 @@ namespace Test
             }
             ));
             __builder.AddAttribute(3, "Footer", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
-                __builder2.AddContent(4, 
 #nullable restore
-#line (3,15)-(3,21) "x:\dir\subdir\Test\TestComponent.cshtml"
-"bye!"
+#line (3,15)-(3,21) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(4, "bye!"
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/MultipleExplictChildContent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/MultipleExplictChildContent/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 ﻿Source Location: (55:2,14 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |"bye!"|
-Generated Location: (1176:28,0 [6] )
+Generated Location: (1161:27,25 [6] )
 |"bye!"|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ProducesEnhancedLinePragmaWhenNecessary/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ProducesEnhancedLinePragmaWhenNecessary/TestComponent.codegen.cs
@@ -18,10 +18,9 @@ namespace Test
         protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
             __builder.AddMarkupContent(0, "<h1>Single line statement</h1>\r\n\r\nTime: ");
-            __builder.AddContent(1, 
 #nullable restore
-#line (3,8)-(3,20) "x:\dir\subdir\Test\TestComponent.cshtml"
-DateTime.Now
+#line (3,8)-(3,20) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(1, DateTime.Now
 
 #line default
 #line hidden
@@ -29,10 +28,9 @@ DateTime.Now
             );
             __builder.AddMarkupContent(2, "\r\n\r\n");
             __builder.AddMarkupContent(3, "<h1>Multiline block statement</h1>\r\n\r\n");
-            __builder.AddContent(4, 
 #nullable restore
-#line (7,2)-(10,4) "x:\dir\subdir\Test\TestComponent.cshtml"
-JsonToHtml(@"{
+#line (7,2)-(10,4) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(4, JsonToHtml(@"{
   'key1': 'value1'
   'key2': 'value2'
 }")

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ProducesEnhancedLinePragmaWhenNecessary/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ProducesEnhancedLinePragmaWhenNecessary/TestComponent.mappings.txt
@@ -1,6 +1,6 @@
 ﻿Source Location: (41:2,7 [12] x:\dir\subdir\Test\TestComponent.cshtml)
 |DateTime.Now|
-Generated Location: (865:23,0 [12] )
+Generated Location: (854:22,24 [12] )
 |DateTime.Now|
 
 Source Location: (96:6,1 [59] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -8,7 +8,7 @@ Source Location: (96:6,1 [59] x:\dir\subdir\Test\TestComponent.cshtml)
   'key1': 'value1'
   'key2': 'value2'
 }")|
-Generated Location: (1210:34,0 [59] )
+Generated Location: (1188:32,24 [59] )
 |JsonToHtml(@"{
   'key1': 'value1'
   'key2': 'value2'
@@ -21,7 +21,7 @@ Source Location: (166:11,7 [79] x:\dir\subdir\Test\TestComponent.cshtml)
         return foo;
     }
 |
-Generated Location: (1468:47,0 [79] )
+Generated Location: (1446:45,0 [79] )
 |
     public string JsonToHtml(string foo)
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ProducesStandardLinePragmaForCSharpCode/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ProducesStandardLinePragmaForCSharpCode/TestComponent.codegen.cs
@@ -28,10 +28,9 @@ for (var i = 0; i < 10; i++)
 #nullable disable
 
             __builder.OpenElement(1, "p");
-            __builder.AddContent(2, 
 #nullable restore
-#line (4,9)-(4,10) "x:\dir\subdir\Test\TestComponent.cshtml"
-i
+#line (4,9)-(4,10) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(2, i
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ProducesStandardLinePragmaForCSharpCode/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/ProducesStandardLinePragmaForCSharpCode/TestComponent.mappings.txt
@@ -9,19 +9,19 @@ Generated Location: (812:22,0 [33] )
 
 Source Location: (74:3,8 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |i|
-Generated Location: (1060:33,0 [1] )
+Generated Location: (1049:32,24 [1] )
 |i|
 
 Source Location: (81:4,0 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |}
 |
-Generated Location: (1248:42,0 [3] )
+Generated Location: (1237:41,0 [3] )
 |}
 |
 
 Source Location: (127:7,2 [56] x:\dir\subdir\Test\TestComponent.cshtml)
 |System.Console.WriteLine(1);System.Console.WriteLine(2);|
-Generated Location: (1469:51,0 [56] )
+Generated Location: (1458:50,0 [56] )
 |System.Console.WriteLine(1);System.Console.WriteLine(2);|
 
 Source Location: (224:10,7 [65] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -29,7 +29,7 @@ Source Location: (224:10,7 [65] x:\dir\subdir\Test\TestComponent.cshtml)
     [Parameter]
     public int IncrementAmount { get; set; }
 |
-Generated Location: (1785:62,0 [65] )
+Generated Location: (1774:61,0 [65] )
 |
     [Parameter]
     public int IncrementAmount { get; set; }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_AsComponentParameter_MixedContent/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_AsComponentParameter_MixedContent/TestComponent.codegen.cs
@@ -28,20 +28,18 @@ namespace Test
             (__builder2) => {
                 __builder2.OpenElement(0, "li");
                 __builder2.AddContent(1, "#");
-                __builder2.AddContent(2, 
 #nullable restore
-#line (1,64)-(1,77) "x:\dir\subdir\Test\TestComponent.cshtml"
-context.Index
+#line (1,64)-(1,77) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(2, context.Index
 
 #line default
 #line hidden
 #nullable disable
                 );
                 __builder2.AddContent(3, " - ");
-                __builder2.AddContent(4, 
 #nullable restore
-#line (1,81)-(1,103) "x:\dir\subdir\Test\TestComponent.cshtml"
-context.Item.ToLower()
+#line (1,81)-(1,103) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(4, context.Item.ToLower()
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_AsComponentParameter_MixedContent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_AsComponentParameter_MixedContent/TestComponent.mappings.txt
@@ -5,26 +5,26 @@ Generated Location: (735:21,0 [54] )
 
 Source Location: (63:0,63 [13] x:\dir\subdir\Test\TestComponent.cshtml)
 |context.Index|
-Generated Location: (1097:33,0 [13] )
+Generated Location: (1082:32,25 [13] )
 |context.Index|
 
 Source Location: (80:0,80 [22] x:\dir\subdir\Test\TestComponent.cshtml)
 |context.Item.ToLower()|
-Generated Location: (1358:43,0 [22] )
+Generated Location: (1328:41,25 [22] )
 |context.Item.ToLower()|
 
 Source Location: (107:0,107 [2] x:\dir\subdir\Test\TestComponent.cshtml)
 |; |
-Generated Location: (1595:53,0 [2] )
+Generated Location: (1565:51,0 [2] )
 |; |
 
 Source Location: (125:1,13 [8] x:\dir\subdir\Test\TestComponent.cshtml)
 |Template|
-Generated Location: (1881:63,0 [8] )
+Generated Location: (1851:61,0 [8] )
 |Template|
 
 Source Location: (136:1,24 [8] x:\dir\subdir\Test\TestComponent.cshtml)
 |template|
-Generated Location: (2119:71,0 [8] )
+Generated Location: (2089:69,0 [8] )
 |template|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_FollowedByComponent/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_FollowedByComponent/TestComponent.codegen.cs
@@ -59,10 +59,9 @@ person.Name
 
             __builder.OpenComponent<global::Test.MyComponent>(3);
             __builder.AddAttribute(4, "ChildContent", (global::Microsoft.AspNetCore.Components.RenderFragment)((__builder2) => {
-                __builder2.AddContent(5, 
 #nullable restore
-#line (5,3)-(5,18) "x:\dir\subdir\Test\TestComponent.cshtml"
-"hello, world!"
+#line (5,3)-(5,18) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(5, "hello, world!"
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_FollowedByComponent/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_FollowedByComponent/TestComponent.mappings.txt
@@ -24,7 +24,7 @@ Generated Location: (1690:53,0 [3] )
 
 Source Location: (116:4,2 [15] x:\dir\subdir\Test\TestComponent.cshtml)
 |"hello, world!"|
-Generated Location: (2066:64,0 [15] )
+Generated Location: (2051:63,25 [15] )
 |"hello, world!"|
 
 Source Location: (159:7,7 [76] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -34,7 +34,7 @@ Source Location: (159:7,7 [76] x:\dir\subdir\Test\TestComponent.cshtml)
         public string Name { get; set; }
     }
 |
-Generated Location: (2356:77,0 [76] )
+Generated Location: (2341:76,0 [76] )
 |
     class Person
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_Generic_AsComponentParameter/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_Generic_AsComponentParameter/TestComponent.codegen.cs
@@ -27,10 +27,9 @@ namespace Test
 
             (__builder2) => {
                 __builder2.OpenElement(0, "div");
-                __builder2.AddContent(1, 
 #nullable restore
-#line (1,57)-(1,68) "x:\dir\subdir\Test\TestComponent.cshtml"
-person.Name
+#line (1,57)-(1,68) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(1, person.Name
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_Generic_AsComponentParameter/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_Generic_AsComponentParameter/TestComponent.mappings.txt
@@ -5,21 +5,21 @@ Generated Location: (735:21,0 [47] )
 
 Source Location: (56:0,56 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |person.Name|
-Generated Location: (1043:32,0 [11] )
+Generated Location: (1028:31,25 [11] )
 |person.Name|
 
 Source Location: (73:0,73 [2] x:\dir\subdir\Test\TestComponent.cshtml)
 |; |
-Generated Location: (1267:42,0 [2] )
+Generated Location: (1252:41,0 [2] )
 |; |
 
 Source Location: (91:1,13 [14] x:\dir\subdir\Test\TestComponent.cshtml)
 |PersonTemplate|
-Generated Location: (1553:52,0 [14] )
+Generated Location: (1538:51,0 [14] )
 |PersonTemplate|
 
 Source Location: (108:1,30 [8] x:\dir\subdir\Test\TestComponent.cshtml)
 |template|
-Generated Location: (1796:60,0 [8] )
+Generated Location: (1781:59,0 [8] )
 |template|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_Generic_InImplicitExpression/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_Generic_InImplicitExpression/TestComponent.codegen.cs
@@ -17,20 +17,18 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
-            __builder.AddContent(0, 
 #nullable restore
-#line (1,2)-(1,27) "x:\dir\subdir\Test\TestComponent.cshtml"
-RenderPerson((person) => 
+#line (1,2)-(1,27) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(0, RenderPerson((person) => 
 
 #line default
 #line hidden
 #nullable disable
             (__builder2) => {
                 __builder2.OpenElement(1, "div");
-                __builder2.AddContent(2, 
 #nullable restore
-#line (1,34)-(1,45) "x:\dir\subdir\Test\TestComponent.cshtml"
-person.Name
+#line (1,34)-(1,45) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(2, person.Name
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_Generic_InImplicitExpression/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_Generic_InImplicitExpression/TestComponent.mappings.txt
@@ -1,16 +1,16 @@
 ﻿Source Location: (1:0,1 [25] x:\dir\subdir\Test\TestComponent.cshtml)
 |RenderPerson((person) => |
-Generated Location: (773:22,0 [25] )
+Generated Location: (762:21,24 [25] )
 |RenderPerson((person) => |
 
 Source Location: (33:0,33 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |person.Name|
-Generated Location: (1057:32,0 [11] )
+Generated Location: (1031:30,25 [11] )
 |person.Name|
 
 Source Location: (50:0,50 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |)|
-Generated Location: (1281:42,0 [1] )
+Generated Location: (1255:40,0 [1] )
 |)|
 
 Source Location: (60:1,7 [138] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -22,7 +22,7 @@ Source Location: (60:1,7 [138] x:\dir\subdir\Test\TestComponent.cshtml)
 
     object RenderPerson(RenderFragment<Person> p) => null;
 |
-Generated Location: (1479:52,0 [138] )
+Generated Location: (1453:50,0 [138] )
 |
     class Person
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_InCodeBlock/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_InCodeBlock/TestComponent.codegen.cs
@@ -28,10 +28,9 @@ namespace Test
 
             (__builder2) => {
                 __builder2.OpenElement(0, "div");
-                __builder2.AddContent(1, 
 #nullable restore
-#line (2,51)-(2,62) "x:\dir\subdir\Test\TestComponent.cshtml"
-person.Name
+#line (2,51)-(2,62) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(1, person.Name
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_InCodeBlock/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_InCodeBlock/TestComponent.mappings.txt
@@ -7,13 +7,13 @@ Generated Location: (735:21,0 [45] )
 
 Source Location: (54:1,50 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |person.Name|
-Generated Location: (1041:33,0 [11] )
+Generated Location: (1026:32,25 [11] )
 |person.Name|
 
 Source Location: (71:1,67 [3] x:\dir\subdir\Test\TestComponent.cshtml)
 |;
 |
-Generated Location: (1264:43,0 [3] )
+Generated Location: (1249:42,0 [3] )
 |;
 |
 
@@ -24,7 +24,7 @@ Source Location: (84:3,7 [76] x:\dir\subdir\Test\TestComponent.cshtml)
         public string Name { get; set; }
     }
 |
-Generated Location: (1448:53,0 [76] )
+Generated Location: (1433:52,0 [76] )
 |
     class Person
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_InExplicitExpression/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_InExplicitExpression/TestComponent.codegen.cs
@@ -17,20 +17,18 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
-            __builder.AddContent(0, 
 #nullable restore
-#line (1,3)-(1,28) "x:\dir\subdir\Test\TestComponent.cshtml"
-RenderPerson((person) => 
+#line (1,3)-(1,28) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(0, RenderPerson((person) => 
 
 #line default
 #line hidden
 #nullable disable
             (__builder2) => {
                 __builder2.OpenElement(1, "div");
-                __builder2.AddContent(2, 
 #nullable restore
-#line (1,35)-(1,46) "x:\dir\subdir\Test\TestComponent.cshtml"
-person.Name
+#line (1,35)-(1,46) 25 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder2.AddContent(2, person.Name
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_InExplicitExpression/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_InExplicitExpression/TestComponent.mappings.txt
@@ -1,16 +1,16 @@
 ﻿Source Location: (2:0,2 [25] x:\dir\subdir\Test\TestComponent.cshtml)
 |RenderPerson((person) => |
-Generated Location: (773:22,0 [25] )
+Generated Location: (762:21,24 [25] )
 |RenderPerson((person) => |
 
 Source Location: (34:0,34 [11] x:\dir\subdir\Test\TestComponent.cshtml)
 |person.Name|
-Generated Location: (1057:32,0 [11] )
+Generated Location: (1031:30,25 [11] )
 |person.Name|
 
 Source Location: (51:0,51 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |)|
-Generated Location: (1281:42,0 [1] )
+Generated Location: (1255:40,0 [1] )
 |)|
 
 Source Location: (62:1,7 [138] x:\dir\subdir\Test\TestComponent.cshtml)
@@ -22,7 +22,7 @@ Source Location: (62:1,7 [138] x:\dir\subdir\Test\TestComponent.cshtml)
 
     object RenderPerson(RenderFragment<Person> p) => null;
 |
-Generated Location: (1479:52,0 [138] )
+Generated Location: (1453:50,0 [138] )
 |
     class Person
     {

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_NonGeneric_InImplicitExpression/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_NonGeneric_InImplicitExpression/TestComponent.codegen.cs
@@ -17,10 +17,9 @@ namespace Test
         #pragma warning disable 1998
         protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
-            __builder.AddContent(0, 
 #nullable restore
-#line (1,2)-(1,15) "x:\dir\subdir\Test\TestComponent.cshtml"
-RenderPerson(
+#line (1,2)-(1,15) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(0, RenderPerson(
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_NonGeneric_InImplicitExpression/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/RazorTemplate_NonGeneric_InImplicitExpression/TestComponent.mappings.txt
@@ -1,18 +1,18 @@
 ﻿Source Location: (1:0,1 [13] x:\dir\subdir\Test\TestComponent.cshtml)
 |RenderPerson(|
-Generated Location: (773:22,0 [13] )
+Generated Location: (762:21,24 [13] )
 |RenderPerson(|
 
 Source Location: (28:0,28 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |)|
-Generated Location: (1032:32,0 [1] )
+Generated Location: (1021:31,0 [1] )
 |)|
 
 Source Location: (38:1,7 [54] x:\dir\subdir\Test\TestComponent.cshtml)
 |
     object RenderPerson(RenderFragment p) => null;
 |
-Generated Location: (1230:42,0 [54] )
+Generated Location: (1219:41,0 [54] )
 |
     object RenderPerson(RenderFragment p) => null;
 |

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/SingleLineControlFlowStatements_InCodeBlock/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/SingleLineControlFlowStatements_InCodeBlock/TestComponent.codegen.cs
@@ -35,10 +35,9 @@ using Microsoft.AspNetCore.Components.RenderTree;
 
             __builder.OpenElement(0, "p");
             __builder.AddContent(1, "Output: ");
-            __builder.AddContent(2, 
 #nullable restore
-#line (7,17)-(7,23) "x:\dir\subdir\Test\TestComponent.cshtml"
-output
+#line (7,17)-(7,23) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(2, output
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/SingleLineControlFlowStatements_InCodeBlock/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/SingleLineControlFlowStatements_InCodeBlock/TestComponent.mappings.txt
@@ -18,11 +18,11 @@ Generated Location: (887:26,0 [134] )
 
 Source Location: (206:6,16 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |output|
-Generated Location: (1287:40,0 [6] )
+Generated Location: (1276:39,24 [6] )
 |output|
 
 Source Location: (218:7,0 [0] x:\dir\subdir\Test\TestComponent.cshtml)
 ||
-Generated Location: (1480:49,0 [0] )
+Generated Location: (1469:48,0 [0] )
 ||
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/SingleLineControlFlowStatements_InCodeDirective/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/SingleLineControlFlowStatements_InCodeDirective/TestComponent.codegen.cs
@@ -39,10 +39,9 @@ using Microsoft.AspNetCore.Components.Rendering;
 
         __builder.OpenElement(0, "p");
         __builder.AddContent(1, "Output: ");
-        __builder.AddContent(2, 
 #nullable restore
-#line (9,21)-(9,27) "x:\dir\subdir\Test\TestComponent.cshtml"
-output
+#line (9,21)-(9,27) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(2, output
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/SingleLineControlFlowStatements_InCodeDirective/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/SingleLineControlFlowStatements_InCodeDirective/TestComponent.mappings.txt
@@ -22,13 +22,13 @@ Generated Location: (935:28,0 [213] )
 
 Source Location: (293:8,20 [6] x:\dir\subdir\Test\TestComponent.cshtml)
 |output|
-Generated Location: (1402:44,0 [6] )
+Generated Location: (1395:43,24 [6] )
 |output|
 
 Source Location: (305:9,0 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |    }
 |
-Generated Location: (1589:53,0 [7] )
+Generated Location: (1582:52,0 [7] )
 |    }
 |
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.codegen.cs
@@ -18,10 +18,9 @@ namespace Test
         protected override void BuildRenderTree(global::Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder __builder)
         {
             __builder.AddMarkupContent(0, "<h1>Hello</h1>\r\n\r\n");
-            __builder.AddContent(1, 
 #nullable restore
-#line (3,3)-(3,13) "x:\dir\subdir\Test\TestComponent.cshtml"
-"My value"
+#line (3,3)-(3,13) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(1, "My value"
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/TrailingWhiteSpace_WithCSharpExpression/TestComponent.mappings.txt
@@ -1,5 +1,5 @@
 ﻿Source Location: (20:2,2 [10] x:\dir\subdir\Test\TestComponent.cshtml)
 |"My value"|
-Generated Location: (843:23,0 [10] )
+Generated Location: (832:22,24 [10] )
 |"My value"|
 

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/WhiteSpace_InMarkupInFunctionsBlock/TestComponent.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/WhiteSpace_InMarkupInFunctionsBlock/TestComponent.codegen.cs
@@ -54,10 +54,9 @@ for (var i = 0; i < 100; i++)
 #nullable disable
 
         __builder.OpenElement(1, "li");
-        __builder.AddContent(2, 
 #nullable restore
-#line (9,22)-(9,23) "x:\dir\subdir\Test\TestComponent.cshtml"
-i
+#line (9,22)-(9,23) 24 "x:\dir\subdir\Test\TestComponent.cshtml"
+__builder.AddContent(2, i
 
 #line default
 #line hidden

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/WhiteSpace_InMarkupInFunctionsBlock/TestComponent.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/TestFiles/IntegrationTests/ComponentRuntimeCodeGenerationTest/WhiteSpace_InMarkupInFunctionsBlock/TestComponent.mappings.txt
@@ -30,20 +30,20 @@ Generated Location: (1319:48,0 [46] )
 
 Source Location: (230:8,21 [1] x:\dir\subdir\Test\TestComponent.cshtml)
 |i|
-Generated Location: (1574:59,0 [1] )
+Generated Location: (1567:58,24 [1] )
 |i|
 
 Source Location: (256:10,0 [15] x:\dir\subdir\Test\TestComponent.cshtml)
 |            }
 |
-Generated Location: (1756:68,0 [15] )
+Generated Location: (1749:67,0 [15] )
 |            }
 |
 
 Source Location: (286:12,0 [7] x:\dir\subdir\Test\TestComponent.cshtml)
 |    }
 |
-Generated Location: (1940:77,0 [7] )
+Generated Location: (1933:76,0 [7] )
 |    }
 |
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentRuntimeNodeWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentRuntimeNodeWriter.cs
@@ -90,25 +90,49 @@ internal class ComponentRuntimeNodeWriter : ComponentNodeWriter
         var methodInvocation = _scopeStack.BuilderVarName + '.' + ComponentsApi.RenderTreeBuilder.AddContent + '(' + sourceSequenceAsString;
         _sourceSequence++;
 
-        // Since we're not in the middle of writing an element, this must evaluate as some
-        // text to display
-        context.CodeWriter
-            .Write(methodInvocation)
-            .WriteParameterSeparator();
-
-        for (var i = 0; i < node.Children.Count; i++)
+        // Sequence points can only be emitted when the eval stack is empty. That means we can't arbitrarily map everything that could be in
+        // the node. Instead we map just the first c# child node by putting the pragma before we start the method invocation and offset it.
+        // This is not a perfect mapping, but generally this works for most cases:
+        // - Common case: there is only a single node and it is c#, so it maps correctly
+        // - There is some C# followed by a render template: the C# gets mapped, and the render template issues a lambda call which conceptually
+        //   is another method so a sequence point can be emitted. Unfortunately any trailing C# is not mapped, although in many cases its uninteresting
+        //   such as closing parenthesis.
+        // - Error cases: there are no nodes, so we do nothing
+        var firstCSharpChild = node.Children.FirstOrDefault(IsCSharpToken) as IntermediateToken;
+        using (context.CodeWriter.BuildEnhancedLinePragma(firstCSharpChild?.Source, context, characterOffset: methodInvocation.Length + 2))
         {
-            if (node.Children[i] is IntermediateToken token && token.IsCSharp)
+            context.CodeWriter
+                .Write(methodInvocation)
+                .WriteParameterSeparator();
+        
+            if (firstCSharpChild is not null)
             {
-                WriteCSharpToken(context, token);
+                context.CodeWriter.Write(firstCSharpChild.Content);
+            }
+        }
+
+        // render the remaining children. We still emit the #line pragmas for the remaining csharp tokens but
+        // these wont actually generate any sequence points for debugging.
+        foreach (var child in node.Children)
+        {
+            if (child == firstCSharpChild)
+            {
+                continue;
+            }
+            else if (IsCSharpToken(child))
+            {
+                WriteCSharpToken(context, (IntermediateToken)child);
             }
             else
             {
                 // There may be something else inside the expression like a Template or another extension node.
-                context.RenderNode(node.Children[i]);
+                context.RenderNode(child);
             }
         }
+
         context.CodeWriter.WriteEndMethodInvocation();
+
+        bool IsCSharpToken(IntermediateNode n) => n is IntermediateToken token && token.IsCSharp;
     }
 
     public override void WriteCSharpExpressionAttributeValue(CodeRenderingContext context, CSharpExpressionAttributeValueIntermediateNode node)


### PR DESCRIPTION
Changes the way we emit `#line` info for `.AddContent(` calls. 

Fixes https://github.com/dotnet/razor/issues/11432

Note this doesn't fix it for component parameters (if, for instance, a null ref happens when accessing something to pass it to a component). I'll fix that in a follow up PR as its a different code path. 
