### PR TITLE
Some code actions ordering and cleanup

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/CodeActionsService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/CodeActionsService.cs
@@ -246,7 +246,7 @@ internal class CodeActionsService(
     {
         var results = await Task.WhenAll(tasks).ConfigureAwait(false);
 
-        using var codeActions = new PooledArrayBuilder<RazorVSInternalCodeAction>();
+        using var codeActions = new PooledArrayBuilder<RazorVSInternalCodeAction>(capacity: tasks.Length);
 
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -255,7 +255,7 @@ internal class CodeActionsService(
             codeActions.AddRange(result);
         }
 
-        return codeActions.ToImmutable();
+        return codeActions.DrainToImmutableOrderedBy(static r => r.Order);
     }
 
     private static ImmutableHashSet<string> GetAllAvailableCodeActionNames()

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/Models/RazorVSInternalCodeAction.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/Models/RazorVSInternalCodeAction.cs
@@ -13,4 +13,10 @@ internal sealed class RazorVSInternalCodeAction : VSInternalCodeAction
     [JsonPropertyName("name")]
     [DataMember(Name = "name")]
     public string? Name { get; set; }
+
+    /// <summary>
+    /// The order code actions should appear. This is not serialized as its just used in the code actions service
+    /// </summary>
+    [JsonIgnore]
+    public int Order { get; set; }
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/Razor/ExtractToCodeBehindCodeActionProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/Razor/ExtractToCodeBehindCodeActionProvider.cs
@@ -57,6 +57,9 @@ internal class ExtractToCodeBehindCodeActionProvider(ILoggerFactory loggerFactor
             // When the caret is '@$$code' or '@c$$ode' or '@co$$de' or '@cod$$e' then tree is:
             // RazorDirective -> RazorDirectiveBody -> MetaCode
             RazorDirectiveBodySyntax { Parent: RazorDirectiveSyntax d } => d,
+            // When the caret is '$$@code' then tree is:
+            // RazorDirective
+            RazorDirectiveSyntax d => d,
             _ => null
         };
         if (directiveNode is null)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/Razor/RazorCodeActionFactory.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/Razor/RazorCodeActionFactory.cs
@@ -50,6 +50,8 @@ internal static class RazorCodeActionFactory
             TelemetryId = s_addComponentUsingTelemetryId,
             Priority = VSInternalPriorityLevel.High,
             Name = LanguageServerConstants.CodeActions.AddUsing,
+            // Adding a using for an existing component should be first
+            Order = -1000,
         };
         return codeAction;
     }
@@ -63,6 +65,8 @@ internal static class RazorCodeActionFactory
             TelemetryId = s_fullyQualifyComponentTelemetryId,
             Priority = VSInternalPriorityLevel.High,
             Name = LanguageServerConstants.CodeActions.FullyQualify,
+            // Fully qualifying an existing component should be very high, but not quite as high as Add Using
+            Order = -900,
         };
         return codeAction;
     }
@@ -102,6 +106,8 @@ internal static class RazorCodeActionFactory
             Data = data,
             TelemetryId = s_createExtractToComponentTelemetryId,
             Name = LanguageServerConstants.CodeActions.ExtractToNewComponentAction,
+            // Since Extract to Component is offered basically everywhere, always offer it last
+            Order = 9999
         };
         return codeAction;
     }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/Razor/RazorCodeActionFactory.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/CodeActions/Razor/RazorCodeActionFactory.cs
@@ -48,7 +48,8 @@ internal static class RazorCodeActionFactory
             Title = newTagName is null ? title : $"{newTagName} - {title}",
             Data = data,
             TelemetryId = s_addComponentUsingTelemetryId,
-            Priority = VSInternalPriorityLevel.High
+            Priority = VSInternalPriorityLevel.High,
+            Name = LanguageServerConstants.CodeActions.AddUsing,
         };
         return codeAction;
     }
@@ -60,46 +61,47 @@ internal static class RazorCodeActionFactory
             Title = fullyQualifiedName,
             Edit = workspaceEdit,
             TelemetryId = s_fullyQualifyComponentTelemetryId,
-            Priority = VSInternalPriorityLevel.High
+            Priority = VSInternalPriorityLevel.High,
+            Name = LanguageServerConstants.CodeActions.FullyQualify,
         };
         return codeAction;
     }
 
     public static RazorVSInternalCodeAction CreateComponentFromTag(RazorCodeActionResolutionParams resolutionParams)
     {
-        var title = SR.Create_Component_FromTag_Title;
         var data = JsonSerializer.SerializeToElement(resolutionParams);
         var codeAction = new RazorVSInternalCodeAction()
         {
-            Title = title,
+            Title = SR.Create_Component_FromTag_Title,
             Data = data,
             TelemetryId = s_createComponentFromTagTelemetryId,
+            Name = LanguageServerConstants.CodeActions.CreateComponentFromTag,
         };
         return codeAction;
     }
 
     public static RazorVSInternalCodeAction CreateExtractToCodeBehind(RazorCodeActionResolutionParams resolutionParams)
     {
-        var title = SR.ExtractTo_CodeBehind_Title;
         var data = JsonSerializer.SerializeToElement(resolutionParams);
         var codeAction = new RazorVSInternalCodeAction()
         {
-            Title = title,
+            Title = SR.ExtractTo_CodeBehind_Title,
             Data = data,
             TelemetryId = s_createExtractToCodeBehindTelemetryId,
+            Name = LanguageServerConstants.CodeActions.ExtractToCodeBehindAction,
         };
         return codeAction;
     }
 
     public static RazorVSInternalCodeAction CreateExtractToComponent(RazorCodeActionResolutionParams resolutionParams)
     {
-        var title = SR.ExtractTo_Component_Title;
         var data = JsonSerializer.SerializeToElement(resolutionParams);
         var codeAction = new RazorVSInternalCodeAction()
         {
-            Title = title,
+            Title = SR.ExtractTo_Component_Title,
             Data = data,
             TelemetryId = s_createExtractToComponentTelemetryId,
+            Name = LanguageServerConstants.CodeActions.ExtractToNewComponentAction,
         };
         return codeAction;
     }
@@ -127,7 +129,8 @@ internal static class RazorCodeActionFactory
         {
             Title = title,
             Data = data,
-            TelemetryId = s_generateMethodTelemetryId
+            TelemetryId = s_generateMethodTelemetryId,
+            Name = LanguageServerConstants.CodeActions.GenerateEventHandler,
         };
         return codeAction;
     }
@@ -155,7 +158,8 @@ internal static class RazorCodeActionFactory
         {
             Title = title,
             Data = data,
-            TelemetryId = s_generateAsyncMethodTelemetryId
+            TelemetryId = s_generateAsyncMethodTelemetryId,
+            Name = LanguageServerConstants.CodeActions.GenerateAsyncEventHandler,
         };
         return codeAction;
     }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/LanguageServerConstants.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/LanguageServerConstants.cs
@@ -35,6 +35,8 @@ internal static class LanguageServerConstants
     {
         public const string GenerateEventHandler = "GenerateEventHandler";
 
+        public const string GenerateAsyncEventHandler = "GenerateAsyncEventHandler";
+
         public const string EditBasedCodeActionCommand = "EditBasedCodeActionCommand";
 
         public const string ExtractToCodeBehindAction = "ExtractToCodeBehind";
@@ -44,6 +46,8 @@ internal static class LanguageServerConstants
         public const string CreateComponentFromTag = "CreateComponentFromTag";
 
         public const string AddUsing = "AddUsing";
+
+        public const string FullyQualify = "FullyQualify";
 
         public const string PromoteUsingDirective = "PromoteUsingDirective";
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndToEndTest.NetFx.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndToEndTest.NetFx.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Microsoft.CodeAnalysis.Razor.CodeActions.Models;
 using Microsoft.CodeAnalysis.Razor.CodeActions.Razor;
 using Microsoft.CodeAnalysis.Razor.Formatting;
+using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Xunit;
@@ -18,11 +19,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
 
 public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEndToEndTestBase(testOutput)
 {
-    private const string GenerateEventHandlerTitle = "Generate Event Handler 'DoesNotExist'";
-    private const string GenerateAsyncEventHandlerTitle = "Generate Async Event Handler 'DoesNotExist'";
-    private const string GenerateEventHandlerReturnType = "void";
-    private const string GenerateAsyncEventHandlerReturnType = "global::System.Threading.Tasks.Task";
-
     #region CSharp CodeAction Tests
 
     [Fact]
@@ -443,7 +439,7 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEn
         var expected = $$"""
             <button @onclick="DoesNotExist"></button>
             @code {
-                private {{GenerateEventHandlerReturnType}} DoesNotExist(global::Microsoft.AspNetCore.Components.Web.MouseEventArgs args)
+                private void DoesNotExist(global::Microsoft.AspNetCore.Components.Web.MouseEventArgs args)
                 {
                     throw new global::System.NotImplementedException();
                 }
@@ -452,7 +448,7 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEn
 
         await ValidateCodeActionAsync(input,
             expected,
-            GenerateEventHandlerTitle,
+            LanguageServerConstants.CodeActions.GenerateEventHandler,
             razorCodeActionProviders: [new GenerateMethodCodeActionProvider()],
             codeActionResolversCreator: CreateRazorCodeActionResolvers,
             diagnostics: [new Diagnostic() { Code = "CS0103", Message = "The name 'DoesNotExist' does not exist in the current context" }]);
@@ -473,7 +469,7 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEn
             @addTagHelper TestComponent, Microsoft.AspNetCore.Components
             <TestComponent OnDragStart="DoesNotExist" />
             @code {
-                private {{GenerateEventHandlerReturnType}} DoesNotExist(global::Microsoft.AspNetCore.Components.Web.DragEventArgs args)
+                private void DoesNotExist(global::Microsoft.AspNetCore.Components.Web.DragEventArgs args)
                 {
                     throw new global::System.NotImplementedException();
                 }
@@ -482,7 +478,7 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEn
 
         await ValidateCodeActionAsync(input,
             expected,
-            GenerateEventHandlerTitle,
+            LanguageServerConstants.CodeActions.GenerateEventHandler,
             razorCodeActionProviders: [new GenerateMethodCodeActionProvider()],
             codeActionResolversCreator: CreateRazorCodeActionResolvers,
             diagnostics: [new Diagnostic() { Code = "CS0103", Message = "The name 'DoesNotExist' does not exist in the current context" }]);
@@ -503,7 +499,7 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEn
             @addTagHelper TestGenericComponent, Microsoft.AspNetCore.Components
             <TestGenericComponent TItem="string" OnDragStart="DoesNotExist" />
             @code {
-                private {{GenerateEventHandlerReturnType}} DoesNotExist(global::Microsoft.AspNetCore.Components.Web.DragEventArgs<string> args)
+                private void DoesNotExist(global::Microsoft.AspNetCore.Components.Web.DragEventArgs<string> args)
                 {
                     throw new global::System.NotImplementedException();
                 }
@@ -512,7 +508,7 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEn
 
         await ValidateCodeActionAsync(input,
             expected,
-            GenerateEventHandlerTitle,
+            LanguageServerConstants.CodeActions.GenerateEventHandler,
             razorCodeActionProviders: [new GenerateMethodCodeActionProvider()],
             codeActionResolversCreator: CreateRazorCodeActionResolvers,
             diagnostics: [new Diagnostic() { Code = "CS0103", Message = "The name 'DoesNotExist' does not exist in the current context" }]);
@@ -532,7 +528,7 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEn
         var expected = $$"""
             <button @onclick="DoesNotExist"></button>
             @code {
-                private {{GenerateEventHandlerReturnType}} DoesNotExist(global::Microsoft.AspNetCore.Components.Web.MouseEventArgs args)
+                private void DoesNotExist(global::Microsoft.AspNetCore.Components.Web.MouseEventArgs args)
                 {
                     throw new global::System.NotImplementedException();
                 }
@@ -541,7 +537,7 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEn
 
         await ValidateCodeActionAsync(input,
             expected,
-            GenerateEventHandlerTitle,
+            LanguageServerConstants.CodeActions.GenerateEventHandler,
             razorCodeActionProviders: [new GenerateMethodCodeActionProvider()],
             codeActionResolversCreator: CreateRazorCodeActionResolvers,
             diagnostics: [new Diagnostic() { Code = "CS0103", Message = "The name 'DoesNotExist' does not exist in the current context" }]);
@@ -562,7 +558,7 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEn
             <button @onclick="DoesNotExist"></button>
                 
             @code {
-                private {{GenerateEventHandlerReturnType}} DoesNotExist(global::Microsoft.AspNetCore.Components.Web.MouseEventArgs args)
+                private void DoesNotExist(global::Microsoft.AspNetCore.Components.Web.MouseEventArgs args)
                 {
                     throw new global::System.NotImplementedException();
                 }
@@ -571,7 +567,7 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEn
 
         await ValidateCodeActionAsync(input,
             expected,
-            GenerateEventHandlerTitle,
+            LanguageServerConstants.CodeActions.GenerateEventHandler,
             razorCodeActionProviders: [new GenerateMethodCodeActionProvider()],
             codeActionResolversCreator: CreateRazorCodeActionResolvers,
             diagnostics: [new Diagnostic() { Code = "CS0103", Message = "The name 'DoesNotExist' does not exist in the current context" }]);
@@ -590,7 +586,7 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEn
         var expected = $$"""
             <button @onclick="DoesNotExist"></button>
             @code {
-                private {{GenerateAsyncEventHandlerReturnType}} DoesNotExist(global::Microsoft.AspNetCore.Components.Web.MouseEventArgs args)
+                private global::System.Threading.Tasks.Task DoesNotExist(global::Microsoft.AspNetCore.Components.Web.MouseEventArgs args)
                 {
                     throw new global::System.NotImplementedException();
                 }
@@ -599,7 +595,7 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEn
 
         await ValidateCodeActionAsync(input,
             expected,
-            GenerateAsyncEventHandlerTitle,
+            LanguageServerConstants.CodeActions.GenerateAsyncEventHandler,
             razorCodeActionProviders: [new GenerateMethodCodeActionProvider()],
             codeActionResolversCreator: CreateRazorCodeActionResolvers,
             diagnostics: [new Diagnostic() { Code = "CS0103", Message = "The name 'DoesNotExist' does not exist in the current context" }]);
@@ -619,7 +615,7 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEn
         var expected = $$"""
             <button @onclick="DoesNotExist"></button>
             @code {
-                private {{GenerateEventHandlerReturnType}} DoesNotExist(global::Microsoft.AspNetCore.Components.Web.MouseEventArgs args)
+                private void DoesNotExist(global::Microsoft.AspNetCore.Components.Web.MouseEventArgs args)
                 {
                     throw new global::System.NotImplementedException();
                 }
@@ -628,7 +624,7 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEn
 
         await ValidateCodeActionAsync(input,
             expected,
-            GenerateEventHandlerTitle,
+            LanguageServerConstants.CodeActions.GenerateEventHandler,
             razorCodeActionProviders: [new GenerateMethodCodeActionProvider()],
             codeActionResolversCreator: CreateRazorCodeActionResolvers,
             diagnostics: [new Diagnostic() { Code = "CS0103", Message = "The name 'DoesNotExist' does not exist in the current context" }]);
@@ -648,7 +644,7 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEn
         var expected = $$"""
             <button @onclick="DoesNotExist"></button>
             @code {
-                private {{GenerateAsyncEventHandlerReturnType}} DoesNotExist(global::Microsoft.AspNetCore.Components.Web.MouseEventArgs args)
+                private global::System.Threading.Tasks.Task DoesNotExist(global::Microsoft.AspNetCore.Components.Web.MouseEventArgs args)
                 {
                     throw new global::System.NotImplementedException();
                 }
@@ -657,17 +653,17 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEn
 
         await ValidateCodeActionAsync(input,
             expected,
-            GenerateAsyncEventHandlerTitle,
+            LanguageServerConstants.CodeActions.GenerateAsyncEventHandler,
             razorCodeActionProviders: [new GenerateMethodCodeActionProvider()],
             codeActionResolversCreator: CreateRazorCodeActionResolvers,
             diagnostics: [new Diagnostic() { Code = "CS0103", Message = "The name 'DoesNotExist' does not exist in the current context" }]);
     }
 
     [Theory]
-    [InlineData("", GenerateEventHandlerReturnType, GenerateEventHandlerTitle)]
-    [InlineData("\r\n", GenerateEventHandlerReturnType, GenerateEventHandlerTitle)]
-    [InlineData("", GenerateAsyncEventHandlerReturnType, GenerateAsyncEventHandlerTitle)]
-    [InlineData("\r\n", GenerateAsyncEventHandlerReturnType, GenerateAsyncEventHandlerTitle)]
+    [InlineData("", "void", LanguageServerConstants.CodeActions.GenerateEventHandler)]
+    [InlineData("\r\n", "void", LanguageServerConstants.CodeActions.GenerateEventHandler)]
+    [InlineData("", "global::System.Threading.Tasks.Task", LanguageServerConstants.CodeActions.GenerateAsyncEventHandler)]
+    [InlineData("\r\n", "global::System.Threading.Tasks.Task", LanguageServerConstants.CodeActions.GenerateAsyncEventHandler)]
     public async Task Handle_GenerateMethod_Nonempty_CodeBlock(string spacing, string returnType, string codeActionTitle)
     {
         var input = $$"""
@@ -722,7 +718,7 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEn
                 {
                 }
 
-                private {{GenerateAsyncEventHandlerReturnType}} DoesNotExist(global::Microsoft.AspNetCore.Components.Web.MouseEventArgs args)
+                private global::System.Threading.Tasks.Task DoesNotExist(global::Microsoft.AspNetCore.Components.Web.MouseEventArgs args)
                 {
                     throw new global::System.NotImplementedException();
                 }
@@ -731,7 +727,7 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEn
 
         await ValidateCodeActionAsync(input,
             expected,
-            GenerateAsyncEventHandlerTitle,
+            LanguageServerConstants.CodeActions.GenerateAsyncEventHandler,
             razorCodeActionProviders: [new GenerateMethodCodeActionProvider()],
             codeActionResolversCreator: CreateRazorCodeActionResolvers,
             diagnostics: [new Diagnostic() { Code = "CS0103", Message = "The name 'DoesNotExist' does not exist in the current context" }]);
@@ -766,8 +762,8 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEn
         Assert.DoesNotContain(
             result,
             e =>
-                ((RazorVSInternalCodeAction)e.Value!).Title == GenerateEventHandlerTitle
-                || ((RazorVSInternalCodeAction)e.Value!).Title == GenerateAsyncEventHandlerTitle);
+                ((RazorVSInternalCodeAction)e.Value!).Name == LanguageServerConstants.CodeActions.GenerateEventHandler
+                || ((RazorVSInternalCodeAction)e.Value!).Name == LanguageServerConstants.CodeActions.GenerateAsyncEventHandler);
     }
 
     [Theory]
@@ -804,8 +800,8 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEn
         Assert.DoesNotContain(
             result,
             e =>
-                ((RazorVSInternalCodeAction)e.Value!).Title == GenerateEventHandlerTitle
-                || ((RazorVSInternalCodeAction)e.Value!).Title == GenerateAsyncEventHandlerTitle);
+                ((RazorVSInternalCodeAction)e.Value!).Name == LanguageServerConstants.CodeActions.GenerateEventHandler
+                || ((RazorVSInternalCodeAction)e.Value!).Name == LanguageServerConstants.CodeActions.GenerateAsyncEventHandler);
     }
 
     [Theory]
@@ -855,7 +851,7 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEn
 
         await ValidateCodeActionAsync(input,
             expected,
-            "Generate Event Handler 'DoesNotExist'",
+            LanguageServerConstants.CodeActions.GenerateEventHandler,
             razorCodeActionProviders: [new GenerateMethodCodeActionProvider()],
             codeActionResolversCreator: CreateRazorCodeActionResolvers,
             optionsMonitor: optionsMonitor,
@@ -890,7 +886,7 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEn
             {
                 public partial class test
                 {{{spacingOrMethod}}
-                    private {{GenerateEventHandlerReturnType}} DoesNotExist(global::Microsoft.AspNetCore.Components.Web.MouseEventArgs args)
+                    private void DoesNotExist(global::Microsoft.AspNetCore.Components.Web.MouseEventArgs args)
                     {
                         throw new global::System.NotImplementedException();
                     }
@@ -903,7 +899,7 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEn
             initialCodeBehindContent,
             expectedRazorContent,
             expectedCodeBehindContent,
-            GenerateEventHandlerTitle);
+            LanguageServerConstants.CodeActions.GenerateEventHandler);
     }
 
     [Theory]
@@ -934,7 +930,7 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEn
             {
                 public partial class test
                 {{{spacingOrMethod}}
-                    private {{GenerateAsyncEventHandlerReturnType}} DoesNotExist(global::Microsoft.AspNetCore.Components.Web.MouseEventArgs args)
+                    private global::System.Threading.Tasks.Task DoesNotExist(global::Microsoft.AspNetCore.Components.Web.MouseEventArgs args)
                     {
                         throw new global::System.NotImplementedException();
                     }
@@ -947,7 +943,7 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEn
             initialCodeBehindContent,
             expectedRazorContent,
             expectedCodeBehindContent,
-            GenerateAsyncEventHandlerTitle);
+            LanguageServerConstants.CodeActions.GenerateAsyncEventHandler);
     }
 
     [Theory]
@@ -974,7 +970,7 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEn
             initialCodeBehindContent,
             expectedRazorContent,
             initialCodeBehindContent,
-            GenerateEventHandlerTitle);
+            LanguageServerConstants.CodeActions.GenerateEventHandler);
     }
 
     [Fact]
@@ -1011,7 +1007,7 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEn
             initialCodeBehindContent,
             expectedRazorContent,
             expectedCodeBehindContent,
-            GenerateEventHandlerTitle);
+            LanguageServerConstants.CodeActions.GenerateEventHandler);
     }
 
     [Fact]
@@ -1033,7 +1029,7 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEn
 
         await ValidateCodeActionAsync(input,
             expected,
-            GenerateEventHandlerTitle,
+            LanguageServerConstants.CodeActions.GenerateEventHandler,
             razorCodeActionProviders: [new GenerateMethodCodeActionProvider()],
             codeActionResolversCreator: CreateRazorCodeActionResolvers,
             diagnostics: [new Diagnostic() { Code = "CS0103", Message = "The name 'DoesNotExist' does not exist in the current context" }]);
@@ -1047,7 +1043,7 @@ public class CodeActionEndToEndTest(ITestOutputHelper testOutput) : CodeActionEn
             """;
 
         await ValidateCodeActionAsync(input,
-            GenerateEventHandlerTitle,
+            LanguageServerConstants.CodeActions.GenerateEventHandler,
             razorCodeActionProviders: [new GenerateMethodCodeActionProvider()],
             codeActionResolversCreator: CreateRazorCodeActionResolvers,
             diagnostics: [new Diagnostic() { Code = "CS0103", Message = "The name 'DoesNotExist' does not exist in the current context" }]);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndToEndTestBase.NetFx.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/CodeActionEndToEndTestBase.NetFx.cs
@@ -191,7 +191,7 @@ public abstract class CodeActionEndToEndTestBase(ITestOutputHelper testOutput) :
 
     internal static VSInternalCodeAction? GetCodeActionToRun(string codeAction, int childActionIndex, SumType<Command, CodeAction>[] result)
     {
-        var codeActionToRun = (VSInternalCodeAction?)result.SingleOrDefault(e => ((RazorVSInternalCodeAction)e.Value!).Name == codeAction || ((RazorVSInternalCodeAction)e.Value!).Title == codeAction).Value;
+        var codeActionToRun = (VSInternalCodeAction?)result.SingleOrDefault(e => ((RazorVSInternalCodeAction)e.Value!).Name == codeAction).Value;
         if (codeActionToRun?.Children?.Length > 0)
         {
             codeActionToRun = codeActionToRun.Children[childActionIndex];
@@ -291,7 +291,7 @@ public abstract class CodeActionEndToEndTestBase(ITestOutputHelper testOutput) :
 
     internal static ImmutableArray<TagHelperDescriptor> CreateTagHelperDescriptors()
     {
-        return BuildTagHelpers().ToImmutableArray();
+        return [.. BuildTagHelpers()];
 
         static IEnumerable<TagHelperDescriptor> BuildTagHelpers()
         {
@@ -346,7 +346,6 @@ public abstract class CodeActionEndToEndTestBase(ITestOutputHelper testOutput) :
                 new(TagHelperMetadata.Common.TypeNamespace, "Microsoft.AspNetCore.Components"),
                 new(TagHelperMetadata.Common.TypeNameIdentifier, "TestGenericComponent"));
             yield return builder.Build();
-
 
             // Sets up a component to make the following available
             // <TestComponent OnDragStart="OnDragStart" />

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ComponentAccessibilityCodeActionProviderTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ComponentAccessibilityCodeActionProviderTest.cs
@@ -19,7 +19,6 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Moq;
 using Xunit;
 using Xunit.Abstractions;
-using WorkspacesSR = Microsoft.CodeAnalysis.Razor.Workspaces.Resources.SR;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
 
@@ -143,20 +142,20 @@ public class ComponentAccessibilityCodeActionProviderTest(ITestOutputHelper test
         Assert.Collection(commandOrCodeActionContainer,
             e =>
             {
-                Assert.Equal("@using Fully.Qualified", e.Title);
+                Assert.Equal(LanguageServerConstants.CodeActions.AddUsing, e.Name);
                 Assert.NotNull(e.Data);
                 Assert.Null(e.Edit);
             },
             e =>
             {
-                Assert.Equal("Fully.Qualified.Component", e.Title);
+                Assert.Equal(LanguageServerConstants.CodeActions.FullyQualify, e.Name);
                 Assert.NotNull(e.Edit);
                 Assert.NotNull(e.Edit.DocumentChanges);
                 Assert.Null(e.Data);
             },
             e =>
             {
-                Assert.Equal(WorkspacesSR.Create_Component_FromTag_Title, e.Title);
+                Assert.Equal(LanguageServerConstants.CodeActions.CreateComponentFromTag, e.Name);
                 Assert.NotNull(e.Data);
                 Assert.Null(e.Edit);
             });
@@ -190,20 +189,20 @@ public class ComponentAccessibilityCodeActionProviderTest(ITestOutputHelper test
         Assert.Collection(commandOrCodeActionContainer,
             e =>
             {
-                Assert.Equal("Component - @using Fully.Qualified", e.Title);
+                Assert.Equal(LanguageServerConstants.CodeActions.AddUsing, e.Name);
                 Assert.NotNull(e.Data);
                 Assert.Null(e.Edit);
             },
             e =>
             {
-                Assert.Equal("Fully.Qualified.Component", e.Title);
+                Assert.Equal(LanguageServerConstants.CodeActions.FullyQualify, e.Name);
                 Assert.NotNull(e.Edit);
                 Assert.NotNull(e.Edit.DocumentChanges);
                 Assert.Null(e.Data);
             },
             e =>
             {
-                Assert.Equal(WorkspacesSR.Create_Component_FromTag_Title, e.Title);
+                Assert.Equal(LanguageServerConstants.CodeActions.CreateComponentFromTag, e.Name);
                 Assert.NotNull(e.Data);
                 Assert.Null(e.Edit);
             });
@@ -239,14 +238,14 @@ public class ComponentAccessibilityCodeActionProviderTest(ITestOutputHelper test
         Assert.Collection(commandOrCodeActionContainer,
             e =>
             {
-                Assert.Equal("Component", e.Title);
+                Assert.Equal(LanguageServerConstants.CodeActions.FullyQualify, e.Name);
                 Assert.NotNull(e.Edit);
                 Assert.NotNull(e.Edit.DocumentChanges);
                 Assert.Null(e.Data);
             },
             e =>
             {
-                Assert.Equal(WorkspacesSR.Create_Component_FromTag_Title, e.Title);
+                Assert.Equal(LanguageServerConstants.CodeActions.CreateComponentFromTag, e.Name);
                 Assert.NotNull(e.Data);
                 Assert.Null(e.Edit);
             });
@@ -280,20 +279,20 @@ public class ComponentAccessibilityCodeActionProviderTest(ITestOutputHelper test
         Assert.Collection(commandOrCodeActionContainer,
             e =>
             {
-                Assert.Equal("@using Fully.Qualified", e.Title);
+                Assert.Equal(LanguageServerConstants.CodeActions.AddUsing, e.Name);
                 Assert.NotNull(e.Data);
                 Assert.Null(e.Edit);
             },
             e =>
             {
-                Assert.Equal("Fully.Qualified.GenericComponent", e.Title);
+                Assert.Equal(LanguageServerConstants.CodeActions.FullyQualify, e.Name);
                 Assert.NotNull(e.Edit);
                 Assert.NotNull(e.Edit.DocumentChanges);
                 Assert.Null(e.Data);
             },
             e =>
             {
-                Assert.Equal(WorkspacesSR.Create_Component_FromTag_Title, e.Title);
+                Assert.Equal(LanguageServerConstants.CodeActions.CreateComponentFromTag, e.Name);
                 Assert.NotNull(e.Data);
                 Assert.Null(e.Edit);
             });
@@ -325,7 +324,7 @@ public class ComponentAccessibilityCodeActionProviderTest(ITestOutputHelper test
 
         // Assert
         var command = Assert.Single(commandOrCodeActionContainer);
-        Assert.Equal(WorkspacesSR.Create_Component_FromTag_Title, command.Title);
+        Assert.Equal(LanguageServerConstants.CodeActions.CreateComponentFromTag, command.Name);
         Assert.NotNull(command.Data);
     }
 
@@ -355,7 +354,7 @@ public class ComponentAccessibilityCodeActionProviderTest(ITestOutputHelper test
 
         // Assert
         var command = Assert.Single(commandOrCodeActionContainer);
-        Assert.Equal(WorkspacesSR.Create_Component_FromTag_Title, command.Title);
+        Assert.Equal(LanguageServerConstants.CodeActions.CreateComponentFromTag, command.Name);
         Assert.NotNull(command.Data);
     }
 
@@ -415,13 +414,13 @@ public class ComponentAccessibilityCodeActionProviderTest(ITestOutputHelper test
         Assert.Collection(commandOrCodeActionContainer,
             e =>
             {
-                Assert.Equal("@using Fully.Qualified", e.Title);
+                Assert.Equal(LanguageServerConstants.CodeActions.AddUsing, e.Name);
                 Assert.NotNull(e.Data);
                 Assert.Null(e.Edit);
             },
             e =>
             {
-                Assert.Equal("Fully.Qualified.Component", e.Title);
+                Assert.Equal(LanguageServerConstants.CodeActions.FullyQualify, e.Name);
                 Assert.NotNull(e.Edit);
                 Assert.NotNull(e.Edit.DocumentChanges);
                 Assert.Null(e.Data);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToComponentCodeActionResolverTest.NetFx.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/CodeActions/Razor/ExtractToComponentCodeActionResolverTest.NetFx.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor.CodeActions.Razor;
+using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Roslyn.Test.Utilities;
@@ -20,8 +21,6 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
 
 public class ExtractToComponentCodeActionResolverTest(ITestOutputHelper testOutput) : CodeActionEndToEndTestBase(testOutput)
 {
-    private const string ExtractToComponentTitle = "Extract element to new component";
-
     [Fact]
     public async Task Handle_SingleElement()
     {
@@ -303,7 +302,7 @@ public class ExtractToComponentCodeActionResolverTest(ITestOutputHelper testOutp
             null);
 
         Assert.NotEmpty(result);
-        var codeActionToRun = GetCodeActionToRun(ExtractToComponentTitle, 0, result);
+        var codeActionToRun = GetCodeActionToRun(LanguageServerConstants.CodeActions.ExtractToNewComponentAction, 0, result);
 
         if (expectedNewComponent is null)
         {

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CodeActions/CohostCodeActionsEndpointTestBase.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CodeActions/CohostCodeActionsEndpointTestBase.cs
@@ -32,6 +32,25 @@ public abstract class CohostCodeActionsEndpointTestBase(ITestOutputHelper testOu
 {
     private protected async Task VerifyCodeActionAsync(TestCode input, string? expected, string codeActionName, int childActionIndex = 0, string? fileKind = null, (string filePath, string contents)[]? additionalFiles = null, (Uri fileUri, string contents)[]? additionalExpectedFiles = null)
     {
+        var document = CreateRazorDocument(input, fileKind, additionalFiles);
+
+        var codeAction = await VerifyCodeActionRequestAsync(document, input, codeActionName, childActionIndex, expectOffer: expected is not null);
+
+        if (codeAction is null)
+        {
+            Assert.Null(expected);
+            return;
+        }
+
+        var workspaceEdit = codeAction.Data is null
+            ? codeAction.Edit.AssumeNotNull()
+            : await ResolveCodeActionAsync(document, codeAction);
+
+        await VerifyCodeActionResultAsync(document, workspaceEdit, expected, additionalExpectedFiles);
+    }
+
+    private protected TextDocument CreateRazorDocument(TestCode input, string? fileKind = null, (string filePath, string contents)[]? additionalFiles = null)
+    {
         var fileSystem = (RemoteFileSystem)OOPExportProvider.GetExportedValue<IFileSystem>();
         fileSystem.GetTestAccessor().SetFileSystem(new TestFileSystem(additionalFiles));
 
@@ -49,23 +68,42 @@ public abstract class CohostCodeActionsEndpointTestBase(ITestOutputHelper testOu
         });
 
         var document = CreateProjectAndRazorDocument(input.Text, fileKind, createSeparateRemoteAndLocalWorkspaces: true, additionalFiles: additionalFiles);
-
-        var codeAction = await VerifyCodeActionRequestAsync(document, input, codeActionName, childActionIndex, expectOffer: expected is not null);
-
-        if (codeAction is null)
-        {
-            Assert.Null(expected);
-            return;
-        }
-
-        var workspaceEdit = codeAction.Data is null
-            ? codeAction.Edit.AssumeNotNull()
-            : await ResolveCodeActionAsync(document, codeAction);
-
-        await VerifyCodeActionResultAsync(document, workspaceEdit, expected, additionalExpectedFiles);
+        return document;
     }
 
     private async Task<CodeAction?> VerifyCodeActionRequestAsync(TextDocument document, TestCode input, string codeActionName, int childActionIndex, bool expectOffer)
+    {
+        var result = await GetCodeActionsAsync(document, input);
+        if (result is null)
+        {
+            return null;
+        }
+
+        var codeActionToRun = (VSInternalCodeAction?)result.SingleOrDefault(e => ((RazorVSInternalCodeAction)e.Value!).Name == codeActionName).Value;
+
+        if (!expectOffer)
+        {
+            Assert.Null(codeActionToRun);
+            return null;
+        }
+
+        AssertEx.NotNull(codeActionToRun, $"""
+            Could not find code action with name '{codeActionName}'.
+
+            Available:
+                {string.Join(Environment.NewLine + "    ", result.Select(e => ((RazorVSInternalCodeAction)e.Value!).Name))}
+            """);
+
+        if (codeActionToRun.Children?.Length > 0)
+        {
+            codeActionToRun = codeActionToRun.Children[childActionIndex];
+        }
+
+        Assert.NotNull(codeActionToRun);
+        return codeActionToRun;
+    }
+
+    private protected async Task<SumType<Command, CodeAction>[]?> GetCodeActionsAsync(TextDocument document, TestCode input)
     {
         var requestInvoker = new TestLSPRequestInvoker();
         var endpoint = new CohostCodeActionsEndpoint(RemoteServiceInvoker, ClientCapabilitiesService, TestHtmlDocumentSynchronizer.Instance, requestInvoker, NoOpTelemetryReporter.Instance);
@@ -107,37 +145,13 @@ public abstract class CohostCodeActionsEndpointTestBase(ITestOutputHelper testOu
         }
 
         var result = await endpoint.GetTestAccessor().HandleRequestAsync(document, request, DisposalToken);
-
         if (result is null)
         {
             return null;
         }
 
-        Assert.NotNull(result);
         Assert.NotEmpty(result);
-
-        var codeActionToRun = (VSInternalCodeAction?)result.SingleOrDefault(e => ((RazorVSInternalCodeAction)e.Value!).Name == codeActionName).Value;
-
-        if (!expectOffer)
-        {
-            Assert.Null(codeActionToRun);
-            return null;
-        }
-
-        AssertEx.NotNull(codeActionToRun, $"""
-            Could not find code action with name '{codeActionName}'.
-
-            Available:
-                {string.Join(Environment.NewLine + "    ", result.Select(e => ((RazorVSInternalCodeAction)e.Value!).Name))}
-            """);
-
-        if (codeActionToRun.Children?.Length > 0)
-        {
-            codeActionToRun = codeActionToRun.Children[childActionIndex];
-        }
-
-        Assert.NotNull(codeActionToRun);
-        return codeActionToRun;
+        return result;
     }
 
     private async Task VerifyCodeActionResultAsync(TextDocument document, WorkspaceEdit workspaceEdit, string? expected, (Uri fileUri, string contents)[]? additionalExpectedFiles = null)

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CodeActions/CohostCodeActionsEndpointTestBase.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CodeActions/CohostCodeActionsEndpointTestBase.cs
@@ -116,7 +116,7 @@ public abstract class CohostCodeActionsEndpointTestBase(ITestOutputHelper testOu
         Assert.NotNull(result);
         Assert.NotEmpty(result);
 
-        var codeActionToRun = (VSInternalCodeAction?)result.SingleOrDefault(e => ((RazorVSInternalCodeAction)e.Value!).Name == codeActionName || ((RazorVSInternalCodeAction)e.Value!).Title == codeActionName).Value;
+        var codeActionToRun = (VSInternalCodeAction?)result.SingleOrDefault(e => ((RazorVSInternalCodeAction)e.Value!).Name == codeActionName).Value;
 
         if (!expectOffer)
         {
@@ -125,10 +125,10 @@ public abstract class CohostCodeActionsEndpointTestBase(ITestOutputHelper testOu
         }
 
         AssertEx.NotNull(codeActionToRun, $"""
-            Could not find code action with name or title '{codeActionName}'.
+            Could not find code action with name '{codeActionName}'.
 
             Available:
-                {string.Join(Environment.NewLine + "    ", result.Select(e => $"{((RazorVSInternalCodeAction)e.Value!).Name} or {((RazorVSInternalCodeAction)e.Value!).Title}"))}
+                {string.Join(Environment.NewLine + "    ", result.Select(e => ((RazorVSInternalCodeAction)e.Value!).Name))}
             """);
 
         if (codeActionToRun.Children?.Length > 0)

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CodeActions/CreateComponentFromTagTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CodeActions/CreateComponentFromTagTests.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Razor.Protocol;
 using Xunit;
 using Xunit.Abstractions;
-using WorkspacesSR = Microsoft.CodeAnalysis.Razor.Workspaces.Resources.SR;
 
 namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost.CodeActions;
 
@@ -24,7 +24,7 @@ public class CreateComponentFromTagTests(ITestOutputHelper testOutputHelper) : C
 
                 <Hello><Hello>
                 """,
-            codeActionName: WorkspacesSR.Create_Component_FromTag_Title,
+            codeActionName: LanguageServerConstants.CodeActions.CreateComponentFromTag,
             additionalExpectedFiles: [
                 (FileUri("Hello.razor"), "")]);
     }
@@ -43,7 +43,7 @@ public class CreateComponentFromTagTests(ITestOutputHelper testOutputHelper) : C
 
                 <Hello><Hello>
                 """,
-            codeActionName: WorkspacesSR.Create_Component_FromTag_Title,
+            codeActionName: LanguageServerConstants.CodeActions.CreateComponentFromTag,
             additionalExpectedFiles: [
                 (FileUri("Hello.razor"), "")]);
     }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CodeActions/ExtractToCodeBehindTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CodeActions/ExtractToCodeBehindTests.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Razor.Protocol;
 using Xunit;
 using Xunit.Abstractions;
-using WorkspacesSR = Microsoft.CodeAnalysis.Razor.Workspaces.Resources.SR;
 
 namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost.CodeActions;
 
@@ -27,7 +27,7 @@ public class ExtractToCodeBehindTests(ITestOutputHelper testOutputHelper) : Coho
 
 
                 """,
-            codeActionName: WorkspacesSR.ExtractTo_CodeBehind_Title,
+            codeActionName: LanguageServerConstants.CodeActions.ExtractToCodeBehindAction,
             additionalExpectedFiles: [
                 (FileUri("File1.razor.cs"), $$"""
                     namespace SomeProject

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CodeActions/ExtractToCodeBehindTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CodeActions/ExtractToCodeBehindTests.cs
@@ -39,4 +39,40 @@ public class ExtractToCodeBehindTests(ITestOutputHelper testOutputHelper) : Coho
                     }
                     """)]);
     }
+
+    [Theory]
+    [InlineData("[||]@code {")]
+    [InlineData("@[||]code {")]
+    [InlineData("@c[||]ode {")]
+    [InlineData("@co[||]de {")]
+    [InlineData("@cod[||]e {")]
+    [InlineData("@code[||] {")]
+    [InlineData("@code[||]{")]
+    public async Task WorkAtAnyCursorPosition(string codeBlockStart)
+    {
+        await VerifyCodeActionAsync(
+            input: $$"""
+                <div></div>
+
+                {{codeBlockStart}}
+                    private int x = 1;
+                }
+                """,
+            expected: """
+                <div></div>
+
+
+                """,
+            codeActionName: LanguageServerConstants.CodeActions.ExtractToCodeBehindAction,
+            additionalExpectedFiles: [
+                (FileUri("File1.razor.cs"), $$"""
+                    namespace SomeProject
+                    {
+                        public partial class File1
+                        {
+                            private int x = 1;
+                        }
+                    }
+                    """)]);
+    }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CodeActions/ExtractToComponentTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CodeActions/ExtractToComponentTests.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Razor.Protocol;
 using Xunit;
 using Xunit.Abstractions;
-using WorkspacesSR = Microsoft.CodeAnalysis.Razor.Workspaces.Resources.SR;
 
 namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost.CodeActions;
 
@@ -30,7 +30,7 @@ public class ExtractToComponentTests(ITestOutputHelper testOutputHelper) : Cohos
 
                 <div></div>
                 """,
-            codeActionName: WorkspacesSR.ExtractTo_Component_Title,
+            codeActionName: LanguageServerConstants.CodeActions.ExtractToNewComponentAction,
             additionalExpectedFiles: [
                 (FileUri("Component.razor"), """
                     <div>
@@ -55,6 +55,6 @@ public class ExtractToComponentTests(ITestOutputHelper testOutputHelper) : Cohos
                 <div></div>
                 """,
             expected: null,
-            codeActionName: WorkspacesSR.ExtractTo_Component_Title);
+            codeActionName: LanguageServerConstants.CodeActions.ExtractToNewComponentAction);
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CodeActions/GenerateEventHandlerTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CodeActions/GenerateEventHandlerTests.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Razor.Protocol;
 using Xunit;
 using Xunit.Abstractions;
-using WorkspacesSR = Microsoft.CodeAnalysis.Razor.Workspaces.Resources.SR;
 
 namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost.CodeActions;
 
@@ -27,7 +27,7 @@ public class GenerateEventHandlerTests(ITestOutputHelper testOutputHelper) : Coh
             }
             """;
 
-        await VerifyCodeActionAsync(input, expected, WorkspacesSR.FormatGenerate_Event_Handler_Title("DoesNotExist"));
+        await VerifyCodeActionAsync(input, expected, LanguageServerConstants.CodeActions.GenerateEventHandler);
     }
 
     [Fact(Skip = "Need to map uri back to source generated document")]
@@ -53,7 +53,7 @@ public class GenerateEventHandlerTests(ITestOutputHelper testOutputHelper) : Coh
             }
             """;
 
-        await VerifyCodeActionAsync(input, expected, WorkspacesSR.FormatGenerate_Event_Handler_Title("DoesNotExist"));
+        await VerifyCodeActionAsync(input, expected, LanguageServerConstants.CodeActions.GenerateEventHandler);
     }
 
     [Fact(Skip = "Need to map uri back to source generated document")]
@@ -81,7 +81,7 @@ public class GenerateEventHandlerTests(ITestOutputHelper testOutputHelper) : Coh
             }
             """;
 
-        await VerifyCodeActionAsync(input, expected, WorkspacesSR.FormatGenerate_Event_Handler_Title("DoesNotExist"));
+        await VerifyCodeActionAsync(input, expected, LanguageServerConstants.CodeActions.GenerateEventHandler);
     }
 
     [Fact(Skip = "Need to map uri back to source generated document")]
@@ -109,7 +109,7 @@ public class GenerateEventHandlerTests(ITestOutputHelper testOutputHelper) : Coh
             }
             """;
 
-        await VerifyCodeActionAsync(input, expected, WorkspacesSR.FormatGenerate_Event_Handler_Title("DoesNotExist"));
+        await VerifyCodeActionAsync(input, expected, LanguageServerConstants.CodeActions.GenerateEventHandler);
     }
 
     [Fact(Skip = "Need to map uri back to source generated document")]
@@ -135,7 +135,7 @@ public class GenerateEventHandlerTests(ITestOutputHelper testOutputHelper) : Coh
             }
             """;
 
-        await VerifyCodeActionAsync(input, expected, WorkspacesSR.FormatGenerate_Event_Handler_Title("DoesNotExist"));
+        await VerifyCodeActionAsync(input, expected, LanguageServerConstants.CodeActions.GenerateEventHandler);
     }
 
     [Fact(Skip = "Need to map uri back to source generated document")]
@@ -161,7 +161,7 @@ public class GenerateEventHandlerTests(ITestOutputHelper testOutputHelper) : Coh
             }
             """;
 
-        await VerifyCodeActionAsync(input, expected, WorkspacesSR.FormatGenerate_Async_Event_Handler_Title("DoesNotExistAsync"));
+        await VerifyCodeActionAsync(input, expected, LanguageServerConstants.CodeActions.GenerateAsyncEventHandler);
     }
 
     [Fact(Skip = "Need to map uri back to source generated document")]
@@ -189,7 +189,7 @@ public class GenerateEventHandlerTests(ITestOutputHelper testOutputHelper) : Coh
                         }
                     }
                     """)],
-            codeActionName: WorkspacesSR.FormatGenerate_Event_Handler_Title("DoesNotExist"));
+            codeActionName: LanguageServerConstants.CodeActions.GenerateEventHandler);
     }
 
     [Fact(Skip = "Need to map uri back to source generated document")]
@@ -228,7 +228,7 @@ public class GenerateEventHandlerTests(ITestOutputHelper testOutputHelper) : Coh
                         }
                     }
                     """)],
-            codeActionName: WorkspacesSR.FormatGenerate_Event_Handler_Title("DoesNotExist"));
+            codeActionName: LanguageServerConstants.CodeActions.GenerateEventHandler);
     }
 
     [Fact(Skip = "Need to map uri back to source generated document")]
@@ -261,7 +261,7 @@ public class GenerateEventHandlerTests(ITestOutputHelper testOutputHelper) : Coh
                         }
                     }
                     """)],
-            codeActionName: WorkspacesSR.FormatGenerate_Event_Handler_Title("DoesNotExist"));
+            codeActionName: LanguageServerConstants.CodeActions.GenerateEventHandler);
     }
 
     [Fact(Skip = "Need to map uri back to source generated document")]
@@ -281,7 +281,7 @@ public class GenerateEventHandlerTests(ITestOutputHelper testOutputHelper) : Coh
             }
             """;
 
-        await VerifyCodeActionAsync(input, expected, WorkspacesSR.FormatGenerate_Async_Event_Handler_Title("DoesNotExist"));
+        await VerifyCodeActionAsync(input, expected, LanguageServerConstants.CodeActions.GenerateAsyncEventHandler);
     }
 
     [Fact(Skip = "Need to map uri back to source generated document")]
@@ -307,6 +307,6 @@ public class GenerateEventHandlerTests(ITestOutputHelper testOutputHelper) : Coh
             }
             """;
 
-        await VerifyCodeActionAsync(input, expected, WorkspacesSR.FormatGenerate_Async_Event_Handler_Title("DoesNotExist"));
+        await VerifyCodeActionAsync(input, expected, LanguageServerConstants.CodeActions.GenerateAsyncEventHandler);
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CodeActions/TypeAccessibilityTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CodeActions/TypeAccessibilityTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Razor.Protocol;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -23,7 +24,7 @@ public class TypeAccessibilityTests(ITestOutputHelper testOutputHelper) : Cohost
 
                 <EditForm></EditForm>
                 """,
-            codeActionName: "EditForm");
+            codeActionName: LanguageServerConstants.CodeActions.FullyQualify);
     }
 
     [Fact]
@@ -40,7 +41,7 @@ public class TypeAccessibilityTests(ITestOutputHelper testOutputHelper) : Cohost
 
                 <Microsoft.AspNetCore.Components.Sections.SectionOutlet></Microsoft.AspNetCore.Components.Sections.SectionOutlet>
                 """,
-            codeActionName: "Microsoft.AspNetCore.Components.Sections.SectionOutlet");
+            codeActionName: LanguageServerConstants.CodeActions.FullyQualify);
     }
 
     [Fact]
@@ -58,7 +59,7 @@ public class TypeAccessibilityTests(ITestOutputHelper testOutputHelper) : Cohost
 
                 <SectionOutlet></SectionOutlet>
                 """,
-            codeActionName: "@using Microsoft.AspNetCore.Components.Sections");
+            codeActionName: LanguageServerConstants.CodeActions.AddUsing);
     }
 
     [Fact]
@@ -76,6 +77,6 @@ public class TypeAccessibilityTests(ITestOutputHelper testOutputHelper) : Cohost
 
                 <SectionOutlet></SectionOutlet>
                 """,
-            codeActionName: "SectionOutlet - @using Microsoft.AspNetCore.Components.Sections");
+            codeActionName: LanguageServerConstants.CodeActions.AddUsing);
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CodeActions/TypeAccessibilityTests.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CodeActions/TypeAccessibilityTests.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Razor.CodeActions.Models;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Xunit;
 using Xunit.Abstractions;
@@ -78,5 +80,20 @@ public class TypeAccessibilityTests(ITestOutputHelper testOutputHelper) : Cohost
                 <SectionOutlet></SectionOutlet>
                 """,
             codeActionName: LanguageServerConstants.CodeActions.AddUsing);
+    }
+
+    [Fact]
+    public async Task AddUsingShouldBeFirst()
+    {
+        var input = """
+            <div></div>
+
+            <Section[||]Outlet></SectionOutlet>
+            """;
+
+        var document = CreateRazorDocument(input);
+        var codeActions = await GetCodeActionsAsync(document, input);
+
+        Assert.Equal(LanguageServerConstants.CodeActions.AddUsing, codeActions.Select(a => ((RazorVSInternalCodeAction)a.Value!).Name).First());
     }
 }


### PR DESCRIPTION
There was some feedback on Reddit this morning about code action ordering and Extract to Component being a little "in your face". See https://www.reddit.com/r/Blazor/comments/1jjg3bh/am_i_doing_something_wrong_or_is_intellisense_and/mjq7jp3/?context=3 and the rest of the thread in general.

This PR:

* Makes sure Extract to Component always last, since it is offered basically everywhere
* Makes sure Add Using and Fully Qualify are always first, since they're the most likely code actions people want
* Ensures Extract to Code Behind is offered at `$$@code` since previously there would be no light bulb in that situation, but now there is and muscle-memory makes people hit it, which extract the code block to a new component, which is not what they want.

Note that the ordering here is only among the Razor code actions. All C# and Html code actions are always still after the Razor code actions, even Extract to Component.