### PR TITLE
Update Ngen Priorities for VS

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
+++ b/src/Razor/src/Microsoft.VisualStudio.RazorExtension/Microsoft.VisualStudio.RazorExtension.csproj
@@ -165,6 +165,7 @@
     <!-- Don't trim this list. It is used to feed into the binding redirects -->
     <ProjectReference Include="$(SharedSourceRoot)\Microsoft.AspNetCore.Razor.Utilities.Shared\Microsoft.AspNetCore.Razor.Utilities.Shared.csproj">
       <AdditionalProperties>TargetFramework=$(NetFxVS)</AdditionalProperties>
+      <NgenPriority>2</NgenPriority>
     </ProjectReference>
     <ProjectReference Include="..\Microsoft.AspNetCore.Razor.ExternalAccess.LegacyEditor\Microsoft.AspNetCore.Razor.ExternalAccess.LegacyEditor.csproj" />
 
@@ -194,7 +195,9 @@
       <Ngen>false</Ngen>
     </ProjectReference>
     <ProjectReference Include="..\Microsoft.VisualStudio.LanguageServer.ContainedLanguage\Microsoft.VisualStudio.LanguageServer.ContainedLanguage.csproj" />
-    <ProjectReference Include="..\Microsoft.VisualStudio.LanguageServices.Razor\Microsoft.VisualStudio.LanguageServices.Razor.csproj" />
+    <ProjectReference Include="..\Microsoft.VisualStudio.LanguageServices.Razor\Microsoft.VisualStudio.LanguageServices.Razor.csproj" >
+      <NgenPriority>1</NgenPriority>
+    </ProjectReference>
     <ProjectReference Include="..\Microsoft.VisualStudio.LegacyEditor.Razor\Microsoft.VisualStudio.LegacyEditor.Razor.csproj" />
     <ProjectReference Include="..\..\..\Compiler\Microsoft.CodeAnalysis.Razor.Compiler\src\Microsoft.CodeAnalysis.Razor.Compiler.csproj">
       <Name>Microsoft.CodeAnalysis.Razor.Compiler</Name>
@@ -226,7 +229,7 @@
       <Ngen>$(Ngen)</Ngen>
       <NgenApplication>$(NgenApplication)</NgenApplication>
       <NgenArchitecture>$(NgenArchitecture)</NgenArchitecture>
-      <NgenPriority>$(NgenPriority)</NgenPriority>
+      <NgenPriority>1</NgenPriority>
     </VSIXSourceItem>
   </ItemGroup>
 


### PR DESCRIPTION
﻿### Summary of the changes

We are experimenting with a mechanism to asynchronously generate important NGEN images immediately after VS setup in 17.14, and to do this are adjusting NGEN priorities of assemblies, so that the most important ones, based on JIT time, usage and user observable scenarios, are generated first. These changes are as a result of that analysis. If you have any questions on this, feel free to reach out to me or the VS Perf and Rel team.

Changes made:
- Microsoft.CodeAnalysis.Razor.Compiler.dll going from ngen priority 3 to priority 1
- Microsoft.VisualStudio.LanguageServices.Razor.dll going from ngen priority 3 to priority 1
- Microsoft.AspNetCore.Razor.Utilities.Shared.dll going from ngen priority 3 to priority 2