### PR TITLE
Upgrade to System.Threading.Tasks.Extensions 4.6.2 for SB

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -105,6 +105,6 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(DotNetBuildSourceOnly)' == 'true'">
     <MicrosoftIORedistVersion>6.1.0</MicrosoftIORedistVersion>
-    <SystemThreadingTasksExtensionsVersion>4.6.0</SystemThreadingTasksExtensionsVersion>
+    <SystemThreadingTasksExtensionsVersion>4.6.2</SystemThreadingTasksExtensionsVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
The source-only VMR build for https://github.com/dotnet/sdk/pull/47869 is failing when building the razor repo with this error:

```
src/razor/src/Analyzers/Razor.Diagnostics.Analyzers/Razor.Diagnostics.Analyzers.csproj(0,0): error NU1109: (NETCORE_ENGINEERING_TELEMETRY=Restore) Detected package downgrade: System.Threading.Tasks.Extensions from 4.6.2 to centrally defined 4.6.0. Update the centrally managed package version to a higher version. 
 Razor.Diagnostics.Analyzers -> Microsoft.CodeAnalysis.CSharp 4.14.0-3.25176.10 -> System.Threading.Tasks.Extensions (>= 4.6.2) 
 Razor.Diagnostics.Analyzers -> System.Threading.Tasks.Extensions (>= 4.6.0)
```

This is caused by Roslyn having a new dependency on version 4.6.2 of System.Threading.Tasks.Extensions while razor is still centrally defining it to version 4.6.0. This is resolved by simply upgrading to 4.6.2.