### PR TITLE
TagHelper resolution should fallback to in-proc on failure

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Discovery/OutOfProcTagHelperResolver.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Discovery/OutOfProcTagHelperResolver.cs
@@ -59,7 +59,7 @@ internal class OutOfProcTagHelperResolver(
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogError(ex, $"Error encountered from project '{projectSnapshot.FilePath}':{Environment.NewLine}{ex}");
-            return default;
+            // if not cancellation, try getting tag helpers in-proc
         }
 
         try


### PR DESCRIPTION
ISSUE:
If the tag helper resolve fails on out-of-proc (a non-cancel exception) the code shold attempt to run it in-proc

FIX:
Remove the `return default` in the catch for non-cancelling exceptions.

TESTIING:
Manually ran scenarios, saw tag helpers appear and the count was reasonable for a basic project even with OOP disabled.  Code colorization and InteliSense completions also appeared commiserate with TagHelpers available. 
Added unittests for "success OOP skips InProc" and "Exception in OOP runs InProc".  Existing unittests cover the other cases.
