### PR TITLE
Add serialization tests back

### DIFF
--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.csproj
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Microsoft.CodeAnalysis.Razor.Workspaces.Test.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFrameworks>$(StandardTestTfms)</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
+
+    <!-- To generate baselines, run tests with /p:GenerateJsonFiles=true -->
+    <DefineConstants Condition="'$(GenerateJsonFiles)'=='true'">$(DefineConstants);GENERATE_JSON_FILES</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Serialization/GenerateJsonFiles.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Serialization/GenerateJsonFiles.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+// Uncomment to easily generate new JSON files
+//#define GENERATE_JSON_FILES
+
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Serialization.Json;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Xunit;
+using Xunit.Abstractions;
+
+///////////////////////////////////////////////////////////////////////////////
+//
+// Note: The JSON files used for testing are very large. When making
+// significant changes to the JSON format for tag helpers or RazorProjectInfo, it
+// can be helpful to update the ObjectWriters first and the write new JSON files
+// before updating the ObjectReaders. This avoids having to make a series of
+// manual edits to the JSON resource files.
+//
+// 1. Update ObjectWriters to write the new JSON format.
+// 2. Uncomment the GENERATE_JSON_FILES #define above.
+// 3. Run the GenerateNewJsonFiles test below.
+// 4. Update ObjectReaders to read the new JSON format.
+// 5. Comment the GENERATE_JSON_FILES #define again.
+// 6. Run all of the tests in SerializerValidationTest to ensure that the
+//    new JSON files deserialize correctly.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+namespace Microsoft.CodeAnalysis.Razor.Serialization;
+
+public class GenerateJsonFiles(ITestOutputHelper testOutput) : ToolingTestBase(testOutput)
+{
+#if GENERATE_JSON_FILES
+    internal static readonly bool ShouldGenerate = true;
+#else
+    internal static readonly bool ShouldGenerate = false;
+#endif
+
+    // This is to prevent you from accidentally checking in with GenerateJsonFiles = true
+    [Fact]
+    public void GenerateJsonFilesMustBeFalse()
+    {
+        Assert.False(ShouldGenerate, "GenerateJsonFiles should be set back to false before you check in!");
+    }
+
+    // This updates shared JSON files
+#if GENERATE_JSON_FILES
+    [Theory]
+#else
+    [Theory(Skip = "Run with /p:GenerateJsonFiles=true or uncomment #define GENERATE_JSON_FILES to run this test.")]
+#endif
+    [MemberData(nameof(JsonFiles))]
+    public void GenerateNewJsonFiles(JsonFile jsonFile)
+    {
+        var filePath = Path.Combine([GetSharedFilesRoot(), .. jsonFile.PathParts]);
+
+        if (jsonFile.IsRazorProjectInfo)
+        {
+            var original = DeserializeProjectInfoFromFile(filePath);
+            JsonDataConvert.SerializeToFile(original, filePath, indented: true);
+        }
+        else
+        {
+            var original = DeserializeTagHelperArrayFromFile(filePath);
+            JsonDataConvert.SerializeToFile(original, filePath, indented: true);
+        }
+    }
+
+    public readonly record struct JsonFile(string[] PathParts, bool IsRazorProjectInfo)
+    {
+        public static JsonFile TagHelpers(params string[] pathParts)
+            => new(pathParts, IsRazorProjectInfo: false);
+
+        public static JsonFile RazorProjectInfo(params string[] pathParts)
+            => new(pathParts, IsRazorProjectInfo: true);
+    }
+
+    public static TheoryData<JsonFile> JsonFiles =>
+        new()
+        {
+            JsonFile.TagHelpers("Compiler", "taghelpers.json"),
+            JsonFile.TagHelpers("Tooling", "BlazorServerApp.TagHelpers.json"),
+            JsonFile.TagHelpers("Tooling", "taghelpers.json"),
+            JsonFile.TagHelpers("Tooling", "Telerik", "Kendo.Mvc.Examples.taghelpers.json"),
+            JsonFile.RazorProjectInfo("Tooling", "project.razor.json"),
+            JsonFile.RazorProjectInfo("Tooling", "Telerik", "Kendo.Mvc.Examples.project.razor.json")
+        };
+
+    private static RazorProjectInfo DeserializeProjectInfoFromFile(string filePath)
+    {
+        using var reader = new StreamReader(filePath);
+        return JsonDataConvert.DeserializeProjectInfo(reader);
+    }
+
+    private static ImmutableArray<TagHelperDescriptor> DeserializeTagHelperArrayFromFile(string filePath)
+    {
+        using var reader = new StreamReader(filePath);
+        return JsonDataConvert.DeserializeTagHelperArray(reader);
+    }
+
+    private static string GetSharedFilesRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current != null && !File.Exists(Path.Combine(current.FullName, "Razor.sln")))
+        {
+            current = current.Parent;
+        }
+
+        Assert.NotNull(current);
+
+        return Path.Combine(current.FullName, "src", "Shared", "files");
+    }
+}

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Serialization/JsonSerializationTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Serialization/JsonSerializationTest.cs
@@ -1,0 +1,143 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Serialization.Json;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Newtonsoft.Json.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.CodeAnalysis.Razor.Serialization;
+
+public class JsonSerializationTest(ITestOutputHelper testOutput) : ToolingTestBase(testOutput)
+{
+    private readonly RazorConfiguration _configuration = new(RazorLanguageVersion.Experimental, ConfigurationName: "Custom", [new("TestExtension")]);
+
+    private readonly ProjectWorkspaceState _projectWorkspaceState = ProjectWorkspaceState.Create(
+        tagHelpers: [TagHelperDescriptorBuilder.Create("Test", "TestAssembly").Build()]);
+
+    [Fact]
+    public void RazorProjectInfo_InvalidVersionThrows()
+    {
+        // Arrange
+        var projectInfo = new RazorProjectInfo(
+            new ProjectKey("/path/to/obj/"),
+            "/path/to/project.csproj",
+            _configuration,
+            rootNamespace: "TestProject",
+            displayName: "project",
+            _projectWorkspaceState,
+            documents: []);
+
+        var jsonText = JsonDataConvert.Serialize(projectInfo);
+        Assert.NotNull(jsonText);
+
+        var serializedJObject = JObject.Parse(jsonText);
+        serializedJObject[WellKnownPropertyNames.Version] = -1;
+
+        var updatedJsonText = serializedJObject.ToString();
+        Assert.NotNull(updatedJsonText);
+
+        // Act
+        RazorProjectInfo? deserializedProjectInfo = null;
+        Assert.Throws<RazorProjectInfoSerializationException>(() =>
+        {
+            deserializedProjectInfo = JsonDataConvert.DeserializeProjectInfo(updatedJsonText);
+        });
+
+        // Assert
+        Assert.Null(deserializedProjectInfo);
+    }
+
+    [Fact]
+    public void RazorProjectInfo_MissingVersionThrows()
+    {
+        // Arrange
+        var projectInfo = new RazorProjectInfo(
+            new ProjectKey("/path/to/obj/"),
+            "/path/to/project.csproj",
+            _configuration,
+            rootNamespace: "TestProject",
+            displayName: "project",
+            _projectWorkspaceState,
+            documents: []);
+
+        var jsonText = JsonDataConvert.Serialize(projectInfo);
+        Assert.NotNull(jsonText);
+
+        var serializedJObject = JObject.Parse(jsonText);
+        serializedJObject.Remove(WellKnownPropertyNames.Version);
+
+        var updatedJsonText = serializedJObject.ToString();
+        Assert.NotNull(updatedJsonText);
+
+        // Act
+        RazorProjectInfo? deserializedProjectInfo = null;
+        Assert.Throws<RazorProjectInfoSerializationException>(() =>
+        {
+            deserializedProjectInfo = JsonDataConvert.DeserializeProjectInfo(updatedJsonText);
+        });
+
+        // Assert
+        Assert.Null(deserializedProjectInfo);
+    }
+
+    [Fact]
+    public void RazorProjectInfo_CanRoundTrip()
+    {
+        // Arrange
+        var legacyDocument = new DocumentSnapshotHandle("/path/to/file.cshtml", "file.cshtml", FileKinds.Legacy);
+        var componentDocument = new DocumentSnapshotHandle("/path/to/otherfile.razor", "otherfile.razor", FileKinds.Component);
+        var projectInfo = new RazorProjectInfo(
+            new ProjectKey("/path/to/obj/"),
+            "/path/to/project.csproj",
+            _configuration,
+            rootNamespace: "TestProject",
+            displayName: "project",
+            _projectWorkspaceState,
+            documents: [legacyDocument, componentDocument]);
+
+        var jsonText = JsonDataConvert.Serialize(projectInfo);
+        Assert.NotNull(jsonText);
+
+        // Act
+        var deserializedProjectInfo = JsonDataConvert.DeserializeProjectInfo(jsonText);
+        Assert.NotNull(deserializedProjectInfo);
+
+        // Assert
+        Assert.Equal(projectInfo.FilePath, deserializedProjectInfo.FilePath);
+        Assert.Equal(projectInfo.Configuration, deserializedProjectInfo.Configuration);
+        Assert.Equal(projectInfo.RootNamespace, deserializedProjectInfo.RootNamespace);
+        Assert.Equal(projectInfo.ProjectWorkspaceState, deserializedProjectInfo.ProjectWorkspaceState);
+        Assert.Collection(projectInfo.Documents.OrderBy(doc => doc.FilePath),
+            document =>
+            {
+                Assert.Equal(legacyDocument.FilePath, document.FilePath);
+                Assert.Equal(legacyDocument.TargetPath, document.TargetPath);
+                Assert.Equal(legacyDocument.FileKind, document.FileKind);
+            },
+            document =>
+            {
+                Assert.Equal(componentDocument.FilePath, document.FilePath);
+                Assert.Equal(componentDocument.TargetPath, document.TargetPath);
+                Assert.Equal(componentDocument.FileKind, document.FileKind);
+            });
+    }
+
+    [Fact]
+    public void RazorConfiguration_CanRoundTrip()
+    {
+        // Arrange
+        var jsonText = JsonDataConvert.Serialize(_configuration);
+        Assert.NotNull(jsonText);
+
+        // Act
+        var deserializedConfiguration = JsonDataConvert.DeserializeConfiguration(jsonText);
+
+        // Assert
+        Assert.Equal(_configuration, deserializedConfiguration);
+    }
+}

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Serialization/ProjectSnapshotHandleSerializationTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Serialization/ProjectSnapshotHandleSerializationTest.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Linq;
+using MessagePack;
+using MessagePack.Resolvers;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.Razor.Serialization.MessagePack.Resolvers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.CodeAnalysis.Razor.Serialization;
+
+public class ProjectSnapshotHandleSerializationTest(ITestOutputHelper testOutput) : ToolingTestBase(testOutput)
+{
+    private static readonly MessagePackSerializerOptions s_options = MessagePackSerializerOptions.Standard
+        .WithResolver(CompositeResolver.Create(
+            ProjectSnapshotHandleResolver.Instance,
+            StandardResolver.Instance));
+
+    [Fact]
+    public void ProjectSnapshotHandle_Serialization_CanKindaRoundTrip()
+    {
+        // Arrange
+        var projectId = ProjectId.CreateNewId();
+        var expectedSnapshot = new ProjectSnapshotHandle(
+            projectId,
+            new(RazorLanguageVersion.Version_1_1,
+                "Test",
+                [new("Test-Extension1"), new("Test-Extension2")],
+                CodeAnalysis.CSharp.LanguageVersion.CSharp7,
+                UseConsolidatedMvcViews: false,
+                SuppressAddComponentParameter: true,
+                UseRoslynTokenizer: true,
+                PreprocessorSymbols: ["DEBUG", "TRACE", "DAVID"]),
+            "Test");
+
+        // Act
+        var bytes = MessagePackConvert.Serialize(expectedSnapshot, s_options);
+        var actualSnapshot = MessagePackConvert.Deserialize<ProjectSnapshotHandle>(bytes, s_options);
+
+        // Assert
+        Assert.NotNull(actualSnapshot);
+        Assert.Equal(expectedSnapshot.ProjectId, actualSnapshot.ProjectId);
+        Assert.NotNull(expectedSnapshot.Configuration);
+        Assert.NotNull(actualSnapshot.Configuration);
+        Assert.Equal(expectedSnapshot.Configuration.ConfigurationName, actualSnapshot.Configuration.ConfigurationName);
+        Assert.Collection(
+            expectedSnapshot.Configuration.Extensions.OrderBy(e => e.ExtensionName),
+            e => Assert.Equal("Test-Extension1", e.ExtensionName),
+            e => Assert.Equal("Test-Extension2", e.ExtensionName));
+        Assert.Equal(expectedSnapshot.Configuration.LanguageVersion, actualSnapshot.Configuration.LanguageVersion);
+        Assert.Equal(expectedSnapshot.RootNamespace, actualSnapshot.RootNamespace);
+        Assert.Equal(expectedSnapshot.Configuration.CSharpLanguageVersion, actualSnapshot.Configuration.CSharpLanguageVersion);
+        Assert.Equal(expectedSnapshot.Configuration.UseConsolidatedMvcViews, actualSnapshot.Configuration.UseConsolidatedMvcViews);
+        Assert.Equal(expectedSnapshot.Configuration.SuppressAddComponentParameter, actualSnapshot.Configuration.SuppressAddComponentParameter);
+        Assert.Equal(expectedSnapshot.Configuration.UseRoslynTokenizer, actualSnapshot.Configuration.UseRoslynTokenizer);
+        Assert.Collection(actualSnapshot.Configuration.PreprocessorSymbols,
+            s => Assert.Equal("DEBUG", s),
+            s => Assert.Equal("TRACE", s),
+            s => Assert.Equal("DAVID", s));
+    }
+
+    [Fact]
+    public void ProjectSnapshotHandle_SerializationWithNulls_CanKindaRoundTrip()
+    {
+        // Arrange
+        var projectId = ProjectId.CreateNewId();
+        var expectedSnapshot = new ProjectSnapshotHandle(projectId, RazorConfiguration.Default, null);
+
+        // Act
+        var bytes = MessagePackConvert.Serialize(expectedSnapshot, s_options);
+        var actualSnapshot = MessagePackConvert.Deserialize<ProjectSnapshotHandle>(bytes, s_options);
+
+        // Assert
+        Assert.NotNull(actualSnapshot);
+        Assert.Equal(expectedSnapshot.ProjectId, actualSnapshot.ProjectId);
+        Assert.NotNull(actualSnapshot.Configuration);
+        Assert.Null(actualSnapshot.RootNamespace);
+    }
+}

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Serialization/SerializerValidationTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Serialization/SerializerValidationTest.cs
@@ -1,0 +1,116 @@
+﻿using System.Collections.Immutable;
+using MessagePack;
+using MessagePack.Resolvers;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Serialization.Json;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.Razor.ProjectSystem;
+using Microsoft.CodeAnalysis.Razor.Serialization.MessagePack.Resolvers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.CodeAnalysis.Razor.Serialization;
+
+public class SerializerValidationTest(ITestOutputHelper testOutput) : ToolingTestBase(testOutput)
+{
+    [Theory]
+    [InlineData("Kendo.Mvc.Examples.project.razor.json", "Telerik")]
+    [InlineData("project.razor.json")]
+    public void VerifyMessagePack_RazorProjectInfo(string resourceName, string? folderName = null)
+    {
+        // Arrange
+        var resourceBytes = RazorTestResources.GetResourceBytes(resourceName, folderName);
+
+        // Read tag helpers from JSON
+        var originalProjectInfo = JsonDataConvert.DeserializeProjectInfo(resourceBytes);
+
+        var options = MessagePackSerializerOptions.Standard
+            .WithResolver(CompositeResolver.Create(
+                RazorProjectInfoResolver.Instance,
+                StandardResolver.Instance));
+
+        // Act
+        var bytes = MessagePackConvert.Serialize(originalProjectInfo, options);
+        var actualProjectInfo = MessagePackConvert.Deserialize<RazorProjectInfo>(bytes, options);
+
+        // Assert
+        Assert.Equal(originalProjectInfo, actualProjectInfo);
+    }
+
+    [Theory]
+    [InlineData("Kendo.Mvc.Examples.taghelpers.json", "Telerik")]
+    [InlineData("taghelpers.json")]
+    public void VerifyMessagePack_TagHelpers(string resourceName, string? folderName = null)
+    {
+        // Arrange
+        var resourceBytes = RazorTestResources.GetResourceBytes(resourceName, folderName);
+
+        // Read tag helpers from JSON
+        var originalTagHelpers = JsonDataConvert.DeserializeTagHelperArray(resourceBytes);
+
+        var options = MessagePackSerializerOptions.Standard.WithResolver(
+            CompositeResolver.Create(
+                FetchTagHelpersResultResolver.Instance,
+                StandardResolver.Instance));
+
+        // Act
+        var bytes = MessagePackConvert.Serialize(originalTagHelpers, options);
+        var actualTagHelpers = MessagePackConvert.Deserialize<ImmutableArray<TagHelperDescriptor>>(bytes, options);
+
+        // Assert
+        Assert.Equal<TagHelperDescriptor>(originalTagHelpers, actualTagHelpers);
+    }
+
+    [Theory]
+    [InlineData("Kendo.Mvc.Examples.project.razor.json", "Telerik")]
+    [InlineData("project.razor.json")]
+    public void VerifyJson_RazorProjectInfo(string resourceName, string? folderName = null)
+    {
+        // Arrange
+        var resourceBytes = RazorTestResources.GetResourceBytes(resourceName, folderName);
+
+        // Read tag helpers from JSON
+        var originalProjectInfo = JsonDataConvert.DeserializeProjectInfo(resourceBytes);
+
+        // Act
+
+        // Serialize to JSON
+        var jsonText = JsonDataConvert.Serialize(originalProjectInfo);
+
+        // Deserialize from JSON
+        var actualProjectInfo = JsonDataConvert.DeserializeProjectInfo(jsonText);
+        Assert.NotNull(actualProjectInfo);
+
+        // Assert
+        Assert.Equal(originalProjectInfo.ProjectKey, actualProjectInfo.ProjectKey);
+        Assert.Equal(originalProjectInfo.FilePath, actualProjectInfo.FilePath);
+        Assert.Equal(originalProjectInfo.Configuration, actualProjectInfo.Configuration);
+        Assert.Equal(originalProjectInfo.RootNamespace, actualProjectInfo.RootNamespace);
+        Assert.Equal(originalProjectInfo.ProjectWorkspaceState, actualProjectInfo.ProjectWorkspaceState);
+        Assert.Equal<DocumentSnapshotHandle>(originalProjectInfo.Documents, actualProjectInfo.Documents);
+    }
+
+    [Theory]
+    [InlineData("Kendo.Mvc.Examples.taghelpers.json", "Telerik")]
+    [InlineData("taghelpers.json")]
+    [InlineData("BlazorServerApp.TagHelpers.json")]
+    public void VerifyJson_TagHelpers(string resourceName, string? folderName = null)
+    {
+        // Arrange
+        var resourceBytes = RazorTestResources.GetResourceBytes(resourceName, folderName);
+
+        // Read tag helpers from JSON
+        var originalTagHelpers = JsonDataConvert.DeserializeTagHelperArray(resourceBytes);
+
+        // Act
+
+        // Serialize to JSON
+        var jsonText = JsonDataConvert.Serialize(originalTagHelpers);
+
+        // Deserialize from JSON
+        var actualTagHelpers = JsonDataConvert.DeserializeTagHelperArray(jsonText);
+
+        // Assert
+        Assert.Equal<TagHelperDescriptor>(originalTagHelpers, actualTagHelpers);
+    }
+}

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Serialization/TagHelperDeltaResultSerializationTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Serialization/TagHelperDeltaResultSerializationTest.cs
@@ -1,0 +1,289 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using MessagePack;
+using MessagePack.Resolvers;
+using Microsoft.AspNetCore.Mvc.Razor.Extensions;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.Razor.Serialization.MessagePack.Resolvers;
+using Xunit;
+using Xunit.Abstractions;
+using static Microsoft.AspNetCore.Razor.Language.CommonMetadata;
+
+namespace Microsoft.CodeAnalysis.Razor.Serialization;
+
+public class TagHelperDeltaResultSerializationTest(ITestOutputHelper testOutput) : ToolingTestBase(testOutput)
+{
+    private static readonly MessagePackSerializerOptions s_options = MessagePackSerializerOptions.Standard
+        .WithResolver(CompositeResolver.Create(
+            TagHelperDeltaResultResolver.Instance,
+            StandardResolver.Instance));
+
+    [Fact]
+    public void TagHelperResolutionResult_DefaultBlazorServerProject_RoundTrips()
+    {
+        // Arrange
+        var tagHelpers = RazorTestResources.BlazorServerAppTagHelpers;
+        var checksums = tagHelpers.SelectAsArray(t => t.Checksum);
+
+        var expectedResult = new TagHelperDeltaResult(
+            IsDelta: true,
+            ResultId: 1,
+            Added: checksums,
+            Removed: checksums);
+
+        // Act
+
+        // Serialize the result to bytes
+        var bytes = MessagePackConvert.Serialize(expectedResult, s_options);
+
+        // Deserialize the bytes we just serialized.
+        var actualResult = MessagePackConvert.Deserialize<TagHelperDeltaResult?>(bytes, s_options);
+
+        // Assert
+        Assert.NotNull(actualResult);
+        Assert.Equal(expectedResult, actualResult);
+    }
+
+    [Fact]
+    public void TagHelperDescriptor_RoundTripsProperly()
+    {
+        // Arrange
+        var descriptor = CreateTagHelperDescriptor(
+            kind: TagHelperConventions.DefaultKind,
+            tagName: "tag-name",
+            typeName: "type name",
+            assemblyName: "assembly name",
+            attributes:
+            [
+                builder => builder
+                    .Name("test-attribute")
+                    .Metadata(PropertyName("TestAttribute"))
+                    .TypeName("string"),
+            ],
+            ruleBuilders:
+            [
+                builder => builder
+                    .RequireAttributeDescriptor(attribute => attribute
+                        .Name("required-attribute-one")
+                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch))
+                    .RequireAttributeDescriptor(attribute => attribute
+                        .Name("required-attribute-two")
+                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)
+                        .Value("something")
+                        .ValueComparisonMode(RequiredAttributeDescriptor.ValueComparisonMode.PrefixMatch))
+                    .RequireParentTag("parent-name")
+                    .RequireTagStructure(TagStructure.WithoutEndTag),
+            ],
+            configureAction: builder =>
+            {
+                builder.AllowChildTag("allowed-child-one");
+                builder.Metadata("foo", "bar");
+            });
+
+        var expectedResult = new TagHelperDeltaResult(
+            IsDelta: true,
+            ResultId: 1,
+            Added: [descriptor.Checksum],
+            Removed: [descriptor.Checksum]);
+
+        // Act
+        var bytes = MessagePackConvert.Serialize(expectedResult, s_options);
+        var actualResult = MessagePackConvert.Deserialize<TagHelperDeltaResult>(bytes, s_options);
+
+        // Assert
+        Assert.Equal(expectedResult, actualResult);
+    }
+
+    [Fact]
+    public void ViewComponentTagHelperDescriptor_RoundTripsProperly()
+    {
+        // Arrange
+        var descriptor = CreateTagHelperDescriptor(
+            kind: ViewComponentTagHelperConventions.Kind,
+            tagName: "tag-name",
+            typeName: "type name",
+            assemblyName: "assembly name",
+            attributes:
+            [
+                builder => builder
+                    .Name("test-attribute")
+                    .Metadata(PropertyName("TestAttribute"))
+                    .TypeName("string"),
+            ],
+            ruleBuilders:
+            [
+                builder => builder
+                    .RequireAttributeDescriptor(attribute => attribute
+                        .Name("required-attribute-one")
+                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch))
+                    .RequireAttributeDescriptor(attribute => attribute
+                        .Name("required-attribute-two")
+                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)
+                        .Value("something")
+                        .ValueComparisonMode(RequiredAttributeDescriptor.ValueComparisonMode.PrefixMatch))
+                    .RequireParentTag("parent-name")
+                    .RequireTagStructure(TagStructure.WithoutEndTag),
+            ],
+            configureAction: builder =>
+            {
+                builder.AllowChildTag("allowed-child-one");
+                builder.Metadata("foo", "bar");
+            });
+
+        var expectedResult = new TagHelperDeltaResult(
+            IsDelta: true,
+            ResultId: 1,
+            Added: [descriptor.Checksum],
+            Removed: [descriptor.Checksum]);
+
+        // Act
+        var bytes = MessagePackConvert.Serialize(expectedResult, s_options);
+        var actualResult = MessagePackConvert.Deserialize<TagHelperDeltaResult>(bytes, s_options);
+
+        // Assert
+        Assert.Equal(expectedResult, actualResult);
+    }
+
+    [Fact]
+    public void TagHelperDescriptor_WithDiagnostic_RoundTripsProperly()
+    {
+        // Arrange
+        var descriptor = CreateTagHelperDescriptor(
+            kind: TagHelperConventions.DefaultKind,
+            tagName: "tag-name",
+            typeName: "type name",
+            assemblyName: "assembly name",
+            attributes:
+            [
+                builder => builder
+                    .Name("test-attribute")
+                    .Metadata(PropertyName("TestAttribute"))
+                    .TypeName("string"),
+            ],
+            ruleBuilders:
+            [
+                builder => builder
+                    .RequireAttributeDescriptor(attribute => attribute
+                        .Name("required-attribute-one")
+                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch))
+                    .RequireAttributeDescriptor(attribute => attribute
+                        .Name("required-attribute-two")
+                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.FullMatch)
+                        .Value("something")
+                        .ValueComparisonMode(RequiredAttributeDescriptor.ValueComparisonMode.PrefixMatch))
+                    .RequireParentTag("parent-name"),
+            ],
+            configureAction: builder => builder.AllowChildTag("allowed-child-one")
+                .Metadata("foo", "bar")
+                .AddDiagnostic(RazorDiagnostic.Create(
+                    new RazorDiagnosticDescriptor("id", "Test Message", RazorDiagnosticSeverity.Error), new SourceSpan(null, 10, 20, 30, 40))));
+
+        var expectedResult = new TagHelperDeltaResult(
+            IsDelta: true,
+            ResultId: 1,
+            Added: [descriptor.Checksum],
+            Removed: [descriptor.Checksum]);
+
+        // Act
+        var bytes = MessagePackConvert.Serialize(expectedResult, s_options);
+        var actualResult = MessagePackConvert.Deserialize<TagHelperDeltaResult>(bytes, s_options);
+
+        // Assert
+        Assert.Equal(expectedResult, actualResult);
+    }
+
+    [Fact]
+    public void TagHelperDescriptor_WithIndexerAttributes_RoundTripsProperly()
+    {
+        // Arrange
+        var descriptor = CreateTagHelperDescriptor(
+            kind: TagHelperConventions.DefaultKind,
+            tagName: "tag-name",
+            typeName: "type name",
+            assemblyName: "assembly name",
+            attributes:
+            [
+                builder => builder
+                    .Name("test-attribute")
+                    .Metadata(PropertyName("TestAttribute"))
+                    .TypeName("SomeEnum")
+                    .AsEnum()
+                    .Documentation("Summary"),
+                builder => builder
+                    .Name("test-attribute2")
+                    .Metadata(PropertyName("TestAttribute2"))
+                    .TypeName("SomeDictionary")
+                    .AsDictionaryAttribute("dict-prefix-", "string"),
+            ],
+            ruleBuilders:
+            [
+                builder => builder
+                    .RequireAttributeDescriptor(attribute => attribute
+                        .Name("required-attribute-one")
+                        .NameComparisonMode(RequiredAttributeDescriptor.NameComparisonMode.PrefixMatch))
+            ],
+            configureAction: builder => builder
+                .AllowChildTag("allowed-child-one")
+                .Metadata("foo", "bar")
+                .TagOutputHint("Hint"));
+
+        var expectedResult = new TagHelperDeltaResult(
+            IsDelta: true,
+            ResultId: 1,
+            Added: [descriptor.Checksum],
+            Removed: [descriptor.Checksum]);
+
+        // Act
+        var bytes = MessagePackConvert.Serialize(expectedResult, s_options);
+        var actualResult = MessagePackConvert.Deserialize<TagHelperDeltaResult>(bytes, s_options);
+
+        // Assert
+        Assert.Equal(expectedResult, actualResult);
+    }
+
+    private static TagHelperDescriptor CreateTagHelperDescriptor(
+        string kind,
+        string tagName,
+        string typeName,
+        string assemblyName,
+        IEnumerable<Action<BoundAttributeDescriptorBuilder>>? attributes = null,
+        IEnumerable<Action<TagMatchingRuleDescriptorBuilder>>? ruleBuilders = null,
+        Action<TagHelperDescriptorBuilder>? configureAction = null)
+    {
+        var builder = TagHelperDescriptorBuilder.Create(kind, typeName, assemblyName);
+        builder.Metadata(TypeName(typeName));
+
+        if (attributes != null)
+        {
+            foreach (var attributeBuilder in attributes)
+            {
+                builder.BoundAttributeDescriptor(attributeBuilder);
+            }
+        }
+
+        if (ruleBuilders != null)
+        {
+            foreach (var ruleBuilder in ruleBuilders)
+            {
+                builder.TagMatchingRuleDescriptor(innerRuleBuilder =>
+                {
+                    innerRuleBuilder.RequireTagName(tagName);
+                    ruleBuilder(innerRuleBuilder);
+                });
+            }
+        }
+        else
+        {
+            builder.TagMatchingRuleDescriptor(ruleBuilder => ruleBuilder.RequireTagName(tagName));
+        }
+
+        configureAction?.Invoke(builder);
+
+        return builder.Build();
+    }
+}


### PR DESCRIPTION
Several serialization tests were unintentionally deleted in https://github.com/dotnet/razor/commit/d9a7e5a8fcc5ebca9e2c0a515f7acdb169a118ea and not added back later, like UrlDecoderTests.cs was (https://github.com/dotnet/razor/commit/9c1bfd6ac9bff6c857ca324e9e7fa87e7e74cf01). That's a super easy mistake to make and miss in code review, so I'm glad I caught it while rebasing some local branches.