### PR TITLE
Optimistically reuse generated output in some cases

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/CompilationHelpers.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/CompilationHelpers.cs
@@ -12,12 +12,12 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 internal static class CompilationHelpers
 {
-    internal static async Task<RazorCodeDocument> GenerateCodeDocumentAsync(
-        DocumentSnapshot document,
-        RazorProjectEngine projectEngine,
-        RazorCompilerOptions compilerOptions,
-        CancellationToken cancellationToken)
+    internal static async Task<RazorCodeDocument> GenerateCodeDocumentAsync(DocumentSnapshot document, CancellationToken cancellationToken)
     {
+        var project = document.Project;
+        var projectEngine = project.ProjectEngine;
+        var compilerOptions = project.CompilerOptions;
+
         var importSources = await GetImportSourcesAsync(document, projectEngine, cancellationToken).ConfigureAwait(false);
         var tagHelpers = await document.Project.GetTagHelpersAsync(cancellationToken).ConfigureAwait(false);
         var source = await GetSourceAsync(document, projectEngine, cancellationToken).ConfigureAwait(false);
@@ -26,11 +26,10 @@ internal static class CompilationHelpers
         return generator.Generate(source, document.FileKind, importSources, tagHelpers, cancellationToken);
     }
 
-    internal static async Task<RazorCodeDocument> GenerateDesignTimeCodeDocumentAsync(
-        DocumentSnapshot document,
-        RazorProjectEngine projectEngine,
-        CancellationToken cancellationToken)
+    internal static async Task<RazorCodeDocument> GenerateDesignTimeCodeDocumentAsync(DocumentSnapshot document, CancellationToken cancellationToken)
     {
+        var projectEngine = document.Project.ProjectEngine;
+
         var importSources = await GetImportSourcesAsync(document, projectEngine, cancellationToken).ConfigureAwait(false);
         var tagHelpers = await document.Project.GetTagHelpersAsync(cancellationToken).ConfigureAwait(false);
         var source = await GetSourceAsync(document, projectEngine, cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/DocumentSnapshot.cs
@@ -63,7 +63,7 @@ internal sealed class DocumentSnapshot(ProjectSnapshot project, DocumentState st
     }
 
     public Task<RazorCodeDocument> GenerateDesignTimeOutputAsync(CancellationToken cancellationToken)
-        => CompilationHelpers.GenerateDesignTimeCodeDocumentAsync(this, Project.ProjectEngine, cancellationToken);
+        => CompilationHelpers.GenerateDesignTimeCodeDocumentAsync(this, cancellationToken);
 
     #region ILegacyDocumentSnapshot support
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshotExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshotExtensions.cs
@@ -11,17 +11,6 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 internal static class IDocumentSnapshotExtensions
 {
-    public static async Task<RazorSourceDocument> GetSourceAsync(this IDocumentSnapshot document, RazorProjectEngine projectEngine, CancellationToken cancellationToken)
-    {
-        var projectItem = document is { FilePath: string filePath, FileKind: var fileKind }
-            ? projectEngine.FileSystem.GetItem(filePath, fileKind)
-            : null;
-
-        var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-        var properties = RazorSourceDocumentProperties.Create(document.FilePath, projectItem?.RelativePhysicalPath);
-        return RazorSourceDocument.Create(text, properties);
-    }
-
     public static async Task<TagHelperDescriptor?> TryGetTagHelperDescriptorAsync(
         this IDocumentSnapshot documentSnapshot,
         CancellationToken cancellationToken)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectState.cs
@@ -193,6 +193,7 @@ internal sealed class ProjectState
         // Then, compute the effect on the import map
         var importsToRelatedDocuments = RemoveFromImportsToRelatedDocuments(hostDocument);
 
+        // Removing a document should retain the project engine and update the semantic version.
         return new(this, HostProject, ProjectWorkspaceState, documents, importsToRelatedDocuments, retainProjectEngine: true);
     }
 
@@ -258,7 +259,7 @@ internal sealed class ProjectState
             return this;
         }
 
-        var documents = UpdateDocuments(static x => x.UpdateVersion());
+        var documents = UpdateDocuments(static x => x.UpdateHostProject());
 
         // If the host project has changed then we need to recompute the imports map
         var importsToRelatedDocuments = BuildImportsMap(documents.Values, ProjectEngine);
@@ -276,7 +277,7 @@ internal sealed class ProjectState
             return this;
         }
 
-        var documents = UpdateDocuments(static x => x.UpdateVersion());
+        var documents = UpdateDocuments(static x => x.UpdateProjectWorkspaceState());
 
         return new(this, HostProject, projectWorkspaceState, documents, ImportsToRelatedDocuments, retainProjectEngine: true);
     }
@@ -377,7 +378,7 @@ internal sealed class ProjectState
             return documents;
         }
 
-        var updates = relatedDocuments.Select(x => KeyValuePair.Create(x, documents[x].UpdateVersion()));
+        var updates = relatedDocuments.Select(x => KeyValuePair.Create(x, documents[x].UpdateImport()));
         return documents.SetItems(updates);
     }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/Sources/GeneratedOutputSource.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/Sources/GeneratedOutputSource.cs
@@ -54,12 +54,8 @@ internal sealed class GeneratedOutputSource
                     return result;
                 }
 
-                var project = document.Project;
-                var projectEngine = project.ProjectEngine;
-                var compilerOptions = project.CompilerOptions;
-
                 result = await CompilationHelpers
-                    .GenerateCodeDocumentAsync(document, projectEngine, compilerOptions, cancellationToken)
+                    .GenerateCodeDocumentAsync(document, cancellationToken)
                     .ConfigureAwait(false);
 
                 if (_weakOutput is null)


### PR DESCRIPTION
This pull request is an attempt to bring back an older behavior of the Razor project system to optimistically re-use the generated output across `DocumentState` instances in certain cases. In particular, the generated `RazorCodeDocument` will be shared across `DocumentState` instances when `ProjectWorkspaceState` is updated or imports are changed. The `RazorCodeDocument` is still held weakly by the `DocumentState` instances, so it will be garbage collected when no longer needed. So, if `ProjectWorkspaceState` or an import impacts the generated output, the IDE will catch up eventually.

VS Test Insertion: https://dev.azure.com/devdiv/DevDiv/_git/VS/pullrequest/625060