### PR TITLE
Disable the first launch dialog in integration tests

### DIFF
--- a/eng/SetupVSHive.ps1
+++ b/eng/SetupVSHive.ps1
@@ -12,6 +12,8 @@ $vsRegEdit = Join-Path (Join-Path (Join-Path $vsDir 'Common7') 'IDE') 'VSRegEdit
 $hive = "RoslynDev"
 &$vsRegEdit set "$vsDir" $hive HKCU "Roslyn\Internal\OnOff\Features" OOP64Bit dword 0
 
+&$vsRegEdit set "$vsDir" $hive HKLM "Profile" DisableFirstLaunchDialog dword 1
+
 Write-Host "-- VS Info --"
 $isolationIni = Join-Path (Join-Path (Join-Path $vsDir 'Common7') 'IDE') 'devenv.isolation.ini'
 Get-Content $isolationIni | Write-Host

--- a/eng/scripts/CreateVSHive.ps1
+++ b/eng/scripts/CreateVSHive.ps1
@@ -33,7 +33,7 @@ if($success -eq $false){
 
 $vsDir = Split-Path -Parent $devenvExePath
 
-$vsRegEdit = Join-Path (Join-Path (Join-Path $vsDir 'Common7') 'IDE') 'VsRegEdit.exe'
+$vsRegEdit = Join-Path $vsDir 'VsRegEdit.exe'
 
 &$vsRegEdit set "$vsDir" RoslynDev HKLM "Profile" DisableFirstLaunchDialog dword 1
 

--- a/eng/scripts/CreateVSHive.ps1
+++ b/eng/scripts/CreateVSHive.ps1
@@ -35,7 +35,7 @@ $vsDir = Split-Path -Parent $devenvExePath
 
 $vsRegEdit = Join-Path (Join-Path (Join-Path $vsDir 'Common7') 'IDE') 'VsRegEdit.exe'
 
-&$vsRegEdit set "$vsDir" $hive HKLM "Profile" DisableFirstLaunchDialog dword 1
+&$vsRegEdit set "$vsDir" RoslynDev HKLM "Profile" DisableFirstLaunchDialog dword 1
 
 Write-Host "-- VS Info --"
 $isolationIni = Join-Path $vsDir 'devenv.isolation.ini'

--- a/eng/scripts/CreateVSHive.ps1
+++ b/eng/scripts/CreateVSHive.ps1
@@ -31,8 +31,13 @@ if($success -eq $false){
   throw "Failed to create hive"
 }
 
-Write-Host "-- VS Info --"
 $vsDir = Split-Path -Parent $devenvExePath
+
+$vsRegEdit = Join-Path (Join-Path (Join-Path $vsDir 'Common7') 'IDE') 'VsRegEdit.exe'
+
+&$vsRegEdit set "$vsDir" $hive HKLM "Profile" DisableFirstLaunchDialog dword 1
+
+Write-Host "-- VS Info --"
 $isolationIni = Join-Path $vsDir 'devenv.isolation.ini'
 Get-Content $isolationIni | Write-Host
 Write-Host "-- /VS Info --"


### PR DESCRIPTION
Recommended not to look at this commit-at-a-time because it's just too embarrassing.

No idea if this works, but I don't think it will make it worse.