### PR TITLE
Remove RLSP alias by limiting direct references to CLaSP types to Microsoft.AspNetCore.Razor.LanguageServer

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCodeActionsBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCodeActionsBenchmark.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
+using Microsoft.AspNetCore.Razor.LanguageServer;
 using Microsoft.AspNetCore.Razor.LanguageServer.CodeActions;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
@@ -15,7 +16,6 @@ using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol.CodeActions;
 using Microsoft.CodeAnalysis.Razor.Telemetry;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.CommonLanguageServerProtocol.Framework;
 
 namespace Microsoft.AspNetCore.Razor.Microbenchmarks.LanguageServer;
 
@@ -75,7 +75,11 @@ public class RazorCodeActionsBenchmark : RazorLanguageServerBenchmarkBase
 
         var documentContext = new DocumentContext(DocumentUri, DocumentSnapshot, projectContext: null);
 
-        RazorRequestContext = new RazorRequestContext(documentContext, RazorLanguageServerHost.GetRequiredService<ILspServices>(), "lsp/method", uri: null);
+        RazorRequestContext = new RazorRequestContext(
+            documentContext,
+            RazorLanguageServerHost.GetRequiredService<LspServices>(),
+            "lsp/method",
+            uri: null);
     }
 
     private string GetFileContents(FileTypes fileType)

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCompletionBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCompletionBenchmark.cs
@@ -19,7 +19,6 @@ using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Telemetry;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.CommonLanguageServerProtocol.Framework;
 
 namespace Microsoft.AspNetCore.Razor.Microbenchmarks.LanguageServer;
 
@@ -79,7 +78,11 @@ public class RazorCompletionBenchmark : RazorLanguageServerBenchmarkBase
         RazorPosition = DocumentText.GetPosition(razorCodeActionIndex);
 
         var documentContext = new DocumentContext(DocumentUri, DocumentSnapshot, projectContext: null);
-        RazorRequestContext = new RazorRequestContext(documentContext, RazorLanguageServerHost.GetRequiredService<ILspServices>(), "lsp/method", uri: null);
+        RazorRequestContext = new RazorRequestContext(
+            documentContext,
+            RazorLanguageServerHost.GetRequiredService<LspServices>(),
+            "lsp/method",
+            uri: null);
     }
 
     private static string GetFileContents()

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCompletionBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorCompletionBenchmark.cs
@@ -37,12 +37,11 @@ public class RazorCompletionBenchmark : RazorLanguageServerBenchmarkBase
     public async Task SetupAsync()
     {
         var razorCompletionListProvider = RazorLanguageServerHost.GetRequiredService<RazorCompletionListProvider>();
-        var lspServices = RazorLanguageServerHost.GetRequiredService<ILspServices>();
-        var documentMappingService = lspServices.GetRequiredService<IDocumentMappingService>();
-        var clientConnection = lspServices.GetRequiredService<IClientConnection>();
-        var completionListCache = lspServices.GetRequiredService<CompletionListCache>();
-        var triggerAndCommitCharacters = lspServices.GetRequiredService<CompletionTriggerAndCommitCharacters>();
-        var loggerFactory = lspServices.GetRequiredService<ILoggerFactory>();
+        var documentMappingService = RazorLanguageServerHost.GetRequiredService<IDocumentMappingService>();
+        var clientConnection = RazorLanguageServerHost.GetRequiredService<IClientConnection>();
+        var completionListCache = RazorLanguageServerHost.GetRequiredService<CompletionListCache>();
+        var triggerAndCommitCharacters = RazorLanguageServerHost.GetRequiredService<CompletionTriggerAndCommitCharacters>();
+        var loggerFactory = RazorLanguageServerHost.GetRequiredService<ILoggerFactory>();
 
         var delegatedCompletionListProvider = new TestDelegatedCompletionListProvider(documentMappingService, clientConnection, completionListCache, triggerAndCommitCharacters);
         var completionListProvider = new CompletionListProvider(razorCompletionListProvider, delegatedCompletionListProvider, triggerAndCommitCharacters);

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorLanguageServerBenchmarkBase.cs
@@ -17,7 +17,6 @@ using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Telemetry;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.Extensions.DependencyInjection;
 using Nerdbank.Streams;
 
@@ -83,7 +82,7 @@ public class RazorLanguageServerBenchmarkBase : ProjectSnapshotManagerBenchmarkB
 
     private sealed class NoOpClientNotifierService : IClientConnection, IOnInitialized
     {
-        public Task OnInitializedAsync(ILspServices services, CancellationToken cancellationToken)
+        public Task OnInitializedAsync(CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
         }

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensRangeEndpointBenchmark.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/LanguageServer/RazorSemanticTokensRangeEndpointBenchmark.cs
@@ -19,7 +19,6 @@ using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.SemanticTokens;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Razor.Microbenchmarks.LanguageServer;
@@ -76,7 +75,11 @@ public class RazorSemanticTokensRangeEndpointBenchmark : RazorLanguageServerBenc
             start: (0, 0),
             end: (text.Lines.Count - 1, text.Lines[^1].Span.Length - 1));
 
-        RequestContext = new RazorRequestContext(DocumentContext, RazorLanguageServerHost.GetRequiredService<ILspServices>(), "lsp/method", uri: null);
+        RequestContext = new RazorRequestContext(
+            DocumentContext,
+            RazorLanguageServerHost.GetRequiredService<LspServices>(),
+            "lsp/method",
+            uri: null);
 
         var random = new Random();
         var codeDocument = await DocumentContext.GetCodeDocumentAsync(CancellationToken);

--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks.csproj
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks.csproj
@@ -38,8 +38,6 @@
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.DiaSymReader" />
-
-    <PackageReference Include="Microsoft.CodeAnalysis.LanguageServer.Protocol" Aliases="RLSP" />
   </ItemGroup>
 
   <Import Project="..\..\..\Shared\Microsoft.AspNetCore.Razor.Serialization.Json\Microsoft.AspNetCore.Razor.Serialization.Json.projitems" Label="Shared" />

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CLaSPTypeHelpers.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CLaSPTypeHelpers.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using Microsoft.CommonLanguageServerProtocol.Framework;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer;
+
+/// <summary>
+///  Useful helpers for accessing CLaSP types and performing reflection.
+///  These are intended to only be used for testing to avoid type ambiguities
+///  that occur because CLaSP is both compiled into the Razor language server
+///  and is referenced as metadata through Microsoft.CodeAnalysis.LanguageServer.Protocol.
+/// </summary>
+internal static class CLaSPTypeHelpers
+{
+    public static Type IMethodHandlerType = typeof(IMethodHandler);
+
+    public static LanguageServerEndpointAttribute? GetLanguageServerEnpointAttribute(Type type)
+        => type.GetCustomAttribute<LanguageServerEndpointAttribute>();
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CapabilitiesManager.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/CapabilitiesManager.cs
@@ -16,7 +16,7 @@ namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
 internal sealed class CapabilitiesManager : IInitializeManager<InitializeParams, InitializeResult>, IClientCapabilitiesService, IWorkspaceRootPathProvider
 {
-    private readonly ILspServices _lspServices;
+    private readonly LspServices _lspServices;
     private readonly TaskCompletionSource<InitializeParams> _initializeParamsTaskSource;
     private readonly VisualStudio.Threading.AsyncLazy<string> _lazyRootPath;
 
@@ -26,7 +26,7 @@ internal sealed class CapabilitiesManager : IInitializeManager<InitializeParams,
 
     public VSInternalClientCapabilities ClientCapabilities => GetInitializeParams().Capabilities.ToVSInternalClientCapabilities();
 
-    public CapabilitiesManager(ILspServices lspServices)
+    public CapabilitiesManager(LspServices lspServices)
     {
         _lspServices = lspServices;
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ClientConnection.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ClientConnection.cs
@@ -5,7 +5,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
-using Microsoft.CommonLanguageServerProtocol.Framework;
 using StreamJsonRpc;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
@@ -47,7 +46,7 @@ internal sealed class ClientConnection(JsonRpc jsonRpc) : IClientConnection, IOn
     /// <summary>
     /// Fires when the language server is set to "Started".
     /// </summary>
-    public Task OnInitializedAsync(ILspServices services, CancellationToken cancellationToken)
+    public Task OnInitializedAsync(CancellationToken cancellationToken)
     {
         _initializedCompletionSource.TrySetResult(true);
         return Task.CompletedTask;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/DefinitionEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Definition/DefinitionEndpoint.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-extern alias RLSP;
-
 using System;
 using System.Linq;
 using System.Threading;
@@ -17,11 +15,11 @@ using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
-using DefinitionResult = RLSP::Roslyn.LanguageServer.Protocol.SumType<
-    RLSP::Roslyn.LanguageServer.Protocol.Location,
-    RLSP::Roslyn.LanguageServer.Protocol.VSInternalLocation,
-    RLSP::Roslyn.LanguageServer.Protocol.VSInternalLocation[],
-    RLSP::Roslyn.LanguageServer.Protocol.DocumentLink[]>;
+using DefinitionResult = Roslyn.LanguageServer.Protocol.SumType<
+    Roslyn.LanguageServer.Protocol.Location,
+    Roslyn.LanguageServer.Protocol.VSInternalLocation,
+    Roslyn.LanguageServer.Protocol.VSInternalLocation[],
+    Roslyn.LanguageServer.Protocol.DocumentLink[]>;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition;
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/FindAllReferences/FindAllReferencesEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/FindAllReferences/FindAllReferencesEndpoint.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-extern alias RLSP;
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -20,7 +18,7 @@ using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
-using RLSP::Roslyn.Text.Adornments;
+using Roslyn.Text.Adornments;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.FindAllReferences;
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/GlobalUsings.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/GlobalUsings.cs
@@ -6,18 +6,16 @@
 
 // The <Using> item doesn't support aliases so we need to define aliased global usings in a .cs file not in the .csproj
 // https://github.com/dotnet/sdk/issues/37814
-extern alias RLSP;
-global using RLSP::Roslyn.LanguageServer.Protocol;
 
 // Avoid extern alias in every file that needs to disambiguate common LSP type names
-global using LspColorPresentation = RLSP::Roslyn.LanguageServer.Protocol.ColorPresentation;
-global using LspDiagnostic = RLSP::Roslyn.LanguageServer.Protocol.Diagnostic;
-global using LspDiagnosticSeverity = RLSP::Roslyn.LanguageServer.Protocol.DiagnosticSeverity;
-global using LspDocumentHighlight = RLSP::Roslyn.LanguageServer.Protocol.DocumentHighlight;
-global using LspHover = RLSP::Roslyn.LanguageServer.Protocol.Hover;
-global using LspLocation = RLSP::Roslyn.LanguageServer.Protocol.Location;
-global using LspRange = RLSP::Roslyn.LanguageServer.Protocol.Range;
-global using LspSignatureHelp = RLSP::Roslyn.LanguageServer.Protocol.SignatureHelp;
+global using LspColorPresentation = Roslyn.LanguageServer.Protocol.ColorPresentation;
+global using LspDiagnostic = Roslyn.LanguageServer.Protocol.Diagnostic;
+global using LspDiagnosticSeverity = Roslyn.LanguageServer.Protocol.DiagnosticSeverity;
+global using LspDocumentHighlight = Roslyn.LanguageServer.Protocol.DocumentHighlight;
+global using LspHover = Roslyn.LanguageServer.Protocol.Hover;
+global using LspLocation = Roslyn.LanguageServer.Protocol.Location;
+global using LspRange = Roslyn.LanguageServer.Protocol.Range;
+global using LspSignatureHelp = Roslyn.LanguageServer.Protocol.SignatureHelp;
 
 // Avoid ambiguity errors because of our global using above
 global using Range = System.Range;

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IOnInitialized.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/IOnInitialized.cs
@@ -3,11 +3,10 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.CommonLanguageServerProtocol.Framework;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
 internal interface IOnInitialized
 {
-    Task OnInitializedAsync(ILspServices services, CancellationToken cancellationToken);
+    Task OnInitializedAsync(CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Implementation/ImplementationEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Implementation/ImplementationEndpoint.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-extern alias RLSP;
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,9 +11,9 @@ using Microsoft.CodeAnalysis.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
-using ImplementationResult = RLSP::Roslyn.LanguageServer.Protocol.SumType<
-    RLSP::Roslyn.LanguageServer.Protocol.Location[],
-    RLSP::Roslyn.LanguageServer.Protocol.VSInternalReferenceItem[]>;
+using ImplementationResult = Roslyn.LanguageServer.Protocol.SumType<
+    Roslyn.LanguageServer.Protocol.Location[],
+    Roslyn.LanguageServer.Protocol.VSInternalReferenceItem[]>;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Implementation;
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LspServices.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LspServices.cs
@@ -36,7 +36,7 @@ internal sealed class LspServices : ILspServices
 
         // By requesting the startup services, we ensure that they are created.
         // This gives them an opportunity to set up any necessary state or perform.
-        _serviceProvider.GetServices<IRazorStartupService>();
+        _ = _serviceProvider.GetServices<IRazorStartupService>();
     }
 
     private LspServices(IServiceProvider serviceProvider)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LspServices.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LspServices.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
-internal class LspServices : ILspServices
+internal sealed class LspServices : ILspServices
 {
     private sealed class EmptyServiceProvider : IServiceProvider
     {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LspServices.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LspServices.cs
@@ -30,6 +30,8 @@ internal sealed class LspServices : ILspServices
     public LspServices(IServiceCollection serviceCollection)
     {
         serviceCollection.AddSingleton<ILspServices>(this);
+        serviceCollection.AddSingleton<LspServices>(this);
+
         _serviceProvider = serviceCollection.BuildServiceProvider();
 
         // By requesting the startup services, we ensure that they are created.

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LspServices.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/LspServices.cs
@@ -24,11 +24,6 @@ internal class LspServices : ILspServices
         _serviceProvider.GetServices<IRazorStartupService>();
     }
 
-    public ImmutableArray<Type> GetRegisteredServices()
-    {
-        throw new NotImplementedException();
-    }
-
     public T GetRequiredService<T>() where T : notnull
     {
         return _serviceProvider.GetRequiredService<T>();
@@ -43,11 +38,6 @@ internal class LspServices : ILspServices
         }
 
         return services;
-    }
-
-    public bool SupportsGetRegisteredServices()
-    {
-        return false;
     }
 
     public void Dispose()

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Microsoft.AspNetCore.Razor.LanguageServer.csproj
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Microsoft.AspNetCore.Razor.LanguageServer.csproj
@@ -5,8 +5,14 @@
     <Description>Razor is a markup syntax for adding server-side logic to web pages. This package contains the language server library assets.</Description>
     <EnableApiCheck>false</EnableApiCheck>
     <IsShippingPackage>false</IsShippingPackage>
+
     <!-- CLaSP is a source package, and has a more lenient approach to using statements than us-->
-    <NoWarn>IDE0005</NoWarn>
+    <NoWarn>$(NoWarn);IDE0005</NoWarn>
+
+    <!-- We are compiling CLaSP as a source package and referencing Microsoft.CodeAnalysis.LanguageServer.Protocol,
+         which includes the same CLaSP types. This results in C# compiler warnings when it prefers types from source
+         over types from metadata to avoid ambiguities. These warnings can be surpressed. -->
+    <NoWarn>$(NoWarn);0436</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -33,14 +39,7 @@
       Now we aren't sure why this exposes a "flaky" issue; however, to workaround the break we pin the following packages to workaround the issue.
     -->
     <PackageReference Include="Microsoft.VisualStudio.RpcContracts" />
-
-    <!--
-      Razor and Roslyn both use CLaSP as the basis for their language servers, but CLaSP is a source package
-      which means when we reference Roslyn's server to get the LSP protocol types (which we have a restricted
-      IVT to) we get ambiguous type errors for everything in CLaSP. To fix this we reference Roslyn with an
-      alias, and then have a global using for the LSP protocol types only.
-    -->
-    <PackageReference Include="Microsoft.CodeAnalysis.LanguageServer.Protocol" Aliases="RLSP" />
+    <PackageReference Include="Microsoft.CodeAnalysis.LanguageServer.Protocol" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorConfigurationEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorConfigurationEndpoint.cs
@@ -7,14 +7,17 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.Protocol;
-using Microsoft.CommonLanguageServerProtocol.Framework;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
-internal class RazorConfigurationEndpoint(RazorLSPOptionsMonitor optionsMonitor, ILoggerFactory loggerFactory)
+internal sealed class RazorConfigurationEndpoint(
+    LspServices services,
+    RazorLSPOptionsMonitor optionsMonitor,
+    ILoggerFactory loggerFactory)
     : IDidChangeConfigurationEndpoint, IOnInitialized
 {
-    private readonly RazorLSPOptionsMonitor _optionsMonitor = optionsMonitor ?? throw new ArgumentNullException(nameof(optionsMonitor));
+    private readonly LspServices _services = services;
+    private readonly RazorLSPOptionsMonitor _optionsMonitor = optionsMonitor;
     private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<RazorConfigurationEndpoint>();
 
     public bool MutatesSolutionState => true;
@@ -26,9 +29,9 @@ internal class RazorConfigurationEndpoint(RazorLSPOptionsMonitor optionsMonitor,
         await _optionsMonitor.UpdateAsync(cancellationToken).ConfigureAwait(false);
     }
 
-    public async Task OnInitializedAsync(ILspServices services, CancellationToken cancellationToken)
+    public async Task OnInitializedAsync(CancellationToken cancellationToken)
     {
-        var capabilitiesService = services.GetRequiredService<IClientCapabilitiesService>();
+        var capabilitiesService = _services.GetRequiredService<IClientCapabilitiesService>();
         var clientCapabilities = capabilitiesService.ClientCapabilities;
 
         if (clientCapabilities.Workspace?.Configuration == true)

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorInitializedEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorInitializedEndpoint.cs
@@ -21,7 +21,7 @@ internal class RazorInitializedEndpoint : INotificationHandler<InitializedParams
 
         foreach (var onStartedItem in onStartedItems)
         {
-            await onStartedItem.OnInitializedAsync(requestContext.LspServices, cancellationToken).ConfigureAwait(false);
+            await onStartedItem.OnInitializedAsync(cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorRequestContextFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorRequestContextFactory.cs
@@ -13,9 +13,9 @@ using Microsoft.CommonLanguageServerProtocol.Framework;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
-internal class RazorRequestContextFactory(ILspServices lspServices) : AbstractRequestContextFactory<RazorRequestContext>
+internal class RazorRequestContextFactory(LspServices lspServices) : AbstractRequestContextFactory<RazorRequestContext>
 {
-    private readonly ILspServices _lspServices = lspServices;
+    private readonly LspServices _lspServices = lspServices;
 
     public override Task<RazorRequestContext> CreateRequestContextAsync<TRequestParams>(IQueueItem<RazorRequestContext> queueItem, IMethodHandler methodHandler, TRequestParams @params, CancellationToken cancellationToken)
     {

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorRequestContextFactory.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorRequestContextFactory.cs
@@ -13,46 +13,47 @@ using Microsoft.CommonLanguageServerProtocol.Framework;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 
-internal class RazorRequestContextFactory(LspServices lspServices) : AbstractRequestContextFactory<RazorRequestContext>
+internal sealed class RazorRequestContextFactory(
+    LspServices lspServices,
+    IDocumentContextFactory documentContextFactory,
+    ILoggerFactory loggerFactory) : AbstractRequestContextFactory<RazorRequestContext>
 {
     private readonly LspServices _lspServices = lspServices;
+    private readonly IDocumentContextFactory _documentContextFactory = documentContextFactory;
+    private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<RazorRequestContextFactory>();
 
     public override Task<RazorRequestContext> CreateRequestContextAsync<TRequestParams>(IQueueItem<RazorRequestContext> queueItem, IMethodHandler methodHandler, TRequestParams @params, CancellationToken cancellationToken)
     {
-        var logger = _lspServices.GetRequiredService<ILoggerFactory>().GetOrCreateLogger<RazorRequestContextFactory>();
-
         DocumentContext? documentContext = null;
-        var textDocumentHandler = methodHandler as ITextDocumentIdentifierHandler;
-
         Uri? uri = null;
-        var documentContextFactory = _lspServices.GetRequiredService<IDocumentContextFactory>();
-        if (textDocumentHandler is not null)
+
+        if (methodHandler is ITextDocumentIdentifierHandler textDocumentHandler)
         {
             if (textDocumentHandler is ITextDocumentIdentifierHandler<TRequestParams, TextDocumentIdentifier> tdiHandler)
             {
                 var textDocumentIdentifier = tdiHandler.GetTextDocumentIdentifier(@params);
                 uri = textDocumentIdentifier.Uri;
 
-                logger.LogDebug($"Trying to create DocumentContext for {queueItem.MethodName} for {textDocumentIdentifier.GetProjectContext()?.Id ?? "(no project context)"} for {uri}");
+                _logger.LogDebug($"Trying to create DocumentContext for {queueItem.MethodName} for {textDocumentIdentifier.GetProjectContext()?.Id ?? "(no project context)"} for {uri}");
 
-                documentContextFactory.TryCreate(textDocumentIdentifier, out documentContext);
+                _documentContextFactory.TryCreate(textDocumentIdentifier, out documentContext);
             }
             else if (textDocumentHandler is ITextDocumentIdentifierHandler<TRequestParams, Uri> uriHandler)
             {
                 uri = uriHandler.GetTextDocumentIdentifier(@params);
 
-                logger.LogDebug($"Trying to create DocumentContext for {queueItem.MethodName}, with no project context, for {uri}");
+                _logger.LogDebug($"Trying to create DocumentContext for {queueItem.MethodName}, with no project context, for {uri}");
 
-                documentContextFactory.TryCreate(uri, out documentContext);
+                _documentContextFactory.TryCreate(uri, out documentContext);
             }
             else
             {
-                throw new NotImplementedException();
+                return Assumed.Unreachable<Task<RazorRequestContext>>();
             }
 
             if (documentContext is null)
             {
-                logger.LogWarning($"Could not create a document context for {queueItem.MethodName} for {uri}. Endpoint may crash later if it calls GetRequiredDocumentContext.");
+                _logger.LogWarning($"Could not create a document context for {queueItem.MethodName} for {uri}. Endpoint may crash later if it calls GetRequiredDocumentContext.");
             }
         }
 

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SignatureHelp/SignatureHelpEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/SignatureHelp/SignatureHelpEndpoint.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-extern alias RLSP;
-
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
@@ -15,8 +13,6 @@ using Microsoft.CodeAnalysis.Razor.Workspaces;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.SignatureHelp;
 
-using SignatureHelp = RLSP::Roslyn.LanguageServer.Protocol.SignatureHelp;
-
 [RazorLanguageServerEndpoint(Methods.TextDocumentSignatureHelpName)]
 internal sealed class SignatureHelpEndpoint(
         LanguageServerFeatureOptions languageServerFeatureOptions,
@@ -24,7 +20,7 @@ internal sealed class SignatureHelpEndpoint(
         IClientConnection clientConnection,
         RazorLSPOptionsMonitor optionsMonitor,
         ILoggerFactory loggerProvider)
-    : AbstractRazorDelegatingEndpoint<SignatureHelpParams, SignatureHelp?>(
+    : AbstractRazorDelegatingEndpoint<SignatureHelpParams, LspSignatureHelp?>(
         languageServerFeatureOptions,
         documentMappingService,
         clientConnection,

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/WorkspaceRootPathWatcher.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/WorkspaceRootPathWatcher.cs
@@ -14,7 +14,6 @@ using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.Utilities;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
-using Microsoft.CommonLanguageServerProtocol.Framework;
 using FileSystemWatcher = System.IO.FileSystemWatcher;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
@@ -161,7 +160,7 @@ internal partial class WorkspaceRootPathWatcher : IOnInitialized, IDisposable
         }
     }
 
-    public async Task OnInitializedAsync(ILspServices services, CancellationToken cancellationToken)
+    public async Task OnInitializedAsync(CancellationToken cancellationToken)
     {
         // Initialized request, this occurs once the server and client have agreed on what sort of features they both support. It only happens once.
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentSymbols/RemoteDocumentSymbolService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentSymbols/RemoteDocumentSymbolService.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-extern alias RLSP;
-
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/FindAllReferences/RemoteFindAllReferencesService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/FindAllReferences/RemoteFindAllReferencesService.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-extern alias RLSP;
-
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
@@ -14,7 +12,8 @@ using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.CodeAnalysis.Remote.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
-using static Microsoft.CodeAnalysis.Razor.Remote.RemoteResponse<RLSP::Roslyn.LanguageServer.Protocol.SumType<RLSP::Roslyn.LanguageServer.Protocol.VSInternalReferenceItem, RLSP::Roslyn.LanguageServer.Protocol.Location>[]?>;
+using static Microsoft.CodeAnalysis.Razor.Remote.RemoteResponse<
+    Roslyn.LanguageServer.Protocol.SumType<Roslyn.LanguageServer.Protocol.VSInternalReferenceItem, Roslyn.LanguageServer.Protocol.Location>[]?>;
 using ExternalHandlers = Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost.Handlers;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/GoToDefinition/RemoteGoToDefinitionService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/GoToDefinition/RemoteGoToDefinitionService.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-extern alias RLSP;
-
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.PooledObjects;
@@ -14,7 +12,7 @@ using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.CodeAnalysis.Remote.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
-using static Microsoft.CodeAnalysis.Razor.Remote.RemoteResponse<RLSP::Roslyn.LanguageServer.Protocol.Location[]?>;
+using static Microsoft.CodeAnalysis.Razor.Remote.RemoteResponse<Roslyn.LanguageServer.Protocol.Location[]?>;
 using ExternalHandlers = Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost.Handlers;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/GoToImplementation/RemoteGoToImplementationService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/GoToImplementation/RemoteGoToImplementationService.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-extern alias RLSP;
-
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.PooledObjects;
@@ -13,7 +11,7 @@ using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.CodeAnalysis.Remote.Razor.DocumentMapping;
 using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Text;
-using static Microsoft.CodeAnalysis.Razor.Remote.RemoteResponse<RLSP::Roslyn.LanguageServer.Protocol.Location[]?>;
+using static Microsoft.CodeAnalysis.Razor.Remote.RemoteResponse<Roslyn.LanguageServer.Protocol.Location[]?>;
 using ExternalHandlers = Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost.Handlers;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Hover/RemoteHoverService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Hover/RemoteHoverService.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-extern alias RLSP;
-
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,7 +12,7 @@ using Microsoft.CodeAnalysis.Razor.Hover;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
-using static Microsoft.CodeAnalysis.Razor.Remote.RemoteResponse<RLSP::Roslyn.LanguageServer.Protocol.Hover?>;
+using static Microsoft.CodeAnalysis.Razor.Remote.RemoteResponse<Roslyn.LanguageServer.Protocol.Hover?>;
 using ExternalHandlers = Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost.Handlers;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Microsoft.CodeAnalysis.Remote.Razor.csproj
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Microsoft.CodeAnalysis.Remote.Razor.csproj
@@ -44,8 +44,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Remote.ServiceHub" />
     <PackageReference Include="Nerdbank.Streams" />
     <PackageReference Include="Microsoft.VisualStudio.RpcContracts" />
-
-    <PackageReference Include="Microsoft.CodeAnalysis.LanguageServer.Protocol" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Microsoft.CodeAnalysis.Remote.Razor.csproj
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Microsoft.CodeAnalysis.Remote.Razor.csproj
@@ -45,7 +45,7 @@
     <PackageReference Include="Nerdbank.Streams" />
     <PackageReference Include="Microsoft.VisualStudio.RpcContracts" />
 
-    <PackageReference Include="Microsoft.CodeAnalysis.LanguageServer.Protocol" Aliases="RLSP" />
+    <PackageReference Include="Microsoft.CodeAnalysis.LanguageServer.Protocol" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Rename/RemoteRenameService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/Rename/RemoteRenameService.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-extern alias RLSP;
-
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
@@ -11,7 +9,7 @@ using Microsoft.CodeAnalysis.Razor.Remote;
 using Microsoft.CodeAnalysis.Razor.Rename;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Remote.Razor.ProjectSystem;
-using static Microsoft.CodeAnalysis.Razor.Remote.RemoteResponse<RLSP::Roslyn.LanguageServer.Protocol.WorkspaceEdit?>;
+using static Microsoft.CodeAnalysis.Razor.Remote.RemoteResponse<Roslyn.LanguageServer.Protocol.WorkspaceEdit?>;
 using ExternalHandlers = Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost.Handlers;
 
 namespace Microsoft.CodeAnalysis.Remote.Razor;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Debugging/ValidateBreakpointRangeEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Debugging/ValidateBreakpointRangeEndpointTest.cs
@@ -10,8 +10,6 @@ using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.CommonLanguageServerProtocol.Framework;
-using Moq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -157,12 +155,8 @@ public class ValidateBreakpointRangeEndpointTest(ITestOutputHelper testOutput) :
         return await endpoint.HandleRequestAsync(request, requestContext, DisposalToken);
     }
 
-    private RazorRequestContext CreateValidateBreakpointRangeRequestContext(DocumentContext documentContext)
+    private static RazorRequestContext CreateValidateBreakpointRangeRequestContext(DocumentContext documentContext)
     {
-        var lspServices = new Mock<ILspServices>(MockBehavior.Strict);
-
-        var requestContext = CreateRazorRequestContext(documentContext, lspServices: lspServices.Object);
-
-        return requestContext;
+        return CreateRazorRequestContext(documentContext, LspServices.Empty);
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultWorkspaceDirectoryPathResolverTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/DefaultWorkspaceDirectoryPathResolverTest.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Test.Common;
-using Microsoft.CommonLanguageServerProtocol.Framework;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -24,7 +22,7 @@ public class DefaultWorkspaceDirectoryPathResolverTest(ITestOutputHelper testOut
         };
 #pragma warning restore CS0618 // Type or member is obsolete
 
-        var capabilitiesManager = new CapabilitiesManager(StrictMock.Of<ILspServices>());
+        var capabilitiesManager = new CapabilitiesManager(LspServices.Empty);
         capabilitiesManager.SetInitializeParams(initializeParams);
 
         // Act
@@ -48,7 +46,7 @@ public class DefaultWorkspaceDirectoryPathResolverTest(ITestOutputHelper testOut
         };
 #pragma warning restore CS0618 // Type or member is obsolete
 
-        var capabilitiesManager = new CapabilitiesManager(StrictMock.Of<ILspServices>());
+        var capabilitiesManager = new CapabilitiesManager(LspServices.Empty);
         capabilitiesManager.SetInitializeParams(initializeParams);
 
         // Act

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/DefinitionEndpointDelegationTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Definition/DefinitionEndpointDelegationTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-extern alias RLSP;
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -15,11 +13,11 @@ using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
 using Xunit;
 using Xunit.Abstractions;
-using DefinitionResult = RLSP::Roslyn.LanguageServer.Protocol.SumType<
-    RLSP::Roslyn.LanguageServer.Protocol.Location,
-    RLSP::Roslyn.LanguageServer.Protocol.VSInternalLocation,
-    RLSP::Roslyn.LanguageServer.Protocol.VSInternalLocation[],
-    RLSP::Roslyn.LanguageServer.Protocol.DocumentLink[]>;
+using DefinitionResult = Roslyn.LanguageServer.Protocol.SumType<
+    Roslyn.LanguageServer.Protocol.Location,
+    Roslyn.LanguageServer.Protocol.VSInternalLocation,
+    Roslyn.LanguageServer.Protocol.VSInternalLocation[],
+    Roslyn.LanguageServer.Protocol.DocumentLink[]>;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Definition;
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/FindReferences/FindAllReferencesEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/FindReferences/FindAllReferencesEndpointTest.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
-extern alias RLSP;
 
 using System;
 using System.Collections.Immutable;
@@ -12,7 +11,7 @@ using Microsoft.AspNetCore.Razor.Test.Common.ProjectSystem;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
-using RLSP::Roslyn.Text.Adornments;
+using Roslyn.Text.Adornments;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Hover/HoverEndpointTest.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-extern alias RLSP;
-
 using System;
 using System.Linq;
 using System.Threading;
@@ -20,7 +18,7 @@ using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Text;
 using Moq;
-using RLSP::Roslyn.Text.Adornments;
+using Roslyn.Text.Adornments;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Microsoft.AspNetCore.Razor.LanguageServer.Test.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Microsoft.AspNetCore.Razor.LanguageServer.Test.csproj
@@ -21,14 +21,4 @@
     <EmbeddedResource Include="Semantic\TestFiles\**\*" />
   </ItemGroup>
 
-  <ItemGroup>
-    <!--
-      Razor and Roslyn both use CLaSP as the basis for their language servers, but CLaSP is a source package
-      which means when we reference Roslyn's server to get the LSP protocol types (which we have a restricted
-      IVT to) we get ambiguous type errors for everything in CLaSP. To fix this we reference Roslyn with an
-      alias, and then have a global using for the LSP protocol types only.
-    -->
-    <PackageReference Include="Microsoft.CodeAnalysis.LanguageServer.Protocol" Aliases="RLSP" />
-  </ItemGroup>
-
 </Project>

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorConfigurationEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorConfigurationEndpointTest.cs
@@ -31,7 +31,7 @@ public class RazorConfigurationEndpointTest : LanguageServerTestBase
     {
         // Arrange
         var optionsMonitor = TestRazorLSPOptionsMonitor.Create(_configurationService);
-        var endpoint = new RazorConfigurationEndpoint(optionsMonitor, LoggerFactory);
+        var endpoint = new RazorConfigurationEndpoint(LspServices.Empty, optionsMonitor, LoggerFactory);
         var request = new DidChangeConfigurationParams();
         var requestContext = CreateRazorRequestContext(documentContext: null);
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLanguageServerTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/RazorLanguageServerTest.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
@@ -16,7 +15,6 @@ using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Telemetry;
-using Microsoft.CommonLanguageServerProtocol.Framework;
 using Microsoft.Extensions.DependencyInjection;
 using Nerdbank.Streams;
 using Xunit;
@@ -81,7 +79,7 @@ public class RazorLanguageServerTest(ITestOutputHelper testOutput) : ToolingTest
 
             var registeredMethods = handlerProvider.GetRegisteredMethods();
             var handlerTypes = typeof(RazorLanguageServerHost).Assembly.GetTypes()
-                .Where(t => typeof(IMethodHandler).IsAssignableFrom(t) && !t.IsAbstract && !t.IsInterface);
+                .Where(t => CLaSPTypeHelpers.IMethodHandlerType.IsAssignableFrom(t) && !t.IsAbstract && !t.IsInterface);
 
             // We turn this into a Set to handle cases like Completion where we have two handlers, only one of which will be registered
             // CLaSP will throw if two handlers register for the same method, so if THAT doesn't hold it's a CLaSP bug, not a Razor bug.
@@ -98,12 +96,12 @@ public class RazorLanguageServerTest(ITestOutputHelper testOutput) : ToolingTest
 
         static string GetMethodFromType(Type t)
         {
-            var attribute = t.GetCustomAttribute<LanguageServerEndpointAttribute>();
+            var attribute = CLaSPTypeHelpers.GetLanguageServerEnpointAttribute(t);
             if (attribute is null)
             {
                 foreach (var inter in t.GetInterfaces())
                 {
-                    attribute = inter.GetCustomAttribute<LanguageServerEndpointAttribute>();
+                    attribute = CLaSPTypeHelpers.GetLanguageServerEnpointAttribute(inter);
 
                     if (attribute is not null)
                     {
@@ -112,10 +110,7 @@ public class RazorLanguageServerTest(ITestOutputHelper testOutput) : ToolingTest
                 }
             }
 
-            if (attribute is null)
-            {
-                throw new NotImplementedException();
-            }
+            Assert.NotNull(attribute);
 
             return attribute.Method;
         }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SingleServerDelegatingEndpointTestBase.TestLanguageServer.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SingleServerDelegatingEndpointTestBase.TestLanguageServer.cs
@@ -3,12 +3,9 @@
 
 #nullable disable
 
-extern alias RLSP;
-
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Razor.LanguageServer.Diagnostics;
 using Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
 using Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
 using Microsoft.CodeAnalysis.Razor.CodeActions.Models;
@@ -17,14 +14,14 @@ using Microsoft.CodeAnalysis.Razor.Protocol.CodeActions;
 using Microsoft.CodeAnalysis.Razor.Protocol.Diagnostics;
 using Microsoft.CodeAnalysis.Razor.Protocol.Folding;
 using Xunit;
-using DefinitionResult = RLSP::Roslyn.LanguageServer.Protocol.SumType<
-    RLSP::Roslyn.LanguageServer.Protocol.Location,
-    RLSP::Roslyn.LanguageServer.Protocol.VSInternalLocation,
-    RLSP::Roslyn.LanguageServer.Protocol.VSInternalLocation[],
-    RLSP::Roslyn.LanguageServer.Protocol.DocumentLink[]>;
-using ImplementationResult = RLSP::Roslyn.LanguageServer.Protocol.SumType<
-    RLSP::Roslyn.LanguageServer.Protocol.Location[],
-    RLSP::Roslyn.LanguageServer.Protocol.VSInternalReferenceItem[]>;
+using DefinitionResult = Roslyn.LanguageServer.Protocol.SumType<
+    Roslyn.LanguageServer.Protocol.Location,
+    Roslyn.LanguageServer.Protocol.VSInternalLocation,
+    Roslyn.LanguageServer.Protocol.VSInternalLocation[],
+    Roslyn.LanguageServer.Protocol.DocumentLink[]>;
+using ImplementationResult = Roslyn.LanguageServer.Protocol.SumType<
+    Roslyn.LanguageServer.Protocol.Location[],
+    Roslyn.LanguageServer.Protocol.VSInternalReferenceItem[]>;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer;
 

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/WorkspaceRootPathWatcherTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/WorkspaceRootPathWatcherTest.cs
@@ -11,7 +11,6 @@ using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
-using Microsoft.CommonLanguageServerProtocol.Framework;
 using Moq;
 using Xunit;
 using Xunit.Abstractions;
@@ -33,7 +32,7 @@ public class WorkspaceRootPathWatcherTest(ITestOutputHelper testOutput) : Toolin
         };
 #pragma warning restore CS0618 // Type or member is obsolete
 
-        var capabilitiesManager = new CapabilitiesManager(StrictMock.Of<ILspServices>());
+        var capabilitiesManager = new CapabilitiesManager(LspServices.Empty);
         capabilitiesManager.SetInitializeParams(initializeParams);
 
         var expectedWorkspaceDirectory = $"\\\\{initialWorkspaceDirectory}";
@@ -50,7 +49,7 @@ public class WorkspaceRootPathWatcherTest(ITestOutputHelper testOutput) : Toolin
             });
 
         // Act
-        await watcher.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await watcher.OnInitializedAsync(LspServices.Empty, DisposalToken);
 
         // Assert
         Assert.True(started);
@@ -83,7 +82,7 @@ public class WorkspaceRootPathWatcherTest(ITestOutputHelper testOutput) : Toolin
             existingRazorFiles);
 
         // Act
-        await watcher.OnInitializedAsync(StrictMock.Of<ILspServices>(), DisposalToken);
+        await watcher.OnInitializedAsync(LspServices.Empty, DisposalToken);
 
         // Assert
         Assert.Equal(existingRazorFiles, actual);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/WorkspaceRootPathWatcherTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/WorkspaceRootPathWatcherTest.cs
@@ -49,7 +49,7 @@ public class WorkspaceRootPathWatcherTest(ITestOutputHelper testOutput) : Toolin
             });
 
         // Act
-        await watcher.OnInitializedAsync(LspServices.Empty, DisposalToken);
+        await watcher.OnInitializedAsync(DisposalToken);
 
         // Assert
         Assert.True(started);
@@ -82,7 +82,7 @@ public class WorkspaceRootPathWatcherTest(ITestOutputHelper testOutput) : Toolin
             existingRazorFiles);
 
         // Act
-        await watcher.OnInitializedAsync(LspServices.Empty, DisposalToken);
+        await watcher.OnInitializedAsync(DisposalToken);
 
         // Assert
         Assert.Equal(existingRazorFiles, actual);

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/AssertExtensions.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/AssertExtensions.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
-extern alias RLSP;
-
-using RLSP::Roslyn.Text.Adornments;
+using Roslyn.Text.Adornments;
 using Xunit;
 
 namespace Microsoft.AspNetCore.Razor.Test.Common;

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/LanguageServerTestBase.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/LanguageServer/LanguageServerTestBase.cs
@@ -22,9 +22,7 @@ using Microsoft.CodeAnalysis.Razor.ProjectEngineHost;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
-
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.CommonLanguageServerProtocol.Framework;
 using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Razor.Test.Common.LanguageServer;
@@ -46,8 +44,8 @@ public abstract class LanguageServerTestBase(ITestOutputHelper testOutput) : Too
 
     private protected static RazorRequestContext CreateRazorRequestContext(
         DocumentContext? documentContext,
-        ILspServices? lspServices = null)
-        => new(documentContext, lspServices ?? StrictMock.Of<ILspServices>(), "lsp/method", uri: null);
+        LspServices? lspServices = null)
+        => new(documentContext, lspServices ?? LspServices.Empty, "lsp/method", uri: null);
 
     protected static RazorCodeDocument CreateCodeDocument(string text, ImmutableArray<TagHelperDescriptor> tagHelpers = default, string? filePath = null, string? rootNamespace = null)
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Microsoft.AspNetCore.Razor.Test.Common.Tooling.csproj
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/Microsoft.AspNetCore.Razor.Test.Common.Tooling.csproj
@@ -49,6 +49,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.EditorFeatures" />
     <PackageReference Include="Microsoft.CodeAnalysis.EditorFeatures.Common" />
+    <PackageReference Include="Microsoft.CodeAnalysis.LanguageServer.Protocol" />
     <PackageReference Include="Microsoft.CodeAnalysis.Test.Utilities" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" />
     <PackageReference Include="Microsoft.VisualStudio.Copilot" />
@@ -62,8 +63,6 @@
     <PackageReference Include="xunit.extensibility.execution" />
     <PackageReference Include="Xunit.Combinatorial" />
     <PackageReference Include="Xunit.StaFact" />
-
-    <PackageReference Include="Microsoft.CodeAnalysis.LanguageServer.Protocol" Aliases="RLSP" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == '$(NetFxVS)'">


### PR DESCRIPTION
Razor now uses the Roslyn.LanguageServer.Protocol types directly, which is awesome! However, it comes at the cost of type ambiguities because Razor compiles CLaSP into Microsoft.AspNetCore.Razor.LanguageServer as a source package, but CLaSP is also compiled into Microsoft.CodeAnalysis.LanguageServer.Protocol, which includes the Roslyn LSP types. Initially, we've avoided the type ambiguities by using RLSP as an extern alias everywhere, which is a bit awkward. This pull request avoids needing an extern alias by restricting direct references to CLaSP types to code within Microsoft.AspNetCore.Razor.LanguageServer. I've left this as a draft PR to see if this approach seems reasonable. Do we like being able to use Roslyn LSP types directly without awkwardness or would we prefer to allow direct access to CLaSP types? To me, the Roslyn LSP types seems like the future direction, and we should lean into that, but I'm curious to know if others feel differently.