### PR TITLE
Don't initialize or dispose if cohosting is on

### DIFF
--- a/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/ProjectSystem/ProjectSnapshotManagerBenchmarkBase.cs
+++ b/src/Razor/benchmarks/Microsoft.AspNetCore.Razor.Microbenchmarks/ProjectSystem/ProjectSnapshotManagerBenchmarkBase.cs
@@ -4,6 +4,7 @@
 using System.Collections.Immutable;
 using System.IO;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Razor.Logging;
@@ -53,5 +54,6 @@ public abstract partial class ProjectSnapshotManagerBenchmarkBase
         => new(
             projectEngineFactoryProvider: StaticProjectEngineFactoryProvider.Instance,
             compilerOptions: RazorCompilerOptions.None,
+            featureOptions: new DefaultLanguageServerFeatureOptions(),
             loggerFactory: EmptyLoggerFactory.Instance);
 }

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/LspProjectSnapshotManager.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/ProjectSystem/LspProjectSnapshotManager.cs
@@ -12,7 +12,7 @@ internal class LspProjectSnapshotManager(
     IProjectEngineFactoryProvider projectEngineFactoryProvider,
     LanguageServerFeatureOptions languageServerFeatureOptions,
     ILoggerFactory loggerFactory)
-    : ProjectSnapshotManager(projectEngineFactoryProvider, languageServerFeatureOptions.ToCompilerOptions(), loggerFactory, initializer: AddMiscFilesProject)
+    : ProjectSnapshotManager(projectEngineFactoryProvider, languageServerFeatureOptions.ToCompilerOptions(), languageServerFeatureOptions, loggerFactory, initializer: AddMiscFilesProject)
 {
     private static void AddMiscFilesProject(Updater updater)
     {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshotManager.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/ProjectSnapshotManager.cs
@@ -12,6 +12,7 @@ using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.AspNetCore.Razor.Threading;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectEngineHost;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
@@ -82,6 +83,7 @@ internal partial class ProjectSnapshotManager : IDisposable
     /// <param name="projectEngineFactoryProvider">The <see cref="IProjectEngineFactoryProvider"/> to
     /// use when creating <see cref="ProjectState"/>.</param>
     /// <param name="compilerOptions">Options used to control Razor compilation.</param>
+    /// <param name="featureOptions">The <see cref="LanguageServerFeatureOptions"/> to use.</param>
     /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> to use.</param>
     /// <param name="initializer">An optional callback to set up the initial set of projects and documents.
     /// Note that this is called during construction, so it does not run on the dispatcher and notifications
@@ -89,12 +91,13 @@ internal partial class ProjectSnapshotManager : IDisposable
     public ProjectSnapshotManager(
         IProjectEngineFactoryProvider projectEngineFactoryProvider,
         RazorCompilerOptions compilerOptions,
+        LanguageServerFeatureOptions featureOptions,
         ILoggerFactory loggerFactory,
         Action<Updater>? initializer = null)
     {
         _projectEngineFactoryProvider = projectEngineFactoryProvider;
         _compilerOptions = compilerOptions;
-        _dispatcher = new(loggerFactory);
+        _dispatcher = new(featureOptions, loggerFactory);
         _logger = loggerFactory.GetOrCreateLogger(GetType());
 
         initializer?.Invoke(new(this));

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/VisualStudioProjectSnapshotManager.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/VisualStudioProjectSnapshotManager.cs
@@ -15,6 +15,6 @@ internal sealed class VisualStudioProjectSnapshotManager(
     IProjectEngineFactoryProvider projectEngineFactoryProvider,
     LanguageServerFeatureOptions languageServerFeatureOptions,
     ILoggerFactory loggerFactory)
-    : ProjectSnapshotManager(projectEngineFactoryProvider, languageServerFeatureOptions.ToCompilerOptions(), loggerFactory)
+    : ProjectSnapshotManager(projectEngineFactoryProvider, languageServerFeatureOptions.ToCompilerOptions(), languageServerFeatureOptions, loggerFactory)
 {
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading;
@@ -64,6 +65,8 @@ internal abstract partial class WindowsRazorProjectHostBase : OnceInitializedOnc
 
     protected sealed override Task InitializeCoreAsync(CancellationToken cancellationToken)
     {
+        Debug.Assert(!_languageServerFeatureOptions.UseRazorCohostServer, "When cohosting is on this should never be initialized.");
+
         CommonServices.UnconfiguredProject.ProjectRenaming += UnconfiguredProject_ProjectRenamingAsync;
 
         // CPS represents the various target frameworks that a project has in configuration groups, which are called "slices". Each

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/ProjectSystem/WindowsRazorProjectHostBase.cs
@@ -64,11 +64,6 @@ internal abstract partial class WindowsRazorProjectHostBase : OnceInitializedOnc
 
     protected sealed override Task InitializeCoreAsync(CancellationToken cancellationToken)
     {
-        if (_languageServerFeatureOptions.UseRazorCohostServer)
-        {
-            return Task.CompletedTask;
-        }
-
         CommonServices.UnconfiguredProject.ProjectRenaming += UnconfiguredProject_ProjectRenamingAsync;
 
         // CPS represents the various target frameworks that a project has in configuration groups, which are called "slices". Each
@@ -168,6 +163,11 @@ internal abstract partial class WindowsRazorProjectHostBase : OnceInitializedOnc
 
     protected override async Task DisposeCoreAsync(bool initialized)
     {
+        if (_languageServerFeatureOptions.UseRazorCohostServer)
+        {
+            return;
+        }
+
         if (initialized)
         {
             CommonServices.UnconfiguredProject.ProjectRenaming -= UnconfiguredProject_ProjectRenamingAsync;
@@ -291,6 +291,11 @@ internal abstract partial class WindowsRazorProjectHostBase : OnceInitializedOnc
 
     Task IProjectDynamicLoadComponent.LoadAsync()
     {
+        if (_languageServerFeatureOptions.UseRazorCohostServer)
+        {
+            return Task.CompletedTask;
+        }
+
         return InitializeAsync();
     }
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorLSPTextViewConnectionListener.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorLSPTextViewConnectionListener.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Razor.Settings;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.VisualStudio.Editor;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.OLE.Interop;
@@ -43,6 +44,7 @@ internal class RazorLSPTextViewConnectionListener : ITextViewConnectionListener
     private readonly ILspEditorFeatureDetector _editorFeatureDetector;
     private readonly IEditorOptionsFactoryService _editorOptionsFactory;
     private readonly IClientSettingsManager _editorSettingsManager;
+    private readonly LanguageServerFeatureOptions _featureOptions;
     private readonly JoinableTaskContext _joinableTaskContext;
     private IVsTextManager4? _textManager;
 
@@ -65,6 +67,7 @@ internal class RazorLSPTextViewConnectionListener : ITextViewConnectionListener
         ILspEditorFeatureDetector editorFeatureDetector,
         IEditorOptionsFactoryService editorOptionsFactory,
         IClientSettingsManager editorSettingsManager,
+        LanguageServerFeatureOptions featureOptions,
         JoinableTaskContext joinableTaskContext)
     {
         _serviceProvider = serviceProvider;
@@ -72,6 +75,7 @@ internal class RazorLSPTextViewConnectionListener : ITextViewConnectionListener
         _editorFeatureDetector = editorFeatureDetector;
         _editorOptionsFactory = editorOptionsFactory;
         _editorSettingsManager = editorSettingsManager;
+        _featureOptions = featureOptions;
         _joinableTaskContext = joinableTaskContext;
     }
 
@@ -94,9 +98,12 @@ internal class RazorLSPTextViewConnectionListener : ITextViewConnectionListener
             throw new ArgumentNullException(nameof(textView));
         }
 
-        // This is a potential entry point for Razor start up, if a project is loaded with an editor already opened.
-        // So, we need to ensure that any Razor start up services are initialized.
-        RazorStartupInitializer.Initialize(_serviceProvider);
+        if (!_featureOptions.UseRazorCohostServer)
+        {
+            // This is a potential entry point for Razor start up, if a project is loaded with an editor already opened.
+            // So, we need to ensure that any Razor start up services are initialized.
+            RazorStartupInitializer.Initialize(_serviceProvider);
+        }
 
         var vsTextView = _editorAdaptersFactory.GetViewAdapter(textView);
 

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorStartupInitializer.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/RazorStartupInitializer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
 using System.Threading;
@@ -11,12 +12,21 @@ using Microsoft.VisualStudio.ComponentModelHost;
 namespace Microsoft.VisualStudio.Razor;
 
 [Export(typeof(RazorStartupInitializer))]
-[method: ImportingConstructor]
-internal sealed class RazorStartupInitializer([ImportMany] IEnumerable<IRazorStartupService> services)
+internal sealed class RazorStartupInitializer
 {
     private static RazorStartupInitializer? s_initializer;
 
-    public IEnumerable<IRazorStartupService> Services { get; } = services;
+    [ImportingConstructor]
+    public RazorStartupInitializer(
+        LanguageServerFeatureOptions options,
+        [ImportMany] IEnumerable<IRazorStartupService> services)
+    {
+        Debug.Assert(!options.UseRazorCohostServer, "If cohosting is on we should never initialize Razor startup services.");
+
+        Services = services;
+    }
+
+    public IEnumerable<IRazorStartupService> Services { get; }
 
     public static void Initialize(IServiceProvider serviceProvider)
     {

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ProjectSystem/TestProjectSnapshotManager.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.Test.Common.Tooling/ProjectSystem/TestProjectSnapshotManager.cs
@@ -17,7 +17,7 @@ internal partial class TestProjectSnapshotManager(
     ILoggerFactory loggerFactory,
     CancellationToken disposalToken,
     Action<ProjectSnapshotManager.Updater>? initializer = null)
-    : ProjectSnapshotManager(projectEngineFactoryProvider, languageServerFeatureOptions.ToCompilerOptions(), loggerFactory, initializer)
+    : ProjectSnapshotManager(projectEngineFactoryProvider, languageServerFeatureOptions.ToCompilerOptions(), languageServerFeatureOptions, loggerFactory, initializer)
 {
     private readonly CancellationToken _disposalToken = disposalToken;
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/DefaultWindowsRazorProjectHostTest.cs
@@ -39,7 +39,7 @@ public class DefaultWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
         _serviceProvider = VsMocks.CreateServiceProvider(static b =>
             b.AddComponentModel(static b =>
             {
-                var startupInitializer = new RazorStartupInitializer([]);
+                var startupInitializer = new RazorStartupInitializer(TestLanguageServerFeatureOptions.Instance, []);
                 b.AddExport(startupInitializer);
             }));
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/FallbackProjectManagerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/FallbackProjectManagerTest.cs
@@ -31,7 +31,7 @@ public class FallbackProjectManagerTest : VisualStudioWorkspaceTestBase
         var serviceProvider = VsMocks.CreateServiceProvider(static b =>
             b.AddComponentModel(static b =>
             {
-                var startupInitializer = new RazorStartupInitializer([]);
+                var startupInitializer = new RazorStartupInitializer(TestLanguageServerFeatureOptions.Instance, []);
                 b.AddExport(startupInitializer);
             }));
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/FallbackWindowsRazorProjectHostTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/FallbackWindowsRazorProjectHostTest.cs
@@ -35,7 +35,7 @@ public class FallbackWindowsRazorProjectHostTest : VisualStudioWorkspaceTestBase
         _serviceProvider = VsMocks.CreateServiceProvider(static b =>
         b.AddComponentModel(static b =>
         {
-            var startupInitializer = new RazorStartupInitializer([]);
+            var startupInitializer = new RazorStartupInitializer(TestLanguageServerFeatureOptions.Instance, []);
             b.AddExport(startupInitializer);
         }));
 

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/RazorDynamicFileInfoProviderTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/ProjectSystem/RazorDynamicFileInfoProviderTest.cs
@@ -64,7 +64,7 @@ public class RazorDynamicFileInfoProviderTest(ITestOutputHelper testOutput) : Vi
         var serviceProvider = VsMocks.CreateServiceProvider(static b =>
             b.AddComponentModel(static b =>
             {
-                var startupInitializer = new RazorStartupInitializer([]);
+                var startupInitializer = new RazorStartupInitializer(TestLanguageServerFeatureOptions.Instance, []);
                 b.AddExport(startupInitializer);
             }));
 

--- a/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/LegacyRazorTextViewConnectionListenerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LegacyEditor.Razor.Test/LegacyRazorTextViewConnectionListenerTest.cs
@@ -4,6 +4,7 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Test.Common;
 using Microsoft.AspNetCore.Razor.Test.Common.VisualStudio;
+using Microsoft.AspNetCore.Razor.Test.Common.Workspaces;
 using Microsoft.VisualStudio.Razor;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
@@ -21,7 +22,7 @@ public class LegacyRazorTextViewConnectionListenerTest(ITestOutputHelper testOut
         var serviceProvider = VsMocks.CreateServiceProvider(static b =>
             b.AddComponentModel(static b =>
             {
-                var startupInitializer = new RazorStartupInitializer([]);
+                var startupInitializer = new RazorStartupInitializer(TestLanguageServerFeatureOptions.Instance, []);
                 b.AddExport(startupInitializer);
             }));
 
@@ -49,7 +50,7 @@ public class LegacyRazorTextViewConnectionListenerTest(ITestOutputHelper testOut
         var serviceProvider = VsMocks.CreateServiceProvider(static b =>
             b.AddComponentModel(static b =>
             {
-                var startupInitializer = new RazorStartupInitializer([]);
+                var startupInitializer = new RazorStartupInitializer(TestLanguageServerFeatureOptions.Instance, []);
                 b.AddExport(startupInitializer);
             }));
 


### PR DESCRIPTION
Dustin pointed out a couple of spots that were missed in the "disable things when cohosting is on" commit in https://github.com/dotnet/razor/pull/11412 and I noticed a slight tweak I could make to one I didn't miss :)