### PR TITLE
Allow graceful handling of ArgumentException when trying to apply changes to SourceText in LspTextChangesLoader

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Services/LspDynamicFileProvider.LspTextChangesTextLoader.cs
+++ b/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Services/LspDynamicFileProvider.LspTextChangesTextLoader.cs
@@ -36,17 +36,18 @@ internal sealed partial class LspDynamicFileProvider
 
         public override async Task<TextAndVersion> LoadTextAndVersionAsync(LoadTextOptions options, CancellationToken cancellationToken)
         {
-            if (_document is null)
-            {
-                var text = ApplyChanges(_emptySourceText.Value, _changes);
-                return TextAndVersion.Create(text, VersionStamp.Default.GetNewerVersion());
-            }
-
-            var sourceText = await _document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-
-            // Validate the checksum information so the edits are known to be correct
             try
             {
+                if (_document is null)
+                {
+                    var text = ApplyChanges(_emptySourceText.Value, _changes);
+                    return TextAndVersion.Create(text, VersionStamp.Default.GetNewerVersion());
+                }
+
+                var sourceText = await _document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+
+                // Validate the checksum information so the edits are known to be correct
+
                 if (IsSourceTextMatching(sourceText))
                 {
                     var version = await _document.GetTextVersionAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Services/LspDynamicFileProvider.LspTextChangesTextLoader.cs
+++ b/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Services/LspDynamicFileProvider.LspTextChangesTextLoader.cs
@@ -45,11 +45,22 @@ internal sealed partial class LspDynamicFileProvider
             var sourceText = await _document.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
             // Validate the checksum information so the edits are known to be correct
-            if (IsSourceTextMatching(sourceText))
+            try
             {
-                var version = await _document.GetTextVersionAsync(cancellationToken).ConfigureAwait(false);
-                var newText = ApplyChanges(sourceText, _changes);
-                return TextAndVersion.Create(newText, version.GetNewerVersion());
+                if (IsSourceTextMatching(sourceText))
+                {
+                    var version = await _document.GetTextVersionAsync(cancellationToken).ConfigureAwait(false);
+                    var newText = ApplyChanges(sourceText, _changes);
+                    return TextAndVersion.Create(newText, version.GetNewerVersion());
+                }
+            }
+            catch (ArgumentException ex)
+            {
+                // This happens if ApplyChanges tries to apply an invalid TextChange.
+                // This is recoverable but incurs a perf hit for getting the full text below.
+
+                // TODO: Add ability to capture a fault here in EA. There's something wrong if
+                // the Checksum matches but the text changes can't be applied.
             }
 
             return await GetFullDocumentFromServerAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Services/LspDynamicFileProvider.LspTextChangesTextLoader.cs
+++ b/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Services/LspDynamicFileProvider.LspTextChangesTextLoader.cs
@@ -54,7 +54,7 @@ internal sealed partial class LspDynamicFileProvider
                     return TextAndVersion.Create(newText, version.GetNewerVersion());
                 }
             }
-            catch (ArgumentException ex)
+            catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 // This happens if ApplyChanges tries to apply an invalid TextChange.
                 // This is recoverable but incurs a perf hit for getting the full text below.


### PR DESCRIPTION
Helps mitigate https://github.com/dotnet/vscode-csharp/issues/8147
