### PR TITLE
Check CSS scope when comparing source generator items

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/SourceGeneratorProjectItem.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/SourceGenerators/SourceGeneratorProjectItem.cs
@@ -54,7 +54,13 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
 
         public bool Equals(SourceGeneratorProjectItem? other)
         {
-            if (ReferenceEquals(AdditionalText, other?.AdditionalText))
+            if (other is null ||
+                CssScope != other.CssScope)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(AdditionalText, other.AdditionalText))
             {
                 return true;
             }
@@ -64,7 +70,7 @@ namespace Microsoft.NET.Sdk.Razor.SourceGenerators
             // It's technically possible for these hashes to collide, but other things would
             // also break in those cases, so for now we're okay with this.
             var thisHash = AdditionalText.GetText()?.GetContentHash() ?? [];
-            var otherHash = other?.AdditionalText.GetText()?.GetContentHash() ?? [];
+            var otherHash = other.AdditionalText.GetText()?.GetContentHash() ?? [];
             return thisHash.SequenceEqual(otherHash);
         }
 


### PR DESCRIPTION
When experimenting with CSS scopes in .net lab, I've noticed Razor source generator doesn't react to their updates (its incrementality is broken there). This PR should fix that.