### PR TITLE
Share document symbol endpoint with VS Code

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/DocumentSymbol/CohostDocumentSymbolEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/DocumentSymbol/CohostDocumentSymbolEndpoint.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
 using Microsoft.CodeAnalysis.Razor.Remote;
 
 namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
@@ -16,10 +17,10 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 [Shared]
 [CohostEndpoint(Methods.TextDocumentDocumentSymbolName)]
 [Export(typeof(IDynamicRegistrationProvider))]
-[ExportCohostStatelessLspService(typeof(CohostDocumentSymbolEndpoint))]
+[ExportRazorStatelessLspService(typeof(CohostDocumentSymbolEndpoint))]
 [method: ImportingConstructor]
 #pragma warning restore RS0030 // Do not use banned APIs
-internal class CohostDocumentSymbolEndpoint(IRemoteServiceInvoker remoteServiceInvoker)
+internal sealed class CohostDocumentSymbolEndpoint(IRemoteServiceInvoker remoteServiceInvoker)
     : AbstractRazorCohostDocumentRequestHandler<DocumentSymbolParams, SumType<DocumentSymbol[], SymbolInformation[]>?>, IDynamicRegistrationProvider
 {
     private readonly IRemoteServiceInvoker _remoteServiceInvoker = remoteServiceInvoker;

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Microsoft.CodeAnalysis.Razor.CohostingShared.projitems
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Microsoft.CodeAnalysis.Razor.CohostingShared.projitems
@@ -12,6 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CohostEndpointAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CohostDocSyncEndpointRegistration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CohostStartupService.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)DocumentSymbol\CohostDocumentSymbolEndpoint.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IRazorCohostStartupService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SemanticTokens\CohostSemanticTokensLegendService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SemanticTokens\CohostSemanticTokensRangeEndpoint.cs" />

--- a/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentSymbols/RemoteDocumentSymbolService.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Remote.Razor/DocumentSymbols/RemoteDocumentSymbolService.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
@@ -43,9 +44,47 @@ internal sealed partial class RemoteDocumentSymbolService(in ServiceArgs args) :
             supportsVSExtensions: _clientCapabilitiesService.ClientCapabilities.SupportsVisualStudioExtensions,
             cancellationToken).ConfigureAwait(false);
 
+        // Roslyn uses an internal "RoslynDocumentSymbol" type, which throws when serialized after we've mapped it, so we have to
+        // convert things back to DocumentSymbol. We only need to do the first level though, as our remapping will take care of
+        // the children.
+        if (csharpSymbols.TryGetFirst(out var roslynDocumentSymbols))
+        {
+            csharpSymbols = ConvertDocumentSymbols(roslynDocumentSymbols);
+        }
+
         var codeDocument = await context.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
         var csharpDocument = codeDocument.GetCSharpDocument();
 
         return _documentSymbolService.GetDocumentSymbols(context.Uri, csharpDocument, csharpSymbols);
+    }
+
+    [return: NotNullIfNotNull(nameof(roslynDocumentSymbols))]
+    private static DocumentSymbol[]? ConvertDocumentSymbols(DocumentSymbol[]? roslynDocumentSymbols)
+    {
+        if (roslynDocumentSymbols is null)
+        {
+            return null;
+        }
+
+        var converted = new DocumentSymbol[roslynDocumentSymbols.Length];
+        for (var i = 0; i < roslynDocumentSymbols.Length; i++)
+        {
+            var symbol = roslynDocumentSymbols[i];
+            converted[i] = new DocumentSymbol
+            {
+                Children = ConvertDocumentSymbols(symbol.Children),
+#pragma warning disable CS0618 // Type or member is obsolete
+                Deprecated = symbol.Deprecated,
+#pragma warning restore CS0618 // Type or member is obsolete
+                Detail = symbol.Detail,
+                Kind = symbol.Kind,
+                Name = symbol.Name,
+                Range = symbol.Range,
+                SelectionRange = symbol.SelectionRange,
+                Tags = symbol.Tags
+            };
+        }
+
+        return converted;
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentSymbolEndpointTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostDocumentSymbolEndpointTest.cs
@@ -3,8 +3,10 @@
 
 using System.Collections.Immutable;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor;
+using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
 using Xunit;
@@ -73,6 +75,9 @@ public class CohostDocumentSymbolEndpointTest(ITestOutputHelper testOutput) : Co
         var endpoint = new CohostDocumentSymbolEndpoint(RemoteServiceInvoker);
 
         var result = await endpoint.GetTestAccessor().HandleRequestAsync(document, hierarchical, DisposalToken);
+
+        // Roslyn's DocumentSymbol type has an annoying property that makes it hard to serialize
+        Assert.NotNull(JsonSerializer.SerializeToDocument(result, JsonHelpers.JsonSerializerOptions));
 
         if (hierarchical)
         {


### PR DESCRIPTION
Also fixes a serialization problem that broke this in VS, when we went to Roslyn LSP types. This one is extra cool because it's still a very low effort port to VS Code, but we previously didn't support document symbols in VS Code at all. Chasing parity while also leapfrogging? 😁

![image](https://github.com/user-attachments/assets/d8454fb0-e6ee-473b-89a8-a718112870c3)
