### PR TITLE
Add something previously published by Roslyn

### DIFF
--- a/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Microsoft.VisualStudioCode.RazorExtension.csproj
+++ b/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Microsoft.VisualStudioCode.RazorExtension.csproj
@@ -48,6 +48,7 @@
       <Content Include="$(PublishDir)\Microsoft.AspNetCore.Razor.Utilities.Shared.dll" Pack="true" PackagePath="content" CopyToOutputDirectory="PreserveNewest" />
       <Content Include="$(PublishDir)\Microsoft.CodeAnalysis.Razor.Compiler.dll" Pack="true" PackagePath="content" CopyToOutputDirectory="PreserveNewest" />
       <Content Include="$(PublishDir)\Microsoft.CodeAnalysis.Razor.Workspaces.dll" Pack="true" PackagePath="content" CopyToOutputDirectory="PreserveNewest" />
+      <Content Include="$(PublishDir)\Microsoft.Extensions.ObjectPool.dll" Pack="true" PackagePath="content" CopyToOutputDirectory="PreserveNewest" />
 
       <!-- We don't need to include everything in the bin folder but we do need to add localization resources for the compiler dll -->
       <Content Include="$(PublishDir)\cs\**\*.*" Pack="true" PackagePath="content\cs\" CopyToOutputDirectory="PreserveNewest" />


### PR DESCRIPTION
Razor side needed after https://github.com/dotnet/roslyn/pull/78286

.roslyn used to contain Microsoft.Extensions.ObjectPool.dll because of the transitive dependency and now it doesn't so it has to be packaged in the .razorExtension
