### PR TITLE
Support inlay hints in cohosting in VS Code

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/InlayHints/CohostInlayHintEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/InlayHints/CohostInlayHintEndpoint.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
 using Microsoft.CodeAnalysis.Razor.Remote;
 
 namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
@@ -16,7 +17,7 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 [Shared]
 [CohostEndpoint(Methods.TextDocumentInlayHintName)]
 [Export(typeof(IDynamicRegistrationProvider))]
-[ExportCohostStatelessLspService(typeof(CohostInlayHintEndpoint))]
+[ExportRazorStatelessLspService(typeof(CohostInlayHintEndpoint))]
 [method: ImportingConstructor]
 #pragma warning restore RS0030 // Do not use banned APIs
 internal class CohostInlayHintEndpoint(IRemoteServiceInvoker remoteServiceInvoker)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/InlayHints/CohostInlayHintResolveEndpoint.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/InlayHints/CohostInlayHintResolveEndpoint.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.Protocol.InlayHints;
 using Microsoft.CodeAnalysis.Razor.Remote;
@@ -18,7 +19,7 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 #pragma warning disable RS0030 // Do not use banned APIs
 [Shared]
 [CohostEndpoint(Methods.InlayHintResolveName)]
-[ExportCohostStatelessLspService(typeof(CohostInlayHintResolveEndpoint))]
+[ExportRazorStatelessLspService(typeof(CohostInlayHintResolveEndpoint))]
 [method: ImportingConstructor]
 #pragma warning restore RS0030 // Do not use banned APIs
 internal class CohostInlayHintResolveEndpoint(IRemoteServiceInvoker remoteServiceInvoker, ILoggerFactory loggerFactory)

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Microsoft.CodeAnalysis.Razor.CohostingShared.projitems
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Microsoft.CodeAnalysis.Razor.CohostingShared.projitems
@@ -12,6 +12,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)CohostEndpointAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CohostDocSyncEndpointRegistration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CohostStartupService.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)InlayHints\CohostInlayHintEndpoint.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)InlayHints\CohostInlayHintResolveEndpoint.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IRazorCohostStartupService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SemanticTokens\CohostSemanticTokensLegendService.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SemanticTokens\CohostSemanticTokensRangeEndpoint.cs" />

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostInlayHintEndpointTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/CohostInlayHintEndpointTest.cs
@@ -151,6 +151,47 @@ public class CohostInlayHintEndpointTest(ITestOutputHelper testOutputHelper) : C
         Assert.Null(hints);
     }
 
+    [Fact]
+    public Task PageDirective()
+       => VerifyInlayHintsAsync(
+           input: """
+            @page {|template:"/"|}
+
+            <div></div>
+
+            """,
+           toolTipMap: new Dictionary<string, string>
+           {
+                { "template", "(parameter) string template" },
+           },
+           output: """
+            @page "/"
+
+            <div></div>
+
+            """);
+
+    [Fact]
+    [System.ComponentModel.Description("Desc")]
+    public Task AttributeDirective()
+       => VerifyInlayHintsAsync(
+           input: """
+            @attribute [System.ComponentModel.Description({|description:"Desc"|})]
+
+            <div></div>
+
+            """,
+           toolTipMap: new Dictionary<string, string>
+           {
+                { "description", "(parameter) string description" },
+           },
+           output: """
+            @attribute [System.ComponentModel.Description(description: "Desc")]
+
+            <div></div>
+
+            """);
+
     private async Task VerifyInlayHintsAsync(string input, Dictionary<string, string> toolTipMap, string output, bool displayAllOverride = false)
     {
         TestFileMarkupParser.GetSpans(input, out input, out ImmutableDictionary<string, ImmutableArray<TextSpan>> spansDict);


### PR DESCRIPTION
Also fixes a bug that I noticed where we add a hint that would be invalid if inserted as an edit. Wasn't a problem in VS since VS doesn't support double clicking on hints.

Part of https://github.com/dotnet/razor/issues/11759