### PR TITLE
Don't return null if we couldn't sync the document for breakpoint validation

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Debugging/ValidateBreakpointRangeEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Debugging/ValidateBreakpointRangeEndpoint.cs
@@ -78,6 +78,12 @@ internal class ValidateBreakpointRangeEndpoint(
             return null;
         }
 
+        if (delegatedResponse == LspFactory.UndefinedRange)
+        {
+            Logger.LogInformation($"Delegation could not get a valid answer, so returning original range so we don't lose user data.");
+            return originalRequest.Range;
+        }
+
         var documentContext = requestContext.DocumentContext;
         if (documentContext is null)
         {

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_ValidateBreakpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_ValidateBreakpoint.cs
@@ -16,7 +16,10 @@ internal partial class RazorCustomMessageTarget
         var delegationDetails = await GetProjectedRequestDetailsAsync(request, cancellationToken).ConfigureAwait(false);
         if (delegationDetails is null)
         {
-            return default;
+            // Normally when things are out of sync (eg C# is ahead due to fast typing) we return null so the LSP client will
+            // ask us again. For breakpoint range though, null means "remove this breakpoint" which is bad for the user. Instead
+            // we signal to our server what is going on with an undefined range.
+            return LspFactory.UndefinedRange;
         }
 
         var validateBreakpointRangeParams = new VSInternalValidateBreakableRangeParams


### PR DESCRIPTION
Fixes https://github.com/dotnet/razor/issues/11789

When typing fast, sometimes we can't sync the document because the request is old, and in those cases we return null. Most of the time this is fine, but for breakpoints null means "please remove this breakpoint" which is bad.