### PR TITLE
Add new shared SelectXXXAsArray helpers

### DIFF
--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/EnumerableExtensionsTests.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/EnumerableExtensionsTests.cs
@@ -140,4 +140,14 @@ public class EnumerableExtensionsTests
         public static CustomReadOnlyCollection Create(ReadOnlySpan<int> span)
             => new(span);
     }
+
+    [Fact]
+    public void SelectAsArray()
+    {
+        IEnumerable<int> data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        ImmutableArray<int> expected = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20];
+
+        var actual = data.SelectAsArray(static x => x * 2);
+        Assert.Equal<int>(expected, actual);
+    }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/EnumerableExtensionsTests.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/EnumerableExtensionsTests.cs
@@ -150,4 +150,14 @@ public class EnumerableExtensionsTests
         var actual = data.SelectAsArray(static x => x * 2);
         Assert.Equal<int>(expected, actual);
     }
+
+    [Fact]
+    public void SelectAsArray_Index()
+    {
+        IEnumerable<int> data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        ImmutableArray<int> expected = [1, 3, 5, 7, 9, 11, 13, 15, 17, 19];
+
+        var actual = data.SelectAsArray(static (x, index) => x + index);
+        Assert.Equal<int>(expected, actual);
+    }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/EnumerableOrderingTests.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/EnumerableOrderingTests.cs
@@ -17,7 +17,7 @@ public class EnumerableOrderingTests : EnumerableOrderingTestBase
     public void OrderAsArray(IEnumerable<int> data, ImmutableArray<int> expected)
     {
         var sorted = data.OrderAsArray();
-        Assert.Equal<int>(expected, sorted);
+        AssertEqual(expected, sorted);
     }
 
     [Theory]
@@ -25,7 +25,7 @@ public class EnumerableOrderingTests : EnumerableOrderingTestBase
     public void OrderAsArray_OddBeforeEven(IEnumerable<int> data, ImmutableArray<int> expected)
     {
         var sorted = data.OrderAsArray(OddBeforeEven);
-        Assert.Equal<int>(expected, sorted);
+        AssertEqual(expected, sorted);
     }
 
     [Theory]
@@ -33,7 +33,7 @@ public class EnumerableOrderingTests : EnumerableOrderingTestBase
     public void OrderDescendingAsArray(IEnumerable<int> data, ImmutableArray<int> expected)
     {
         var sorted = data.OrderDescendingAsArray();
-        Assert.Equal<int>(expected, sorted);
+        AssertEqual(expected, sorted);
     }
 
     [Theory]
@@ -41,7 +41,7 @@ public class EnumerableOrderingTests : EnumerableOrderingTestBase
     public void OrderDescendingAsArray_OddBeforeEven(IEnumerable<int> data, ImmutableArray<int> expected)
     {
         var sorted = data.OrderDescendingAsArray(OddBeforeEven);
-        Assert.Equal<int>(expected, sorted);
+        AssertEqual(expected, sorted);
     }
 
     [Theory]
@@ -73,6 +73,70 @@ public class EnumerableOrderingTests : EnumerableOrderingTestBase
     public void OrderByDescendingAsArray_OddBeforeEven(IEnumerable<ValueHolder<int>> data, ImmutableArray<ValueHolder<int>> expected)
     {
         var sorted = data.OrderByDescendingAsArray(static x => x.Value, OddBeforeEven);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderTestData))]
+    public void SelectAndOrderAsArray(IEnumerable<int> data, ImmutableArray<string> expected, Func<int, string> selector)
+    {
+        var sorted = data.SelectAndOrderAsArray(selector);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderTestData_OddBeforeEven))]
+    public void SelectAndOrderAsArray_OddBeforeEven(IEnumerable<int> data, ImmutableArray<string> expected, Func<int, string> selector)
+    {
+        var sorted = data.SelectAndOrderAsArray(selector, OddBeforeEvenString);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderDescendingTestData))]
+    public void SelectAndOrderDescendingAsArray(IEnumerable<int> data, ImmutableArray<string> expected, Func<int, string> selector)
+    {
+        var sorted = data.SelectAndOrderDescendingAsArray(selector);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderDescendingTestData_OddBeforeEven))]
+    public void SelectAndOrderDescendingAsArray_OddBeforeEven(IEnumerable<int> data, ImmutableArray<string> expected, Func<int, string> selector)
+    {
+        var sorted = data.SelectAndOrderDescendingAsArray(selector, OddBeforeEvenString);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderByTestData))]
+    public void SelectAndOrderByAsArray(IEnumerable<ValueHolder<int>> data, ImmutableArray<ValueHolder<string>> expected, Func<ValueHolder<int>, ValueHolder<string>> selector)
+    {
+        var sorted = data.SelectAndOrderByAsArray(selector, static x => x.Value);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderByTestData_OddBeforeEven))]
+    public void SelectAndOrderByAsArray_OddBeforeEven(IEnumerable<ValueHolder<int>> data, ImmutableArray<ValueHolder<string>> expected, Func<ValueHolder<int>, ValueHolder<string>> selector)
+    {
+        var sorted = data.SelectAndOrderByAsArray(selector, static x => x.Value, OddBeforeEvenString);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderByDescendingTestData))]
+    public void SelectAndOrderByDescendingAsArray(IEnumerable<ValueHolder<int>> data, ImmutableArray<ValueHolder<string>> expected, Func<ValueHolder<int>, ValueHolder<string>> selector)
+    {
+        var sorted = data.SelectAndOrderByDescendingAsArray(selector, static x => x.Value);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderByDescendingTestData_OddBeforeEven))]
+    public void SelectAndOrderByDescendingAsArray_OddBeforeEven(IEnumerable<ValueHolder<int>> data, ImmutableArray<ValueHolder<string>> expected, Func<ValueHolder<int>, ValueHolder<string>> selector)
+    {
+        var sorted = data.SelectAndOrderByDescendingAsArray(selector, static x => x.Value, OddBeforeEvenString);
         AssertEqual(expected, sorted);
     }
 

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ImmutableArrayExtensionsTests.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ImmutableArrayExtensionsTests.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using Xunit;
 
@@ -35,5 +36,39 @@ public class ImmutableArrayExtensionsTests
                 Assert.Same(items[4], s);
             },
             s => Assert.Equal("WoRlD", s));
+    }
+
+    [Fact]
+    public void SelectAsArray()
+    {
+        ImmutableArray<int> data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        ImmutableArray<int> expected = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20];
+
+        var actual = data.SelectAsArray(static x => x * 2);
+        Assert.Equal<int>(expected, actual);
+    }
+
+    [Fact]
+    public void SelectAsArray_ReadOnlyList()
+    {
+        ImmutableArray<int> data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        ImmutableArray<int> expected = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20];
+
+        var list = (IReadOnlyList<int>)data;
+
+        var actual = list.SelectAsArray(static x => x * 2);
+        Assert.Equal<int>(expected, actual);
+    }
+
+    [Fact]
+    public void SelectAsArray_Enumerable()
+    {
+        ImmutableArray<int> data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        ImmutableArray<int> expected = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20];
+
+        var enumerable = (IEnumerable<int>)data;
+
+        var actual = enumerable.SelectAsArray(static x => x * 2);
+        Assert.Equal<int>(expected, actual);
     }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ImmutableArrayExtensionsTests.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ImmutableArrayExtensionsTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
@@ -69,6 +69,40 @@ public class ImmutableArrayExtensionsTests
         var enumerable = (IEnumerable<int>)data;
 
         var actual = enumerable.SelectAsArray(static x => x * 2);
+        Assert.Equal<int>(expected, actual);
+    }
+
+    [Fact]
+    public void SelectAsArray_Index()
+    {
+        ImmutableArray<int> data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        ImmutableArray<int> expected = [1, 3, 5, 7, 9, 11, 13, 15, 17, 19];
+
+        var actual = data.SelectAsArray(static (x, index) => x + index);
+        Assert.Equal<int>(expected, actual);
+    }
+
+    [Fact]
+    public void SelectAsArray_Index_ReadOnlyList()
+    {
+        ImmutableArray<int> data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        ImmutableArray<int> expected = [1, 3, 5, 7, 9, 11, 13, 15, 17, 19];
+
+        var list = (IReadOnlyList<int>)data;
+
+        var actual = list.SelectAsArray(static (x, index) => x + index);
+        Assert.Equal<int>(expected, actual);
+    }
+
+    [Fact]
+    public void SelectAsArray_Index_Enumerable()
+    {
+        ImmutableArray<int> data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        ImmutableArray<int> expected = [1, 3, 5, 7, 9, 11, 13, 15, 17, 19];
+
+        var enumerable = (IEnumerable<int>)data;
+
+        var actual = enumerable.SelectAsArray(static (x, index) => x + index);
         Assert.Equal<int>(expected, actual);
     }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ImmutableArrayOrderingTests.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ImmutableArrayOrderingTests.cs
@@ -222,6 +222,214 @@ public class ImmutableArrayOrderingTests : ImmutableArrayOrderingTestBase
     }
 
     [Theory]
+    [MemberData(nameof(SelectAndOrderTestData))]
+    public void SelectAndOrderAsArray(ImmutableArray<int> data, ImmutableArray<string> expected, Func<int, string> selector)
+    {
+        var sorted = data.SelectAndOrderAsArray(selector);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderTestData_OddBeforeEven))]
+    public void SelectAndOrderAsArray_OddBeforeEven(ImmutableArray<int> data, ImmutableArray<string> expected, Func<int, string> selector)
+    {
+        var sorted = data.SelectAndOrderAsArray(selector, OddBeforeEvenString);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderDescendingTestData))]
+    public void SelectAndOrderDescendingAsArray(ImmutableArray<int> data, ImmutableArray<string> expected, Func<int, string> selector)
+    {
+        var sorted = data.SelectAndOrderDescendingAsArray(selector);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderDescendingTestData_OddBeforeEven))]
+    public void SelectAndOrderDescendingAsArray_OddBeforeEven(ImmutableArray<int> data, ImmutableArray<string> expected, Func<int, string> selector)
+    {
+        var sorted = data.SelectAndOrderDescendingAsArray(selector, OddBeforeEvenString);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderByTestData))]
+    public void SelectAndOrderByAsArray(ImmutableArray<ValueHolder<int>> data, ImmutableArray<ValueHolder<string>> expected, Func<ValueHolder<int>, ValueHolder<string>> selector)
+    {
+        var sorted = data.SelectAndOrderByAsArray(selector, static x => x.Value);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderByTestData_OddBeforeEven))]
+    public void SelectAndOrderByAsArray_OddBeforeEven(ImmutableArray<ValueHolder<int>> data, ImmutableArray<ValueHolder<string>> expected, Func<ValueHolder<int>, ValueHolder<string>> selector)
+    {
+        var sorted = data.SelectAndOrderByAsArray(selector, static x => x.Value, OddBeforeEvenString);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderByDescendingTestData))]
+    public void SelectAndOrderByDescendingAsArray(ImmutableArray<ValueHolder<int>> data, ImmutableArray<ValueHolder<string>> expected, Func<ValueHolder<int>, ValueHolder<string>> selector)
+    {
+        var sorted = data.SelectAndOrderByDescendingAsArray(selector, static x => x.Value);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderByDescendingTestData_OddBeforeEven))]
+    public void SelectAndOrderByDescendingAsArray_OddBeforeEven(ImmutableArray<ValueHolder<int>> data, ImmutableArray<ValueHolder<string>> expected, Func<ValueHolder<int>, ValueHolder<string>> selector)
+    {
+        var sorted = data.SelectAndOrderByDescendingAsArray(selector, static x => x.Value, OddBeforeEvenString);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderTestData))]
+    public void SelectAndOrderAsArray_ReadOnlyList(ImmutableArray<int> data, ImmutableArray<string> expected, Func<int, string> selector)
+    {
+        var readOnlyList = (IReadOnlyList<int>)data;
+        var sorted = readOnlyList.SelectAndOrderAsArray(selector);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderTestData_OddBeforeEven))]
+    public void SelectAndOrderAsArray_ReadOnlyList_OddBeforeEven(ImmutableArray<int> data, ImmutableArray<string> expected, Func<int, string> selector)
+    {
+        var readOnlyList = (IReadOnlyList<int>)data;
+        var sorted = readOnlyList.SelectAndOrderAsArray(selector, OddBeforeEvenString);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderDescendingTestData))]
+    public void SelectAndOrderDescendingAsArray_ReadOnlyList(ImmutableArray<int> data, ImmutableArray<string> expected, Func<int, string> selector)
+    {
+        var readOnlyList = (IReadOnlyList<int>)data;
+        var sorted = readOnlyList.SelectAndOrderDescendingAsArray(selector);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderDescendingTestData_OddBeforeEven))]
+    public void SelectAndOrderDescendingAsArray_ReadOnlyList_OddBeforeEven(ImmutableArray<int> data, ImmutableArray<string> expected, Func<int, string> selector)
+    {
+        var readOnlyList = (IReadOnlyList<int>)data;
+        var sorted = readOnlyList.SelectAndOrderDescendingAsArray(selector, OddBeforeEvenString);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderByTestData))]
+    public void SelectAndOrderByAsArray_ReadOnlyList(ImmutableArray<ValueHolder<int>> data, ImmutableArray<ValueHolder<string>> expected, Func<ValueHolder<int>, ValueHolder<string>> selector)
+    {
+        var readOnlyList = (IReadOnlyList<ValueHolder<int>>)data;
+        var sorted = readOnlyList.SelectAndOrderByAsArray(selector, static x => x.Value);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderByTestData_OddBeforeEven))]
+    public void SelectAndOrderByAsArray_ReadOnlyList_OddBeforeEven(ImmutableArray<ValueHolder<int>> data, ImmutableArray<ValueHolder<string>> expected, Func<ValueHolder<int>, ValueHolder<string>> selector)
+    {
+        var readOnlyList = (IReadOnlyList<ValueHolder<int>>)data;
+        var sorted = readOnlyList.SelectAndOrderByAsArray(selector, static x => x.Value, OddBeforeEvenString);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderByDescendingTestData))]
+    public void SelectAndOrderByDescendingAsArray_ReadOnlyList(ImmutableArray<ValueHolder<int>> data, ImmutableArray<ValueHolder<string>> expected, Func<ValueHolder<int>, ValueHolder<string>> selector)
+    {
+        var readOnlyList = (IReadOnlyList<ValueHolder<int>>)data;
+        var sorted = readOnlyList.SelectAndOrderByDescendingAsArray(selector, static x => x.Value);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderByDescendingTestData_OddBeforeEven))]
+    public void SelectAndOrderByDescendingAsArray_ReadOnlyList_OddBeforeEven(ImmutableArray<ValueHolder<int>> data, ImmutableArray<ValueHolder<string>> expected, Func<ValueHolder<int>, ValueHolder<string>> selector)
+    {
+        var readOnlyList = (IReadOnlyList<ValueHolder<int>>)data;
+        var sorted = readOnlyList.SelectAndOrderByDescendingAsArray(selector, static x => x.Value, OddBeforeEvenString);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderTestData))]
+    public void SelectAndOrderAsArray_Enumerable(ImmutableArray<int> data, ImmutableArray<string> expected, Func<int, string> selector)
+    {
+        var enumerable = (IEnumerable<int>)data;
+        var sorted = enumerable.SelectAndOrderAsArray(selector);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderTestData_OddBeforeEven))]
+    public void SelectAndOrderAsArray_Enumerable_OddBeforeEven(ImmutableArray<int> data, ImmutableArray<string> expected, Func<int, string> selector)
+    {
+        var enumerable = (IEnumerable<int>)data;
+        var sorted = enumerable.SelectAndOrderAsArray(selector, OddBeforeEvenString);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderDescendingTestData))]
+    public void SelectAndOrderDescendingAsArray_Enumerable(ImmutableArray<int> data, ImmutableArray<string> expected, Func<int, string> selector)
+    {
+        var enumerable = (IEnumerable<int>)data;
+        var sorted = enumerable.SelectAndOrderDescendingAsArray(selector);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderDescendingTestData_OddBeforeEven))]
+    public void SelectAndOrderDescendingAsArray_Enumerable_OddBeforeEven(ImmutableArray<int> data, ImmutableArray<string> expected, Func<int, string> selector)
+    {
+        var enumerable = (IEnumerable<int>)data;
+        var sorted = enumerable.SelectAndOrderDescendingAsArray(selector, OddBeforeEvenString);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderByTestData))]
+    public void SelectAndOrderByAsArray_Enumerable(ImmutableArray<ValueHolder<int>> data, ImmutableArray<ValueHolder<string>> expected, Func<ValueHolder<int>, ValueHolder<string>> selector)
+    {
+        var enumerable = (IEnumerable<ValueHolder<int>>)data;
+        var sorted = enumerable.SelectAndOrderByAsArray(selector, static x => x.Value);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderByTestData_OddBeforeEven))]
+    public void SelectAndOrderByAsArray_Enumerable_OddBeforeEven(ImmutableArray<ValueHolder<int>> data, ImmutableArray<ValueHolder<string>> expected, Func<ValueHolder<int>, ValueHolder<string>> selector)
+    {
+        var enumerable = (IEnumerable<ValueHolder<int>>)data;
+        var sorted = enumerable.SelectAndOrderByAsArray(selector, static x => x.Value, OddBeforeEvenString);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderByDescendingTestData))]
+    public void SelectAndOrderByDescendingAsArray_Enumerable(ImmutableArray<ValueHolder<int>> data, ImmutableArray<ValueHolder<string>> expected, Func<ValueHolder<int>, ValueHolder<string>> selector)
+    {
+        var enumerable = (IEnumerable<ValueHolder<int>>)data;
+        var sorted = enumerable.SelectAndOrderByDescendingAsArray(selector, static x => x.Value);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderByDescendingTestData_OddBeforeEven))]
+    public void SelectAndOrderByDescendingAsArray_Enumerable_OddBeforeEven(ImmutableArray<ValueHolder<int>> data, ImmutableArray<ValueHolder<string>> expected, Func<ValueHolder<int>, ValueHolder<string>> selector)
+    {
+        var enumerable = (IEnumerable<ValueHolder<int>>)data;
+        var sorted = enumerable.SelectAndOrderByDescendingAsArray(selector, static x => x.Value, OddBeforeEvenString);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
     [MemberData(nameof(OrderTestData))]
     public void ToImmutableOrdered(ImmutableArray<int> data, ImmutableArray<int> expected)
     {

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ReadOnlyListExtensionsTests.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ReadOnlyListExtensionsTests.cs
@@ -300,4 +300,26 @@ public class ReadOnlyListExtensionsTest
         var actual = enumerable.SelectAsArray(static x => x * 2);
         Assert.Equal<int>(expected, actual);
     }
+
+    [Fact]
+    public void SelectAsArray_Index()
+    {
+        IReadOnlyList<int> data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        ImmutableArray<int> expected = [1, 3, 5, 7, 9, 11, 13, 15, 17, 19];
+
+        var actual = data.SelectAsArray(static (x, index) => x + index);
+        Assert.Equal<int>(expected, actual);
+    }
+
+    [Fact]
+    public void SelectAsArray_Index_Enumerable()
+    {
+        IReadOnlyList<int> data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        ImmutableArray<int> expected = [1, 3, 5, 7, 9, 11, 13, 15, 17, 19];
+
+        var enumerable = (IEnumerable<int>)data;
+
+        var actual = enumerable.SelectAsArray(static (x, index) => x + index);
+        Assert.Equal<int>(expected, actual);
+    }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ReadOnlyListExtensionsTests.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ReadOnlyListExtensionsTests.cs
@@ -278,4 +278,26 @@ public class ReadOnlyListExtensionsTest
         public static CustomReadOnlyList Create(ReadOnlySpan<int> span)
             => new(span);
     }
+
+    [Fact]
+    public void SelectAsArray()
+    {
+        IReadOnlyList<int> data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        ImmutableArray<int> expected = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20];
+
+        var actual = data.SelectAsArray(static x => x * 2);
+        Assert.Equal<int>(expected, actual);
+    }
+
+    [Fact]
+    public void SelectAsArray_Enumerable()
+    {
+        IReadOnlyList<int> data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        ImmutableArray<int> expected = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20];
+
+        var enumerable = (IEnumerable<int>)data;
+
+        var actual = enumerable.SelectAsArray(static x => x * 2);
+        Assert.Equal<int>(expected, actual);
+    }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ReadOnlyListOrderingTests.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/ReadOnlyListOrderingTests.cs
@@ -148,6 +148,142 @@ public class ReadOnlyListOrderingTests : ReadOnlyListOrderingTestBase
         AssertEqual(expected, sorted);
     }
 
+    [Theory]
+    [MemberData(nameof(SelectAndOrderTestData))]
+    public void SelectAndOrderAsArray(IReadOnlyList<int> data, ImmutableArray<string> expected, Func<int, string> selector)
+    {
+        var sorted = data.SelectAndOrderAsArray(selector);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderTestData_OddBeforeEven))]
+    public void SelectAndOrderAsArray_OddBeforeEven(IReadOnlyList<int> data, ImmutableArray<string> expected, Func<int, string> selector)
+    {
+        var sorted = data.SelectAndOrderAsArray(selector, OddBeforeEvenString);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderDescendingTestData))]
+    public void SelectAndOrderDescendingAsArray(IReadOnlyList<int> data, ImmutableArray<string> expected, Func<int, string> selector)
+    {
+        var sorted = data.SelectAndOrderDescendingAsArray(selector);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderDescendingTestData_OddBeforeEven))]
+    public void SelectAndOrderDescendingAsArray_OddBeforeEven(IReadOnlyList<int> data, ImmutableArray<string> expected, Func<int, string> selector)
+    {
+        var sorted = data.SelectAndOrderDescendingAsArray(selector, OddBeforeEvenString);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderByTestData))]
+    public void SelectAndOrderByAsArray(IReadOnlyList<ValueHolder<int>> data, ImmutableArray<ValueHolder<string>> expected, Func<ValueHolder<int>, ValueHolder<string>> selector)
+    {
+        var sorted = data.SelectAndOrderByAsArray(selector, static x => x.Value);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderByTestData_OddBeforeEven))]
+    public void SelectAndOrderByAsArray_OddBeforeEven(IReadOnlyList<ValueHolder<int>> data, ImmutableArray<ValueHolder<string>> expected, Func<ValueHolder<int>, ValueHolder<string>> selector)
+    {
+        var sorted = data.SelectAndOrderByAsArray(selector, static x => x.Value, OddBeforeEvenString);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderByDescendingTestData))]
+    public void SelectAndOrderByDescendingAsArray(IReadOnlyList<ValueHolder<int>> data, ImmutableArray<ValueHolder<string>> expected, Func<ValueHolder<int>, ValueHolder<string>> selector)
+    {
+        var sorted = data.SelectAndOrderByDescendingAsArray(selector, static x => x.Value);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderByDescendingTestData_OddBeforeEven))]
+    public void SelectAndOrderByDescendingAsArray_OddBeforeEven(IReadOnlyList<ValueHolder<int>> data, ImmutableArray<ValueHolder<string>> expected, Func<ValueHolder<int>, ValueHolder<string>> selector)
+    {
+        var sorted = data.SelectAndOrderByDescendingAsArray(selector, static x => x.Value, OddBeforeEvenString);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderTestData))]
+    public void SelectAndOrderAsArray_Enumerable(IReadOnlyList<int> data, ImmutableArray<string> expected, Func<int, string> selector)
+    {
+        var enumerable = (IEnumerable<int>)data;
+        var sorted = enumerable.SelectAndOrderAsArray(selector);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderTestData_OddBeforeEven))]
+    public void SelectAndOrderAsArray_Enumerable_OddBeforeEven(IReadOnlyList<int> data, ImmutableArray<string> expected, Func<int, string> selector)
+    {
+        var enumerable = (IEnumerable<int>)data;
+        var sorted = enumerable.SelectAndOrderAsArray(selector, OddBeforeEvenString);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderDescendingTestData))]
+    public void SelectAndOrderDescendingAsArray_Enumerable(IReadOnlyList<int> data, ImmutableArray<string> expected, Func<int, string> selector)
+    {
+        var enumerable = (IEnumerable<int>)data;
+        var sorted = enumerable.SelectAndOrderDescendingAsArray(selector);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderDescendingTestData_OddBeforeEven))]
+    public void SelectAndOrderDescendingAsArray_Enumerable_OddBeforeEven(IReadOnlyList<int> data, ImmutableArray<string> expected, Func<int, string> selector)
+    {
+        var enumerable = (IEnumerable<int>)data;
+        var sorted = enumerable.SelectAndOrderDescendingAsArray(selector, OddBeforeEvenString);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderByTestData))]
+    public void SelectAndOrderByAsArray_Enumerable(IReadOnlyList<ValueHolder<int>> data, ImmutableArray<ValueHolder<string>> expected, Func<ValueHolder<int>, ValueHolder<string>> selector)
+    {
+        var enumerable = (IEnumerable<ValueHolder<int>>)data;
+        var sorted = enumerable.SelectAndOrderByAsArray(selector, static x => x.Value);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderByTestData_OddBeforeEven))]
+    public void SelectAndOrderByAsArray_Enumerable_OddBeforeEven(IReadOnlyList<ValueHolder<int>> data, ImmutableArray<ValueHolder<string>> expected, Func<ValueHolder<int>, ValueHolder<string>> selector)
+    {
+        var enumerable = (IEnumerable<ValueHolder<int>>)data;
+        var sorted = enumerable.SelectAndOrderByAsArray(selector, static x => x.Value, OddBeforeEvenString);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderByDescendingTestData))]
+    public void SelectAndOrderByDescendingAsArray_Enumerable(IReadOnlyList<ValueHolder<int>> data, ImmutableArray<ValueHolder<string>> expected, Func<ValueHolder<int>, ValueHolder<string>> selector)
+    {
+        var enumerable = (IEnumerable<ValueHolder<int>>)data;
+        var sorted = enumerable.SelectAndOrderByDescendingAsArray(selector, static x => x.Value);
+        AssertEqual(expected, sorted);
+    }
+
+    [Theory]
+    [MemberData(nameof(SelectAndOrderByDescendingTestData_OddBeforeEven))]
+    public void SelectAndOrderByDescendingAsArray_Enumerable_OddBeforeEven(IReadOnlyList<ValueHolder<int>> data, ImmutableArray<ValueHolder<string>> expected, Func<ValueHolder<int>, ValueHolder<string>> selector)
+    {
+        var enumerable = (IEnumerable<ValueHolder<int>>)data;
+        var sorted = enumerable.SelectAndOrderByDescendingAsArray(selector, static x => x.Value, OddBeforeEvenString);
+        AssertEqual(expected, sorted);
+    }
+
 #if NET // Enumerable.Order(...) and Enumerable.OrderDescending(...) were introduced in .NET 7
 
     [Fact]

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/TestData/OrderingTestBase.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/TestData/OrderingTestBase.cs
@@ -22,20 +22,59 @@ public abstract class OrderingTestBase<TOrderCollection, TOrderByCollection, TCa
     private static readonly TheoryData<TOrderByCollection, ImmutableArray<ValueHolder<int>>> s_orderByDescendingTestData = [];
     private static readonly TheoryData<TOrderByCollection, ImmutableArray<ValueHolder<int>>> s_orderByDescendingTestData_OddBeforeEven = [];
 
-    protected static void AddCase(TOrderCollection collection)
+    private static readonly TheoryData<TOrderCollection, ImmutableArray<string>, Func<int, string>> s_selectAndOrderTestData = [];
+    private static readonly TheoryData<TOrderCollection, ImmutableArray<string>, Func<int, string>> s_selectAndOrderTestData_OddBeforeEven = [];
+    private static readonly TheoryData<TOrderCollection, ImmutableArray<string>, Func<int, string>> s_selectAndOrderDescendingTestData = [];
+    private static readonly TheoryData<TOrderCollection, ImmutableArray<string>, Func<int, string>> s_selectAndOrderDescendingTestData_OddBeforeEven = [];
+    private static readonly TheoryData<TOrderByCollection, ImmutableArray<ValueHolder<string>>, Func<ValueHolder<int>, ValueHolder<string>>> s_selectAndOrderByTestData = [];
+    private static readonly TheoryData<TOrderByCollection, ImmutableArray<ValueHolder<string>>, Func<ValueHolder<int>, ValueHolder<string>>> s_selectAndOrderByTestData_OddBeforeEven = [];
+    private static readonly TheoryData<TOrderByCollection, ImmutableArray<ValueHolder<string>>, Func<ValueHolder<int>, ValueHolder<string>>> s_selectAndOrderByDescendingTestData = [];
+    private static readonly TheoryData<TOrderByCollection, ImmutableArray<ValueHolder<string>>, Func<ValueHolder<int>, ValueHolder<string>>> s_selectAndOrderByDescendingTestData_OddBeforeEven = [];
+
+    private static readonly ImmutableArray<int> s_expectedOrder = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    private static readonly ImmutableArray<int> s_expectedOrder_OddBeforeEven = [1, 3, 5, 7, 9, 2, 4, 6, 8, 10];
+    private static readonly ImmutableArray<int> s_expectedOrderDescending = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
+    private static readonly ImmutableArray<int> s_expectedOrderDescending_OddBeforeEven = [10, 8, 6, 4, 2, 9, 7, 5, 3, 1];
+
+    private static readonly ImmutableArray<ValueHolder<int>> s_expectedOrderBy = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    private static readonly ImmutableArray<ValueHolder<int>> s_expectedOrderBy_OddBeforeEven = [1, 3, 5, 7, 9, 2, 4, 6, 8, 10];
+    private static readonly ImmutableArray<ValueHolder<int>> s_expectedOrderByDescending = [10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
+    private static readonly ImmutableArray<ValueHolder<int>> s_expectedOrderByDescending_OddBeforeEven = [10, 8, 6, 4, 2, 9, 7, 5, 3, 1];
+
+    private static readonly ImmutableArray<string> s_expectedSelectAndOrder = ["1", "10", "2", "3", "4", "5", "6", "7", "8", "9"];
+    private static readonly ImmutableArray<string> s_expectedSelectAndOrder_OddBeforeEven = ["1", "3", "5", "7", "9", "10", "2", "4", "6", "8"];
+    private static readonly ImmutableArray<string> s_expectedSelectAndOrderDescending = ["9", "8", "7", "6", "5", "4", "3", "2", "10", "1"];
+    private static readonly ImmutableArray<string> s_expectedSelectAndOrderDescending_OddBeforeEven = ["8", "6", "4", "2", "10", "9", "7", "5", "3", "1"];
+
+    private static readonly ImmutableArray<ValueHolder<string>> s_expectedSelectAndOrderBy = ["1", "10", "2", "3", "4", "5", "6", "7", "8", "9"];
+    private static readonly ImmutableArray<ValueHolder<string>> s_expectedSelectAndOrderBy_OddBeforeEven = ["1", "3", "5", "7", "9", "10", "2", "4", "6", "8"];
+    private static readonly ImmutableArray<ValueHolder<string>> s_expectedSelectAndOrderByDescending = ["9", "8", "7", "6", "5", "4", "3", "2", "10", "1"];
+    private static readonly ImmutableArray<ValueHolder<string>> s_expectedSelectAndOrderByDescending_OddBeforeEven = ["8", "6", "4", "2", "10", "9", "7", "5", "3", "1"];
+
+    private static void AddCase(TOrderCollection collection)
     {
-        s_orderTestData.Add(collection, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-        s_orderTestData_OddBeforeEven.Add(collection, [1, 3, 5, 7, 9, 2, 4, 6, 8, 10]);
-        s_orderDescendingTestData.Add(collection, [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
-        s_orderDescendingTestData_OddBeforeEven.Add(collection, [10, 8, 6, 4, 2, 9, 7, 5, 3, 1]);
+        s_orderTestData.Add(collection, s_expectedOrder);
+        s_orderTestData_OddBeforeEven.Add(collection, s_expectedOrder_OddBeforeEven);
+        s_orderDescendingTestData.Add(collection, s_expectedOrderDescending);
+        s_orderDescendingTestData_OddBeforeEven.Add(collection, s_expectedOrderDescending_OddBeforeEven);
+
+        s_selectAndOrderTestData.Add(collection, s_expectedSelectAndOrder, static x => x.ToString());
+        s_selectAndOrderTestData_OddBeforeEven.Add(collection, s_expectedSelectAndOrder_OddBeforeEven, static x => x.ToString());
+        s_selectAndOrderDescendingTestData.Add(collection, s_expectedSelectAndOrderDescending, static x => x.ToString());
+        s_selectAndOrderDescendingTestData_OddBeforeEven.Add(collection, s_expectedSelectAndOrderDescending_OddBeforeEven, static x => x.ToString());
     }
 
-    protected static void AddCase(TOrderByCollection collection)
+    private static void AddCase(TOrderByCollection collection)
     {
-        s_orderByTestData.Add(collection, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-        s_orderByTestData_OddBeforeEven.Add(collection, [1, 3, 5, 7, 9, 2, 4, 6, 8, 10]);
-        s_orderByDescendingTestData.Add(collection, [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
-        s_orderByDescendingTestData_OddBeforeEven.Add(collection, [10, 8, 6, 4, 2, 9, 7, 5, 3, 1]);
+        s_orderByTestData.Add(collection, s_expectedOrderBy);
+        s_orderByTestData_OddBeforeEven.Add(collection, s_expectedOrderBy_OddBeforeEven);
+        s_orderByDescendingTestData.Add(collection, s_expectedOrderByDescending);
+        s_orderByDescendingTestData_OddBeforeEven.Add(collection, s_expectedOrderByDescending_OddBeforeEven);
+
+        s_selectAndOrderByTestData.Add(collection, s_expectedSelectAndOrderBy, static x => x.Value.ToString());
+        s_selectAndOrderByTestData_OddBeforeEven.Add(collection, s_expectedSelectAndOrderBy_OddBeforeEven, static x => x.Value.ToString());
+        s_selectAndOrderByDescendingTestData.Add(collection, s_expectedSelectAndOrderByDescending, static x => x.Value.ToString());
+        s_selectAndOrderByDescendingTestData_OddBeforeEven.Add(collection, s_expectedSelectAndOrderByDescending_OddBeforeEven, static x => x.Value.ToString());
     }
 
     static OrderingTestBase()
@@ -63,6 +102,14 @@ public abstract class OrderingTestBase<TOrderCollection, TOrderByCollection, TCa
             _ => x.CompareTo(y)
         };
 
+    protected static Comparison<string> OddBeforeEvenString
+        => (x, y) => (int.Parse(x) % 2 != 0, int.Parse(y) % 2 != 0) switch
+        {
+            (true, false) => -1,
+            (false, true) => 1,
+            _ => x.CompareTo(y)
+        };
+
     public static TheoryData<TOrderCollection, ImmutableArray<int>> OrderTestData => s_orderTestData;
     public static TheoryData<TOrderCollection, ImmutableArray<int>> OrderTestData_OddBeforeEven => s_orderTestData_OddBeforeEven;
     public static TheoryData<TOrderCollection, ImmutableArray<int>> OrderDescendingTestData => s_orderDescendingTestData;
@@ -71,6 +118,15 @@ public abstract class OrderingTestBase<TOrderCollection, TOrderByCollection, TCa
     public static TheoryData<TOrderByCollection, ImmutableArray<ValueHolder<int>>> OrderByTestData_OddBeforeEven => s_orderByTestData_OddBeforeEven;
     public static TheoryData<TOrderByCollection, ImmutableArray<ValueHolder<int>>> OrderByDescendingTestData => s_orderByDescendingTestData;
     public static TheoryData<TOrderByCollection, ImmutableArray<ValueHolder<int>>> OrderByDescendingTestData_OddBeforeEven => s_orderByDescendingTestData_OddBeforeEven;
+
+    public static TheoryData<TOrderCollection, ImmutableArray<string>, Func<int, string>> SelectAndOrderTestData => s_selectAndOrderTestData;
+    public static TheoryData<TOrderCollection, ImmutableArray<string>, Func<int, string>> SelectAndOrderTestData_OddBeforeEven => s_selectAndOrderTestData_OddBeforeEven;
+    public static TheoryData<TOrderCollection, ImmutableArray<string>, Func<int, string>> SelectAndOrderDescendingTestData => s_selectAndOrderDescendingTestData;
+    public static TheoryData<TOrderCollection, ImmutableArray<string>, Func<int, string>> SelectAndOrderDescendingTestData_OddBeforeEven => s_selectAndOrderDescendingTestData_OddBeforeEven;
+    public static TheoryData<TOrderByCollection, ImmutableArray<ValueHolder<string>>, Func<ValueHolder<int>, ValueHolder<string>>> SelectAndOrderByTestData => s_selectAndOrderByTestData;
+    public static TheoryData<TOrderByCollection, ImmutableArray<ValueHolder<string>>, Func<ValueHolder<int>, ValueHolder<string>>> SelectAndOrderByTestData_OddBeforeEven => s_selectAndOrderByTestData_OddBeforeEven;
+    public static TheoryData<TOrderByCollection, ImmutableArray<ValueHolder<string>>, Func<ValueHolder<int>, ValueHolder<string>>> SelectAndOrderByDescendingTestData => s_selectAndOrderByDescendingTestData;
+    public static TheoryData<TOrderByCollection, ImmutableArray<ValueHolder<string>>, Func<ValueHolder<int>, ValueHolder<string>>> SelectAndOrderByDescendingTestData_OddBeforeEven => s_selectAndOrderByDescendingTestData_OddBeforeEven;
 
     protected void AssertEqual<T>(ImmutableArray<T> result, ImmutableArray<T> expected)
     {

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/EnumerableExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/EnumerableExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
@@ -43,6 +43,49 @@ internal static class EnumerableExtensions
             foreach (var item in items)
             {
                 results.Add(selector(item));
+            }
+
+            return results.DrainToImmutable();
+        }
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="IEnumerable{T}"/> into a new form by incorporating the element's index.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="source"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="source">A sequence of values to invoke a transform function on.</param>
+    /// <param name="selector">
+    ///  A transform function to apply to each source element; the second parameter of
+    ///  the function represents the index of the source element.
+    /// </param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="source"/>.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAsArray<T, TResult>(this IEnumerable<T> source, Func<T, int, TResult> selector)
+    {
+        if (source is ImmutableArray<T> array)
+        {
+            return ImmutableArrayExtensions.SelectAsArray(array, selector);
+        }
+
+        if (source is IReadOnlyList<T> list)
+        {
+            return ReadOnlyListExtensions.SelectAsArray(list, selector);
+        }
+
+        return BuildResult(source, selector);
+
+        static ImmutableArray<TResult> BuildResult(IEnumerable<T> items, Func<T, int, TResult> selector)
+        {
+            using var results = new PooledArrayBuilder<TResult>();
+
+            var index = 0;
+
+            foreach (var item in items)
+            {
+                results.Add(selector(item, index++));
             }
 
             return results.DrainToImmutable();

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/EnumerableExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/EnumerableExtensions.cs
@@ -132,7 +132,7 @@ internal static class EnumerableExtensions
     ///  Sorts the elements of an <see cref="IEnumerable{T}"/> in ascending order.
     /// </summary>
     /// <typeparam name="T">The type of the elements in <paramref name="sequence"/>.</typeparam>
-    /// <param name="sequence">An <see cref="IEnumerable{T}"/> to ordered.</param>
+    /// <param name="sequence">An <see cref="IEnumerable{T}"/> whose elements will be sorted.</param>
     /// <returns>
     ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in ascending order.
     /// </returns>
@@ -156,7 +156,7 @@ internal static class EnumerableExtensions
     ///  Sorts the elements of an <see cref="IEnumerable{T}"/> in ascending order.
     /// </summary>
     /// <typeparam name="T">The type of the elements in <paramref name="sequence"/>.</typeparam>
-    /// <param name="sequence">An <see cref="IEnumerable{T}"/> to ordered.</param>
+    /// <param name="sequence">An <see cref="IEnumerable{T}"/> whose elements will be sorted.</param>
     /// <param name="comparer">An <see cref="IComparer{T}"/> to compare elements.</param>
     /// <returns>
     ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in ascending order.
@@ -181,7 +181,7 @@ internal static class EnumerableExtensions
     ///  Sorts the elements of an <see cref="IEnumerable{T}"/> in ascending order.
     /// </summary>
     /// <typeparam name="T">The type of the elements in <paramref name="sequence"/>.</typeparam>
-    /// <param name="sequence">An <see cref="IEnumerable{T}"/> to ordered.</param>
+    /// <param name="sequence">An <see cref="IEnumerable{T}"/> whose elements will be sorted.</param>
     /// <param name="comparison">An <see cref="Comparison{T}"/> to compare elements.</param>
     /// <returns>
     ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in ascending order.
@@ -206,7 +206,7 @@ internal static class EnumerableExtensions
     ///  Sorts the elements of an <see cref="IEnumerable{T}"/> in descending order.
     /// </summary>
     /// <typeparam name="T">The type of the elements in <paramref name="sequence"/>.</typeparam>
-    /// <param name="sequence">An <see cref="IEnumerable{T}"/> to ordered.</param>
+    /// <param name="sequence">An <see cref="IEnumerable{T}"/> whose elements will be sorted.</param>
     /// <returns>
     ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in descending order.
     /// </returns>
@@ -230,7 +230,7 @@ internal static class EnumerableExtensions
     ///  Sorts the elements of an <see cref="IEnumerable{T}"/> in descending order.
     /// </summary>
     /// <typeparam name="T">The type of the elements in <paramref name="sequence"/>.</typeparam>
-    /// <param name="sequence">An <see cref="IEnumerable{T}"/> to ordered.</param>
+    /// <param name="sequence">An <see cref="IEnumerable{T}"/> whose elements will be sorted.</param>
     /// <param name="comparer">An <see cref="IComparer{T}"/> to compare elements.</param>
     /// <returns>
     ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in descending order.
@@ -255,7 +255,7 @@ internal static class EnumerableExtensions
     ///  Sorts the elements of an <see cref="IEnumerable{T}"/> in descending order.
     /// </summary>
     /// <typeparam name="T">The type of the elements in <paramref name="sequence"/>.</typeparam>
-    /// <param name="sequence">An <see cref="IEnumerable{T}"/> to ordered.</param>
+    /// <param name="sequence">An <see cref="IEnumerable{T}"/> whose elements will be sorted.</param>
     /// <param name="comparison">An <see cref="Comparison{T}"/> to compare elements.</param>
     /// <returns>
     ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in descending order.
@@ -281,7 +281,7 @@ internal static class EnumerableExtensions
     /// </summary>
     /// <typeparam name="TElement">The type of the elements in <paramref name="sequence"/>.</typeparam>
     /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
-    /// <param name="sequence">An <see cref="IEnumerable{T}"/> to ordered.</param>
+    /// <param name="sequence">An <see cref="IEnumerable{T}"/> whose elements will be sorted.</param>
     /// <param name="keySelector">A function to extract a key from an element.</param>
     /// <returns>
     ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in ascending order according to a key.
@@ -308,7 +308,7 @@ internal static class EnumerableExtensions
     /// </summary>
     /// <typeparam name="TElement">The type of the elements in <paramref name="sequence"/>.</typeparam>
     /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
-    /// <param name="sequence">An <see cref="IEnumerable{T}"/> to ordered.</param>
+    /// <param name="sequence">An <see cref="IEnumerable{T}"/> whose elements will be sorted.</param>
     /// <param name="keySelector">A function to extract a key from an element.</param>
     /// <param name="comparer">An <see cref="IComparer{T}"/> to compare keys.</param>
     /// <returns>
@@ -336,7 +336,7 @@ internal static class EnumerableExtensions
     /// </summary>
     /// <typeparam name="TElement">The type of the elements in <paramref name="sequence"/>.</typeparam>
     /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
-    /// <param name="sequence">An <see cref="IEnumerable{T}"/> to ordered.</param>
+    /// <param name="sequence">An <see cref="IEnumerable{T}"/> whose elements will be sorted.</param>
     /// <param name="keySelector">A function to extract a key from an element.</param>
     /// <param name="comparison">An <see cref="Comparison{T}"/> to compare keys.</param>
     /// <returns>
@@ -364,7 +364,7 @@ internal static class EnumerableExtensions
     /// </summary>
     /// <typeparam name="TElement">The type of the elements in <paramref name="sequence"/>.</typeparam>
     /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
-    /// <param name="sequence">An <see cref="IEnumerable{T}"/> to ordered.</param>
+    /// <param name="sequence">An <see cref="IEnumerable{T}"/> whose elements will be sorted.</param>
     /// <param name="keySelector">A function to extract a key from an element.</param>
     /// <returns>
     ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in descending order according to a key.
@@ -391,7 +391,7 @@ internal static class EnumerableExtensions
     /// </summary>
     /// <typeparam name="TElement">The type of the elements in <paramref name="sequence"/>.</typeparam>
     /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
-    /// <param name="sequence">An <see cref="IEnumerable{T}"/> to ordered.</param>
+    /// <param name="sequence">An <see cref="IEnumerable{T}"/> whose elements will be sorted.</param>
     /// <param name="keySelector">A function to extract a key from an element.</param>
     /// <param name="comparer">An <see cref="IComparer{T}"/> to compare keys.</param>
     /// <returns>
@@ -419,7 +419,7 @@ internal static class EnumerableExtensions
     /// </summary>
     /// <typeparam name="TElement">The type of the elements in <paramref name="sequence"/>.</typeparam>
     /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
-    /// <param name="sequence">An <see cref="IEnumerable{T}"/> to ordered.</param>
+    /// <param name="sequence">An <see cref="IEnumerable{T}"/> whose elements will be sorted.</param>
     /// <param name="keySelector">A function to extract a key from an element.</param>
     /// <param name="comparison">An <see cref="Comparison{T}"/> to compare keys.</param>
     /// <returns>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/EnumerableExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/EnumerableExtensions.cs
@@ -496,4 +496,382 @@ internal static class EnumerableExtensions
             return builder.ToArray();
         }
     }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="IEnumerable{T}"/> into a new form and sorts them in ascending order.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="sequence"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="sequence">An <see cref="IEnumerable{T}"/> of elements to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="sequence"/> and sorted in ascending order.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderAsArray<T, TResult>(this IEnumerable<T> sequence, Func<T, TResult> selector)
+    {
+        if (sequence is ImmutableArray<T> array)
+        {
+            return ImmutableArrayExtensions.SelectAndOrderAsArray(array, selector);
+        }
+
+        if (sequence is IReadOnlyList<T> list)
+        {
+            return ReadOnlyListExtensions.SelectAndOrderAsArray(list, selector);
+        }
+
+        var result = sequence.SelectAsArray(selector);
+        result.Unsafe().Order();
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="IEnumerable{T}"/> into a new form and sorts them in ascending order.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="sequence"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="sequence">An <see cref="IEnumerable{T}"/> of elements to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <param name="comparer">An <see cref="IComparer{T}"/> to compare elements.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="sequence"/> and sorted in ascending order.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderAsArray<T, TResult>(
+        this IEnumerable<T> sequence, Func<T, TResult> selector, IComparer<TResult> comparer)
+    {
+        if (sequence is ImmutableArray<T> array)
+        {
+            return ImmutableArrayExtensions.SelectAndOrderAsArray(array, selector, comparer);
+        }
+
+        if (sequence is IReadOnlyList<T> list)
+        {
+            return ReadOnlyListExtensions.SelectAndOrderAsArray(list, selector, comparer);
+        }
+
+        var result = sequence.SelectAsArray(selector);
+        result.Unsafe().Order(comparer);
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="IEnumerable{T}"/> into a new form and sorts them in ascending order.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="sequence"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="sequence">An <see cref="IEnumerable{T}"/> of elements to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <param name="comparison">An <see cref="Comparison{T}"/> to compare elements.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="sequence"/> and sorted in ascending order.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderAsArray<T, TResult>(
+        this IEnumerable<T> sequence, Func<T, TResult> selector, Comparison<TResult> comparison)
+    {
+        if (sequence is ImmutableArray<T> array)
+        {
+            return ImmutableArrayExtensions.SelectAndOrderAsArray(array, selector, comparison);
+        }
+
+        if (sequence is IReadOnlyList<T> list)
+        {
+            return ReadOnlyListExtensions.SelectAndOrderAsArray(list, selector, comparison);
+        }
+
+        var result = sequence.SelectAsArray(selector);
+        result.Unsafe().Order(comparison);
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="IEnumerable{T}"/> into a new form and sorts them in descending order.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="sequence"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="sequence">An <see cref="IEnumerable{T}"/> of elements to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="sequence"/> and sorted in descending order.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderDescendingAsArray<T, TResult>(this IEnumerable<T> sequence, Func<T, TResult> selector)
+    {
+        if (sequence is ImmutableArray<T> array)
+        {
+            return ImmutableArrayExtensions.SelectAndOrderDescendingAsArray(array, selector);
+        }
+
+        if (sequence is IReadOnlyList<T> list)
+        {
+            return ReadOnlyListExtensions.SelectAndOrderDescendingAsArray(list, selector);
+        }
+
+        var result = sequence.SelectAsArray(selector);
+        result.Unsafe().OrderDescending();
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="IEnumerable{T}"/> into a new form and sorts them in descending order.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="sequence"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="sequence">An <see cref="IEnumerable{T}"/> of elements to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <param name="comparer">An <see cref="IComparer{T}"/> to compare elements.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="sequence"/> and sorted in descending order.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderDescendingAsArray<T, TResult>(
+        this IEnumerable<T> sequence, Func<T, TResult> selector, IComparer<TResult> comparer)
+    {
+        if (sequence is ImmutableArray<T> array)
+        {
+            return ImmutableArrayExtensions.SelectAndOrderDescendingAsArray(array, selector, comparer);
+        }
+
+        if (sequence is IReadOnlyList<T> list)
+        {
+            return ReadOnlyListExtensions.SelectAndOrderDescendingAsArray(list, selector, comparer);
+        }
+
+        var result = sequence.SelectAsArray(selector);
+        result.Unsafe().OrderDescending(comparer);
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="IEnumerable{T}"/> into a new form and sorts them in descending order.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="sequence"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="sequence">An <see cref="IEnumerable{T}"/> of elements to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <param name="comparison">An <see cref="Comparison{T}"/> to compare elements.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="sequence"/> and sorted in descending order.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderDescendingAsArray<T, TResult>(
+        this IEnumerable<T> sequence, Func<T, TResult> selector, Comparison<TResult> comparison)
+    {
+        if (sequence is ImmutableArray<T> array)
+        {
+            return ImmutableArrayExtensions.SelectAndOrderDescendingAsArray(array, selector, comparison);
+        }
+
+        if (sequence is IReadOnlyList<T> list)
+        {
+            return ReadOnlyListExtensions.SelectAndOrderDescendingAsArray(list, selector, comparison);
+        }
+
+        var result = sequence.SelectAsArray(selector);
+        result.Unsafe().OrderDescending(comparison);
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="IEnumerable{T}"/> into a new form and sorts them in ascending order according to a key.
+    /// </summary>
+    /// <typeparam name="TElement">The type of the elements in <paramref name="sequence"/>.</typeparam>
+    /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="sequence">An <see cref="IEnumerable{T}"/> of elements to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <param name="keySelector">A function to extract a key from an element.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="sequence"/> and sorted in ascending order according to a key.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderByAsArray<TElement, TKey, TResult>(
+        this IEnumerable<TElement> sequence, Func<TElement, TResult> selector, Func<TResult, TKey> keySelector)
+    {
+        if (sequence is ImmutableArray<TElement> array)
+        {
+            return ImmutableArrayExtensions.SelectAndOrderByAsArray(array, selector, keySelector);
+        }
+
+        if (sequence is IReadOnlyList<TElement> list)
+        {
+            return ReadOnlyListExtensions.SelectAndOrderByAsArray(list, selector, keySelector);
+        }
+
+        var result = sequence.SelectAsArray(selector);
+        result.Unsafe().OrderBy(keySelector);
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="IEnumerable{T}"/> into a new form and sorts them in ascending order according to a key.
+    /// </summary>
+    /// <typeparam name="TElement">The type of the elements in <paramref name="sequence"/>.</typeparam>
+    /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="sequence">An <see cref="IEnumerable{T}"/> of elements to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <param name="keySelector">A function to extract a key from an element.</param>
+    /// <param name="comparer">An <see cref="IComparer{T}"/> to compare keys.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="sequence"/> and sorted in ascending order according to a key.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderByAsArray<TElement, TKey, TResult>(
+        this IEnumerable<TElement> sequence, Func<TElement, TResult> selector, Func<TResult, TKey> keySelector, IComparer<TKey> comparer)
+    {
+        if (sequence is ImmutableArray<TElement> array)
+        {
+            return ImmutableArrayExtensions.SelectAndOrderByAsArray(array, selector, keySelector, comparer);
+        }
+
+        if (sequence is IReadOnlyList<TElement> list)
+        {
+            return ReadOnlyListExtensions.SelectAndOrderByAsArray(list, selector, keySelector, comparer);
+        }
+
+        var result = sequence.SelectAsArray(selector);
+        result.Unsafe().OrderBy(keySelector, comparer);
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="IEnumerable{T}"/> into a new form and sorts them in ascending order according to a key.
+    /// </summary>
+    /// <typeparam name="TElement">The type of the elements in <paramref name="sequence"/>.</typeparam>
+    /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="sequence">An <see cref="IEnumerable{T}"/> of elements to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <param name="keySelector">A function to extract a key from an element.</param>
+    /// <param name="comparison">An <see cref="Comparison{T}"/> to compare keys.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="sequence"/> and sorted in ascending order according to a key.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderByAsArray<TElement, TKey, TResult>(
+        this IEnumerable<TElement> sequence, Func<TElement, TResult> selector, Func<TResult, TKey> keySelector, Comparison<TKey> comparison)
+    {
+        if (sequence is ImmutableArray<TElement> array)
+        {
+            return ImmutableArrayExtensions.SelectAndOrderByAsArray(array, selector, keySelector, comparison);
+        }
+
+        if (sequence is IReadOnlyList<TElement> list)
+        {
+            return ReadOnlyListExtensions.SelectAndOrderByAsArray(list, selector, keySelector, comparison);
+        }
+
+        var result = sequence.SelectAsArray(selector);
+        result.Unsafe().OrderBy(keySelector, comparison);
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="IEnumerable{T}"/> into a new form and sorts them in descending order according to a key.
+    /// </summary>
+    /// <typeparam name="TElement">The type of the elements in <paramref name="sequence"/>.</typeparam>
+    /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="sequence">An <see cref="IEnumerable{T}"/> of elements to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <param name="keySelector">A function to extract a key from an element.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="sequence"/> and sorted in decending order according to a key.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderByDescendingAsArray<TElement, TKey, TResult>(
+        this IEnumerable<TElement> sequence, Func<TElement, TResult> selector, Func<TResult, TKey> keySelector)
+    {
+        if (sequence is ImmutableArray<TElement> array)
+        {
+            return ImmutableArrayExtensions.SelectAndOrderByDescendingAsArray(array, selector, keySelector);
+        }
+
+        if (sequence is IReadOnlyList<TElement> list)
+        {
+            return ReadOnlyListExtensions.SelectAndOrderByDescendingAsArray(list, selector, keySelector);
+        }
+
+        var result = sequence.SelectAsArray(selector);
+        result.Unsafe().OrderByDescending(keySelector);
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="IEnumerable{T}"/> into a new form and sorts them in descending order according to a key.
+    /// </summary>
+    /// <typeparam name="TElement">The type of the elements in <paramref name="sequence"/>.</typeparam>
+    /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="sequence">An <see cref="IEnumerable{T}"/> of elements to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <param name="keySelector">A function to extract a key from an element.</param>
+    /// <param name="comparer">An <see cref="IComparer{T}"/> to compare keys.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="sequence"/> and sorted in decending order according to a key.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderByDescendingAsArray<TElement, TKey, TResult>(
+        this IEnumerable<TElement> sequence, Func<TElement, TResult> selector, Func<TResult, TKey> keySelector, IComparer<TKey> comparer)
+    {
+        if (sequence is ImmutableArray<TElement> array)
+        {
+            return ImmutableArrayExtensions.SelectAndOrderByDescendingAsArray(array, selector, keySelector, comparer);
+        }
+
+        if (sequence is IReadOnlyList<TElement> list)
+        {
+            return ReadOnlyListExtensions.SelectAndOrderByDescendingAsArray(list, selector, keySelector, comparer);
+        }
+
+        var result = sequence.SelectAsArray(selector);
+        result.Unsafe().OrderByDescending(keySelector, comparer);
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="IEnumerable{T}"/> into a new form and sorts them in descending order according to a key.
+    /// </summary>
+    /// <typeparam name="TElement">The type of the elements in <paramref name="sequence"/>.</typeparam>
+    /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="sequence">An <see cref="IEnumerable{T}"/> of elements to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <param name="keySelector">A function to extract a key from an element.</param>
+    /// <param name="comparison">An <see cref="Comparison{T}"/> to compare keys.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="sequence"/> and sorted in decending order according to a key.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderByDescendingAsArray<TElement, TKey, TResult>(
+        this IEnumerable<TElement> sequence, Func<TElement, TResult> selector, Func<TResult, TKey> keySelector, Comparison<TKey> comparison)
+    {
+        if (sequence is ImmutableArray<TElement> array)
+        {
+            return ImmutableArrayExtensions.SelectAndOrderByDescendingAsArray(array, selector, keySelector, comparison);
+        }
+
+        if (sequence is IReadOnlyList<TElement> list)
+        {
+            return ReadOnlyListExtensions.SelectAndOrderByDescendingAsArray(list, selector, keySelector, comparison);
+        }
+
+        var result = sequence.SelectAsArray(selector);
+        result.Unsafe().OrderByDescending(keySelector, comparison);
+
+        return result;
+    }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/EnumerableExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/EnumerableExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
@@ -11,6 +11,17 @@ namespace System.Collections.Generic;
 
 internal static class EnumerableExtensions
 {
+    /// <summary>
+    ///  Projects each element of an <see cref="IEnumerable{T}"/> into a new form.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="source"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="source">A sequence of values to invoke a transform function on.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="source"/>.
+    /// </returns>
     public static ImmutableArray<TResult> SelectAsArray<T, TResult>(this IEnumerable<T> source, Func<T, TResult> selector)
     {
         if (source is ImmutableArray<T> array)
@@ -20,7 +31,7 @@ internal static class EnumerableExtensions
 
         if (source is IReadOnlyList<T> list)
         {
-            return list.SelectAsArray(selector);
+            return ReadOnlyListExtensions.SelectAsArray(list, selector);
         }
 
         return BuildResult(source, selector);

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -977,5 +977,263 @@ internal static partial class ImmutableArrayExtensions
         var array = builder.DrainToImmutable();
         array.Unsafe().OrderByDescending(keySelector, comparison);
         return array;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="ImmutableArray{T}"/> into a new form and sorts them in ascending order.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="array">An array of values to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="array"/> and sorted in ascending order.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderAsArray<T, TResult>(this ImmutableArray<T> array, Func<T, TResult> selector)
+    {
+        var result = array.SelectAsArray(selector);
+        result.Unsafe().Order();
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="ImmutableArray{T}"/> into a new form and sorts them in ascending order.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="array">An array of values to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <param name="comparer">An <see cref="IComparer{T}"/> to compare projected elements.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="array"/> and sorted in ascending order.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderAsArray<T, TResult>(
+        this ImmutableArray<T> array, Func<T, TResult> selector, IComparer<TResult> comparer)
+    {
+        var result = array.SelectAsArray(selector);
+        result.Unsafe().Order(comparer);
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="ImmutableArray{T}"/> into a new form and sorts them in ascending order.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="array">An array of values to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <param name="comparison">A <see cref="Comparison{T}"/> to compare elements.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="array"/> and sorted in ascending order.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderAsArray<T, TResult>(
+        this ImmutableArray<T> array, Func<T, TResult> selector, Comparison<TResult> comparison)
+    {
+        var result = array.SelectAsArray(selector);
+        result.Unsafe().Order(comparison);
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="ImmutableArray{T}"/> into a new form and sorts them in descending order.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="array">An array of values to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="array"/> and sorted in descending order.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderDescendingAsArray<T, TResult>(this ImmutableArray<T> array, Func<T, TResult> selector)
+    {
+        var result = array.SelectAsArray(selector);
+        result.Unsafe().OrderDescending();
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="ImmutableArray{T}"/> into a new form and sorts them in descending order.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="array">An array of values to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <param name="comparer">An <see cref="IComparer{T}"/> to compare elements.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="array"/> and sorted in descending order.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderDescendingAsArray<T, TResult>(
+        this ImmutableArray<T> array, Func<T, TResult> selector, IComparer<TResult> comparer)
+    {
+        var result = array.SelectAsArray(selector);
+        result.Unsafe().OrderDescending(comparer);
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="ImmutableArray{T}"/> into a new form and sorts them in descending order.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="array">An array of values to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <param name="comparison">A <see cref="Comparison{T}"/> to compare elements.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="array"/> and sorted in descending order.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderDescendingAsArray<T, TResult>(
+        this ImmutableArray<T> array, Func<T, TResult> selector, Comparison<TResult> comparison)
+    {
+        var result = array.SelectAsArray(selector);
+        result.Unsafe().OrderDescending(comparison);
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="ImmutableArray{T}"/> into a new form and sorts them in ascending order according to a key.
+    /// </summary>
+    /// <typeparam name="TElement">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="array">An array of values to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <param name="keySelector">A function to extract a key from a projected element.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="array"/> and sorted in ascending order according to a key.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderByAsArray<TElement, TKey, TResult>(
+        this ImmutableArray<TElement> array, Func<TElement, TResult> selector, Func<TResult, TKey> keySelector)
+    {
+        var result = array.SelectAsArray(selector);
+        result.Unsafe().OrderBy(keySelector);
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="ImmutableArray{T}"/> into a new form and sorts them in ascending order according to a key.
+    /// </summary>
+    /// <typeparam name="TElement">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="array">An array of values to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <param name="keySelector">A function to extract a key from a projected element.</param>
+    /// <param name="comparer">An <see cref="IComparer{T}"/> to compare keys.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="array"/> and sorted in ascending order according to a key.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderByAsArray<TElement, TKey, TResult>(
+        this ImmutableArray<TElement> array, Func<TElement, TResult> selector, Func<TResult, TKey> keySelector, IComparer<TKey> comparer)
+    {
+        var result = array.SelectAsArray(selector);
+        result.Unsafe().OrderBy(keySelector, comparer);
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="ImmutableArray{T}"/> into a new form and sorts them in ascending order according to a key.
+    /// </summary>
+    /// <typeparam name="TElement">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="array">An array of values to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <param name="keySelector">A function to extract a key from a projected element.</param>
+    /// <param name="comparison">A <see cref="Comparison{T}"/> to compare keys.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="array"/> and sorted in ascending order according to a key.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderByAsArray<TElement, TKey, TResult>(
+        this ImmutableArray<TElement> array, Func<TElement, TResult> selector, Func<TResult, TKey> keySelector, Comparison<TKey> comparison)
+    {
+        var result = array.SelectAsArray(selector);
+        result.Unsafe().OrderBy(keySelector, comparison);
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="ImmutableArray{T}"/> into a new form and sorts them in descending order according to a key.
+    /// </summary>
+    /// <typeparam name="TElement">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="array">An array of values to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <param name="keySelector">A function to extract a key from a projected element.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="array"/> and sorted in descending order according to a key.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderByDescendingAsArray<TElement, TKey, TResult>(
+        this ImmutableArray<TElement> array, Func<TElement, TResult> selector, Func<TResult, TKey> keySelector)
+    {
+        var result = array.SelectAsArray(selector);
+        result.Unsafe().OrderByDescending(keySelector);
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="ImmutableArray{T}"/> into a new form and sorts them in descending order according to a key.
+    /// </summary>
+    /// <typeparam name="TElement">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="array">An array of values to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <param name="keySelector">A function to extract a key from a projected element.</param>
+    /// <param name="comparer">An <see cref="IComparer{T}"/> to compare keys.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="array"/> and sorted in descending order according to a key.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderByDescendingAsArray<TElement, TKey, TResult>(
+        this ImmutableArray<TElement> array, Func<TElement, TResult> selector, Func<TResult, TKey> keySelector, IComparer<TKey> comparer)
+    {
+        var result = array.SelectAsArray(selector);
+        result.Unsafe().OrderByDescending(keySelector, comparer);
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="ImmutableArray{T}"/> into a new form and sorts them in descending order according to a key.
+    /// </summary>
+    /// <typeparam name="TElement">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="array">An array of values to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <param name="keySelector">A function to extract a key from a projected element.</param>
+    /// <param name="comparison">A <see cref="Comparison{T}"/> to compare keys.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="array"/> and sorted in descending order according to a key.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderByDescendingAsArray<TElement, TKey, TResult>(
+        this ImmutableArray<TElement> array, Func<TElement, TResult> selector, Func<TResult, TKey> keySelector, Comparison<TKey> comparison)
+    {
+        var result = array.SelectAsArray(selector);
+        result.Unsafe().OrderByDescending(keySelector, comparison);
+
+        return result;
     }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -227,7 +227,7 @@ internal static partial class ImmutableArrayExtensions
     ///  Sorts the elements of an <see cref="ImmutableArray{T}"/> in ascending order.
     /// </summary>
     /// <typeparam name="T">The type of the elements in <paramref name="array"/>.</typeparam>
-    /// <param name="array">An array to ordered.</param>
+    /// <param name="array">An array to be sorted.</param>
     /// <returns>
     ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in ascending order.
     /// </returns>
@@ -241,7 +241,7 @@ internal static partial class ImmutableArrayExtensions
     ///  Sorts the elements of an <see cref="ImmutableArray{T}"/> in ascending order.
     /// </summary>
     /// <typeparam name="T">The type of the elements in <paramref name="array"/>.</typeparam>
-    /// <param name="array">An array to ordered.</param>
+    /// <param name="array">An array to be sorted.</param>
     /// <param name="comparer">An <see cref="IComparer{T}"/> to compare elements.</param>
     /// <returns>
     ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in ascending order.
@@ -256,7 +256,7 @@ internal static partial class ImmutableArrayExtensions
     ///  Sorts the elements of an <see cref="ImmutableArray{T}"/> in ascending order.
     /// </summary>
     /// <typeparam name="T">The type of the elements in <paramref name="array"/>.</typeparam>
-    /// <param name="array">An array to ordered.</param>
+    /// <param name="array">An array to be sorted.</param>
     /// <param name="comparison">A <see cref="Comparison{T}"/> to compare elements.</param>
     /// <returns>
     ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in ascending order.
@@ -271,7 +271,7 @@ internal static partial class ImmutableArrayExtensions
     ///  Sorts the elements of an <see cref="ImmutableArray{T}"/> in descending order.
     /// </summary>
     /// <typeparam name="T">The type of the elements in <paramref name="array"/>.</typeparam>
-    /// <param name="array">An array to ordered.</param>
+    /// <param name="array">An array to be sorted.</param>
     /// <returns>
     ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in descending order.
     /// </returns>
@@ -285,7 +285,7 @@ internal static partial class ImmutableArrayExtensions
     ///  Sorts the elements of an <see cref="ImmutableArray{T}"/> in descending order.
     /// </summary>
     /// <typeparam name="T">The type of the elements in <paramref name="array"/>.</typeparam>
-    /// <param name="array">An array to ordered.</param>
+    /// <param name="array">An array to be sorted.</param>
     /// <param name="comparer">An <see cref="IComparer{T}"/> to compare elements.</param>
     /// <returns>
     ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in descending order.
@@ -300,7 +300,7 @@ internal static partial class ImmutableArrayExtensions
     ///  Sorts the elements of an <see cref="ImmutableArray{T}"/> in descending order.
     /// </summary>
     /// <typeparam name="T">The type of the elements in <paramref name="array"/>.</typeparam>
-    /// <param name="array">An array to ordered.</param>
+    /// <param name="array">An array to be sorted.</param>
     /// <param name="comparison">A <see cref="Comparison{T}"/> to compare elements.</param>
     /// <returns>
     ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in descending order.
@@ -316,7 +316,7 @@ internal static partial class ImmutableArrayExtensions
     /// </summary>
     /// <typeparam name="TElement">The type of the elements in <paramref name="array"/>.</typeparam>
     /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
-    /// <param name="array">An array to ordered.</param>
+    /// <param name="array">An array to be sorted.</param>
     /// <param name="keySelector">A function to extract a key from an element.</param>
     /// <returns>
     ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in ascending order according to a key.
@@ -333,7 +333,7 @@ internal static partial class ImmutableArrayExtensions
     /// </summary>
     /// <typeparam name="TElement">The type of the elements in <paramref name="array"/>.</typeparam>
     /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
-    /// <param name="array">An array to ordered.</param>
+    /// <param name="array">An array to be sorted.</param>
     /// <param name="keySelector">A function to extract a key from an element.</param>
     /// <param name="comparer">An <see cref="IComparer{T}"/> to compare keys.</param>
     /// <returns>
@@ -351,7 +351,7 @@ internal static partial class ImmutableArrayExtensions
     /// </summary>
     /// <typeparam name="TElement">The type of the elements in <paramref name="array"/>.</typeparam>
     /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
-    /// <param name="array">An array to ordered.</param>
+    /// <param name="array">An array to be sorted.</param>
     /// <param name="keySelector">A function to extract a key from an element.</param>
     /// <param name="comparison">A <see cref="Comparison{T}"/> to compare keys.</param>
     /// <returns>
@@ -369,7 +369,7 @@ internal static partial class ImmutableArrayExtensions
     /// </summary>
     /// <typeparam name="TElement">The type of the elements in <paramref name="array"/>.</typeparam>
     /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
-    /// <param name="array">An array to ordered.</param>
+    /// <param name="array">An array to be sorted.</param>
     /// <param name="keySelector">A function to extract a key from an element.</param>
     /// <returns>
     ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in descending order according to a key.
@@ -386,7 +386,7 @@ internal static partial class ImmutableArrayExtensions
     /// </summary>
     /// <typeparam name="TElement">The type of the elements in <paramref name="array"/>.</typeparam>
     /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
-    /// <param name="array">An array to ordered.</param>
+    /// <param name="array">An array to be sorted.</param>
     /// <param name="keySelector">A function to extract a key from an element.</param>
     /// <param name="comparer">An <see cref="IComparer{T}"/> to compare keys.</param>
     /// <returns>
@@ -404,7 +404,7 @@ internal static partial class ImmutableArrayExtensions
     /// </summary>
     /// <typeparam name="TElement">The type of the elements in <paramref name="array"/>.</typeparam>
     /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
-    /// <param name="array">An array to ordered.</param>
+    /// <param name="array">An array to be sorted.</param>
     /// <param name="keySelector">A function to extract a key from an element.</param>
     /// <param name="comparison">A <see cref="Comparison{T}"/> to compare keys.</param>
     /// <returns>

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -30,9 +30,20 @@ internal static partial class ImmutableArrayExtensions
         }
     }
 
-    public static ImmutableArray<TResult> SelectAsArray<T, TResult>(this ImmutableArray<T> source, Func<T, TResult> selector)
+    /// <summary>
+    ///  Projects each element of an <see cref="ImmutableArray{T}"/> into a new form.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="array">An array of values to invoke a transform function on.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="array"/>.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAsArray<T, TResult>(this ImmutableArray<T> array, Func<T, TResult> selector)
     {
-        return source switch
+        return array switch
         {
             [] => [],
             [var item] => [selector(item)],

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ImmutableArrayExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
@@ -60,6 +60,44 @@ internal static partial class ImmutableArrayExtensions
             foreach (var item in items)
             {
                 results.Add(selector(item));
+            }
+
+            return results.DrainToImmutable();
+        }
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="ImmutableArray{T}"/> into a new form by incorporating the element's index.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="array"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="array">An array of values to invoke a transform function on.</param>
+    /// <param name="selector">
+    ///  A transform function to apply to each element; the second parameter of the function represents the index of the element.
+    /// </param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="array"/>.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAsArray<T, TResult>(this ImmutableArray<T> array, Func<T, int, TResult> selector)
+    {
+        return array switch
+        {
+            [] => [],
+            [var item] => [selector(item, 0)],
+            [var item1, var item2] => [selector(item1, 0), selector(item2, 1)],
+            [var item1, var item2, var item3] => [selector(item1, 0), selector(item2, 1), selector(item3, 2)],
+            [var item1, var item2, var item3, var item4] => [selector(item1, 0), selector(item2, 1), selector(item3, 2), selector(item4, 3)],
+            var items => BuildResult(items, selector)
+        };
+
+        static ImmutableArray<TResult> BuildResult(ImmutableArray<T> items, Func<T, int, TResult> selector)
+        {
+            using var results = new PooledArrayBuilder<TResult>(capacity: items.Length);
+
+            for (var i = 0; i < items.Length; i++)
+            {
+                results.Add(selector(items[i], i));
             }
 
             return results.DrainToImmutable();

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ReadOnlyListExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ReadOnlyListExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
@@ -11,9 +11,25 @@ namespace System.Collections.Generic;
 
 internal static class ReadOnlyListExtensions
 {
-    public static ImmutableArray<TResult> SelectAsArray<T, TResult>(this IReadOnlyList<T> source, Func<T, TResult> selector)
+    /// <summary>
+    ///  Projects each element of an <see cref="IReadOnlyList{T}"/> into a new form.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="list"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="list">An <see cref="IReadOnlyList{T}"/> of values to invoke a transform function on.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="list"/>.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAsArray<T, TResult>(this IReadOnlyList<T> list, Func<T, TResult> selector)
     {
-        return source switch
+        if (list is ImmutableArray<T> array)
+        {
+            return ImmutableArrayExtensions.SelectAsArray(array, selector);
+        }
+
+        return list switch
         {
             [] => [],
             [var item] => [selector(item)],

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ReadOnlyListExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ReadOnlyListExtensions.cs
@@ -1324,4 +1324,322 @@ internal static class ReadOnlyListExtensions
 
         return ImmutableCollectionsMarshal.AsImmutableArray(newArray);
     }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="IReadOnlyList{T}"/> into a new form and sorts them in ascending order.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="list"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="list">An <see cref="IReadOnlyList{T}"/> of elements to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="list"/> and sorted in ascending order.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderAsArray<T, TResult>(this IReadOnlyList<T> list, Func<T, TResult> selector)
+    {
+        if (list is ImmutableArray<T> array)
+        {
+            return ImmutableArrayExtensions.SelectAndOrderAsArray(array, selector);
+        }
+
+        var result = list.SelectAsArray(selector);
+        result.Unsafe().Order();
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="IReadOnlyList{T}"/> into a new form and sorts them in ascending order.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="list"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="list">An <see cref="IReadOnlyList{T}"/> of elements to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <param name="comparer">An <see cref="IComparer{T}"/> to compare elements.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="list"/> and sorted in ascending order.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderAsArray<T, TResult>(
+        this IReadOnlyList<T> list, Func<T, TResult> selector, IComparer<TResult> comparer)
+    {
+        if (list is ImmutableArray<T> array)
+        {
+            return ImmutableArrayExtensions.SelectAndOrderAsArray(array, selector, comparer);
+        }
+
+        var result = list.SelectAsArray(selector);
+        result.Unsafe().Order(comparer);
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="IReadOnlyList{T}"/> into a new form and sorts them in ascending order.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="list"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="list">An <see cref="IReadOnlyList{T}"/> of elements to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <param name="comparison">An <see cref="Comparison{T}"/> to compare elements.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="list"/> and sorted in ascending order.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderAsArray<T, TResult>(
+        this IReadOnlyList<T> list, Func<T, TResult> selector, Comparison<TResult> comparison)
+    {
+        if (list is ImmutableArray<T> array)
+        {
+            return ImmutableArrayExtensions.SelectAndOrderAsArray(array, selector, comparison);
+        }
+
+        var result = list.SelectAsArray(selector);
+        result.Unsafe().Order(comparison);
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="IReadOnlyList{T}"/> into a new form and sorts them in descending order.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="list"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="list">An <see cref="IReadOnlyList{T}"/> of elements to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="list"/> and sorted in decending order.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderDescendingAsArray<T, TResult>(this IReadOnlyList<T> list, Func<T, TResult> selector)
+    {
+        if (list is ImmutableArray<T> array)
+        {
+            return ImmutableArrayExtensions.SelectAndOrderDescendingAsArray(array, selector);
+        }
+
+        var result = list.SelectAsArray(selector);
+        result.Unsafe().OrderDescending();
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="IReadOnlyList{T}"/> into a new form and sorts them in descending order.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="list"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="list">An <see cref="IReadOnlyList{T}"/> of elements to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <param name="comparer">An <see cref="IComparer{T}"/> to compare elements.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="list"/> and sorted in decending order.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderDescendingAsArray<T, TResult>(
+        this IReadOnlyList<T> list, Func<T, TResult> selector, IComparer<TResult> comparer)
+    {
+        if (list is ImmutableArray<T> array)
+        {
+            return ImmutableArrayExtensions.SelectAndOrderDescendingAsArray(array, selector, comparer);
+        }
+
+        var result = list.SelectAsArray(selector);
+        result.Unsafe().OrderDescending(comparer);
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="IReadOnlyList{T}"/> into a new form and sorts them in descending order.
+    /// </summary>
+    /// <typeparam name="T">The type of the elements in <paramref name="list"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="list">An <see cref="IReadOnlyList{T}"/> of elements to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <param name="comparison">An <see cref="Comparison{T}"/> to compare elements.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="list"/> and sorted in decending order.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderDescendingAsArray<T, TResult>(
+        this IReadOnlyList<T> list, Func<T, TResult> selector, Comparison<TResult> comparison)
+    {
+        if (list is ImmutableArray<T> array)
+        {
+            return ImmutableArrayExtensions.SelectAndOrderDescendingAsArray(array, selector, comparison);
+        }
+
+        var result = list.SelectAsArray(selector);
+        result.Unsafe().OrderDescending(comparison);
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="IReadOnlyList{T}"/> into a new form and sorts them in ascending order according to a key.
+    /// </summary>
+    /// <typeparam name="TElement">The type of the elements in <paramref name="list"/>.</typeparam>
+    /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="list">An <see cref="IReadOnlyList{T}"/> of elements to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <param name="keySelector">A function to extract a key from a projected element.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="list"/> and sorted in ascending order according to a key.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderByAsArray<TElement, TKey, TResult>(
+        this IReadOnlyList<TElement> list, Func<TElement, TResult> selector, Func<TResult, TKey> keySelector)
+    {
+        if (list is ImmutableArray<TElement> array)
+        {
+            return ImmutableArrayExtensions.SelectAndOrderByAsArray(array, selector, keySelector);
+        }
+
+        var result = list.SelectAsArray(selector);
+        result.Unsafe().OrderBy(keySelector);
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="IReadOnlyList{T}"/> into a new form and sorts them in ascending order according to a key.
+    /// </summary>
+    /// <typeparam name="TElement">The type of the elements in <paramref name="list"/>.</typeparam>
+    /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="list">An <see cref="IReadOnlyList{T}"/> of elements to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <param name="keySelector">A function to extract a key from a projected element.</param>
+    /// <param name="comparer">An <see cref="IComparer{T}"/> to compare keys.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="list"/> and sorted in ascending order according to a key.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderByAsArray<TElement, TKey, TResult>(
+        this IReadOnlyList<TElement> list, Func<TElement, TResult> selector, Func<TResult, TKey> keySelector, IComparer<TKey> comparer)
+    {
+        if (list is ImmutableArray<TElement> array)
+        {
+            return ImmutableArrayExtensions.SelectAndOrderByAsArray(array, selector, keySelector, comparer);
+        }
+
+        var result = list.SelectAsArray(selector);
+        result.Unsafe().OrderBy(keySelector, comparer);
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="IReadOnlyList{T}"/> into a new form and sorts them in ascending order according to a key.
+    /// </summary>
+    /// <typeparam name="TElement">The type of the elements in <paramref name="list"/>.</typeparam>
+    /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="list">An <see cref="IReadOnlyList{T}"/> of elements to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <param name="keySelector">A function to extract a key from a projected element.</param>
+    /// <param name="comparison">An <see cref="Comparison{T}"/> to compare keys.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="list"/> and sorted in ascending order according to a key.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderByAsArray<TElement, TKey, TResult>(
+        this IReadOnlyList<TElement> list, Func<TElement, TResult> selector, Func<TResult, TKey> keySelector, Comparison<TKey> comparison)
+    {
+        if (list is ImmutableArray<TElement> array)
+        {
+            return ImmutableArrayExtensions.SelectAndOrderByAsArray(array, selector, keySelector, comparison);
+        }
+
+        var result = list.SelectAsArray(selector);
+        result.Unsafe().OrderBy(keySelector, comparison);
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="IReadOnlyList{T}"/> into a new form and sorts them in descending order according to a key.
+    /// </summary>
+    /// <typeparam name="TElement">The type of the elements in <paramref name="list"/>.</typeparam>
+    /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="list">An <see cref="IReadOnlyList{T}"/> of elements to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <param name="keySelector">A function to extract a key from a projected element.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="list"/> and sorted in descending order according to a key.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderByDescendingAsArray<TElement, TKey, TResult>(
+        this IReadOnlyList<TElement> list, Func<TElement, TResult> selector, Func<TResult, TKey> keySelector)
+    {
+        if (list is ImmutableArray<TElement> array)
+        {
+            return ImmutableArrayExtensions.SelectAndOrderByDescendingAsArray(array, selector, keySelector);
+        }
+
+        var result = list.SelectAsArray(selector);
+        result.Unsafe().OrderByDescending(keySelector);
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="IReadOnlyList{T}"/> into a new form and sorts them in descending order according to a key.
+    /// </summary>
+    /// <typeparam name="TElement">The type of the elements in <paramref name="list"/>.</typeparam>
+    /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="list">An <see cref="IReadOnlyList{T}"/> of elements to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <param name="keySelector">A function to extract a key from a projected element.</param>
+    /// <param name="comparer">An <see cref="IComparer{T}"/> to compare keys.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="list"/> and sorted in descending order according to a key.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderByDescendingAsArray<TElement, TKey, TResult>(
+        this IReadOnlyList<TElement> list, Func<TElement, TResult> selector, Func<TResult, TKey> keySelector, IComparer<TKey> comparer)
+    {
+        if (list is ImmutableArray<TElement> array)
+        {
+            return ImmutableArrayExtensions.SelectAndOrderByDescendingAsArray(array, selector, keySelector, comparer);
+        }
+
+        var result = list.SelectAsArray(selector);
+        result.Unsafe().OrderByDescending(keySelector, comparer);
+
+        return result;
+    }
+
+    /// <summary>
+    ///  Projects each element of an <see cref="IReadOnlyList{T}"/> into a new form and sorts them in descending order according to a key.
+    /// </summary>
+    /// <typeparam name="TElement">The type of the elements in <paramref name="list"/>.</typeparam>
+    /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
+    /// <typeparam name="TResult">The type of the value returned by <paramref name="selector"/>.</typeparam>
+    /// <param name="list">An <see cref="IReadOnlyList{T}"/> of elements to invoke a transform function on and sort.</param>
+    /// <param name="selector">A transform function to apply to each element.</param>
+    /// <param name="keySelector">A function to extract a key from a projected element.</param>
+    /// <param name="comparison">An <see cref="Comparison{T}"/> to compare keys.</param>
+    /// <returns>
+    ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are the result of invoking the transform function
+    ///  on each element of <paramref name="list"/> and sorted in descending order according to a key.
+    /// </returns>
+    public static ImmutableArray<TResult> SelectAndOrderByDescendingAsArray<TElement, TKey, TResult>(
+        this IReadOnlyList<TElement> list, Func<TElement, TResult> selector, Func<TResult, TKey> keySelector, Comparison<TKey> comparison)
+    {
+        if (list is ImmutableArray<TElement> array)
+        {
+            return ImmutableArrayExtensions.SelectAndOrderByDescendingAsArray(array, selector, keySelector, comparison);
+        }
+
+        var result = list.SelectAsArray(selector);
+        result.Unsafe().OrderByDescending(keySelector, comparison);
+
+        return result;
+    }
 }

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ReadOnlyListExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/ReadOnlyListExtensions.cs
@@ -1043,7 +1043,7 @@ internal static class ReadOnlyListExtensions
     ///  Sorts the elements of an <see cref="IReadOnlyList{T}"/> in ascending order.
     /// </summary>
     /// <typeparam name="T">The type of the elements in <paramref name="list"/>.</typeparam>
-    /// <param name="list">An <see cref="IReadOnlyList{T}"/> to ordered.</param>
+    /// <param name="list">An <see cref="IReadOnlyList{T}"/> whose elements will be sorted.</param>
     /// <returns>
     ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in ascending order.
     /// </returns>
@@ -1062,7 +1062,7 @@ internal static class ReadOnlyListExtensions
     ///  Sorts the elements of an <see cref="IReadOnlyList{T}"/> in ascending order.
     /// </summary>
     /// <typeparam name="T">The type of the elements in <paramref name="list"/>.</typeparam>
-    /// <param name="list">An <see cref="IReadOnlyList{T}"/> to ordered.</param>
+    /// <param name="list">An <see cref="IReadOnlyList{T}"/> whose elements will be sorted.</param>
     /// <param name="comparer">An <see cref="IComparer{T}"/> to compare elements.</param>
     /// <returns>
     ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in ascending order.
@@ -1082,7 +1082,7 @@ internal static class ReadOnlyListExtensions
     ///  Sorts the elements of an <see cref="IReadOnlyList{T}"/> in ascending order.
     /// </summary>
     /// <typeparam name="T">The type of the elements in <paramref name="list"/>.</typeparam>
-    /// <param name="list">An <see cref="IReadOnlyList{T}"/> to ordered.</param>
+    /// <param name="list">An <see cref="IReadOnlyList{T}"/> whose elements will be sorted.</param>
     /// <param name="comparison">An <see cref="Comparison{T}"/> to compare elements.</param>
     /// <returns>
     ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in ascending order.
@@ -1102,7 +1102,7 @@ internal static class ReadOnlyListExtensions
     ///  Sorts the elements of an <see cref="IReadOnlyList{T}"/> in descending order.
     /// </summary>
     /// <typeparam name="T">The type of the elements in <paramref name="list"/>.</typeparam>
-    /// <param name="list">An <see cref="IReadOnlyList{T}"/> to ordered.</param>
+    /// <param name="list">An <see cref="IReadOnlyList{T}"/> whose elements will be sorted.</param>
     /// <returns>
     ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in descending order.
     /// </returns>
@@ -1121,7 +1121,7 @@ internal static class ReadOnlyListExtensions
     ///  Sorts the elements of an <see cref="IReadOnlyList{T}"/> in descending order.
     /// </summary>
     /// <typeparam name="T">The type of the elements in <paramref name="list"/>.</typeparam>
-    /// <param name="list">An <see cref="IReadOnlyList{T}"/> to ordered.</param>
+    /// <param name="list">An <see cref="IReadOnlyList{T}"/> whose elements will be sorted.</param>
     /// <param name="comparer">An <see cref="IComparer{T}"/> to compare elements.</param>
     /// <returns>
     ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in descending order.
@@ -1141,7 +1141,7 @@ internal static class ReadOnlyListExtensions
     ///  Sorts the elements of an <see cref="IReadOnlyList{T}"/> in descending order.
     /// </summary>
     /// <typeparam name="T">The type of the elements in <paramref name="list"/>.</typeparam>
-    /// <param name="list">An <see cref="IReadOnlyList{T}"/> to ordered.</param>
+    /// <param name="list">An <see cref="IReadOnlyList{T}"/> whose elements will be sorted.</param>
     /// <param name="comparison">An <see cref="Comparison{T}"/> to compare elements.</param>
     /// <returns>
     ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in descending order.
@@ -1162,7 +1162,7 @@ internal static class ReadOnlyListExtensions
     /// </summary>
     /// <typeparam name="TElement">The type of the elements in <paramref name="list"/>.</typeparam>
     /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
-    /// <param name="list">An <see cref="IReadOnlyList{T}"/> to ordered.</param>
+    /// <param name="list">An <see cref="IReadOnlyList{T}"/> whose elements will be sorted.</param>
     /// <param name="keySelector">A function to extract a key from an element.</param>
     /// <returns>
     ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in ascending order according to a key.
@@ -1184,7 +1184,7 @@ internal static class ReadOnlyListExtensions
     /// </summary>
     /// <typeparam name="TElement">The type of the elements in <paramref name="list"/>.</typeparam>
     /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
-    /// <param name="list">An <see cref="IReadOnlyList{T}"/> to ordered.</param>
+    /// <param name="list">An <see cref="IReadOnlyList{T}"/> whose elements will be sorted.</param>
     /// <param name="keySelector">A function to extract a key from an element.</param>
     /// <param name="comparer">An <see cref="IComparer{T}"/> to compare keys.</param>
     /// <returns>
@@ -1207,7 +1207,7 @@ internal static class ReadOnlyListExtensions
     /// </summary>
     /// <typeparam name="TElement">The type of the elements in <paramref name="list"/>.</typeparam>
     /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
-    /// <param name="list">An <see cref="IReadOnlyList{T}"/> to ordered.</param>
+    /// <param name="list">An <see cref="IReadOnlyList{T}"/> whose elements will be sorted.</param>
     /// <param name="keySelector">A function to extract a key from an element.</param>
     /// <param name="comparison">An <see cref="Comparison{T}"/> to compare keys.</param>
     /// <returns>
@@ -1230,7 +1230,7 @@ internal static class ReadOnlyListExtensions
     /// </summary>
     /// <typeparam name="TElement">The type of the elements in <paramref name="list"/>.</typeparam>
     /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
-    /// <param name="list">An <see cref="IReadOnlyList{T}"/> to ordered.</param>
+    /// <param name="list">An <see cref="IReadOnlyList{T}"/> whose elements will be sorted.</param>
     /// <param name="keySelector">A function to extract a key from an element.</param>
     /// <returns>
     ///  Returns a new <see cref="ImmutableArray{T}"/> whose elements are sorted in descending order according to a key.
@@ -1252,7 +1252,7 @@ internal static class ReadOnlyListExtensions
     /// </summary>
     /// <typeparam name="TElement">The type of the elements in <paramref name="list"/>.</typeparam>
     /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
-    /// <param name="list">An <see cref="IReadOnlyList{T}"/> to ordered.</param>
+    /// <param name="list">An <see cref="IReadOnlyList{T}"/> whose elements will be sorted.</param>
     /// <param name="keySelector">A function to extract a key from an element.</param>
     /// <param name="comparer">An <see cref="IComparer{T}"/> to compare keys.</param>
     /// <returns>
@@ -1275,7 +1275,7 @@ internal static class ReadOnlyListExtensions
     /// </summary>
     /// <typeparam name="TElement">The type of the elements in <paramref name="list"/>.</typeparam>
     /// <typeparam name="TKey">The type of key returned by <paramref name="keySelector"/>.</typeparam>
-    /// <param name="list">An <see cref="IReadOnlyList{T}"/> to ordered.</param>
+    /// <param name="list">An <see cref="IReadOnlyList{T}"/> whose elements will be sorted.</param>
     /// <param name="keySelector">A function to extract a key from an element.</param>
     /// <param name="comparison">An <see cref="Comparison{T}"/> to compare keys.</param>
     /// <returns>


### PR DESCRIPTION
This adds a handful of new SelectXXXAsArray extension methods and overloads. In particular, there are new `SelectAndOrderXXXAsArray` methods that transform elements _and_ order them in a single pass.