### PR TITLE
Fix span calculation on RazorMapToDocumentRangesEndpoint

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Mapping/RazorMapToDocumentRangesEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Mapping/RazorMapToDocumentRangesEndpoint.cs
@@ -72,7 +72,7 @@ internal sealed class RazorMapToDocumentRangesEndpoint :
             }
 
             ranges[i] = originalRange;
-            spans[i] = originalRange.ToRazorTextSpan(generatedDocument.Text);
+            spans[i] = originalRange.ToRazorTextSpan(codeDocument.Source.Text);
         }
 
         return new RazorMapToDocumentRangesResponse()


### PR DESCRIPTION
It turns out when converting a range to a span you need to use the right SourceText...
