### PR TITLE
Bind directive attribute `event` parameter HTML event completions

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Extensions/IServiceCollectionExtensions.cs
@@ -90,6 +90,7 @@ internal static class IServiceCollectionExtensions
         services.AddSingleton<IRazorCompletionItemProvider, DirectiveCompletionItemProvider>();
         services.AddSingleton<IRazorCompletionItemProvider, DirectiveAttributeCompletionItemProvider>();
         services.AddSingleton<IRazorCompletionItemProvider, DirectiveAttributeParameterCompletionItemProvider>();
+        services.AddSingleton<IRazorCompletionItemProvider, DirectiveAttributeEventParameterCompletionItemProvider>();
         services.AddSingleton<IRazorCompletionItemProvider, DirectiveAttributeTransitionCompletionItemProvider>();
         services.AddSingleton<IRazorCompletionItemProvider, MarkupTransitionCompletionItemProvider>();
         services.AddSingleton<IRazorCompletionItemProvider, TagHelperCompletionProvider>();

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeEventParameterCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/DirectiveAttributeEventParameterCompletionItemProvider.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Microsoft.VisualStudio.Editor.Razor;
+
+namespace Microsoft.CodeAnalysis.Razor.Completion;
+
+internal class DirectiveAttributeEventParameterCompletionItemProvider() : IRazorCompletionItemProvider
+{
+    private static readonly ImmutableArray<RazorCompletionItem> s_eventCompletionItems = HtmlFacts.FormEvents
+        .SelectAsArray(e => RazorCompletionItem.CreateDirectiveAttributeEventParameterHtmlEventValue(e, e, s_commitCharacters));
+
+    private static readonly ImmutableArray<RazorCommitCharacter> s_commitCharacters = RazorCommitCharacter.CreateArray(["\"", " ", "'"]);
+
+    public ImmutableArray<RazorCompletionItem> GetCompletionItems(RazorCompletionContext context)
+    {
+        var owner = context.Owner?.FirstAncestorOrSelf<MarkupTagHelperDirectiveAttributeSyntax>();
+        if (owner is null)
+        {
+            return [];
+        }
+
+        if (owner is not
+            {
+                Colon.IsMissing: false,
+                ParameterName: { IsMissing: false, LiteralTokens: [{ Content: "event" }] },
+                EqualsToken.IsMissing: false,
+                ValuePrefix.IsMissing: false,
+                Value: { IsMissing: false } valueSyntax,
+            })
+        {
+            return [];
+        }
+
+        if (!valueSyntax.FullSpan.Contains(context.AbsoluteIndex) && valueSyntax.EndPosition != context.AbsoluteIndex)
+        {
+            return [];
+        }
+
+        return s_eventCompletionItems;
+    }
+}

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItem.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItem.cs
@@ -89,4 +89,9 @@ internal sealed class RazorCompletionItem
         AggregateBoundAttributeDescription descriptionInfo,
         ImmutableArray<RazorCommitCharacter> commitCharacters, bool isSnippet)
         => new(RazorCompletionItemKind.TagHelperAttribute, displayText, insertText, sortText, descriptionInfo, commitCharacters, isSnippet);
+
+    public static RazorCompletionItem CreateDirectiveAttributeEventParameterHtmlEventValue(
+        string displayText, string insertText,
+        ImmutableArray<RazorCommitCharacter> commitCharacters)
+        => new(RazorCompletionItemKind.DirectiveAttributeParameterEventValue, displayText, insertText, sortText: null, descriptionInfo: AggregateBoundAttributeDescription.Empty, commitCharacters, isSnippet: false);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItemKind.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionItemKind.cs
@@ -8,6 +8,7 @@ internal enum RazorCompletionItemKind
     Directive,
     DirectiveAttribute,
     DirectiveAttributeParameter,
+    DirectiveAttributeParameterEventValue,
     MarkupTransition,
     TagHelperElement,
     TagHelperAttribute,

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionListProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/RazorCompletionListProvider.cs
@@ -189,6 +189,23 @@ internal class RazorCompletionListProvider(
                     completionItem = parameterCompletionItem;
                     return true;
                 }
+            case RazorCompletionItemKind.DirectiveAttributeParameterEventValue:
+                {
+                    var eventValueCompletionItem = new VSInternalCompletionItem()
+                    {
+                        Label = razorCompletionItem.DisplayText,
+                        InsertText = razorCompletionItem.InsertText,
+                        FilterText = razorCompletionItem.InsertText,
+                        SortText = razorCompletionItem.SortText,
+                        InsertTextFormat = insertTextFormat,
+                        Kind = CompletionItemKind.Event,
+                    };
+
+                    eventValueCompletionItem.UseCommitCharactersFrom(razorCompletionItem, clientCapabilities);
+
+                    completionItem = eventValueCompletionItem;
+                    return true;
+                }
             case RazorCompletionItemKind.MarkupTransition:
                 {
                     var markupTransitionCompletionItem = new VSInternalCompletionItem()

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/HtmlFacts.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/HtmlFacts.cs
@@ -2,7 +2,8 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Frozen;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Razor.Language.Syntax;
 using Microsoft.CodeAnalysis.Text;
@@ -11,7 +12,7 @@ namespace Microsoft.VisualStudio.Editor.Razor;
 
 internal static class HtmlFacts
 {
-    private static readonly HashSet<string> s_htmlSchemaTagNames = new(StringComparer.OrdinalIgnoreCase)
+    private static readonly FrozenSet<string> s_htmlSchemaTagNames = new string[]
     {
         "DOCTYPE",
         "a",
@@ -136,7 +137,33 @@ internal static class HtmlFacts
         "var",
         "video",
         "wbr",
-    };
+    }.ToFrozenSet(StringComparer.Ordinal);
+
+    internal static readonly ImmutableArray<string> FormEvents =
+    [
+        "onabort",
+        "onblur",
+        "onchange",
+        "onclick",
+        "oncontextmenu",
+        "ondblclick",
+        "onerror",
+        "onfocus",
+        "oninput",
+        "onkeydown",
+        "onkeypress",
+        "onkeyup",
+        "onload",
+        "onmousedown",
+        "onmousemove",
+        "onmouseout",
+        "onmouseover",
+        "onmouseup",
+        "onreset",
+        "onscroll",
+        "onselect",
+        "onsubmit",
+    ];
 
     public static bool IsHtmlTagName(string name)
         => s_htmlSchemaTagNames.Contains(name);

--- a/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeEventParameterCompletionItemProviderTest.cs
+++ b/src/Razor/test/Microsoft.CodeAnalysis.Razor.Workspaces.Test/Completion/DirectiveAttributeEventParameterCompletionItemProviderTest.cs
@@ -1,0 +1,230 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.IntegrationTests;
+using Microsoft.AspNetCore.Razor.Language.Syntax;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.CodeAnalysis.Razor.Completion;
+
+public class DirectiveAttributeEventParameterCompletionItemProviderTest : RazorToolingIntegrationTestBase
+{
+    private readonly DirectiveAttributeEventParameterCompletionItemProvider _provider;
+
+    internal override string FileKind => FileKinds.Component;
+    internal override bool UseTwoPhaseCompilation => true;
+
+    public DirectiveAttributeEventParameterCompletionItemProviderTest(ITestOutputHelper testOutput)
+        : base(testOutput)
+    {
+        // Most of these completions rely on stuff in the web namespace.
+        ImportItems.Add(CreateProjectItem(
+            "_Imports.razor",
+            "@using Microsoft.AspNetCore.Components.Web"));
+
+        _provider = new DirectiveAttributeEventParameterCompletionItemProvider();
+    }
+
+    private RazorCodeDocument GetCodeDocument(string content)
+    {
+        var result = CompileToCSharp(content, throwOnFailure: false);
+        return result.CodeDocument;
+    }
+
+    [Fact]
+    public void GetCompletionItems_OnEmptyDirectiveAttributeEventParameter_ReturnsCompletions()
+    {
+        // Arrange
+        var context = CreateRazorCompletionContext("""
+            <input @bind="str" @bind:event="$$" />
+
+            @code {
+                private string? str;
+            }
+            """);
+
+        // Act
+        var completions = _provider.GetCompletionItems(context);
+
+        // Assert
+        AssertContains(completions, "oninput");
+        AssertContains(completions, "onchange");
+        AssertContains(completions, "onblur");
+    }
+
+    [Fact]
+    public void GetCompletionItems_OnNonEmptyDirectiveAttributeEventParameter_ReturnsCompletions()
+    {
+        // Arrange
+        var context = CreateRazorCompletionContext("""
+            <input @bind="str" @bind:event="onin$$put" />
+
+            @code {
+                private string? str;
+            }
+            """);
+
+        // Act
+        var completions = _provider.GetCompletionItems(context);
+
+        // Assert
+        AssertContains(completions, "oninput");
+        AssertContains(completions, "onchange");
+        AssertContains(completions, "onblur");
+    }
+
+    [Fact]
+    public void GetCompletionItems_OnEmptyButNotClosedDirectiveAttributeEventParameter_ReturnsCompletions()
+    {
+        // Arrange
+        var context = CreateRazorCompletionContext("""
+            <input @bind="str" @bind:event="$$ />
+
+            @code {
+                private string? str;
+            }
+            """);
+
+        // Act
+        var completions = _provider.GetCompletionItems(context);
+
+        // Assert
+        AssertContains(completions, "oninput");
+        AssertContains(completions, "onchange");
+        AssertContains(completions, "onblur");
+    }
+
+    [Fact]
+    public void GetCompletionItems_OnNonEmptyAndNotClosedDirectiveAttributeEventParameter_ReturnsCompletions()
+    {
+        // Arrange
+        var context = CreateRazorCompletionContext("""
+            <input @bind="str" @bind:event="oninput$$ />
+
+            @code {
+                private string? str;
+            }
+            """);
+
+        // Act
+        var completions = _provider.GetCompletionItems(context);
+
+        // Assert
+        AssertContains(completions, "oninput");
+        AssertContains(completions, "onchange");
+        AssertContains(completions, "onblur");
+    }
+
+    [Fact]
+    public void GetCompletionItems_BeforeDirectiveAttributeEventParameterAttributePrefix_DoesNotReturnCompletions()
+    {
+        // Arrange
+        var context = CreateRazorCompletionContext("""
+            <input @bind="str" @bind:event=$$"oninput" />
+
+            @code {
+                private string? str;
+            }
+            """);
+
+        // Act
+        var completions = _provider.GetCompletionItems(context);
+
+        // Assert
+        Assert.Empty(completions);
+    }
+
+    [Fact]
+    public void GetCompletionItems_AfterDirectiveAttributeEventParameterAttributeSuffix_DoesNotReturnCompletions()
+    {
+        // Arrange
+        var context = CreateRazorCompletionContext("""
+            <input @bind="str" @bind:event="oninput"$$ />
+
+            @code {
+                private string? str;
+            }
+            """);
+
+        // Act
+        var completions = _provider.GetCompletionItems(context);
+
+        // Assert
+        Assert.Empty(completions);
+    }
+
+    [Fact]
+    public void GetCompletionItems_OnHtmlEventAttribute_DoesNotReturnCompletions()
+    {
+        // Arrange
+        var context = CreateRazorCompletionContext("""
+            <input @bind="str" event="oni$$nput" />
+
+            @code {
+                private string? str;
+            }
+            """);
+
+        // Act
+        var completions = _provider.GetCompletionItems(context);
+
+        // Assert
+        Assert.Empty(completions);
+    }
+
+    [Fact]
+    public void GetCompletionItems_OnBindDirectiveAttribute_DoesNotReturnCompletions()
+    {
+        // Arrange
+        var context = CreateRazorCompletionContext("""
+            <input @bind="s$$tr" />
+
+            @code {
+                private string? str;
+            }
+            """);
+
+        // Act
+        var completions = _provider.GetCompletionItems(context);
+
+        // Assert
+        Assert.Empty(completions);
+    }
+
+    private static void AssertContains(IReadOnlyList<RazorCompletionItem> completions, string insertText)
+    {
+        Assert.Contains(completions, completion => insertText == completion.InsertText &&
+            insertText == completion.DisplayText &&
+            RazorCompletionItemKind.DirectiveAttributeParameterEventValue == completion.Kind);
+    }
+
+    private RazorCompletionContext CreateRazorCompletionContext(string documentContent)
+    {
+        documentContent = ExtractCaretPosition(documentContent, out var absoluteIndex);
+
+        var codeDocument = GetCodeDocument(documentContent);
+        var syntaxTree = codeDocument.GetSyntaxTree();
+        var tagHelperDocumentContext = codeDocument.GetTagHelperContext();
+
+        var owner = syntaxTree.Root.FindInnermostNode(absoluteIndex);
+        owner = AbstractRazorCompletionFactsService.AdjustSyntaxNodeForWordBoundary(owner, absoluteIndex);
+        return new RazorCompletionContext(absoluteIndex, owner, syntaxTree, tagHelperDocumentContext);
+
+        static string ExtractCaretPosition(string document, out int caretPosition)
+        {
+            var index = document.IndexOf("$$", StringComparison.Ordinal);
+            if (index == -1)
+            {
+                caretPosition = -1;
+                return document;
+            }
+
+            caretPosition = index;
+            return document.Remove(index, 2);
+        }
+    }
+}


### PR DESCRIPTION
﻿### Summary of the changes
Created a basic completion provider for completing HTML event names for `@bind:event` directive attribute parameter, primarily to cover the most common use case: setting it to `oninput` or `onchange`.

What is not included:
- Semantics of the HTML element the binding is applied on (see below at Alternatives)
- Event symbols of Component, it lists the HTML events only
- The "applicable to span" is not set, if I'm not mistaken it is not supported to set by the completion provider yet

Alternatives for schema data:
- Simple list of common form control events to cover the 99% use case (implemented in this PR)
- Include a schema for the list of all events as data (like VS Code HTML LS does)
  - But this seems like a broader initiative to have this in place as a fundamental service to be queried by other services
  - It also needs a process to be kept up to date
  - The [schema](https://github.com/microsoft/vscode-html-languageservice/blob/main/src/languageFacts/data/webCustomData.ts) found in the HTML LS repository doesn't contain any semantics, it is flat list among all attributes
- Dispatch call to the HTML LS in a virtual document to a virtual position to list the attributes of the element in context and then filter those to keep "events" only.
  - But how to distinguish event symbols, if the HTML LS does not seem to either
  - Use a name based "starts with on..." hack, which is not reliable
  - Altogether very complicated for small value but also incomplete and/or unreliable


