### PR TITLE
Support more expressions in `@page` directive

### DIFF
--- a/global.json
+++ b/global.json
@@ -19,7 +19,7 @@
   "sdk": {
     "version": "9.0.104",
     "allowPrerelease": false,
-    "rollForward": "major"
+    "rollForward": "latestPatch"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.25204.5",

--- a/global.json
+++ b/global.json
@@ -19,7 +19,7 @@
   "sdk": {
     "version": "9.0.104",
     "allowPrerelease": false,
-    "rollForward": "latestPatch"
+    "rollForward": "major"
   },
   "msbuild-sdks": {
     "Microsoft.DotNet.Arcade.Sdk": "9.0.0-beta.25204.5",

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/AssemblyAttributeInjectionPassTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/AssemblyAttributeInjectionPassTest.cs
@@ -427,6 +427,13 @@ public class AssemblyAttributeInjectionPassTest : RazorProjectEngineTestBase
         var pageDirective = new DirectiveIntermediateNode
         {
             Directive = PageDirective.Directive,
+            Children =
+            {
+                new DirectiveTokenIntermediateNode
+                {
+                    Content = "AppRoutes.Home",
+                }
+            },
         };
 
         builder.Add(pageDirective);

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/IntegrationTests/CodeGenerationIntegrationTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/IntegrationTests/CodeGenerationIntegrationTest.cs
@@ -165,7 +165,7 @@ public class MyModel
         AssertCSharpDocumentMatchesBaseline(compiled.CodeDocument.GetCSharpDocument());
 
         var diagnotics = compiled.CodeDocument.GetCSharpDocument().Diagnostics;
-        Assert.Equal("RZ1016", Assert.Single(diagnotics).Id);
+        Assert.Equal("RZ1046", Assert.Single(diagnotics).Id);
     }
 
     [Fact]
@@ -620,7 +620,7 @@ public class MyModel
         AssertSourceMappingsMatchBaseline(compiled.CodeDocument);
 
         var diagnotics = compiled.CodeDocument.GetCSharpDocument().Diagnostics;
-        Assert.Equal("RZ1016", Assert.Single(diagnotics).Id);
+        Assert.Equal("RZ1046", Assert.Single(diagnotics).Id);
     }
 
     [Fact]

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/PageDirectiveTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/PageDirectiveTest.cs
@@ -31,10 +31,9 @@ public class PageDirectiveTest : RazorProjectEngineTestBase
         var documentNode = processor.GetDocumentNode();
 
         // Act
-        var result = PageDirective.TryGetPageDirective(documentNode, out var pageDirective);
+        Assert.True(PageDirective.TryGetPageDirective(documentNode, out var pageDirective));
 
         // Assert
-        Assert.True(result);
         Assert.Equal("some-route-template", pageDirective.RouteTemplate);
         Assert.NotNull(pageDirective.DirectiveNode);
     }
@@ -51,10 +50,9 @@ public class PageDirectiveTest : RazorProjectEngineTestBase
         var documentNode = processor.GetDocumentNode();
 
         // Act
-        var result = PageDirective.TryGetPageDirective(documentNode, out var pageDirective);
+        Assert.True(PageDirective.TryGetPageDirective(documentNode, out var pageDirective));
 
         // Assert
-        Assert.True(result);
         Assert.Null(pageDirective.RouteTemplate);
     }
 
@@ -87,10 +85,9 @@ public class PageDirectiveTest : RazorProjectEngineTestBase
         var documentNode = processor.GetDocumentNode();
 
         // Act
-        var result = PageDirective.TryGetPageDirective(documentNode, out var pageDirective);
+        Assert.True(PageDirective.TryGetPageDirective(documentNode, out var pageDirective));
 
         // Assert
-        Assert.True(result);
         Assert.Null(pageDirective.RouteTemplate);
         Assert.NotNull(pageDirective.DirectiveNode);
     }
@@ -106,10 +103,9 @@ public class PageDirectiveTest : RazorProjectEngineTestBase
         var documentNode = processor.GetDocumentNode();
 
         // Act
-        var result = PageDirective.TryGetPageDirective(documentNode, out var pageDirective);
+        Assert.True(PageDirective.TryGetPageDirective(documentNode, out var pageDirective));
 
         // Assert
-        Assert.True(result);
         Assert.Null(pageDirective.RouteTemplate);
     }
 
@@ -124,10 +120,9 @@ public class PageDirectiveTest : RazorProjectEngineTestBase
         var documentNode = processor.GetDocumentNode();
 
         // Act
-        var result = PageDirective.TryGetPageDirective(documentNode, out var pageDirective);
+        Assert.True(PageDirective.TryGetPageDirective(documentNode, out var pageDirective));
 
         // Assert
-        Assert.True(result);
         Assert.Equal("some-route-template", pageDirective.RouteTemplate);
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
@@ -18,6 +18,14 @@ namespace AspNetCore
         #pragma warning disable 219
         private void __RazorDirectiveTokenHelpers__() {
         ((global::System.Action)(() => {
+#line 4 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+ 
+
+#line default
+#line hidden
+        }
+        ))();
+        ((global::System.Action)(() => {
 #line 8 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
  
 

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.diagnostics.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.diagnostics.txt
@@ -1,6 +1,6 @@
 ﻿TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(4,1): Error RZ2001: The 'page' directive may only occur once per document.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(5,1): Error RZ2001: The 'page' directive may only occur once per document.
-TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(5,7): Error RZ1016: The 'page' directive expects a string surrounded by double quotes.
+TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(5,7): Error RZ1046: The 'page' directive expects an identifier or explicit razor expression ("@()") or a string surrounded by double quotes.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(7,7): Error RZ1013: The 'model' directive expects a type name.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(8,1): Error RZ2001: The 'model' directive may only occur once per document.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(8,8): Error RZ1013: The 'model' directive expects a type name.

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
@@ -23,6 +23,7 @@
                 DirectiveToken - (617:12,14 [96] ) - Microsoft.AspNetCore.Mvc.Razor.TagHelpers.UrlResolutionTagHelper, Microsoft.AspNetCore.Mvc.Razor
                 DirectiveToken - (729:13,14 [87] ) - Microsoft.AspNetCore.Mvc.Razor.TagHelpers.HeadTagHelper, Microsoft.AspNetCore.Mvc.Razor
                 DirectiveToken - (832:14,14 [87] ) - Microsoft.AspNetCore.Mvc.Razor.TagHelpers.BodyTagHelper, Microsoft.AspNetCore.Mvc.Razor
+                DirectiveToken - (100:3,6 [0] IncompleteDirectives.cshtml) - 
                 DirectiveToken - (128:7,7 [0] IncompleteDirectives.cshtml) - 
                 DirectiveToken - (149:10,8 [0] IncompleteDirectives.cshtml) - 
                 DirectiveToken - (159:11,8 [17] IncompleteDirectives.cshtml) - MyService<TModel>
@@ -37,6 +38,7 @@
                 HtmlContent - (85:1,0 [2] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (85:1,0 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (94:3,0 [8] IncompleteDirectives.cshtml) - page
+                    DirectiveToken - (100:3,6 [0] IncompleteDirectives.cshtml) - 
                 MalformedDirective - (102:4,0 [6] IncompleteDirectives.cshtml) - page
                 HtmlContent - (108:4,6 [5] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (108:4,6 [5] IncompleteDirectives.cshtml) - Html - "\n\n

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
@@ -1,35 +1,40 @@
-﻿Source Location: (128:7,7 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+﻿Source Location: (100:3,6 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
 Generated Location: (813:21,0 [0] )
 ||
 
+Source Location: (128:7,7 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+||
+Generated Location: (1011:29,0 [0] )
+||
+
 Source Location: (149:10,8 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (1012:29,0 [0] )
+Generated Location: (1210:37,0 [0] )
 ||
 
 Source Location: (159:11,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 |MyService<TModel>|
-Generated Location: (1211:37,0 [17] )
+Generated Location: (1409:45,0 [17] )
 |MyService<TModel>|
 
 Source Location: (203:14,11 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (1450:45,0 [0] )
+Generated Location: (1648:53,0 [0] )
 ||
 
 Source Location: (119:6,6 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (1910:60,6 [0] )
+Generated Location: (2108:68,6 [0] )
 ||
 
 Source Location: (139:9,7 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (2047:65,7 [0] )
+Generated Location: (2245:73,7 [0] )
 ||
 
 Source Location: (190:13,10 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (2187:70,10 [0] )
+Generated Location: (2385:78,10 [0] )
 ||
 

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.diagnostics.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.diagnostics.txt
@@ -1,6 +1,6 @@
 ﻿TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(4,1): Error RZ2001: The 'page' directive may only occur once per document.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(5,1): Error RZ2001: The 'page' directive may only occur once per document.
-TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(5,7): Error RZ1016: The 'page' directive expects a string surrounded by double quotes.
+TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(5,7): Error RZ1046: The 'page' directive expects an identifier or explicit razor expression ("@()") or a string surrounded by double quotes.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(7,7): Error RZ1013: The 'model' directive expects a type name.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(8,1): Error RZ2001: The 'model' directive may only occur once per document.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(8,8): Error RZ1013: The 'model' directive expects a type name.

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
@@ -20,6 +20,7 @@
                 CSharpCode - 
                     IntermediateToken -  - CSharp - EndContext();
                 MalformedDirective - (94:3,0 [8] IncompleteDirectives.cshtml) - page
+                    DirectiveToken - (100:3,6 [0] IncompleteDirectives.cshtml) - 
                 MalformedDirective - (102:4,0 [6] IncompleteDirectives.cshtml) - page
                 CSharpCode - 
                     IntermediateToken -  - CSharp - BeginContext(108, 5, true);

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective_DesignTime.diagnostics.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective_DesignTime.diagnostics.txt
@@ -1,1 +1,1 @@
-﻿TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective.cshtml(1,7): Error RZ1016: The 'page' directive expects a string surrounded by double quotes.
+﻿TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective.cshtml(1,7): Error RZ1046: The 'page' directive expects an identifier or explicit razor expression ("@()") or a string surrounded by double quotes.

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective_Runtime.diagnostics.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions.Version2_X/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective_Runtime.diagnostics.txt
@@ -1,1 +1,1 @@
-﻿TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective.cshtml(1,7): Error RZ1016: The 'page' directive expects a string surrounded by double quotes.
+﻿TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective.cshtml(1,7): Error RZ1046: The 'page' directive expects an identifier or explicit razor expression ("@()") or a string surrounded by double quotes.

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/IntegrationTests/CodeGenerationIntegrationTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/IntegrationTests/CodeGenerationIntegrationTest.cs
@@ -201,7 +201,7 @@ public class CodeGenerationIntegrationTest : IntegrationTestBase
         AssertLinePragmas(compiled.CodeDocument, designTime: false);
 
         var diagnotics = compiled.CodeDocument.GetCSharpDocument().Diagnostics;
-        Assert.Equal("RZ1016", Assert.Single(diagnotics).Id);
+        Assert.Equal("RZ1046", Assert.Single(diagnotics).Id);
     }
 
     [Fact]
@@ -1113,7 +1113,7 @@ public class CodeGenerationIntegrationTest : IntegrationTestBase
         AssertSourceMappingsMatchBaseline(compiled.CodeDocument);
 
         var diagnotics = compiled.CodeDocument.GetCSharpDocument().Diagnostics;
-        Assert.Equal("RZ1016", Assert.Single(diagnotics).Id);
+        Assert.Equal("RZ1046", Assert.Single(diagnotics).Id);
     }
 
     [Fact]

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/PageDirectiveTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/PageDirectiveTest.cs
@@ -109,4 +109,20 @@ public class PageDirectiveTest : RazorProjectEngineTestBase
         // Assert
         Assert.Equal("some-route-template", pageDirective.RouteTemplate);
     }
+
+    [Fact]
+    public void TryGetPageDirective_ParsesExpressionRouteTemplate()
+    {
+        // Arrange
+        var codeDocument = ProjectEngine.CreateCodeDocument("@page AppRoutes.Home");
+        var processor = CreateCodeDocumentProcessor(codeDocument);
+        var documentNode = processor.GetDocumentNode();
+
+        // Act
+        Assert.True(PageDirective.TryGetPageDirective(documentNode, out var pageDirective));
+
+        // Assert
+        Assert.Null(pageDirective!.RouteTemplate);
+        Assert.Equal("AppRoutes.Home", pageDirective.RouteTemplateNode!.Content);
+    }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/PageDirectiveTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/PageDirectiveTest.cs
@@ -122,7 +122,103 @@ public class PageDirectiveTest : RazorProjectEngineTestBase
         Assert.True(PageDirective.TryGetPageDirective(documentNode, out var pageDirective));
 
         // Assert
-        Assert.Null(pageDirective!.RouteTemplate);
+        Assert.Null(pageDirective.RouteTemplate);
         Assert.Equal("AppRoutes.Home", pageDirective.RouteTemplateNode!.Content);
+        Assert.Null(pageDirective.RouteTemplateToken);
+    }
+
+    [Fact]
+    public void TryGetPageDirective_DoesNotParseInterpolatedStringRouteTemplate()
+    {
+        // Arrange
+        var content = "@page $\"some-route-template\"";
+        var source = TestRazorSourceDocument.Create(content, filePath: "file");
+        var codeDocument = ProjectEngine.CreateCodeDocument(source);
+        var processor = CreateCodeDocumentProcessor(codeDocument);
+        var documentNode = processor.GetDocumentNode();
+
+        // Act
+        Assert.True(PageDirective.TryGetPageDirective(documentNode, out var pageDirective));
+
+        // Assert
+        Assert.Null(pageDirective.RouteTemplate);
+        Assert.Null(pageDirective.RouteTemplateNode);
+        Assert.Null(pageDirective.RouteTemplateToken);
+    }
+
+    [Fact]
+    public void TryGetPageDirective_ParsesCSharpExpression()
+    {
+        // Arrange
+        var content = "@page @(AppRoutes.Content + AppRoutes.Content.Home)";
+        var source = TestRazorSourceDocument.Create(content, filePath: "file");
+        var codeDocument = ProjectEngine.CreateCodeDocument(source);
+        var processor = CreateCodeDocumentProcessor(codeDocument);
+        var documentNode = processor.GetDocumentNode();
+
+        // Act
+        Assert.True(PageDirective.TryGetPageDirective(documentNode, out var pageDirective));
+
+        // Assert
+        Assert.Null(pageDirective.RouteTemplate);
+        Assert.Null(pageDirective.RouteTemplateNode);
+        Assert.Equal("AppRoutes.Content + AppRoutes.Content.Home", pageDirective.RouteTemplateToken!.Content);
+    }
+
+    [Fact]
+    public void TryGetPageDirective_ParsesCSharpExpressionContainingInterpolatedString()
+    {
+        // Arrange
+        var content = "@page @($\"{AppRoutes.Content}{AppRoutes.Content.Home}\")";
+        var source = TestRazorSourceDocument.Create(content, filePath: "file");
+        var codeDocument = ProjectEngine.CreateCodeDocument(source);
+        var processor = CreateCodeDocumentProcessor(codeDocument);
+        var documentNode = processor.GetDocumentNode();
+
+        // Act
+        Assert.True(PageDirective.TryGetPageDirective(documentNode, out var pageDirective));
+
+        // Assert
+        Assert.Null(pageDirective.RouteTemplate);
+        Assert.Null(pageDirective.RouteTemplateNode);
+        Assert.Equal("$\"{AppRoutes.Content}{AppRoutes.Content.Home}\"", pageDirective.RouteTemplateToken!.Content);
+    }
+
+    [Fact]
+    public void TryGetPageDirective_ParsesCSharpExpressionContainingVerbatimInterpolatedString()
+    {
+        // Arrange
+        var content = "@page @(@$\"{AppRoutes.Content}{AppRoutes.Content.Home}\")";
+        var source = TestRazorSourceDocument.Create(content, filePath: "file");
+        var codeDocument = ProjectEngine.CreateCodeDocument(source);
+        var processor = CreateCodeDocumentProcessor(codeDocument);
+        var documentNode = processor.GetDocumentNode();
+
+        // Act
+        Assert.True(PageDirective.TryGetPageDirective(documentNode, out var pageDirective));
+
+        // Assert
+        Assert.Null(pageDirective.RouteTemplate);
+        Assert.Null(pageDirective.RouteTemplateNode);
+        Assert.Equal("@$\"{AppRoutes.Content}{AppRoutes.Content.Home}\"", pageDirective.RouteTemplateToken!.Content);
+    }
+
+    [Fact]
+    public void TryGetPageDirective_ParsesCSharpExpressionContainingInterpolatedVerbatimString()
+    {
+        // Arrange
+        var content = "@page @($@\"{AppRoutes.Content}{AppRoutes.Content.Home}\")";
+        var source = TestRazorSourceDocument.Create(content, filePath: "file");
+        var codeDocument = ProjectEngine.CreateCodeDocument(source);
+        var processor = CreateCodeDocumentProcessor(codeDocument);
+        var documentNode = processor.GetDocumentNode();
+
+        // Act
+        Assert.True(PageDirective.TryGetPageDirective(documentNode, out var pageDirective));
+
+        // Assert
+        Assert.Null(pageDirective.RouteTemplate);
+        Assert.Null(pageDirective.RouteTemplateNode);
+        Assert.Equal("$@\"{AppRoutes.Content}{AppRoutes.Content.Home}\"", pageDirective.RouteTemplateToken!.Content);
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.codegen.cs
@@ -23,6 +23,16 @@ namespace AspNetCoreGeneratedDocument
         private void __RazorDirectiveTokenHelpers__() {
         ((global::System.Action)(() => {
 #nullable restore
+#line 4 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
+ 
+
+#line default
+#line hidden
+#nullable disable
+        }
+        ))();
+        ((global::System.Action)(() => {
+#nullable restore
 #line 8 "TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml"
  
 

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.diagnostics.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.diagnostics.txt
@@ -1,6 +1,6 @@
 ﻿TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(4,1): Error RZ2001: The 'page' directive may only occur once per document.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(5,1): Error RZ2001: The 'page' directive may only occur once per document.
-TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(5,7): Error RZ1016: The 'page' directive expects a string surrounded by double quotes.
+TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(5,7): Error RZ1046: The 'page' directive expects an identifier or explicit razor expression ("@()") or a string surrounded by double quotes.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(7,7): Error RZ1013: The 'model' directive expects a type name.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(8,1): Error RZ2001: The 'model' directive may only occur once per document.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(8,8): Error RZ1013: The 'model' directive expects a type name.

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.ir.txt
@@ -25,6 +25,7 @@
                 DirectiveToken - (673:12,14 [104] ) - global::Microsoft.AspNetCore.Mvc.Razor.TagHelpers.UrlResolutionTagHelper, Microsoft.AspNetCore.Mvc.Razor
                 DirectiveToken - (793:13,14 [95] ) - global::Microsoft.AspNetCore.Mvc.Razor.TagHelpers.HeadTagHelper, Microsoft.AspNetCore.Mvc.Razor
                 DirectiveToken - (904:14,14 [95] ) - global::Microsoft.AspNetCore.Mvc.Razor.TagHelpers.BodyTagHelper, Microsoft.AspNetCore.Mvc.Razor
+                DirectiveToken - (100:3,6 [0] IncompleteDirectives.cshtml) - 
                 DirectiveToken - (128:7,7 [0] IncompleteDirectives.cshtml) - 
                 DirectiveToken - (149:10,8 [0] IncompleteDirectives.cshtml) - 
                 DirectiveToken - (159:11,8 [17] IncompleteDirectives.cshtml) - MyService<TModel>
@@ -39,6 +40,7 @@
                 HtmlContent - (85:1,0 [2] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (85:1,0 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (94:3,0 [8] IncompleteDirectives.cshtml) - page
+                    DirectiveToken - (100:3,6 [0] IncompleteDirectives.cshtml) - 
                 MalformedDirective - (102:4,0 [6] IncompleteDirectives.cshtml) - page
                 HtmlContent - (108:4,6 [5] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (108:4,6 [5] IncompleteDirectives.cshtml) - Html - "\n\n

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_DesignTime.mappings.txt
@@ -1,35 +1,40 @@
-﻿Source Location: (128:7,7 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+﻿Source Location: (100:3,6 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
 Generated Location: (1230:26,0 [0] )
 ||
 
+Source Location: (128:7,7 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
+||
+Generated Location: (1466:36,0 [0] )
+||
+
 Source Location: (149:10,8 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (1467:36,0 [0] )
+Generated Location: (1703:46,0 [0] )
 ||
 
 Source Location: (159:11,8 [17] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 |MyService<TModel>|
-Generated Location: (1704:46,0 [17] )
+Generated Location: (1940:56,0 [17] )
 |MyService<TModel>|
 
 Source Location: (203:14,11 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (1982:56,0 [0] )
+Generated Location: (2218:66,0 [0] )
 ||
 
 Source Location: (119:6,6 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (2480:73,6 [0] )
+Generated Location: (2716:83,6 [0] )
 ||
 
 Source Location: (139:9,7 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (2655:80,7 [0] )
+Generated Location: (2891:90,7 [0] )
 ||
 
 Source Location: (190:13,10 [0] TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml)
 ||
-Generated Location: (2833:87,10 [0] )
+Generated Location: (3069:97,10 [0] )
 ||
 

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.diagnostics.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.diagnostics.txt
@@ -1,6 +1,6 @@
 ﻿TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(4,1): Error RZ2001: The 'page' directive may only occur once per document.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(5,1): Error RZ2001: The 'page' directive may only occur once per document.
-TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(5,7): Error RZ1016: The 'page' directive expects a string surrounded by double quotes.
+TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(5,7): Error RZ1046: The 'page' directive expects an identifier or explicit razor expression ("@()") or a string surrounded by double quotes.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(7,7): Error RZ1013: The 'model' directive expects a type name.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(8,1): Error RZ2001: The 'model' directive may only occur once per document.
 TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives.cshtml(8,8): Error RZ1013: The 'model' directive expects a type name.

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/IncompleteDirectives_Runtime.ir.txt
@@ -16,6 +16,7 @@
                 HtmlContent - (85:1,0 [2] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (85:1,0 [2] IncompleteDirectives.cshtml) - Html - \n
                 MalformedDirective - (94:3,0 [8] IncompleteDirectives.cshtml) - page
+                    DirectiveToken - (100:3,6 [0] IncompleteDirectives.cshtml) - 
                 MalformedDirective - (102:4,0 [6] IncompleteDirectives.cshtml) - page
                 HtmlContent - (108:4,6 [5] IncompleteDirectives.cshtml)
                     LazyIntermediateToken - (108:4,6 [5] IncompleteDirectives.cshtml) - Html - "\n\n

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective_DesignTime.diagnostics.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective_DesignTime.diagnostics.txt
@@ -1,1 +1,1 @@
-﻿TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective.cshtml(1,7): Error RZ1016: The 'page' directive expects a string surrounded by double quotes.
+﻿TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective.cshtml(1,7): Error RZ1046: The 'page' directive expects an identifier or explicit razor expression ("@()") or a string surrounded by double quotes.

--- a/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective_Runtime.diagnostics.txt
+++ b/src/Compiler/Microsoft.AspNetCore.Mvc.Razor.Extensions/test/TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective_Runtime.diagnostics.txt
@@ -1,1 +1,1 @@
-﻿TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective.cshtml(1,7): Error RZ1016: The 'page' directive expects a string surrounded by double quotes.
+﻿TestFiles/IntegrationTests/CodeGenerationIntegrationTest/MalformedPageDirective.cshtml(1,7): Error RZ1046: The 'page' directive expects an identifier or explicit razor expression ("@()") or a string surrounded by double quotes.

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentPageDirective.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Components/ComponentPageDirective.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Razor.Language.Intermediate;
 
 namespace Microsoft.AspNetCore.Razor.Language.Components;
 
+// HELP: Is this used anywhere?
 internal class ComponentPageDirective
 {
     public static readonly DirectiveDescriptor Directive = DirectiveDescriptor.CreateDirective(

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DirectiveDescriptorBuilderExtensions.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DirectiveDescriptorBuilderExtensions.cs
@@ -284,4 +284,21 @@ public static class DirectiveDescriptorBuilderExtensions
 
         return builder;
     }
+
+    public static IDirectiveDescriptorBuilder AddOptionalIdentifierOrExpressionOrString(this IDirectiveDescriptorBuilder builder, string name, string description)
+    {
+        if (builder == null)
+        {
+            throw new ArgumentNullException(nameof(builder));
+        }
+
+        builder.Tokens.Add(
+            DirectiveTokenDescriptor.CreateToken(
+                DirectiveTokenKind.IdentifierOrExpressionOrString,
+                optional: true,
+                name: name,
+                description: description));
+
+        return builder;
+    }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DirectiveTokenKind.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DirectiveTokenKind.cs
@@ -14,5 +14,6 @@ public enum DirectiveTokenKind
     Attribute,
     Boolean,
     GenericTypeConstraint,
-    IdentifierOrExpression
+    IdentifierOrExpression,
+    IdentifierOrExpressionOrString
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Extensions/DesignTimeDirectiveTargetExtension.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Extensions/DesignTimeDirectiveTargetExtension.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System;
+using System.Diagnostics;
 using Microsoft.AspNetCore.Razor.Language.CodeGeneration;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
 
@@ -215,6 +216,9 @@ internal class DesignTimeDirectiveTargetExtension : IDesignTimeDirectiveTargetEx
                         context.CodeWriter.WriteLine(";");
                     }
                     break;
+
+                case DirectiveTokenKind.IdentifierOrExpressionOrString:
+                    throw new NotSupportedException("This directive token kind is not supported");
             }
             context.CodeWriter.CurrentIndent = originalIndent;
         }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Extensions/DesignTimeDirectiveTargetExtension.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Extensions/DesignTimeDirectiveTargetExtension.cs
@@ -218,6 +218,9 @@ internal class DesignTimeDirectiveTargetExtension : IDesignTimeDirectiveTargetEx
                     break;
 
                 case DirectiveTokenKind.IdentifierOrExpressionOrString:
+                    // This token is only used in the @page directive so far,
+                    // which should not trigger a call here. Hence this remains
+                    // unsupported until demanded.
                     throw new NotSupportedException("This directive token kind is not supported");
             }
             context.CodeWriter.CurrentIndent = originalIndent;

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Extensions/DesignTimeDirectiveTargetExtension.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Extensions/DesignTimeDirectiveTargetExtension.cs
@@ -54,6 +54,17 @@ internal class DesignTimeDirectiveTargetExtension : IDesignTimeDirectiveTargetEx
             return;
         }
 
+        if (tokenKind is DirectiveTokenKind.IdentifierOrExpressionOrString)
+        {
+            // We need to evaluate the kind of content that we have received,
+            // either an identifier or expression, or a simple string
+            // This does not support verbatim/interpolated/raw strings
+            // We simply check the expression's type and reuse the logic below
+            tokenKind = node.Content.StartsWith('"')
+                ? DirectiveTokenKind.String
+                : DirectiveTokenKind.IdentifierOrExpression;
+        }
+
         // Wrap the directive token in a lambda to isolate variable names.
         context.CodeWriter
             .Write("((global::")
@@ -218,10 +229,7 @@ internal class DesignTimeDirectiveTargetExtension : IDesignTimeDirectiveTargetEx
                     break;
 
                 case DirectiveTokenKind.IdentifierOrExpressionOrString:
-                    // This token is only used in the @page directive so far,
-                    // which should not trigger a call here. Hence this remains
-                    // unsupported until demanded.
-                    throw new NotSupportedException("This directive token kind is not supported");
+                    throw new NotSupportedException("This directive token kind should have been handled");
             }
             context.CodeWriter.CurrentIndent = originalIndent;
         }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/FieldDeclarationIntermediateNode.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Intermediate/FieldDeclarationIntermediateNode.cs
@@ -20,6 +20,8 @@ public sealed class FieldDeclarationIntermediateNode : MemberDeclarationIntermed
 
     public string FieldType { get; set; }
 
+    public string Initializer { get; set; }
+
     public override void Accept(IntermediateNodeVisitor visitor)
     {
         if (visitor == null)
@@ -37,5 +39,6 @@ public sealed class FieldDeclarationIntermediateNode : MemberDeclarationIntermed
         formatter.WriteProperty(nameof(FieldName), FieldName);
         formatter.WriteProperty(nameof(FieldType), FieldType);
         formatter.WriteProperty(nameof(Modifiers), string.Join(" ", Modifiers));
+        formatter.WriteProperty(nameof(Initializer), Initializer);
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/CSharpCodeParser.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/CSharpCodeParser.cs
@@ -1736,9 +1736,8 @@ internal class CSharpCodeParser : TokenizerBackedParser<CSharpTokenizer>
                             }
                             else
                             {
-                                // TODO: Create a specialized error for this token kind
                                 Context.ErrorSink.OnError(
-                                    RazorDiagnosticFactory.CreateParsing_DirectiveExpectsQuotedStringLiteral(
+                                    RazorDiagnosticFactory.CreateParsing_DirectiveExpectsIdentifierOrExpressionOrString(
                                         new SourceSpan(CurrentStart, CurrentToken.Content.Length), descriptor.Directive));
 
                                 // Default to a string literal as the missing token's kind

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/CSharpCodeParser.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/CSharpCodeParser.cs
@@ -1511,7 +1511,8 @@ internal class CSharpCodeParser : TokenizerBackedParser<CSharpTokenizer>
                             tokenDescriptor.Kind == DirectiveTokenKind.Attribute ||
                             tokenDescriptor.Kind == DirectiveTokenKind.GenericTypeConstraint ||
                             tokenDescriptor.Kind == DirectiveTokenKind.Boolean ||
-                            tokenDescriptor.Kind == DirectiveTokenKind.IdentifierOrExpression)
+                            tokenDescriptor.Kind == DirectiveTokenKind.IdentifierOrExpression ||
+                            tokenDescriptor.Kind == DirectiveTokenKind.IdentifierOrExpressionOrString)
                         {
                             directiveBuilder.Add(OutputTokensAsStatementLiteral());
 
@@ -1715,6 +1716,37 @@ internal class CSharpCodeParser : TokenizerBackedParser<CSharpTokenizer>
                             }
 
                             break;
+
+                        case DirectiveTokenKind.IdentifierOrExpressionOrString:
+                            if (At(SyntaxKind.Transition) && NextIs(SyntaxKind.LeftParenthesis))
+                            {
+                                AcceptAndMoveNext();
+                                directiveBuilder.Add(OutputAsMetaCode(Output()));
+
+                                var expression = ParseExplicitExpressionBody();
+                                directiveBuilder.Add(expression);
+                            }
+                            else if (TryParseQualifiedIdentifier(out _))
+                            {
+                                break;
+                            }
+                            else if (At(SyntaxKind.StringLiteral) && !CurrentToken.ContainsDiagnostics)
+                            {
+                                AcceptAndMoveNext();
+                            }
+                            else
+                            {
+                                // TODO: Create a specialized error for this token kind
+                                Context.ErrorSink.OnError(
+                                    RazorDiagnosticFactory.CreateParsing_DirectiveExpectsQuotedStringLiteral(
+                                        new SourceSpan(CurrentStart, CurrentToken.Content.Length), descriptor.Directive));
+
+                                // Default to a string literal as the missing token's kind
+                                builder.Add(BuildDirective(SyntaxKind.StringLiteral));
+                                return;
+                            }
+                            break;
+
                     }
 
                     chunkGenerator = new DirectiveTokenChunkGenerator(tokenDescriptor);

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorDiagnosticFactory.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/RazorDiagnosticFactory.cs
@@ -396,6 +396,14 @@ internal static class RazorDiagnosticFactory
     public static RazorDiagnostic CreateParsing_DefineAndUndefNotAllowed(SourceSpan location)
         => RazorDiagnostic.Create(Parsing_DefineAndUndefNotAllowed, location);
 
+    internal static readonly RazorDiagnosticDescriptor Parsing_DirectiveExpectsIdentifierOrExpressionOrString =
+        new($"{DiagnosticPrefix}1046",
+            Resources.DirectiveExpectsIdentifierOrExpressionOrStringLiteral,
+            RazorDiagnosticSeverity.Error);
+
+    public static RazorDiagnostic CreateParsing_DirectiveExpectsIdentifierOrExpressionOrString(SourceSpan location, string directiveName)
+        => RazorDiagnostic.Create(Parsing_DirectiveExpectsIdentifierOrExpressionOrString, location, directiveName);
+
     #endregion
 
     #region Semantic Errors

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Resources.resx
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Resources.resx
@@ -616,4 +616,7 @@
   <data name="Possible_preprocessor_directive_is_misplaced" xml:space="preserve">
     <value>Possible C# preprocessor directive is misplaced. C# preprocessor directives must be at the start of the line, except for whitespace.</value>
   </data>
+  <data name="DirectiveExpectsIdentifierOrExpressionOrStringLiteral" xml:space="preserve">
+    <value>The '{0}' directive expects an identifier or explicit razor expression ("@()") or a string surrounded by double quotes.</value>
+  </data>
 </root>

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Mvc.Version2_X/AssemblyAttributeInjectionPass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Mvc.Version2_X/AssemblyAttributeInjectionPass.cs
@@ -83,7 +83,7 @@ public class AssemblyAttributeInjectionPass : IntermediateNodePassBase, IRazorOp
             return MakeVerbatimStringLiteral(directive.RouteTemplate);
         }
 
-        if (!string.IsNullOrEmpty(directive.RouteTemplateNode?.Content))
+        if (!string.IsNullOrEmpty(directive.RouteTemplateContent))
         {
             // If we have a complex expression assigned to the route template,
             // we generate a public const field named __RouteTemplate assigned

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Mvc/PageDirective.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Mvc/PageDirective.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
@@ -55,7 +56,7 @@ public class PageDirective
         return builder;
     }
 
-    public static bool TryGetPageDirective(DocumentIntermediateNode documentNode, out PageDirective? pageDirective)
+    public static bool TryGetPageDirective(DocumentIntermediateNode documentNode, [NotNullWhen(true)] out PageDirective? pageDirective)
     {
         var visitor = new Visitor();
         for (var i = 0; i < documentNode.Children.Count; i++)

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Mvc/PageDirective.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Mvc/PageDirective.cs
@@ -44,6 +44,8 @@ public class PageDirective
 
     public IntermediateToken? RouteTemplateToken { get; }
 
+    public string? RouteTemplateContent => RouteTemplateNode?.Content ?? RouteTemplateToken?.Content;
+
     public IntermediateNode DirectiveNode { get; }
 
     public SourceSpan? Source { get; }
@@ -96,7 +98,8 @@ public class PageDirective
 
         Debug.Assert(visitor.DirectiveNode is not null);
 
-        pageDirective = new PageDirective(routeTemplate, routeTemplateNode, routeTemplateLazyToken, visitor.DirectiveNode, sourceSpan);
+        pageDirective = new PageDirective(routeTemplate, routeTemplateNode,
+            routeTemplateLazyToken, visitor.DirectiveNode, sourceSpan);
         return true;
     }
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Mvc/RazorPageDocumentClassifierPass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Mvc/RazorPageDocumentClassifierPass.cs
@@ -5,8 +5,10 @@
 
 using System.Diagnostics;
 using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.Language.Components;
 using Microsoft.AspNetCore.Razor.Language.Extensions;
 using Microsoft.AspNetCore.Razor.Language.Intermediate;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Microsoft.AspNetCore.Mvc.Razor.Extensions;
 
@@ -110,17 +112,19 @@ public class RazorPageDocumentClassifierPass : DocumentClassifierPassBase
         EnsureValidPageDirective(codeDocument, pageDirective);
 
         AddRouteTemplateMetadataAttribute(@namespace, @class, pageDirective);
+
+        AddRouteTemplateConstant(@class, pageDirective);
     }
 
-    private static void AddRouteTemplateMetadataAttribute(NamespaceDeclarationIntermediateNode @namespace, ClassDeclarationIntermediateNode @class, PageDirective pageDirective)
+    private void AddRouteTemplateMetadataAttribute(NamespaceDeclarationIntermediateNode @namespace, ClassDeclarationIntermediateNode @class, PageDirective pageDirective)
     {
-        if (string.IsNullOrEmpty(pageDirective.RouteTemplate))
+        var classIndex = @namespace.Children.IndexOf(@class);
+        if (classIndex == -1)
         {
             return;
         }
 
-        var classIndex = @namespace.Children.IndexOf(@class);
-        if (classIndex == -1)
+        if (pageDirective.RouteTemplateNode is null)
         {
             return;
         }
@@ -134,6 +138,42 @@ public class RazorPageDocumentClassifierPass : DocumentClassifierPassBase
         };
         // Metadata attributes need to be inserted right before the class declaration.
         @namespace.Children.Insert(classIndex, metadataAttributeNode);
+    }
+
+    private void AddRouteTemplateConstant(ClassDeclarationIntermediateNode @class, PageDirective pageDirective)
+    {
+        if (pageDirective.RouteTemplateNode is null)
+        {
+            return;
+        }
+
+        // If we have a constant route template known to the Razor compiler,
+        // like a simple quoted string, we do not generate an internal constant
+        // member for the route template
+        if (pageDirective.RouteTemplate is not null)
+        {
+            return;
+        }
+
+        var routeTemplateConstNode = new FieldDeclarationIntermediateNode
+        {
+            Annotations =
+            {
+                [ComponentMetadata.Common.IsDesignTimePropertyAccessHelper] = bool.TrueString,
+            },
+            Modifiers =
+            {
+                "public",
+                "const",
+            },
+            FieldName = ViewComponentTypes.PageRouteTemplateFieldName,
+            FieldType = "string",
+            Initializer = pageDirective.RouteTemplateNode.Content,
+        };
+        var constBuilder = IntermediateNodeBuilder.Create(@class);
+        constBuilder.Push(routeTemplateConstNode);
+
+        @class.Children.Insert(0, routeTemplateConstNode);
     }
 
     private void EnsureValidPageDirective(RazorCodeDocument codeDocument, PageDirective pageDirective)

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Mvc/RazorPageDocumentClassifierPass.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Mvc/RazorPageDocumentClassifierPass.cs
@@ -124,7 +124,8 @@ public class RazorPageDocumentClassifierPass : DocumentClassifierPassBase
             return;
         }
 
-        if (pageDirective.RouteTemplateNode is null)
+        // Only generate this attribute on Razor compile-time-known strings
+        if (pageDirective.RouteTemplate is null)
         {
             return;
         }
@@ -142,7 +143,8 @@ public class RazorPageDocumentClassifierPass : DocumentClassifierPassBase
 
     private void AddRouteTemplateConstant(ClassDeclarationIntermediateNode @class, PageDirective pageDirective)
     {
-        if (pageDirective.RouteTemplateNode is null)
+        var content = pageDirective.RouteTemplateContent;
+        if (content is null)
         {
             return;
         }
@@ -168,7 +170,7 @@ public class RazorPageDocumentClassifierPass : DocumentClassifierPassBase
             },
             FieldName = ViewComponentTypes.PageRouteTemplateFieldName,
             FieldType = "string",
-            Initializer = pageDirective.RouteTemplateNode.Content,
+            Initializer = content,
         };
         var constBuilder = IntermediateNodeBuilder.Create(@class);
         constBuilder.Push(routeTemplateConstNode);

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Mvc/ViewComponentTypes.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Mvc/ViewComponentTypes.cs
@@ -29,6 +29,8 @@ internal static class ViewComponentTypes
 
     public const string SyncMethodName = "Invoke";
 
+    public const string PageRouteTemplateFieldName = "__RouteTemplate";
+
     public static class ViewComponent
     {
         public const string Name = "Name";

--- a/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/IntermediateNodeWriter.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/Language/IntegrationTests/IntermediateNodeWriter.cs
@@ -88,7 +88,23 @@ public class IntermediateNodeWriter :
 
     public override void VisitFieldDeclaration(FieldDeclarationIntermediateNode node)
     {
-        WriteContentNode(node, string.Join(" ", node.Modifiers), node.FieldType, node.FieldName);
+        List<string> entries =
+        [
+            string.Join(" ", node.Modifiers),
+            node.FieldType,
+            node.FieldName
+        ];
+
+        if (node.Initializer is not null)
+        {
+            entries.AddRange(
+            [
+                "=",
+                node.Initializer
+            ]);
+        }
+
+        WriteContentNode(node, entries.ToArray());
     }
 
     public override void VisitHtmlAttribute(HtmlAttributeIntermediateNode node)


### PR DESCRIPTION
Closes #7519
 
# Details
 
The issue asks about being able to provide constant expressions into the page directive, possibly including constant string interpolations, string concatenations, or mixes of the two.
 
This PR provides a primitive solution to that by accepting either a double-quoted string, or an identifier (single or qualified), or a razor expression. It is not required to place a @ before the identifier, but the razor expression requires that the expression be placed inside `@()`.
 
To support this new syntax, a new token kind had to be created, IdentifierOrExpressionOrString. This follows the logic of its components, IdentifierOrExpression and String. The parser tries to first parse a razor expression, else an identifier, else a string, otherwise fails. While directly using a non-simple string literal is not supported, there exists the workaround of placing the non-simple string literal into a razor expression (like so: `@($"{AppRoutes.Forms}/{{id:int}}")`)
 
Retrieving the string value is not possible when a non-string literal expression is used, since we don't have the ability to look into the compilation while generating the files. So instead, we introduce a new public constant field in the generated page class, named `__RouteTemplate`, which is used to contain the compilable expression, in order to guarantee the expression is always validly evaluated. If we directly used that expression in the assembly attribute, resolving the actual expression would fail 99% of the time, as we'd be in the global namespace and the expression's top level identifier will possibly refer to a namespaced member.
 
We can also leverage that technique when any expression other than a double-quoted string is used. This ensures we don't introduce custom parsing logic which would introduce the risk of deviating from the intended C# behavior. So, arbitrary razor expressions are also accepted, whose contents will be used for the instantiation of the generated constant.
 
The assembly attribute containing the page name will refer to the generated class's public field by fully qualifying the member. This is possible because we know the namespace and the class name of the generated class, and the public field's name is defined by us, which is placed in a constant. The field is only used when the route template isn't a simple string, and thus isn't known in Razor's context. If the field doesn't exist (because the `@page` directive has no defined template), no field is used and the behavior remains the same.
 
# Consequences
 
- A new diagnostic (RZ1046) was introduced to inform about the new acceptable syntax forms since it's not just a string enclosed in double quotes anymore.
- Some incomplete directory errors will be different now. The test diffs cover that.
- The newly introduced field assumes the name be unreserved by user code. It's a pathological case to have a field named like that, so this breaking change should not affect anybody.
 
# Risks
 
The parser becomes more complicated by having a new token kind. Especially with the string part of the new token kind not adhering to all C# rules.
 
The `@page` directive generates a new public constant field for every non-simple route template page. This bloats the generated code (very minorly).

The `@page` directive is now designed to accept both `DirectiveTokenIntermediateNode` and `LazyIntermediateToken`, aside from the simple double-quoted string literal, possibly evaluating both newly added properties in some cases. while the runtime overhead is negligible, code involving a `PageDirective` instance must be aware of these changes.

CC @chsienki @javiercn
