### PR TITLE
Fix MEF Composition Error

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/ISnippetCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Completion/ISnippetCompletionItemProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.Razor.Protocol;
 
@@ -9,4 +10,5 @@ namespace Microsoft.CodeAnalysis.Razor.Completion;
 internal interface ISnippetCompletionItemProvider
 {
     void AddSnippetCompletions(ref PooledArrayBuilder<VSInternalCompletionItem> builder, RazorLanguageKind projectedKind, VSInternalCompletionInvokeKind invokeKind, string? triggerCharacter);
+    bool TryResolveInsertString(VSInternalCompletionItem completionItem, [NotNullWhen(true)] out string? insertString);
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Razor.Completion;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Protocol;
@@ -14,7 +15,6 @@ using Microsoft.CodeAnalysis.Razor.Telemetry;
 using Microsoft.CodeAnalysis.Razor.Workspaces;
 using Microsoft.CodeAnalysis.Razor.Workspaces.Settings;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
-using Microsoft.VisualStudio.Razor.Snippets;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Threading;
 using static Microsoft.VisualStudio.LanguageServer.ContainedLanguage.DefaultLSPDocumentSynchronizer;
@@ -30,7 +30,7 @@ internal partial class RazorCustomMessageTarget
     private readonly ITelemetryReporter _telemetryReporter;
     private readonly LanguageServerFeatureOptions _languageServerFeatureOptions;
     private readonly ProjectSnapshotManager _projectManager;
-    private readonly SnippetCompletionItemProvider _snippetCompletionItemProvider;
+    private readonly ISnippetCompletionItemProvider _snippetCompletionItemProvider;
     private readonly FormattingOptionsProvider _formattingOptionsProvider;
     private readonly IClientSettingsManager _editorSettingsManager;
     private readonly LSPDocumentSynchronizer _documentSynchronizer;
@@ -49,7 +49,7 @@ internal partial class RazorCustomMessageTarget
         ITelemetryReporter telemetryReporter,
         LanguageServerFeatureOptions languageServerFeatureOptions,
         ProjectSnapshotManager projectManager,
-        SnippetCompletionItemProvider snippetCompletionItemProvider,
+        ISnippetCompletionItemProvider snippetCompletionItemProvider,
         ILoggerFactory loggerFactory)
     {
         if (documentManager is not TrackingLSPDocumentManager trackingDocumentManager)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_Completion.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_Completion.cs
@@ -13,7 +13,6 @@ using Microsoft.CodeAnalysis.Razor.Protocol;
 using Microsoft.CodeAnalysis.Razor.Protocol.Completion;
 using Microsoft.CodeAnalysis.Razor.Telemetry;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
-using Microsoft.VisualStudio.Razor.Snippets;
 using StreamJsonRpc;
 
 namespace Microsoft.VisualStudio.Razor.LanguageClient.Endpoints;
@@ -250,9 +249,7 @@ internal partial class RazorCustomMessageTarget
     [JsonRpcMethod(LanguageServerConstants.RazorCompletionResolveEndpointName, UseSingleObjectParameterDeserialization = true)]
     public async Task<VSInternalCompletionItem?> ProvideResolvedCompletionItemAsync(DelegatedCompletionItemResolveParams request, CancellationToken cancellationToken)
     {
-        // Check if we're completing a snippet item that we provided
-        if (SnippetCompletionData.TryParse(request.CompletionItem.Data, out var snippetCompletionData) &&
-            _snippetCompletionItemProvider.SnippetCache.TryResolveSnippetString(snippetCompletionData) is { } snippetInsertText)
+        if (_snippetCompletionItemProvider.TryResolveInsertString(request.CompletionItem, out var snippetInsertText))
         {
             request.CompletionItem.InsertText = snippetInsertText;
             return request.CompletionItem;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Snippets/SnippetCompletionItemProvider.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/Snippets/SnippetCompletionItemProvider.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel.Composition;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Microsoft.AspNetCore.Razor.PooledObjects;
 using Microsoft.CodeAnalysis.Razor.Completion;
@@ -64,6 +65,19 @@ internal sealed class SnippetCompletionItemProvider : ISnippetCompletionItemProv
                 Kind = CompletionItemKind.Snippet,
                 CommitCharacters = []
             }));
+    }
+
+    public bool TryResolveInsertString(VSInternalCompletionItem completionItem, [NotNullWhen(true)] out string? insertString)
+    {
+        if (SnippetCompletionData.TryParse(completionItem.Data, out var snippetCompletionData) &&
+            SnippetCache.TryResolveSnippetString(snippetCompletionData) is { } snippetInsertText)
+        {
+            insertString = snippetInsertText;
+            return true;
+        }
+
+        insertString = null;
+        return false;
     }
 
     private static SnippetLanguage ConvertLanguageKind(RazorLanguageKind languageKind)


### PR DESCRIPTION
SnippetCompletionItemProvider was changed to export as ISnippetCompletionItemProvider but not updated in RazorCustomMessageTargets
