### PR TITLE
Improve document handling in VS Code and cohosting

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/HtmlDocumentServices/IHtmlDocumentPublisher.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/HtmlDocumentServices/IHtmlDocumentPublisher.cs
@@ -9,5 +9,5 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 
 internal interface IHtmlDocumentPublisher
 {
-    Task PublishAsync(TextDocument document, string htmlText, CancellationToken cancellationToken);
+    Task PublishAsync(TextDocument document, SynchronizationResult synchronizationResult, string htmlText, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/HtmlDocumentServices/IHtmlDocumentSynchronizer.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/HtmlDocumentServices/IHtmlDocumentSynchronizer.cs
@@ -11,5 +11,5 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 internal interface IHtmlDocumentSynchronizer
 {
     void DocumentRemoved(Uri uri);
-    Task<bool> TrySynchronizeAsync(TextDocument document, CancellationToken cancellationToken);
+    Task<SynchronizationResult> TrySynchronizeAsync(TextDocument document, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/HtmlDocumentServices/SynchronizationResult.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/HtmlDocumentServices/SynchronizationResult.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+
+/// <summary>
+/// A result of a synchronization operation for a Html document
+/// </summary>
+/// <remarks>
+/// If <see cref="Synchronized" /> is <see langword="false" />, <see cref="Checksum" /> will be <see langword="default" />.
+/// </remarks>
+internal readonly record struct SynchronizationResult(bool Synchronized, ChecksumWrapper Checksum);

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Microsoft.CodeAnalysis.Razor.CohostingShared.projitems
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/Microsoft.CodeAnalysis.Razor.CohostingShared.projitems
@@ -24,6 +24,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)DocumentSymbol\CohostDocumentSymbolEndpoint.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Formatting\CohostDocumentFormattingEndpoint.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FindAllReferences\CohostFindAllReferencesEndpoint.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HtmlDocumentServices\SynchronizationResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Navigation\CohostGoToDefinitionEndpoint.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Navigation\CohostGoToImplementationEndpoint.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LinkedEditingRange\CohostLinkedEditingRangeEndpoint.cs" />

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentPublisher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentPublisher.cs
@@ -6,6 +6,7 @@ using System.ComponentModel.Composition;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Microsoft.CodeAnalysis.Razor.Logging;
@@ -25,11 +26,9 @@ internal sealed class HtmlDocumentPublisher(
     private readonly TrackingLSPDocumentManager _documentManager = documentManager as TrackingLSPDocumentManager ?? throw new InvalidOperationException("Expected TrackingLSPDocumentManager");
     private readonly ILogger _logger = loggerFactory.GetOrCreateLogger<HtmlDocumentPublisher>();
 
-    public async Task PublishAsync(TextDocument document, string htmlText, CancellationToken cancellationToken)
+    public async Task PublishAsync(TextDocument document, SynchronizationResult synchronizationResult, string htmlText, CancellationToken cancellationToken)
     {
-        // TODO: Eventually, for VS Code, the following piece of logic needs to make an LSP call rather than directly update the
-        // buffer, but the assembly this code currently lives in doesn't ship in VS Code, so we need to solve a few other things
-        // before we get there.
+        Assumed.True(synchronizationResult.Synchronized);
 
         var uri = document.CreateUri();
         if (!_documentManager.TryGetDocument(uri, out var documentSnapshot) ||
@@ -55,7 +54,7 @@ internal sealed class HtmlDocumentPublisher(
         }
 
         VisualStudioTextChange[] changes = [new(0, htmlDocument.Snapshot.Length, htmlText)];
-        _documentManager.UpdateVirtualDocument<HtmlVirtualDocument>(uri, changes, documentSnapshot.Version, state: null);
+        _documentManager.UpdateVirtualDocument<HtmlVirtualDocument>(uri, changes, documentSnapshot.Version, state: synchronizationResult.Checksum.ToString());
 
         _logger.LogDebug($"Finished Html document generation for {document.FilePath} (into {uri})");
     }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentPublisher.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentPublisher.cs
@@ -54,7 +54,7 @@ internal sealed class HtmlDocumentPublisher(
         }
 
         VisualStudioTextChange[] changes = [new(0, htmlDocument.Snapshot.Length, htmlText)];
-        _documentManager.UpdateVirtualDocument<HtmlVirtualDocument>(uri, changes, documentSnapshot.Version, state: synchronizationResult.Checksum.ToString());
+        _documentManager.UpdateVirtualDocument<HtmlVirtualDocument>(uri, changes, documentSnapshot.Version, state: synchronizationResult.Checksum);
 
         _logger.LogDebug($"Finished Html document generation for {document.FilePath} (into {uri})");
     }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlRequestInvoker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlRequestInvoker.cs
@@ -6,6 +6,7 @@ using System.ComponentModel.Composition;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Microsoft.CodeAnalysis.Razor.Logging;
@@ -32,7 +33,7 @@ internal sealed class HtmlRequestInvoker(
     public async Task<TResponse?> MakeHtmlLspRequestAsync<TRequest, TResponse>(TextDocument razorDocument, string method, TRequest request, TimeSpan threshold, Guid correlationId, CancellationToken cancellationToken) where TRequest : notnull
     {
         var syncResult = await _htmlDocumentSynchronizer.TrySynchronizeAsync(razorDocument, cancellationToken).ConfigureAwait(false);
-        if (!syncResult)
+        if (!syncResult.Synchronized)
         {
             _logger.LogDebug($"Couldn't synchronize for {razorDocument.FilePath}");
             return default;
@@ -50,6 +51,12 @@ internal sealed class HtmlRequestInvoker(
             return default;
         }
 
+        if ((string)htmlDocument.State.AssumeNotNull() != syncResult.Checksum.ToString())
+        {
+            _logger.LogError($"Checksum for {snapshot.Uri}, {htmlDocument.State} doesn't match {syncResult.Checksum}.");
+            return default;
+        }
+
         // If the request is for a text document, we need to update the Uri to point to the Html document,
         // and most importantly set it back again before leaving the method in case a caller uses it.
         Uri? originalUri = null;
@@ -62,8 +69,7 @@ internal sealed class HtmlRequestInvoker(
 
         try
         {
-
-            _logger.LogDebug($"Making LSP request for {method} from {htmlDocument.Uri}{(request is ITextDocumentPositionParams positionParams ? $" at {positionParams.Position}" : "")}.");
+            _logger.LogDebug($"Making LSP request for {method} from {htmlDocument.Uri}{(request is ITextDocumentPositionParams positionParams ? $" at {positionParams.Position}" : "")}, checksum {syncResult.Checksum}.");
 
             // Passing Guid.Empty to this method will mean no tracking
             using var _ = _telemetryReporter.TrackLspRequest(Methods.TextDocumentCodeActionName, RazorLSPConstants.HtmlLanguageServerName, threshold, correlationId);

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlRequestInvoker.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlRequestInvoker.cs
@@ -51,7 +51,8 @@ internal sealed class HtmlRequestInvoker(
             return default;
         }
 
-        if ((string)htmlDocument.State.AssumeNotNull() != syncResult.Checksum.ToString())
+        var existingChecksum = (ChecksumWrapper)htmlDocument.State.AssumeNotNull();
+        if (!existingChecksum.Equals(syncResult.Checksum))
         {
             _logger.LogError($"Checksum for {snapshot.Uri}, {htmlDocument.State} doesn't match {syncResult.Checksum}.");
             return default;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/HtmlVirtualDocument.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/HtmlVirtualDocument.cs
@@ -10,5 +10,5 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient;
 internal class HtmlVirtualDocument(Uri uri, ITextBuffer textBuffer, ITelemetryReporter telemetryReporter)
     : GeneratedVirtualDocument<HtmlVirtualDocumentSnapshot>(uri, textBuffer, telemetryReporter)
 {
-    protected override HtmlVirtualDocumentSnapshot GetUpdatedSnapshot(object? state) => new(Uri, TextBuffer.CurrentSnapshot, HostDocumentVersion);
+    protected override HtmlVirtualDocumentSnapshot GetUpdatedSnapshot(object? state) => new(Uri, TextBuffer.CurrentSnapshot, HostDocumentVersion, state);
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/HtmlVirtualDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/HtmlVirtualDocumentSnapshot.cs
@@ -12,7 +12,8 @@ internal class HtmlVirtualDocumentSnapshot : VirtualDocumentSnapshot
     public HtmlVirtualDocumentSnapshot(
         Uri uri,
         ITextSnapshot snapshot,
-        long? hostDocumentSyncVersion)
+        long? hostDocumentSyncVersion,
+        object? state)
     {
         if (uri is null)
         {
@@ -27,6 +28,7 @@ internal class HtmlVirtualDocumentSnapshot : VirtualDocumentSnapshot
         Uri = uri;
         Snapshot = snapshot;
         HostDocumentSyncVersion = hostDocumentSyncVersion;
+        State = state;
     }
 
     public override Uri Uri { get; }
@@ -34,4 +36,6 @@ internal class HtmlVirtualDocumentSnapshot : VirtualDocumentSnapshot
     public override ITextSnapshot Snapshot { get; }
 
     public override long? HostDocumentSyncVersion { get; }
+
+    public object? State { get; }
 }

--- a/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Endpoints/RazorDocumentClosedEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Endpoints/RazorDocumentClosedEndpoint.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor;
+using Microsoft.AspNetCore.Razor.Threading;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Cohost;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor.Features;
+using Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
+
+namespace Microsoft.VisualStudioCode.RazorExtension.Endpoints;
+
+[Shared]
+[ExportRazorStatelessLspService(typeof(RazorDocumentClosedEndpoint))]
+[RazorEndpoint("razor/documentClosed")]
+[method: ImportingConstructor]
+internal class RazorDocumentClosedEndpoint(IHtmlDocumentSynchronizer htmlDocumentSynchronizer) : AbstractRazorCohostDocumentRequestHandler<TextDocumentIdentifier, VoidResult>
+{
+    private readonly IHtmlDocumentSynchronizer _htmlDocumentSynchronizer = htmlDocumentSynchronizer;
+
+    protected override bool MutatesSolutionState => false;
+
+    protected override bool RequiresLSPSolution => true;
+
+    protected override RazorTextDocumentIdentifier? GetRazorTextDocumentIdentifier(TextDocumentIdentifier request)
+        => request.ToRazorTextDocumentIdentifier();
+
+    protected override Task<VoidResult> HandleRequestAsync(TextDocumentIdentifier textDocument, RazorCohostRequestContext requestContext, CancellationToken cancellationToken)
+    {
+        _htmlDocumentSynchronizer.DocumentRemoved(requestContext.Uri.AssumeNotNull());
+        return SpecializedTasks.Default<VoidResult>();
+    }
+}

--- a/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Services/HtmlRequestInvoker.cs
+++ b/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Services/HtmlRequestInvoker.cs
@@ -3,11 +3,13 @@
 
 using System;
 using System.ComponentModel.Composition;
+using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor;
 using Microsoft.AspNetCore.Razor.LanguageServer;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.ExternalAccess.Razor;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 
@@ -27,14 +29,30 @@ internal sealed class HtmlRequestInvoker(
     public async Task<TResponse?> MakeHtmlLspRequestAsync<TRequest, TResponse>(TextDocument razorDocument, string method, TRequest request, TimeSpan threshold, Guid correlationId, CancellationToken cancellationToken) where TRequest : notnull
     {
         var syncResult = await _htmlDocumentSynchronizer.TrySynchronizeAsync(razorDocument, cancellationToken).ConfigureAwait(false);
-        if (!syncResult)
+        if (!syncResult.Synchronized)
         {
             return default;
         }
 
-        _logger.LogDebug($"Making Html request for {method} on {razorDocument.FilePath}");
+        _logger.LogDebug($"Making Html request for {method} on {razorDocument.FilePath}, checksum {syncResult.Checksum}");
+
+        var forwardedRequest = new HtmlForwardedRequest<TRequest>(
+            new TextDocumentIdentifier
+            {
+                Uri = razorDocument.CreateUri()
+            },
+            syncResult.Checksum.ToString(),
+            request);
 
         var clientConnection = _razorClientServerManagerProvider.ClientLanguageServerManager.AssumeNotNull();
-        return await clientConnection.SendRequestAsync<TRequest, TResponse>(method, request, cancellationToken).ConfigureAwait(false);
+        return await clientConnection.SendRequestAsync<HtmlForwardedRequest<TRequest>, TResponse>(method, forwardedRequest, cancellationToken).ConfigureAwait(false);
     }
+
+    private record HtmlForwardedRequest<TRequest>(
+        [property: JsonPropertyName("textDocument")]
+        TextDocumentIdentifier TextDocument,
+        [property: JsonPropertyName("checksum")]
+        string Checksum,
+        [property: JsonPropertyName("request")]
+        TRequest Request);
 }

--- a/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Services/HtmlRequestInvoker.cs
+++ b/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Services/HtmlRequestInvoker.cs
@@ -34,14 +34,15 @@ internal sealed class HtmlRequestInvoker(
             return default;
         }
 
-        _logger.LogDebug($"Making Html request for {method} on {razorDocument.FilePath}, checksum {syncResult.Checksum}");
+        var checksumString = syncResult.Checksum.ToString();
+        _logger.LogDebug($"Making Html request for {method} on {razorDocument.FilePath}, checksum {checksumString}");
 
         var forwardedRequest = new HtmlForwardedRequest<TRequest>(
             new TextDocumentIdentifier
             {
                 Uri = razorDocument.CreateUri()
             },
-            syncResult.Checksum.ToString(),
+            checksumString,
             request);
 
         var clientConnection = _razorClientServerManagerProvider.ClientLanguageServerManager.AssumeNotNull();

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/HtmlDocumentSynchronizerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/HtmlDocumentSynchronizerTest.cs
@@ -45,8 +45,8 @@ public class HtmlDocumentSynchronizerTest(ITestOutputHelper testOutput) : Visual
         Assert.Collection(publisher.Publishes,
             i =>
             {
-                Assert.Equal(_documentId, i.Item1.Id);
-                Assert.Equal("<div></div>", i.Item2);
+                Assert.Equal(_documentId, i.Document.Id);
+                Assert.Equal("<div></div>", i.Text);
             });
     }
 
@@ -59,7 +59,8 @@ public class HtmlDocumentSynchronizerTest(ITestOutputHelper testOutput) : Visual
         var remoteServiceInvoker = new RemoteServiceInvoker(document);
         var synchronizer = new HtmlDocumentSynchronizer(remoteServiceInvoker, publisher, LoggerFactory);
 
-        Assert.True((await synchronizer.TrySynchronizeAsync(document, DisposalToken)).Synchronized);
+        var syncResult = await synchronizer.TrySynchronizeAsync(document, DisposalToken);
+        Assert.True(syncResult.Synchronized);
 
         // "Close" the document
         synchronizer.DocumentRemoved(document.CreateUri());
@@ -69,13 +70,15 @@ public class HtmlDocumentSynchronizerTest(ITestOutputHelper testOutput) : Visual
         Assert.Collection(publisher.Publishes,
             i =>
             {
-                Assert.Equal(_documentId, i.Item1.Id);
-                Assert.Equal("<div></div>", i.Item2);
+                Assert.Equal(_documentId, i.Document.Id);
+                Assert.Equal("<div></div>", i.Text);
+                Assert.Equal(syncResult.Checksum, i.Checksum);
             },
             i =>
             {
-                Assert.Equal(_documentId, i.Item1.Id);
-                Assert.Equal("<div></div>", i.Item2);
+                Assert.Equal(_documentId, i.Document.Id);
+                Assert.Equal("<div></div>", i.Text);
+                Assert.Equal(syncResult.Checksum, i.Checksum); // Same document, so same checksum, even though its a different publish
             });
     }
 
@@ -97,8 +100,8 @@ public class HtmlDocumentSynchronizerTest(ITestOutputHelper testOutput) : Visual
         Assert.Collection(publisher.Publishes,
             i =>
             {
-                Assert.Equal(_documentId, i.Item1.Id);
-                Assert.Equal("<div></div>", i.Item2);
+                Assert.Equal(_documentId, i.Document.Id);
+                Assert.Equal("<div></div>", i.Text);
             });
     }
 
@@ -120,8 +123,8 @@ public class HtmlDocumentSynchronizerTest(ITestOutputHelper testOutput) : Visual
         Assert.Collection(publisher.Publishes,
             i =>
             {
-                Assert.Equal(_documentId, i.Item1.Id);
-                Assert.Equal("<div></div>", i.Item2);
+                Assert.Equal(_documentId, i.Document.Id);
+                Assert.Equal("<div></div>", i.Text);
             });
     }
 
@@ -136,7 +139,8 @@ public class HtmlDocumentSynchronizerTest(ITestOutputHelper testOutput) : Visual
 
         var version1 = await RazorDocumentVersion.CreateAsync(document, DisposalToken);
 
-        Assert.True((await synchronizer.TrySynchronizeAsync(document, DisposalToken)).Synchronized);
+        var syncResult = await synchronizer.TrySynchronizeAsync(document, DisposalToken);
+        Assert.True(syncResult.Synchronized);
 
         // Add a new document, moving the workspace forward but leaving our document unaffected
         Assert.True(Workspace.TryApplyChanges(document.Project.AddAdditionalDocument("Foo2.razor", SourceText.From(""), filePath: "file://Foo2.razor").Project.Solution));
@@ -144,7 +148,9 @@ public class HtmlDocumentSynchronizerTest(ITestOutputHelper testOutput) : Visual
         document = Workspace.CurrentSolution.GetAdditionalDocument(_documentId).AssumeNotNull();
         var version2 = await RazorDocumentVersion.CreateAsync(document, DisposalToken);
 
-        Assert.True((await synchronizer.TrySynchronizeAsync(document, DisposalToken)).Synchronized);
+        var syncResult2 = await synchronizer.TrySynchronizeAsync(document, DisposalToken);
+        Assert.True(syncResult2.Synchronized);
+        Assert.Equal(syncResult.Checksum, syncResult2.Checksum);
 
         // Validate that the workspace moved forward
         Assert.NotEqual(version1.WorkspaceVersion, version2.WorkspaceVersion);
@@ -153,8 +159,9 @@ public class HtmlDocumentSynchronizerTest(ITestOutputHelper testOutput) : Visual
         Assert.Collection(publisher.Publishes,
             i =>
             {
-                Assert.Equal(_documentId, i.Item1.Id);
-                Assert.Equal("<div></div>", i.Item2);
+                Assert.Equal(_documentId, i.Document.Id);
+                Assert.Equal("<div></div>", i.Text);
+                Assert.Equal(syncResult.Checksum, i.Checksum);
             });
     }
 
@@ -169,29 +176,34 @@ public class HtmlDocumentSynchronizerTest(ITestOutputHelper testOutput) : Visual
 
         var version1 = await RazorDocumentVersion.CreateAsync(document, DisposalToken);
 
-        Assert.True((await synchronizer.TrySynchronizeAsync(document, DisposalToken)).Synchronized);
+        var syncResult = await synchronizer.TrySynchronizeAsync(document, DisposalToken);
+        Assert.True(syncResult.Synchronized);
 
         // Change our document directly, but without applying changes (equivalent to LSP didChange)
         var solution = Workspace.CurrentSolution.WithAdditionalDocumentText(_documentId.AssumeNotNull(), SourceText.From("<span></span>"));
         document = solution.GetAdditionalDocument(_documentId).AssumeNotNull();
         var version2 = await RazorDocumentVersion.CreateAsync(document, DisposalToken);
 
-        Assert.True((await synchronizer.TrySynchronizeAsync(document, DisposalToken)).Synchronized);
+        var syncResult2 = await synchronizer.TrySynchronizeAsync(document, DisposalToken);
+        Assert.True(syncResult2.Synchronized);
 
         // Validate that the workspace hasn't moved forward
         Assert.Equal(version1.WorkspaceVersion, version2.WorkspaceVersion);
+        Assert.NotEqual(syncResult.Checksum, syncResult2.Checksum);
 
         // We should have two publishes
         Assert.Collection(publisher.Publishes,
             i =>
             {
-                Assert.Equal(_documentId, i.Item1.Id);
-                Assert.Equal("<div></div>", i.Item2);
+                Assert.Equal(_documentId, i.Document.Id);
+                Assert.Equal("<div></div>", i.Text);
+                Assert.Equal(syncResult.Checksum, i.Checksum);
             },
             i =>
             {
-                Assert.Equal(_documentId, i.Item1.Id);
-                Assert.Equal("<span></span>", i.Item2);
+                Assert.Equal(_documentId, i.Document.Id);
+                Assert.Equal("<span></span>", i.Text);
+                Assert.Equal(syncResult2.Checksum, i.Checksum);
             });
     }
 
@@ -222,8 +234,8 @@ public class HtmlDocumentSynchronizerTest(ITestOutputHelper testOutput) : Visual
         Assert.Collection(publisher.Publishes,
             i =>
             {
-                Assert.Equal(_documentId, i.Item1.Id);
-                Assert.Equal("<span></span>", i.Item2);
+                Assert.Equal(_documentId, i.Document.Id);
+                Assert.Equal("<span></span>", i.Text);
             });
     }
 
@@ -247,8 +259,8 @@ public class HtmlDocumentSynchronizerTest(ITestOutputHelper testOutput) : Visual
         Assert.Collection(publisher.Publishes,
             i =>
             {
-                Assert.Equal(_documentId, i.Item1.Id);
-                Assert.Equal("<div></div>", i.Item2);
+                Assert.Equal(_documentId, i.Document.Id);
+                Assert.Equal("<div></div>", i.Text);
             });
     }
 
@@ -280,8 +292,8 @@ public class HtmlDocumentSynchronizerTest(ITestOutputHelper testOutput) : Visual
         Assert.Collection(publisher.Publishes,
             i =>
             {
-                Assert.Equal(_documentId, i.Item1.Id);
-                Assert.Equal("<span></span>", i.Item2);
+                Assert.Equal(_documentId, i.Document.Id);
+                Assert.Equal("<span></span>", i.Text);
             });
     }
 
@@ -337,13 +349,13 @@ public class HtmlDocumentSynchronizerTest(ITestOutputHelper testOutput) : Visual
 
     private class TestHtmlDocumentPublisher : IHtmlDocumentPublisher
     {
-        private List<(TextDocument, string)> _publishes = [];
+        private List<(TextDocument, string, ChecksumWrapper)> _publishes = [];
 
-        public List<(TextDocument, string)> Publishes => _publishes;
+        public List<(TextDocument Document, string Text, ChecksumWrapper Checksum)> Publishes => _publishes;
 
-        public Task PublishAsync(TextDocument document, SynchronizationResult SynchronizationResult, string htmlText, CancellationToken cancellationToken)
+        public Task PublishAsync(TextDocument document, SynchronizationResult synchronizationResult, string htmlText, CancellationToken cancellationToken)
         {
-            _publishes.Add((document, htmlText));
+            _publishes.Add((document, htmlText, synchronizationResult.Checksum));
             return Task.CompletedTask;
         }
     }


### PR DESCRIPTION
Part of https://github.com/dotnet/razor/issues/11759
Goes with https://github.com/dotnet/vscode-csharp/pull/8259

This adds a notification for VS Code to tell us that a Razor file has closed, so we can clear our cache, and also adds checksum matching to Html requests in VS and VS Code so we can ensure we're not out-of-sync.