### PR TITLE
Allow html requests to be properly cancelled

### DIFF
--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/HtmlDocumentServices/HtmlDocumentSynchronizer.SynchronizationRequest.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/HtmlDocumentServices/HtmlDocumentSynchronizer.SynchronizationRequest.cs
@@ -31,7 +31,7 @@ internal sealed partial class HtmlDocumentSynchronizer
         private void Start(TextDocument document, Func<TextDocument, RazorDocumentVersion, CancellationToken, Task<SynchronizationResult>> syncFunction, CancellationToken cancellationToken)
         {
             _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            _cts.CancelAfter(TimeSpan.FromMinutes(1));
+            _cts.CancelAfter(TimeSpan.FromMilliseconds(500));
             _cts.Token.Register(Dispose);
             _ = syncFunction.Invoke(document, _requestedVersion, _cts.Token).ContinueWith((t, state) =>
             {

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/HtmlDocumentServices/HtmlDocumentSynchronizer.SynchronizationRequest.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/HtmlDocumentServices/HtmlDocumentSynchronizer.SynchronizationRequest.cs
@@ -31,9 +31,10 @@ internal sealed partial class HtmlDocumentSynchronizer
         private void Start(TextDocument document, Func<TextDocument, RazorDocumentVersion, CancellationToken, Task<SynchronizationResult>> syncFunction, CancellationToken cancellationToken)
         {
             _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var token = _cts.Token;
             _cts.CancelAfter(TimeSpan.FromMilliseconds(500));
             _cts.Token.Register(Dispose);
-            _ = syncFunction.Invoke(document, _requestedVersion, _cts.Token).ContinueWith((t, state) =>
+            _ = syncFunction.Invoke(document, _requestedVersion, token).ContinueWith((t, state) =>
             {
                 var tcs = (TaskCompletionSource<SynchronizationResult>)state.AssumeNotNull();
                 if (t.IsCanceled)
@@ -51,7 +52,7 @@ internal sealed partial class HtmlDocumentSynchronizer
 
                 _cts?.Dispose();
                 _cts = null;
-            }, _tcs, _cts.Token, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+            }, _tcs, token, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
         }
 
         public void Dispose()

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/HtmlDocumentServices/IHtmlDocumentSynchronizer.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.CohostingShared/HtmlDocumentServices/IHtmlDocumentSynchronizer.cs
@@ -10,6 +10,6 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Cohost;
 
 internal interface IHtmlDocumentSynchronizer
 {
-    void DocumentRemoved(Uri uri);
+    void DocumentRemoved(Uri uri, CancellationToken cancellationToken);
     Task<SynchronizationResult> TrySynchronizeAsync(TextDocument document, CancellationToken cancellationToken);
 }

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentRemoveListener.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Cohost/HtmlDocumentRemoveListener.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 using System.ComponentModel.Composition;
+using System.Threading;
 using Microsoft.VisualStudio.LanguageServer.ContainedLanguage;
 using Microsoft.VisualStudio.Utilities;
 
@@ -20,7 +21,7 @@ internal sealed partial class HtmlDocumentRemoveListener(
     {
         if (kind == LSPDocumentChangeKind.Removed && old is not null)
         {
-            _htmlDocumentSynchronizer.DocumentRemoved(old.Uri);
+            _htmlDocumentSynchronizer.DocumentRemoved(old.Uri, CancellationToken.None);
         }
     }
 }

--- a/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Endpoints/RazorDocumentClosedEndpoint.cs
+++ b/src/Razor/src/Microsoft.VisualStudioCode.RazorExtension/Endpoints/RazorDocumentClosedEndpoint.cs
@@ -29,7 +29,7 @@ internal class RazorDocumentClosedEndpoint(IHtmlDocumentSynchronizer htmlDocumen
 
     protected override Task<VoidResult> HandleRequestAsync(TextDocumentIdentifier textDocument, RazorCohostRequestContext requestContext, CancellationToken cancellationToken)
     {
-        _htmlDocumentSynchronizer.DocumentRemoved(requestContext.Uri.AssumeNotNull());
+        _htmlDocumentSynchronizer.DocumentRemoved(requestContext.Uri.AssumeNotNull(), cancellationToken);
         return SpecializedTasks.Default<VoidResult>();
     }
 }

--- a/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/HtmlDocumentSynchronizerTest.cs
+++ b/src/Razor/test/Microsoft.VisualStudio.LanguageServices.Razor.Test/Cohost/HtmlDocumentSynchronizerTest.cs
@@ -230,7 +230,6 @@ public class HtmlDocumentSynchronizerTest(ITestOutputHelper testOutput) : Visual
 
         Assert.True((await task).Synchronized);
 
-        // We should have two publishes
         Assert.Collection(publisher.Publishes,
             i =>
             {


### PR DESCRIPTION
Part of https://github.com/dotnet/razor/issues/11759

I'm not honestly sure what I was thinking in not passing on the cancellation token. The idea of "well we might need this work later, lets run it in the background" might have made some sense (though likely not, as Roslyn essentially does the same sort of thing with its compilation tracker) but since none of the tasks here are fire and forget, nor do we want them to be, there was never any real cancellation.

It's purely anecdotal, but this seems to have fixed (or at least reduced) the amount of cancellation happening (and erroneously logged errors due to cancellation), I think because new requests would come in (or things might have been timing out) after old requests were cancelled by the client, but of course we never honoured that.