### PR TITLE
Fix aligned buffer write

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/CodeGeneration/CSharpCodeWriterTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/CodeGeneration/CSharpCodeWriterTest.cs
@@ -449,18 +449,18 @@ public class CSharpCodeWriterTest
         const string FirstLine = "First Line";
         pages.AddLast([(FirstLine + FirstLine).AsMemory(), "Second".AsMemory()]);
 
-        var testWriter = CodeWriter.GetTestTextReader(pages);
+        var testReader = CodeWriter.GetTestTextReader(pages);
         var output = new char[FirstLine.Length];
 
-        testWriter.Read(output, 0, output.Length);
+        testReader.Read(output, 0, output.Length);
         Assert.Equal(FirstLine, string.Join("", output));
         Array.Clear(output, 0, output.Length);
 
-        testWriter.Read(output, 0, output.Length);
+        testReader.Read(output, 0, output.Length);
         Assert.Equal(FirstLine, string.Join("", output));
         Array.Clear(output, 0, output.Length);
 
-        testWriter.Read(output, 0, output.Length);
+        testReader.Read(output, 0, output.Length);
         Assert.Equal("Second\0\0\0\0", string.Join("", output));
     }
 
@@ -472,14 +472,14 @@ public class CSharpCodeWriterTest
         const string FirstLine = "First Line";
         pages.AddLast([FirstLine.AsMemory()]);
 
-        var testWriter = CodeWriter.GetTestTextReader(pages);
+        var testReader = CodeWriter.GetTestTextReader(pages);
         var output = new char[FirstLine.Length];
 
-        testWriter.Read(output, 0, 2);
+        testReader.Read(output, 0, 2);
         Assert.Equal("Fi\0\0\0\0\0\0\0\0", string.Join("", output));
         Array.Clear(output, 0, output.Length);
 
-        testWriter.Read(output, 0, output.Length);
+        testReader.Read(output, 0, output.Length);
         Assert.Equal("rst Line\0\0", string.Join("", output));
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/CodeGeneration/CSharpCodeWriterTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/CodeGeneration/CSharpCodeWriterTest.cs
@@ -453,15 +453,15 @@ public class CSharpCodeWriterTest
         var output = new char[FirstLine.Length];
 
         testWriter.Read(output, 0, output.Length);
-        Assert.Equal(output, FirstLine);
+        Assert.Equal(FirstLine, string.Join("", output));
         Array.Clear(output, 0, output.Length);
 
         testWriter.Read(output, 0, output.Length);
-        Assert.Equal(output, FirstLine);
+        Assert.Equal(FirstLine, string.Join("", output));
         Array.Clear(output, 0, output.Length);
 
         testWriter.Read(output, 0, output.Length);
-        Assert.Equal(output, "Second\0\0\0\0");
+        Assert.Equal("Second\0\0\0\0", string.Join("", output));
     }
 
     [Fact]
@@ -476,10 +476,10 @@ public class CSharpCodeWriterTest
         var output = new char[FirstLine.Length];
 
         testWriter.Read(output, 0, 2);
-        Assert.Equal(output, "Fi\0\0\0\0\0\0\0\0");
+        Assert.Equal("Fi\0\0\0\0\0\0\0\0", string.Join("", output));
         Array.Clear(output, 0, output.Length);
 
         testWriter.Read(output, 0, output.Length);
-        Assert.Equal(output, "rst Line\0\0");
+        Assert.Equal("rst Line\0\0", string.Join("", output));
     }
 }

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/CodeGeneration/CSharpCodeWriterTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/CodeGeneration/CSharpCodeWriterTest.cs
@@ -453,15 +453,15 @@ public class CSharpCodeWriterTest
         var output = new char[FirstLine.Length];
 
         testWriter.Read(output, 0, output.Length);
-        Assert.Equal(output, FirstLine.AsSpan());
-        Array.Clear(output);
+        Assert.Equal(output, FirstLine);
+        Array.Clear(output, 0, output.Length);
 
         testWriter.Read(output, 0, output.Length);
-        Assert.Equal(output, FirstLine.AsSpan());
-        Array.Clear(output);
+        Assert.Equal(output, FirstLine);
+        Array.Clear(output, 0, output.Length);
 
         testWriter.Read(output, 0, output.Length);
-        Assert.Equal(output, "Second\0\0\0\0".AsSpan());
+        Assert.Equal(output, "Second\0\0\0\0");
     }
 
     [Fact]
@@ -476,10 +476,10 @@ public class CSharpCodeWriterTest
         var output = new char[FirstLine.Length];
 
         testWriter.Read(output, 0, 2);
-        Assert.Equal(output, "Fi\0\0\0\0\0\0\0\0".AsSpan());
-        Array.Clear(output);
+        Assert.Equal(output, "Fi\0\0\0\0\0\0\0\0");
+        Array.Clear(output, 0, output.Length);
 
         testWriter.Read(output, 0, output.Length);
-        Assert.Equal(output, "rst Line\0\0".AsSpan());
+        Assert.Equal(output, "rst Line\0\0");
     }
 }

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriter.cs
@@ -323,14 +323,20 @@ public sealed partial class CodeWriter : IDisposable
 
     public SourceText GetText()
     {
-        using var reader = new Reader(this);
+        using var reader = new Reader(_pages, Length);
         return SourceText.From(reader, Length, Encoding.UTF8);
     }
 
-    private sealed class Reader(CodeWriter codeWriter) : TextReader
+    // Internal for testing
+    internal static TextReader GetTestTextReader(LinkedList<ReadOnlyMemory<char>[]> pages)
     {
-        private LinkedListNode<ReadOnlyMemory<char>[]>? _page = codeWriter._pages.First;
-        private int _remainingLength = codeWriter.Length;
+        return new Reader(pages, pages.Count);
+    }
+
+    private sealed class Reader(LinkedList<ReadOnlyMemory<char>[]> pages, int length) : TextReader
+    {
+        private LinkedListNode<ReadOnlyMemory<char>[]>? _page = pages.First;
+        private int _remainingLength = length;
         private int _chunkIndex;
         private int _charIndex;
 

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriter.cs
@@ -449,31 +449,23 @@ public sealed partial class CodeWriter : IDisposable
                         }
                     }
 
-                    var endOfChunkWritten = true;
-
                     // Are we about to write past the end of the buffer? If so, adjust source.
                     // This will be the last chunk we write, so be sure to update charIndex.
                     if (source.Length > destination.Length)
                     {
                         source = source[..destination.Length];
                         charIndex += source.Length;
-
-                        // There's more to this chunk to write! Note this so that we don't update
-                        // chunkIndex later.
-                        endOfChunkWritten = false;
+                    }
+                    else
+                    {
+                        chunkIndex++;
+                        charIndex = 0;
                     }
 
                     source.CopyTo(destination);
                     destination = destination[source.Length..];
 
                     charsWritten += source.Length;
-
-                    // Be careful not to increment chunkIndex unless we actually wrote to the end of the chunk.
-                    if (endOfChunkWritten)
-                    {
-                        chunkIndex++;
-                        charIndex = 0;
-                    }
 
                     // Break if we are done writing. chunkIndex and charIndex should have their correct values at this point.
                     if (destination.IsEmpty)

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriter.cs
@@ -413,7 +413,7 @@ public sealed partial class CodeWriter : IDisposable
                 return -1;
             }
 
-            var destination = buffer.AsSpan(index);
+            var destination = buffer.AsSpan(index, count);
             var charsWritten = 0;
 
             var page = _page;

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/CodeGeneration/CodeWriter.cs
@@ -466,6 +466,7 @@ public sealed partial class CodeWriter : IDisposable
                     if (endOfChunkWritten)
                     {
                         chunkIndex++;
+                        charIndex = 0;
                     }
 
                     // Break if we are done writing. chunkIndex and charIndex should have their correct values at this point.
@@ -473,8 +474,6 @@ public sealed partial class CodeWriter : IDisposable
                     {
                         break;
                     }
-
-                    charIndex = 0;
                 }
 
                 if (destination.IsEmpty)


### PR DESCRIPTION
This is a particularly subtle bug that requires a chunk (or remaining bit of a chunk) and the destination buffer being _exactly_ the same size. When this happens, the following sequence occurs:

1. `source.Length` and `destination.Length` are exactly aligned. This means that we do not enter the `if` on line 450, and `endOfChunkWritten` will be true.
2. We slice `destination` by `source.Length`. This leaves us with a `destination` that has 0 elements, and `IsEmpty` is true.
3. Because `endOfChunkWritten` is true, we enter the `if` on line 466. This increments us to the next chunk.
4. On line 472 (in the before diff), `destination.IsEmpty` is true, so we enter the `if`, and break out of the loop, never reseting `charIndex` to 0.
5. 4 happens again, this time on line 480 (in the before diff). Again, we do not reset `charIndex` to 0.
6. We start reading the next chunk with the wrong offset: 38, instead of 0.

To fix this, we want to unconditionally reset `charIndex` when we increment a chunk, not wait until after the destination has been checked for empty.
