### PR TITLE
[release/dev17.14] Tooling: Don't throw exceptions when generating code for file rooted outside of project

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultRazorProjectFileSystem.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultRazorProjectFileSystem.cs
@@ -103,6 +103,14 @@ internal class DefaultRazorProjectFileSystem : RazorProjectFileSystem
             return normalizedPath;
         }
 
+        // This might be an absolute path rooted outside of the project root. In that case,
+        // we just return it. This will mean that the GetItem(...) method will throw above,
+        // but it could be overridden by a descendant file system.
+        if (PathUtilities.IsPathFullyQualified(path))
+        {
+            return normalizedPath;
+        }
+
         // This is not an absolute path, so we combine it with Root to produce the final path.
 
         // If the root doesn't end in a '/', and the path doesn't start with a '/', we'll need to add one.

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultRazorProjectFileSystem.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/DefaultRazorProjectFileSystem.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using Microsoft.AspNetCore.Razor.Utilities;
 
 namespace Microsoft.AspNetCore.Razor.Language;
 
@@ -93,20 +94,29 @@ internal class DefaultRazorProjectFileSystem : RazorProjectFileSystem
 
         var normalizedPath = path.Replace('\\', '/');
 
+        // On Windows, check to see if this is a rooted file path. If it is, just return it.
+        // This covers the following cases:
+        //
+        // 1. It is rooted within the project root. That's valid and we would have checked
+        //    specifically for that case below.
+        // 2. It is rooted outside of the project root. That's invalid, and we don't want to
+        //    concatenate it with the project root. That would potentially produce an invalid
+        //    Windows path like 'C:/project/C:/other-project/some-file.cshtml'.
+        //
+        // Note that returning a path that is rooted outside of the project root will cause
+        // the GetItem(...) method to throw, but it could be overridden by a descendant file
+        // system.
+        if (PlatformInformation.IsWindows && PathUtilities.IsPathFullyQualified(path))
+        {
+            return normalizedPath;
+        }
+
         // Check if the given path is an absolute path. It is absolute if...
         //
         // 1. It is a network share path and starts with a '//' (e.g. //server/some/network/folder) or...
         // 2. It starts with Root
         if (normalizedPath is ['/', '/', ..] ||
             normalizedPath.StartsWith(Root, StringComparison.OrdinalIgnoreCase))
-        {
-            return normalizedPath;
-        }
-
-        // This might be an absolute path rooted outside of the project root. In that case,
-        // we just return it. This will mean that the GetItem(...) method will throw above,
-        // but it could be overridden by a descendant file system.
-        if (PathUtilities.IsPathFullyQualified(path))
         {
             return normalizedPath;
         }

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshotExtensions.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/IDocumentSnapshotExtensions.cs
@@ -11,14 +11,12 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem;
 
 internal static class IDocumentSnapshotExtensions
 {
-    public static async Task<RazorSourceDocument> GetSourceAsync(this IDocumentSnapshot document, RazorProjectEngine projectEngine, CancellationToken cancellationToken)
+    public static async Task<RazorSourceDocument> GetSourceAsync(
+        this IDocumentSnapshot document,
+        CancellationToken cancellationToken)
     {
-        var projectItem = document is { FilePath: string filePath, FileKind: var fileKind }
-            ? projectEngine.FileSystem.GetItem(filePath, fileKind)
-            : null;
-
         var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-        var properties = RazorSourceDocumentProperties.Create(document.FilePath, projectItem?.RelativePhysicalPath);
+        var properties = RazorSourceDocumentProperties.Create(document.FilePath, document.TargetPath);
         return RazorSourceDocument.Create(text, properties);
     }
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/Legacy/ILegacyDocumentSnapshot.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/ProjectSystem/Legacy/ILegacyDocumentSnapshot.cs
@@ -11,5 +11,6 @@ namespace Microsoft.CodeAnalysis.Razor.ProjectSystem.Legacy;
 /// </remarks>
 internal interface ILegacyDocumentSnapshot
 {
+    string TargetPath { get; }
     string FileKind { get; }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestRazorProjectService.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/TestRazorProjectService.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Razor.Language;
 using Microsoft.AspNetCore.Razor.LanguageServer.Common;
 using Microsoft.AspNetCore.Razor.Test.Common;
+using Microsoft.CodeAnalysis.Razor;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.ProjectSystem;
 using Microsoft.CodeAnalysis.Razor.Serialization;
@@ -45,7 +46,7 @@ internal class TestRazorProjectService(
             var projectDirectory = FilePathNormalizer.GetNormalizedDirectoryName(projectSnapshot.FilePath);
             var normalizedFilePath = FilePathNormalizer.Normalize(filePath);
 
-            var targetPath = normalizedFilePath.StartsWith(projectDirectory)
+            var targetPath = normalizedFilePath.StartsWith(projectDirectory, FilePathComparison.Instance)
                 ? normalizedFilePath[projectDirectory.Length..]
                 : normalizedFilePath;
 

--- a/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/ConditionalFactAttribute.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Test.Common/ConditionalFactAttribute.cs
@@ -121,6 +121,11 @@ public static class Is
     /// </summary>
     public const string FreeBSD = nameof(FreeBSD);
 
+    /// <summary>
+    ///  Only execute if the current operating system platform is Unix-based.
+    /// </summary>
+    public const string AnyUnix = nameof(AnyUnix);
+
     public static class Not
     {
         /// <summary>
@@ -142,6 +147,12 @@ public static class Is
         ///  Only execute if the current operating system platform is not FreeBSD.
         /// </summary>
         public const string FreeBSD = $"!{nameof(FreeBSD)}";
+
+        /// <summary>
+        ///  Only execute if the current operating system platform is not Unix-based.
+        /// </summary>
+        public const string AnyUnix = $"!{nameof(AnyUnix)}";
+
     }
 }
 
@@ -157,6 +168,9 @@ public static class Conditions
         Add(Is.Linux, static () => PlatformInformation.IsLinux);
         Add(Is.MacOS, static () => PlatformInformation.IsMacOS);
         Add(Is.FreeBSD, static () => PlatformInformation.IsFreeBSD);
+        Add(Is.AnyUnix, static () => PlatformInformation.IsLinux ||
+                                     PlatformInformation.IsMacOS ||
+                                     PlatformInformation.IsFreeBSD);
 
         return map.ToFrozenDictionary();
 

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/PathUtilitiesTests.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared.Test/PathUtilitiesTests.cs
@@ -42,6 +42,84 @@ public class PathUtilitiesTests
         Assert.Equal(!string.IsNullOrEmpty(expected), PathUtilities.HasExtension(path.AsSpan()));
     }
 
+    // The tests below are derived from the .NET Runtime:
+    // - https://github.com/dotnet/runtime/blob/91195a7948a16c769ccaf7fd8ca84b1d210f6841/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/IO/Path.IsPathFullyQualified.cs
+
+    [Fact]
+    public static void IsPathFullyQualified_NullArgument()
+    {
+        Assert.Throws<ArgumentNullException>(() => PathUtilities.IsPathFullyQualified(null!));
+    }
+
+    [Fact]
+    public static void IsPathFullyQualified_Empty()
+    {
+        Assert.False(PathUtilities.IsPathFullyQualified(""));
+        Assert.False(PathUtilities.IsPathFullyQualified(ReadOnlySpan<char>.Empty));
+    }
+
+    [ConditionalTheory(Is.Windows)]
+    [InlineData("/")]
+    [InlineData(@"\")]
+    [InlineData(".")]
+    [InlineData("C:")]
+    [InlineData("C:foo.txt")]
+    public static void IsPathFullyQualified_Windows_Invalid(string path)
+    {
+        Assert.False(PathUtilities.IsPathFullyQualified(path));
+        Assert.False(PathUtilities.IsPathFullyQualified(path.AsSpan()));
+    }
+
+    [ConditionalTheory(Is.Windows)]
+    [InlineData(@"\\")]
+    [InlineData(@"\\\")]
+    [InlineData(@"\\Server")]
+    [InlineData(@"\\Server\Foo.txt")]
+    [InlineData(@"\\Server\Share\Foo.txt")]
+    [InlineData(@"\\Server\Share\Test\Foo.txt")]
+    [InlineData(@"C:\")]
+    [InlineData(@"C:\foo1")]
+    [InlineData(@"C:\\")]
+    [InlineData(@"C:\\foo2")]
+    [InlineData(@"C:/")]
+    [InlineData(@"C:/foo1")]
+    [InlineData(@"C://")]
+    [InlineData(@"C://foo2")]
+    public static void IsPathFullyQualified_Windows_Valid(string path)
+    {
+        Assert.True(PathUtilities.IsPathFullyQualified(path));
+        Assert.True(PathUtilities.IsPathFullyQualified(path.AsSpan()));
+    }
+
+    [ConditionalTheory(Is.AnyUnix)]
+    [InlineData(@"\")]
+    [InlineData(@"\\")]
+    [InlineData(".")]
+    [InlineData("./foo.txt")]
+    [InlineData("..")]
+    [InlineData("../foo.txt")]
+    [InlineData(@"C:")]
+    [InlineData(@"C:/")]
+    [InlineData(@"C://")]
+    public static void IsPathFullyQualified_Unix_Invalid(string path)
+    {
+        Assert.False(PathUtilities.IsPathFullyQualified(path));
+        Assert.False(PathUtilities.IsPathFullyQualified(path.AsSpan()));
+    }
+
+    [ConditionalTheory(Is.AnyUnix)]
+    [InlineData("/")]
+    [InlineData("/foo.txt")]
+    [InlineData("/..")]
+    [InlineData("//")]
+    [InlineData("//foo.txt")]
+    [InlineData("//..")]
+    public static void IsPathFullyQualified_Unix_Valid(string path)
+    {
+        Assert.True(PathUtilities.IsPathFullyQualified(path));
+        Assert.True(PathUtilities.IsPathFullyQualified(path.AsSpan()));
+    }
+
     private static void AssertEqual(ReadOnlySpan<char> expected, ReadOnlySpan<char> actual)
     {
         if (!actual.SequenceEqual(expected))

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PathUtilities.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/PathUtilities.cs
@@ -36,7 +36,7 @@ internal static class PathUtilities
             {
                 return i != length - 1
                     ? path[i..length]
-                    :  [];
+                    : [];
             }
 
             if (IsDirectorySeparator(ch))
@@ -70,5 +70,95 @@ internal static class PathUtilities
     private static bool IsDirectorySeparator(char ch)
         => ch == Path.DirectorySeparatorChar ||
           (PlatformInformation.IsWindows && ch == Path.AltDirectorySeparatorChar);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsValidDriveChar(char value)
+        => (uint)((value | 0x20) - 'a') <= (uint)('z' - 'a');
+#endif
+
+    public static bool IsPathFullyQualified(string path)
+    {
+        ArgHelper.ThrowIfNull(path);
+
+        return IsPathFullyQualified(path.AsSpan());
+    }
+
+    public static bool IsPathFullyQualified(ReadOnlySpan<char> path)
+    {
+#if NET
+        return Path.IsPathFullyQualified(path);
+#else
+        if (PlatformInformation.IsWindows)
+        {
+            // Derived from .NET Runtime:
+            // - https://github.com/dotnet/runtime/blob/c7c961a330395152e5ec4000032cd3204ceb4a10/src/libraries/Common/src/System/IO/PathInternal.Windows.cs#L250-L274
+
+            if (path.Length < 2)
+            {
+                // It isn't fixed, it must be relative.  There is no way to specify a fixed
+                // path with one character (or less).
+                return false;
+            }
+
+            if (IsDirectorySeparator(path[0]))
+            {
+                // There is no valid way to specify a relative path with two initial slashes or
+                // \? as ? isn't valid for drive relative paths and \??\ is equivalent to \\?\
+                return path[1] == '?' || IsDirectorySeparator(path[1]);
+            }
+
+            // The only way to specify a fixed path that doesn't begin with two slashes
+            // is the drive, colon, slash format- i.e. C:\
+            return (path.Length >= 3)
+                && (path[1] == Path.VolumeSeparatorChar)
+                && IsDirectorySeparator(path[2])
+                // To match old behavior we'll check the drive character for validity as the path is technically
+                // not qualified if you don't have a valid drive. "=:\" is the "=" file's default data stream.
+                && IsValidDriveChar(path[0]);
+        }
+        else
+        {
+            // Derived from .NET Runtime:
+            // - https://github.com/dotnet/runtime/blob/c7c961a330395152e5ec4000032cd3204ceb4a10/src/libraries/Common/src/System/IO/PathInternal.Unix.cs#L77-L82
+
+            // This is much simpler than Windows where paths can be rooted, but not fully qualified (such as Drive Relative)
+            // As long as the path is rooted in Unix it doesn't use the current directory and therefore is fully qualified.
+            return IsPathRooted(path);
+        }
 #endif
     }
+
+    public static bool IsPathRooted(string path)
+    {
+#if NET
+        return Path.IsPathRooted(path);
+#else
+        return IsPathRooted(path.AsSpan());
+#endif
+    }
+
+    public static bool IsPathRooted(ReadOnlySpan<char> path)
+    {
+#if NET
+        return Path.IsPathRooted(path);
+
+#else
+        if (PlatformInformation.IsWindows)
+        {
+            // Derived from .NET Runtime
+            // - https://github.com/dotnet/runtime/blob/850c0ab4519b904a28f2d67abdaba1ac78c955ff/src/libraries/System.Private.CoreLib/src/System/IO/Path.Windows.cs#L271-L276
+
+            var length = path.Length;
+            return (length >= 1 && IsDirectorySeparator(path[0]))
+                || (length >= 2 && IsValidDriveChar(path[0]) && path[1] == Path.VolumeSeparatorChar);
+        }
+        else
+        {
+            // Derived from .NET Runtime
+            // - https://github.com/dotnet/runtime/blob/850c0ab4519b904a28f2d67abdaba1ac78c955ff/src/libraries/System.Private.CoreLib/src/System/IO/Path.Unix.cs#L132-L135
+
+            return path.StartsWith(Path.DirectorySeparatorChar);
+        }
+#endif
+    }
+}

--- a/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/SpanExtensions.cs
+++ b/src/Shared/Microsoft.AspNetCore.Razor.Utilities.Shared/SpanExtensions.cs
@@ -2,9 +2,10 @@
 // Licensed under the MIT license. See License.txt in the project root for license information.
 
 #if !NET8_0_OR_GREATER
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 #endif
+
+using System.Runtime.CompilerServices;
 
 namespace System;
 
@@ -61,4 +62,32 @@ internal static class SpanExtensions
         }
 #endif
     }
+
+    /// <summary>
+    /// Determines whether the specified value appears at the start of the span.
+    /// </summary>
+    /// <param name="span">The span to search.</param>
+    /// <param name="value">The value to compare.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool StartsWith<T>(this ReadOnlySpan<T> span, T value)
+        where T : IEquatable<T>? =>
+#if NET9_0_OR_GREATER
+        MemoryExtensions.StartsWith(span, value);
+#else
+        span.Length != 0 && (span[0]?.Equals(value) ?? (object?)value is null);
+#endif
+
+    /// <summary>
+    /// Determines whether the specified value appears at the end of the span.
+    /// </summary>
+    /// <param name="span">The span to search.</param>
+    /// <param name="value">The value to compare.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool EndsWith<T>(this ReadOnlySpan<T> span, T value)
+        where T : IEquatable<T>? =>
+#if NET9_0_OR_GREATER
+        MemoryExtensions.EndsWith(span, value);
+#else
+        span.Length != 0 && (span[^1]?.Equals(value) ?? (object?)value is null);
+#endif
 }


### PR DESCRIPTION
Backport of #11864 to release/dev17.14

## Customer Impact

## Regression

- [x] Yes - https://github.com/dotnet/razor/pull/11320 (This change inadvertently removed some exception swallowing that "hid" the problem from the user.)
- [ ] No

## Testing

- Manual testing of scenario with known repro project. The issue is present without the fix and resolved with the fix.
- Tested mainline scenarios, such as OrchardCore and MudBlazor. These continue working with the fix.

## Risk

Medium. This affects how every Razor file is compiled in Visual Studio at design-time. However, this risk is mitigated by testing large solutions such as OrchardCore and MudBlazor.