### PR TITLE
Improve debugging tooltip support

### DIFF
--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Debugging/DataTipRangeHandlerEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Debugging/DataTipRangeHandlerEndpoint.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
+using Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
+using Microsoft.AspNetCore.Razor.Threading;
+using Microsoft.CodeAnalysis.Razor.DocumentMapping;
+using Microsoft.CodeAnalysis.Razor.Logging;
+using Microsoft.CodeAnalysis.Razor.Protocol;
+using Microsoft.CodeAnalysis.Razor.Workspaces;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Debugging;
+
+[RazorLanguageServerEndpoint(VSInternalMethods.TextDocumentDataTipRangeName)]
+internal class DataTipRangeHandlerEndpoint(
+    IDocumentMappingService documentMappingService,
+    LanguageServerFeatureOptions languageServerFeatureOptions,
+    IClientConnection clientConnection,
+    ILoggerFactory loggerFactory)
+    : AbstractRazorDelegatingEndpoint<TextDocumentPositionParams, VSInternalDataTip?>(
+        languageServerFeatureOptions,
+        documentMappingService,
+        clientConnection,
+        loggerFactory.GetOrCreateLogger<DataTipRangeHandlerEndpoint>()), ICapabilitiesProvider
+{
+    protected override bool OnlySingleServer => false;
+
+    protected override string CustomMessageTarget => CustomMessageNames.RazorDataTipRangeName;
+
+    public void ApplyCapabilities(VSInternalServerCapabilities serverCapabilities, VSInternalClientCapabilities clientCapabilities)
+    {
+        serverCapabilities.EnableDataTipRangeProvider();
+    }
+
+    protected override Task<IDelegatedParams?> CreateDelegatedParamsAsync(TextDocumentPositionParams request, RazorRequestContext requestContext, DocumentPositionInfo positionInfo, CancellationToken cancellationToken)
+    {
+        // only C# supports breakpoints
+        if (positionInfo.LanguageKind != RazorLanguageKind.CSharp)
+        {
+            return SpecializedTasks.Null<IDelegatedParams>();
+        }
+
+        var documentContext = requestContext.DocumentContext;
+        if (documentContext is null)
+        {
+            return SpecializedTasks.Null<IDelegatedParams>();
+        }
+
+        return Task.FromResult<IDelegatedParams?>(new DelegatedDataTipRangeParams(
+            documentContext.GetTextDocumentIdentifierAndVersion(),
+            positionInfo.Position,
+            positionInfo.LanguageKind));
+    }
+
+    protected override async Task<VSInternalDataTip?> HandleDelegatedResponseAsync(VSInternalDataTip? delegatedResponse, TextDocumentPositionParams originalRequest, RazorRequestContext requestContext, DocumentPositionInfo positionInfo, CancellationToken cancellationToken)
+    {
+        if (delegatedResponse is null)
+        {
+            return null;
+        }
+
+        var documentContext = requestContext.DocumentContext;
+        if (documentContext is null)
+        {
+            return null;
+        }
+
+        var codeDocument = await documentContext.GetCodeDocumentAsync(cancellationToken).ConfigureAwait(false);
+        var csharpDocument = codeDocument.GetCSharpDocument();
+
+        if (!DocumentMappingService.TryMapToHostDocumentRange(csharpDocument, delegatedResponse.HoverRange, out var hoverRange))
+        {
+            return null;
+        }
+
+        LspRange? expressionRange = null;
+        if (delegatedResponse.ExpressionRange != null && !DocumentMappingService.TryMapToHostDocumentRange(csharpDocument, delegatedResponse.ExpressionRange, out expressionRange))
+        {
+            return null;
+        }
+
+        return new VSInternalDataTip()
+        {
+            HoverRange = hoverRange,
+            ExpressionRange = expressionRange,
+            DataTipTags = delegatedResponse.DataTipTags,
+        };
+    }
+}

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Debugging/DataTipRangeHandlerEndpoint.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/Debugging/DataTipRangeHandlerEndpoint.cs
@@ -15,7 +15,7 @@ using Microsoft.CodeAnalysis.Razor.Workspaces;
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Debugging;
 
 [RazorLanguageServerEndpoint(VSInternalMethods.TextDocumentDataTipRangeName)]
-internal class DataTipRangeHandlerEndpoint(
+internal sealed class DataTipRangeHandlerEndpoint(
     IDocumentMappingService documentMappingService,
     LanguageServerFeatureOptions languageServerFeatureOptions,
     IClientConnection clientConnection,
@@ -49,7 +49,7 @@ internal class DataTipRangeHandlerEndpoint(
             return SpecializedTasks.Null<IDelegatedParams>();
         }
 
-        return Task.FromResult<IDelegatedParams?>(new DelegatedDataTipRangeParams(
+        return Task.FromResult<IDelegatedParams?>(new DelegatedPositionParams(
             documentContext.GetTextDocumentIdentifierAndVersion(),
             positionInfo.Position,
             positionInfo.LanguageKind));

--- a/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
+++ b/src/Razor/src/Microsoft.AspNetCore.Razor.LanguageServer/RazorLanguageServer.cs
@@ -14,7 +14,6 @@ using Microsoft.AspNetCore.Razor.LanguageServer.EndpointContracts;
 using Microsoft.AspNetCore.Razor.LanguageServer.Extensions;
 using Microsoft.AspNetCore.Razor.LanguageServer.FindAllReferences;
 using Microsoft.AspNetCore.Razor.LanguageServer.Folding;
-using Microsoft.AspNetCore.Razor.LanguageServer.Formatting;
 using Microsoft.AspNetCore.Razor.LanguageServer.Hosting;
 using Microsoft.AspNetCore.Razor.LanguageServer.Implementation;
 using Microsoft.AspNetCore.Razor.LanguageServer.InlayHints;
@@ -26,7 +25,6 @@ using Microsoft.AspNetCore.Razor.LanguageServer.SignatureHelp;
 using Microsoft.AspNetCore.Razor.LanguageServer.WrapWithTag;
 using Microsoft.CodeAnalysis.Razor.AutoInsert;
 using Microsoft.CodeAnalysis.Razor.FoldingRanges;
-using Microsoft.CodeAnalysis.Razor.Formatting;
 using Microsoft.CodeAnalysis.Razor.GoToDefinition;
 using Microsoft.CodeAnalysis.Razor.Logging;
 using Microsoft.CodeAnalysis.Razor.Protocol.DocumentSymbols;
@@ -213,6 +211,7 @@ internal partial class RazorLanguageServer : SystemTextJsonLanguageServer<RazorR
             services.AddHandlerWithCapabilities<ValidateBreakpointRangeEndpoint>();
             services.AddHandler<RazorBreakpointSpanEndpoint>();
             services.AddHandler<RazorProximityExpressionsEndpoint>();
+            services.AddHandlerWithCapabilities<DataTipRangeHandlerEndpoint>();
 
             services.AddHandler<WrapWithTagEndpoint>();
 

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/CustomMessageNames.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/CustomMessageNames.cs
@@ -15,6 +15,7 @@ internal static class CustomMessageNames
     // VS Windows only
     public const string RazorInlineCompletionEndpoint = "razor/inlineCompletion";
     public const string RazorValidateBreakpointRangeName = "razor/validateBreakpointRange";
+    public const string RazorDataTipRangeName = "razor/dataTipRange";
     public const string RazorOnAutoInsertEndpointName = "razor/onAutoInsert";
     public const string RazorSemanticTokensRefreshEndpoint = "razor/semanticTokensRefresh";
     public const string RazorTextPresentationEndpoint = "razor/textPresentation";

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/DelegatedTypes.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/DelegatedTypes.cs
@@ -39,6 +39,11 @@ internal record DelegatedValidateBreakpointRangeParams(
     [property: JsonPropertyName("projectedRange")] LspRange ProjectedRange,
     [property: JsonPropertyName("projectedKind")] RazorLanguageKind ProjectedKind) : IDelegatedParams;
 
+internal record DelegatedDataTipRangeParams(
+    [property: JsonPropertyName("identifier")] TextDocumentIdentifierAndVersion Identifier,
+    [property: JsonPropertyName("projectedPosition")] Position ProjectedPosition,
+    [property: JsonPropertyName("projectedKind")] RazorLanguageKind ProjectedKind) : IDelegatedParams;
+
 internal record DelegatedOnAutoInsertParams(
     [property: JsonPropertyName("identifier")] TextDocumentIdentifierAndVersion Identifier,
     [property: JsonPropertyName("projectedPosition")] Position ProjectedPosition,

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/DelegatedTypes.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/DelegatedTypes.cs
@@ -39,11 +39,6 @@ internal record DelegatedValidateBreakpointRangeParams(
     [property: JsonPropertyName("projectedRange")] LspRange ProjectedRange,
     [property: JsonPropertyName("projectedKind")] RazorLanguageKind ProjectedKind) : IDelegatedParams;
 
-internal record DelegatedDataTipRangeParams(
-    [property: JsonPropertyName("identifier")] TextDocumentIdentifierAndVersion Identifier,
-    [property: JsonPropertyName("projectedPosition")] Position ProjectedPosition,
-    [property: JsonPropertyName("projectedKind")] RazorLanguageKind ProjectedKind) : IDelegatedParams;
-
 internal record DelegatedOnAutoInsertParams(
     [property: JsonPropertyName("identifier")] TextDocumentIdentifierAndVersion Identifier,
     [property: JsonPropertyName("projectedPosition")] Position ProjectedPosition,

--- a/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/LspInitializationHelpers.cs
+++ b/src/Razor/src/Microsoft.CodeAnalysis.Razor.Workspaces/Protocol/LspInitializationHelpers.cs
@@ -82,6 +82,11 @@ internal static class LspInitializationHelpers
         serverCapabilities.BreakableRangeProvider = true;
     }
 
+    public static void EnableDataTipRangeProvider(this VSInternalServerCapabilities serverCapabilities)
+    {
+        serverCapabilities.DataTipRangeProvider = true;
+    }
+
     public static void EnableMapCodeProvider(this VSInternalServerCapabilities serverCapabilities)
     {
         serverCapabilities.MapCodeProvider = true;

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_DataTipRange.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_DataTipRange.cs
@@ -11,7 +11,7 @@ namespace Microsoft.VisualStudio.Razor.LanguageClient.Endpoints;
 internal partial class RazorCustomMessageTarget
 {
     [JsonRpcMethod(CustomMessageNames.RazorDataTipRangeName, UseSingleObjectParameterDeserialization = true)]
-    public async Task<VSInternalDataTip?> DataTipRangeAsync(DelegatedDataTipRangeParams request, CancellationToken cancellationToken)
+    public async Task<VSInternalDataTip?> DataTipRangeAsync(DelegatedPositionParams request, CancellationToken cancellationToken)
     {
         var delegationDetails = await GetProjectedRequestDetailsAsync(request, cancellationToken).ConfigureAwait(false);
         if (delegationDetails is null)

--- a/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_DataTipRange.cs
+++ b/src/Razor/src/Microsoft.VisualStudio.LanguageServices.Razor/LanguageClient/Endpoints/RazorCustomMessageTarget_DataTipRange.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Razor.Protocol;
+using StreamJsonRpc;
+
+namespace Microsoft.VisualStudio.Razor.LanguageClient.Endpoints;
+
+internal partial class RazorCustomMessageTarget
+{
+    [JsonRpcMethod(CustomMessageNames.RazorDataTipRangeName, UseSingleObjectParameterDeserialization = true)]
+    public async Task<VSInternalDataTip?> DataTipRangeAsync(DelegatedDataTipRangeParams request, CancellationToken cancellationToken)
+    {
+        var delegationDetails = await GetProjectedRequestDetailsAsync(request, cancellationToken).ConfigureAwait(false);
+        if (delegationDetails is null)
+        {
+            return default;
+        }
+
+        var dataTipRangeParams = new TextDocumentPositionParams
+        {
+            TextDocument = request.Identifier.TextDocumentIdentifier.WithUri(delegationDetails.Value.ProjectedUri),
+            Position = request.ProjectedPosition,
+        };
+
+        var response = await _requestInvoker.ReinvokeRequestOnServerAsync<TextDocumentPositionParams, VSInternalDataTip?>(
+            delegationDetails.Value.TextBuffer,
+            VSInternalMethods.TextDocumentDataTipRangeName,
+            delegationDetails.Value.LanguageServerName,
+            dataTipRangeParams,
+            cancellationToken).ConfigureAwait(false);
+
+        return response?.Response;
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Debugging/DataTipRangeHandlerEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Debugging/DataTipRangeHandlerEndpointTest.cs
@@ -13,7 +13,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.AspNetCore.Razor.LanguageServer.Debugging;
 
-public class DataTipRangeHandlerEndpointTest(ITestOutputHelper testOutput) : SingleServerDelegatingEndpointTestBase(testOutput)
+public sealed class DataTipRangeHandlerEndpointTest(ITestOutputHelper testOutput) : SingleServerDelegatingEndpointTestBase(testOutput)
 {
     [Fact]
     public async Task Handle_CSharpInHtml_DataTipRange_FirstExpression()

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Debugging/DataTipRangeHandlerEndpointTest.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/Debugging/DataTipRangeHandlerEndpointTest.cs
@@ -1,0 +1,115 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the MIT license. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Razor.Language;
+using Microsoft.AspNetCore.Razor.LanguageServer.ProjectSystem;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Text;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Microsoft.AspNetCore.Razor.LanguageServer.Debugging;
+
+public class DataTipRangeHandlerEndpointTest(ITestOutputHelper testOutput) : SingleServerDelegatingEndpointTestBase(testOutput)
+{
+    [Fact]
+    public async Task Handle_CSharpInHtml_DataTipRange_FirstExpression()
+    {
+        var input = """
+                @{
+                    {|expression:{|hover:a$$aa|}|}.bbb.ccc;
+                }
+                """;
+
+        await VerifyDataTipRangeAsync(input);
+    }
+
+    [Fact]
+    public async Task Handle_CSharpInHtml_DataTipRange_SecondExpression()
+    {
+        var input = """
+                @{
+                    {|expression:{|hover:aaa.b$$bb|}|}.ccc;
+                }
+                """;
+
+        await VerifyDataTipRangeAsync(input);
+    }
+
+    [Fact]
+    public async Task Handle_CSharpInHtml_DataTipRange_LastExpression()
+    {
+        var input = """
+                @{
+                    {|expression:{|hover:aaa.bbb.c$$cc|}|};
+                }
+                """;
+
+        await VerifyDataTipRangeAsync(input);
+    }
+
+    [Fact]
+    public async Task Handle_CSharpInHtml_DataTipRange_LinqExpression()
+    {
+        var input = """
+                @using System.Linq;
+
+                @{
+                    int[] args;
+                    var v = {|expression:{|hover:args.Se$$lect|}(a => a.ToString())|}.Where(a => a.Length >= 0);
+                }
+                """;
+
+        await VerifyDataTipRangeAsync(input, VSInternalDataTipTags.LinqExpression);
+    }
+
+    private async Task VerifyDataTipRangeAsync(string input, VSInternalDataTipTags dataTipTags = 0)
+    {
+        // Arrange
+        TestFileMarkupParser.GetPositionAndSpans(input, out var output, out int position, out ImmutableDictionary<string, ImmutableArray<TextSpan>> spans);
+
+        Assert.True(spans.TryGetValue("expression", out var expressionSpans), "Test authoring failure: Expected at least one span named 'expression'.");
+        Assert.True(expressionSpans.Length == 1, "Test authoring failure: Expected only one 'expression' span.");
+        Assert.True(spans.TryGetValue("hover", out var hoverSpans), "Test authoring failure: Expected at least one span named 'hover'.");
+        Assert.True(hoverSpans.Length == 1, "Test authoring failure: Expected only one 'hover' span.");
+
+        var codeDocument = CreateCodeDocument(output);
+        var razorFilePath = "C:/path/to/file.razor";
+
+        // Act
+        var result = await GetDataTipRangeAsync(codeDocument, razorFilePath, position);
+
+        // Assert
+        var expectedExpressionRange = codeDocument.Source.Text.GetRange(expressionSpans[0]);
+        Assert.Equal(expectedExpressionRange, result!.ExpressionRange);
+
+        var expectedHoverRange = codeDocument.Source.Text.GetRange(hoverSpans[0]);
+        Assert.Equal(expectedHoverRange, result!.HoverRange);
+
+        Assert.Equal(dataTipTags, result!.DataTipTags);
+    }
+
+    private async Task<VSInternalDataTip?> GetDataTipRangeAsync(RazorCodeDocument codeDocument, string razorFilePath, int position)
+    {
+        await using var languageServer = await CreateLanguageServerAsync(codeDocument, razorFilePath);
+
+        var endpoint = new DataTipRangeHandlerEndpoint(DocumentMappingService, LanguageServerFeatureOptions, languageServer, LoggerFactory);
+
+        var request = new TextDocumentPositionParams
+        {
+            TextDocument = new TextDocumentIdentifier
+            {
+                Uri = new Uri(razorFilePath)
+            },
+            Position = codeDocument.Source.Text.GetPosition(position)
+        };
+
+        Assert.True(DocumentContextFactory.TryCreate(request.TextDocument, out var documentContext));
+        var requestContext = CreateRazorRequestContext(documentContext, LspServices.Empty);
+
+        return await endpoint.HandleRequestAsync(request, requestContext, DisposalToken);
+    }
+}

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SingleServerDelegatingEndpointTestBase.TestLanguageServer.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SingleServerDelegatingEndpointTestBase.TestLanguageServer.cs
@@ -63,6 +63,7 @@ public abstract partial class SingleServerDelegatingEndpointTestBase
                 CustomMessageNames.RazorRenameEndpointName => await HandleRenameAsync(@params, cancellationToken),
                 CustomMessageNames.RazorOnAutoInsertEndpointName => await HandleOnAutoInsertAsync(@params, cancellationToken),
                 CustomMessageNames.RazorValidateBreakpointRangeName => await HandleValidateBreakpointRangeAsync(@params, cancellationToken),
+                CustomMessageNames.RazorDataTipRangeName => await HandleDataTipRangeAsync(@params, cancellationToken),
                 CustomMessageNames.RazorReferencesEndpointName => await HandleReferencesAsync(@params, cancellationToken),
                 CustomMessageNames.RazorProvideCodeActionsEndpoint => await HandleProvideCodeActionsAsync(@params, cancellationToken),
                 CustomMessageNames.RazorResolveCodeActionsEndpoint => await HandleResolveCodeActionsAsync(@params, cancellationToken),
@@ -382,6 +383,23 @@ public abstract partial class SingleServerDelegatingEndpointTestBase
 
             return _csharpServer.ExecuteRequestAsync<VSInternalValidateBreakableRangeParams, LspRange>(
                 VSInternalMethods.TextDocumentValidateBreakableRangeName, delegatedRequest, cancellationToken);
+        }
+
+        private Task<VSInternalDataTip> HandleDataTipRangeAsync<T>(T @params, CancellationToken cancellationToken)
+        {
+            var delegatedParams = Assert.IsType<DelegatedDataTipRangeParams>(@params);
+            var delegatedRequest = new TextDocumentPositionParams()
+            {
+                TextDocument = new VSTextDocumentIdentifier()
+                {
+                    Uri = _csharpDocumentUri,
+                    ProjectContext = delegatedParams.Identifier.TextDocumentIdentifier.GetProjectContext(),
+                },
+                Position = delegatedParams.ProjectedPosition,
+            };
+
+            return _csharpServer.ExecuteRequestAsync<TextDocumentPositionParams, VSInternalDataTip>(
+                VSInternalMethods.TextDocumentDataTipRangeName, delegatedRequest, cancellationToken);
         }
     }
 }

--- a/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SingleServerDelegatingEndpointTestBase.TestLanguageServer.cs
+++ b/src/Razor/test/Microsoft.AspNetCore.Razor.LanguageServer.Test/SingleServerDelegatingEndpointTestBase.TestLanguageServer.cs
@@ -387,7 +387,7 @@ public abstract partial class SingleServerDelegatingEndpointTestBase
 
         private Task<VSInternalDataTip> HandleDataTipRangeAsync<T>(T @params, CancellationToken cancellationToken)
         {
-            var delegatedParams = Assert.IsType<DelegatedDataTipRangeParams>(@params);
+            var delegatedParams = Assert.IsType<DelegatedPositionParams>(@params);
             var delegatedRequest = new TextDocumentPositionParams()
             {
                 TextDocument = new VSTextDocumentIdentifier()


### PR DESCRIPTION
Implement textdocument/_vs_dataTipRange lsp message which allows the vs debugger to better handle showing tooltips for the returned ranges.

This is my first PR into razor since joining the team, so I'm expecting/hoping for lots of feedback about these changes as I'm still just getting a feel for the codebase. This change is fairly simple, adding a new endpoint for _vs_dataTipRange, and forwarding the request to the csharp lsp implementation. AbstractRazorDelegatingEndpoint is extended to hook into the existing delegating infrastructure.

Fixes https://github.com/dotnet/razor/issues/6688, https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2459195