### PR TITLE
Reduce costs in ComponentDirectiveVisitor.VisitRazorDirective

### DIFF
--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/DefaultRazorTagHelperBinderPhaseTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/DefaultRazorTagHelperBinderPhaseTest.cs
@@ -1255,11 +1255,17 @@ public class DefaultRazorTagHelperContextDiscoveryPhaseTest : RazorProjectEngine
     [InlineData("Project.Foo", "global::Project.Bar", false)]
     [InlineData("Project.Bar.Foo", "Project", false)]
     [InlineData("Bar.Foo", "Project", false)]
-    public void IsTypeInNamespace_WorksAsExpected(string typeName, string @namespace, bool expected)
+    public void IsTypeNamespaceInNormalizedNamespace_WorksAsExpected(string typeName, string @namespace, bool expected)
     {
         // Arrange & Act
         var descriptor = CreateComponentDescriptor(typeName, typeName, "Test.dll");
-        var result = DefaultRazorTagHelperContextDiscoveryPhase.ComponentDirectiveVisitor.IsTypeInNamespace(descriptor, @namespace);
+
+        // Remove global:: prefix from namespace.
+        var normalizedNamespaceSpan = DefaultRazorTagHelperContextDiscoveryPhase.GetSpanWithoutGlobalPrefix(@namespace);
+
+        var typeNamespace = descriptor.GetTypeNamespace();
+
+        var result = DefaultRazorTagHelperContextDiscoveryPhase.ComponentDirectiveVisitor.IsTypeNamespaceInNormalizedNamespace(typeNamespace, normalizedNamespaceSpan);
 
         // Assert
         Assert.Equal(expected, result);
@@ -1273,11 +1279,13 @@ public class DefaultRazorTagHelperContextDiscoveryPhaseTest : RazorProjectEngine
     [InlineData("Project.Foo", "Project.Bar", true)]
     [InlineData("Project.Bar.Foo", "Project", false)]
     [InlineData("Bar.Foo", "Project", false)]
-    public void IsTypeInScope_WorksAsExpected(string typeName, string currentNamespace, bool expected)
+    public void IsTypeNamespaceInScope_WorksAsExpected(string typeName, string currentNamespace, bool expected)
     {
         // Arrange & Act
         var descriptor = CreateComponentDescriptor(typeName, typeName, "Test.dll");
-        var result = DefaultRazorTagHelperContextDiscoveryPhase.ComponentDirectiveVisitor.IsTypeInScope(descriptor, currentNamespace);
+        var tagHelperTypeNamespace = descriptor.GetTypeNamespace();
+
+        var result = DefaultRazorTagHelperContextDiscoveryPhase.ComponentDirectiveVisitor.IsTypeNamespaceInScope(tagHelperTypeNamespace, currentNamespace);
 
         // Assert
         Assert.Equal(expected, result);

--- a/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/DefaultRazorTagHelperBinderPhaseTest.cs
+++ b/src/Compiler/Microsoft.AspNetCore.Razor.Language/test/DefaultRazorTagHelperBinderPhaseTest.cs
@@ -1249,32 +1249,6 @@ public class DefaultRazorTagHelperContextDiscoveryPhaseTest : RazorProjectEngine
     [InlineData("", "", true)]
     [InlineData("Foo", "Project", true)]
     [InlineData("Project.Foo", "Project", true)]
-    [InlineData("Project.Foo", "global::Project", true)]
-    [InlineData("Project.Bar.Foo", "Project.Bar", true)]
-    [InlineData("Project.Foo", "Project.Bar", false)]
-    [InlineData("Project.Foo", "global::Project.Bar", false)]
-    [InlineData("Project.Bar.Foo", "Project", false)]
-    [InlineData("Bar.Foo", "Project", false)]
-    public void IsTypeNamespaceInNormalizedNamespace_WorksAsExpected(string typeName, string @namespace, bool expected)
-    {
-        // Arrange & Act
-        var descriptor = CreateComponentDescriptor(typeName, typeName, "Test.dll");
-
-        // Remove global:: prefix from namespace.
-        var normalizedNamespaceSpan = DefaultRazorTagHelperContextDiscoveryPhase.GetSpanWithoutGlobalPrefix(@namespace);
-
-        var typeNamespace = descriptor.GetTypeNamespace();
-
-        var result = DefaultRazorTagHelperContextDiscoveryPhase.ComponentDirectiveVisitor.IsTypeNamespaceInNormalizedNamespace(typeNamespace, normalizedNamespaceSpan);
-
-        // Assert
-        Assert.Equal(expected, result);
-    }
-
-    [Theory]
-    [InlineData("", "", true)]
-    [InlineData("Foo", "Project", true)]
-    [InlineData("Project.Foo", "Project", true)]
     [InlineData("Project.Bar.Foo", "Project.Bar", true)]
     [InlineData("Project.Foo", "Project.Bar", true)]
     [InlineData("Project.Bar.Foo", "Project", false)]

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/ReadOnlyMemoryOfCharComparer.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/ReadOnlyMemoryOfCharComparer.cs
@@ -1,0 +1,42 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Internal;
+
+namespace Microsoft.AspNetCore.Razor.Language;
+
+internal sealed class ReadOnlyMemoryOfCharComparer : IEqualityComparer<ReadOnlyMemory<char>>
+{
+    public static readonly ReadOnlyMemoryOfCharComparer Instance = new ReadOnlyMemoryOfCharComparer();
+
+    private ReadOnlyMemoryOfCharComparer()
+    {
+    }
+
+    public static bool Equals(ReadOnlySpan<char> x, ReadOnlyMemory<char> y)
+        => x.SequenceEqual(y.Span);
+
+    public bool Equals(ReadOnlyMemory<char> x, ReadOnlyMemory<char> y)
+        => x.Span.SequenceEqual(y.Span);
+
+    public int GetHashCode(ReadOnlyMemory<char> memory)
+    {
+#if NET
+        return string.GetHashCode(memory.Span);
+#else
+        // We don't rely on ReadOnlyMemory<char>.GetHashCode() because it includes
+        // the index and length, but we just want a hash based on the characters.
+        var hashCombiner = HashCodeCombiner.Start();
+
+        foreach (var ch in memory.Span)
+        {
+            hashCombiner.Add(ch);
+        }
+
+        return hashCombiner.CombinedHash;
+#endif
+    }
+}


### PR DESCRIPTION
Customer feedback ticket shows ~40% of CPU costs are in this method. Of the 33 seconds of CPU time in this method, 21 seconds are in it's calls to GetTypeNamespace and GetSpanWithoutGlobalPrefix.

VisitRazorDirective is called many times (we'll call that number 'l'), depending on the number of directives in the page. Each call costs O(m x n) where m is the number of import statements in the page and n is the number of directives that aren't fully qualified. Evidently, for this customer on this page, this O(l * m * n) is too much.

1) GetTypeNamespace -- Reduced to O(n) calls by storing it's result in _nonFullyQualifiedComponents 
2) GetSpanWithoutGlobalPrefix -- Reduced to O(l * m) by moving outside the innnermost loop

Fixes: https://developercommunity.visualstudio.com/t/Razor-Development:-30-Second-CPU-Churn-A/10904811

![image](https://github.com/user-attachments/assets/1ae07e42-5b74-419d-8e69-0172e6e0551a)

