### PR TITLE
Reduce allocations in TagHelperParseTreeRewriter.Rewrite

### DIFF
--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/TagHelperParseTreeRewriter.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/Legacy/TagHelperParseTreeRewriter.cs
@@ -36,10 +36,7 @@ internal static class TagHelperParseTreeRewriter
 
         foreach (var descriptor in binder.Descriptors)
         {
-            foreach (var diagnostic in descriptor.GetAllDiagnostics())
-            {
-                builder.Add(diagnostic);
-            }
+            descriptor.AppendAllDiagnostics(ref builder.AsRef());
         }
 
         var diagnostics = builder.ToImmutableOrderedBy(static d => d.Span.AbsoluteIndex);

--- a/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagHelperDescriptor.cs
+++ b/src/Compiler/Microsoft.CodeAnalysis.Razor.Compiler/src/Language/TagHelperDescriptor.cs
@@ -174,34 +174,34 @@ public sealed class TagHelperDescriptor : TagHelperObject<TagHelperDescriptor>
 
     public IEnumerable<RazorDiagnostic> GetAllDiagnostics()
     {
+        using var diagnostics = new PooledArrayBuilder<RazorDiagnostic>();
+
+        AppendAllDiagnostics(ref diagnostics.AsRef());
+
+        foreach (var diagnostic in diagnostics)
+        {
+            yield return diagnostic;
+        }
+    }
+
+    internal void AppendAllDiagnostics(ref PooledArrayBuilder<RazorDiagnostic> diagnostics)
+    {
         foreach (var allowedChildTag in AllowedChildTags)
         {
-            foreach (var diagnostic in allowedChildTag.Diagnostics)
-            {
-                yield return diagnostic;
-            }
+            diagnostics.AddRange(allowedChildTag.Diagnostics);
         }
 
         foreach (var boundAttribute in BoundAttributes)
         {
-            foreach (var diagnostic in boundAttribute.Diagnostics)
-            {
-                yield return diagnostic;
-            }
+            diagnostics.AddRange(boundAttribute.Diagnostics);
         }
 
         foreach (var tagMatchingRule in TagMatchingRules)
         {
-            foreach (var diagnostic in tagMatchingRule.Diagnostics)
-            {
-                yield return diagnostic;
-            }
+            diagnostics.AddRange(tagMatchingRule.Diagnostics);
         }
 
-        foreach (var diagnostic in Diagnostics)
-        {
-            yield return diagnostic;
-        }
+        diagnostics.AddRange(Diagnostics);
     }
 
     public override string ToString()


### PR DESCRIPTION
Customer profile is showing a very large number of allocations in the GetAllDiagnostics call, due to the yield state machinery. Added internal method to TagHelperDescriptor that allows callers to pass in a PooledArrayBuilder for the diagnostics to be added directly to, instead of using "return yield".

Customer profile showed 1.2 GB(!!) of memory allocations due to this.
![image](https://github.com/user-attachments/assets/c9cb920b-31ba-4dc3-bf31-e78ee5072d59)

Partial fix for https://github.com/dotnet/roslyn/issues/78639